### PR TITLE
switch to using application.yml and figaro gem for local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@
 public/assets/**
 
 # Ignore local config
-config/local_env.yml
+config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'redis-namespace'
 gem 'virtus'
 #emphasize this is an api only app
 gem 'rails-api'
+gem 'figaro'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
     fakeredis (0.5.0)
       redis (~> 3.0)
     ffi (1.9.10)
+    figaro (1.1.1)
+      thor (~> 0.14)
     formatador (0.2.5)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -258,6 +260,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   fakeredis
+  figaro
   guard-rspec
   pry-nav
   puma (~> 2.16.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,13 +30,5 @@ module VetsAPI
     # config.i18n.default_locale = :de
 
     config.api_only = true
-
-    # load local configuration file as environment variables
-    config.before_configuration do
-      env_file = File.join(Rails.root, 'config', 'local_env.yml')
-      YAML.load(File.open(env_file)).each do |key, value|
-        ENV[key.to_s] = value
-      end if File.exists?(env_file)
-    end
   end
 end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,0 +1,7 @@
+# These are local environment settings that will get picked up as environment variables
+# by the Figaro gem.
+# Change to match your local settings and save the file as application.yml
+
+CERTIFICATE_FILE: '/Users/shauni/workspace/certs/vetsgov-localhost.crt'
+KEY_FILE: '/Users/shauni/workspace/certs/vetsgov-localhost.key'
+SAML_ISSUER: 'saml-rp.vetsgov.localhost'

--- a/config/local_env.yml.example
+++ b/config/local_env.yml.example
@@ -1,6 +1,0 @@
-# These are local environment settings that will get picked up as environment variables.
-# Change to match your settings and save the file as local_env.yml
-
-CERTIFICATE_FILE: '/Users/shauni/workspace/certs/vetsgov-localhost.crt'
-KEY_FILE: '/Users/shauni/workspace/certs/vetsgov-localhost.key'
-SAML_ISSUER: 'saml-rp.vetsgov.localhost'


### PR DESCRIPTION
I saw that prescriptions-api was using figaro, so I switched our env-specific config setup to be consistent (and also be able to re-use the ansible template).

We should have a mechanism for getting changes like this that would be relevant to multiple apps back into roadrunner-rails .... thoughts?

cc people who might care about app config:
@cfeeney-va @robbiethegeek @ayaleloehr @kreek @saneshark @knkski 