### PR TITLE
upgrade rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,9 +30,8 @@ group :development, :test do
   gem 'bundler-audit'
 
   # Testing tools
-  gem 'rspec'
-  gem 'rspec-rails'
-  gem 'guard-rspec'
+  gem 'rspec-rails', '~> 3.5'
+  gem 'guard-rspec', '~> 4.7'
   gem 'simplecov'
   gem 'webmock'
   gem 'pry-nav'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       shellany (~> 0.0)
       thor (>= 0.18.1)
     guard-compat (1.2.1)
-    guard-rspec (4.6.4)
+    guard-rspec (4.7.3)
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
@@ -177,27 +177,27 @@ GEM
     redis (3.3.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.3)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.1)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-rails (3.4.2)
-      actionpack (>= 3.0, < 4.3)
-      activesupport (>= 3.0, < 4.3)
-      railties (>= 3.0, < 4.3)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
+      rspec-support (~> 3.5.0)
+    rspec-rails (3.5.1)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     rubocop (0.36.0)
       parser (>= 2.3.0.0, < 3.0)
       powerpack (~> 0.1)
@@ -266,7 +266,7 @@ DEPENDENCIES
   byebug
   fakeredis
   figaro
-  guard-rspec
+  guard-rspec (~> 4.7)
   guard-rubocop
   pry-nav
   puma (~> 2.16.0)
@@ -275,8 +275,7 @@ DEPENDENCIES
   rainbow
   redis
   redis-namespace
-  rspec
-  rspec-rails
+  rspec-rails (~> 3.5)
   rubocop (~> 0.36.0)
   ruby-saml (~> 1.3.0)
   sdoc (~> 0.4.0)


### PR DESCRIPTION
upgrade rspec to fix this deprecation
```
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
```
