### PR TITLE
Move rainbow require into rake task body

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,8 +1,9 @@
 require "open3"
-require "rainbow"
 
 desc "shortcut to run all linting tools, at the same time."
 task :lint do
+  require "rainbow"
+
   opts = ENV["CI"] ? "" : "--auto-correct"
   puts "running rubocop..."
   rubocop_result = ShellCommand.run("rubocop #{opts} --color")

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -1,8 +1,9 @@
 require "open3"
-require "rainbow"
 
 desc "shortcut to run all linting tools, at the same time."
 task :security do
+  require "rainbow"
+
   puts "running Brakeman security scan..."
   brakeman_result = ShellCommand.run(
     "brakeman --exit-on-warn --run-all-checks --confidence-level=2"


### PR DESCRIPTION
Having an issue running deployment specific rake tasks (db:migrate) since rainbow is a dev dependency and not available on production systems. This moves the rainbow require statement into the rake task body and prevents loading it until the task is run.