### PR TITLE
ID.me account creation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The first endpoint, below, doesn't require authentication while the second does:
 curl localhost:3000/v0/status
 curl localhost:3000/v0/welcome
 ```
-It is easiest to go through the auth flow in your browser. Curl or browse to `http://localhost:3000/v0/sessions/new`; copy and paste the ID.me URL into your browser.  Create your ID.me account if you have not already done so. (*Note* creating your account on the ID.me site is separate from the api.idmelabs.com sandbox) The token returned in the json response at the end of the login flow can be used as follows (You may wish to use Postman instead of curl to test within the browser):
+It is easiest to go through the auth flow in your browser. Curl or browse to `http://localhost:3000/v0/sessions/new`; copy and paste the ID.me URL into your browser.  Create your ID.me account if you have not already done so. (**Note**: creating your account on the ID.me site is separate from the api.idmelabs.com sandbox) The token returned in the json response at the end of the login flow can be used as follows (You may wish to use Postman instead of curl to test within the browser):
 
 ```
 curl --header "Authorization: Token token=GvmkAW231VxGHkYxyppr2QQsi1D7PStqeiJXyyja" localhost:3000/v0/welcome

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The first endpoint, below, doesn't require authentication while the second does:
 curl localhost:3000/v0/status
 curl localhost:3000/v0/welcome
 ```
-It is easiest to go through the auth flow in your browser. Curl or browse to `http://localhost:3000/v0/sessions/new`; copy and paste the ID.me URL into your browser and log in on ID.me. The token returned in the json response at the end of the login flow can be used as follows (You may wish to use Postman instead of curl to test within the browser):
+It is easiest to go through the auth flow in your browser. Curl or browse to `http://localhost:3000/v0/sessions/new`; copy and paste the ID.me URL into your browser.  Create your ID.me account if you have not already done so. (*Note* creating your account on the ID.me site is separate from the api.idmelabs.com sandbox) The token returned in the json response at the end of the login flow can be used as follows (You may wish to use Postman instead of curl to test within the browser):
 
 ```
 curl --header "Authorization: Token token=GvmkAW231VxGHkYxyppr2QQsi1D7PStqeiJXyyja" localhost:3000/v0/welcome


### PR DESCRIPTION
It was not clear in the existing readme.md that the ID.me account must be created from within the api.idmelabs.com sandbox as opposed to on the http://www.ID.me website directly.