### PR TITLE
EVSS service specs: Use sample claimant VAAFI headers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,8 @@ class User < RedisStore
     {
       # Always the same
       'va_eauth_csid' => 'DSLogon',
+      # TODO: Change va_eauth_authenticationmethod to vets.gov
+      # once the EVSS team is ready for us to use it
       'va_eauth_authenticationmethod' => 'DSLogon',
       'va_eauth_assurancelevel' => '2',
       'va_eauth_pnidtype' => 'SSN',

--- a/spec/lib/evss/claims_service_spec.rb
+++ b/spec/lib/evss/claims_service_spec.rb
@@ -4,22 +4,7 @@ require_dependency 'evss/claims_service'
 
 describe EVSS::ClaimsService do
   let(:vaafi_headers) do
-    {
-      'va_eauth_pnidtype' => 'SSN',
-      'va_eauth_csid' => 'DSLogon',
-      'va_eauth_firstName' => 'Jane',
-      'va_eauth_lastName' => 'Doe',
-      'va_eauth_authenticationauthority' => 'eauth',
-      'iv-user' => 'dslogoneauthuser',
-      'va_eauth_emailAddress' => 'jane.doe@va.gov',
-      'va_eauth_birthdate' => '1999-10-09T08:06:12-04:00',
-      'va_eauth_pid' => '123456789',
-      'va_eauth_issueinstant' => '2015-04-17T14:52:48Z',
-      'va_eauth_dodedipnid' => '1105051936',
-      'va_eauth_middleName' => 'A',
-      'va_eauth_authenticationmethod' => 'DSLogon',
-      'va_eauth_assurancelevel' => '2'
-    }
+    User.sample_claimant.vaafi_headers
   end
 
   subject { described_class.new(vaafi_headers) }

--- a/spec/lib/evss/documents_service_spec.rb
+++ b/spec/lib/evss/documents_service_spec.rb
@@ -4,22 +4,7 @@ require_dependency 'evss/documents_service'
 
 describe EVSS::DocumentsService do
   let(:vaafi_headers) do
-    {
-      'va_eauth_pnidtype' => 'SSN',
-      'va_eauth_csid' => 'DSLogon',
-      'va_eauth_firstName' => 'Jane',
-      'va_eauth_lastName' => 'Doe',
-      'va_eauth_authenticationauthority' => 'eauth',
-      'iv-user' => 'dslogoneauthuser',
-      'va_eauth_emailAddress' => 'jane.doe@va.gov',
-      'va_eauth_birthdate' => '1999-10-09T08:06:12-04:00',
-      'va_eauth_pid' => '123456789',
-      'va_eauth_issueinstant' => '2015-04-17T14:52:48Z',
-      'va_eauth_dodedipnid' => '1105051936',
-      'va_eauth_middleName' => 'A',
-      'va_eauth_authenticationmethod' => 'DSLogon',
-      'va_eauth_assurancelevel' => '2'
-    }
+    User.sample_claimant.vaafi_headers
   end
 
   subject { described_class.new(vaafi_headers) }


### PR DESCRIPTION
I was trying to test the endpoint with a different sample user and then confused why nothing changed: it was because I wasn't modifying the right headers to change the service spec! DRYing it out to simplify this in the future.