### PR TITLE
Return HTTP 401 (not 500) if browser sends invalid Auth Token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,6 +49,7 @@ class ApplicationController < ActionController::API
   def authenticate_token
     authenticate_with_http_token do |token, _options|
       @session = Session.find(token)
+      return false if @session.nil?
       # TODO: ensure that this prevents against timing attack vectors
       ActiveSupport::SecurityUtils.secure_compare(
         ::Digest::SHA256.hexdigest(token),

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -5,6 +5,17 @@ RSpec.describe V0::SessionsController, type: :controller do
   let(:saml_attrs) { { 'uuid' => ['1234'], 'email' => ['test@test.com'] } }
 
   context 'when not logged in' do
+    context 'when browser contains an invalid authorization token' do
+      let(:invalid_token) { 'iam-aninvalid-tokenvalue' }
+      let(:auth_header) { ActionController::HttpAuthentication::Token.encode_credentials(invalid_token) }
+
+      it 'GET show - returns unauthorized' do
+        request.env['HTTP_AUTHORIZATION'] = auth_header
+        get :show
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
     it 'GET new - shows the ID.me authentication url' do
       allow_any_instance_of(OneLogin::RubySaml::Authrequest)
         .to receive(:create).and_return('url_string')


### PR DESCRIPTION
This relates to issue #39 .

Previously, this code would raise an exception on line 56:

```undefined method `token' for nil:NilClass.```

Because the `Session.find(token)` returned `nil`.