### PR TITLE
Add a Procfile, and Foreman to use it.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ group :development, :test do
   gem 'guard-rspec', '~> 4.7'
   gem 'pry-nav'
   gem 'factory_girl_rails'
+
+  gem 'foreman'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     ffi (1.9.10)
     figaro (1.1.1)
       thor (~> 0.14)
+    foreman (0.82.0)
+      thor (~> 0.19.1)
     formatador (0.2.5)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -341,6 +343,7 @@ DEPENDENCIES
   faraday
   faraday_middleware
   figaro
+  foreman
   guard-rspec (~> 4.7)
   guard-rubocop
   httpclient

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec bin/rails s
+job: bundle exec sidekiq

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For an example, see `application.yml.example` - these are just mock endpoints.
 For actual backend testing you will need to reference the appropriate private repository.
 
 ### Running the App
-1. Start the application: `bundle exec rails s`
+1. Start the application: `foreman start`
 1. Navigate to <http://localhost:3000/v0/status> in your browser.
 
 ## Testing Commands


### PR DESCRIPTION
Now that we sometimes need to start both the rails and sidekiq servers, I'd like to add Foreman as a standard way to manage the starting and stopping of those services. It's a bit more complexity (that you can always choose to bypass), but I've found it useful in the past.