### PR TITLE
Exception Notifications in Slack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,10 @@ gem 'net-sftp'
 # `multi_json` will prefer `oj` if installed, so include it here.
 gem 'oj'
 
+# This gem will allow us to show exceptions for Staging environment in Slack
+gem 'exception_notification'
+gem 'slack-notifier'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,9 @@ GEM
     encryptor (3.0.0)
     equalizer (0.0.11)
     erubis (2.7.0)
+    exception_notification (4.2.1)
+      actionmailer (>= 4.0, < 6)
+      activesupport (>= 4.0, < 6)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.7.0)
@@ -282,6 +285,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slack-notifier (1.5.1)
     slim (3.0.6)
       temple (~> 0.7.3)
       tilt (>= 1.3.3, < 2.1)
@@ -336,6 +340,7 @@ DEPENDENCIES
   brakeman
   bundler-audit
   byebug
+  exception_notification
   factory_girl_rails
   fakeredis
   faraday
@@ -365,6 +370,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   sidekiq
   simplecov
+  slack-notifier
   spring
   spring-commands-rspec
   timecop

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'exception_notification/rails'
+require 'exception_notification/sidekiq'
+
+ExceptionNotification.configure do |config|
+  config.add_notifier :slack, webhook_url: ENV['EXCEPTIONS_SLACK_WEBHOOK'],
+                              channel: '#exceptions',
+                              backtrace_lines: 10,
+                              additional_parameters: {
+                                mrkdwn: true
+                              }
+end


### PR DESCRIPTION
Currently dev and staging environments suppress the backtrace from exceptions raised because that is the preference for production. But for debugging, it is incredibly helpful to have this backtrace. In lieu of a mechanism for querying logs in a realtime manner, this is a good compromise for now.

This PR can be merged irrespective of https://github.com/department-of-veterans-affairs/devops/pull/685 but will not start to track the exceptions in slack until those ENV variables are present.