### PR TITLE
LOA parsing/caching

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -59,7 +59,7 @@ module V0
     # which LOA was performed on the ID.me side.
     def level_of_assurance
       Hash.from_xml(@saml_response.response)
-        .dig('Response', 'Assertion', 'AuthnStatement', 'AuthnContext', 'AuthnContextClassRef')
+          .dig('Response', 'Assertion', 'AuthnStatement', 'AuthnContext', 'AuthnContextClassRef')
     end
   end
 end

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -46,8 +46,16 @@ module V0
         last_name: attributes['lname']&.first,
         zip: attributes['zip']&.first,
         email: attributes['email']&.first,
-        uuid: attributes['uuid']&.first
+        uuid: attributes['uuid']&.first,
+        level_of_assurance: level_of_assurance
       }
+    end
+
+    # Ruby-Saml does not parse the <samlp:Response> xml so we do it ourselves to find
+    # which LOA was performed on the ID.me side.
+    def level_of_assurance
+      Hash.from_xml(@saml_response.response)
+        .dig('Response', 'Assertion', 'AuthnStatement', 'AuthnContext', 'AuthnContextClassRef')
     end
   end
 end

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -42,11 +42,15 @@ module V0
     def user_attributes
       attributes = @saml_response.attributes.all.to_h
       {
-        first_name: attributes['fname']&.first,
-        last_name: attributes['lname']&.first,
-        zip: attributes['zip']&.first,
-        email: attributes['email']&.first,
-        uuid: attributes['uuid']&.first,
+        first_name:   attributes['fname']&.first,
+        middle_name:  attributes['mname']&.first,
+        last_name:    attributes['lname']&.first,
+        zip:          attributes['zip']&.first,
+        email:        attributes['email']&.first,
+        ssn:          attributes['social']&.first,
+        birth_date:   attributes['birth_date']&.first,
+        uuid:         attributes['uuid']&.first,
+
         level_of_assurance: level_of_assurance
       }
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,9 @@ class User < Common::RedisStore
   attribute :last_name
   attribute :zip
 
+  # id.me returned loa
+  attribute :level_of_assurance
+
   # vaafi attributes
   attribute :last_signed_in, Common::UTCTime
   attribute :edipi

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,11 @@ class User < Common::RedisStore
   attribute :uuid
   attribute :email
   attribute :first_name
+  attribute :middle_name
   attribute :last_name
   attribute :zip
+  attribute :ssn
+  attribute :birth_date
 
   # id.me returned loa
   attribute :level_of_assurance

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -2,17 +2,17 @@
 require 'rails_helper'
 
 RSpec.describe V0::SessionsController, type: :controller do
-  let(:saml_attrs) { 
-    { 
-    'uuid' => ['1234'],
-    'email' => ['test@test.com'],
-    'fname' => ['abraham'],
-    'lname' => ['lincoln'],
-    'mname' => [''],
-    'social' => ['111-22-3333'],
-    'birth_date' => ['1809-02-12'] 
-    } 
-  }
+  let(:saml_attrs) do
+    {
+      'uuid' => ['1234'],
+      'email' => ['test@test.com'],
+      'fname' => ['abraham'],
+      'lname' => ['lincoln'],
+      'mname' => [''],
+      'social' => ['111-22-3333'],
+      'birth_date' => ['1809-02-12']
+    }
+  end
   # has an LOA of 'http://idmanagement.gov/ns/assurance/loa/2'
   let(:response_xml) { File.read("#{::Rails.root}/spec/fixtures/files/saml_response.xml") }
 
@@ -49,7 +49,7 @@ RSpec.describe V0::SessionsController, type: :controller do
       let(:attributes) { double('attributes') }
       let(:saml_response) { double('saml_response', is_valid?: true, attributes: attributes) }
 
-      before(:example) do 
+      before(:example) do
         allow(attributes).to receive_message_chain(:all, :to_h).and_return(saml_attrs)
         allow(OneLogin::RubySaml::Response).to receive(:new).and_return(saml_response)
         allow(saml_response).to receive(:response).and_return(response_xml)
@@ -83,7 +83,7 @@ RSpec.describe V0::SessionsController, type: :controller do
 
         uuid = JSON.parse(response.body)['uuid']
         user = User.find(uuid)
-        expect(user.level_of_assurance).to eq("http://idmanagement.gov/ns/assurance/loa/2")
+        expect(user.level_of_assurance).to eq('http://idmanagement.gov/ns/assurance/loa/2')
       end
     end
 

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe V0::SessionsController, type: :controller do
   let(:saml_attrs) { { 'uuid' => ['1234'], 'email' => ['test@test.com'] } }
-  let(:response_xml) {'<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"></samlp:Response>'}
+  let(:response_xml) { '<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"></samlp:Response>' }
 
   context 'when not logged in' do
     context 'when browser contains an invalid authorization token' do

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 RSpec.describe V0::SessionsController, type: :controller do
   let(:saml_attrs) { { 'uuid' => ['1234'], 'email' => ['test@test.com'] } }
+  let(:response_xml) {'<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"></samlp:Response>'}
 
   context 'when not logged in' do
     context 'when browser contains an invalid authorization token' do
@@ -35,9 +36,11 @@ RSpec.describe V0::SessionsController, type: :controller do
 
     it 'GET saml_callback - creates a session from a valid SAML response' do
       attributes = double('attributes')
+      saml_response = double('saml_response', is_valid?: true, attributes: attributes)
+
       allow(attributes).to receive_message_chain(:all, :to_h).and_return(saml_attrs)
-      allow(OneLogin::RubySaml::Response)
-        .to receive(:new).and_return(double('saml_response', is_valid?: true, attributes: attributes))
+      allow(OneLogin::RubySaml::Response).to receive(:new).and_return(saml_response)
+      allow(saml_response).to receive(:response).and_return(response_xml)
 
       get :saml_callback
       expect(response).to have_http_status(:success)

--- a/spec/fixtures/files/saml_response.xml
+++ b/spec/fixtures/files/saml_response.xml
@@ -1,3 +1,10 @@
 <?xml version="1.0"?>
-<samlp:Response>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+  <saml:Assertion>
+    <saml:AuthnStatement>
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>http://idmanagement.gov/ns/assurance/loa/2</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+  </saml:Assertion>
 </samlp:Response>

--- a/spec/fixtures/files/saml_response.xml
+++ b/spec/fixtures/files/saml_response.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<samlp:Response>
+</samlp:Response>


### PR DESCRIPTION
- Parse out LOA from SAML Assertion & store in Redis
- Add extra SAML Attributes  (middle name, ssn, & birthday) to SAML attribute parsing & User model

Related: https://github.com/department-of-veterans-affairs/platform-team/issues/127