### PR TITLE
Collection Filtering Improvement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'common/exceptions'
+require 'common/client/errors'
 
 class ApplicationController < ActionController::API
   include ActionController::HttpAuthentication::Token::ControllerMethods

--- a/app/controllers/v0/prescriptions_controller.rb
+++ b/app/controllers/v0/prescriptions_controller.rb
@@ -14,6 +14,7 @@ module V0
     #        (ie: ?sort=facility_name,-prescription_id)
     def index
       resource = collection_resource
+      resource = params[:filter].present? ? resource.find_by(params[:filter]) : resource
       resource = resource.sort(params[:sort] || DEFAULT_SORT, allowed: SORT_TYPES)
       resource = resource.paginate(pagination_params)
       render json: resource.data,
@@ -44,8 +45,6 @@ module V0
         client.get_history_rxs
       when 'active'
         client.get_active_rxs
-      else
-        client.get_history_rxs.find_by(:refill_status, params[:refill_status])
       end
     end
   end

--- a/lib/common/exceptions/invalid_filters_syntax.rb
+++ b/lib/common/exceptions/invalid_filters_syntax.rb
@@ -5,12 +5,13 @@ module Common
     class InvalidFiltersSyntax < BaseError
       attr_reader :filters
 
-      def initialize(filters)
+      def initialize(filters, options = {})
         @filters = filters
+        @detail = options[:detail]
       end
 
       def errors
-        detail = "#{filters} is not a valid syntax for filtering"
+        detail = @detail || "#{filters} is not a valid syntax for filtering"
         Array(SerializableError.new(MinorCodes::INVALID_FILTERS_SYNTAX.merge(detail: detail)))
       end
     end

--- a/lib/common/models/collection.rb
+++ b/lib/common/models/collection.rb
@@ -16,6 +16,13 @@ module Common
     alias to_h attributes
     alias to_hash attributes
 
+    OPERATIONS_MAP = {
+      'eq' => :==,
+      'lteq' => :<=,
+      'gteq' => :>=,
+      'not_eq' => :!=
+    }
+
     def initialize(klass = Array, data: [], metadata: {}, errors: {})
       @type = klass
       @attributes = data
@@ -27,14 +34,14 @@ module Common
       end
     end
 
-    def find_by(method, value)
-      result = @data.select { |item| item.send(method.to_sym) == value }
-      metadata = @metadata.merge(filter: { for: method.to_s, having: value })
+    def find_by(search = {})
+      result = @data.select { |item|  finder(item, search) }
+      metadata = @metadata.merge(filter: search)
       Collection.new(type, data: result, metadata: metadata, errors: errors)
     end
 
-    def find_first_by(method, value)
-      result = @data.detect { |item| item.send(method.to_sym) == value }
+    def find_first_by(search = {})
+      result = @data.detect { |item| finder(item, search) }
       return nil if result.nil?
       result.metadata = metadata
       result
@@ -45,7 +52,7 @@ module Common
     end
 
     def sort(sort_params, allowed: sortable_attributes)
-      fields = filtered_sort_fields(sort_params, allowed)
+      fields = sort_fields(sort_params, allowed)
       result = @data.sort_by do |item|
         fields.map do |k, v|
           v == 'ASC' ? item.send(k) : Descending.new(item.send(k))
@@ -65,6 +72,22 @@ module Common
 
     private
 
+    def mock_comparator_object
+      @mock_comparator_object ||= type.new
+    end
+
+    def finder(object, search)
+      search.all? do |attribute, predicates|
+        actual_value = object.send(attribute)
+        # raise exception if attribute is not supported by filter
+        predicates.all? do |operator, expected_value|
+          op = OPERATIONS_MAP.fetch(operator)
+          mock_comparator_object.send("#{attribute}=", expected_value)
+          actual_value.send(op, mock_comparator_object.send(attribute))
+        end
+      end
+    end
+
     def paginator(page, per_page)
       if defined?(::WillPaginate::Collection)
         WillPaginate::Collection.create(page, per_page, @data.length) do |pager|
@@ -81,7 +104,7 @@ module Common
       { pagination: { current_page: page, per_page: per_page, total_pages: total_pages, total_entries: total_entries } }
     end
 
-    def filtered_sort_fields(sort_params, allowed)
+    def sort_fields(sort_params, allowed)
       fields = sort_params.to_s.split(',')
       ordered_fields = convert_fields_to_ordered_hash(fields)
       ordered_fields.select { |k, _| Array.wrap(allowed).include?(k) }

--- a/lib/common/models/collection.rb
+++ b/lib/common/models/collection.rb
@@ -35,7 +35,7 @@ module Common
     end
 
     def find_by(search = {})
-      result = @data.select { |item|  finder(item, search) }
+      result = @data.select { |item| finder(item, search) }
       metadata = @metadata.merge(filter: search)
       Collection.new(type, data: result, metadata: metadata, errors: errors)
     end

--- a/lib/common/models/collection.rb
+++ b/lib/common/models/collection.rb
@@ -21,7 +21,7 @@ module Common
       'lteq' => :<=,
       'gteq' => :>=,
       'not_eq' => :!=
-    }
+    }.with_indifferent_access.freeze
 
     def initialize(klass = Array, data: [], metadata: {}, errors: {})
       @type = klass

--- a/lib/rx/api/prescriptions.rb
+++ b/lib/rx/api/prescriptions.rb
@@ -17,7 +17,7 @@ module Rx
 
       def get_rx(id)
         collection = get_history_rxs
-        collection.find_first_by(:prescription_id, id)
+        collection.find_first_by(prescription_id: { eq: id })
       end
 
       def get_tracking_rx(id)

--- a/spec/controllers/collection_filtering_spec.rb
+++ b/spec/controllers/collection_filtering_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'common/models/collection'
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    skip_before_action :authenticate
+
+    def index
+      tt = []
+      10.times do |i|
+        tt << TriageTeam.new(
+          triage_team_id: i,
+          name: "name-#{i}",
+          relation_type: 'patient'
+        )
+      end
+
+      collection = Common::Collection.new(TriageTeam, data: tt)
+      collection = params[:filter].present? ? collection.find_by(params[:filter]) : collection
+      render json: collection.data,
+             serializer: CollectionSerializer,
+             each_serializer: TriageTeamSerializer,
+             meta: collection.metadata
+    end
+  end
+
+  before(:each) do
+    routes.draw { get 'index' => 'anonymous#index' }
+  end
+
+  subject { JSON.parse(response.body)['data'] }
+
+  it 'has a collection' do
+    get :index
+    expect(subject).to be_an(Array)
+    expect(subject.length).to eq(10)
+  end
+
+  context 'filter with one attribute' do
+    context 'and one predicate' do
+      let(:params) { { filter: { name: { eq: 'name-1' } } } }
+      it 'can filter on name eq' do
+        get :index, params
+        expect(subject).to be_an(Array)
+        expect(subject.length).to eq(1)
+        expect(subject.first['attributes']['name']).to eq('name-1')
+      end
+    end
+
+    context 'and two predicates' do
+      let(:params) { { filter: { triage_team_id: { gteq: '6', lteq: '9' } } } }
+      it 'can filter on name eq (with coercion)' do
+        get :index, params
+        expect(subject).to be_an(Array)
+        expect(subject.length).to eq(4)
+      end
+    end
+  end
+
+  context 'filter with two attributes' do
+    let(:params) { { filter: { triage_team_id: { gteq: 6, lteq: 9 }, name: { not_eq: 'name-7' } } } }
+
+    it 'can filter on name and id' do
+      get :index, params
+      expect(subject).to be_an(Array)
+      expect(subject.length).to eq(3)
+      expect(subject.map { |item| item['attributes']['name'] })
+        .to_not include('name-7')
+    end
+  end
+end

--- a/spec/lib/common/exceptions/invalid_filters_syntax_spec.rb
+++ b/spec/lib/common/exceptions/invalid_filters_syntax_spec.rb
@@ -5,7 +5,7 @@ describe Common::Exceptions::InvalidFiltersSyntax do
   context 'with no filters provided' do
     it do
       expect { described_class.new }
-        .to raise_error(ArgumentError, 'wrong number of arguments (given 0, expected 1)')
+        .to raise_error(ArgumentError, 'wrong number of arguments (given 0, expected 1..2)')
     end
   end
 

--- a/spec/lib/common/models/collection_spec.rb
+++ b/spec/lib/common/models/collection_spec.rb
@@ -54,11 +54,12 @@ describe Common::Collection do
   end
 
   context 'find_by, sort, and paginate' do
-    let(:filtered_collection)  { subject.find_by(:prescription_id, 1_435_525) }
+    let(:filter) { { prescription_id: { eq: 1_435_525 } } }
+    let(:filtered_collection)  { subject.find_by(filter) }
     let(:sorted_collection)    { subject.sort('prescription_id') }
     let(:paginated_collection) { subject.paginate(page: 1, per_page: 2) }
     let(:all_three) do
-      subject.find_by(:refill_status, 'active').sort('-refill_date').paginate(page: 1, per_page: 3)
+      subject.find_by(refill_status: { eq: 'active' }).sort('-refill_date').paginate(page: 1, per_page: 3)
     end
 
     it 'can filter a collection' do
@@ -67,7 +68,7 @@ describe Common::Collection do
       expect(filtered_collection.metadata)
         .to eq(updated_at: 'Thu, 26 May 2016 13:05:43 EDT',
                failed_station_list: '',
-               filter: { for: 'prescription_id', having: 1_435_525 })
+               filter: filter)
     end
 
     it 'can sort a collection' do
@@ -95,7 +96,7 @@ describe Common::Collection do
       expect(all_three.metadata)
         .to eq(updated_at: 'Thu, 26 May 2016 13:05:43 EDT',
                failed_station_list: '',
-               filter: { for: 'refill_status', having: 'active' },
+               filter: { refill_status: { eq: 'active' } },
                sort: { 'refill_date' => 'DESC' },
                pagination: { current_page: 1, per_page: 3, total_pages: 2, total_entries: 6 })
     end

--- a/spec/request/prescriptions_request_spec.rb
+++ b/spec/request/prescriptions_request_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe 'Prescriptions Integration', type: :request do
     end
   end
 
-  it 'responds to GET #index with refill_status=unknown' do
+  it 'responds to GET #index with filter' do
     VCR.use_cassette('prescriptions/1435525/index/refill_status_unknown') do
-      get '/v0/prescriptions?refill_status=unknown'
+      get '/v0/prescriptions?filter[[refill_status][eq]]=unknown'
       expect(response).to be_success
       expect(response.body).to be_a(String)
       expect(response).to match_response_schema('prescriptions_filtered')

--- a/spec/support/schemas/prescriptions_filtered.json
+++ b/spec/support/schemas/prescriptions_filtered.json
@@ -81,12 +81,7 @@
           "type": "object"
         },
         "filter": {
-          "type": "object",
-          "require": ["for", "having"],
-          "properties": {
-            "for": { "type": ["string", "null"] },
-            "having": { "type": ["string", "null"] }
-          }
+          "type": "object"
         },
         "pagination": {
           "type": "object",


### PR DESCRIPTION
This is ready to be merged.

TODO: 

- Identify a way to only allow filtering on certain attributes
- Identify a way to only allow certain operators for an attribute
- Add exception handling around filter syntax not being valid

In addition:

- Update documentation to reflect the syntax specified here
- Ensure both Prescriptions and Messages support this feature and have proper documentation