### PR TITLE
Remove vets-api server startup dependency on ID.me

### DIFF
--- a/config/initializers/saml_settings.rb
+++ b/config/initializers/saml_settings.rb
@@ -16,5 +16,11 @@ module SAML
   # SAML_SETTINGS.authn_context            = "http://idmanagement.gov/ns/assurance/loa/3"
 
   parser = OneLogin::RubySaml::IdpMetadataParser.new
-  parser.parse_remote(CONFIG['metadata_url'], true, settings: SETTINGS)
+  begin
+    parser.parse_remote(CONFIG['metadata_url'], true, settings: SETTINGS)
+  rescue OneLogin::RubySaml::HttpError => exception
+    Rails.logger.error "Unable to connect to ID.me to fetch metadata!"
+    Rails.logger.error "#{exception.message}."
+    Rails.logger.error exception.backtrace.join("\n") unless exception.backtrace.nil?
+  end
 end

--- a/config/initializers/saml_settings.rb
+++ b/config/initializers/saml_settings.rb
@@ -19,7 +19,7 @@ module SAML
   begin
     parser.parse_remote(CONFIG['metadata_url'], true, settings: SETTINGS)
   rescue OneLogin::RubySaml::HttpError => exception
-    Rails.logger.error "Unable to connect to ID.me to fetch metadata!"
+    Rails.logger.error 'Unable to connect to ID.me to fetch metadata!'
     Rails.logger.error "#{exception.message}."
     Rails.logger.error exception.backtrace.join("\n") unless exception.backtrace.nil?
   end


### PR DESCRIPTION
The vets-api rails server was failing to start because we make an external web call to ID.me in the `saml_settings.rb` initializer.  I wrapped that call in a rescue block so that the server will still startup if ID.me is unresponsive.

There will still be a fix for #123 in a later PR.  This PR is a short-term fix since this issue can block many people.