### PR TITLE
Update `vets_json_schema` reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'whenever', require: false
 gem 'multi_json'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'net-sftp'
-gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', ref: 'cdc48375d79cce57ceae86c1095e7a7c00c27324'
+gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', ref: '93185f9adbc97bd9ada9ba1f0188848b2bbdb5f6'
 
 # Amazon Linux's system `json` gem causes conflicts, but
 # `multi_json` will prefer `oj` if installed, so include it here.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: cdc48375d79cce57ceae86c1095e7a7c00c27324
-  ref: cdc48375d79cce57ceae86c1095e7a7c00c27324
+  revision: 93185f9adbc97bd9ada9ba1f0188848b2bbdb5f6
+  ref: 93185f9adbc97bd9ada9ba1f0188848b2bbdb5f6
   specs:
     vets_json_schema (1.0.0)
 


### PR DESCRIPTION
Due to issues with the Amazon Linux system ruby's `json` gem, we need to use a version supplied with rubygems. This change supports this condition.