### PR TITLE
Bumping version of vets-json-schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'whenever', require: false
 gem 'multi_json'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'net-sftp'
-gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', ref: '93185f9adbc97bd9ada9ba1f0188848b2bbdb5f6'
+gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 
 # Amazon Linux's system `json` gem causes conflicts, but
 # `multi_json` will prefer `oj` if installed, so include it here.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 93185f9adbc97bd9ada9ba1f0188848b2bbdb5f6
-  ref: 93185f9adbc97bd9ada9ba1f0188848b2bbdb5f6
+  revision: 8deb337069d5866c0ab4d6ec91f29178f1455571
+  branch: master
   specs:
     vets_json_schema (1.0.0)
+      multi_json (~> 1.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Changed Gemfile to use master instead of reference branch. Whoever does an update, can just verify the SHA1 used in Gemfile.lock, but this is much easier to update and maintain.