### PR TITLE
Add a temporary dev-only endpoint to fetch spool files while testing

### DIFF
--- a/app/controllers/v0/education_benefits_claims_controller.rb
+++ b/app/controllers/v0/education_benefits_claims_controller.rb
@@ -27,7 +27,7 @@ module V0
       known_tmp_path = Rails.root.join('tmp', 'spool_files')
       archive_file = known_tmp_path.join('spool.tar')
 
-      system('bundle', 'exec', 'rake', 'jobs:create_daily_spool_files')
+      ::EducationForm::CreateDailySpoolFiles.perform_now
       system('cd', known_tmp_path.to_s, '&&', 'tar', '-cf', archive_file.to_s, '*.spl')
       send_file archive_file, filename: 'spool.tar'
     end

--- a/app/controllers/v0/education_benefits_claims_controller.rb
+++ b/app/controllers/v0/education_benefits_claims_controller.rb
@@ -22,6 +22,16 @@ module V0
       render text: txt
     end
 
+    def daily_file
+      return redirect_to(root_path) unless FeatureFlipper.show_education_benefit_form?
+      known_tmp_path = Rails.root.join('tmp', 'spool_files')
+      archive_file = known_tmp_path.join('spool.tar')
+
+      `bundle exec rake jobs:create_daily_spool_files`
+      `cd #{known_tmp_path} && tar -cf #{archive_file} *.spl`
+      send_file archive_file, filename: 'spool.tar'
+    end
+
     private
 
     def education_benefits_claim_params

--- a/app/controllers/v0/education_benefits_claims_controller.rb
+++ b/app/controllers/v0/education_benefits_claims_controller.rb
@@ -27,8 +27,8 @@ module V0
       known_tmp_path = Rails.root.join('tmp', 'spool_files')
       archive_file = known_tmp_path.join('spool.tar')
 
-      `bundle exec rake jobs:create_daily_spool_files`
-      `cd #{known_tmp_path} && tar -cf #{archive_file} *.spl`
+      system('bundle', 'exec', 'rake', 'jobs:create_daily_spool_files')
+      system('cd', known_tmp_path.to_s, '&&', 'tar', '-cf', archive_file.to_s, '*.spl')
       send_file archive_file, filename: 'spool.tar'
     end
 

--- a/app/jobs/education_form/create_daily_spool_files.rb
+++ b/app/jobs/education_form/create_daily_spool_files.rb
@@ -72,10 +72,9 @@ module EducationForm
     end
 
     def create_files(structured_data)
-      if Rails.env.development?
+      if Rails.env.development? || ENV['EDU_SFTP_HOST'].blank?
         write_files(structured_data: structured_data)
       else
-        # TODO: Will be implemented in a follow-up PR.
         Net::SFTP.start(ENV['EDU_SFTP_HOST'], ENV['EDU_SFTP_USER'], password: ENV['EDU_SFTP_PASS']) do |sftp|
           write_files(sftp: sftp, structured_data: structured_data)
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
     get 'profile', to: 'users#show'
 
     resource :education_benefits_claims, only: [:create] do
+      get 'daily', to: 'education_benefits_claims#daily_file',
+                   as: :daily_file,
+                   constraints: ->(_) { FeatureFlipper.show_education_benefit_form? }
       get ':id', to: 'education_benefits_claims#show',
                  defaults: { format: :text },
                  as: :show,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,11 +18,13 @@ Rails.application.routes.draw do
 
     resource :education_benefits_claims, only: [:create] do
       get 'daily', to: 'education_benefits_claims#daily_file',
+                   defaults: { format: :tar },
                    as: :daily_file,
                    constraints: ->(_) { FeatureFlipper.show_education_benefit_form? }
       get ':id', to: 'education_benefits_claims#show',
                  defaults: { format: :text },
                  as: :show,
+                 id: /\d+/,
                  constraints: ->(_) { FeatureFlipper.show_education_benefit_form? }
     end
 

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
     end
 
     it 'writes files out over sftp' do
+      ENV['EDU_SFTP_HOST'] = 'localhost'
       mock_file = double(File)
       mock_writer = StringIO.new
       sftp_mock = double(file: mock_file)
@@ -116,6 +117,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
       # read back the written file
       mock_writer.rewind
       expect(mock_writer.read).to include('EDUCATION BENEFIT BEING APPLIED FOR: Chapter 1606')
+      ENV['EDU_SFTP_HOST'] = nil
     end
   end
 

--- a/spec/request/education_benefits_claims_request_spec.rb
+++ b/spec/request/education_benefits_claims_request_spec.rb
@@ -14,6 +14,19 @@ RSpec.describe 'Education Benefits Claims Integration', type: [:request, :serial
     end
   end
 
+  describe 'GET daily' do
+    let(:submission) { FactoryGirl.create(:education_benefits_claim) }
+    subject do
+      submission.save
+      get(daily_file_v0_education_benefits_claims_path(format: :tar))
+    end
+
+    it 'should send a tar file successfully' do
+      subject
+      expect(response.body).not_to be_empty
+    end
+  end
+
   describe 'POST create' do
     subject do
       post(


### PR DESCRIPTION
Right now, we're unable to SFTP these files over to the end system, but we'd like to still get them over for end-to-end testing. This feature hides behind a feature flag we defined earlier, and will be removed before we enter production.