### PR TITLE
Change temp EDU download path to use the index

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,10 +17,10 @@ Rails.application.routes.draw do
     get 'profile', to: 'users#show'
 
     resource :education_benefits_claims, only: [:create] do
-      get 'daily', to: 'education_benefits_claims#daily_file',
-                   defaults: { format: :tar },
-                   as: :daily_file,
-                   constraints: ->(_) { FeatureFlipper.show_education_benefit_form? }
+      get :index, to: 'education_benefits_claims#daily_file',
+                  defaults: { format: :tar },
+                  as: :daily_file,
+                  constraints: ->(_) { FeatureFlipper.show_education_benefit_form? }
       get ':id', to: 'education_benefits_claims#show',
                  defaults: { format: :text },
                  as: :show,


### PR DESCRIPTION
Adding the constraint on the `id` param worked locally, but it also just makes more sense to have the index return the "canonical" representation of the group of applications. Running in `dev` this was causing 500s before -- hopefully this fixes it.