### PR TITLE
Add createUserAccount job when user logs in

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -51,7 +51,7 @@ module V0
         ssn:            attributes['social']&.first&.delete('-'),
         birth_date:     parse_date(attributes['birth_date']&.first),
         uuid:           attributes['uuid']&.first,
-        last_signed_in: Time.zone.now,
+        last_signed_in: Time.current.utc,
 
         level_of_assurance: level_of_assurance
       }

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -37,19 +37,21 @@ module V0
       @session = Session.new(user_attributes.slice(:uuid))
       @current_user = User.find(@session.uuid) || create_new_user
       @session.save && @current_user.save
+      async_create_evss_account(@current_user)
     end
 
     def user_attributes
       attributes = @saml_response.attributes.all.to_h
       {
-        first_name:   attributes['fname']&.first,
-        middle_name:  attributes['mname']&.first,
-        last_name:    attributes['lname']&.first,
-        zip:          attributes['zip']&.first,
-        email:        attributes['email']&.first,
-        ssn:          attributes['social']&.first&.delete('-'),
-        birth_date:   parse_date(attributes['birth_date']&.first),
-        uuid:         attributes['uuid']&.first,
+        first_name:     attributes['fname']&.first,
+        middle_name:    attributes['mname']&.first,
+        last_name:      attributes['lname']&.first,
+        zip:            attributes['zip']&.first,
+        email:          attributes['email']&.first,
+        ssn:            attributes['social']&.first&.delete('-'),
+        birth_date:     parse_date(attributes['birth_date']&.first),
+        uuid:           attributes['uuid']&.first,
+        last_signed_in: Time.zone.now,
 
         level_of_assurance: level_of_assurance
       }
@@ -77,6 +79,11 @@ module V0
       else
         Decorators::MviUserDecorator.new(User.new(user_attributes)).create
       end
+    end
+
+    def async_create_evss_account(user)
+      auth_headers = EVSS::AuthHeaders.new(user).to_h
+      EVSS::CreateUserAccountJob.perform_later(auth_headers)
     end
   end
 end

--- a/app/jobs/evss/create_user_account_job.rb
+++ b/app/jobs/evss/create_user_account_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require_dependency 'evss/common_service'
+
+module EVSS
+  class CreateUserAccountJob < ActiveJob::Base
+    queue_as :default
+
+    def perform(headers)
+      client = EVSS::CommonService.new(headers)
+      client.create_user_account
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,10 +59,6 @@ class User < Common::RedisStore
     level_of_assurance == LOA::THREE
   end
 
-  def async_create_evss_account
-    EVSS::CreateUserAccount.perform_later(evss_auth_headers)
-  end
-
   def rating_record
     client = EVSS::CommonService.new(evss_auth_headers)
     client.find_rating_info(participant_id).body.fetch('ratingRecord', {})

--- a/app/services/disability_claim_service.rb
+++ b/app/services/disability_claim_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 require_dependency 'evss/claims_service'
+require_dependency 'evss/documents_service'
+require_dependency 'evss/auth_headers'
 
 class DisabilityClaimService
   EVSS_CLAIM_KEYS = %w(openClaims historicalClaims).freeze
@@ -46,11 +48,15 @@ class DisabilityClaimService
   private
 
   def client
-    @client ||= EVSS::ClaimsService.new(@user)
+    @client ||= EVSS::ClaimsService.new(auth_headers)
   end
 
   def document_client
-    @document_client ||= EVSS::DocumentsService.new(@user)
+    @document_client ||= EVSS::DocumentsService.new(auth_headers)
+  end
+
+  def auth_headers
+    @auth_headers ||= EVSS::AuthHeaders.new(@user).to_h
   end
 
   def claims_scope

--- a/lib/evss/auth_headers.rb
+++ b/lib/evss/auth_headers.rb
@@ -14,6 +14,7 @@ module EVSS
         # TODO: Change va_eauth_authenticationmethod to vets.gov
         # once the EVSS team is ready for us to use it
         'va_eauth_authenticationmethod' => 'DSLogon',
+        # TODO: (CMJ or AJM) Change to user.loa from ID.me
         'va_eauth_assurancelevel' => '2',
         'va_eauth_pnidtype' => 'SSN',
         # Vary by user

--- a/lib/evss/auth_headers.rb
+++ b/lib/evss/auth_headers.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require_dependency 'evss/error_middleware'
+
+module EVSS
+  class AuthHeaders
+    def initialize(user)
+      @user = user
+    end
+
+    def to_h
+      @headers ||= {
+        # Always the same
+        'va_eauth_csid' => 'DSLogon',
+        # TODO: Change va_eauth_authenticationmethod to vets.gov
+        # once the EVSS team is ready for us to use it
+        'va_eauth_authenticationmethod' => 'DSLogon',
+        'va_eauth_assurancelevel' => '2',
+        'va_eauth_pnidtype' => 'SSN',
+        # Vary by user
+        'va_eauth_firstName' => @user.first_name,
+        'va_eauth_lastName' => @user.last_name,
+        'va_eauth_issueinstant' => @user.last_signed_in.iso8601,
+        'va_eauth_dodedipnid' => @user.edipi,
+        'va_eauth_pid' => @user.participant_id,
+        'va_eauth_pnid' => @user.ssn,
+        'va_eauth_authorization' => eauth_json
+      }
+    end
+
+    private
+
+    def eauth_json
+      {
+        authorizationResponse: {
+          status: 'VETERAN',
+          idType: 'SSN',
+          id: @user.ssn,
+          edi: @user.edipi,
+          firstName: @user.first_name,
+          lastName: @user.last_name
+        }
+      }.to_json
+    end
+  end
+end

--- a/lib/evss/base_service.rb
+++ b/lib/evss/base_service.rb
@@ -4,10 +4,10 @@ require_dependency 'evss/error_middleware'
 module EVSS
   class BaseService
     SYSTEM_NAME = 'vets.gov'
+    DEFAULT_TIMEOUT = 5 # seconds
 
-    def initialize(user)
-      @user = user
-      @default_timeout = 5 # seconds
+    def initialize(headers)
+      @headers = headers
     end
 
     protected
@@ -29,46 +29,13 @@ module EVSS
     # Uses HTTPClient adapter because headers need to be sent unmanipulated
     # Net/HTTP capitalizes headers
     def conn
-      @conn ||= Faraday.new(base_url, headers: vaafi_headers, ssl: ssl_options) do |faraday|
-        faraday.options.timeout = @default_timeout
+      @conn ||= Faraday.new(base_url, headers: @headers, ssl: ssl_options) do |faraday|
+        faraday.options.timeout = DEFAULT_TIMEOUT
         faraday.use      EVSS::ErrorMiddleware
         faraday.use      Faraday::Response::RaiseError
         faraday.response :json, content_type: /\bjson$/
         faraday.adapter  :httpclient
       end
-    end
-
-    def vaafi_headers
-      @vaafi_headers ||= {
-        # Always the same
-        'va_eauth_csid' => 'DSLogon',
-        # TODO: Change va_eauth_authenticationmethod to vets.gov
-        # once the EVSS team is ready for us to use it
-        'va_eauth_authenticationmethod' => 'DSLogon',
-        'va_eauth_assurancelevel' => '2',
-        'va_eauth_pnidtype' => 'SSN',
-        # Vary by user
-        'va_eauth_firstName' => @user.first_name,
-        'va_eauth_lastName' => @user.last_name,
-        'va_eauth_issueinstant' => @user.last_signed_in.iso8601,
-        'va_eauth_dodedipnid' => @user.edipi,
-        'va_eauth_pid' => @user.participant_id,
-        'va_eauth_pnid' => @user.ssn,
-        'va_eauth_authorization' => eauth_json
-      }
-    end
-
-    def eauth_json
-      {
-        authorizationResponse: {
-          status: 'VETERAN',
-          idType: 'SSN',
-          id: @user.ssn,
-          edi: @user.edipi,
-          firstName: @user.first_name,
-          lastName: @user.last_name
-        }
-      }.to_json
     end
 
     def ssl_options

--- a/lib/evss/common_service.rb
+++ b/lib/evss/common_service.rb
@@ -3,9 +3,13 @@ require_dependency 'evss/base_service'
 
 module EVSS
   class CommonService < BaseService
-    def find_rating_info
+    def find_rating_info(participant_id)
       post 'ratingInfoService/11.1/findRatingInfoPID',
-           { participantId: @user.participant_id }.to_json
+           { participantId: participant_id }.to_json
+    end
+
+    def create_user_account
+      post 'persistentPropertiesService/11.1/createUserAccount'
     end
 
     protected

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -68,6 +68,11 @@ RSpec.describe V0::SessionsController, type: :controller do
         expect(JSON.parse(response.body).keys).to include('token', 'uuid')
       end
 
+      it 'creates a job to create an evss user' do
+        ActiveJob::Base.queue_adapter = :test
+        expect { get :saml_callback }.to have_enqueued_job(EVSS::CreateUserAccountJob)
+      end
+
       it 'creates a valid session' do
         get :saml_callback
 

--- a/spec/jobs/evss/create_user_account_job_spec.rb
+++ b/spec/jobs/evss/create_user_account_job_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe EVSS::CreateUserAccountJob, type: :job do
+  include ActiveJob::TestHelper
+  let(:user) { User.sample_claimant }
+  let(:auth_headers) { EVSS::AuthHeaders.new(user).to_h }
+
+  it 'calls create_user_account EVSS API' do
+    client_stub = instance_double('EVSS::CommonService')
+    allow(EVSS::CommonService).to receive(:new).with(auth_headers) { client_stub }
+    expect(client_stub).to receive(:create_user_account).once
+    described_class.perform_now(auth_headers)
+  end
+end

--- a/spec/lib/evss/claims_service_spec.rb
+++ b/spec/lib/evss/claims_service_spec.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 require 'rails_helper'
 require_dependency 'evss/claims_service'
+require_dependency 'evss/auth_headers'
 
 describe EVSS::ClaimsService do
   let(:current_user) do
     User.sample_claimant
   end
+  let(:auth_headers) do
+    EVSS::AuthHeaders.new(current_user).to_h
+  end
 
-  subject { described_class.new(current_user) }
+  subject { described_class.new(auth_headers) }
 
   context 'with headers' do
     it 'should get claims' do

--- a/spec/lib/evss/documents_service_spec.rb
+++ b/spec/lib/evss/documents_service_spec.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 require 'rails_helper'
 require_dependency 'evss/documents_service'
+require_dependency 'evss/auth_headers'
 
 describe EVSS::DocumentsService do
   let(:current_user) do
     User.sample_claimant
   end
+  let(:auth_headers) do
+    EVSS::AuthHeaders.new(current_user).to_h
+  end
 
-  subject { described_class.new(current_user) }
+  subject { described_class.new(auth_headers) }
 
   context 'with headers' do
     it 'should get claims' do


### PR DESCRIPTION
Main change here is to add a class that creates the hash needed for EVSS headers so that a job can be serialized/deserialized with the auth info needed

There will be a follow up PR that limits this to users with the necessary attributes (EDIPI and PID) as part of a larger authorization cleanup for disability claims