### PR TITLE
Use a cleaner way to get to the right spool file directory

### DIFF
--- a/app/controllers/v0/education_benefits_claims_controller.rb
+++ b/app/controllers/v0/education_benefits_claims_controller.rb
@@ -28,7 +28,9 @@ module V0
       archive_file = known_tmp_path.join('spool.tar')
 
       ::EducationForm::CreateDailySpoolFiles.perform_now
-      system('cd', known_tmp_path.to_s, '&&', 'tar', '-cf', archive_file.to_s, '*.spl')
+      Dir.chdir(known_tmp_path.to_s) do
+        system('tar', '-cf', 'spool.tar', '*.spl')
+      end
       send_file archive_file, filename: 'spool.tar'
     end
 


### PR DESCRIPTION
Before the `&&` was failing in some places - this is a nice, ruby
way to get to the right directory so tar can do it's job.