### PR TITLE
Add breakers for protection against Rx outages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'multi_json'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'net-sftp'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
+gem 'breakers'
 
 # Amazon Linux's system `json` gem causes conflicts, but
 # `multi_json` will prefer `oj` if installed, so include it here.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,9 @@ GEM
       sass (~> 3.0)
       slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
+    breakers (0.2.0)
+      faraday (>= 0.7.4, < 0.10)
+      multi_json (~> 1.0)
     builder (3.2.2)
     bundler-audit (0.5.0)
       bundler (~> 1.2)
@@ -353,6 +356,7 @@ DEPENDENCIES
   attr_encrypted
   awrence
   brakeman
+  breakers
   bundler-audit
   byebug
   climate_control (= 0.0.3)

--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -1,30 +1,20 @@
 # frozen_string_literal: true
 require 'rx/configuration'
+require 'sm/configuration'
 
 # Read the redis config, create a connection and a namespace for breakers
 redis_config = Rails.application.config_for(:redis).freeze
 redis = Redis.new(redis_config['redis'])
 redis_namespace = Redis::Namespace.new('breakers', redis: redis)
 
-# The Rx::Configuration class contains the host and path for Rx requests.
-# Create a matcher proc that returns true for POST requests to that host and path.
-rx_path = URI.parse(Rx::Configuration.instance.base_path).path
-rx_host = URI.parse(Rx::Configuration.instance.base_path).host
-rx_matcher = proc do |request_env|
-  request_env.method == :post &&
-    request_env.url.host == rx_host &&
-    request_env.url.path =~ /^#{rx_path}/
-end
-
-# And then create the Breakers service and client
-BREAKERS_RX_SERVICE = Breakers::Service.new(
-  name: 'Rx',
-  request_matcher: rx_matcher
-)
+services = [
+  Rx::Configuration.instance.breakers_service,
+  SM::Configuration.instance.breakers_service
+]
 
 client = Breakers::Client.new(
   redis_connection: redis_namespace,
-  services: [BREAKERS_RX_SERVICE],
+  services: services,
   logger: Rails.logger
 )
 

--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rx/configuration'
+
+# Read the redis config, create a connection and a namespace for breakers
+redis_config = Rails.application.config_for(:redis).freeze
+redis = Redis.new(redis_config['redis'])
+redis_namespace = Redis::Namespace.new('breakers', redis: redis)
+
+# The Rx::Configuration class contains the host and path for Rx requests.
+# Create a matcher proc that returns true for POST requests to that host and path.
+rx_path = URI.parse(Rx::Configuration.instance.base_path).path
+rx_host = URI.parse(Rx::Configuration.instance.base_path).host
+rx_matcher = proc do |request_env|
+  request_env.method == :post &&
+    request_env.url.host == rx_host &&
+    request_env.url.path =~ /^#{rx_path}/
+end
+
+# And then create the Breakers service and client
+BREAKERS_RX_SERVICE = Breakers::Service.new(
+  name: 'Rx',
+  request_matcher: rx_matcher
+)
+
+client = Breakers::Client.new(
+  redis_connection: redis_namespace,
+  services: [BREAKERS_RX_SERVICE],
+  logger: Rails.logger
+)
+
+# No need to prefix it when using the namespace
+Breakers.redis_prefix = ''
+Breakers.client = client

--- a/lib/rx/client.rb
+++ b/lib/rx/client.rb
@@ -91,7 +91,10 @@ module Rx
     end
 
     def connection
-      @connection ||= Faraday.new(config.base_path, headers: BASE_REQUEST_HEADERS, request: request_options)
+      @connection ||= Faraday.new(config.base_path, headers: BASE_REQUEST_HEADERS, request: request_options) do |conn|
+        conn.use :breakers
+        conn.adapter :httpclient
+      end
     end
 
     def auth_headers

--- a/lib/rx/client.rb
+++ b/lib/rx/client.rb
@@ -93,7 +93,7 @@ module Rx
     def connection
       @connection ||= Faraday.new(config.base_path, headers: BASE_REQUEST_HEADERS, request: request_options) do |conn|
         conn.use :breakers
-        conn.adapter :httpclient
+        conn.adapter Faraday.default_adapter
       end
     end
 

--- a/lib/rx/configuration.rb
+++ b/lib/rx/configuration.rb
@@ -17,5 +17,20 @@ module Rx
     def base_path
       "#{host}/mhv-api/patient/v1/"
     end
+
+    def breakers_service
+      return @service if defined?(@service)
+
+      path = URI.parse(base_path).path
+      host = URI.parse(base_path).host
+      matcher = proc do |request_env|
+        request_env.url.host == host && request_env.url.path =~ /^#{path}/
+      end
+
+      @service = Breakers::Service.new(
+        name: 'Rx',
+        request_matcher: matcher
+      )
+    end
   end
 end

--- a/lib/sm/client.rb
+++ b/lib/sm/client.rb
@@ -107,10 +107,10 @@ module SM
 
     def connection
       @connection ||= Faraday.new(@config.base_path, headers: BASE_REQUEST_HEADERS, request: request_options) do |conn|
+        conn.use :breakers
         conn.request :multipart
         conn.request :json
         # conn.response :logger, ::Logger.new(STDOUT), bodies: true
-
         conn.adapter Faraday.default_adapter
       end
     end

--- a/lib/sm/configuration.rb
+++ b/lib/sm/configuration.rb
@@ -17,5 +17,20 @@ module SM
     def base_path
       "#{@host}/mhv-sm-api/patient/v1/"
     end
+
+    def breakers_service
+      return @service if defined?(@service)
+
+      path = URI.parse(base_path).path
+      host = URI.parse(base_path).host
+      matcher = proc do |request_env|
+        request_env.url.host == host && request_env.url.path =~ /^#{path}/
+      end
+
+      @service = Breakers::Service.new(
+        name: 'SM',
+        request_matcher: matcher
+      )
+    end
   end
 end

--- a/spec/lib/rx/api/prescriptions_spec.rb
+++ b/spec/lib/rx/api/prescriptions_spec.rb
@@ -49,6 +49,17 @@ describe Rx::Client do
     expect(response.body).to eq('')
   end
 
+  context 'when there is an outage' do
+    before do
+      BREAKERS_RX_SERVICE.begin_forced_outage!
+    end
+
+    it 'does not post to the service and gets a 503' do
+      # stub_varx_request(:post, 'mhv-api/patient/v1/prescription/rxrefill/1435525', nil)
+      expect { client.post_refill_rx(1_435_525) }.to raise_error(Breakers::OutageException)
+    end
+  end
+
   context 'errors' do
     subject(:not_authenticated_client) { setup_client }
     let(:base_path) { "#{Rx::ClientHelpers::HOST}/mhv-api/patient/v1" }

--- a/spec/lib/rx/api/prescriptions_spec.rb
+++ b/spec/lib/rx/api/prescriptions_spec.rb
@@ -51,10 +51,10 @@ describe Rx::Client do
 
   context 'when there is an outage' do
     before do
-      BREAKERS_RX_SERVICE.begin_forced_outage!
+      Rx::Configuration.instance.breakers_service.begin_forced_outage!
     end
 
-    it 'does not post to the service and gets a 503' do
+    it 'does not post to the service and gets an error' do
       # stub_varx_request(:post, 'mhv-api/patient/v1/prescription/rxrefill/1435525', nil)
       expect { client.post_refill_rx(1_435_525) }.to raise_error(Breakers::OutageException)
     end

--- a/spec/lib/sm/api/messages_spec.rb
+++ b/spec/lib/sm/api/messages_spec.rb
@@ -83,6 +83,20 @@ describe SM::Client do
           expect(client_response).to be_a(Message)
         end
       end
+
+      context 'when there is an outage' do
+        before do
+          SM::Configuration.instance.breakers_service.begin_forced_outage!
+        end
+
+        it 'does not post to the service and gets an error' do
+          VCR.use_cassette('sm/messages/10616687/update_draft') do
+            new_draft[:id] = 620_096
+            new_draft[:body] = 'Updated Body'
+            expect { client.post_create_message_draft(new_draft) }.to raise_error(Breakers::OutageException)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This adds the new breakers gem for doing circuit breaking against outages on backend services. The bulk of the work is in the configuration for the gem, which happens in an initializer. It configures a service for Rx, which matches POST requests against the host and path defined in its configuration class. Once that configuration is in place, I just added the breakers middleware to the Faraday connection used by the Rx client. I've also added a test to show the exception being thrown when there is an outage against the service. I think this ought to be sufficient, since the breakers gem is itself well tested against various conditions, but I'm curious if people think there are other things that need testing.

For reviewers, I have a question about the Redis connection created in the initializer. Redis has its own initializer (redis.rb) which creates a connection and saves it in `Redis.current`. I would like to use that and not create a new one, but since the initializers are run in alphabetical order it will not have been initialized yet. I think the options are to do it this way or to prefix the initializer files with 01 and 02 to enforce the ordering. Although there is some code duplication involved, I think this way seems cleaner, since creating a Redis connection is so lightweight, but I'm interested in feedback there.