### PR TITLE
Add sidekiq-uniq-jobs to ensure EDU transfer only runs once

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'olive_branch'
 gem 'ox', '~> 2.4'
 gem 'savon', '~> 2.0'
 gem 'sidekiq'
+gem 'sidekiq-unique-jobs'
 gem 'whenever', require: false
 gem 'multi_json'
 gem "fog-aws", "~> 0.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,6 +321,9 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (~> 1.5)
       redis (~> 3.2, >= 3.2.1)
+    sidekiq-unique-jobs (4.0.18)
+      sidekiq (>= 2.6)
+      thor
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -418,6 +421,7 @@ DEPENDENCIES
   savon (~> 2.0)
   sdoc (~> 0.4.0)
   sidekiq
+  sidekiq-unique-jobs
   simplecov (~> 0.11)
   spring
   spring-commands-rspec

--- a/app/controllers/v0/education_benefits_claims_controller.rb
+++ b/app/controllers/v0/education_benefits_claims_controller.rb
@@ -30,7 +30,7 @@ module V0
       known_tmp_path = Rails.root.join('tmp', 'spool_files')
       archive_file = known_tmp_path.join('spool.tar')
 
-      ::EducationForm::CreateDailySpoolFiles.perform_now
+      ::EducationForm::CreateDailySpoolFiles.new.perform
       Dir.chdir(known_tmp_path.to_s) do
         system('tar -cf spool.tar *.spl')
       end

--- a/app/jobs/education_form/README.md
+++ b/app/jobs/education_form/README.md
@@ -13,6 +13,6 @@
 If you want to generate spool files locally, you have two options:
 
 * With at least Sidekiq running, run `rake jobs:create_daily_spool_files`
-* With a rails console (`bin/rails c`), run `EducationForm::CreateDailySpoolFiles.perform_now`
+* With a rails console (`bin/rails c`), run `EducationForm::CreateDailySpoolFiles.new.perform`
 
 The files will be written into `tmp/spool_files`, with each regional file starting with the current date.

--- a/app/jobs/education_form/create_daily_spool_files.rb
+++ b/app/jobs/education_form/create_daily_spool_files.rb
@@ -2,12 +2,17 @@
 require 'net/sftp'
 
 module EducationForm
-  class CreateDailySpoolFiles < ActiveJob::Base
+  class CreateDailySpoolFiles
+    include Sidekiq::Worker
     include ActionView::Helpers::TextHelper # Needed for word_wrap
     require 'erb'
     require 'ostruct'
 
-    queue_as :default
+    sidekiq_options queue: :default,
+                    # Stop multiple rake tasks from running this concurrently
+                    unique: :until_timeout,
+                    unique_expiration: 1.minute
+
     TEMPLATE_PATH = Rails.root.join('app', 'jobs', 'education_form', 'templates')
     TEMPLATE = File.read(File.join(TEMPLATE_PATH, '22-1990.erb'))
 

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -2,6 +2,6 @@
 namespace :jobs do
   desc 'Create daily spool files'
   task create_daily_spool_files: :environment do
-    EducationForm::CreateDailySpoolFiles.perform_later
+    EducationForm::CreateDailySpoolFiles.perform_async
   end
 end


### PR DESCRIPTION
Because the Rake job that queues this job is run by a cron task, it may be run on multiple servers at the same time, resulting in concurrent connections and writes to the remote SFTP server. With this, the job should only be run once a minute, at most, which allows for retries.