### PR TITLE
improving client response errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,8 +27,8 @@ class ApplicationController < ActionController::API
       when Common::Exceptions::BaseError
         exception
       when Common::Client::Errors::ClientResponse
-        meta = exception.to_json unless Rails.env.production?
-        Common::Exceptions::ClientError.new(exception.message.capitalize, meta: meta)
+        additional_attributes = { source: exception.developer_message, meta: exception.as_json }
+        Common::Exceptions::ClientError.new(exception.message, additional_attributes)
       when Breakers::OutageException
         Common::Exceptions::ServiceOutage.new(exception.outage)
       else

--- a/lib/common/exceptions/client_error.rb
+++ b/lib/common/exceptions/client_error.rb
@@ -7,11 +7,12 @@ module Common
 
       def initialize(detail, options = {})
         @detail = detail
-        @meta = options[:meta]
+        @source = options[:source].presence
+        @meta = options[:meta].presence unless Rails.env.production?
       end
 
       def errors
-        Array(SerializableError.new(MinorCodes::CLIENT_ERROR.merge(detail: @detail, meta: @meta)))
+        Array(SerializableError.new(MinorCodes::CLIENT_ERROR.merge(detail: @detail, source: @source, meta: @meta)))
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
-  context 'InvalidServerError' do
+  context 'ClientResponseError' do
     subject { JSON.parse(response.body)['errors'].first }
     before(:each) { routes.draw { get 'other_error' => 'anonymous#other_error' } }
     let(:keys_for_production) { %w(title detail code status) }

--- a/spec/lib/common/client/errors_spec.rb
+++ b/spec/lib/common/client/errors_spec.rb
@@ -23,7 +23,7 @@ describe Common::Client::Errors::ClientResponse do
     end
 
     it 'should have message' do
-      expect(subject.message).to eq('Prescription is not Refillable')
+      expect(subject.message).to eq('Prescription is not refillable')
     end
 
     it 'should have developer message' do

--- a/spec/lib/rx/api/prescriptions_spec.rb
+++ b/spec/lib/rx/api/prescriptions_spec.rb
@@ -99,7 +99,7 @@ describe Rx::Client do
                         post_refill_error,
                         status_code: 400)
       expect { client.post_refill_rx(1_435_525) }
-        .to raise_error(Common::Client::Errors::ClientResponse, 'Prescription is not Refillable')
+        .to raise_error(Common::Client::Errors::ClientResponse, 'Prescription is not refillable')
     end
   end
 end

--- a/spec/support/fixtures/error_message.txt
+++ b/spec/support/fixtures/error_message.txt
@@ -1,1 +1,1 @@
-{"major":400,"minor":139,"message":"Prescription is not Refillable","developer_message":"","error":null,"cause":{}}
+{"major":400,"minor":139,"message":"Prescription is not refillable","developer_message":"","error":null,"cause":{}}


### PR DESCRIPTION
Including the developer_message from Rx, SM, and others as the source for Client Response errors is handy for debugging in both development and production, so including that, but the stack trace will still only be shown in test and development.