### PR TITLE
Add faraday_curl gem for debugging MHV calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,10 @@ group :development, :test do
   gem 'factory_girl_rails'
 
   gem 'foreman'
+
+  # This middleware logs your HTTP requests as CURL compatible commands so you can share the calls with downstream
+  # assists in debugging
+  gem 'faraday_curl'
 end
 
 group :test do
@@ -90,8 +94,4 @@ group :development do
   # POSIX systems should have this already, so we're not going to bring it in on other platforms
   gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
   gem 'guard-rubocop'
-
-  # This middleware logs your HTTP requests as CURL compatible commands so you can share the calls with downstream
-  # assists in debugging
-  gem 'faraday_curl'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -90,4 +90,8 @@ group :development do
   # POSIX systems should have this already, so we're not going to bring it in on other platforms
   gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
   gem 'guard-rubocop'
+
+  # This middleware logs your HTTP requests as CURL compatible commands so you can share the calls with downstream
+  # assists in debugging
+  gem 'faraday_curl'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,8 @@ GEM
       redis (~> 3.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faraday_curl (0.0.2)
+      faraday (>= 0.9.0)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     ffi (1.9.10)
@@ -391,6 +393,7 @@ DEPENDENCIES
   faker
   fakeredis
   faraday
+  faraday_curl
   faraday_middleware
   figaro
   foreman

--- a/lib/sm/client.rb
+++ b/lib/sm/client.rb
@@ -11,6 +11,7 @@ require 'sm/api/folders'
 require 'sm/api/messages'
 require 'sm/api/message_drafts'
 require 'sm/api/attachments'
+require 'faraday_curl'
 
 module SM
   class Client
@@ -110,6 +111,8 @@ module SM
         conn.use :breakers
         conn.request :multipart
         conn.request :json
+        # conn.request :curl, ::Logger.new(STDOUT), :warn
+
         # conn.response :logger, ::Logger.new(STDOUT), bodies: true
         conn.adapter Faraday.default_adapter
       end

--- a/lib/sm/client.rb
+++ b/lib/sm/client.rb
@@ -11,7 +11,6 @@ require 'sm/api/folders'
 require 'sm/api/messages'
 require 'sm/api/message_drafts'
 require 'sm/api/attachments'
-require 'faraday_curl' if Rails.env.development?
 
 module SM
   class Client

--- a/lib/sm/client.rb
+++ b/lib/sm/client.rb
@@ -110,6 +110,7 @@ module SM
         conn.use :breakers
         conn.request :multipart
         conn.request :json
+        # Uncomment this out for generating curl output to send to MHV dev and test only
         # conn.request :curl, ::Logger.new(STDOUT), :warn
 
         # conn.response :logger, ::Logger.new(STDOUT), bodies: true

--- a/lib/sm/client.rb
+++ b/lib/sm/client.rb
@@ -11,7 +11,7 @@ require 'sm/api/folders'
 require 'sm/api/messages'
 require 'sm/api/message_drafts'
 require 'sm/api/attachments'
-require 'faraday_curl'
+require 'faraday_curl' if Rails.env.development?
 
 module SM
   class Client


### PR DESCRIPTION
This middleware logs your HTTP requests as CURL compatible commands so you can share the calls with downstream to assist in debugging issues