### PR TITLE
Log cron jobs to cron.log

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -20,7 +20,7 @@
 
 # Learn more: http://github.com/javan/whenever
 
-set(:output, "#{Dir.pwd}/log/production.log")
+set(:output, "#{Dir.pwd}/log/cron.log")
 
 # we want 3:00am EST, don't care about daylight savings
 every 1.day, at: '8:00 am' do


### PR DESCRIPTION
I think that as we move this to production status, it will help to have the output from cron jobs logged separately from the main production.log