### PR TITLE
loa.highest should be serialized as an Number instead of a string the…

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -53,7 +53,7 @@ module V0
         birth_date:     parse_date(attributes['birth_date']&.first),
         uuid:           attributes['uuid']&.first,
         last_signed_in: Time.current.utc,
-        loa:            { current: parse_current_loa, highest: attributes['level_of_assurance']&.first }
+        loa:            { current: parse_current_loa, highest: attributes['level_of_assurance']&.first&.to_i }
       }
     end
 

--- a/spec/support/schemas/profile.json
+++ b/spec/support/schemas/profile.json
@@ -39,8 +39,8 @@
                   "type": "object",
                   "required": ["current", "highest"],
                   "properties": {
-                    "current": { "type": [ "string", null ] },
-                    "highest": { "type": [ "string", null ] }
+                    "current": { "type": "integer" },
+                    "highest": { "type": [ "integer", null ] }
                   }
                 }
               }


### PR DESCRIPTION
… same way loa.current is

`GET /profile`
**current** 
```javascript
{"loa":{"current":1, "highest":"1"}}
```
**what we want**
```javascript
{"loa":{"current":1, "highest":1}}
```