### PR TITLE
Include sentry for exception reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'pg'
 gem 'json-schema'
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'will_paginate'
+gem 'sentry-raven'            # Sentry integration. SENTRY_DSN provided in ENV
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'httpclient'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    sentry-raven (2.1.2)
+      faraday (>= 0.7.6, < 0.10.x)
     sexp_processor (4.7.0)
     shellany (0.0.1)
     sidekiq (4.2.1)
@@ -427,6 +429,7 @@ DEPENDENCIES
   ruby-saml (~> 1.3.0)
   savon (~> 2.0)
   sdoc (~> 0.4.0)
+  sentry-raven
   sidekiq
   sidekiq-scheduler (~> 2.0)
   sidekiq-unique-jobs


### PR DESCRIPTION
This provides Sentry's "raven" integration (https://github.com/getsentry/raven-ruby), which should report application exceptions to Sentry. The `SENTRY_DSN` is included in the application environment for all deployments, and no additional configuration should be necessary aside from including the gem.

Contact me in a side channel for access to sentry.