### PR TITLE
update breakers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       sass (~> 3.0)
       slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
-    breakers (0.2.0)
+    breakers (0.2.1)
       faraday (>= 0.7.4, < 0.10)
       multi_json (~> 1.0)
     builder (3.2.2)


### PR DESCRIPTION
This bumps the version of breakers to 0.2.1, which allows global disabling just in case something goes horribly wrong.