### PR TITLE
Changed default sorting on prescriptions

### DIFF
--- a/app/models/prescription.rb
+++ b/app/models/prescription.rb
@@ -5,11 +5,11 @@ require 'common/models/base'
 class Prescription < Common::Base
   attribute :prescription_id, Integer, sortable: { order: 'ASC' }, filterable: %w(eq not_eq)
   attribute :refill_status, String, sortable: { order: 'ASC' }, filterable: %w(eq not_eq)
-  attribute :refill_submit_date, Common::UTCTime
+  attribute :refill_submit_date, Common::UTCTime, sortable: { order: 'DESC', default: true }, filterable: %w(eq not_eq)
   attribute :refill_date, Common::UTCTime, sortable: { order: 'DESC' }
   attribute :refill_remaining, Integer
   attribute :facility_name, String, sortable: { order: 'ASC' }, filterable: %w(eq not_eq)
-  attribute :ordered_date, Common::UTCTime, sortable: { order: 'DESC', default: true }
+  attribute :ordered_date, Common::UTCTime, sortable: { order: 'DESC' }
   attribute :quantity, Integer
   attribute :expiration_date, Common::UTCTime
   attribute :prescription_number, String

--- a/spec/models/prescription_spec.rb
+++ b/spec/models/prescription_spec.rb
@@ -39,19 +39,19 @@ describe Prescription do
   context 'it sorts' do
     let(:p1) { described_class.new(parsed_json_object) }
     let(:p2) { described_class.new(parsed_json_object) }
-    let(:p3) { described_class.new(data_attr_merge(prescription_id: '2', refill_date: Time.now.utc)) }
-    let(:p4) { described_class.new(data_attr_merge(prescription_id: '3', refill_data: 1.year.ago.utc)) }
+    let(:p3) { described_class.new(data_attr_merge(prescription_id: '2', refill_submit_date: Time.now.utc)) }
+    let(:p4) { described_class.new(data_attr_merge(prescription_id: '3', refill_submit_date: 1.year.ago.utc)) }
 
     subject { [p1, p2, p3, p4] }
 
-    it 'sorts by prescription_id by default' do
+    it 'sorts by refill_submit_date by default' do
       expect(subject.sort.map(&:prescription_id))
         .to eq([2, 3, 1_435_525, 1_435_525])
     end
 
     it 'sorts by sort_by field' do
-      expect(subject.sort_by(&:refill_date).map(&:prescription_id))
-        .to eq([1_435_525, 1_435_525, 3, 2])
+      expect(subject.sort_by(&:refill_submit_date).map(&:prescription_id))
+        .to eq([3, 1_435_525, 1_435_525, 2])
     end
   end
 

--- a/spec/request/prescriptions_request_spec.rb
+++ b/spec/request/prescriptions_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'prescriptions', type: :request do
     expect(response).to be_success
     expect(response.body).to be_a(String)
     expect(response).to match_response_schema('prescriptions')
-    expect(JSON.parse(response.body)['meta']['sort']).to eq('ordered_date' => 'DESC')
+    expect(JSON.parse(response.body)['meta']['sort']).to eq('refill_submit_date' => 'DESC')
   end
 
   it 'responds to GET #index with refill_status=active', :vcr do
@@ -39,7 +39,7 @@ RSpec.describe 'prescriptions', type: :request do
     expect(response).to be_success
     expect(response.body).to be_a(String)
     expect(response).to match_response_schema('prescriptions')
-    expect(JSON.parse(response.body)['meta']['sort']).to eq('ordered_date' => 'DESC')
+    expect(JSON.parse(response.body)['meta']['sort']).to eq('refill_submit_date' => 'DESC')
   end
 
   it 'responds to GET #index with filter', :vcr do


### PR DESCRIPTION
Sorting on prescriptions is now refill_submit_date, descending.