### PR TITLE
EVSS: Add an old claim reaper

### DIFF
--- a/app/workers/evss/delete_old_claims.rb
+++ b/app/workers/evss/delete_old_claims.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module EVSS
+  class DeleteOldClaims
+    include Sidekiq::Worker
+
+    def perform
+      claims = DisabilityClaim.where("updated_at < '#{1.day.ago}'")
+      logger.info("Deleting #{claims.count} old disability claims")
+      claims.delete_all
+    end
+  end
+end

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -16,7 +16,7 @@ SidekiqStatsJob:
   cron: "* * * * *"
   description: "Update Sidekiq stats for export to statsd gauges"
 
-DeleteOldApplications:
-  cron: "0 0 * * * America/New_York"
+DeleteOldClaims:
+  cron: "0 2 * * * America/New_York"
   class: EVSS::DeleteOldClaims
   description: "Clear out EVSS disability claims that have not been updated in 24 hours"

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -15,3 +15,8 @@ DeleteOldApplications:
 SidekiqStatsJob:
   cron: "* * * * *"
   description: "Update Sidekiq stats for export to statsd gauges"
+
+DeleteOldApplications:
+  cron: "0 0 * * * America/New_York"
+  class: EVSS::DeleteOldClaims
+  description: "Clear out EVSS disability claims that have not been updated in 24 hours"

--- a/spec/jobs/evss/delete_old_claims_spec.rb
+++ b/spec/jobs/evss/delete_old_claims_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe EVSS::DeleteOldClaims do
+  before do
+    @claim_nil = create(:disability_claim, updated_at: nil)
+    @claim_new = create(:disability_claim, updated_at: Time.now.utc)
+    @claim_old = create(:disability_claim, updated_at: 2.days.ago)
+  end
+
+  describe '#perform' do
+    it 'deletes old records' do
+      expect { subject.perform }.to change { DisabilityClaim.count }.from(3).to(2)
+      expect { @claim_old.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
We don't have the ATO to store claims indefinitely, so we need to delete
old ones periodically.