### PR TITLE
Fix folder create

### DIFF
--- a/lib/sm/api/folders.rb
+++ b/lib/sm/api/folders.rb
@@ -17,7 +17,7 @@ module SM
       end
 
       def post_create_folder(name)
-        json = perform(:post, 'folder', %({ "name":"#{name}" }), token_headers).body
+        json = perform(:post, 'folder', { 'name' => name }, token_headers).body
         Folder.new(json)
       end
 


### PR DESCRIPTION
The parameters to perform in post_create_folder were passed as a string, should have been a hash.