### PR TITLE
stop using a singleton for SAML::SettingsService

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,7 +86,7 @@ class ApplicationController < ActionController::API
   end
 
   def saml_settings
-    settings = SAML::SettingsService.instance.saml_settings
+    settings = SAML::SettingsService.new.saml_settings
     # TODO: 'level' should be its own class with proper validation
     level = LOA::MAPPING.invert[params[:level]&.to_i]
     settings.authn_context = level || LOA::MAPPING.invert[1]

--- a/lib/saml/settings_service.rb
+++ b/lib/saml/settings_service.rb
@@ -13,7 +13,12 @@ module SAML
     end
 
     def self.metadata
-      @metadata ||= Net::HTTP.get(METADATA_URI)
+      return @metadata if defined?(@metadata)
+      http = Net::HTTP.new(METADATA_URI.host, METADATA_URI.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      get = Net::HTTP::Get.new(METADATA_URI.request_uri)
+      @metadata = http.request(get).body
     end
 
     private

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe V0::SessionsController, type: :controller do
   let(:query_token) { Rack::Utils.parse_query(URI.parse(response.location).query)['token'] }
 
   before(:each) do
+    stub_request(:get, SAML_CONFIG['metadata_url']).to_return(body: 'abc')
     allow_any_instance_of(Decorators::MviUserDecorator).to receive(:create).and_return(mvi_user)
-    allow(settings_service).to receive_message_chain(:instance, :saml_settings).and_return(settings_no_context)
+    allow_any_instance_of(SAML::SettingsService).to receive(:saml_settings).and_return(settings_no_context)
   end
 
   context 'when not logged in' do

--- a/spec/lib/saml/saml_settings_service_spec.rb
+++ b/spec/lib/saml/saml_settings_service_spec.rb
@@ -3,15 +3,11 @@ require 'rails_helper'
 require 'saml/settings_service'
 
 RSpec.describe SAML::SettingsService do
-  # testing singletons is tricky since it may be initialized in a previous spec example,
-  # use this this instance variable for testing instead
-  before(:each) { @service_instance = SAML::SettingsService.clone }
-
   it 'should only ever make 1 external web call' do
-    stub_request(:get, SAML_CONFIG['metadata_url'])
-    @service_instance.instance.saml_settings
-    @service_instance.instance.saml_settings
-    @service_instance.instance.saml_settings
+    stub_request(:get, SAML_CONFIG['metadata_url']).to_return(body: 'abc')
+    SAML::SettingsService.new.saml_settings
+    SAML::SettingsService.new.saml_settings
+    SAML::SettingsService.new.saml_settings
     expect(a_request(:get, SAML_CONFIG['metadata_url'])).to have_been_made.times(1)
   end
 end

--- a/spec/lib/saml/saml_settings_service_spec.rb
+++ b/spec/lib/saml/saml_settings_service_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe SAML::SettingsService do
     SAML::SettingsService.new.saml_settings
     SAML::SettingsService.new.saml_settings
     SAML::SettingsService.new.saml_settings
-    expect(a_request(:get, SAML_CONFIG['metadata_url'])).to have_been_made.times(1)
+    expect(a_request(:get, SAML_CONFIG['metadata_url'])).to have_been_made.at_most_once
   end
 end


### PR DESCRIPTION
We were using a singleton for storing the SAML settings, but then in the controllers we would get back the data from it and change it. Not great. This gets rid of the singleton and generates the data each time it's requested but still only queries the metadata endpoint once per app server instance.