### PR TITLE
use breakers for MVI

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -7,6 +7,8 @@ require 'evss/claims_service'
 require 'evss/common_service'
 require 'evss/documents_service'
 
+require 'mvi/service'
+
 # Read the redis config, create a connection and a namespace for breakers
 redis_config = Rails.application.config_for(:redis).freeze
 redis = Redis.new(redis_config['redis'])
@@ -17,7 +19,8 @@ services = [
   SM::Configuration.instance.breakers_service,
   EVSS::ClaimsService.breakers_service,
   EVSS::CommonService.breakers_service,
-  EVSS::DocumentsService.breakers_service
+  EVSS::DocumentsService.breakers_service,
+  MVI::Service.breakers_service
 ]
 
 plugin = Breakers::StatsdPlugin.new

--- a/lib/mvi/settings.rb
+++ b/lib/mvi/settings.rb
@@ -5,16 +5,20 @@ module MVI
     SSL_CERT = begin
       OpenSSL::X509::Certificate.new(File.read(ENV['MVI_CLIENT_CERT_PATH']))
     rescue => e
+      # :nocov:
       Rails.logger.warn "Could not load MVI SSL cert: #{e.message}"
       raise e if Rails.env.production?
       nil
+      # :nocov:
     end
     SSL_KEY = begin
       OpenSSL::PKey::RSA.new(File.read(ENV['MVI_CLIENT_KEY_PATH']))
     rescue => e
+      # :nocov:
       Rails.logger.warn "Could not load MVI SSL key: #{e.message}"
       raise e if Rails.env.production?
       nil
+      # :nocov:
     end
   end
 end

--- a/spec/lib/mvi/service_spec.rb
+++ b/spec/lib/mvi/service_spec.rb
@@ -121,6 +121,13 @@ describe MVI::Service do
           expect { subject.find_candidate(message) }.to raise_error(MVI::RecordNotFound)
         end
       end
+
+      context 'with an ongoing breakers outage' do
+        it 'returns the correct thing' do
+          MVI::Service.breakers_service.begin_forced_outage!
+          expect { subject.find_candidate(message) }.to raise_error(Breakers::OutageException)
+        end
+      end
     end
 
     context 'when MVI returns 500 but VAAFI sends 200' do


### PR DESCRIPTION
This uses breakers in the faraday client for MVI. I've also moved the mvi_settings initializer into a file in the lib directory, since it doesn't seem to need to be an initializer, and having it in there was causing problems for breakers with the order in which initializers were run.