### PR TITLE
[WIP - sync with devops] Make mvi processing code env var i451

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_script:
   "Doe","edipi": "1105051936","participant_id": "123456789"}'''
 - export MVI_CLIENT_CERT_PATH='/fake/client/cert/path'
 - export MVI_CLIENT_KEY_PATH='/fake/client/key/path'
+- export MVI_PROCESSING_CODE='T'
 - export EVSS_S3_UPLOADS=false
 - export VHA_MAPSERVER_URL='https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/VHA_Facilities/FeatureServer/0'
 - export NCA_MAPSERVER_URL='https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/NCA_Facilities/FeatureServer/0'

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -22,6 +22,7 @@ VBA_MAPSERVER_URL: 'https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/se
 MVI_URL: 'http://see.project.readme.for.instructions.org'
 MVI_CLIENT_CERT_PATH: '/fake/client/cert/path'
 MVI_CLIENT_KEY_PATH: '/fake/client/key/path'
+MVI_PROCESSING_CODE: 'T'
 MOCK_MVI_SERVICE: 'true'
 GOV_DELIVERY_SERVER: stage-tms.govdelivery.com
 

--- a/lib/mvi/messages/message_builder.rb
+++ b/lib/mvi/messages/message_builder.rb
@@ -42,7 +42,7 @@ module MVI
         message << element('creationTime', value: Time.now.utc.strftime('%Y%m%d%H%M%S'))
         message << element('versionCode', code: '3.0')
         message << element('interactionId', root: '2.16.840.1.113883.1.6', extension: extension)
-        message << element('processingCode', code: Rails.env.production? ? 'P' : 'T')
+        message << element('processingCode', code: ENV['MVI_PROCESSING_CODE'])
         message << element('processingModeCode', code: 'T')
         message << element('acceptAckCode', code: 'AL')
         message << build_receiver

--- a/lib/mvi/messages/message_builder.rb
+++ b/lib/mvi/messages/message_builder.rb
@@ -42,7 +42,7 @@ module MVI
         message << element('creationTime', value: Time.now.utc.strftime('%Y%m%d%H%M%S'))
         message << element('versionCode', code: '3.0')
         message << element('interactionId', root: '2.16.840.1.113883.1.6', extension: extension)
-        message << element('processingCode', code: ENV['MVI_PROCESSING_CODE'])
+        message << element('processingCode', code: processing_code)
         message << element('processingModeCode', code: 'T')
         message << element('acceptAckCode', code: 'AL')
         message << build_receiver
@@ -74,6 +74,12 @@ module MVI
           'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
         )
         env << element('env:Header')
+      end
+
+      private
+
+      def processing_code
+        ENV['MVI_PROCESSING_CODE']
       end
     end
     class MessageBuilderError < StandardError

--- a/spec/lib/mvi/messages/message_builder_spec.rb
+++ b/spec/lib/mvi/messages/message_builder_spec.rb
@@ -45,8 +45,21 @@ describe MVI::Messages::MessageBuilder do
       )
     end
 
-    it 'has a processing code node' do
-      expect(message.locate('processingCode').first.attributes).to eq(code: 'T')
+    describe 'processing code node' do
+      context 'in non production environments' do
+        it 'has a processing code node of T' do
+          ClimateControl.modify MVI_PROCESSING_CODE: 'T' do
+            expect(message.locate('processingCode').first.attributes).to eq(code: 'T')
+          end
+        end
+      end
+      context 'in production environments' do
+        it 'has a processing code node of P' do
+          ClimateControl.modify MVI_PROCESSING_CODE: 'P' do
+            expect(message.locate('processingCode').first.attributes).to eq(code: 'P')
+          end
+        end
+      end
     end
 
     it 'has a processing mode code node' do


### PR DESCRIPTION
During MVI demo we found out 'processingCode' in MVI XML messages should be 'T' in all envs other than prod, where it should be 'P'.