### PR TITLE
Adding Rake task to create test sessions

### DIFF
--- a/lib/tasks/redis.rake
+++ b/lib/tasks/redis.rake
@@ -20,4 +20,60 @@ namespace :redis do
       redis.del(key)
     end
   end
+
+  desc 'Create test sessions'
+  task :create_sessions, [:count] => [:environment] do |t, args|
+    args.with_defaults(:count => 50)
+    namespace = User.new.redis_namespace.namespace
+    redis = Redis.current
+
+    args[:count].to_i.times do
+      uuid = SecureRandom.uuid.gsub(/-/, '')
+      token = SecureRandom.uuid.gsub(/-/, '')
+
+      redis.set "vets-api-session:#{token}", {
+        :uuid => uuid,
+        :token => token,
+      }.to_json
+
+      redis.set "mvi-data:#{uuid}", {
+        ":uuid": uuid,
+        ":email": "vets.gov.user+134@gmail.com",
+        ":first_name": "TEST",
+        ":middle_name": "T",
+        ":last_name": "USER",
+        ":gender": ['M', 'F'].sample,
+        ":birth_date": {"^t": Time.now.getutc},
+        ":zip": nil,
+        ":ssn": "123456789",
+        ":loa": {
+          ":current": 3,
+          ":highest": 3,
+        },
+        ":last_signed_in": {"^t": Time.now.getutc},
+        ":edipi": nil,
+        ":participant_id": "600017293",
+        ":mhv_id": nil,
+        ":icn": "1008702225V536415",
+        ":mvi": {
+          "^o": "ActiveSupport::HashWithIndifferentAccess",
+          "self": {
+            "birth_date": "19840101",
+            "edipi": nil,
+            "family_name": 'USER',
+            "gender": ['M', 'F'].sample,
+            "given_names": ['TEST'],
+            "icn": "1008702225V536415^NI^200M^USVHA^P",
+            "mhv_id": nil,
+            "vba_corp_id": "600017293^PI^200CORP^USVBA^A",
+            "ssn": "123456789",
+            "status": "OK",
+          }
+        },
+        ":mhv_last_signed_in": nil,
+      }.to_json
+
+      puts token
+    end
+  end
 end

--- a/lib/tasks/redis.rake
+++ b/lib/tasks/redis.rake
@@ -56,7 +56,7 @@ namespace :redis do
         },
         ":edipi": nil,
         ":participant_id": '600062099',
-        ":mhv_id": nil,
+        ":mhv_id": %w(12210827 10894456 13408508 13492196).sample,
         ":icn": '1008710255V058302',
         ":mvi": {
           "^o": 'ActiveSupport::HashWithIndifferentAccess',

--- a/lib/tasks/redis.rake
+++ b/lib/tasks/redis.rake
@@ -22,13 +22,14 @@ namespace :redis do
   end
 
   desc 'Create test sessions'
-  task :create_sessions, [:count] => [:environment] do |_, args|
-    args.with_defaults(count: 50)
+  task :create_sessions, [:count, :mhv_id] => [:environment] do |_, args|
+    args.with_defaults(count: 50, mhv_id: nil)
     redis = Redis.current
 
     args[:count].to_i.times do
       uuid = SecureRandom.uuid.delete '-'
       token = SecureRandom.uuid.delete '-'
+      mhv_id = args[:mhv_id] || %w(12210827 10894456 13408508 13492196).sample
 
       redis.set "vets-api-session:#{token}", {
         ":uuid": uuid,
@@ -56,7 +57,7 @@ namespace :redis do
         },
         ":edipi": nil,
         ":participant_id": '600062099',
-        ":mhv_id": %w(12210827 10894456 13408508 13492196).sample,
+        ":mhv_id": mhv_id,
         ":icn": '1008710255V058302',
         ":mvi": {
           "^o": 'ActiveSupport::HashWithIndifferentAccess',
@@ -67,7 +68,7 @@ namespace :redis do
             "gender": 'M',
             "given_names": ['TEST'],
             "icn": '1008710255V058302^NI^200M^USVHA^P',
-            "mhv_id": nil,
+            "mhv_id": mhv_id,
             "vba_corp_id": '600062099^PI^200CORP^USVBA^A',
             "ssn": '123456789',
             "status": 'OK'

--- a/lib/tasks/redis.rake
+++ b/lib/tasks/redis.rake
@@ -22,55 +22,58 @@ namespace :redis do
   end
 
   desc 'Create test sessions'
-  task :create_sessions, [:count] => [:environment] do |t, args|
-    args.with_defaults(:count => 50)
-    namespace = User.new.redis_namespace.namespace
+  task :create_sessions, [:count] => [:environment] do |_, args|
+    args.with_defaults(count: 50)
     redis = Redis.current
 
     args[:count].to_i.times do
-      uuid = SecureRandom.uuid.gsub(/-/, '')
-      token = SecureRandom.uuid.gsub(/-/, '')
+      uuid = SecureRandom.uuid.delete '-'
+      token = SecureRandom.uuid.delete '-'
 
       redis.set "vets-api-session:#{token}", {
-        :uuid => uuid,
-        :token => token,
+        ":uuid": uuid,
+        ":token": token
       }.to_json
 
       redis.set "mvi-data:#{uuid}", {
         ":uuid": uuid,
-        ":email": "vets.gov.user+134@gmail.com",
-        ":first_name": "TEST",
-        ":middle_name": "T",
-        ":last_name": "USER",
-        ":gender": ['M', 'F'].sample,
-        ":birth_date": {"^t": Time.now.getutc},
+        ":email": 'vets.gov.user+134@gmail.com',
+        ":first_name": 'TEST',
+        ":middle_name": 'T',
+        ":last_name": 'USER',
+        ":gender": 'M',
+        ":birth_date": {
+          "^t": Time.now.utc
+        },
         ":zip": nil,
-        ":ssn": "123456789",
+        ":ssn": '123456789',
         ":loa": {
           ":current": 3,
-          ":highest": 3,
+          ":highest": 3
         },
-        ":last_signed_in": {"^t": Time.now.getutc},
+        ":last_signed_in": {
+          "^t": Time.now.utc
+        },
         ":edipi": nil,
-        ":participant_id": "600017293",
+        ":participant_id": '600017293',
         ":mhv_id": nil,
-        ":icn": "1008702225V536415",
+        ":icn": '1008702225V536415',
         ":mvi": {
-          "^o": "ActiveSupport::HashWithIndifferentAccess",
+          "^o": 'ActiveSupport::HashWithIndifferentAccess',
           "self": {
-            "birth_date": "19840101",
+            "birth_date": '19840101',
             "edipi": nil,
             "family_name": 'USER',
-            "gender": ['M', 'F'].sample,
+            "gender": 'M',
             "given_names": ['TEST'],
-            "icn": "1008702225V536415^NI^200M^USVHA^P",
+            "icn": '1008702225V536415^NI^200M^USVHA^P',
             "mhv_id": nil,
-            "vba_corp_id": "600017293^PI^200CORP^USVBA^A",
-            "ssn": "123456789",
-            "status": "OK",
+            "vba_corp_id": '600017293^PI^200CORP^USVBA^A',
+            "ssn": '123456789',
+            "status": 'OK'
           }
         },
-        ":mhv_last_signed_in": nil,
+        ":mhv_last_signed_in": nil
       }.to_json
 
       puts token

--- a/lib/tasks/redis.rake
+++ b/lib/tasks/redis.rake
@@ -37,7 +37,7 @@ namespace :redis do
 
       redis.set "mvi-data:#{uuid}", {
         ":uuid": uuid,
-        ":email": 'vets.gov.user+134@gmail.com',
+        ":email": "vets.gov.user+#{rand(200)}@gmail.com",
         ":first_name": 'TEST',
         ":middle_name": 'T',
         ":last_name": 'USER',
@@ -55,9 +55,9 @@ namespace :redis do
           "^t": Time.now.utc
         },
         ":edipi": nil,
-        ":participant_id": '600017293',
+        ":participant_id": '600062099',
         ":mhv_id": nil,
-        ":icn": '1008702225V536415',
+        ":icn": '1008710255V058302',
         ":mvi": {
           "^o": 'ActiveSupport::HashWithIndifferentAccess',
           "self": {
@@ -66,9 +66,9 @@ namespace :redis do
             "family_name": 'USER',
             "gender": 'M',
             "given_names": ['TEST'],
-            "icn": '1008702225V536415^NI^200M^USVHA^P',
+            "icn": '1008710255V058302^NI^200M^USVHA^P',
             "mhv_id": nil,
-            "vba_corp_id": '600017293^PI^200CORP^USVBA^A',
+            "vba_corp_id": '600062099^PI^200CORP^USVBA^A',
             "ssn": '123456789',
             "status": 'OK'
           }


### PR DESCRIPTION
Run with

    bundle exec rake redis:create_sessions[10]

Useful for doing automated testing, such as load testing, and avoids talking to id.me completely.