### PR TITLE
memoize saml_settings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,11 +86,15 @@ class ApplicationController < ActionController::API
   end
 
   def saml_settings
-    return @saml_settings if defined?(@saml_settings)
+    if defined?(@saml_settings)
+      @saml_settings.name_identifier_value = @session&.uuid if defined?(@session)
+      return @saml_settings
+    end
     @saml_settings = SAML::SettingsService.new.saml_settings
     # TODO: 'level' should be its own class with proper validation
     level = LOA::MAPPING.invert[params[:level]&.to_i]
     @saml_settings.authn_context = level || LOA::MAPPING.invert[1]
+    @saml_settings.name_identifier_value = @session&.uuid if defined?(@session)
     @saml_settings
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -87,14 +87,14 @@ class ApplicationController < ActionController::API
 
   def saml_settings
     if defined?(@saml_settings)
-      @saml_settings.name_identifier_value = @session&.uuid if defined?(@session)
+      @saml_settings.name_identifier_value = @session&.uuid
       return @saml_settings
     end
     @saml_settings = SAML::SettingsService.new.saml_settings
     # TODO: 'level' should be its own class with proper validation
     level = LOA::MAPPING.invert[params[:level]&.to_i]
     @saml_settings.authn_context = level || LOA::MAPPING.invert[1]
-    @saml_settings.name_identifier_value = @session&.uuid if defined?(@session)
+    @saml_settings.name_identifier_value = @session&.uuid
     @saml_settings
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,11 +86,12 @@ class ApplicationController < ActionController::API
   end
 
   def saml_settings
-    settings = SAML::SettingsService.new.saml_settings
+    return @saml_settings if defined?(@saml_settings)
+    @saml_settings = SAML::SettingsService.new.saml_settings
     # TODO: 'level' should be its own class with proper validation
     level = LOA::MAPPING.invert[params[:level]&.to_i]
-    settings.authn_context = level || LOA::MAPPING.invert[1]
-    settings
+    @saml_settings.authn_context = level || LOA::MAPPING.invert[1]
+    @saml_settings
   end
 
   def pagination_params

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -114,7 +114,13 @@ module V0
         logger.error "ERROR MESSAGES #{logout_response.errors.join(' ---- ')}"
         redirect_to SAML_CONFIG['logout_relay'] + '?success=false'
       elsif logout_response.success?
-        MHVLoggingService.logout(current_user)
+        begin
+          session = Session.find(params[:RelayState])
+          user = User.find(session.uuid)
+          MHVLoggingService.logout(user)
+        rescue
+          logger.error "Error in MHV Logout: #{e.message}"
+        end
         delete_session(params[:RelayState])
         redirect_to SAML_CONFIG['logout_relay'] + '?success=true'
       end

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -16,10 +16,6 @@ module V0
       logout_request = OneLogin::RubySaml::Logoutrequest.new
       logger.info "New SP SLO for userid '#{@session.uuid}'"
 
-      saml_settings.name_identifier_value = @session.uuid
-      saml_settings.security[:logout_requests_signed] = true
-      saml_settings.security[:embed_sign] = true
-
       render json: { logout_via_get: logout_request.create(saml_settings, RelayState: @session.token) }, status: 202
     end
 

--- a/lib/saml/settings_service.rb
+++ b/lib/saml/settings_service.rb
@@ -32,6 +32,7 @@ module SAML
       settings.assertion_consumer_service_url = SAML_CONFIG['callback_url']
 
       settings.security[:authn_requests_signed]   = true
+      settings.security[:logout_requests_signed]  = true
       settings.security[:embed_sign]              = false
       settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA1
 


### PR DESCRIPTION
When I rewrote that singleton stuff earlier part of the point was to make it so changes to the saml settings in one request would not affect the next request. But it seems I went too far, and the old implementation would return a new settings object every time the method was called. This meant that in the sessions_controller#destroy action we would make changes to the settings but they would not show up when trying to use them. Womp womp.