### PR TITLE
Remove /profile route and just use /user instead

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -8,10 +8,6 @@ module V0
       render json: { authenticate_via_get: saml_auth_request.create(saml_settings) }
     end
 
-    def show
-      render json: @session
-    end
-
     def destroy
       logout_request = OneLogin::RubySaml::Logoutrequest.new
       logger.info "New SP SLO for userid '#{@session.uuid}'"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,11 +11,9 @@ Rails.application.routes.draw do
     resource :sessions, only: [:new, :destroy] do
       post :saml_callback, to: 'sessions#saml_callback'
       post :saml_slo_callback, to: 'sessions#saml_slo_callback'
-      get 'current', to: 'sessions#show'
     end
 
-    get 'user', to: 'users#show'
-    get 'profile', to: 'users#show'
+    resource :user, only: [:show]
 
     resource :education_benefits_claims, only: [:create] do
       get :index, to: 'education_benefits_claims#daily_file',

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -36,11 +36,10 @@ RSpec.describe V0::SessionsController, type: :controller do
 
       it 'GET show - returns unauthorized' do
         request.env['HTTP_AUTHORIZATION'] = auth_header
-        get :show
+        delete :destroy
         expect(response).to have_http_status(:unauthorized)
       end
     end
-
     it 'GET new - shows the ID.me authentication url' do
       allow_any_instance_of(OneLogin::RubySaml::Authrequest)
         .to receive(:create).and_return('url_string')
@@ -77,11 +76,6 @@ RSpec.describe V0::SessionsController, type: :controller do
       response_body = JSON.parse(response.body)
       authn_request = SAML::AuthnRequestHelper.new(response_body['authenticate_via_get'])
       expect(authn_request.loa1?).to eq(true)
-    end
-
-    it 'GET show - returns unauthorized' do
-      get :show
-      expect(response).to have_http_status(:unauthorized)
     end
 
     it 'DELETE destroy - returns returns unauthorized' do
@@ -184,17 +178,6 @@ RSpec.describe V0::SessionsController, type: :controller do
     before(:each) do
       Session.create(uuid: test_user.uuid, token: token)
       User.create(test_user)
-    end
-
-    it 'returns a JSON the session' do
-      request.env['HTTP_AUTHORIZATION'] = auth_header
-      get :show
-      assert_response :success
-
-      json = JSON.parse(response.body)
-
-      expect(json['uuid']).to eq(test_user.uuid)
-      expect(json['token']).to eq(token)
     end
 
     it 'destroys a session' do

--- a/spec/request/profile_request_spec.rb
+++ b/spec/request/profile_request_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe 'Fetching profile data', type: :request do
       User.create(mvi_user)
 
       auth_header = { 'Authorization' => "Token token=#{token}" }
-      get v0_profile_url, nil, auth_header
+      get v0_user_url, nil, auth_header
     end
 
-    it 'GET /profile - returns proper json' do
+    it 'GET /v0/user - returns proper json' do
       assert_response :success
       expect(response).to match_response_schema('profile')
     end
@@ -42,10 +42,10 @@ RSpec.describe 'Fetching profile data', type: :request do
       User.create(loa1_user)
 
       auth_header = { 'Authorization' => "Token token=#{token}" }
-      get v0_profile_url, nil, auth_header
+      get v0_user_url, nil, auth_header
     end
 
-    it 'GET /profile - returns proper json' do
+    it 'GET /v0/user - returns proper json' do
       assert_response :success
       expect(response).to match_response_schema('profile')
     end


### PR DESCRIPTION
Removed routes:
- GET `/v0/profile`
- GET `/v0/sessions/current`

Reasons:
- Reduce number of API's we must support after release
- GET `/v0/sessions/current` doesnt serve a purpose and exposes the ID.me `uuid`