### PR TITLE
spell response correctly

### DIFF
--- a/lib/facilities/multi_client.rb
+++ b/lib/facilities/multi_client.rb
@@ -14,7 +14,7 @@ module Facilities
       @hydra.run
       requests.map do |req|
         raise Common::Client::RequestTimeout if req.response.timed_out?
-        raise Common::Client::Errors::ClientResponse.new(req.reponse.code, {}) unless
+        raise Common::Client::Errors::ClientResponse.new(req.response.code, {}) unless
           req.response.success?
         result = JSON.parse(req.response.body)
         if result['error']


### PR DESCRIPTION
Found via a crash report in Sentry.