### PR TITLE
RaiseError middleware should not raise an error unless status >= 500

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,13 +7,6 @@ require 'saml/settings_service'
 class ApplicationController < ActionController::API
   include ActionController::HttpAuthentication::Token::ControllerMethods
 
-  SKIP_SENTRY_EXCEPTION_TYPES = [
-    Common::Exceptions::Unauthorized,
-    Common::Exceptions::RoutingError,
-    Common::Exceptions::Forbidden,
-    Breakers::OutageException
-  ].freeze
-
   before_action :authenticate
   before_action :set_app_info_headers
   skip_before_action :authenticate, only: [:cors_preflight, :routing_error]
@@ -59,9 +52,7 @@ class ApplicationController < ActionController::API
   end
 
   def log_error(exception)
-    unless SKIP_SENTRY_EXCEPTION_TYPES.include?(exception.class)
-      Raven.capture_exception(exception) if ENV['SENTRY_DSN'].present?
-    end
+    Raven.capture_exception(exception) if ENV['SENTRY_DSN'].present?
     Rails.logger.error "#{exception.message}."
     Rails.logger.error exception.backtrace.join("\n") unless exception.backtrace.nil?
   end

--- a/lib/common/client/middleware/response/raise_error.rb
+++ b/lib/common/client/middleware/response/raise_error.rb
@@ -5,7 +5,7 @@ module Common
       module Response
         class RaiseError < Faraday::Response::Middleware
           def on_complete(env)
-            return if env.success?
+            return if env.status < 500
             raise Common::Client::Errors::ClientResponse.new(env.status.to_i, env[:body])
           end
         end

--- a/spec/lib/common/client/middleware/response_middleware_spec.rb
+++ b/spec/lib/common/client/middleware/response_middleware_spec.rb
@@ -7,7 +7,7 @@ require 'common/client/errors'
 
 describe 'Response Middleware' do
   let(:message_json) { attributes_for(:message).to_json }
-  let(:four_o_four) { { "errorCode": 400, "message": 'Record Not Found' }.to_json }
+  let(:five_o_o) { { "errorCode": 500, "message": 'Server Error' }.to_json }
 
   subject(:faraday_client) do
     Faraday.new do |conn|
@@ -17,7 +17,7 @@ describe 'Response Middleware' do
 
       conn.adapter :test do |stub|
         stub.get('ok') { [200, { 'Content-Type' => 'application/json' }, message_json] }
-        stub.get('not-found') { [404, { 'Content-Type' => 'application/json' }, four_o_four] }
+        stub.get('error') { [500, { 'Content-Type' => 'application/json' }, five_o_o] }
       end
     end
   end
@@ -30,7 +30,7 @@ describe 'Response Middleware' do
   end
 
   it 'raises client response error' do
-    expect { subject.get('not-found') }
+    expect { subject.get('error') }
       .to raise_error(Common::Client::Errors::ClientResponse)
   end
 end


### PR DESCRIPTION
This middleware is currently raising an error for any response not in the 2xx range. That's causing plenty of non-error responses to be missed because the exception is raised. It's also causing Breakers to initiate outages on non-error responses. It seems like the semantics of this middleware are that it should only raise an error on 5xx responses.