### PR TITLE
Default loa.highest

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -62,7 +62,7 @@ module V0
         birth_date:     attributes['birth_date']&.first,
         uuid:           attributes['uuid']&.first,
         last_signed_in: Time.current.utc,
-        loa:            { current: parse_current_loa, highest: attributes['level_of_assurance']&.first&.to_i }
+        loa:            { current: loa_current, highest: attributes['level_of_assurance']&.first&.to_i || loa_current }
       }
     end
 
@@ -71,9 +71,9 @@ module V0
       gender[0].upcase
     end
 
-    def parse_current_loa
-      raw_loa = REXML::XPath.first(@saml_response.decrypted_document, '//saml:AuthnContextClassRef')&.text
-      LOA::MAPPING[raw_loa]
+    def loa_current
+      @raw_loa ||= REXML::XPath.first(@saml_response.decrypted_document, '//saml:AuthnContextClassRef')&.text
+      LOA::MAPPING[@raw_loa]
     end
 
     def saml_user

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -102,11 +102,19 @@ RSpec.describe V0::SessionsController, type: :controller do
       end
       let(:attributes) { double('attributes') }
       let(:saml_response) { double('saml_response', is_valid?: true, attributes: attributes) }
+      let(:created_session) { Session.find(query_token) }
+      let(:created_user) { User.find(created_session.uuid) }
 
       before(:example) do
         allow(attributes).to receive_message_chain(:all, :to_h).and_return(saml_attrs)
         allow(OneLogin::RubySaml::Response).to receive(:new).and_return(saml_response)
         allow(saml_response).to receive(:decrypted_document).and_return(REXML::Document.new(loa3_xml))
+      end
+
+      it 'should default loa.highest to loa.current if highest is null' do
+        saml_attrs.delete 'level_of_assurance'
+        post :saml_callback
+        expect(created_user.loa['highest']).to eq(created_user.loa['current'])
       end
 
       it 'should uplevel an LOA 1 session to LOA 3' do
@@ -126,10 +134,8 @@ RSpec.describe V0::SessionsController, type: :controller do
       it 'returns a valid session and user' do
         post :saml_callback
 
-        token = Rack::Utils.parse_query(URI.parse(response.location).query)['token']
-        session = Session.find(token)
-        expect(session).to_not be_nil
-        expect(User.find(session.uuid).attributes).to eq(mvi_user.attributes)
+        expect(created_session).to_not be_nil
+        expect(created_user.attributes).to eq(mvi_user.attributes)
       end
 
       it 'creates a job to create an evss user when user has loa3 and evss attrs' do
@@ -144,19 +150,13 @@ RSpec.describe V0::SessionsController, type: :controller do
       it 'parses and stores the current level of assurance' do
         post :saml_callback, RelayState: fake_relay
         assert_response :found
-
-        session = Session.find(query_token)
-        user = User.find(session.uuid)
-        expect(user.loa[:current]).to eq(LOA::TWO)
+        expect(created_user.loa[:current]).to eq(LOA::TWO)
       end
 
       it 'parses and stores the highest level of assurance proofing' do
         post :saml_callback, RelayState: fake_relay
         assert_response :found
-
-        session = Session.find(query_token)
-        user = User.find(session.uuid)
-        expect(user.loa[:highest]).to eq(LOA::THREE)
+        expect(created_user.loa[:highest]).to eq(LOA::THREE)
       end
     end
 


### PR DESCRIPTION
ID.me does not garauntee to send us `loa.highest` (which arrives as a SAML Attribute named `level_of_assurance`).  We dont want to ever send `loa { highest: null } }` to the F/E when they call GET `/v0/user`.

This PR defaults the value of `loa.highest` to be `loa.current` in the event that ID.me does not send us an `loa.highest`.