### PR TITLE
tell breakers whether exceptions look like outages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       sass (~> 3.0)
       slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
-    breakers (0.2.2)
+    breakers (0.2.3)
       faraday (>= 0.7.4, < 0.10)
       multi_json (~> 1.0)
     builder (3.2.2)

--- a/lib/rx/configuration.rb
+++ b/lib/rx/configuration.rb
@@ -27,9 +27,19 @@ module Rx
         request_env.url.host == host && request_env.url.path =~ /^#{path}/
       end
 
+      exception_handler = proc do |exception|
+        # :nocov:
+        if exception.is_a?(Common::Client::Errors::ClientResponse)
+          return (500..599).cover?(e.major)
+        end
+        false
+        # :nocov:
+      end
+
       @service = Breakers::Service.new(
         name: 'Rx',
-        request_matcher: matcher
+        request_matcher: matcher,
+        exception_handler: exception_handler
       )
     end
   end

--- a/lib/rx/configuration.rb
+++ b/lib/rx/configuration.rb
@@ -28,12 +28,11 @@ module Rx
       end
 
       exception_handler = proc do |exception|
-        # :nocov:
         if exception.is_a?(Common::Client::Errors::ClientResponse)
-          return (500..599).cover?(e.major)
+          (500..599).cover?(exception.major)
+        else
+          false
         end
-        false
-        # :nocov:
       end
 
       @service = Breakers::Service.new(

--- a/lib/sm/configuration.rb
+++ b/lib/sm/configuration.rb
@@ -27,9 +27,19 @@ module SM
         request_env.url.host == host && request_env.url.path =~ /^#{path}/
       end
 
+      exception_handler = proc do |exception|
+        # :nocov:
+        if exception.is_a?(Common::Client::Errors::ClientResponse)
+          return (500..599).cover?(e.major)
+        end
+        false
+        # :nocov:
+      end
+
       @service = Breakers::Service.new(
         name: 'SM',
-        request_matcher: matcher
+        request_matcher: matcher,
+        exception_handler: exception_handler
       )
     end
   end

--- a/lib/sm/configuration.rb
+++ b/lib/sm/configuration.rb
@@ -30,9 +30,10 @@ module SM
       exception_handler = proc do |exception|
         # :nocov:
         if exception.is_a?(Common::Client::Errors::ClientResponse)
-          return (500..599).cover?(e.major)
+          (500..599).cover?(exception.major)
+        else
+          false
         end
-        false
         # :nocov:
       end
 


### PR DESCRIPTION
***This change really ought to get into production ASAP, but I'm not sure what I'm supposed to do to make that happen.***

This goes together with (a PR)[https://github.com/department-of-veterans-affairs/breakers/pull/8] on the breakers side. The immediate, bad, problem is that because our Faraday middleware raises exceptions for any type of errors in the >= 300 range, and because breakers was treating all exceptions as indicating a potential outage, outages would be created by a service returning a response status like 400 or 302.

The change to breakers was to ignore all exceptions other than Timeout by default while allowing clients to define a callback for each exception to indicate if they are representative of an outage. This change bumps the version of breakers and adds one of those callbacks for Rx and SM to indicate a problem only when the response status is in the 5xx range.
