### PR TITLE
Remove unused choiceact controller/route; behave reasonably for bare facilities/va request

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -4,8 +4,10 @@ class FacilitiesController < ApplicationController
   skip_before_action :authenticate
 
   def validate_params
-    raise ArgumentError unless params[:bbox]&.length == 4
-    params[:bbox].each { |x| Float(x) }
+    if params[:bbox]
+      raise ArgumentError unless params[:bbox]&.length == 4
+      params[:bbox].each { |x| Float(x) }
+    end
   rescue ArgumentError
     raise Common::Exceptions::InvalidFieldValue.new('bbox', params[:bbox])
   end

--- a/app/controllers/v0/facilities/choiceact_controller.rb
+++ b/app/controllers/v0/facilities/choiceact_controller.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-class V0::Facilities::ChoiceactController < ApplicationController
-end

--- a/app/controllers/v0/facilities/va_controller.rb
+++ b/app/controllers/v0/facilities/va_controller.rb
@@ -9,7 +9,10 @@ class V0::Facilities::VaController < FacilitiesController
   # @param type - Optional facility type, values = all (default), health, benefits, cemetery
   # @param services - Optional specialty services filter
   def index
-    results = VAFacility.query(bbox: params[:bbox], type: params[:type], services: params[:services])
+    results = []
+    if params[:bbox]
+      results = VAFacility.query(bbox: params[:bbox], type: params[:type], services: params[:services])
+    end
     resource = Common::Collection.new(::VAFacility, data: results)
     resource = resource.paginate(pagination_params)
     render json: resource.data,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,6 @@ Rails.application.routes.draw do
 
     scope :facilities, module: 'facilities' do
       resources :va, only: [:index, :show], defaults: { format: :json }
-      resources :choiceact, only: [:index, :show], defaults: { format: :json }
     end
   end
 

--- a/spec/controllers/v0/facilities/choiceact_controller_spec.rb
+++ b/spec/controllers/v0/facilities/choiceact_controller_spec.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-require 'rails_helper'
-
-RSpec.describe V0::Facilities::ChoiceactController, type: :controller do
-end


### PR DESCRIPTION
Choice Act implementation will happen later so removing controller/route for now. @knkski requested that bare `v0/facilities/va` not return a 400 error due to missing bounding box, so we now return an empty list result in JSON API format.