### PR TITLE
Add encryption to disability claims uploads

### DIFF
--- a/app/uploaders/disability_claim_document_uploader.rb
+++ b/app/uploaders/disability_claim_document_uploader.rb
@@ -39,6 +39,7 @@ class DisabilityClaimDocumentUploader < CarrierWave::Uploader::Base
       }
       self.aws_acl = 'private'
       self.aws_bucket = ENV['EVSS_AWS_S3_BUCKET']
+      self.aws_attributes = { server_side_encryption: 'AES256' }
       self.class.storage = :aws
     else
       self.class.storage = :file


### PR DESCRIPTION
This is a late addition, but a requirement for ATO. I've tested this
manually on the development server. This method (AES256 SSE) is used by
the appeals team, though we should put further time into figuring out
how to get compatibility with carrierwave for SSE with KMS.