### PR TITLE
Claims cleanup

### DIFF
--- a/app/controllers/v0/disability_claims_controller.rb
+++ b/app/controllers/v0/disability_claims_controller.rb
@@ -19,8 +19,7 @@ module V0
     def request_decision
       claim = DisabilityClaim.for_user(current_user).find_by(evss_id: params[:id])
       jid = claim_service.request_decision(claim)
-      claim.requested_decision = true
-      claim.save
+      claim.update_attributes(requested_decision: true)
       render_job_id(jid)
     end
   end

--- a/app/models/disability_claim.rb
+++ b/app/models/disability_claim.rb
@@ -2,7 +2,5 @@
 require 'evss/documents_service'
 
 class DisabilityClaim < ActiveRecord::Base
-  attr_accessor :successful_sync
-
   scope :for_user, ->(user) { where(user_uuid: user.uuid) }
 end

--- a/app/serializers/disability_claim_base_serializer.rb
+++ b/app/serializers/disability_claim_base_serializer.rb
@@ -2,7 +2,7 @@
 class DisabilityClaimBaseSerializer < ActiveModel::Serializer
   attributes :id, :evss_id, :date_filed, :min_est_date, :max_est_date,
              :phase_change_date, :open, :waiver_submitted, :documents_needed,
-             :development_letter_sent, :decision_letter_sent, :successful_sync,
+             :development_letter_sent, :decision_letter_sent,
              :updated_at, :phase
 
   # Our IDs are not stable due to 24 hour expiration, use EVSS IDs for consistency

--- a/app/services/disability_claim_service.rb
+++ b/app/services/disability_claim_service.rb
@@ -83,10 +83,6 @@ class DisabilityClaimService
     @client ||= EVSS::ClaimsService.new(auth_headers)
   end
 
-  def document_client
-    @document_client ||= EVSS::DocumentsService.new(auth_headers)
-  end
-
   def auth_headers
     @auth_headers ||= EVSS::AuthHeaders.new(@user).to_h
   end

--- a/app/services/disability_claim_service.rb
+++ b/app/services/disability_claim_service.rb
@@ -43,20 +43,15 @@ class DisabilityClaimService
     return claims, true
   rescue Faraday::Error::TimeoutError, Breakers::OutageException => e
     log_error(e)
-    claims = claims_scope.all.map do |claim|
-      claim.successful_sync = false
-      claim
-    end
-    return claims, false
+    return claims_scope.all, false
   end
 
   def update_from_remote(claim)
     begin
       raw_claim = client.find_claim_by_id(claim.evss_id).body.fetch('claim', {})
-      claim.update_attributes(data: raw_claim, successful_sync: true)
+      claim.update_attributes(data: raw_claim)
       successful_sync = true
     rescue Faraday::Error::TimeoutError, Breakers::OutageException => e
-      claim.successful_sync = false
       log_error(e)
       successful_sync = false
     end
@@ -93,7 +88,7 @@ class DisabilityClaimService
 
   def create_or_update_claim(raw_claim)
     claim = claims_scope.where(evss_id: raw_claim['id']).first_or_initialize(data: {})
-    claim.update_attributes(list_data: raw_claim, successful_sync: true)
+    claim.update_attributes(list_data: raw_claim)
     claim
   end
 

--- a/spec/services/disability_claim_service_spec.rb
+++ b/spec/services/disability_claim_service_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe DisabilityClaimService do
         claims, synchronized = subject.all
         expect(claims).to eq([claim])
         expect(synchronized).to eq(false)
-        expect(claims.first.successful_sync).to eq(false)
       end
     end
 
@@ -27,7 +26,6 @@ RSpec.describe DisabilityClaimService do
         updated_claim, synchronized = subject.update_from_remote(claim)
         expect(updated_claim).to eq(claim)
         expect(synchronized).to eq(false)
-        expect(updated_claim.successful_sync).to eq(false)
       end
     end
   end

--- a/spec/support/schemas/disability_claim.json
+++ b/spec/support/schemas/disability_claim.json
@@ -25,7 +25,6 @@
             "documents_needed",
             "development_letter_sent",
             "decision_letter_sent",
-            "successful_sync",
             "updated_at",
             "phase",
             "claim_type"
@@ -44,7 +43,6 @@
             "documents_needed": { "type": "boolean" },
             "development_letter_sent": { "type": "boolean" },
             "decision_letter_sent": { "type": "boolean" },
-            "successful_sync": { "type": "boolean" },
             "updated_at": { "type": "string" },
             "phase": { "type": ["integer", "null"] },
             "claim_type": { "type": "string" }

--- a/spec/support/schemas/disability_claims.json
+++ b/spec/support/schemas/disability_claims.json
@@ -25,7 +25,6 @@
               "documents_needed",
               "development_letter_sent",
               "decision_letter_sent",
-              "successful_sync",
               "updated_at",
               "phase"
             ],
@@ -40,7 +39,6 @@
               "documents_needed": { "type": "boolean" },
               "development_letter_sent": { "type": "boolean" },
               "decision_letter_sent" : { "type": "boolean" },
-              "successful_sync": { "type": "boolean" },
               "updated_at": { "type": "string" },
               "phase": { "type": ["integer", "null"] }
             }


### PR DESCRIPTION
- Remove an unused method
- Remove `successful_sync` attribute on claim, this is now passed in the JSON API response as `meta`, the frontend is already handling this change