### PR TITLE
EVSS: Override attributes in document data

### DIFF
--- a/app/models/disability_claim_document.rb
+++ b/app/models/disability_claim_document.rb
@@ -47,6 +47,16 @@ class DisabilityClaimDocument < Common::Base
     attributes == other.attributes
   end
 
+  # Redefining attributes method so that it picks up changes made after initialization
+  def attributes
+    Hash[attribute_set.map do |attribute|
+      [attribute.name.to_s, send(attribute.name)]
+    end]
+  end
+
+  alias to_h attributes
+  alias to_hash attributes
+
   private
 
   def known_document_type?

--- a/app/models/disability_claim_document.rb
+++ b/app/models/disability_claim_document.rb
@@ -49,9 +49,7 @@ class DisabilityClaimDocument < Common::Base
 
   # Redefining attributes method so that it picks up changes made after initialization
   def attributes
-    Hash[attribute_set.map do |attribute|
-      [attribute.name.to_s, send(attribute.name)]
-    end]
+    Hash[attribute_set.map { |attr| [attr.name.to_s, send(attr.name)] }]
   end
 
   alias to_h attributes

--- a/app/services/disability_claim_service.rb
+++ b/app/services/disability_claim_service.rb
@@ -67,8 +67,7 @@ class DisabilityClaimService
     uploader = DisabilityClaimDocumentUploader.new(@user.uuid, disability_claim_document.tracked_item_id)
     uploader.store!(file)
     # the uploader sanitizes the filename before storing, so set our doc to match
-    # TODO: set this directly on the model, need to modify common/model/base to update attributes hash
-    disability_claim_document.attributes[:file_name] = uploader.filename
+    disability_claim_document.file_name = uploader.filename
     DisabilityClaim::DocumentUpload.perform_async(auth_headers, @user.uuid, disability_claim_document.to_h)
   end
 


### PR DESCRIPTION
Because attributes was set at initialization time, it was not receiving
updates to instance values. This fixes that. May be added to base class
later. CC @saneshark 