### PR TITLE
No breakers for MHV audit logging, and async

### DIFF
--- a/app/workers/mhv/audit_login_job.rb
+++ b/app/workers/mhv/audit_login_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module MHV
+  class AuditLoginJob
+    include Sidekiq::Worker
+
+    sidekiq_options retry: false
+
+    def perform(uuid)
+      user = User.find(uuid)
+
+      MHVLogging::Client.new(session: { user_id: user.mhv_correlation_id })
+                        .authenticate
+                        .auditlogin
+
+      # Update the user object with the time of login
+      user.mhv_last_signed_in = Time.current
+      user.save
+    end
+  end
+end

--- a/app/workers/mhv/audit_login_job.rb
+++ b/app/workers/mhv/audit_login_job.rb
@@ -8,6 +8,8 @@ module MHV
     def perform(uuid)
       user = User.find(uuid)
 
+      return if user.mhv_last_signed_in
+
       MHVLogging::Client.new(session: { user_id: user.mhv_correlation_id })
                         .authenticate
                         .auditlogin

--- a/app/workers/mhv/audit_logout_job.rb
+++ b/app/workers/mhv/audit_logout_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module MHV
+  class AuditLogoutJob
+    include Sidekiq::Worker
+
+    sidekiq_options retry: false
+
+    def perform(uuid, mhv_correlation_id)
+      MHVLogging::Client.new(session: { user_id: mhv_correlation_id })
+                        .authenticate
+                        .auditlogout
+      # Update the user object with nil to indicate not logged in
+      user = User.find(uuid)
+
+      if user
+        user.mhv_last_signed_in = nil
+        user.save
+      end
+    end
+  end
+end

--- a/lib/mhv_logging/client.rb
+++ b/lib/mhv_logging/client.rb
@@ -74,7 +74,6 @@ module MHVLogging
 
     def connection
       @connection ||= Faraday.new(config.base_path, headers: BASE_REQUEST_HEADERS, request: request_options) do |conn|
-        conn.use :breakers
         conn.request :json
         # Uncomment this out for generating curl output to send to MHV dev and test only
         # conn.request :curl, ::Logger.new(STDOUT), :warn

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -41,10 +41,16 @@ FactoryGirl.define do
   end
 
   factory :mhv_user, class: 'User' do
+    uuid 'b2fab2b5-6af0-45e1-a9e2-394347af91ef'
     edipi '1234'
     icn '1000123456V123456'
     mhv_last_signed_in Time.current
     participant_id '12345678'
+    email 'abraham.lincoln@vets.gov'
+    first_name 'abraham'
+    last_name 'lincoln'
+    birth_date Time.new(1809, 2, 12).utc
+    ssn '272111863'
     loa do
       {
         current: LOA::THREE,


### PR DESCRIPTION
Two problems were happening with the MHV audit logging thing:

1. In breakers, its requests weren't distinguishable from Rx ones, so reported errors were confusing, and
1. If the service were down then an attempt would be made to start the login on each MHV-related request. Since that request would fail, the entire user request would fail and all MHV-related endpoints would effectively be down.

This removes breakers as a middleware for this service, since we really kinda don't care if it's down or not. It also makes the login and logout requests happen in sidekiq so that they no longer block up the normal request cycle.