### PR TITLE
Add GA/UA Tracking on the backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/
 gem 'breakers'
 gem 'govdelivery-tms', require: 'govdelivery/tms/mail/delivery_method'
 gem 'statsd-instrument'
+gem 'staccato'
 
 # Amazon Linux's system `json` gem causes conflicts, but
 # `multi_json` will prefer `oj` if installed, so include it here.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,6 +358,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    staccato (0.5.0)
     statsd-instrument (2.1.1)
     temple (0.7.6)
     terminal-table (1.5.2)
@@ -444,6 +445,7 @@ DEPENDENCIES
   simplecov (~> 0.11)
   spring
   spring-commands-rspec
+  staccato
   statsd-instrument
   timecop
   typhoeus

--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -44,7 +44,6 @@ module EducationForm
       structured_data.each do |region, records|
         region_id = EducationFacility.facility_for(region: region)
         filename = "#{region_id}_#{Time.zone.today.strftime('%m%d%Y')}_vetsgov.spl"
-        logger.info("Writing #{records.count} application(s) to #{filename}")
         # create the single textual spool file
         contents = records.map do |record|
           format_application(record.open_struct_form)
@@ -61,13 +60,13 @@ module EducationForm
         end
 
         # mark the records as processed once the file has been written
+        # this should be an each / update_attributes to trigger callbacks
         records.each do |record|
           record.update_attributes!(processed_at: Time.zone.now)
         end
         log_write(records, region, filename)
       end
     end
-
 
     def create_files(structured_data)
       logger.error('No applications to write') && return if structured_data.empty?

--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -64,8 +64,10 @@ module EducationForm
         records.each do |record|
           record.update_attributes!(processed_at: Time.zone.now)
         end
+        log_write(records, region, filename)
       end
     end
+
 
     def create_files(structured_data)
       logger.error('No applications to write') && return if structured_data.empty?
@@ -96,6 +98,15 @@ module EducationForm
     end
 
     private
+
+    def log_write(records, region_id, filename)
+      logger.info("Writing #{records.count} application(s) to #{filename}")
+      UA_TRACKERS['education_benefits'].event(category: 'Daily Transmissions',
+                                              action: 'spool-file-written',
+                                              label: "RPO #{region_id}",
+                                              value: records.count,
+                                              non_interactive: true)
+    end
 
     # If multiple benefit types are selected, we've been told to just include whichever
     # one is 'first' in the header.

--- a/config/google_analytics.yml
+++ b/config/google_analytics.yml
@@ -1,0 +1,2 @@
+global: 'UA-50123418'
+education_benefits: 'UA-50123418-7'

--- a/config/initializers/staccato.rb
+++ b/config/initializers/staccato.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'staccato/adapter/logger'
+require 'staccato/adapter/faraday'
+
+trackers = YAML.load_file(Rails.root.join('config', 'google_analytics.yml'))
+
+UA_TRACKERS = trackers.each_with_object({}) do |(name, id), memo|
+  memo[name] = Staccato.tracker(id, nil, ssl: true) do |c|
+    if Rails.env.production?
+      c.adapter = Staccato::Adapter::Faraday.new(Staccato.ga_collection_uri)
+    elsif Rails.env.development?
+      c.adapter = Staccato::Adapter::Logger.new(Staccato.ga_collection_uri, Logger.new(STDOUT),
+                                                ->(params) { JSON.dump(params) })
+    else
+      c.adapter = Staccato::Adapter::Logger.new(Staccato.ga_collection_uri, Logger.new(StringIO.new))
+    end
+  end
+  memo
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ unless ENV['NOCOVERAGE']
     add_filter 'lib/feature_flipper.rb'
     add_filter 'spec/support/authenticated_session_helper'
     add_filter 'config/initializers/figaro.rb'
+    add_filter 'config/initializers/staccato.rb'
     SimpleCov.minimum_coverage_by_file 90
   end
 end


### PR DESCRIPTION
Pushing these events up to GA should let us quickly correlate the number of fronted submissions each day with the number of backend transmissions each night.