### PR TITLE
Add :draft_id to strong params

### DIFF
--- a/app/controllers/v0/messages_controller.rb
+++ b/app/controllers/v0/messages_controller.rb
@@ -98,7 +98,7 @@ module V0
     private
 
     def message_params
-      @message_params ||= params.require(:message).permit(:category, :body, :recipient_id, :subject)
+      @message_params ||= params.require(:message).permit(:id, :draft_id, :category, :body, :recipient_id, :subject)
     end
 
     def upload_params

--- a/app/controllers/v0/messages_controller.rb
+++ b/app/controllers/v0/messages_controller.rb
@@ -98,7 +98,7 @@ module V0
     private
 
     def message_params
-      @message_params ||= params.require(:message).permit(:id, :draft_id, :category, :body, :recipient_id, :subject)
+      @message_params ||= params.require(:message).permit(:draft_id, :category, :body, :recipient_id, :subject)
     end
 
     def upload_params


### PR DESCRIPTION
 If `:draft_id` and `:id` are not explicitly permitted they will be `nil` from the strong params. Hence the drafts aren't getting deleted.