### PR TITLE
Tell statsd about refills

### DIFF
--- a/lib/rx/api/prescriptions.rb
+++ b/lib/rx/api/prescriptions.rb
@@ -34,6 +34,10 @@ module Rx
 
       def post_refill_rx(id)
         perform(:post, "prescription/rxrefill/#{id}", nil, token_headers)
+        StatsD.increment('api.prescriptions.refill.request.succeeded', 1)
+      rescue
+        StatsD.increment('api.prescriptions.refill.request.failed', 1)
+        raise
       end
     end
   end

--- a/lib/rx/api/prescriptions.rb
+++ b/lib/rx/api/prescriptions.rb
@@ -33,8 +33,9 @@ module Rx
       end
 
       def post_refill_rx(id)
-        perform(:post, "prescription/rxrefill/#{id}", nil, token_headers)
+        result = perform(:post, "prescription/rxrefill/#{id}", nil, token_headers)
         StatsD.increment('api.prescriptions.refill.request.succeeded', 1)
+        result
       rescue
         StatsD.increment('api.prescriptions.refill.request.failed', 1)
         raise


### PR DESCRIPTION
Fix for #476 

This adds an increment to a couple of StatsD counters whenever prescription refills either proceed or fail.

@saneshark I debated doing this in the controller vs. the client but decided on here because presumably the client could be used in several places. If you have thoughts on this I'd happily move it. Also, is rescuing the exception the correct way to detect a failure?