### PR TITLE
Stop using tap for building the list

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -36,14 +36,14 @@ class UserSerializer < ActiveModel::Serializer
   end
 
   def services
-    [
+    service_list = [
       BackendServices::FACILITIES,
       BackendServices::HCA,
       BackendServices::EDUCATION_BENEFITS
-    ].tap do |service_list|
-      service_list += [BackendServices::RX, BackendServices::MESSAGING] if object.can_access_mhv?
-      service_list << BackendServices::DISABILITY_BENEFITS if object.can_access_evss?
-      service_list << BackendServices::USER_PROFILE if object.can_access_user_profile?
-    end
+    ]
+    service_list += [BackendServices::RX, BackendServices::MESSAGING] if object.can_access_mhv?
+    service_list << BackendServices::DISABILITY_BENEFITS if object.can_access_evss?
+    service_list << BackendServices::USER_PROFILE if object.can_access_user_profile?
+    service_list
   end
 end

--- a/spec/request/profile_request_spec.rb
+++ b/spec/request/profile_request_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe 'Fetching profile data', type: :request do
   let(:token) { 'abracadabra-open-sesame' }
 
   context 'when an LOA 3 user is logged in' do
-    let(:mvi_user) { build :mvi_user }
+    let(:mhv_user) { build :mhv_user }
 
     before do
-      Session.create(uuid: mvi_user.uuid, token: token)
-      User.create(mvi_user)
+      Session.create(uuid: mhv_user.uuid, token: token)
+      User.create(mhv_user)
 
       auth_header = { 'Authorization' => "Token token=#{token}" }
       get v0_user_url, nil, auth_header
@@ -28,7 +28,9 @@ RSpec.describe 'Fetching profile data', type: :request do
           BackendServices::HCA,
           BackendServices::EDUCATION_BENEFITS,
           BackendServices::DISABILITY_BENEFITS,
-          BackendServices::USER_PROFILE
+          BackendServices::USER_PROFILE,
+          BackendServices::RX,
+          BackendServices::MESSAGING
         ].sort
       )
     end


### PR DESCRIPTION
Stop using tap to build up the profile services list, fixing the problem where some services were not returned. It turns out the problem is my use of += in the first line of the tap block. That will not append to the list in-place, but will instead create a new list and reassign it to the service_list variable so the remaining code is no longer dealing with the argument to the block.

Fixes #525 