### PR TITLE
Filter secure messaging post params from logs

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,4 +2,5 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :education_benefits_claim]
+Rails.application.config.filter_parameters +=
+  %i(password education_benefits_claim message message_draft folder)


### PR DESCRIPTION
@patrickvinograd this will remove secure messaging params from the logs as well. Better safe than sorry on these.

That being said, in the case vets.gov we might be better off if there is a way of having a WHITELIST of parameters that should be allowed in the logs vs a BLACKLIST of things that should be removed. 

I can investigate a more nuclear option of not including parameters in production logs altogether if you think that's advisable.

@aub tagging you on this as well since you were investigating some of structured logging. 