### PR TITLE
Change how EDU transfers files over SFTP

### DIFF
--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -98,8 +98,10 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
       end
 
       it 'writes a file to the tmp dir' do
+        expect(EducationBenefitsClaim.unprocessed).not_to be_empty
         perform_with_frozen_time
         expect(File.read(file_path).include?('APPLICATION FOR VA EDUCATION BENEFITS')).to eq(true)
+        expect(EducationBenefitsClaim.unprocessed).to be_empty
       end
 
       after do
@@ -108,6 +110,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
     end
 
     it 'writes files out over sftp' do
+      expect(EducationBenefitsClaim.unprocessed).not_to be_empty
       ClimateControl.modify EDU_SFTP_HOST: 'localhost', EDU_SFTP_PASS: 'test' do
         sftp_mock = double
         expect(Net::SFTP).to receive(:start).once.and_yield(sftp_mock)
@@ -116,6 +119,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
           expect(contents.read).to include('EDUCATION BENEFIT BEING APPLIED FOR: Chapter 1606')
         end
         perform_with_frozen_time
+        expect(EducationBenefitsClaim.unprocessed).to be_empty
       end
     end
   end

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -109,17 +109,13 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
 
     it 'writes files out over sftp' do
       ClimateControl.modify EDU_SFTP_HOST: 'localhost', EDU_SFTP_PASS: 'test' do
-        mock_file = double(File)
-        mock_writer = StringIO.new
-        sftp_mock = double(file: mock_file)
+        sftp_mock = double
         expect(Net::SFTP).to receive(:start).once.and_yield(sftp_mock)
-        expect(mock_file).to receive('open').with(filename, 'w').and_return(mock_writer)
-        expect(mock_writer).to receive('close').once
+        expect(sftp_mock).to receive(:upload!) do |contents, path|
+          expect(path).to eq filename
+          expect(contents.read).to include('EDUCATION BENEFIT BEING APPLIED FOR: Chapter 1606')
+        end
         perform_with_frozen_time
-
-        # read back the written file
-        mock_writer.rewind
-        expect(mock_writer.read).to include('EDUCATION BENEFIT BEING APPLIED FOR: Chapter 1606')
       end
     end
   end


### PR DESCRIPTION
Nightly transfers have been failing, with no clear explaination in the logs. By changing how files are transmitted and using an explicit `upload!` method, the hope is that whatever circumstances causing failures and subsequent connection timeouts can be avoided.