### PR TITLE
Send data about API requests to StatsD

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ require 'action_controller/railtie'
 require 'action_mailer/railtie'
 # require "action_view/railtie"
 # require "sprockets/railtie"
+require_relative '../lib/statsd_middleware'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -47,5 +48,6 @@ module VetsAPI
     end
 
     config.middleware.use 'OliveBranch::Middleware'
+    config.middleware.use 'StatsdMiddleware'
   end
 end

--- a/lib/statsd_middleware.rb
+++ b/lib/statsd_middleware.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class StatsdMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, response = @app.call(env)
+    params = env['action_dispatch.request.path_parameters']
+    key = "api.external.request#status=#{status},controller=#{params[:controller]},action=#{params[:action]}"
+    StatsD.increment(key, 1)
+    [status, headers, response]
+  end
+end

--- a/lib/statsd_middleware.rb
+++ b/lib/statsd_middleware.rb
@@ -8,7 +8,13 @@ class StatsdMiddleware
     status, headers, response = @app.call(env)
     params = env['action_dispatch.request.path_parameters']
     key = "api.external.request#status=#{status},controller=#{params[:controller]},action=#{params[:action]}"
-    StatsD.increment(key, 1)
+    # rubocop:disable Lint/HandleExceptions
+    begin
+      StatsD.increment(key, 1)
+    rescue
+      # we want to ensure this doesn't break the response cyce
+    end
+    # rubocop:enable Lint/HandleExceptions
     [status, headers, response]
   end
 end

--- a/lib/statsd_middleware.rb
+++ b/lib/statsd_middleware.rb
@@ -14,14 +14,10 @@ class StatsdMiddleware
     status_key = "api.external.request#status=#{status},controller=#{controller},action=#{action}"
     duration_key = "api.external.request.duration#controller=#{controller},action=#{action}"
 
-    # rubocop:disable Lint/HandleExceptions
-    begin
-      StatsD.increment(status_key, 1)
-      StatsD.measure(duration_key, duration)
-    rescue
-      # we want to ensure this doesn't break the response cyce
-    end
-    # rubocop:enable Lint/HandleExceptions
+    # rubocop:disable Style/RescueModifier
+    StatsD.increment(status_key, 1) rescue nil
+    StatsD.measure(duration_key, duration) rescue nil
+    # rubocop:enable Style/RescueModifier
     [status, headers, response]
   end
 end

--- a/lib/statsd_middleware.rb
+++ b/lib/statsd_middleware.rb
@@ -7,7 +7,7 @@ class StatsdMiddleware
   def call(env)
     start_time = Time.current
     status, headers, response = @app.call(env)
-    duration = Time.current - start_time
+    duration = (Time.current - start_time) * 1000.0
 
     controller = env['action_dispatch.request.path_parameters'][:controller]
     action = env['action_dispatch.request.path_parameters'][:action]

--- a/lib/statsd_middleware.rb
+++ b/lib/statsd_middleware.rb
@@ -11,8 +11,8 @@ class StatsdMiddleware
 
     controller = env['action_dispatch.request.path_parameters'][:controller]
     action = env['action_dispatch.request.path_parameters'][:action]
-    status_key = "api.external.request#status=#{status},controller=#{controller},action=#{action}"
-    duration_key = "api.external.request.duration#controller=#{controller},action=#{action}"
+    status_key = "api.rack.request#status=#{status},controller=#{controller},action=#{action}"
+    duration_key = "api.rack.request.duration#controller=#{controller},action=#{action}"
 
     # rubocop:disable Style/RescueModifier
     StatsD.increment(status_key, 1) rescue nil

--- a/spec/request/statsd_middleware_spec.rb
+++ b/spec/request/statsd_middleware_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe StatsdMiddleware, type: :request do
 
   it 'sends status data to statsd' do
     stub_varx_request(:get, 'mhv-api/patient/v1/prescription/gethistoryrx', history_rxs, status_code: 200)
-    key = 'api.external.request#status=200,controller=v0/prescriptions,action=index'
+    key = 'api.rack.request#status=200,controller=v0/prescriptions,action=index'
     expect do
       get '/v0/prescriptions'
     end.to trigger_statsd_increment(key, times: 1, value: 1)
@@ -37,21 +37,21 @@ RSpec.describe StatsdMiddleware, type: :request do
 
   it 'sends duration data to statsd' do
     stub_varx_request(:get, 'mhv-api/patient/v1/prescription/gethistoryrx', history_rxs, status_code: 200)
-    key = 'api.external.request.duration#controller=v0/prescriptions,action=index'
+    key = 'api.rack.request.duration#controller=v0/prescriptions,action=index'
     expect do
       get '/v0/prescriptions'
     end.to trigger_statsd_measure(key, times: 1, value: 0.0)
   end
 
   it 'handles a missing route correctly' do
-    key = 'api.external.request#status=404,controller=application,action=routing_error'
+    key = 'api.rack.request#status=404,controller=application,action=routing_error'
     expect do
       get '/v0/blahblah'
     end.to trigger_statsd_increment(key, times: 1, value: 1)
   end
 
   it 'provides duration for missing routes' do
-    key = 'api.external.request.duration#controller=application,action=routing_error'
+    key = 'api.rack.request.duration#controller=application,action=routing_error'
     expect do
       get '/v0/blahblah'
     end.to trigger_statsd_measure(key, times: 1, value: 0.0)

--- a/spec/request/statsd_middleware_spec.rb
+++ b/spec/request/statsd_middleware_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'rx/client'
+require 'support/rx_client_helpers'
+require 'statsd_middleware'
+
+# TODO: possibly refactor this spec to be generic, not dependent on PrescriptionsController
+RSpec.describe StatsdMiddleware, type: :request do
+  include Rx::ClientHelpers
+
+  let(:active_rxs) { File.read('spec/support/fixtures/get_active_rxs.json') }
+  let(:history_rxs) { File.read('spec/support/fixtures/get_history_rxs.json') }
+  let(:session) do
+    Rx::ClientSession.new(
+      user_id: '123',
+      expires_at: 3.weeks.from_now,
+      token: Rx::ClientHelpers::TOKEN
+    )
+  end
+  let(:user) { build(:mhv_user) }
+
+  before(:each) do
+    allow_any_instance_of(ApplicationController).to receive(:authenticate_token).and_return(:true)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    allow_any_instance_of(Rx::Client).to receive(:get_session).and_return(session)
+  end
+
+  it 'sends data to statsd' do
+    stub_varx_request(:get, 'mhv-api/patient/v1/prescription/gethistoryrx', history_rxs, status_code: 200)
+    key = 'api.external.request#status=200,controller=v0/prescriptions,action=index'
+    expect do
+      get '/v0/prescriptions'
+    end.to trigger_statsd_increment(key, times: 1, value: 1)
+  end
+end


### PR DESCRIPTION
This adds a middleware that sends data to statsd for each request against the API. The data includes the controller name, the action hit, and the status code returned, like this:

`api.external.request#status=200,controller=v0/prescriptions,action=index`

@jkassemi you should probably double check my work in terms of the formatting of the data here.