### PR TITLE
cleanup common/models/base a bit

### DIFF
--- a/app/models/disability_claim_document.rb
+++ b/app/models/disability_claim_document.rb
@@ -47,14 +47,6 @@ class DisabilityClaimDocument < Common::Base
     attributes == other.attributes
   end
 
-  # Redefining attributes method so that it picks up changes made after initialization
-  def attributes
-    Hash[attribute_set.map { |attr| [attr.name.to_s, send(attr.name)] }]
-  end
-
-  alias to_h attributes
-  alias to_hash attributes
-
   private
 
   def known_document_type?

--- a/app/models/disability_rating.rb
+++ b/app/models/disability_rating.rb
@@ -2,5 +2,5 @@
 require 'common/models/base'
 class DisabilityRating < Common::Base
   attribute :ratings, Array
-  attribute :service_connected_combined_degree, String
+  attribute :serviceConnectedCombinedDegree, String
 end

--- a/app/serializers/disability_rating_serializer.rb
+++ b/app/serializers/disability_rating_serializer.rb
@@ -6,4 +6,8 @@ class DisabilityRatingSerializer < ActiveModel::Serializer
   def id
     nil
   end
+
+  def service_connected_combined_degree
+    object.serviceConnectedCombinedDegree
+  end
 end

--- a/lib/common/models/base.rb
+++ b/lib/common/models/base.rb
@@ -11,8 +11,6 @@ module Common
     include Virtus.model(nullify_blank: true)
 
     attr_accessor :metadata, :errors_hash
-    alias to_h attributes
-    alias to_hash attributes
 
     class << self
       def per_page(value = nil)

--- a/lib/common/models/base.rb
+++ b/lib/common/models/base.rb
@@ -5,12 +5,11 @@ require 'common/models/attribute_types/utc_time'
 module Common
   # This is a base serialization class
   class Base
-    include Comparable
-    include ActiveModel::Serialization
     extend ActiveModel::Naming
+    include ActiveModel::Serialization
+    include Comparable
     include Virtus.model(nullify_blank: true)
 
-    attr_reader :attributes
     attr_accessor :metadata, :errors_hash
     alias to_h attributes
     alias to_hash attributes
@@ -53,14 +52,23 @@ module Common
       end
     end
 
-    def initialize(attributes = {})
-      @attributes = attributes[:data] || attributes
-      @metadata = attributes[:metadata] || {}
-      @errors_hash = attributes[:errors] || {}
-      @attributes.each do |key, value|
-        setter = "#{key.to_s.underscore}=".to_sym
-        send(setter, value) if respond_to?(setter)
-      end
+    def initialize(init_attributes = {})
+      super(init_attributes[:data] || init_attributes)
+      @metadata = init_attributes[:metadata] || {}
+      @errors_hash = init_attributes[:errors] || {}
+      @original_attributes = attributes
+    end
+
+    def changed?
+      changed.any?
+    end
+
+    def changed
+      attributes.map { |k, v| k if @original_attributes[k] != v }.compact
+    end
+
+    def changes
+      Hash[changed.map { |k, _v| [k, [@original_attributes[k], attributes[k]]] }]
     end
   end
 end

--- a/spec/lib/common/models/base_spec.rb
+++ b/spec/lib/common/models/base_spec.rb
@@ -1,7 +1,80 @@
 # frozen_string_literal: true
 require 'rails_helper'
-require 'common/models/base'
+require 'support/author'
 
-# FIXME: Add this spec
 describe Common::Base do
+  context 'class methods' do
+    subject { Author }
+
+    it 'responds to model_name' do
+      expect(subject.model_name.name).to eq('Author')
+      expect(subject.model_name.singular).to eq('author')
+      expect(subject.model_name.plural).to eq('authors')
+    end
+
+    it 'responds to per_page' do
+      expect(subject.per_page).to eq(20)
+    end
+
+    it 'responds to max_per_page' do
+      expect(subject.max_per_page).to eq(1000)
+    end
+
+    it 'responds to attribute_set' do
+      expect(subject.attribute_set).to be_a(Virtus::AttributeSet)
+    end
+
+    it 'responds to sortable_attributes' do
+      expect(subject.sortable_attributes)
+        .to eq(
+                'id' => 'ASC',
+                'first_name' => 'ASC',
+                'last_name' => 'ASC',
+                'birthdate' => 'DESC'
+              )
+    end
+
+    it 'responds to default_sort' do
+      expect(subject.default_sort)
+        .to eq('first_name')
+    end
+
+    it 'responds to filterable_attributes' do
+      expect(subject.filterable_attributes)
+        .to eq(
+                'id' => %w(eq not_eq),
+                'first_name' => %w(eq not_eq match),
+                'last_name' => %w(eq not_eq match),
+                'birthdate' => %w(eq lteq gteq not_eq)
+              )
+    end
+  end
+
+  context 'instance methods' do
+    subject { Author.new(id: '1', first_name: 'Jill', last_name: '', birthdate: '', zipcode: '20001') }
+
+    it 'correctly coerces, nullifying blank' do
+      expect(subject.id).to eq(1)
+      expect(subject.first_name).to eq('Jill')
+      expect(subject.last_name).to eq('')
+      expect(subject.birthdate).to be_nil
+      expect(subject.zipcode).to eq(20001)
+    end
+
+    it 'responds to attributes, to_h, and, to_hash' do
+      expect(subject.attributes).to eq(subject.to_h)
+      expect(subject.attributes).to eq(subject.to_hash)
+      expect(subject.attributes).to eq(id: 1, first_name: 'Jill', last_name: '', birthdate: nil, zipcode: 20001)
+    end
+
+    it 'identifies if values are changed?' do
+      expect(subject.changed?).to eq(false)
+      expect(subject.changed).to eq([])
+      expect(subject.changes).to eq({})
+      subject.first_name = 'Jack'
+      expect(subject.changed?).to eq(true)
+      expect(subject.changed).to eq([:first_name])
+      expect(subject.changes).to eq({first_name: %w(Jill Jack)})
+    end
+  end
 end

--- a/spec/lib/common/models/base_spec.rb
+++ b/spec/lib/common/models/base_spec.rb
@@ -27,11 +27,11 @@ describe Common::Base do
     it 'responds to sortable_attributes' do
       expect(subject.sortable_attributes)
         .to eq(
-                'id' => 'ASC',
-                'first_name' => 'ASC',
-                'last_name' => 'ASC',
-                'birthdate' => 'DESC'
-              )
+          'id' => 'ASC',
+          'first_name' => 'ASC',
+          'last_name' => 'ASC',
+          'birthdate' => 'DESC'
+        )
     end
 
     it 'responds to default_sort' do
@@ -42,11 +42,11 @@ describe Common::Base do
     it 'responds to filterable_attributes' do
       expect(subject.filterable_attributes)
         .to eq(
-                'id' => %w(eq not_eq),
-                'first_name' => %w(eq not_eq match),
-                'last_name' => %w(eq not_eq match),
-                'birthdate' => %w(eq lteq gteq not_eq)
-              )
+          'id' => %w(eq not_eq),
+          'first_name' => %w(eq not_eq match),
+          'last_name' => %w(eq not_eq match),
+          'birthdate' => %w(eq lteq gteq not_eq)
+        )
     end
   end
 
@@ -58,13 +58,13 @@ describe Common::Base do
       expect(subject.first_name).to eq('Jill')
       expect(subject.last_name).to eq('')
       expect(subject.birthdate).to be_nil
-      expect(subject.zipcode).to eq(20001)
+      expect(subject.zipcode).to eq(20_001)
     end
 
     it 'responds to attributes, to_h, and, to_hash' do
       expect(subject.attributes).to eq(subject.to_h)
       expect(subject.attributes).to eq(subject.to_hash)
-      expect(subject.attributes).to eq(id: 1, first_name: 'Jill', last_name: '', birthdate: nil, zipcode: 20001)
+      expect(subject.attributes).to eq(id: 1, first_name: 'Jill', last_name: '', birthdate: nil, zipcode: 20_001)
     end
 
     it 'identifies if values are changed?' do
@@ -74,7 +74,7 @@ describe Common::Base do
       subject.first_name = 'Jack'
       expect(subject.changed?).to eq(true)
       expect(subject.changed).to eq([:first_name])
-      expect(subject.changes).to eq({first_name: %w(Jill Jack)})
+      expect(subject.changes).to eq(first_name: %w(Jill Jack))
     end
   end
 end

--- a/spec/lib/common/models/collection_spec.rb
+++ b/spec/lib/common/models/collection_spec.rb
@@ -2,20 +2,9 @@
 require 'rails_helper'
 require 'common/models/base'
 require 'common/models/collection'
+require 'support/author'
 
 describe Common::Collection do
-  class Author < Common::Base
-    attribute :id, Integer, sortable: { order: 'ASC' }, filterable: %w(eq not_eq)
-    attribute :first_name, String, sortable: { order: 'ASC' }, filterable: %w(eq not_eq match)
-    attribute :last_name, String, sortable: { order: 'ASC' }, filterable: %w(eq not_eq match)
-    attribute :birthdate, Common::UTCTime, sortable: { order: 'DESC' }, filterable: %w(eq lteq gteq not_eq)
-    attribute :zipcode, Integer
-
-    def <=>(other)
-      name <=> other.name
-    end
-  end
-
   let(:klass)       { Author }
   let(:klass_array) { Array.new(25) { |i| attributes_for(:author, id: i + 1) } }
   subject { described_class.new(klass, data: klass_array, metadata: { nobel_winner: 'Bob Dylan' }, errors: {}) }

--- a/spec/support/author.rb
+++ b/spec/support/author.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'common/models/base'
+
+class Author < Common::Base
+  per_page 20
+  max_per_page 1000
+
+  attribute :id, Integer, sortable: { order: 'ASC' }, filterable: %w(eq not_eq)
+  attribute :first_name, String, sortable: { order: 'ASC', default: true }, filterable: %w(eq not_eq match)
+  attribute :last_name, String, sortable: { order: 'ASC' }, filterable: %w(eq not_eq match)
+  attribute :birthdate, Common::UTCTime, sortable: { order: 'DESC' }, filterable: %w(eq lteq gteq not_eq)
+  attribute :zipcode, Integer
+
+  def <=>(other)
+    first_name <=> other.first_name
+  end
+end


### PR DESCRIPTION
This begins to fix the issue with attributes not automatically updating in lib/common/models/base.rb

However, I'd also like to remove the automatic snakecasing of attributes that was previously taking place. I do not believe this is a responsibility for this model. It should happen prior to lib/common/models/base.rb being used, perhaps in a Faraday::Middleware similar to the one that Rx and Sm use to snakecase keys.