### PR TITLE
Use dogstats format for statsd tags

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -3,7 +3,7 @@ host = ENV['STATSD_HOST']
 port = ENV['STATSD_PORT']
 
 StatsD.backend = if host.present? && port.present?
-                   StatsD::Instrument::Backends::UDPBackend.new("#{host}:#{port}", :statsd)
+                   StatsD::Instrument::Backends::UDPBackend.new("#{host}:#{port}", :datadog)
                  else
                    StatsD::Instrument::Backends::LoggerBackend.new(Rails.logger)
                  end

--- a/lib/statsd_middleware.rb
+++ b/lib/statsd_middleware.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class StatsdMiddleware
-  STATUS_KEY   = "api.rack.request"
-  DURATION_KEY = "api.rack.request.duration"
+  STATUS_KEY   = 'api.rack.request'
+  DURATION_KEY = 'api.rack.request.duration'
 
   def initialize(app)
     @app = app

--- a/spec/request/statsd_middleware_spec.rb
+++ b/spec/request/statsd_middleware_spec.rb
@@ -29,31 +29,31 @@ RSpec.describe StatsdMiddleware, type: :request do
 
   it 'sends status data to statsd' do
     stub_varx_request(:get, 'mhv-api/patient/v1/prescription/gethistoryrx', history_rxs, status_code: 200)
-    key = 'api.rack.request#status=200,controller=v0/prescriptions,action=index'
+    tags = %w(controller:v0/prescriptions action:index status:200)
     expect do
       get '/v0/prescriptions'
-    end.to trigger_statsd_increment(key, times: 1, value: 1)
+    end.to trigger_statsd_increment(StatsdMiddleware::STATUS_KEY, tags: tags, times: 1, value: 1)
   end
 
   it 'sends duration data to statsd' do
     stub_varx_request(:get, 'mhv-api/patient/v1/prescription/gethistoryrx', history_rxs, status_code: 200)
-    key = 'api.rack.request.duration#controller=v0/prescriptions,action=index'
+    tags = %w(controller:v0/prescriptions action:index)
     expect do
       get '/v0/prescriptions'
-    end.to trigger_statsd_measure(key, times: 1, value: 0.0)
+    end.to trigger_statsd_measure(StatsdMiddleware::DURATION_KEY, tags: tags, times: 1, value: 0.0)
   end
 
   it 'handles a missing route correctly' do
-    key = 'api.rack.request#status=404,controller=application,action=routing_error'
+    tags = %w(controller:application action:routing_error status:404)
     expect do
       get '/v0/blahblah'
-    end.to trigger_statsd_increment(key, times: 1, value: 1)
+    end.to trigger_statsd_increment(StatsdMiddleware::STATUS_KEY, tags: tags, times: 1, value: 1)
   end
 
   it 'provides duration for missing routes' do
-    key = 'api.rack.request.duration#controller=application,action=routing_error'
+    tags = %w(controller:application action:routing_error)
     expect do
       get '/v0/blahblah'
-    end.to trigger_statsd_measure(key, times: 1, value: 0.0)
+    end.to trigger_statsd_measure(StatsdMiddleware::DURATION_KEY, tags: tags, times: 1, value: 0.0)
   end
 end


### PR DESCRIPTION
Required format (https://github.com/prometheus/statsd_exporter#dogstatsd-extensions) includes an additional "|" modifier before the key value pairs. Current implementation doesn't send a format that the prometheus statsd exporter understands as dogstatsd compatible, so we end up with:

<img width="675" alt="screen shot 2016-11-19 at 8 17 56 pm" src="https://cloud.githubusercontent.com/assets/215266/20460081/47c4dca4-ae95-11e6-8a3b-9f021f38d62b.png">

This PR sets up the statsd-instrument client with dogstatsd support and modifies the StatsdMiddleware to utilize the tags feature.