### PR TITLE
allow mvi queries if gender is nil (dslogon users)

### DIFF
--- a/app/models/mvi.rb
+++ b/app/models/mvi.rb
@@ -70,7 +70,7 @@ class Mvi < Common::RedisStore
 
   def mvi_response
     return nil unless @user.loa3?
-    response || query_and_cache_response
+    @memoized_response ||= response || query_and_cache_response
   end
 
   def mvi_service

--- a/app/models/mvi.rb
+++ b/app/models/mvi.rb
@@ -78,7 +78,7 @@ class Mvi < Common::RedisStore
   end
 
   def create_message
-    raise Common::Exceptions::ValidationErrors, @user unless @user.valid?(:loa3?)
+    raise Common::Exceptions::ValidationErrors, @user unless @user.valid?(:loa3_user)
     given_names = [@user.first_name]
     given_names.push @user.middle_name unless @user.middle_name.nil?
     MVI::Messages::FindCandidateMessage.new(

--- a/app/models/mvi.rb
+++ b/app/models/mvi.rb
@@ -42,6 +42,7 @@ class Mvi < Common::RedisStore
   def va_profile
     return { status: 'NOT_AUTHORIZED' } unless @user.loa3?
     response = mvi_response
+    return { status: 'SERVER_ERROR' } unless response
     return response unless response[:status] == MVI_RESPONSE_STATUS[:ok]
     {
       status: response[:status],
@@ -68,7 +69,7 @@ class Mvi < Common::RedisStore
   end
 
   def mvi_response
-    return nil unless @user.loa3? && !user.gender.nil?
+    return nil unless @user.loa3?
     response || query_and_cache_response
   end
 
@@ -77,7 +78,7 @@ class Mvi < Common::RedisStore
   end
 
   def create_message
-    raise Common::Exceptions::ValidationErrors, @user unless @user.valid?
+    raise Common::Exceptions::ValidationErrors, @user unless @user.valid?(:loa3?)
     given_names = [@user.first_name]
     given_names.push @user.middle_name unless @user.middle_name.nil?
     MVI::Messages::FindCandidateMessage.new(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < Common::RedisStore
   validates :loa, presence: true
 
   # conditionally validate if user is LOA3
-  with_options unless: :loa1? do |user|
+  with_options(on: :loa3_user) do |user|
     user.validates :first_name, presence: true
     user.validates :last_name, presence: true
     user.validates :birth_date, presence: true

--- a/lib/mvi/messages/find_candidate_message.rb
+++ b/lib/mvi/messages/find_candidate_message.rb
@@ -75,7 +75,7 @@ module MVI
 
       def build_parameter_list
         el = element('parameterList')
-        el << build_gender unless @gender.nil?
+        el << build_gender unless @gender.blank?
         el << build_living_subject_birth_time
         el << build_living_subject_id
         el << build_living_subject_name

--- a/lib/mvi/messages/find_candidate_message.rb
+++ b/lib/mvi/messages/find_candidate_message.rb
@@ -75,7 +75,7 @@ module MVI
 
       def build_parameter_list
         el = element('parameterList')
-        el << build_gender
+        el << build_gender unless @gender.nil?
         el << build_living_subject_birth_time
         el << build_living_subject_id
         el << build_living_subject_name

--- a/spec/lib/mvi/messages/find_candidate_message_spec.rb
+++ b/spec/lib/mvi/messages/find_candidate_message_spec.rb
@@ -73,6 +73,28 @@ describe MVI::Messages::FindCandidateMessage do
       end
     end
 
+    context 'with nil gender' do
+      let(:xml) do
+        MVI::Messages::FindCandidateMessage.new(
+          %w(John William), 'Smith', '1980-1-1', '555-44-3333', nil
+        ).to_xml
+      end
+      let(:idm_path) { 'env:Body/idm:PRPA_IN201305UV02' }
+      let(:parameter_list_path) { "#{idm_path}/controlActProcess/queryByParameter/parameterList" }
+
+      it 'does not have a gender node' do
+        expect(xml).to eq_at_path("#{parameter_list_path}/livingSubjectAdministrativeGender/value/@code", nil)
+      end
+
+      it 'has the correct query parameter order' do
+        parsed_xml = Ox.parse(xml)
+        nodes = parsed_xml.locate(parameter_list_path).first.nodes
+        expect(nodes[0].value).to eq('livingSubjectBirthTime')
+        expect(nodes[1].value).to eq('livingSubjectId')
+        expect(nodes[2].value).to eq('livingSubjectName')
+      end
+    end
+
     context 'missing arguments' do
       it 'should throw an argument error' do
         expect do

--- a/spec/models/mvi_spec.rb
+++ b/spec/models/mvi_spec.rb
@@ -77,9 +77,10 @@ describe Mvi, skip_mvi: true do
     end
 
     context 'when there is cached data' do
-      let(:user) { FactoryGirl.build(:loa3_user, gender: nil) }
-      let(:mvi) { Mvi.from_user(user) }
-      it 'returns nil' do
+      it 'returns the cached data' do
+        mvi.response = find_candidate_response.merge(status: 'OK')
+        mvi.save
+        expect_any_instance_of(MVI::Service).to_not receive(:find_candidate)
         expect(mvi.va_profile).to eq(
           active_status: 'active',
           birth_date: '19800101',

--- a/spec/models/mvi_spec.rb
+++ b/spec/models/mvi_spec.rb
@@ -77,10 +77,9 @@ describe Mvi, skip_mvi: true do
     end
 
     context 'when there is cached data' do
-      it 'returns the cached data' do
-        mvi.response = find_candidate_response.merge(status: 'OK')
-        mvi.save
-        expect_any_instance_of(MVI::Service).to_not receive(:find_candidate)
+      let(:user) { FactoryGirl.build(:loa3_user, gender: nil) }
+      let(:mvi) { Mvi.from_user(user) }
+      it 'returns nil' do
         expect(mvi.va_profile).to eq(
           active_status: 'active',
           birth_date: '19800101',

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,52 +41,52 @@ RSpec.describe User, type: :model do
       subject(:loa3_user) { described_class.new(FactoryGirl.build(:user, loa: loa_three)) }
       it 'should not allow a blank ssn' do
         loa3_user.ssn = ''
-        expect(loa3_user.valid?).to be_falsey
+        expect(loa3_user.valid?(:loa3_user)).to be_falsey
         expect(loa3_user.errors[:ssn].size).to be_positive
       end
       it 'should not allow a blank first_name' do
         loa3_user.first_name = ''
-        expect(loa3_user.valid?).to be_falsey
+        expect(loa3_user.valid?(:loa3_user)).to be_falsey
         expect(loa3_user.errors[:first_name].size).to be_positive
       end
       it 'should not allow a blank last_name' do
         loa3_user.last_name = ''
-        expect(loa3_user.valid?).to be_falsey
+        expect(loa3_user.valid?(:loa3_user)).to be_falsey
         expect(loa3_user.errors[:last_name].size).to be_positive
       end
       it 'should not allow a blank birth_date' do
         loa3_user.birth_date = ''
-        expect(loa3_user.valid?).to be_falsey
+        expect(loa3_user.valid?(:loa3_user)).to be_falsey
         expect(loa3_user.errors[:birth_date].size).to be_positive
       end
       it 'should allow a blank gender' do
         loa3_user.gender = ''
-        expect(loa3_user.valid?).to be_truthy
+        expect(loa3_user.valid?(:loa3_user)).to be_truthy
         expect(loa3_user.errors[:gender].size).to eq(0)
       end
       it 'should allow a nil gender' do
         loa3_user.gender = nil
-        expect(loa3_user.valid?).to be_truthy
+        expect(loa3_user.valid?(:loa3_user)).to be_truthy
         expect(loa3_user.errors[:gender].size).to eq(0)
       end
       it 'should not allow a gender other than M or F' do
         loa3_user.gender = 'male'
-        expect(loa3_user.valid?).to be_falsey
+        expect(loa3_user.valid?(:loa3_user)).to be_falsey
         expect(loa3_user.errors[:gender].size).to be_positive
         loa3_user.gender = 'female'
-        expect(loa3_user.valid?).to be_falsey
+        expect(loa3_user.valid?(:loa3_user)).to be_falsey
         expect(loa3_user.errors[:gender].size).to be_positive
         loa3_user.gender = 'Z'
-        expect(loa3_user.valid?).to be_falsey
+        expect(loa3_user.valid?(:loa3_user)).to be_falsey
         expect(loa3_user.errors[:gender].size).to be_positive
       end
       it 'should allow a gender of M' do
         loa3_user.gender = 'M'
-        expect(loa3_user.valid?).to be_truthy
+        expect(loa3_user.valid?(:loa3_user)).to be_truthy
       end
       it 'should allow a gender of F' do
         loa3_user.gender = 'F'
-        expect(loa3_user.valid?).to be_truthy
+        expect(loa3_user.valid?(:loa3_user)).to be_truthy
       end
     end
   end
@@ -95,7 +95,7 @@ RSpec.describe User, type: :model do
   context 'with an invalid ssn' do
     it 'should have an error on ssn' do
       subject.ssn = '111-22-3333'
-      expect(subject.valid?).to be_falsey
+      expect(subject.valid?(:loa3_user)).to be_falsey
       expect(subject.errors[:ssn].size).to eq(1)
     end
   end

--- a/spec/support/vcr_cassettes/mvi/find_candidate/valid_no_gender.yml
+++ b/spec/support/vcr_cassettes/mvi/find_candidate/valid_no_gender.yml
@@ -1,0 +1,148 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<MVI_URL>"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        CjxlbnY6RW52ZWxvcGUgeG1sbnM6c29hcGVuYz0iaHR0cDovL3NjaGVtYXMu
+        eG1sc29hcC5vcmcvc29hcC9lbmNvZGluZy8iIHhtbG5zOnhzZD0iaHR0cDov
+        L3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiIHhtbG5zOmVudj0iaHR0cDov
+        L3NjaGVtYXMueG1sc29hcC5vcmcvc29hcC9lbnZlbG9wZS8iIHhtbG5zOnhz
+        aT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2Ui
+        PgogIDxlbnY6SGVhZGVyLz4KICA8ZW52OkJvZHk+CiAgICA8aWRtOlBSUEFf
+        SU4yMDEzMDVVVjAyIHhtbG5zOmlkbT0iaHR0cDovL3Zhd3cub2VkLm9pdC52
+        YS5nb3YiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxT
+        Y2hlbWHigJBpbnN0YW5jZSIgeHNpOnNjaGVtYUxvY2F0aW9uPSJ1cm46aGw3
+        4oCQb3JnOnYzIC4uLy4uL3NjaGVtYS9ITDdWMy9ORTIwMDgvbXVsdGljYWNo
+        ZXNjaGVtYXMvUFJQQV9JTjIwMTMwNVVWMDIueHNkIiB4bWxucz0idXJuOmhs
+        N+KAkG9yZzp2MyIgSVRTVmVyc2lvbj0iWE1MXzEuMCI+CiAgICAgIDxpZCBy
+        b290PSIxLjIuODQwLjExNDM1MC4xLjEzLjAuMS43LjEuMSIgZXh0ZW5zaW9u
+        PSIyMDBWR09WLTRhNWUxYTlmLTk3NTMtNDU3MC05MjUzLTllYjIwMGFmYjhm
+        MCIvPgogICAgICA8Y3JlYXRpb25UaW1lIHZhbHVlPSIyMDE2MTEyMjE3MTA0
+        NCIvPgogICAgICA8dmVyc2lvbkNvZGUgY29kZT0iMy4wIi8+CiAgICAgIDxp
+        bnRlcmFjdGlvbklkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjEuNiIgZXh0
+        ZW5zaW9uPSJQUlBBX0lOMjAxMzA1VVYwMiIvPgogICAgICA8cHJvY2Vzc2lu
+        Z0NvZGUgY29kZT0iVCIvPgogICAgICA8cHJvY2Vzc2luZ01vZGVDb2RlIGNv
+        ZGU9IlQiLz4KICAgICAgPGFjY2VwdEFja0NvZGUgY29kZT0iQUwiLz4KICAg
+        ICAgPHJlY2VpdmVyIHR5cGVDb2RlPSJSQ1YiPgogICAgICAgIDxkZXZpY2Ug
+        Y2xhc3NDb2RlPSJERVYiIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAg
+        ICAgICAgICA8aWQgcm9vdD0iMS4yLjg0MC4xMTQzNTAuMS4xMy45OTkuMjM0
+        IiBleHRlbnNpb249IjIwME0iLz4KICAgICAgICA8L2RldmljZT4KICAgICAg
+        PC9yZWNlaXZlcj4KICAgICAgPHNlbmRlciB0eXBlQ29kZT0iU05EIj4KICAg
+        ICAgICA8ZGV2aWNlIGNsYXNzQ29kZT0iREVWIiBkZXRlcm1pbmVyQ29kZT0i
+        SU5TVEFOQ0UiPgogICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEz
+        ODgzLjQuMzQ5IiBleHRlbnNpb249IjIwMFZHT1YiLz4KICAgICAgICA8L2Rl
+        dmljZT4KICAgICAgPC9zZW5kZXI+CiAgICAgIDxjb250cm9sQWN0UHJvY2Vz
+        cyBjbGFzc0NvZGU9IkNBQ1QiIG1vb2RDb2RlPSJFVk4iPgogICAgICAgIDxj
+        b2RlIGNvZGU9IlBSUEFfVEUyMDEzMDVVVjAyIiBjb2RlU3lzdGVtPSIyLjE2
+        Ljg0MC4xLjExMzg4My4xLjYiLz4KICAgICAgICA8ZGF0YUVudGVyZXIgdHlw
+        ZUNvZGU9IkVOVCIgY29udGV4dENvbnRyb2xDb2RlPSJBUCI+CiAgICAgICAg
+        ICA8YXNzaWduZWRQZXJzb24gY2xhc3NDb2RlPSJBU1NJR05FRCI+CiAgICAg
+        ICAgICAgIDxpZCBleHRlbnNpb249Ijc5NjEyMjMwNiIgcm9vdD0iMi4xNi44
+        NDAuMS4xMTM4ODMuNzc3Ljk5OSIvPgogICAgICAgICAgICA8YXNzaWduZWRQ
+        ZXJzb24gY2xhc3NDb2RlPSJQU04iIGRldGVybWluZXJDb2RlPSJJTlNUQU5D
+        RSI+CiAgICAgICAgICAgICAgPG5hbWU+CiAgICAgICAgICAgICAgICA8Z2l2
+        ZW4+TWl0Y2hlbGw8L2dpdmVuPgogICAgICAgICAgICAgICAgPGdpdmVuPkc8
+        L2dpdmVuPgogICAgICAgICAgICAgICAgPGZhbWlseT5KZW5raW5zPC9mYW1p
+        bHk+CiAgICAgICAgICAgICAgPC9uYW1lPgogICAgICAgICAgICA8L2Fzc2ln
+        bmVkUGVyc29uPgogICAgICAgICAgPC9hc3NpZ25lZFBlcnNvbj4KICAgICAg
+        ICA8L2RhdGFFbnRlcmVyPgogICAgICAgIDxxdWVyeUJ5UGFyYW1ldGVyPgog
+        ICAgICAgICAgPHF1ZXJ5SWQgcm9vdD0iMS4yLjg0MC4xMTQzNTAuMS4xMy4y
+        OC4xLjE4LjUuOTk5IiBleHRlbnNpb249IjE4MjA0Ii8+CiAgICAgICAgICA8
+        c3RhdHVzQ29kZSBjb2RlPSJuZXciLz4KICAgICAgICAgIDxtb2RpZnlDb2Rl
+        IGNvZGU9Ik1WSS5DT01QMSIvPgogICAgICAgICAgPGluaXRpYWxRdWFudGl0
+        eSB2YWx1ZT0iMSIvPgogICAgICAgICAgPHBhcmFtZXRlckxpc3Q+CiAgICAg
+        ICAgICAgIDxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPgogICAgICAgICAgICAg
+        IDx2YWx1ZSB2YWx1ZT0iMTk0OTAzMDQiLz4KICAgICAgICAgICAgICA8c2Vt
+        YW50aWNzVGV4dD5EYXRlIG9mIEJpcnRoPC9zZW1hbnRpY3NUZXh0PgogICAg
+        ICAgICAgICA8L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+CiAgICAgICAgICAg
+        IDxsaXZpbmdTdWJqZWN0SWQ+CiAgICAgICAgICAgICAgPHZhbHVlIHJvb3Q9
+        IjIuMTYuODQwLjEuMTEzODgzLjQuMSIgZXh0ZW5zaW9uPSI3OTYxMjIzMDYi
+        Lz4KICAgICAgICAgICAgICA8c2VtYW50aWNzVGV4dD5TU048L3NlbWFudGlj
+        c1RleHQ+CiAgICAgICAgICAgIDwvbGl2aW5nU3ViamVjdElkPgogICAgICAg
+        ICAgICA8bGl2aW5nU3ViamVjdE5hbWU+CiAgICAgICAgICAgICAgPHZhbHVl
+        IHVzZT0iTCI+CiAgICAgICAgICAgICAgICA8Z2l2ZW4+TWl0Y2hlbGw8L2dp
+        dmVuPgogICAgICAgICAgICAgICAgPGdpdmVuPkc8L2dpdmVuPgogICAgICAg
+        ICAgICAgICAgPGZhbWlseT5KZW5raW5zPC9mYW1pbHk+CiAgICAgICAgICAg
+        ICAgPC92YWx1ZT4KICAgICAgICAgICAgICA8c2VtYW50aWNzVGV4dD5MZWdh
+        bCBOYW1lPC9zZW1hbnRpY3NUZXh0PgogICAgICAgICAgICA8L2xpdmluZ1N1
+        YmplY3ROYW1lPgogICAgICAgICAgPC9wYXJhbWV0ZXJMaXN0PgogICAgICAg
+        IDwvcXVlcnlCeVBhcmFtZXRlcj4KICAgICAgPC9jb250cm9sQWN0UHJvY2Vz
+        cz4KICAgIDwvaWRtOlBSUEFfSU4yMDEzMDVVVjAyPgogIDwvZW52OkJvZHk+
+        CjwvZW52OkVudmVsb3BlPgo=
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Date:
+      - Tue, 22 Nov 2016 17:10:44 GMT
+      Content-Length:
+      - '2942'
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Soapaction:
+      - PRPA_IN201305UV02
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 22 Nov 2016 17:10:17 GMT
+      Content-Length:
+      - '3893'
+      Content-Type:
+      - text/xml
+      Set-Cookie:
+      - JSESSIONID=H7RLY07ZnFGvkySD5tnSZqkvyV2gtv3vm32x10y88m5wqYv3ZJy9!1048776870;
+        path=/; HttpOnly
+      X-Powered-By:
+      - Servlet/2.5 JSP/2.1
+    body:
+      encoding: UTF-8
+      string: <env:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><env:Header/><env:Body><idm:PRPA_IN201306UV02
+        xmlns="urn:hl7-org:v3" xmlns:idm="http://vaww.oed.oit.va.gov" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        ITSVersion="XML_1.0" xsi:schemaLocation="urn:hl7-org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/PRPA_IN201306UV02.xsd"><id
+        extension="WSDOC1611221110177780767377060" root="2.16.840.1.113883.4.349"/><creationTime
+        value="20161122111018"/><versionCode code="3.0"/><interactionId extension="PRPA_IN201306UV02"
+        root="2.16.840.1.113883.1.6"/><processingCode code="T"/><processingModeCode
+        code="T"/><acceptAckCode code="NE"/><receiver typeCode="RCV"><device determinerCode="INSTANCE"
+        classCode="DEV"><id extension="200VGOV" root="2.16.840.1.113883.4.349"/></device></receiver><sender
+        typeCode="SND"><device determinerCode="INSTANCE" classCode="DEV"><id extension="200M"
+        root="2.16.840.1.113883.4.349"/></device></sender><acknowledgement><typeCode
+        code="AA"/><targetMessage><id extension="200VGOV-4a5e1a9f-9753-4570-9253-9eb200afb8f0"
+        root="1.2.840.114350.1.13.0.1.7.1.1"/></targetMessage><acknowledgementDetail><code
+        codeSystemName="MVI" code="132" displayName="IMT"/><text>Identity Match Threshold</text></acknowledgementDetail><acknowledgementDetail><code
+        codeSystemName="MVI" code="120" displayName="PDT"/><text>Potential Duplicate
+        Threshold</text></acknowledgementDetail></acknowledgement><controlActProcess
+        classCode="CACT" moodCode="EVN"><code codeSystem="2.16.840.1.113883.1.6" code="PRPA_TE201306UV02"/><subject
+        typeCode="SUBJ"><registrationEvent classCode="REG" moodCode="EVN"><id nullFlavor="NA"/><statusCode
+        code="active"/><subject1 typeCode="SBJ"><patient classCode="PAT"><id extension="1008714701V416111^NI^200M^USVHA^P"
+        root="2.16.840.1.113883.4.349"/><id extension="796122306^PI^200BRLS^USVBA^A"
+        root="2.16.840.1.113883.4.349"/><id extension="9100792239^PI^200CORP^USVBA^A"
+        root="2.16.840.1.113883.4.349"/><statusCode code="active"/><patientPerson><name
+        use="L"><given>MITCHELL</given><given>G</given><family>JENKINS</family></name><administrativeGenderCode
+        code="M"/><birthTime value="19490304"/><addr use="PHYS"><streetAddressLine>121
+        A St</streetAddressLine><city>Austin</city><state>TX</state><postalCode>78772</postalCode><country>USA</country></addr><asOtherIDs
+        classCode="SSN"><id extension="796122306" root="2.16.840.1.113883.4.1"/><scopingOrganization
+        determinerCode="INSTANCE" classCode="ORG"><id root="1.2.840.114350.1.13.99997.2.3412"/></scopingOrganization></asOtherIDs></patientPerson><subjectOf1><queryMatchObservation
+        classCode="COND" moodCode="EVN"><code code="IHE_PDQ"/><value value="166" xsi:type="INT"/></queryMatchObservation></subjectOf1></patient></subject1><custodian
+        typeCode="CST"><assignedEntity classCode="ASSIGNED"><id root="2.16.840.1.113883.4.349"/></assignedEntity></custodian></registrationEvent></subject><queryAck><queryId
+        extension="18204" root="1.2.840.114350.1.13.28.1.18.5.999"/><queryResponseCode
+        code="OK"/><resultCurrentQuantity value="1"/></queryAck><queryByParameter><queryId
+        extension="18204" root="1.2.840.114350.1.13.28.1.18.5.999"/><statusCode code="new"/><modifyCode
+        code="MVI.COMP1"/><initialQuantity value="1"/><parameterList><livingSubjectBirthTime><value
+        value="19490304"/><semanticsText>Date of Birth</semanticsText></livingSubjectBirthTime><livingSubjectId><value
+        extension="796122306" root="2.16.840.1.113883.4.1"/><semanticsText>SSN</semanticsText></livingSubjectId><livingSubjectName><value
+        use="L"><given>Mitchell</given><given>G</given><family>Jenkins</family></value><semanticsText>Legal
+        Name</semanticsText></livingSubjectName></parameterList></queryByParameter></controlActProcess></idm:PRPA_IN201306UV02></env:Body></env:Envelope>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 17:10:45 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets-api/issues/564, in tests some users are found without gender, but MVI team lists it as a required field.