### PR TITLE
Shorten user store expiration

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -31,6 +31,10 @@ module V0
         async_create_evss_account(@current_user)
         redirect_to SAML_CONFIG['relay'] + '?token=' + @session.token
       else
+        logger.warn "Authentication attempt did not succeed in saml_callback, reasons..."
+        logger.warn "  SAML Response: valid?=#{@saml_response.is_valid?} errors=#{@saml_response.errors}"
+        logger.warn "  User: valid?=#{@current_user&.valid?} errors=#{@current_user&.errors&.messages}"
+        logger.warn "  Session: valid?=#{@session&.valid?} errors=#{@session&.errors&.messages}"
         redirect_to SAML_CONFIG['relay'] + '?auth=fail'
       end
     end

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -31,7 +31,7 @@ module V0
         async_create_evss_account(@current_user)
         redirect_to SAML_CONFIG['relay'] + '?token=' + @session.token
       else
-        logger.warn "Authentication attempt did not succeed in saml_callback, reasons..."
+        logger.warn 'Authentication attempt did not succeed in saml_callback, reasons...'
         logger.warn "  SAML Response: valid?=#{@saml_response.is_valid?} errors=#{@saml_response.errors}"
         logger.warn "  User: valid?=#{@current_user&.valid?} errors=#{@current_user&.errors&.messages}"
         logger.warn "  Session: valid?=#{@session&.valid?} errors=#{@session&.errors&.messages}"
@@ -44,7 +44,7 @@ module V0
     def persist_session_and_user
       @session = Session.new(user_attributes.slice(:uuid))
       @current_user = User.find(@session.uuid)
-      @current_user = (@current_user.nil?) ? saml_user : User.from_merged_attrs(@current_user, saml_user)
+      @current_user = @current_user.nil? ? saml_user : User.from_merged_attrs(@current_user, saml_user)
       @session.save && @current_user.save
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,7 @@ class User < Common::RedisStore
   end
 
   def self.from_merged_attrs(existing_user, new_user)
+    # we want to always use the more recent attrs so long as they exist
     attrs = new_user.attributes.map do |key, val|
       if val.blank?
         { key => existing_user[key] }
@@ -76,6 +77,7 @@ class User < Common::RedisStore
       end
     end.reduce Hash.new, :merge
 
+    # for loa, we want the higher of the two
     attrs[:loa][:current] = [existing_user[:loa][:current], new_user[:loa][:current]].max
     attrs[:loa][:highest] = [existing_user[:loa][:highest], new_user[:loa][:highest]].max
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,7 +78,6 @@ class User < Common::RedisStore
     end.reduce({}, :merge)
 
     # for loa, we want the higher of the two
-    byebug
     attrs[:loa][:current] = [existing_user[:loa][:current], new_user[:loa][:current]].max
     attrs[:loa][:highest] = [existing_user[:loa][:highest], new_user[:loa][:highest]].max
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,9 +75,10 @@ class User < Common::RedisStore
       else
         { key => val }
       end
-    end.reduce Hash.new, :merge
+    end.reduce({}, :merge)
 
     # for loa, we want the higher of the two
+    byebug
     attrs[:loa][:current] = [existing_user[:loa][:current], new_user[:loa][:current]].max
     attrs[:loa][:highest] = [existing_user[:loa][:highest], new_user[:loa][:highest]].max
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,6 +67,21 @@ class User < Common::RedisStore
     edipi.present? && ssn.present? && participant_id.present?
   end
 
+  def self.from_merged_attrs(existing_user, new_user)
+    attrs = new_user.attributes.map do |key, val|
+      if val.blank?
+        { key => existing_user[key] }
+      else
+        { key => val }
+      end
+    end.reduce Hash.new, :merge
+
+    attrs[:loa][:current] = [existing_user[:loa][:current], new_user[:loa][:current]].max
+    attrs[:loa][:highest] = [existing_user[:loa][:highest], new_user[:loa][:highest]].max
+
+    User.new(attrs)
+  end
+
   delegate :edipi, to: :mvi
   delegate :icn, to: :mvi
   delegate :mhv_correlation_id, to: :mvi

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,11 +70,7 @@ class User < Common::RedisStore
   def self.from_merged_attrs(existing_user, new_user)
     # we want to always use the more recent attrs so long as they exist
     attrs = new_user.attributes.map do |key, val|
-      if val.blank?
-        { key => existing_user[key] }
-      else
-        { key => val }
-      end
+      { key => val.presence || existing_user[key] }
     end.reduce({}, :merge)
 
     # for loa, we want the higher of the two

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -13,7 +13,7 @@ development: &defaults
     each_ttl: 1200
   user_store:
     namespace: users
-    each_ttl: 86400
+    each_ttl: 3600
   mvi_store:
     namespace: mvi-service
     each_ttl: 86400

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -44,7 +44,7 @@ FactoryGirl.define do
     last_name 'lincoln'
     gender 'M'
     birth_date Time.new(1809, 2, 12).utc
-    ssn '272111863'
+    ssn '272111864'
     loa do
       {
         current: LOA::THREE,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,6 +5,32 @@ RSpec.describe User, type: :model do
   let(:loa_one) { { current: LOA::ONE } }
   let(:loa_three) { { current: LOA::THREE } }
 
+  describe '.from_merged_attrs()' do
+    subject(:loa1_user) { build(:loa1_user) }
+    subject(:loa3_user) { build(:loa3_user) }
+    it 'should not down-level' do
+      user = described_class.from_merged_attrs(loa3_user, loa1_user)
+      expect(user.loa[:current]).to eq(loa3_user.loa[:current])
+      expect(user.loa[:highest]).to eq(loa3_user.loa[:highest])
+      expect(user).to be_valid
+    end
+    it 'should up-level' do
+      user = described_class.from_merged_attrs(loa1_user, loa3_user)
+      expect(user.loa[:current]).to eq(loa3_user.loa[:current])
+      expect(user.loa[:highest]).to eq(loa3_user.loa[:highest])
+      expect(user).to be_valid
+    end
+    it 'should use newer attrs unless they are empty or nil' do
+      new_user = build(:loa1_user, first_name: 'George', last_name: 'Washington', gender: '', birth_date: nil)
+      user = described_class.from_merged_attrs(loa3_user, new_user)
+      expect(user.first_name).to eq('George')
+      expect(user.last_name).to eq('Washington')
+      expect(user.gender).to eq(loa3_user.gender)
+      expect(user.birth_date).to eq(loa3_user.birth_date)
+      expect(user.zip).to eq(loa3_user.zip)
+    end
+  end
+
   describe '.create()' do
     context 'with LOA 1' do
       subject(:loa1_user) { described_class.new(FactoryGirl.build(:user, loa: loa_one)) }


### PR DESCRIPTION
- shortened user-store Redis cache lifetime from 24 hours to 1 hour
- User model creation logic modified to always accept the newer attributes from ID.me over the old ones (except for `loa`)
- auth-failure warning logging to explain why the authentication failed

This addresses:
https://github.com/department-of-veterans-affairs/platform-team/issues/170