### PR TITLE
Fixes to handle some errors captured in Sentry

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,9 +8,11 @@ class ApplicationController < ActionController::API
   include ActionController::HttpAuthentication::Token::ControllerMethods
 
   SKIP_SENTRY_EXCEPTION_TYPES = [
-    Common::Exceptions::Unauthorized,
-    Common::Exceptions::RoutingError,
     Common::Exceptions::Forbidden,
+    Common::Exceptions::InvalidFieldValue,
+    Common::Exceptions::RoutingError,
+    Common::Exceptions::Unauthorized,
+    Common::Exceptions::ValidationErrors,
     Breakers::OutageException
   ].freeze
 

--- a/lib/common/models/collection.rb
+++ b/lib/common/models/collection.rb
@@ -31,7 +31,8 @@ module Common
       @attributes = data
       @metadata = metadata
       @errors = errors
-      (@data = data) && return if defined?(::WillPaginate::Collection) && data.is_a?(WillPaginate::Collection)
+      @data = data || []
+      return if defined?(::WillPaginate::Collection) && data.is_a?(WillPaginate::Collection)
       @data = data.collect do |element|
         element.is_a?(Hash) ? klass.new(element) : element
       end

--- a/lib/facilities/multi_client.rb
+++ b/lib/facilities/multi_client.rb
@@ -18,9 +18,14 @@ module Facilities
           Rails.logger.error "GIS request timed out: #{req.url}"
           raise Common::Exceptions::ClientError.new('Facility request timed out', {})
         end
-        raise Common::Client::Errors::BackendServiceError.new(req.response.code, {}) unless
-          req.response.success?
-        result = JSON.parse(req.response.body)
+        raise Common::Client::Errors::BackendServiceError.new(req.response.code, {}) unless req.response&.success?
+
+        begin
+          result = JSON.parse(req.response.body)
+        rescue JSON::ParserError
+          # What to raise here?
+        end
+
         if result['error']
           Rails.logger.error "GIS returned error: #{result['error']['code']}, message: #{result['error']['message']}"
           raise Common::Client::Errors::BackendServiceError.new(result['error']['code'], {})


### PR DESCRIPTION
* Add some more error types to skip Sentry for
* Handle the case where Collection gets a nil set of data
* Handle facilities multi_client getting a nil response
* Catch JSON::ParserError exceptions in multi_client

@saneshark on the last item here, what type of exception should it raise when the backend service returns bogus JSON?