### PR TITLE
temporarily add endpoint that triggers a 500 error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::API
 
   before_action :authenticate
   before_action :set_app_info_headers
-  skip_before_action :authenticate, only: [:cors_preflight, :routing_error]
+  skip_before_action :authenticate, only: [:cors_preflight, :routing_error, :raise_500]
 
   def cors_preflight
     head(:ok)
@@ -24,6 +24,10 @@ class ApplicationController < ActionController::API
 
   def routing_error
     raise Common::Exceptions::RoutingError, params[:path]
+  end
+
+  def raise_500
+    100/0
   end
 
   # I'm commenting this out for now, we can put it back in if we encounter it

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::API
   end
 
   def raise_500
-    100/0
+    100 / 0
   end
 
   # I'm commenting this out for now, we can put it back in if we encounter it

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,9 @@ Rails.application.routes.draw do
     mount Sidekiq::Web, at: '/sidekiq'
   end
 
+  # This is a temporary route that will be removed after testing
+  match 'v0/raise_500', to: 'application#raise_500', via: :get
+
   # This globs all unmatched routes and routes them as routing errors
   match '*path', to: 'application#routing_error', via: %i(get post put patch delete)
 end


### PR DESCRIPTION
This is a temporary thing to help @jkassemi with testing some stuff related to sentry.