### PR TITLE
Include HH:MM:SS in EDU Spool filenames

### DIFF
--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -43,7 +43,7 @@ module EducationForm
     def write_files(sftp: nil, structured_data:)
       structured_data.each do |region, records|
         region_id = EducationFacility.facility_for(region: region)
-        filename = "#{region_id}_#{Time.zone.today.strftime('%m%d%Y')}_vetsgov.spl"
+        filename = "#{region_id}_#{Time.zone.now.strftime('%m%d%Y_%H%M%S')}_vetsgov.spl"
         logger.info("Writing #{records.count} application(s) to #{filename}")
         # create the single textual spool file
         contents = records.map do |record|

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
           json = File.read(File.join(basepath, "#{application_name}.json"))
           expect(json).to match_vets_schema('education_benefits')
           application = EducationBenefitsClaim.new(form: json)
-          result = Timecop.freeze(Time.zone.parse('2016-10-06 03:00:00 EDT')) do
+          result = Timecop.freeze(Time.zone.parse('2016-10-06 03:02:01 EDT')) do
             subject.format_application(application.open_struct_form)
           end
           spl = File.read(File.join(basepath, "#{application_name}.spl"))
@@ -83,12 +83,12 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
 
   context 'create_files' do
     def perform_with_frozen_time
-      Timecop.freeze(Time.zone.parse('2016-09-16 03:00:00 EDT')) do
+      Timecop.freeze(Time.zone.parse('2016-09-16 03:02:01 EDT')) do
         subject.perform
       end
     end
 
-    let(:filename) { '307_09162016_vetsgov.spl' }
+    let(:filename) { '307_09162016_070201_vetsgov.spl' }
 
     context 'in the development env' do
       let(:file_path) { "tmp/spool_files/#{filename}" }


### PR DESCRIPTION
Including more than the day will allow us to run this job multiples times a day if needed, as in the case of manual re-submissions to different regional files.