### PR TITLE
Prevent NoMethodError in logs for 2nd+ SLO request

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -117,8 +117,10 @@ module V0
 
     def delete_session(token)
       session = Session.find(token)
-      User.find(session.uuid).destroy
-      session.destroy
+      unless session.nil?
+        User.find(session.uuid)&.destroy
+        session.destroy
+      end
     end
     # :nocov:
   end


### PR DESCRIPTION
The session may have already been destroyed, so now we safely attempt to destroy the session so as to not pollute the logs with `NoMethodError`.