### PR TITLE
Tag production logs with uuid

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::API
 
   before_action :authenticate
   before_action :set_app_info_headers
+  before_action :set_raven_uuid_tag
   skip_before_action :authenticate, only: [:cors_preflight, :routing_error]
 
   def cors_preflight
@@ -65,6 +66,10 @@ class ApplicationController < ActionController::API
     end
     Rails.logger.error "#{exception.message}."
     Rails.logger.error exception.backtrace.join("\n") unless exception.backtrace.nil?
+  end
+
+  def set_raven_uuid_tag
+    Raven.extra_context(request_uuid: request.uuid)
   end
 
   def set_app_info_headers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
+  config.log_tags = [:uuid]
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)


### PR DESCRIPTION
Because our cloudwatch logs are interleaved across all requests and servers, it can be difficult or impossible to trace which lines go with which request. This enables a uuid tag on each log line, giving us something to hang searches off of.

Example:
```
[1c3befef-f9cc-45a5-a531-701eb2115d02] Started GET "/" for ::1 at 2016-12-14 16:13:18 -0500
[1c3befef-f9cc-45a5-a531-701eb2115d02] Processing by V0::ExampleController#index as HTML
[1c3befef-f9cc-45a5-a531-701eb2115d02]   Parameters: {"module"=>"FILTERED"}
[1c3befef-f9cc-45a5-a531-701eb2115d02] [active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.06ms)
[1c3befef-f9cc-45a5-a531-701eb2115d02] Completed 200 OK in 1ms (Views: 0.4ms | ActiveRecord: 0.0ms)
[1c3befef-f9cc-45a5-a531-701eb2115d02] [StatsD] increment api.rack.request:1 #controller:v0/example #action:index #status:200
[1c3befef-f9cc-45a5-a531-701eb2115d02] [StatsD] measure api.rack.request.duration:1.343 #controller:v0/example #action:index
```