### PR TITLE
EVSS: Change systemName to EBN (Do not merge)

### DIFF
--- a/lib/evss/base_service.rb
+++ b/lib/evss/base_service.rb
@@ -3,7 +3,9 @@ require 'evss/error_middleware'
 
 module EVSS
   class BaseService
-    SYSTEM_NAME = 'vets.gov'
+    # System name changed per request of EVSS
+    # TODO: Change back to 'vets.gov' once they can accept it
+    SYSTEM_NAME = 'EBN'
     DEFAULT_TIMEOUT = 15 # in seconds
 
     def initialize(headers)

--- a/spec/support/vcr_cassettes/evss/claims/set_5103_waiver.yml
+++ b/spec/support/vcr_cassettes/evss/claims/set_5103_waiver.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: <EVSS_BASE_URL>/wss-claims-services-web-3.0/rest/vbaClaimStatusService/set5103Waiver
     body:
       encoding: UTF-8
-      string: '{"claimId":189625,"systemName":"vets.gov"}'
+      string: '{"claimId":189625,"systemName":"EBN"}'
     headers:
       User-Agent:
       - Faraday v0.9.2

--- a/spec/support/vcr_cassettes/evss/documents/upload.yml
+++ b/spec/support/vcr_cassettes/evss/documents/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: <EVSS_BASE_URL>/wss-document-services-web-3.0/rest/queuedDocumentUploadService/ajaxUploadFile?claimId=189625&docType=L023&docTypeDescription=Other%20Correspondence&qqfile=doctors-note.pdf&systemName=vets.gov&trackedItemIds=33
+    uri: <EVSS_BASE_URL>/wss-document-services-web-3.0/rest/queuedDocumentUploadService/ajaxUploadFile?claimId=189625&docType=L023&docTypeDescription=Other%20Correspondence&qqfile=doctors-note.pdf&systemName=EBN&trackedItemIds=33
     body:
       encoding: ASCII-8BIT
       string: !binary |-


### PR DESCRIPTION
Documents uploaded as 'vets.gov' aren't surfacing in eFolder, so we're temporarily changing the name.

Do not merge until we get the thumbs up from EVSS.