### PR TITLE
Don't validate submissions once we're about to send them

### DIFF
--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -62,7 +62,7 @@ module EducationForm
         end
 
         # mark the records as processed once the file has been written
-        records.each { |r| r.update_attributes!(processed_at: Time.zone.now) }
+        records.each { |r| r.update_attribute(:processed_at, Time.zone.now) }
       end
     end
 

--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -45,6 +45,7 @@ module EducationForm
         region_id = EducationFacility.facility_for(region: region)
         filename = "#{region_id}_#{Time.zone.today.strftime('%m%d%Y')}_vetsgov.spl"
         logger.info("Writing #{records.count} application(s) to #{filename}")
+        logger.info("IDs: #{records.map(&:id)}")
         # create the single textual spool file
         contents = records.map do |record|
           format_application(record.open_struct_form)


### PR DESCRIPTION
At this point in the process, we should have good confidence that the
submissions we get are valid and can be formatted and sent along. Switch
from `update_attributes`, which runs validations, to `update_attribute`,
which does not, but still runs the needed callbacks.