### PR TITLE
Cache SAML SLO Requests in Redis instead of using RelayState=token

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -12,7 +12,10 @@ module V0
       logout_request = OneLogin::RubySaml::Logoutrequest.new
       logger.info "New SP SLO for userid '#{@session.uuid}'"
 
-      render json: { logout_via_get: logout_request.create(saml_settings, RelayState: @session.token) }, status: 202
+      # cache the request for @session.token lookup when we receive the response
+      SingleLogoutRequest.create(uuid: logout_request.uuid, token: @session.token)
+
+      render json: { logout_via_get: logout_request.create(saml_settings) }, status: 202
     end
 
     def saml_logout_callback
@@ -60,6 +63,7 @@ module V0
     # :nocov:
     def handle_completed_slo
       logout_response = OneLogin::RubySaml::Logoutresponse.new(params[:SAMLResponse], saml_settings)
+      logout_request = SingleLogoutRequest.find(logout_response.in_response_to)
 
       logger.info "LogoutResponse is: #{logout_response}"
 
@@ -69,13 +73,14 @@ module V0
         redirect_to SAML_CONFIG['logout_relay'] + '?success=false'
       elsif logout_response.success?
         begin
-          session = Session.find(params[:RelayState])
+          session = Session.find(logout_request.token)
           user = User.find(session.uuid)
           MHVLoggingService.logout(user)
         rescue => e
           logger.error "Error in MHV Logout: #{e.message}"
         end
-        delete_session(params[:RelayState])
+        delete_session(logout_request.token)
+        logout_request.destroy
         redirect_to SAML_CONFIG['logout_relay'] + '?success=true'
       end
     end

--- a/app/models/single_logout_request.rb
+++ b/app/models/single_logout_request.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'common/models/redis_store'
+
+class SingleLogoutRequest < Common::RedisStore
+  redis_store REDIS_CONFIG['saml_store']['namespace']
+  redis_ttl REDIS_CONFIG['saml_store']['each_ttl']
+  redis_key :uuid
+
+  attribute :uuid
+  attribute :token
+
+  validates :uuid, presence: true
+  validates :token, presence: true
+end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -17,6 +17,9 @@ development: &defaults
   mvi_store:
     namespace: mvi-service
     each_ttl: 86400
+  saml_store:
+    namespace: single-logout-request
+    each_ttl: 3600
 
 test:
   <<: *defaults

--- a/spec/models/single_logout_request_spec.rb
+++ b/spec/models/single_logout_request_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SingleLogoutRequest, type: :model do
+  it 'requires the precense of token' do
+    slr = SingleLogoutRequest.new(uuid: '1234')
+    expect(slr).to be_invalid
+  end
+  it 'requires the precense of uuid' do
+    slr = SingleLogoutRequest.new(token: '1234')
+    expect(slr).to be_invalid
+  end
+end

--- a/spec/models/single_logout_request_spec.rb
+++ b/spec/models/single_logout_request_spec.rb
@@ -2,11 +2,11 @@
 require 'rails_helper'
 
 RSpec.describe SingleLogoutRequest, type: :model do
-  it 'requires the precense of token' do
+  it 'requires the presence of token' do
     slr = SingleLogoutRequest.new(uuid: '1234')
     expect(slr).to be_invalid
   end
-  it 'requires the precense of uuid' do
+  it 'requires the presence of uuid' do
     slr = SingleLogoutRequest.new(token: '1234')
     expect(slr).to be_invalid
   end


### PR DESCRIPTION
- Created a new Redis model "SingleLogoutRequest"
- Upon SLO callback, use the `InResponseTo` saml element attribute to lookup original SLO request

The motivation for this PR is preventing the session token value from being sent to ID.me during logout.  The fewer places we send out the `session token`, the better.