### PR TITLE
Change up EDU stats to use tags instead of namespacing

### DIFF
--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -44,8 +44,7 @@ module EducationForm
       structured_data.each do |region, records|
         region_id = EducationFacility.facility_for(region: region)
         filename = "#{region_id}_#{Time.zone.today.strftime('%m%d%Y')}_vetsgov.spl"
-        logger.info("Writing #{records.count} application(s) to #{filename}")
-        logger.info("IDs: #{records.map(&:id)}")
+        log_submissions(records, filename, region_id)
         # create the single textual spool file
         contents = records.map do |record|
           format_application(record.open_struct_form)
@@ -53,7 +52,6 @@ module EducationForm
 
         if sftp
           sftp.upload!(StringIO.new(contents), filename)
-          StatsD.gauge("worker.education_benefits_claim.221990.#{region_id}", records.count)
         else
           dir_name = Rails.root.join('tmp', 'spool_files')
           FileUtils.mkdir_p(dir_name)
@@ -96,6 +94,13 @@ module EducationForm
     end
 
     private
+
+    def log_submissions(records, filename, region_id)
+      logger.info("Writing #{records.count} application(s) to #{filename}")
+      logger.info("IDs: #{records.map(&:id)}")
+      StatsD.gauge('worker.education_benefits_claim.transmissions', records.count, tags:
+        { form: '22-1990', rpo: region_id })
+    end
 
     # If multiple benefit types are selected, we've been told to just include whichever
     # one is 'first' in the header.

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -120,8 +120,12 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
         end
 
         expect { perform_with_frozen_time }.to trigger_statsd_gauge(
-          'worker.education_benefits_claim.221990.307',
-          value: 1
+          'worker.education_benefits_claim.transmissions',
+          value: 1,
+          tags: [
+            'form:22-1990',
+            'rpo:307'
+          ]
         )
 
         expect(EducationBenefitsClaim.unprocessed).to be_empty


### PR DESCRIPTION
Prometheus rather likes tagged stats, and using it this way instead of embedding data in the stat name itself should let us make better triggers and graphs for this process.