### PR TITLE
Error Logging for Failed Login Attempts

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -31,10 +31,7 @@ module V0
         async_create_evss_account(@current_user)
         redirect_to SAML_CONFIG['relay'] + '?token=' + @session.token
       else
-        logger.warn 'Authentication attempt did not succeed in saml_callback, reasons...'
-        logger.warn "  SAML Response: valid?=#{@saml_response.is_valid?} errors=#{@saml_response.errors}"
-        logger.warn "  User: valid?=#{@current_user&.valid?} errors=#{@current_user&.errors&.messages}"
-        logger.warn "  Session: valid?=#{@session&.valid?} errors=#{@session&.errors&.messages}"
+        log_errors
         redirect_to SAML_CONFIG['relay'] + '?auth=fail'
       end
     end
@@ -88,5 +85,25 @@ module V0
       end
     end
     # :nocov:
+
+    def log_errors
+      saml_error    = "valid?=#{@saml_response.is_valid?} errors=#{@saml_response.errors}"
+      user_error    = "valid?=#{@current_user&.valid?} errors=#{@current_user&.errors&.full_messages}"
+      session_error = "valid?=#{@session&.valid?} errors=#{@session&.errors&.full_messages}"
+
+      logger.error 'Login with ID.me failed!'
+      logger.error saml_error
+      logger.error user_error
+      logger.error session_error
+
+      if ENV['SENTRY_DSN'].present?
+        Raven.extra_context(
+          saml_response: saml_error,
+          session: session_error,
+          user: user_error
+        )
+        Raven.capture_exception('Login with ID.me failed!')
+      end
+    end
   end
 end

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -87,23 +87,15 @@ module V0
     # :nocov:
 
     def log_errors
-      saml_error    = "valid?=#{@saml_response.is_valid?} errors=#{@saml_response.errors}"
-      user_error    = "valid?=#{@current_user&.valid?} errors=#{@current_user&.errors&.full_messages}"
-      session_error = "valid?=#{@session&.valid?} errors=#{@session&.errors&.full_messages}"
+      message = <<-MESSAGE.strip_heredoc
+        SAML Login attempt failed! Reasons...
+          saml:    'valid?=#{@saml_response.is_valid?} errors=#{@saml_response.errors}'
+          user:    'valid?=#{@current_user&.valid?} errors=#{@current_user&.errors&.full_messages}'
+          session: 'valid?=#{@session&.valid?} errors=#{@session&.errors&.full_messages}'
+      MESSAGE
 
-      logger.error 'Login with ID.me failed!'
-      logger.error saml_error
-      logger.error user_error
-      logger.error session_error
-
-      if ENV['SENTRY_DSN'].present?
-        Raven.extra_context(
-          saml_response: saml_error,
-          session: session_error,
-          user: user_error
-        )
-        Raven.capture_exception('Login with ID.me failed!')
-      end
+      logger.error message
+      Raven.capture_message(message) if ENV['SENTRY_DSN'].present?
     end
   end
 end

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe V0::SessionsController, type: :controller do
       it 'redirects to an auth failure page if saml_response is invalid' do
         allow(OneLogin::RubySaml::Response).to receive(:new).and_return(invalid_saml_response)
 
-        expect(Rails.logger).to receive(:error).exactly(4).times
+        expect(Rails.logger).to receive(:error).exactly(1).times
         expect(post(:saml_callback)).to redirect_to(SAML_CONFIG['relay'] + '?auth=fail')
         expect(response).to have_http_status(:found)
       end

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe V0::SessionsController, type: :controller do
       it 'redirects to an auth failure page if saml_response is invalid' do
         allow(OneLogin::RubySaml::Response).to receive(:new).and_return(invalid_saml_response)
 
-        expect(Rails.logger).to receive(:warn).exactly(4).times
+        expect(Rails.logger).to receive(:error).exactly(4).times
         expect(post(:saml_callback)).to redirect_to(SAML_CONFIG['relay'] + '?auth=fail')
         expect(response).to have_http_status(:found)
       end


### PR DESCRIPTION
- Added Sentry exception for a failed login attempt
- Changed `warn` Rails logging to `error`

Failed logins _can be_ normal behavior but I'm realizing that _most of the time_, it's an `error`.  If this gets to be too noisy, we can re-calibrate.