### PR TITLE
Add claim type

### DIFF
--- a/app/serializers/disability_claim_base_serializer.rb
+++ b/app/serializers/disability_claim_base_serializer.rb
@@ -31,7 +31,7 @@ class DisabilityClaimBaseSerializer < ActiveModel::Serializer
              :phase_change_date, :open, :waiver_submitted, :documents_needed,
              :development_letter_sent, :decision_letter_sent,
              :updated_at, :phase, :ever_phase_back, :current_phase_back,
-             :requested_decision
+             :requested_decision, :claim_type
 
   # Our IDs are not stable due to 24 hour expiration, use EVSS IDs for consistency
   # This can be removed if our IDs become stable
@@ -67,6 +67,10 @@ class DisabilityClaimBaseSerializer < ActiveModel::Serializer
   # TODO: (CMJ) Remove once front end is integrated
   def waiver_submitted
     requested_decision
+  end
+
+  def claim_type
+    object_data['status_type']
   end
 
   def phase

--- a/spec/support/schemas/disability_claim.json
+++ b/spec/support/schemas/disability_claim.json
@@ -30,7 +30,8 @@
             "phase",
             "claim_type",
             "ever_phase_back",
-            "current_phase_back"
+            "current_phase_back",
+            "claim_type"
           ],
           "properties": {
             "evss_id": { "type": "integer" },
@@ -51,7 +52,8 @@
             "phase": { "type": ["integer", "null"] },
             "claim_type": { "type": "string" },
             "ever_phase_back": { "type": "boolean" },
-            "current_phase_back": { "type": "boolean" }
+            "current_phase_back": { "type": "boolean" },
+            "claim_type": { "type": ["string", "null"] }
           }
         }
       }

--- a/spec/support/schemas/disability_claims.json
+++ b/spec/support/schemas/disability_claims.json
@@ -29,7 +29,8 @@
               "updated_at",
               "phase",
               "ever_phase_back",
-              "current_phase_back"
+              "current_phase_back",
+              "claim_type"
             ],
             "properties": {
               "evss_id": { "type": "integer" },
@@ -46,7 +47,8 @@
               "updated_at": { "type": "string" },
               "phase": { "type": ["integer", "null"] },
               "ever_phase_back": { "type": "boolean" },
-              "current_phase_back": { "type": "boolean" }
+              "current_phase_back": { "type": "boolean" },
+              "claim_type": { "type": ["string", "null"] }
             }
           }
         }


### PR DESCRIPTION
API addition for https://github.com/department-of-veterans-affairs/sunsets-team/issues/286
Currently, 400SUPP claims do not have a `status_type` from EVSS, this is being looked into and may require us to assign a type when none is present, but not required for this PR