### PR TITLE
use capture message

### DIFF
--- a/app/controllers/v0/education_benefits_claims_controller.rb
+++ b/app/controllers/v0/education_benefits_claims_controller.rb
@@ -11,8 +11,7 @@ module V0
       unless education_benefits_claim.save
         validation_error = education_benefits_claim.errors.full_messages.join(', ')
 
-        Raven.tags_context(validation: 'education_benefits_claim')
-        Raven.capture_exception(validation_error)
+        Raven.capture_message(validation_error, tags: { validation: 'education_benefits_claim' })
 
         logger.error(validation_error)
 

--- a/spec/request/education_benefits_claims_request_spec.rb
+++ b/spec/request/education_benefits_claims_request_spec.rb
@@ -62,8 +62,9 @@ RSpec.describe 'Education Benefits Claims Integration', type: [:request, :serial
         allow(Rails.logger).to receive(:error)
         expect(Rails.logger).to receive(:error).with(validation_error).once
 
-        expect(Raven).to receive(:tags_context).once.with(validation: 'education_benefits_claim')
-        expect(Raven).to receive(:capture_exception).once.with(validation_error)
+        expect(Raven).to receive(:capture_message)
+          .once
+          .with(validation_error, tags: { validation: 'education_benefits_claim' })
 
         subject
       end


### PR DESCRIPTION
https://docs.sentry.io/clients/ruby/usage/
capture_message is supposed to be used for strings, i tested it in rails console on a dev server and it works