### PR TITLE
Happy 2017! Fix some spec failures around 'current year'

### DIFF
--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -18,16 +18,14 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
       expect(application_1606.form).to match_vets_schema('edu_benefits')
     end
 
-    context 'conformance' do
+    context 'conformance', run_at: '2016-10-06 03:00:00 EDT' do
       basepath = Rails.root.join('spec', 'fixtures', 'education_benefits_claims')
       SAMPLE_APPLICATIONS.each do |application_name|
         it "generates #{application_name} correctly" do
           json = File.read(File.join(basepath, "#{application_name}.json"))
           expect(json).to match_vets_schema('edu_benefits')
           application = EducationBenefitsClaim.new(form: json)
-          result = Timecop.freeze(Time.zone.parse('2016-10-06 03:00:00 EDT')) do
-            subject.format_application(application.open_struct_form)
-          end
+          result = subject.format_application(application.open_struct_form)
           spl = File.read(File.join(basepath, "#{application_name}.spl"))
           expect(result).to eq(spl)
         end
@@ -81,13 +79,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
     end
   end
 
-  context 'create_files' do
-    def perform_with_frozen_time
-      Timecop.freeze(Time.zone.parse('2016-09-16 03:00:00 EDT')) do
-        subject.perform
-      end
-    end
-
+  context 'create_files', run_at: '2016-09-16 03:00:00 EDT' do
     let(:filename) { '307_09162016_vetsgov.spl' }
 
     context 'in the development env' do
@@ -99,7 +91,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
 
       it 'writes a file to the tmp dir' do
         expect(EducationBenefitsClaim.unprocessed).not_to be_empty
-        perform_with_frozen_time
+        subject.perform
         expect(File.read(file_path).include?('APPLICATION FOR VA EDUCATION BENEFITS')).to eq(true)
         expect(EducationBenefitsClaim.unprocessed).to be_empty
       end
@@ -119,7 +111,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
           expect(contents.read).to include('EDUCATION BENEFIT BEING APPLIED FOR: Chapter 1606')
         end
 
-        expect { perform_with_frozen_time }.to trigger_statsd_gauge(
+        expect { subject.perform }.to trigger_statsd_gauge(
           'worker.education_benefits_claim.transmissions',
           value: 1,
           tags: [

--- a/spec/jobs/education_form/create_daily_year_to_date_report_spec.rb
+++ b/spec/jobs/education_form/create_daily_year_to_date_report_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EducationForm::CreateDailyYearToDateReport, type: :aws_helpers do
     described_class.new
   end
 
-  context 'with some sample submissions' do
+  context 'with some sample submissions', run_at: '2017-01-03 03:00:00 EDT' do
     before do
       2.times do
         create(
@@ -27,10 +27,10 @@ RSpec.describe EducationForm::CreateDailyYearToDateReport, type: :aws_helpers do
 
       # outside of yearly range
       create(:education_benefits_submission, created_at: date - 1.year, status: 'processed')
-      # outside of daily range
-      create(:education_benefits_submission, created_at: date - 1.month, status: 'processed')
+      # outside of daily range, given the timecop freeze.
+      create(:education_benefits_submission, created_at: date - 26.hours, status: 'processed')
 
-      create(:education_benefits_submission, status: 'submitted')
+      create(:education_benefits_submission, created_at: date, status: 'submitted')
     end
 
     context 'with the date variable set' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,16 @@ RSpec.configure do |config|
     stub_mvi unless example.metadata[:skip_mvi]
   end
 
+  config.around(:each) do |example|
+    if example.metadata[:run_at]
+      Timecop.freeze(Time.zone.parse(example.metadata[:run_at])) do
+        example.run
+      end
+    else
+      example.run
+    end
+  end
+
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
   #   # These two settings work together to allow you to limit a spec run


### PR DESCRIPTION
Adds Timecop around some time-sensative code that only triggers on year changes, and includes a small helper to cut down on timecop cruft.