### PR TITLE
Add rails_12factor to stream logs to standard out in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,3 +99,7 @@ group :development do
   gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
   gem 'guard-rubocop'
 end
+
+group :production do
+  gem 'rails_12factor'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (4.2.7.1)
       actionpack (= 4.2.7.1)
       activesupport (= 4.2.7.1)
@@ -428,6 +433,7 @@ DEPENDENCIES
   rack-cors
   rails (= 4.2.7.1)
   rails-api
+  rails_12factor
   rainbow
   redis
   redis-namespace


### PR DESCRIPTION
Fixes #273. Standard out is redirected to vets-api.log and from there to cloudwatch. 

cc @jkassemi @knkski for awareness of any downstream log processing tasks. 