### PR TITLE
Standard out logging without rails_12factor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,3 @@ group :development do
   gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
   gem 'guard-rubocop'
 end
-
-group :production do
-  gem 'rails_12factor'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,11 +252,6 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (4.2.7.1)
       actionpack (= 4.2.7.1)
       activesupport (= 4.2.7.1)
@@ -433,7 +428,6 @@ DEPENDENCIES
   rack-cors
   rails (= 4.2.7.1)
   rails-api
-  rails_12factor
   rainbow
   redis
   redis-namespace

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:uuid]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :info
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:uuid]
@@ -81,10 +81,11 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # Log to standard out, with specified formatter
   STDOUT.sync = config.autoflush_log
-  config.logger = ActiveSupport::Logger.new(STDOUT)
-  config.logger.formatter = config.log_formatter
-  config.logger.level = config.log_level
+  logger = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,11 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  STDOUT.sync = config.autoflush_log
+  config.logger = ActiveSupport::Logger.new(STDOUT)
+  config.logger.formatter = config.log_formatter
+  config.logger.level = config.log_level
+
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false
   ConfigHelper.setup_action_mailer(config)


### PR DESCRIPTION
Reverts #680 and fixes #273 via direct configuration of a standard out logger. Turns out rails_12factor does not respect custom log formatters (or even the standard rails log formatter), so timestamps were missing from cloudwatch. This puts things back as expected. 

There's a PR against rails_12factor to allow it to use log formatters, but I get the sense that rails_12factor is somewhat deprecated with Heroku recommending use of Rails 5 which logs to stdout directly.

cc @knkski @jkassemi