### PR TITLE
Log user id and add uuid to logs in dev

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,6 +85,7 @@ class ApplicationController < ActionController::API
     authenticate_with_http_token do |token, _options|
       @session = Session.find(token)
       return false if @session.nil?
+      Rails.logger.info("Logged in user with id #{@session.uuid}")
       # TODO: ensure that this prevents against timing attack vectors
       ActiveSupport::SecurityUtils.secure_compare(
         ::Digest::SHA256.hexdigest(token),

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,6 +29,9 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   # config.active_record.migration_error = :page_load
 
+  # Prepend all log lines with the following tags.
+  config.log_tags = [:uuid]
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.


### PR DESCRIPTION
Fixes department-of-veterans-affairs/vets.gov-team#556

This logs the id of the user as we find their session so that we can tie the user information together with the rest of the data from the request. Since we also have the UUID appended to each bit of logging from the request, this ought to be sufficient to make the connection. I also turned on the UUID logging in dev mode just for parity, but that's not really important at all.