### PR TITLE
Use default BUNDLE_PATH for Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
 
     stage('Run tests') {
       steps {
-        sh 'bash --login -c "bundle install --path vendor/bundle --without development"'
+        sh 'bash --login -c "bundle install --without development"'
         withEnv(env_vars) {
           sh 'bash --login -c "bundle exec rake db:create db:schema:load ci"'
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
 
     stage('Run tests') {
       steps {
-        sh 'bash --login -c "bundle install --without development"'
+        sh 'bash --login -c "bundle install --without development -j 4"'
         withEnv(env_vars) {
           sh 'bash --login -c "bundle exec rake db:create db:schema:load ci"'
         }


### PR DESCRIPTION
Utilize the ~/.bundle directory for caching bundle install. Increases concurrency for initial install to 4. 