### PR TITLE
Make log_tags Play Nice with HTTP-Basic Auth

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,6 @@ Rails.application.configure do
   config.log_tags = [
     :uuid,
     proc do |request|
-      byebug
       if request.headers['Authorization'] =~ /Token token=(.*)/
         Session.obscure_token(Regexp.last_match[1])
       else

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,8 +59,8 @@ Rails.application.configure do
   config.log_tags = [
     :uuid,
     proc do |request|
-      if request.headers['Authorization'].present?
-        request.headers['Authorization'] =~ /Token token=(.*)/
+      byebug
+      if request.headers['Authorization'] =~ /Token token=(.*)/
         Session.obscure_token(Regexp.last_match[1])
       else
         'unauthenticated'


### PR DESCRIPTION
The `staging` environment is seeing the following error:
http://sentry.vetsgov-internal/vets-gov/platform-api-staging/issues/553/

The current code assumes that if an `Authorization` header is present, then it is of the `token` variety.  In the `staging` environment, the `Authorization` header may _either_ be `token` or `Basic`.

Example:
```
Authorization : Basic abcd1234
```
or
```
Authorization : Token token=abcd1234
```

This fix makes no assumption of `presence?` and only triggers if the regex gets matched.