### PR TITLE
Remove duplicated method

### DIFF
--- a/app/serializers/evss_claim_detail_serializer.rb
+++ b/app/serializers/evss_claim_detail_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class EVSSClaimDetailSerializer < EVSSClaimBaseSerializer
-  attributes :contention_list, :va_representative, :events_timeline, :claim_type
+  attributes :contention_list, :va_representative, :events_timeline
 
   def contention_list
     object.data['contention_list']
@@ -8,10 +8,6 @@ class EVSSClaimDetailSerializer < EVSSClaimBaseSerializer
 
   def va_representative
     object.data['poa']
-  end
-
-  def claim_type
-    object.data['status_type']
   end
 
   def events_timeline


### PR DESCRIPTION
The `claim_type` attribute definition was moved to the base serializer in an earlier PR

https://github.com/department-of-veterans-affairs/vets-api/pull/656