### PR TITLE
Help Sentry tally logout error events

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -78,7 +78,8 @@ module V0
 
       errors = []
       errors.concat(logout_response.errors) unless logout_response.validate(true)
-      errors << "Logout Request not found! ID=#{logout_response&.in_response_to}" if logout_request.nil?
+      errors << 'inResponseTo attribute is nil!' if logout_response&.in_response_to.nil?
+      errors << 'Logout Request not found!' if logout_request.nil?
       errors << 'Session not found!' if session.nil?
       errors << 'User not found!' if user.nil?
 

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -102,7 +102,7 @@ module V0
       errors
     end
 
-    def log_errors(message, context={})
+    def log_errors(message, context = {})
       logger.error message
       if ENV['SENTRY_DSN'].present?
         Raven.extra_context(context) unless !context.is_a?(Hash) || context.empty?


### PR DESCRIPTION
Sentry is not properly tallying logout failures:
![image](https://cloud.githubusercontent.com/assets/3077884/22088051/77a95b54-ddaf-11e6-9661-6898be2196e0.png)
The above two failures are the same but the logging used the unique SAML Logout ID in the message so it's not tallied properly.  This PR, makes the messages more generic so they are properly tallied.