### PR TITLE
Close SFTP Connections

### DIFF
--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -22,7 +22,12 @@ module EducationForm
     def perform(records: EducationBenefitsClaim.unprocessed)
       return false if federal_holiday?
       # Group the formatted records into different regions
-      logger.info("Processing #{records.count} application(s)")
+      if records.count.zero?
+        logger.info('No records to process.')
+        return true
+      else
+        logger.info("Processing #{records.count} application(s)")
+      end
       regional_data = group_submissions_by_region(records)
       formatted_records = format_records(regional_data)
       # Create a remote file for each region, and write the records into them

--- a/app/workers/education_form/writer/remote.rb
+++ b/app/workers/education_form/writer/remote.rb
@@ -13,8 +13,9 @@ module EducationForm
     end
 
     def close
+      return unless sftp && sftp.open?
       @logger.info('Disconnected from SFTP')
-      sftp.close
+      sftp.session.close
       true
     end
 

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -82,6 +82,19 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
     end
   end
 
+  context '#perform' do
+    context 'with no records' do
+      before do
+        EducationBenefitsClaim.delete_all
+      end
+      it 'prints a statement and exits' do
+        expect(subject).not_to receive(:create_files)
+        expect(subject.logger).to receive(:info).with('No records to process.')
+        expect(subject.perform).to be(true)
+      end
+    end
+  end
+
   context '#group_submissions_by_region' do
     it 'takes a list of records into chunked forms' do
       base_address = { street: 'A', city: 'B', country: 'USA' }
@@ -132,15 +145,16 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
     it 'writes files out over sftp' do
       expect(EducationBenefitsClaim.unprocessed).not_to be_empty
       ClimateControl.modify EDU_SFTP_HOST: 'localhost', EDU_SFTP_PASS: 'test' do
-        sftp_session_mock = double
-        sftp_mock = double(session: sftp_session_mock)
+        sftp_session_mock = instance_double('Net::SSH::Connection::Session')
+        sftp_mock = instance_double('Net::SFTP::Session', session: sftp_session_mock)
 
         expect(Net::SFTP).to receive(:start).once.and_return(sftp_mock)
+        expect(sftp_mock).to receive(:open?).once.and_return(true)
         expect(sftp_mock).to receive(:upload!) do |contents, path|
           expect(path).to eq filename
           expect(contents.read).to include('EDUCATION BENEFIT BEING APPLIED FOR: Chapter 1606')
         end
-        expect(sftp_mock.session).to receive(:close)
+        expect(sftp_session_mock).to receive(:close)
         expect { subject.perform }.to trigger_statsd_gauge(
           'worker.education_benefits_claim.transmissions',
           value: 2,


### PR DESCRIPTION
Per https://github.com/net-ssh/net-sftp/blob/9d4e24ad006f309efd88e518b28b2cfe292a6d1a/lib/net/sftp.rb#L36, it's the session that's closed. Otherwise we get fun `ArgumentError: wrong number of arguments (given 0, expected 1)` errors _after_ the file has been written out.

Also adds an early return if there are no records to process, so that we don't even bother to connect.