### PR TITLE
SLO Signature Validation

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -71,7 +71,7 @@ module V0
     end
 
     def handle_completed_slo
-      logout_response = OneLogin::RubySaml::Logoutresponse.new(params[:SAMLResponse], saml_settings)
+      logout_response = OneLogin::RubySaml::Logoutresponse.new(params[:SAMLResponse], saml_settings, get_params: params)
       logout_request  = SingleLogoutRequest.find(logout_response&.in_response_to)
       session         = Session.find(logout_request&.token)
       user            = User.find(session&.uuid)


### PR DESCRIPTION
We have been ignoring the `Signature` and `SigAlg` query params from ID.me in our SAML Single Logout (SLO) callback.  Now we pass the `get_params: params` to `ruby-saml`.

See ruby-saml source:
https://github.com/onelogin/ruby-saml/blob/v1.3.0/lib/onelogin/ruby-saml/logoutresponse.rb#L208

Related Issue : https://github.com/department-of-veterans-affairs/vets.gov-team/issues/769