### PR TITLE
Add SOAP faraday requirements to HCA service config

### DIFF
--- a/lib/hca/configuration.rb
+++ b/lib/hca/configuration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 require 'common/client/configuration/soap'
+require 'common/client/middleware/request/soap_headers'
+require 'common/client/middleware/response/soap_parser'
 
 module HCA
   class Configuration < Common::Client::Configuration::SOAP


### PR DESCRIPTION
This will fix `:soap_headers is not registered on Faraday::Request.` issues on HCA requests.