### PR TITLE
test for hca-service-requires

### DIFF
--- a/spec/lib/hca/service_spec.rb
+++ b/spec/lib/hca/service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 require 'hca/service'
 
-describe HCA::Service do
+describe HCA::Service, skip_mvi: true do
   let(:cert) { instance_double('OpenSSL::X509::Certificate') }
   let(:key) { instance_double('OpenSSL::PKey::RSA') }
   let(:store) { instance_double('OpenSSL::X509::Store') }


### PR DESCRIPTION
test for this PR https://github.com/department-of-veterans-affairs/vets-api/pull/732
with this change the HCA service will raise an error without the requires