### PR TITLE
Add new date range qualifier for VHA access to care data

### DIFF
--- a/app/models/vha_facility_adapter.rb
+++ b/app/models/vha_facility_adapter.rb
@@ -68,6 +68,7 @@ class VHAFacilityAdapter
   ).each_with_object({}) { |d, h| h[d] = d }
 
   FEEDBACK_KEYMAP = {
+    'effective_date_range' => 'ScoreDateRange',
     'primary_care_routine' => 'Primary_Care_Routine_Score',
     'primary_care_urgent' => 'Primary_Care_Urgent_Score',
     'specialty_care_routine' => 'Specialty_Care_Routine_Score',

--- a/spec/factories/vha_gis_records.rb
+++ b/spec/factories/vha_gis_records.rb
@@ -82,9 +82,14 @@ FactoryGirl.define do
         'Rehabilitation' => '',
         'UrgentCare' => '',
         'WellnessAndPreventativeCare' => '',
-        'First_InternetAddress' => 'http://www.portland.va.gov/',
+        'Website_URL' => 'http://www.portland.va.gov/',
         'MHClinicPhone' => '5032735187',
-        'Extension' => nil
+        'Extension' => nil,
+        'Primary_Care_Urgent_Score' => 0.66,
+        'Specialty_Care_Urgent_Score' => 0.67,
+        'Primary_Care_Routine_Score' => 0.81,
+        'Specialty_Care_Routine_Score' => 0.77,
+        'ScoreDateRange' => 'Jun 2016 - Nov 2016'
       }
     end
     geometry do

--- a/spec/models/vha_facility_adapter_spec.rb
+++ b/spec/models/vha_facility_adapter_spec.rb
@@ -70,4 +70,10 @@ RSpec.describe VHAFacilityAdapter, type: :adapter do
     model = described_class.from_gis(input)
     expect(model.services[:health].length).to eq(2)
   end
+
+  it 'populates access to care date range field' do
+    input = FactoryGirl.build(:vha_gis_record)
+    model = described_class.from_gis(input)
+    expect(model.feedback[:health]['effective_date_range']).to eq('Jun 2016 - Nov 2016')
+  end
 end


### PR DESCRIPTION
Additional field for dynamically populating the "Current as of" date range under the access to care facility detail page. 

This comes all the way from SHEP to ArcGIS to us as a string like "Jun 2016 - Nov 2016". I didn't see much value in parsing it out and exposing it as ISO-style dates, so passed it through as-is. 

I ran a quick query, and  `effective_date_range` can be null, but currently that's only the case if there is no access to care data for a facility - i.e. all the scores are null as well. That's not to say that they will always follow that constraint in the future so we should code defensively in vets-website when displaying this.

