### PR TITLE
instead of the ARGV expression, use NOCOVERAGE=true

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ unless ENV['NOCOVERAGE']
     add_filter 'lib/config_helper.rb'
     add_filter 'lib/feature_flipper.rb'
     add_filter 'spec/support/authenticated_session_helper'
+    add_filter 'spec/support/attr_encrypted_matcher'
     add_filter 'config/initializers/figaro.rb'
     SimpleCov.minimum_coverage_by_file 90
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ require 'fakeredis/rspec'
 require 'support/mvi/stub_mvi'
 require 'support/spec_builders'
 require 'support/api_schema_matcher'
-require 'pry'
 
 # By default run SimpleCov, but allow an environment variable to disable.
 unless ENV['NOCOVERAGE']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,24 +3,23 @@ require 'fakeredis/rspec'
 require 'support/mvi/stub_mvi'
 require 'support/spec_builders'
 require 'support/api_schema_matcher'
+require 'pry'
 
 # By default run SimpleCov, but allow an environment variable to disable.
 unless ENV['NOCOVERAGE']
   require 'simplecov'
 
-  if ARGV.grep(/spec\.rb/).empty?
-    SimpleCov.start do
-      track_files '{app,lib}/**/*.rb'
-      add_filter 'config/initializers/sidekiq.rb'
-      add_filter 'config/initializers/statsd.rb'
-      add_filter 'config/initializers/mvi_settings.rb'
-      add_filter 'lib/tasks/support/shell_command.rb'
-      add_filter 'lib/config_helper.rb'
-      add_filter 'lib/feature_flipper.rb'
-      add_filter 'spec/support/authenticated_session_helper'
-      add_filter 'config/initializers/figaro.rb'
-      SimpleCov.minimum_coverage_by_file 90
-    end
+  SimpleCov.start do
+    track_files '{app,lib}/**/*.rb'
+    add_filter 'config/initializers/sidekiq.rb'
+    add_filter 'config/initializers/statsd.rb'
+    add_filter 'config/initializers/mvi_settings.rb'
+    add_filter 'lib/tasks/support/shell_command.rb'
+    add_filter 'lib/config_helper.rb'
+    add_filter 'lib/feature_flipper.rb'
+    add_filter 'spec/support/authenticated_session_helper'
+    add_filter 'config/initializers/figaro.rb'
+    SimpleCov.minimum_coverage_by_file 90
   end
 end
 


### PR DESCRIPTION
The purpose of this PR is to get the automatic travis build to once again start running simplecov code coverage.

The ARGV.grep(/spec\.rb/).empty? clause was causing simplecov to not run on travis CI, because of the way the rake task invokes rspec.

If one wants to run an individual spec without coverage, passing the additional NOCOVERAGE=true environment flag will do the trick.