### PR TITLE
VA900 (Generic Backend Service Exception) and Sentry Logging

### DIFF
--- a/lib/common/client/middleware/response/raise_error.rb
+++ b/lib/common/client/middleware/response/raise_error.rb
@@ -25,13 +25,13 @@ module Common
 
           def raise_error!
             if status&.between?(400, 599)
-              raise Common::Exceptions::BackendServiceException.new(service_specific_i18n_key, response_values, @status, @body)
+              raise Common::Exceptions::BackendServiceException.new(service_i18n_key, response_values, @status, @body)
             else
               raise BackendUnhandledException, "Unhandled Exception - status: #{@status}, body: #{@body}"
             end
           end
 
-          def service_specific_i18n_key
+          def service_i18n_key
             "#{error_prefix.upcase}#{body['code']}"
           end
 
@@ -39,7 +39,7 @@ module Common
             {
               status: status,
               detail: body['detail'],
-              code:   service_specific_i18n_key,
+              code:   service_i18n_key,
               source: body['source']
             }
           end

--- a/lib/common/client/middleware/response/raise_error.rb
+++ b/lib/common/client/middleware/response/raise_error.rb
@@ -25,7 +25,7 @@ module Common
 
           def raise_error!
             if status&.between?(400, 599)
-              raise Common::Exceptions::BackendServiceException.new(service_specific_i18n_key, response_values)
+              raise Common::Exceptions::BackendServiceException.new(service_specific_i18n_key, response_values, @status, @body)
             else
               raise BackendUnhandledException, "Unhandled Exception - status: #{@status}, body: #{@body}"
             end

--- a/lib/common/exceptions/external/backend_service_exception.rb
+++ b/lib/common/exceptions/external/backend_service_exception.rb
@@ -5,13 +5,16 @@ module Common
     # you must define the minor code in the locales file and call this class from
     # raise_error middleware.
     class BackendServiceException < BaseError
-      attr_reader :response_values
+      attr_reader :response_values, :original_status, :original_body
 
-      def initialize(key = nil, response_values = {})
+      def initialize(key = nil, response_values = {}, original_status = nil, original_body = nil)
         @response_values = response_values
         @key = key || 'VA900'
+        @original_status = original_status
+        @original_body = original_body
         validate_arguments!
         warn_about_error_not_in_locales!
+        warn_about_va900!
       end
 
       # The message will be the actual backend service response from middleware,
@@ -71,6 +74,7 @@ module Common
       # identified it does not actually raise an exception.
       # NOTE: in the future detail will just fallback to 'Operation failed'
       def warn_about_error_not_in_locales!
+        return if code == 'VA900'
         unless i18n_data[:detail].present?
           message = <<-MESSAGE.strip_heredoc
             Referencing detail from response values is deprecated. Add the following to exceptions.en.yml
@@ -80,6 +84,15 @@ module Common
               status: <http status code you want rendered (400 or 422)>
               source: ~
           MESSAGE
+          Rails.logger.warn message
+          Raven.capture_message(message, level: :warning) if ENV['SENTRY_DSN'].present?
+        end
+      end
+
+      # Logging the VA900 errors when they occur (result of backend service providing unparsable errors)
+      def warn_about_va900!
+        if code == 'VA900'
+          message = "Unmapped VA900 (Backend Response: { status: #{original_status}, message: #{original_body}) }"
           Rails.logger.warn message
           Raven.capture_message(message, level: :warning) if ENV['SENTRY_DSN'].present?
         end


### PR DESCRIPTION
make sure the original JSON provided by backend service is tracked in Sentry when BackendServiceException is raised.

Additionally, warn about VA900 so that we can determine why the minor codes are not being properly mapped by the backend service.

Essentially what happens for Rx and other services is that the raise_error middleware cannot properly parses the minor codes from the JSON response that the backend server provides, perhaps they are no longer providing it or something else is happening. Without better logging the original status and original JSON body of the backend server responses, it is impossible to determine why this is failing. This is just a fix to have better tracking around when these occur.

See also: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1241