### PR TITLE
Make up and down migration actions explicit to isolate data transformation

### DIFF
--- a/db/migrate/20170329210115_submission_changes_for1995.rb
+++ b/db/migrate/20170329210115_submission_changes_for1995.rb
@@ -1,9 +1,7 @@
 class SubmissionChangesFor1995 < ActiveRecord::Migration
-  def change
-    %w(transfer_of_entitlement chapter1607).each do |benefit|
-      add_column(:education_benefits_submissions, benefit, :boolean, default: false, null: false)
-    end
-
+  def up
+    add_column(:education_benefits_submissions, :transfer_of_entitlement, :boolean, default: false, null: false)
+    add_column(:education_benefits_submissions, :chapter1607, :boolean, default: false, null: false)
     # reload the model info so that it picks up the new column
     EducationBenefitsSubmission.reset_column_information
     EducationBenefitsSubmission.where(form_type: '1995').find_each do |education_benefits_submission|
@@ -11,5 +9,10 @@ class SubmissionChangesFor1995 < ActiveRecord::Migration
       benefit = parsed_form['benefit']&.underscore
       education_benefits_submission.update!(benefit => true) if benefit.present?
     end
+  end
+
+  def down
+    remove_column(:education_benefits_submissions, :transfer_of_entitlement)
+    remove_column(:education_benefits_submissions, :chapter1607)
   end
 end


### PR DESCRIPTION
This migration caused 2 failures when being deployed on staging because of various issues resolved in a previous PR. Hoping that this change is just cleanup so the data transformation doesn't run every time the file is loaded into ruby.