### PR TITLE
Fixes desync for vets-api deployment

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -6,16 +6,6 @@ def notify(message, color='good') {
     }
 }
 
-// Delay is introduced to de-synchronize the vets-api
-// and vets-api-worker deployments that are triggered simultaneously
-// on a merge to this repository. The simultaneous deployments
-// were leading to a race condition during the db migration step.
-def delay() {
-    if (${application} == 'vets-api-worker') {
-        sleep time: 1, unit: 'MINUTES'
-    }
-}
-
 pipeline {
   agent {
     label 'app-deploys'
@@ -48,6 +38,10 @@ pipeline {
       }
     }
 
+    // Delay is introduced to de-synchronize the vets-api
+    // and vets-api-worker deployments that are triggered simultaneously
+    // on a merge to this repository. The simultaneous deployments
+    // were leading to a race condition during the db migration step.
     stage('De-synchronize') {
       when {
         expression { return application == 'vets-api-worker' }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -49,8 +49,12 @@ pipeline {
     }
 
     stage('De-synchronize') {
+      when {
+        expression { return application == 'vets-api-worker' }
+      }
+
       steps {
-        delay
+        sleep time: 1, unit: 'MINUTES'
       }
     }
 


### PR DESCRIPTION
Fixes configuration that caused failure in vets-api-prod #34 and vets-api-worker-prod #31:

```
Checking out Revision a93b7fcd794ea92aefeba8036f14debd1d3ed133 (refs/remotes/origin/production)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f a93b7fcd794ea92aefeba8036f14debd1d3ed133
 > git rev-list d2543118f28fba7a710bc65abd98569a34c13a35 # timeout=10
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 53: Expected a step @ line 53, column 9.
           delay
           ^

1 error

	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
	at org.codehaus.groovy.control.CompilationUnit.applyToPrimaryClassNodes(CompilationUnit.java:1085)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:603)
	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:581)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:558)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:67)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:430)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:393)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:238)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:405)
Finished: FAILURE
```