### PR TITLE
EDU Claim routing

### DIFF
--- a/app/workers/education_form/education_facility.rb
+++ b/app/workers/education_form/education_facility.rb
@@ -93,10 +93,10 @@ module EducationForm
         record.school&.address || record.veteranAddress
       when '1990N'
         record.educationProgram&.address || record.veteranAddress
-      when '1990E', '5490'
+      when '1990E', '5490', '5495'
         record.educationProgram&.address || record.relativeAddress
-      when '1995', '5495'
-        record.newSchool&.address || record.relativeAddress
+      when '1995'
+        record.newSchool&.address || record.veteranAddress
       end
     end
 

--- a/app/workers/education_form/education_facility.rb
+++ b/app/workers/education_form/education_facility.rb
@@ -66,7 +66,7 @@ module EducationForm
 
     def self.region_for(model)
       record = model.open_struct_form
-      address = routing_address(record)
+      address = routing_address(record, form_type: model.form_type)
       # special case Philippines
       return :western if address&.country == 'PHL'
 
@@ -82,6 +82,24 @@ module EducationForm
         DEFAULT
       end
     end
+
+    # Claims are sent to different RPOs based first on the location of the school
+    # that the claim is relating to (either `school` or `newSchool` in our submissions)
+    # or to the applicant's address (either as a relative or the veteran themselves)
+    # rubocop:disable Metrics/CyclomaticComplexity
+    def self.routing_address(record, form_type:)
+      case form_type.upcase
+      when '1990'
+        record.school&.address || record.veteranAddress
+      when '1990N'
+        record.educationProgram&.address || record.veteranAddress
+      when '1990E', '5490'
+        record.educationProgram&.address || record.relativeAddress
+      when '1995', '5495'
+        record.newSchool&.address || record.relativeAddress
+      end
+    end
+
     # rubocop:enable Metrics/CyclomaticComplexity
 
     def self.regional_office_for(model)
@@ -89,16 +107,6 @@ module EducationForm
       address = ["#{region.to_s.capitalize} Region", 'VA Regional Office']
       address += ADDRESSES[region]
       address.join("\n")
-    end
-
-    # Claims are sent to different RPOs based first on the location of the school
-    # that the claim is relating to (either `school` or `newSchool` in our submissions)
-    # or to the applicant's address (either as a relative or the veteran themselves)
-    def self.routing_address(record)
-      record.school&.address ||
-        record.newSchool&.address ||
-        record.relativeAddress ||
-        record.veteranAddress
     end
   end
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -5,7 +5,7 @@ desc 'shortcut to run all linting tools, at the same time.'
 task :lint do
   require 'rainbow'
 
-  opts = ENV['CI'] ? '' : '--auto-correct'
+  opts = ENV['CI'] ? '' : '--display-cop-names --auto-correct'
   puts 'running rubocop...'
   rubocop_result = ShellCommand.run("rubocop #{opts} --color")
 

--- a/spec/fixtures/education_benefits_claims/1995/kitchen_sink.json
+++ b/spec/fixtures/education_benefits_claims/1995/kitchen_sink.json
@@ -8,10 +8,10 @@
   "newSchool": {
     "name": "school name",
     "address": {
-      "city": "Baltimore",
+      "city": "Milwaukee",
       "country": "USA",
-      "postalCode": "21231",
-      "state": "MD",
+      "postalCode": "53135",
+      "state": "WI",
       "street": "111 Uni Drive"
     }
   },

--- a/spec/fixtures/education_benefits_claims/1995/kitchen_sink.spl
+++ b/spec/fixtures/education_benefits_claims/1995/kitchen_sink.spl
@@ -50,7 +50,7 @@ Education or Career Goal: bachelor's degree
 New School or Training Establishment:
 school name
 111 UNI DRIVE
-BALTIMORE, MD, 21231
+MILWAUKEE, WI, 53135
 USA
 
 Current/Prior School or Training Establishment:

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -105,13 +105,13 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
         # clear out old test files
         FileUtils.rm_rf(Dir.glob(spool_files))
         # ensure our test data is spread across 3 regions..
-        expect(EducationBenefitsClaim.unprocessed.pluck(:regional_processing_office).uniq.count).to be(3)
+        expect(EducationBenefitsClaim.unprocessed.pluck(:regional_processing_office).uniq.count).to eq(3)
       end
 
       it 'it processes the valid messages' do
         expect(subject).to receive(:log_exception_to_sentry).once
         expect { subject.perform }.to change { EducationBenefitsClaim.unprocessed.count }.from(3).to(1)
-        expect(Dir[spool_files].count).to be(2)
+        expect(Dir[spool_files].count).to eq(2)
       end
     end
 

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -30,16 +30,6 @@ RSpec.describe EducationForm::EducationFacility do
         expect(described_class.routing_address(form, form_type: '1990').state).to eq(western_address.state)
       end
     end
-    context '22-1990E' do
-      let(:form) { OpenStruct.new(relativeAddress: western_address) }
-      it 'uses educationProgram over relativeAddress' do
-        form.educationProgram = school(central_address)
-        expect(described_class.routing_address(form, form_type: '1990e').state).to eq(central_address.state)
-      end
-      it 'uses relativeAddress when no educationProgram address is given' do
-        expect(described_class.routing_address(form, form_type: '1990e').state).to eq(western_address.state)
-      end
-    end
     context '22-1990N' do
       let(:form) { OpenStruct.new(veteranAddress: western_address) }
       it 'uses educationProgram over veteranAddress' do
@@ -51,33 +41,25 @@ RSpec.describe EducationForm::EducationFacility do
       end
     end
     context '22-1995' do
-      let(:form) { OpenStruct.new(relativeAddress: western_address) }
-      it 'uses school over relativeAddress' do
+      let(:form) { OpenStruct.new(veteranAddress: western_address) }
+      it 'uses newSchool over relativeAddress' do
         form.newSchool = school(central_address)
         expect(described_class.routing_address(form, form_type: '1995').state).to eq(central_address.state)
       end
-      it 'uses relativeAddress when no school address is given' do
+      it 'uses veteranAddress when no school address is given' do
         expect(described_class.routing_address(form, form_type: '1995').state).to eq(western_address.state)
       end
     end
-    context '22-5490' do
-      let(:form) { OpenStruct.new(relativeAddress: western_address) }
-      it 'uses educationProgram over relativeAddress' do
-        form.educationProgram = school(central_address)
-        expect(described_class.routing_address(form, form_type: '5490').state).to eq(central_address.state)
-      end
-      it 'uses relativeAddress when no educationProgram address is given' do
-        expect(described_class.routing_address(form, form_type: '5490').state).to eq(western_address.state)
-      end
-    end
-    context '22-5495' do
-      let(:form) { OpenStruct.new(relativeAddress: western_address) }
-      it 'uses newSchool over relativeAddress' do
-        form.newSchool = school(central_address)
-        expect(described_class.routing_address(form, form_type: '5495').state).to eq(central_address.state)
-      end
-      it 'uses relativeAddress when no school address is given' do
-        expect(described_class.routing_address(form, form_type: '5495').state).to eq(western_address.state)
+    %w(1990E 5490 5495).each do |form_type|
+      context "22-#{form_type}" do
+        let(:form) { OpenStruct.new(relativeAddress: western_address) }
+        it 'uses educationProgram over relativeAddress' do
+          form.educationProgram = school(central_address)
+          expect(described_class.routing_address(form, form_type: form_type).state).to eq(central_address.state)
+        end
+        it 'uses relativeAddress when no educationProgram address is given' do
+          expect(described_class.routing_address(form, form_type: form_type).state).to eq(western_address.state)
+        end
       end
     end
   end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -3,6 +3,84 @@ require 'rails_helper'
 
 RSpec.describe EducationForm::EducationFacility do
   let(:education_benefits_claim) { build(:education_benefits_claim) }
+  let(:eastern_address) do
+    OpenStruct.new(country: 'USA', state: 'DE')
+  end
+  let(:central_address) do
+    OpenStruct.new(country: 'USA', state: 'IL')
+  end
+  let(:western_address) do
+    OpenStruct.new(country: 'USA', state: 'CA')
+  end
+
+  def school(data)
+    OpenStruct.new(address: data)
+  end
+
+  describe '#routing_address' do
+    let(:form) { OpenStruct.new }
+    context '22-1990' do
+      it 'uses school over veteranAddress' do
+        form.school = school(eastern_address)
+        form.veteranAddress = western_address
+        expect(described_class.routing_address(form, form_type: '1990').state).to eq(eastern_address.state)
+      end
+      it 'uses veteranAddress when no school address is given' do
+        form.veteranAddress = western_address
+        expect(described_class.routing_address(form, form_type: '1990').state).to eq(western_address.state)
+      end
+    end
+    context '22-1990E' do
+      let(:form) { OpenStruct.new(relativeAddress: western_address) }
+      it 'uses educationProgram over relativeAddress' do
+        form.educationProgram = school(central_address)
+        expect(described_class.routing_address(form, form_type: '1990e').state).to eq(central_address.state)
+      end
+      it 'uses relativeAddress when no educationProgram address is given' do
+        expect(described_class.routing_address(form, form_type: '1990e').state).to eq(western_address.state)
+      end
+    end
+    context '22-1990N' do
+      let(:form) { OpenStruct.new(veteranAddress: western_address) }
+      it 'uses educationProgram over veteranAddress' do
+        form.educationProgram = school(central_address)
+        expect(described_class.routing_address(form, form_type: '1990n').state).to eq(central_address.state)
+      end
+      it 'uses veteranAddress when no school address is given' do
+        expect(described_class.routing_address(form, form_type: '1990n').state).to eq(western_address.state)
+      end
+    end
+    context '22-1995' do
+      let(:form) { OpenStruct.new(relativeAddress: western_address) }
+      it 'uses school over relativeAddress' do
+        form.newSchool = school(central_address)
+        expect(described_class.routing_address(form, form_type: '1995').state).to eq(central_address.state)
+      end
+      it 'uses relativeAddress when no school address is given' do
+        expect(described_class.routing_address(form, form_type: '1995').state).to eq(western_address.state)
+      end
+    end
+    context '22-5490' do
+      let(:form) { OpenStruct.new(relativeAddress: western_address) }
+      it 'uses educationProgram over relativeAddress' do
+        form.educationProgram = school(central_address)
+        expect(described_class.routing_address(form, form_type: '5490').state).to eq(central_address.state)
+      end
+      it 'uses relativeAddress when no educationProgram address is given' do
+        expect(described_class.routing_address(form, form_type: '5490').state).to eq(western_address.state)
+      end
+    end
+    context '22-5495' do
+      let(:form) { OpenStruct.new(relativeAddress: western_address) }
+      it 'uses newSchool over relativeAddress' do
+        form.newSchool = school(central_address)
+        expect(described_class.routing_address(form, form_type: '5495').state).to eq(central_address.state)
+      end
+      it 'uses relativeAddress when no school address is given' do
+        expect(described_class.routing_address(form, form_type: '5495').state).to eq(western_address.state)
+      end
+    end
+  end
 
   describe '#regional_office_for' do
     {


### PR DESCRIPTION
SUPER repetitive specs right now, but this adds some form-specific behavior to ensure we always route the claims to the right RPO based on where the educational facility is located, then falling back to where the person claiming the money is located. 