### PR TITLE
[WIP] health records streaming client

### DIFF
--- a/app/controllers/bb_controller.rb
+++ b/app/controllers/bb_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'bb/client'
+require 'bb/streaming_client'
 
 class BBController < ApplicationController
   include ActionController::Serialization
@@ -9,6 +10,10 @@ class BBController < ApplicationController
 
   def client
     @client ||= BB::Client.new(session: { user_id: current_user.mhv_correlation_id })
+  end
+
+  def streaming_client
+    @streaming_client ||= BB::StreamingClient.new(client)
   end
 
   def raise_access_denied

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -38,7 +38,7 @@ module V0
       first = true
       chunk_stream.each do |c|
         if first
-          response_headers.each { |k,v| response[k] = v }
+          response_headers.each { |k, v| response[k] = v }
           first = false
         end
         response.stream.write c

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 module V0
   class HealthRecordsController < BBController
+    include ActionController::Live
+
+    REPORT_HEADERS = %w(Content-Type Content-Disposition).freeze
+
     def refresh
       resource = client.get_extract_status
 
@@ -27,11 +31,19 @@ module V0
     def show
       # doc_type will default to 'pdf' if any value, including nil is provided.
       doc_type = params[:doc_type] == 'txt' ? 'txt' : 'pdf'
-      resource = client.get_download_report(doc_type)
-
-      send_data resource.body,
-                type: resource.response_headers['content-type'],
-                disposition: resource.response_headers['content-disposition']
+      response_headers = Hash[REPORT_HEADERS.map { |h| [h, ''] }]
+      chunk_stream = Enumerator.new do |stream|
+        streaming_client.get_download_report(doc_type, response_headers, stream)
+      end
+      first = true
+      chunk_stream.each do |c|
+        if first
+          response_headers.each { |k,v| response[k] = v }
+          first = false
+        end
+        response.stream.write c
+      end
+      response.stream.close
     end
   end
 end

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -35,11 +35,9 @@ module V0
       chunk_stream = Enumerator.new do |stream|
         streaming_client.get_download_report(doc_type, response_headers, stream)
       end
-      first = true
-      chunk_stream.each do |c|
-        if first
+      chunk_stream.each.with_index do |c, index|
+        if index == 0
           response_headers.each { |k, v| response[k] = v }
-          first = false
         end
         response.stream.write c
       end

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -19,7 +19,9 @@ module BB
 
     # doctype must be one of: txt or pdf
     def get_download_report(doctype, headers, yielder)
-      uri = URI('https://essapi-sysb.myhealth.va.gov/vetsgov/90mb.file')
+      uri = URI("#{Settings.mhv.rx.host}/vetsgov/1mb.file")
+      #uri = URI("#{Settings.mhv.rx.host}/vetsgov/90mb.file")
+      #uri = URI('https://essapi-sysb.myhealth.va.gov/vetsgov/90mb.file')
       # uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
       request = Net::HTTP::Get.new(uri)
       @api_client.token_headers.each do |k, v|

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'common/client/concerns/mhv_session_based_client'
+require 'bb/generate_report_request_form'
+require 'bb/configuration'
+require 'rx/client_session'
+
+module BB
+  # Core class responsible for api interface operations
+  class StreamingClient
+    include Common::Client::MHVSessionBasedClient
+
+    def initialize(api_client)
+      @api_client = api_client
+    end
+
+    def base_path
+      @api_client.class.configuration.base_path
+    end
+
+    # doctype must be one of: txt or pdf
+    def get_download_report(doctype, headers, yielder)
+      uri = URI('https://essapi-sysb.myhealth.va.gov/vetsgov/90mb.file')
+      # uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
+      request = Net::HTTP::Get.new(uri)
+      @api_client.token_headers.each do |k, v|
+        request[k] = v
+      end
+      Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == 'https')) do |http|
+        http.request request do |response|
+          headers.keys.each do |k|
+            headers[k] = response[k]
+          end
+          response.read_body do |chunk|
+            yielder << chunk
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -19,9 +19,9 @@ module BB
 
     # doctype must be one of: txt or pdf
     def get_download_report(doctype, headers, yielder)
-      # TODO For testing purposes, use one of the following static files:
-      #uri = URI("#{Settings.mhv.rx.host}/vetsgov/1mb.file")
-      #uri = URI("#{Settings.mhv.rx.host}/vetsgov/90mb.file")
+      # TODO: For testing purposes, use one of the following static files:
+      # uri = URI("#{Settings.mhv.rx.host}/vetsgov/1mb.file")
+      # uri = URI("#{Settings.mhv.rx.host}/vetsgov/90mb.file")
       uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
       request = Net::HTTP::Get.new(uri)
       @api_client.token_headers.each do |k, v|

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -26,14 +26,12 @@ module BB
       request = Net::HTTP::Get.new(uri)
       @api_client.token_headers.each { |k, v| request[k] = v }
       begin
-        Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == 'https')) do |http|
+        Net::HTTP.start(uri.host, uri.port, read_timeout: 20, use_ssl: (uri.scheme == 'https')) do |http|
           http.request request do |response|
-            if response.is_a?(Net::HTTPClientError) or response.is_a?(Net::HTTPServerError)
+            if response.is_a?(Net::HTTPClientError) || response.is_a?(Net::HTTPServerError)
               raise Common::Client::Errors::ClientError, "Health record request failed: #{response.code}"
             end
-            headers.keys.each do |k|
-              headers[k] = response[k]
-            end
+            headers.keys.each { |k| headers[k] = response[k] }
             response.read_body do |chunk|
               yielder << chunk
             end

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -19,10 +19,10 @@ module BB
 
     # doctype must be one of: txt or pdf
     def get_download_report(doctype, headers, yielder)
-      uri = URI("#{Settings.mhv.rx.host}/vetsgov/1mb.file")
+      # TODO For testing purposes, use one of the following static files:
+      #uri = URI("#{Settings.mhv.rx.host}/vetsgov/1mb.file")
       #uri = URI("#{Settings.mhv.rx.host}/vetsgov/90mb.file")
-      #uri = URI('https://essapi-sysb.myhealth.va.gov/vetsgov/90mb.file')
-      # uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
+      uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
       request = Net::HTTP::Get.new(uri)
       @api_client.token_headers.each do |k, v|
         request[k] = v

--- a/lib/common/client/concerns/mhv_session_based_client.rb
+++ b/lib/common/client/concerns/mhv_session_based_client.rb
@@ -33,14 +33,14 @@ module Common
         end
       end
 
+      def token_headers
+        config.base_request_headers.merge('Token' => session.token)
+      end
+
       private
 
       def auth_headers
         config.base_request_headers.merge('appToken' => config.app_token, 'mhvCorrelationId' => session.user_id.to_s)
-      end
-
-      def token_headers
-        config.base_request_headers.merge('Token' => session.token)
       end
     end
   end

--- a/spec/request/health_records_request_spec.rb
+++ b/spec/request/health_records_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 require 'bb/generate_report_request_form'
 require 'bb/client'
 
-RSpec.describe 'prescriptions', type: :request do
+RSpec.describe 'health records', type: :request do
   TOKEN = 'GkuX2OZ4dCE=48xrH6ObGXZ45ZAg70LBahi7CjswZe8SZGKMUVFIU88='
 
   def authenticated_client
@@ -77,7 +77,6 @@ RSpec.describe 'prescriptions', type: :request do
     expect(response).to be_success
     expect(response.headers['Content-Disposition'])
       .to eq('inline; filename=mhv_GPTESTKFIVE_20161229_0057.pdf')
-    expect(response.headers['Content-Transfer-Encoding']).to eq('binary')
     expect(response.headers['Content-Type']).to eq('application/pdf')
     expect(response.body).to be_a(String)
   end
@@ -90,7 +89,6 @@ RSpec.describe 'prescriptions', type: :request do
     expect(response).to be_success
     expect(response.headers['Content-Disposition'])
       .to eq('inline; filename=mhv_GPTESTKFIVE_20170130_1901.txt')
-    expect(response.headers['Content-Transfer-Encoding']).to eq('binary')
     expect(response.headers['Content-Type']).to eq('text/plain')
     expect(response.body).to be_a(String)
   end

--- a/spec/request/health_records_request_spec.rb
+++ b/spec/request/health_records_request_spec.rb
@@ -92,4 +92,12 @@ RSpec.describe 'health records', type: :request do
     expect(response.headers['Content-Type']).to eq('text/plain')
     expect(response.body).to be_a(String)
   end
+
+  it 'handles an error response for a report request' do
+    VCR.use_cassette('bb_client/report_error_response') do
+      get '/v0/health_records', doc_type: 'txt'
+    end
+
+    expect(response).to have_http_status(503)
+  end
 end

--- a/spec/support/vcr_cassettes/bb_client/report_error_response.yml
+++ b/spec/support/vcr_cassettes/bb_client/report_error_response.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<MHV_HOST>/mhv-api/patient/v1/bluebutton/bbreport/txt"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Token: "<SESSION_TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - text/plain
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 31 Jan 2017 00:01:49 GMT
+    body:
+      encoding: UTF-8
+      string: '{"errorCode":99,"developerMessage":"Index: 0, Size: 0","message":"Unknown application error occurred"}'
+    http_version: 
+  recorded_at: Tue, 31 Jan 2017 00:01:49 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2012

Rationale for streaming implementation is noted here: https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Blue%20Button/Performance%20and%20Load%20Testing/Streaming%20Implementation%20Notes.md 

Unfortunately there's no way to do this using Faraday directly. This approach encapsulates the existing MHV client so that it can still be used for session token generation/refresh. 

The call path between HealthRecordsController and StreamingClient is also pretty awkward due to some constraints - the need to pass in a yielder to the Net::HTTP request block, and the need to write headers to the controller response stream before any chunks are written.

WIP because some minimal error handling is needed - I think most of the interesting/actionable error messages would come back earlier in the overall health record request flow, e.g. during the request to generate the report, but of course we should handle getting a 4xx/5xx/timeout during the actual download attempt.
