### PR TITLE
Pv healthrec streaming typhoeus

### DIFF
--- a/app/controllers/bb_controller.rb
+++ b/app/controllers/bb_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'bb/client'
+require 'bb/streaming_client'
 
 class BBController < ApplicationController
   include ActionController::Serialization
@@ -9,6 +10,10 @@ class BBController < ApplicationController
 
   def client
     @client ||= BB::Client.new(session: { user_id: current_user.mhv_correlation_id })
+  end
+
+  def streaming_client
+    @streaming_client ||= BB::StreamingClient.new(client)
   end
 
   def raise_access_denied

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -36,16 +36,13 @@ module V0
       header_callback = lambda do |headers|
         headers.each { |k, v| response[k] = v if REPORT_HEADERS.include? k }
       end
-      begin
-        chunk_stream = Enumerator.new do |stream|
-          streaming_client.get_download_report(doc_type, header_callback, stream)
-        end
-        chunk_stream.each do |c|
-          response.stream.write c
-        end
-      ensure
-        response.stream.close
+      chunk_stream = Enumerator.new do |stream|
+        streaming_client.get_download_report(doc_type, header_callback, stream)
       end
+      chunk_stream.each do |c|
+        response.stream.write c
+      end
+      response.stream.close
     end
   end
 end

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -38,7 +38,7 @@ module V0
       first = true
       chunk_stream.each do |c|
         if first
-          response_headers.each { |k,v| response[k] = v }
+          response_headers.each { |k, v| response[k] = v }
           first = false
         end
         response.stream.write c

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -34,13 +34,18 @@ module V0
       header_callback = lambda do |headers|
         headers.each { |k, v| response[k] = v if REPORT_HEADERS.include? k }
       end
-      chunk_stream = Enumerator.new do |stream|
-        streaming_client.get_download_report(doc_type, header_callback, stream)
+      begin
+        chunk_stream = Enumerator.new do |stream|
+          streaming_client.get_download_report(doc_type, header_callback, stream)
+        end
+        chunk_stream.each do |c|
+          response.stream.write c
+        end
+        response.stream.close
+      rescue Common::Client::Errors::StreamingError
+        response.stream.close
+        raise
       end
-      chunk_stream.each do |c|
-        response.stream.write c
-      end
-      response.stream.close
     end
   end
 end

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -28,8 +28,6 @@ module V0
       render nothing: true, status: :accepted
     end
 
-    # TODO implement lambda header_callback that writes header responses,
-    # pass to get_download_report instead of dict reference
     def show
       # doc_type will default to 'pdf' if any value, including nil is provided.
       doc_type = params[:doc_type] == 'txt' ? 'txt' : 'pdf'

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 module V0
   class HealthRecordsController < BBController
+    include ActionController::Live
+
+    REPORT_HEADERS = %w(Content-Type Content-Disposition).freeze
+
     def refresh
       resource = client.get_extract_status
 
@@ -27,11 +31,19 @@ module V0
     def show
       # doc_type will default to 'pdf' if any value, including nil is provided.
       doc_type = params[:doc_type] == 'txt' ? 'txt' : 'pdf'
-      resource = client.get_download_report(doc_type)
-
-      send_data resource.body,
-                type: resource.response_headers['content-type'],
-                disposition: resource.response_headers['content-disposition']
+      response_headers = Hash[REPORT_HEADERS.map { |h| [h, ''] }]
+      chunk_stream = Enumerator.new do |stream|
+        streaming_client.get_download_report(doc_type, response_headers, stream)
+      end
+      first = true
+      chunk_stream.each do |c|
+        if first
+          response_headers.each { |k,v| response[k] = v }
+          first = false
+        end
+        response.stream.write c
+      end
+      response.stream.close
     end
   end
 end

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -34,19 +34,18 @@ module V0
       # doc_type will default to 'pdf' if any value, including nil is provided.
       doc_type = params[:doc_type] == 'txt' ? 'txt' : 'pdf'
       header_callback = lambda do |headers|
-        headers.each do |k, v|
-          puts "#{k}: #{v}"
-          response[k] = v if REPORT_HEADERS.include? k
+        headers.each { |k, v| response[k] = v if REPORT_HEADERS.include? k }
+      end
+      begin
+        chunk_stream = Enumerator.new do |stream|
+          streaming_client.get_download_report(doc_type, header_callback, stream)
         end
+        chunk_stream.each do |c|
+          response.stream.write c
+        end
+      ensure
+        response.stream.close
       end
-      response_headers = Hash[REPORT_HEADERS.map { |h| [h, ''] }]
-      chunk_stream = Enumerator.new do |stream|
-        streaming_client.get_download_report(doc_type, header_callback, stream)
-      end
-      chunk_stream.each.with_index do |c, index|
-        response.stream.write c
-      end
-      response.stream.close
     end
   end
 end

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -35,11 +35,9 @@ module V0
       chunk_stream = Enumerator.new do |stream|
         streaming_client.get_download_report(doc_type, response_headers, stream)
       end
-      first = true
-      chunk_stream.each do |c|
-        if first
+      chunk_stream.each.with_index do |c, index|
+        if index == 0
           response_headers.each { |k, v| response[k] = v }
-          first = false
         end
         response.stream.write c
       end

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -26,7 +26,7 @@ module BB
       # uri = URI("#{Settings.mhv.rx.host}/vetsgov/90mb.file")
       uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
       request = Typhoeus::Request.new(uri.to_s, headers: @api_client.token_headers,
-                                                timeout: 10, connecttimeout: 10)
+                                                connecttimeout: 10)
       request.on_headers do |response|
         raise Common::Client::Errors::ClientError, 'Health record request timed out' if response.timed_out?
         raise Common::Client::Errors::ClientError, "Health record request failed: #{response.code}" if
@@ -39,7 +39,8 @@ module BB
       end
 
       request.on_complete do |response|
-        raise Common::Client::Errors::StreamingError, 'Health record streaming failed' unless response.success?
+        raise Common::Client::Errors::StreamingError, "Health record stream failed: #{response.return_message}" unless
+          response.success?
       end
 
       request.run

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -19,7 +19,9 @@ module BB
 
     # doctype must be one of: txt or pdf
     def get_download_report(doctype, headers, yielder)
-      uri = URI('https://essapi-sysb.myhealth.va.gov/vetsgov/90mb.file')
+      uri = URI("#{Settings.mhv.rx.host}/vetsgov/1mb.file")
+      #uri = URI("#{Settings.mhv.rx.host}/vetsgov/90mb.file")
+      #uri = URI('https://essapi-sysb.myhealth.va.gov/vetsgov/90mb.file')
       # uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
       request = Net::HTTP::Get.new(uri)
       @api_client.token_headers.each do |k, v|

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'common/client/concerns/mhv_session_based_client'
+require 'bb/generate_report_request_form'
+require 'bb/configuration'
+require 'rx/client_session'
+
+module BB
+  # Core class responsible for api interface operations
+  class StreamingClient
+    include Common::Client::MHVSessionBasedClient
+
+    def initialize(api_client)
+      @api_client = api_client
+    end
+
+    def base_path
+      @api_client.class.configuration.base_path
+    end
+
+    # doctype must be one of: txt or pdf
+    def get_download_report(doctype, headers, yielder)
+      uri = URI('https://essapi-sysb.myhealth.va.gov/vetsgov/90mb.file')
+      # uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
+      request = Net::HTTP::Get.new(uri)
+      @api_client.token_headers.each do |k, v|
+        request[k] = v
+      end
+      Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == 'https')) do |http|
+        http.request request do |response|
+          headers.keys.each do |k|
+            headers[k] = response[k]
+          end
+          response.read_body do |chunk|
+            yielder << chunk
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -39,7 +39,7 @@ module BB
       end
 
       request.on_complete do |response|
-        raise Common::Client::Errors::ClientError, 'Health record request failed' unless response.success?
+        raise Common::Client::Errors::StreamingError, 'Health record streaming failed' unless response.success?
       end
 
       request.run

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -25,10 +25,12 @@ module BB
       # uri = URI("#{Settings.mhv.rx.host}/vetsgov/1mb.file")
       # uri = URI("#{Settings.mhv.rx.host}/vetsgov/90mb.file")
       uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
-      request = Typhoeus::Request.new(uri.to_s, headers: @api_client.token_headers)
+      request = Typhoeus::Request.new(uri.to_s, headers: @api_client.token_headers,
+                                                timeout: 10, connecttimeout: 10)
       request.on_headers do |response|
         raise Common::Client::Errors::ClientError, 'Health record request timed out' if response.timed_out?
-        raise Common::Client::Errors::ClientError, "Health record request failed: #{response.code.to_s} #{response.return_message}" if response.code != 200 
+        raise Common::Client::Errors::ClientError, "Health record request failed: #{response.code}" if
+          response.code != 200
         header_callback.call(response.headers)
       end
 

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -19,9 +19,9 @@ module BB
 
     # doctype must be one of: txt or pdf
     def get_download_report(doctype, headers, yielder)
-      # TODO For testing purposes, use one of the following static files:
-      #uri = URI("#{Settings.mhv.rx.host}/vetsgov/1mb.file")
-      #uri = URI("#{Settings.mhv.rx.host}/vetsgov/90mb.file")
+      # TODO: For testing purposes, use one of the following static files:
+      # uri = URI("#{Settings.mhv.rx.host}/vetsgov/1mb.file")
+      # uri = URI("#{Settings.mhv.rx.host}/vetsgov/90mb.file")
       uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
       request = Net::HTTP::Get.new(uri)
       @api_client.token_headers.each do |k, v|

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -19,10 +19,10 @@ module BB
 
     # doctype must be one of: txt or pdf
     def get_download_report(doctype, headers, yielder)
-      uri = URI("#{Settings.mhv.rx.host}/vetsgov/1mb.file")
+      # TODO For testing purposes, use one of the following static files:
+      #uri = URI("#{Settings.mhv.rx.host}/vetsgov/1mb.file")
       #uri = URI("#{Settings.mhv.rx.host}/vetsgov/90mb.file")
-      #uri = URI('https://essapi-sysb.myhealth.va.gov/vetsgov/90mb.file')
-      # uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
+      uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
       request = Net::HTTP::Get.new(uri)
       @api_client.token_headers.each do |k, v|
         request[k] = v

--- a/lib/bb/streaming_client.rb
+++ b/lib/bb/streaming_client.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'common/client/concerns/mhv_session_based_client'
+require 'common/client/errors'
 require 'bb/generate_report_request_form'
 require 'bb/configuration'
 require 'rx/client_session'
@@ -26,8 +27,8 @@ module BB
       uri = URI.join(base_path, "bluebutton/bbreport/#{doctype}")
       request = Typhoeus::Request.new(uri.to_s, headers: @api_client.token_headers)
       request.on_headers do |response|
-        raise Common::Client::Errors::ClientError 'Health record request timed out' if response.timed_out?
-        raise Common::Client::Errors::ClientError "Health record request failed: #{response.code.to_s}" if response.code != 200 
+        raise Common::Client::Errors::ClientError, 'Health record request timed out' if response.timed_out?
+        raise Common::Client::Errors::ClientError, "Health record request failed: #{response.code.to_s} #{response.return_message}" if response.code != 200 
         header_callback.call(response.headers)
       end
 
@@ -36,7 +37,7 @@ module BB
       end
 
       request.on_complete do |response|
-        raise Common::Client::Errors::ClientError 'Health record request failed' unless response.success?
+        raise Common::Client::Errors::ClientError, 'Health record request failed' unless response.success?
       end
 
       request.run

--- a/lib/common/client/concerns/mhv_session_based_client.rb
+++ b/lib/common/client/concerns/mhv_session_based_client.rb
@@ -33,14 +33,14 @@ module Common
         end
       end
 
+      def token_headers
+        config.base_request_headers.merge('Token' => session.token)
+      end
+
       private
 
       def auth_headers
         config.base_request_headers.merge('appToken' => config.app_token, 'mhvCorrelationId' => session.user_id.to_s)
-      end
-
-      def token_headers
-        config.base_request_headers.merge('Token' => session.token)
       end
     end
   end

--- a/lib/common/client/errors.rb
+++ b/lib/common/client/errors.rb
@@ -8,6 +8,7 @@ module Common
       class ClientError < Error; end
       class NotAuthenticated < ClientError; end
       class Serialization < ClientError; end
+      class StreamingError < ClientError; end
       class HTTPError < ClientError
         attr_accessor :code
 

--- a/spec/request/health_records_request_spec.rb
+++ b/spec/request/health_records_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 require 'bb/generate_report_request_form'
 require 'bb/client'
 
-RSpec.describe 'prescriptions', type: :request do
+RSpec.describe 'health records', type: :request do
   TOKEN = 'GkuX2OZ4dCE=48xrH6ObGXZ45ZAg70LBahi7CjswZe8SZGKMUVFIU88='
 
   def authenticated_client
@@ -77,7 +77,6 @@ RSpec.describe 'prescriptions', type: :request do
     expect(response).to be_success
     expect(response.headers['Content-Disposition'])
       .to eq('inline; filename=mhv_GPTESTKFIVE_20161229_0057.pdf')
-    expect(response.headers['Content-Transfer-Encoding']).to eq('binary')
     expect(response.headers['Content-Type']).to eq('application/pdf')
     expect(response.body).to be_a(String)
   end
@@ -90,7 +89,6 @@ RSpec.describe 'prescriptions', type: :request do
     expect(response).to be_success
     expect(response.headers['Content-Disposition'])
       .to eq('inline; filename=mhv_GPTESTKFIVE_20170130_1901.txt')
-    expect(response.headers['Content-Transfer-Encoding']).to eq('binary')
     expect(response.headers['Content-Type']).to eq('text/plain')
     expect(response.body).to be_a(String)
   end


### PR DESCRIPTION
Alternative to #931 

I got spooked by Net::HTTP error handling and tried this approach with Typhoeus (which we are using elsewhere in vets-api already). A slightly different abstraction - using a callback to set the headers instead of a pass-by-reference thing. I have been staring at this too long - does it seems cleaner? 