### PR TITLE
Update README: Get cert before running setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ To start, fetch this code:
 
 `git clone https://github.com/department-of-veterans-affairs/vets-api.git`
 
+Setup localhost certificates / keys:
+ - Create a hidden folder in your home directory:  `mkdir ~/.certs`
+ - Copy the [certificate][certificate] to `~/.certs/vetsgov-localhost.crt`
+ - Copy the [key][key] to `~/.certs/vetsgov-localhost.key`
+ - *NOTE*: If you don't have access to these keys, running the following
+   commands will provide basic functionality, such as for running unit tests:
+ - `touch ~/.certs/vetsgov-localhost.crt`
+ - `touch ~/.certs/vetsgov-localhost.key`
+
 #### Automated (OSX)
 
 If you are developing on OSX, you can run the automated setup script. From
@@ -23,35 +32,27 @@ the `vets-api` directory, run `./bin/setup-osx && source ~/.bash_profile && cd .
 #### Alternative (OSX)
 
 1. Install Ruby 2.3.
-  - It is suggested that you use a Ruby version manager such as
+   - It is suggested that you use a Ruby version manager such as
     [rbenv](https://github.com/rbenv/rbenv#installation) and
     [install Ruby 2.3](https://github.com/rbenv/rbenv#installing-ruby-versions).
-  - *NOTE*: rbenv will also provide additional installation instructions in the
+   - *NOTE*: rbenv will also provide additional installation instructions in the
     console output. Make sure to follow those too.
 1. Install Bundler to manage dependencies
-  - `gem install bundler`
+   - `gem install bundler`
 1. Install Postgres and enable on startup
-  - `brew install postgres`
-  - `brew services start postgres`
+   - `brew install postgres`
+   - `brew services start postgres`
 1. Install Redis
-  - `brew install redis`
-  - Follow post-install instructions to enable Redis on startup. Otherwise,
+   - `brew install redis`
+   - Follow post-install instructions to enable Redis on startup. Otherwise,
     launch it manually with `brew services start redis`.
 1. Install gem dependencies: `cd vets-api; bundle install`
 1. Install overcommit `overcommit --install --sign`
-1. Setup localhost certificates / keys
-  - Create a hidden folder in your home directory:  `mkdir ~/.certs`
-  - Copy the [certificate][certificate] to `~/.certs/vetsgov-localhost.crt`
-  - Copy the [key][key] to `~/.certs/vetsgov-localhost.key`
-  - *NOTE*: If you don't have access to these keys, running the following
-    commands will provide basic functionality, such as for running unit tests:
-  - `touch ~/.certs/vetsgov-localhost.crt`
-  - `touch ~/.certs/vetsgov-localhost.key`
 1. Create dev database: `bundle exec rake db:setup`
 
 
-[certificate]: https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Identity/Identity%20Discovery%202016/certificates/vetsgov-localhost.crt
-[key]: https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Identity/Identity%20Discovery%202016/certificates/vetsgov-localhost.key
+[certificate]: https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Identity/Files_From_IDme/development-certificates/vetsgov-localhost.crt
+[key]: https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Identity/Files_From_IDme/development-certificates/vetsgov-localhost.key
 
 ### Configuration
 

--- a/bin/setup-osx
+++ b/bin/setup-osx
@@ -125,5 +125,5 @@ if [ "$CERT_INSTALL_REQUIRED" = true ]; then
   echo
   echo "  https://github.com/department-of-veterans-affairs/vets.gov-team/tree/master/Products/Identity/Files_From_IDme/development-certificates"
   echo
-  echo "and install the .crt and .key files in ~/.certs/${RESET}"
+  echo "and copy the .crt and .key files to ~/.certs/${RESET}"
 fi

--- a/bin/setup-osx
+++ b/bin/setup-osx
@@ -5,6 +5,7 @@ command_exists () {
 }
 RED=`tput setaf 1`
 GREEN=`tput setaf 2`
+YELLOW=`tput setaf 3`
 RESET=`tput sgr0`
 
 # Check for homebrew
@@ -80,6 +81,29 @@ fi
 
 brew services start postgresql
 
+# Make vetsgov-localhost.crt and .key
+
+CERT_INSTALL_REQUIRED=false
+if [ ! -d ~/.certs ]; then
+  mkdir ~/.certs
+fi
+
+if [ -f ~/.certs/vetsgov-localhost.crt ]; then
+  echo "${GREEN} * vetsgov-localhost.crt installed.${RESET}"
+else
+  echo "${RED} * Installing vetsgov-localhost.crt.${RESET}"
+  touch ~/.certs/vetsgov-localhost.crt
+  CERT_INSTALL_REQUIRED=true
+fi
+
+if [ -f ~/.certs/vetsgov-localhost.key ]; then
+  echo "${GREEN} * vetsgov-localhost.key installed.${RESET}"
+else
+  echo "${RED} * Installing vetsgov-localhost.key.${RESET}"
+  touch ~/.certs/vetsgov-localhost.key
+  CERT_INSTALL_REQUIRED=true
+fi
+
 # Install ruby / vet-api deps
 
 bundle install -j4
@@ -89,8 +113,17 @@ bundle exec overcommit --install --sign
 rake db:create db:setup db:seed
 
 cp config/mvi_schema/mock_mvi_responses.yml.example config/mvi_schema/mock_mvi_responses.yml
-cp config/application.yml.example config/application.yml
 
 # Run a test to make sure things are working after setup
 
 rake
+
+# Warn the user that the certs installed are blank and have limited functionality
+
+if [ "$CERT_INSTALL_REQUIRED" = true ]; then
+  echo "${YELLOW}Notice: Blank certificate files were installed for limited functionality. If you have access, go to:"
+  echo
+  echo "  https://github.com/department-of-veterans-affairs/vets.gov-team/tree/master/Products/Identity/Files_From_IDme/development-certificates"
+  echo
+  echo "and install the .crt and .key files in ~/.certs/${RESET}"
+fi


### PR DESCRIPTION
I ran the automated script without setting up the cert first and got an error because it expected it. I got the cert, reran the script, and it all worked out.

Not sure who to ask for a review from, so I'll just @mention GitHub's suggested reviewers, @knkski, @robbiethegeek, and @markolson.