### PR TITLE
Separate out streaming method to avoid streaming/olive branch conflict

### DIFF
--- a/app/controllers/v0/health_record_contents_controller.rb
+++ b/app/controllers/v0/health_record_contents_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module V0
+  class HealthRecordContentsController < BBController
+    include ActionController::Live
+
+    REPORT_HEADERS = %w(Content-Type Content-Disposition).freeze
+
+    def show
+      # doc_type will default to 'pdf' if any value, including nil is provided.
+      doc_type = params[:doc_type] == 'txt' ? 'txt' : 'pdf'
+      header_callback = lambda do |headers|
+        headers.each { |k, v| response[k] = v if REPORT_HEADERS.include? k }
+      end
+      begin
+        chunk_stream = Enumerator.new do |stream|
+          client.get_download_report(doc_type, header_callback, stream)
+        end
+        chunk_stream.each { |c| response.stream.write c }
+      ensure
+        response.stream.close if response.committed?
+      end
+    end
+  end
+end

--- a/app/controllers/v0/health_records_controller.rb
+++ b/app/controllers/v0/health_records_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 module V0
   class HealthRecordsController < BBController
-    include ActionController::Live
-
-    REPORT_HEADERS = %w(Content-Type Content-Disposition).freeze
-
     def refresh
       resource = client.get_extract_status
 
@@ -26,22 +22,6 @@ module V0
       client.post_generate(params)
 
       render nothing: true, status: :accepted
-    end
-
-    def show
-      # doc_type will default to 'pdf' if any value, including nil is provided.
-      doc_type = params[:doc_type] == 'txt' ? 'txt' : 'pdf'
-      header_callback = lambda do |headers|
-        headers.each { |k, v| response[k] = v if REPORT_HEADERS.include? k }
-      end
-      begin
-        chunk_stream = Enumerator.new do |stream|
-          client.get_download_report(doc_type, header_callback, stream)
-        end
-        chunk_stream.each { |c| response.stream.write c }
-      ensure
-        response.stream.close if response.committed?
-      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,9 +48,10 @@ Rails.application.routes.draw do
       end
     end
 
-    resource :health_records, only: [:create, :show], defaults: { format: :json } do
+    resource :health_records, only: [:create], defaults: { format: :json } do
       get :refresh, to: 'health_records#refresh', on: :collection
       get :eligible_data_classes, to: 'health_records#eligible_data_classes', on: :collection
+      get :show, controller: 'health_record_contents', on: :collection
     end
 
     resources :appeals, only: [:index]


### PR DESCRIPTION
ActionController::Live should not be used in any controller that also returns JSON payloads because olive_branch tries to replace the response body and fails silently and leaks database connections/threads. 

Tested by deploying to staging. Also filed an issue with olive_branch. 