### PR TITLE
move stub mvi to rails helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -124,7 +124,8 @@ RSpec.configure do |config|
 
   config.include StatsD::Instrument::Matchers
 
-  config.before(:each) do
+  config.before(:each) do |example|
+    stub_mvi unless example.metadata[:skip_mvi]
     Sidekiq::Worker.clear_all
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,7 +87,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do |example|
-    stub_mvi unless example.metadata[:skip_mvi]
     stub_veteran_status unless example.metadata[:skip_veteran_status]
   end
 


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2925

stub_mvi is calling factory_girl's build method but factory girl isn't required in spec_helper, only in rails_helper