### PR TITLE
Track mhv account eligibility in serializer

### DIFF
--- a/app/controllers/concerns/mhv_controller_concerns.rb
+++ b/app/controllers/concerns/mhv_controller_concerns.rb
@@ -17,12 +17,12 @@ module MHVControllerConcerns
   end
 
   def raise_requires_terms_acceptance
-    raise Common::Exceptions::Forbidden, detail: 'You have not accepted the terms of service.'
+    raise Common::Exceptions::Forbidden, detail: 'You have not accepted the terms of service'
   end
 
   def raise_something_went_wrong
     # TODO: any additional data could probably be provided in source.
-    raise Common::Exceptions::Forbidden, detail: 'Something went wrong. Please contact support.'
+    raise Common::Exceptions::Forbidden, detail: 'Something went wrong. Please contact support'
   end
 
   def authenticate_client

--- a/app/controllers/concerns/mhv_controller_concerns.rb
+++ b/app/controllers/concerns/mhv_controller_concerns.rb
@@ -10,14 +10,10 @@ module MHVControllerConcerns
   protected
 
   def authorize
-    raise_access_denied if mhv_account.ineligible?
-    raise_requires_terms_acceptance if mhv_account.needs_terms_acceptance?
-    mhv_account.create_and_upgrade! unless mhv_account.upgraded?
-    raise_something_went_wrong unless mhv_account.upgraded?
-  end
-
-  def mhv_account
-    @account ||= MhvAccount.find_or_initialize_by(user_uuid: current_user.uuid)
+    raise_access_denied if current_user.mhv_account.ineligible?
+    raise_requires_terms_acceptance if current_user.mhv_account.needs_terms_acceptance?
+    current_user.mhv_account.create_and_upgrade! unless current_user.mhv_account.upgraded?
+    raise_something_went_wrong unless current_user.mhv_account.upgraded?
   end
 
   def raise_requires_terms_acceptance

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -13,7 +13,7 @@ class MhvAccount < ActiveRecord::Base
     state :needs_terms_acceptance, :ineligible, :registered, :upgraded, :register_failed, :upgrade_failed
 
     event :check_eligibility do
-      transitions from: ALL_STATES, to: :ineligible, unless: :mhv_account_eligible?
+      transitions from: ALL_STATES, to: :ineligible, unless: :eligible?
       transitions from: ALL_STATES, to: :upgraded, if: :previously_upgraded?
       transitions from: ALL_STATES, to: :registered, if: :previously_registered?
       transitions from: ALL_STATES, to: :unknown
@@ -38,7 +38,7 @@ class MhvAccount < ActiveRecord::Base
   end
 
   def eligible?
-    mhv_account_eligible? || !ineligible?
+    va_patient?
   end
 
   def terms_and_conditions_accepted?
@@ -90,10 +90,6 @@ class MhvAccount < ActiveRecord::Base
     @user ||= User.find(user_uuid)
   end
 
-  def mhv_account_eligible?
-    va_patient?
-  end
-
   def va_patient?
     # TODO: This needs to be changed to check if ICN is within a certain range.
     user&.icn.present?
@@ -138,11 +134,11 @@ class MhvAccount < ActiveRecord::Base
   end
 
   def previously_upgraded?
-    mhv_account_eligible? && upgraded_at?
+    eligible? && upgraded_at?
   end
 
   def previously_registered?
-    mhv_account_eligible? && registered_at?
+    eligible? && registered_at?
   end
 
   def setup

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -38,7 +38,7 @@ class MhvAccount < ActiveRecord::Base
   end
 
   def eligible?
-    !ineligible?
+    mhv_account_eligible? || !ineligible?
   end
 
   def terms_and_conditions_accepted?

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -37,6 +37,10 @@ class MhvAccount < ActiveRecord::Base
     upgrade_mhv_account!
   end
 
+  def eligible?
+    !ineligible?
+  end
+
   def terms_and_conditions_accepted?
     terms_and_conditions_accepted.present?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,8 +60,14 @@ class User < Common::RedisStore
     loa1? || loa2? || loa3?
   end
 
+  # Must be LOA3 and a va patient
   def mhv_account_eligible?
-    loa3? && mhv_account.eligible?
+    (MhvAccount::ALL_STATES - [:ineligible]).map(&:to_s).include?(mhv_account_state)
+  end
+
+  def mhv_account_state
+    return nil unless loa3?
+    mhv_account.account_state
   end
 
   def can_access_evss?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,8 +60,8 @@ class User < Common::RedisStore
     loa1? || loa2? || loa3?
   end
 
-  def can_access_mhv?
-    loa3? && mhv_correlation_id
+  def mhv_account_eligible?
+    loa3? && mhv_account.eligible?
   end
 
   def can_access_evss?
@@ -97,6 +97,10 @@ class User < Common::RedisStore
 
   def va_profile_status
     mvi.status
+  end
+
+  def mhv_account
+    @mhv_account ||= MhvAccount.find_or_initialize_by(user_uuid: uuid)
   end
 
   private

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -56,9 +56,13 @@ class UserSerializer < ActiveModel::Serializer
       BackendServices::HCA,
       BackendServices::EDUCATION_BENEFITS
     ]
-    service_list += BackendServices::MHV_BASED_SERVICES if object.can_access_mhv?
+    service_list += BackendServices::MHV_BASED_SERVICES if object.mhv_account_eligible?
     service_list << BackendServices::EVSS_CLAIMS if object.can_access_evss?
     service_list << BackendServices::USER_PROFILE if object.can_access_user_profile?
     service_list
+  end
+
+  def mhv_account_state
+    object.mhv_account.account_state
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -5,7 +5,7 @@ require 'common/client/concerns/service_status'
 class UserSerializer < ActiveModel::Serializer
   include Common::Client::ServiceStatus
 
-  attributes :services, :profile, :va_profile, :veteran_status
+  attributes :services, :profile, :va_profile, :veteran_status, :mhv_account_state
 
   def id
     nil
@@ -60,9 +60,5 @@ class UserSerializer < ActiveModel::Serializer
     service_list << BackendServices::EVSS_CLAIMS if object.can_access_evss?
     service_list << BackendServices::USER_PROFILE if object.can_access_user_profile?
     service_list
-  end
-
-  def mhv_account_state
-    object.mhv_account.account_state
   end
 end

--- a/app/services/mhv_logging_service.rb
+++ b/app/services/mhv_logging_service.rb
@@ -2,7 +2,7 @@
 require 'mhv_logging/client'
 class MHVLoggingService
   def self.login(current_user)
-    if current_user.can_access_mhv? && !current_user.mhv_last_signed_in
+    if current_user.mhv_account.upgraded? && !current_user.mhv_last_signed_in
       MHV::AuditLoginJob.perform_async(current_user.uuid)
       true
     else
@@ -11,7 +11,7 @@ class MHVLoggingService
   end
 
   def self.logout(current_user)
-    if current_user.can_access_mhv? && current_user.mhv_last_signed_in
+    if current_user.mhv_account.upgraded? && current_user.mhv_last_signed_in
       MHV::AuditLogoutJob.perform_async(current_user.uuid, current_user.mhv_correlation_id)
       true
     else

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -74,6 +74,8 @@ RSpec.describe V0::SessionsController, type: :controller do
       end
       context ' logout_response is success' do
         before do
+          mhv_account = double('mhv_account', ineligible?: false, needs_terms_acceptance?: false, upgraded?: true)
+          allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
           allow(OneLogin::RubySaml::Logoutresponse).to receive(:new).and_return(succesful_logout_response)
         end
         it 'redirects to success and destroy the session' do

--- a/spec/models/mhv_account_spec.rb
+++ b/spec/models/mhv_account_spec.rb
@@ -59,24 +59,32 @@ RSpec.describe MhvAccount, type: :model do
           subject = described_class.new(base_attributes)
           subject.send(:setup) # This gets called when object is first loaded
           expect(subject.account_state).to eq('ineligible')
+          expect(subject.eligible?).to be_falsey
+          expect(subject.terms_and_conditions_accepted?).to be_truthy
         end
 
         it 'is able to transition back to upgraded' do
           subject = described_class.new(base_attributes.merge(upgraded_at: Time.current))
           subject.send(:setup) # This gets called when object is first loaded
           expect(subject.account_state).to eq('upgraded')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_truthy
         end
 
         it 'is able to transition back to registered' do
           subject = described_class.new(base_attributes.merge(registered_at: Time.current))
           subject.send(:setup) # This gets called when object is first loaded
           expect(subject.account_state).to eq('registered')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_truthy
         end
 
         it 'it falls back to unknown' do
           subject = described_class.new(base_attributes)
           subject.send(:setup) # This gets called when object is first loaded
           expect(subject.account_state).to eq('unknown')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_truthy
         end
       end
 
@@ -86,24 +94,32 @@ RSpec.describe MhvAccount, type: :model do
           subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
           subject.send(:setup) # This gets called when object is first loaded
           expect(subject.account_state).to eq('ineligible')
+          expect(subject.eligible?).to be_falsey
+          expect(subject.terms_and_conditions_accepted?).to be_falsey
         end
 
         it 'transitions to needs_terms_acceptance' do
           subject = described_class.new(user_uuid: user.uuid, account_state: 'upgraded', upgraded_at: Time.current)
           subject.send(:setup) # This gets called when object is first loaded
           expect(subject.account_state).to eq('needs_terms_acceptance')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_falsey
         end
 
         it 'is able to transition back to registered' do
           subject = described_class.new(user_uuid: user.uuid, account_state: 'registered', registered_at: Time.current)
           subject.send(:setup) # This gets called when object is first loaded
           expect(subject.account_state).to eq('needs_terms_acceptance')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_falsey
         end
 
         it 'it falls back to unknown' do
           subject = described_class.new(user_uuid: user.uuid, account_state: 'unknown')
           subject.send(:setup) # This gets called when object is first loaded
           expect(subject.account_state).to eq('needs_terms_acceptance')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_falsey
         end
       end
     end
@@ -130,6 +146,8 @@ RSpec.describe MhvAccount, type: :model do
           expect(subject.registered_at).to be_a(Time)
           expect(subject.upgraded_at).to be_a(Time)
           expect(User.find(user.uuid).mhv_correlation_id).to eq('14221465')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_truthy
         end
       end
     end
@@ -147,6 +165,8 @@ RSpec.describe MhvAccount, type: :model do
           expect(subject.account_state).to eq('upgraded')
           expect(subject.registered_at).to be_nil
           expect(subject.upgraded_at).to be_a(Time)
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_truthy
         end
       end
     end
@@ -164,6 +184,8 @@ RSpec.describe MhvAccount, type: :model do
           expect(subject.account_state).to eq('upgraded')
           expect(subject.registered_at).to be_nil
           expect(subject.upgraded_at).to be_nil
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_truthy
         end
       end
     end

--- a/spec/request/prescriptions_request_spec.rb
+++ b/spec/request/prescriptions_request_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe 'prescriptions', type: :request do
     end
   end
 
+  context 'terms of service not accepted' do
+    let(:mhv_account) { double('mhv_account', ineligible?: false, needs_terms_acceptance?: true, upgraded?: false) }
+    let(:current_user) { build(:user) }
+
+    it 'raises access denied' do
+      get '/v0/prescriptions/13651310'
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)['errors'].first['detail'])
+        .to eq('You have not accepted the terms of service')
+    end
+  end
+
   it 'responds to GET #show' do
     VCR.use_cassette('rx_client/prescriptions/gets_a_single_prescription') do
       get '/v0/prescriptions/13651310'

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
 
   let(:rubysaml_settings) { build(:rubysaml_settings) }
   let(:token) { 'lemmein' }
-  let(:mhv_account) { double('mhv_account', ineligible?: false, eligible?: true, needs_terms_acceptance?: false, upgraded?: true) }
+  let(:mhv_account) do
+    double('mhv_account', ineligible?: false, eligible?: true, needs_terms_acceptance?: false, upgraded?: true)
+  end
   let(:mhv_user) { build :mhv_user }
 
   before do

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
 
   let(:rubysaml_settings) { build(:rubysaml_settings) }
   let(:token) { 'lemmein' }
-  let(:mhv_account) { double('mhv_account', ineligible?: false, needs_terms_acceptance?: false, upgraded?: true) }
+  let(:mhv_account) { double('mhv_account', ineligible?: false, eligible?: true, needs_terms_acceptance?: false, upgraded?: true) }
   let(:mhv_user) { build :mhv_user }
 
   before do

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -27,7 +27,11 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
   let(:rubysaml_settings) { build(:rubysaml_settings) }
   let(:token) { 'lemmein' }
   let(:mhv_account) do
-    double('mhv_account', ineligible?: false, eligible?: true, needs_terms_acceptance?: false, upgraded?: true)
+    double('mhv_account', account_state: 'updated',
+                          ineligible?: false,
+                          eligible?: true,
+                          needs_terms_acceptance?: false,
+                          upgraded?: true)
   end
   let(:mhv_user) { build :mhv_user }
 

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe 'Fetching user data', type: :request do
 
     before do
       Session.create(uuid: mhv_user.uuid, token: token)
+      mhv_account = double('MhvAccount', account_state: 'upgraded')
+      allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
       User.create(mhv_user)
 
       auth_header = { 'Authorization' => "Token token=#{token}" }

--- a/spec/services/mhv_logging_service_spec.rb
+++ b/spec/services/mhv_logging_service_spec.rb
@@ -20,7 +20,11 @@ RSpec.describe MHVLoggingService do
                                       token: '<SESSION_TOKEN>' })
   end
 
-  before(:each) { allow(MHVLogging::Client).to receive(:new).and_return(authenticated_client) }
+  before(:each) do
+    mhv_account = double('mhv_account', ineligible?: false, needs_terms_acceptance?: false, upgraded?: true)
+    allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
+    allow(MHVLogging::Client).to receive(:new).and_return(authenticated_client)
+  end
 
   context 'with current_user not having logged in to MHV' do
     let(:mhv_user) { create(:mhv_user, :mhv_not_logged_in) }

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -11,8 +11,9 @@
         "type": { "type": "string"},
         "attributes": {
           "type": "object",
-          "required": ["services", "profile"],
+          "required": ["services", "profile", "mhv_account_state"],
           "properties": {
+            "mhv_account_state": { "type": [null]},
             "services": { "type": [ "array", null ] },
             "profile": {
               "type": "object",

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -11,8 +11,9 @@
         "type": { "type": "string"},
         "attributes": {
           "type": "object",
-          "required": ["services", "profile"],
+          "required": ["services", "profile", "mhv_account_state"],
           "properties": {
+            "mhv_account_state": { "type": ["string"]},
             "services": { "type": [ "array", null ] },
             "profile": {
               "type": "object",


### PR DESCRIPTION
- moved mhv_account into user.rb
- changed can_user_mhv? to be based on mhv_account eligibility. NOTE: this will mean that buttons will not show for non-va patients.
- this makes a little more sense, the only downside of course is that we have to initialize MhvAccount, triggering a database query lookup for every user, not just a user going to one of the three mhv controllers.