### PR TITLE
MVI profile audit rake task

### DIFF
--- a/lib/tasks/redis.rake
+++ b/lib/tasks/redis.rake
@@ -89,14 +89,14 @@ namespace :redis do
     mhv_users = 0
     vha_patients = 0
     addressees = 0
-    namespace = "mvi-profile-response"
+    namespace = 'mvi-profile-response'
     redis = Redis.current
     redis.scan_each(match: "#{namespace}:*") do |key|
       begin
         resp = Oj.load(redis.get(key))[:response]
         count += 1
-        mhv_users +=1 unless resp.profile.mhv_ids.blank?
-        vha_patients +=1 if patient?(resp.profile.vha_facility_ids)
+        mhv_users += 1 unless resp.profile.mhv_ids.blank?
+        vha_patients += 1 if patient?(resp.profile.vha_facility_ids)
         addressees += 1 if addressee?(resp.profile.address)
       rescue
         puts "Couldn't parse #{key}"
@@ -108,11 +108,10 @@ namespace :redis do
     puts "Users who are VA patients: #{mhv_users}"
     puts "Users with baseline address fields: #{addressees}"
   end
-
 end
 
 def patient?(vha_ids)
-  return vha_ids.to_a.any? { |id| id.to_i.between?(358,758) }
+  vha_ids.to_a.any? { |id| id.to_i.between?(358, 758) }
 end
 
 def addressee?(addr)

--- a/lib/tasks/redis.rake
+++ b/lib/tasks/redis.rake
@@ -82,4 +82,32 @@ namespace :redis do
       puts token
     end
   end
+
+  desc 'Flush RedisStore: Session'
+  task flush_session_store: :environment do
+    count = 0
+    mhv_users = 0
+    vha_patients = 0
+    addressees = 0
+    namespace = MVI::Responses::FindProfileResponse.new.redis_namespace.namespace
+    redis = Redis.current
+    redis.scan_each(match: "#{namespace}:*") do |key|
+      resp = Oj.load(redis.get(key))
+      count += 1
+      mhv_users +=1 unless resp.profile.mhv_correlation_ids.blank?
+      vha_patients +=1 if patient?(resp.profile.vha_facility_ids)
+      addressees += 1 if addressee?(resp.profile.address)
+    end
+  end
+
+end
+
+def patient?(vha_ids)
+  return vha_ids.to_a.any? { |id| id.between?(358,758) }
+end
+
+def addressee?(addr)
+  return false if addr.blank?
+  return false if addr.country.blank?
+  return false if addr.state.blank?
 end

--- a/lib/tasks/redis.rake
+++ b/lib/tasks/redis.rake
@@ -88,6 +88,8 @@ namespace :redis do
     count = 0
     mhv_users = 0
     vha_patients = 0
+    mhv_non_patient = 0
+    patient_non_mhv = 0
     addressees = 0
     namespace = 'mvi-profile-response'
     redis = Redis.current
@@ -95,8 +97,12 @@ namespace :redis do
       begin
         resp = Oj.load(redis.get(key))[:response]
         count += 1
-        mhv_users += 1 unless resp.profile.mhv_ids.blank?
-        vha_patients += 1 if patient?(resp.profile.vha_facility_ids)
+        mhvu = !resp.profile.mhv_ids.blank?
+        patient = patient?(resp.profile.vha_facility_ids)
+        mhv_users += 1 if mhvu
+        vha_patients += 1 if patient
+        mhv_non_patient += 1 if mhvu && !patient
+        patient_non_mhv += 1 if patient && !mhvu
         addressees += 1 if addressee?(resp.profile.address)
       rescue
         puts "Couldn't parse #{key}"
@@ -106,6 +112,8 @@ namespace :redis do
     puts "Total cached users: #{count}"
     puts "Users with MHV correlation ID: #{mhv_users}"
     puts "Users who are VA patients: #{mhv_users}"
+    puts "VA patients with no MHV ID: #{patient_non_mhv}"
+    puts "MHV ID holders who are not patients: #{mhv_non_patient}"
     puts "Users with baseline address fields: #{addressees}"
   end
 end


### PR DESCRIPTION
Rake task to answer some questions we have about users and their MHV/VA patient status. 

Plan is to run this against production during off hours, to get a sample of currently-cached profiles. 