### PR TITLE
Add a Shrine plugin to verify the ASCIIness of .txt files

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,3 +24,5 @@ en:
     pdf:
       locked: PDF must not be encrypted or locked. Please re-save it without a password
       invalid: PDF is not able to be opened. Try re-saving or re-uploading it.
+    text:
+      not_ascii: Cannot read file encoding. Text files must be ASCII encoded.

--- a/lib/shrine/plugins/validate_ascii.rb
+++ b/lib/shrine/plugins/validate_ascii.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+class Shrine
+  module Plugins
+    module ValidateAscii
+      module AttacherMethods
+        def validate_ascii
+          return unless get.original_filename.ends_with?('.txt')
+          text = get.to_io.read.encode('ascii')
+          tempfile = Tempfile.new(encoding: 'ascii')
+          tempfile.write text
+          tempfile.flush
+          tempfile.rewind
+          get.replace(tempfile)
+        rescue Encoding::UndefinedConversionError
+          add_error(I18n.t('uploads.text.not_ascii'))
+          false
+        end
+
+        private
+
+        def add_error(msg)
+          errors << msg
+        end
+      end
+    end
+    register_plugin(:validate_ascii, ValidateAscii)
+  end
+end

--- a/spec/lib/shrine/plugins/validate_ascii_spec.rb
+++ b/spec/lib/shrine/plugins/validate_ascii_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'shrine/plugins/validate_unlocked_pdf'
+
+describe Shrine::Plugins::ValidateAscii do
+  include SpecTempFiles
+  describe '#validate_ascii' do
+    let(:ascii) { 'yes hello' }
+    let(:nonascii) { "I \u2661 Unicode!" }
+
+    let(:klass) do
+      Class.new do
+        include Shrine::Plugins::ValidateAscii::AttacherMethods
+        def get
+          raise "shouldn't be called"
+        end
+
+        def errors
+          @errors ||= []
+        end
+      end
+    end
+
+    let(:instance) { klass.new }
+
+    let(:attachment) do
+      instance_double('Shrine::UploadedFile', original_filename: File.basename(file), to_io: File.open(file, 'r+'))
+    end
+
+    before do
+      allow(instance).to receive(:get).and_return(attachment)
+      allow(attachment).to receive(:replace)
+    end
+
+    context 'with non-txt file' do
+      let(:file) { temp(['test', '.doc'], ascii) }
+
+      it 'does not run any checks' do
+        expect(attachment).not_to receive(:to_io)
+        expect { instance.validate_ascii }.not_to change { instance.errors.count }
+      end
+    end
+
+    context 'with normal ascii file' do
+      let(:file) { temp(['test', '.doc'], ascii) }
+
+      it 'does not add any errors' do
+        expect { instance.validate_ascii }.not_to change { instance.errors.count }
+      end
+    end
+
+    context 'with utf16 ascii file' do
+      let(:file) { temp(['test', '.txt'], ascii, encoding: 'utf-16be') }
+
+      it 'does not add any errors' do
+        expect { instance.validate_ascii }.not_to change { instance.errors.count }
+      end
+    end
+
+    context 'with a file containing unicode' do
+      let(:file) { temp(['test', '.txt'], nonascii) }
+
+      it 'adds an error' do
+        expect { instance.validate_ascii }.to change { instance.errors.count }.from(0).to(1)
+        expect(instance.errors.first).to eq I18n.t('uploads.text.not_ascii')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'support/mvi/stub_mvi'
 require 'support/spec_builders'
 require 'support/schema_matchers'
 require 'support/spool_helpers'
+require 'support/spec_temp_files'
 require 'support/have_deep_attributes_matcher'
 require 'support/veteran_status/stub_veteran_status'
 

--- a/spec/support/spec_temp_files.rb
+++ b/spec/support/spec_temp_files.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module SpecTempFiles
+  def temp(name, contents, args = {})
+    f = Tempfile.new(name, **args)
+    f.write(contents)
+    f.flush
+    f
+  end
+end


### PR DESCRIPTION
Ported from `EVSSClaimDocument#normalize_text`