### PR TITLE
Return listings of InprogressForms

### DIFF
--- a/app/controllers/v0/in_progress_forms_controller.rb
+++ b/app/controllers/v0/in_progress_forms_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 module V0
   class InProgressFormsController < ApplicationController
+    def index
+      render json: InProgressForm.where(user_uuid: @current_user.uuid)
+    end
+
     def show
       form_id = params[:id]
       form = InProgressForm.form_for_user(form_id, @current_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,6 +99,10 @@ class User < Common::RedisStore
     mvi.status
   end
 
+  def in_progress_forms
+    InProgressForm.where(user_uuid: uuid)
+  end
+
   private
 
   def mvi

--- a/app/serializers/in_progress_form_serializer.rb
+++ b/app/serializers/in_progress_form_serializer.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class InProgressFormSerializer < ActiveModel::Serializer
+  attributes :form_id, :created_at, :updated_at, :metadata
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -51,7 +51,7 @@ class UserSerializer < ActiveModel::Serializer
   end
 
   def in_progress_forms
-    object.in_progress_forms.pluck(:form_id)
+    object.in_progress_forms.map(&:form_id)
   end
 
   def services

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -5,7 +5,7 @@ require 'common/client/concerns/service_status'
 class UserSerializer < ActiveModel::Serializer
   include Common::Client::ServiceStatus
 
-  attributes :services, :profile, :va_profile, :veteran_status
+  attributes :in_progress_forms, :services, :profile, :va_profile, :veteran_status
 
   def id
     nil
@@ -48,6 +48,10 @@ class UserSerializer < ActiveModel::Serializer
     { status: RESPONSE_STATUS[:not_found] }
   rescue StandardError
     { status: RESPONSE_STATUS[:server_error] }
+  end
+
+  def in_progress_forms
+    object.in_progress_forms.pluck(:form_id)
   end
 
   def services

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   post '/auth/saml/callback', to: 'v0/sessions#saml_callback', module: 'v0'
 
   namespace :v0, defaults: { format: 'json' } do
-    resources :in_progress_forms, only: [:show, :update]
+    resources :in_progress_forms, only: [:index, :show, :update]
     resources :letters, only: [:index, :show]
 
     resource :sessions, only: [:new, :destroy] do

--- a/spec/controllers/v0/users_controller_spec.rb
+++ b/spec/controllers/v0/users_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe V0::UsersController, type: :controller do
     before(:each) do
       Session.create(uuid: loa1_user.uuid, token: token)
       User.create(loa1_user)
+      FactoryGirl.create(:in_progress_form, user_uuid: loa1_user.uuid, form_id: 'edu-1990')
     end
 
     it 'returns a JSON user profile' do
@@ -25,7 +26,6 @@ RSpec.describe V0::UsersController, type: :controller do
       assert_response :success
 
       json = JSON.parse(response.body)
-
       expect(json['data']['attributes']['profile']['email']).to eq(loa1_user.email)
     end
   end

--- a/spec/request/in_progress_forms_request_spec.rb
+++ b/spec/request/in_progress_forms_request_spec.rb
@@ -18,7 +18,22 @@ RSpec.describe 'in progress forms', type: :request do
     )
   end
 
-  describe 'GET' do
+  describe '#index' do
+    let!(:in_progress_form_edu) { FactoryGirl.create(:in_progress_form, form_id: 'edu-1990', user_uuid: user.uuid) }
+    let!(:in_progress_form_hca) { FactoryGirl.create(:in_progress_form, form_id: 'hca', user_uuid: user.uuid) }
+    subject do
+      get v0_in_progress_forms_url, nil, auth_header
+    end
+
+    it 'returns details about saved forms' do
+      subject
+      items = JSON.parse(response.body)['data']
+      expect(items.size).to eq(2)
+      expect(items.dig(0, 'attributes', 'form_id')).to be_a(String)
+    end
+  end
+
+  describe '#show' do
     let!(:in_progress_form) { FactoryGirl.create(:in_progress_form, user_uuid: user.uuid) }
 
     context 'when a form is found' do
@@ -88,7 +103,7 @@ RSpec.describe 'in progress forms', type: :request do
     end
   end
 
-  describe 'PUT' do
+  describe '#update' do
     context 'with a new form' do
       let(:new_form) { FactoryGirl.build(:in_progress_form, user_uuid: user.uuid) }
 

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -11,9 +11,10 @@
         "type": { "type": "string"},
         "attributes": {
           "type": "object",
-          "required": ["services", "profile"],
+          "required": ["services", "profile", "in_progress_forms"],
           "properties": {
             "services": { "type": [ "array", null ] },
+            "in_progress_forms": { "type": [ "array", null ] },
             "profile": {
               "type": "object",
               "required": [

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -11,8 +11,9 @@
         "type": { "type": "string"},
         "attributes": {
           "type": "object",
-          "required": ["services", "profile"],
+          "required": ["services", "profile", "in_progress_forms"],
           "properties": {
+            "in_progress_forms": { "type": [ "array", null ] },
             "services": { "type": [ "array", null ] },
             "profile": {
               "type": "object",


### PR DESCRIPTION
Includes a `in_progress_forms` array in the user object that lists the form_ids that the user has saved.
Creates an `index` endpoint that returns everything but the form data itself.

For https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3244