### PR TITLE
Enable an accidentally disabled spec

### DIFF
--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -642,7 +642,7 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
   end
 
   context 'and' do
-    xit 'tests all documented routes' do
+    it 'tests all documented routes' do
       expect(subject).to validate_all_paths
     end
   end


### PR DESCRIPTION
Disabled this during work on a previous PR and forgot to re-enable it before merging 😄 