### PR TITLE
Fix a seed-based spec failure

### DIFF
--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -545,7 +545,9 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
     context 'terms and conditions routes' do
       context 'with some terms and acceptances' do
         let!(:terms) { create(:terms_and_conditions, latest: true) }
-        let!(:terms2) { create(:terms_and_conditions, latest: true) }
+        # The Faker in the factory will _sometimes_ return the same name. make sure it's different
+        # so that the association in terms_acc works as expected with these tests.
+        let!(:terms2) { create(:terms_and_conditions, latest: true, name: "#{terms.name}-again") }
         let!(:terms_acc) do
           create(:terms_and_conditions_acceptance, user_uuid: mhv_user.uuid, terms_and_conditions: terms)
         end


### PR DESCRIPTION
Another nit fix that was bugging me. The Swagger spec creates 2 TermsAndService instances, which use Faker underneath. If Faker returns the same string for both instances, an association lookup with fail to pick the correct instance and a spec will fail. This makes the lookup value explicitly different.

Tested with `bundle exec rspec spec/request/swagger_spec.rb:550 --seed 55395`  against `04eac2`