### PR TITLE
Allow dynamic text in PDF Stamping

### DIFF
--- a/lib/workflow/task/common/datestamp_pdf_task.rb
+++ b/lib/workflow/task/common/datestamp_pdf_task.rb
@@ -15,8 +15,10 @@ module Workflow::Task::Common
     private
 
     def generate_stamp(stamp_path, text, x, y)
+      text = Time.now.utc.strftime("#{text} %FT%T%:z")
+      text += ('. ' + data[:append_to_stamp]) if data[:append_to_stamp]
       Prawn::Document.generate stamp_path do |pdf|
-        pdf.draw_text Time.now.utc.strftime("#{text} %FT%T%:z"), at: [x, y], size: 10
+        pdf.draw_text text, at: [x, y], size: 10
       end
     rescue StandardError => e
       Rails.logger.error "Failed to generate datestamp file: #{e.message}"

--- a/spec/lib/workflow/task/common/datestamp_pdf_task_spec.rb
+++ b/spec/lib/workflow/task/common/datestamp_pdf_task_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Workflow::Task::Common::DatestampPdfTask do
     end
 
     let(:instance) do
-      described_class.new({ text: 'Received via vets.gov at', x: 10, y: 10 }, internal: { file: attacher.read })
+      described_class.new({ append_to_stamp: 'Confirmation=VETS-XX-1234' }, internal: { file: attacher.read })
     end
 
     context 'with a succesful pdf stamp' do
@@ -24,7 +24,8 @@ RSpec.describe Workflow::Task::Common::DatestampPdfTask do
         Timecop.travel(Time.zone.local(1999, 12, 31, 23, 59, 59)) do
           instance.run(text: 'Received via vets.gov at', x: 10, y: 10)
           text_analysis = PDF::Inspector::Text.analyze(instance.file.read)
-          expect(text_analysis.strings.first).to eq('Received via vets.gov at 1999-12-31T23:59:59+00:00')
+          stamp = 'Received via vets.gov at 1999-12-31T23:59:59+00:00. Confirmation=VETS-XX-1234'
+          expect(text_analysis.strings.first).to eq(stamp)
         end
       end
     end


### PR DESCRIPTION
More than just the typical fixed Vets.gov stamp, we may want to stamp a dynamic confirmation number or some other data to the PDFs.