### PR TITLE
Pv terms beta

### DIFF
--- a/app/controllers/concerns/mhv_controller_concerns.rb
+++ b/app/controllers/concerns/mhv_controller_concerns.rb
@@ -15,7 +15,7 @@ module MHVControllerConcerns
 
   def authorize
     if beta_enabled?(current_user.uuid, 'health_account')
-     authorize_beta
+      authorize_beta
     else
       (current_user&.loa3? && current_user&.mhv_correlation_id.present?) || raise_access_denied
     end

--- a/app/controllers/concerns/mhv_controller_concerns.rb
+++ b/app/controllers/concerns/mhv_controller_concerns.rb
@@ -15,13 +15,17 @@ module MHVControllerConcerns
 
   def authorize
     if beta_enabled?(current_user.uuid)
-     raise_access_denied if current_user.mhv_account.ineligible?
-      raise_requires_terms_acceptance if current_user.mhv_account.needs_terms_acceptance?
-      current_user.mhv_account.create_and_upgrade! unless current_user.mhv_account.upgraded?
-      raise_something_went_wrong unless current_user.mhv_account.upgraded?
+     authorize_beta
     else
       (current_user&.loa3? && current_user&.mhv_correlation_id.present?) || raise_access_denied
     end
+  end
+
+  def authorize_beta
+    raise_access_denied if current_user.mhv_account.ineligible?
+    raise_requires_terms_acceptance if current_user.mhv_account.needs_terms_acceptance?
+    current_user.mhv_account.create_and_upgrade! unless current_user.mhv_account.upgraded?
+    raise_something_went_wrong unless current_user.mhv_account.upgraded?
   end
 
   def raise_requires_terms_acceptance

--- a/app/controllers/concerns/mhv_controller_concerns.rb
+++ b/app/controllers/concerns/mhv_controller_concerns.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'health_beta'
+require 'beta_switch'
 
 module MHVControllerConcerns
   extend ActiveSupport::Concern
-  include HealthBeta
+  include BetaSwitch
 
   included do
     before_action :authorize
@@ -14,7 +14,7 @@ module MHVControllerConcerns
   protected
 
   def authorize
-    if beta_enabled?(current_user.uuid)
+    if beta_enabled?(current_user.uuid, 'health_account')
      authorize_beta
     else
       (current_user&.loa3? && current_user&.mhv_correlation_id.present?) || raise_access_denied

--- a/app/controllers/concerns/mhv_controller_concerns.rb
+++ b/app/controllers/concerns/mhv_controller_concerns.rb
@@ -15,20 +15,12 @@ module MHVControllerConcerns
 
   def authorize
     if beta_enabled?(current_user.uuid)
-      authorize_beta
+     raise_access_denied if current_user.mhv_account.ineligible?
+      raise_requires_terms_acceptance if current_user.mhv_account.needs_terms_acceptance?
+      current_user.mhv_account.create_and_upgrade! unless current_user.mhv_account.upgraded?
+      raise_something_went_wrong unless current_user.mhv_account.upgraded?
     else
       (current_user&.loa3? && current_user&.mhv_correlation_id.present?) || raise_access_denied
-    end
-  end
-
-  def authorize_beta
-    raise_access_denied if current_user.mhv_account.ineligible?
-    raise_requires_terms_acceptance if current_user.mhv_account.needs_terms_acceptance?
-    begin
-      current_user.mhv_account.create_and_upgrade! unless current_user.mhv_account.upgraded?
-    # TODO: rescue more specifically if mhv_account raises more specifically
-    ensure
-      raise_something_went_wrong unless current_user.mhv_account.upgraded?
     end
   end
 

--- a/app/controllers/concerns/mhv_controller_concerns.rb
+++ b/app/controllers/concerns/mhv_controller_concerns.rb
@@ -24,8 +24,12 @@ module MHVControllerConcerns
   def authorize_beta
     raise_access_denied if current_user.mhv_account.ineligible?
     raise_requires_terms_acceptance if current_user.mhv_account.needs_terms_acceptance?
-    current_user.mhv_account.create_and_upgrade! unless current_user.mhv_account.upgraded?
-    raise_something_went_wrong unless current_user.mhv_account.upgraded?
+    begin
+      current_user.mhv_account.create_and_upgrade! unless current_user.mhv_account.upgraded?
+    # TODO: rescue more specifically if mhv_account raises more specifically
+    ensure
+      raise_something_went_wrong unless current_user.mhv_account.upgraded?
+    end
   end
 
   def raise_requires_terms_acceptance

--- a/app/controllers/v0/beta_registrations_controller.rb
+++ b/app/controllers/v0/beta_registrations_controller.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 module V0
-  class HealthBetaRegistrationsController < ApplicationController
+  class BetaRegistrationsController < ApplicationController
     def show
-      reg = HealthBetaRegistration.find_by(user_uuid: current_user.uuid)
+      reg = BetaRegistration.find_by(user_uuid: current_user.uuid, feature: params[:feature])
       raise Common::Exceptions::RecordNotFound, current_user.uuid if reg.nil?
       render json: { 'user': current_user.email, 'status': 'OK' }
     end
 
     def create
-      HealthBetaRegistration.find_or_create_by(user_uuid: current_user.uuid)
+      BetaRegistration.find_or_create_by(user_uuid: current_user.uuid, feature: params[:feature])
       render json: { 'user': current_user.email, 'status': 'OK' }
     end
   end

--- a/app/controllers/v0/health_beta_registrations_controller.rb
+++ b/app/controllers/v0/health_beta_registrations_controller.rb
@@ -8,8 +8,8 @@ module V0
     end
 
     def create
-      HealthBetaRegistration.create(user_uuid: current_user.uuid)
-      render nothing: true, status: :accepted
+      HealthBetaRegistration.find_or_create_by(user_uuid: current_user.uuid)
+      render json: { 'user': current_user.email, 'status': 'OK' }
     end
   end
 end

--- a/app/controllers/v0/health_beta_registrations_controller.rb
+++ b/app/controllers/v0/health_beta_registrations_controller.rb
@@ -8,8 +8,8 @@ module V0
     end
 
     def create
-      HealthBetaRegistration.find_or_create_by(user_uuid: current_user.uuid)
-      render json: { 'user': current_user.email, 'status': 'OK' }
+      HealthBetaRegistration.create(user_uuid: current_user.uuid)
+      render nothing: true, status: :accepted
     end
   end
 end

--- a/app/models/beta_registration.rb
+++ b/app/models/beta_registration.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+class BetaRegistration < ActiveRecord::Base
+end

--- a/app/models/health_beta_registration.rb
+++ b/app/models/health_beta_registration.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
 class HealthBetaRegistration < ActiveRecord::Base
-
 end

--- a/app/models/health_beta_registration.rb
+++ b/app/models/health_beta_registration.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-class HealthBetaRegistration < ActiveRecord::Base
-end

--- a/app/models/health_beta_registration.rb
+++ b/app/models/health_beta_registration.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 class HealthBetaRegistration < ActiveRecord::Base
+
 end

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 require 'mhv_ac/client'
-require 'health_beta'
+require 'beta_switch'
 
 class MhvAccount < ActiveRecord::Base
   include AASM
-  include HealthBeta
+  include BetaSwitch
 
   TERMS_AND_CONDITIONS_NAME = 'mhvac'
   # Everything except ineligible accounts should be able to transition to :needs_terms_acceptance
@@ -153,7 +153,7 @@ class MhvAccount < ActiveRecord::Base
 
   def setup
     raise StandardError, 'You must use find_or_initialize_by(user_uuid: #)' if user_uuid.nil?
-    if beta_enabled?(user_uuid)
+    if beta_enabled?(user_uuid, 'health_account')
       check_eligibility
       check_terms_acceptance if may_check_terms_acceptance?
     end

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -102,7 +102,7 @@ class MhvAccount < ActiveRecord::Base
   end
 
   def user
-    @user ||= User.find(user_uuid.tr('-',''))
+    @user ||= User.find(user_uuid)
   end
 
   # User's profile contains a list of VHA facility-specific identifiers.

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -87,5 +87,4 @@ class UserSerializer < ActiveModel::Serializer
     service_list << BackendServices::USER_PROFILE if object.can_access_user_profile?
     service_list
   end
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -87,5 +87,5 @@ class UserSerializer < ActiveModel::Serializer
     service_list << BackendServices::USER_PROFILE if object.can_access_user_profile?
     service_list
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 require 'feature_flipper'
+
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   match '/v0/*path', to: 'application#cors_preflight', via: [:options]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,7 +107,8 @@ Rails.application.routes.draw do
     get 'terms_and_conditions/:name/versions/latest/user_data', to: 'terms_and_conditions#latest_user_data'
     post 'terms_and_conditions/:name/versions/latest/user_data', to: 'terms_and_conditions#accept_latest'
 
-    resource :health_beta_registrations, only: [:show, :create]
+    resource :beta_registrations, path: '/beta_registration/health_account', only: [:show, :create], defaults: { feature: 'health_accounts' }
+
   end
 
   root 'v0/example#index', module: 'v0'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,7 +107,7 @@ Rails.application.routes.draw do
     get 'terms_and_conditions/:name/versions/latest/user_data', to: 'terms_and_conditions#latest_user_data'
     post 'terms_and_conditions/:name/versions/latest/user_data', to: 'terms_and_conditions#accept_latest'
 
-    resource :beta_registrations, path: '/beta_registration/health_account', only: [:show, :create], defaults: { feature: 'health_accounts' }
+    resource :beta_registrations, path: '/beta_registration/health_account', only: [:show, :create], defaults: { feature: 'health_account' }
 
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 require 'feature_flipper'
-
-# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   match '/v0/*path', to: 'application#cors_preflight', via: [:options]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,8 +107,8 @@ Rails.application.routes.draw do
     get 'terms_and_conditions/:name/versions/latest/user_data', to: 'terms_and_conditions#latest_user_data'
     post 'terms_and_conditions/:name/versions/latest/user_data', to: 'terms_and_conditions#accept_latest'
 
-    resource :beta_registrations, path: '/beta_registration/health_account', only: [:show, :create], defaults: { feature: 'health_account' }
-
+    resource :beta_registrations, path: '/beta_registration/health_account', only: [:show, :create],
+                                  defaults: { feature: 'health_account' }
   end
 
   root 'v0/example#index', module: 'v0'

--- a/db/migrate/20170518001612_create_mhv_accounts.rb
+++ b/db/migrate/20170518001612_create_mhv_accounts.rb
@@ -1,7 +1,7 @@
 class CreateMhvAccounts < ActiveRecord::Migration
   def change
     create_table :mhv_accounts do |t|
-      t.uuid :user_uuid, unique: true, null: false
+      t.string :user_uuid, unique: true, null: false
       t.string :account_state, null: false
       t.datetime :registered_at, null: true
       t.datetime :upgraded_at, null: true

--- a/db/migrate/20170607043549_add_health_account_beta.rb
+++ b/db/migrate/20170607043549_add_health_account_beta.rb
@@ -1,7 +1,7 @@
 class AddHealthAccountBeta < ActiveRecord::Migration
   def change
     create_table :beta_registrations do |t|
-      t.uuid :user_uuid, null: false
+      t.string :user_uuid, null: false
       t.string :feature, null: false
       t.timestamps null: false
     end

--- a/db/migrate/20170607043549_add_health_account_beta.rb
+++ b/db/migrate/20170607043549_add_health_account_beta.rb
@@ -1,10 +1,11 @@
 class AddHealthAccountBeta < ActiveRecord::Migration
   def change
-    create_table :health_beta_registrations do |t|
-      t.uuid :user_uuid, unique: true, null: false
+    create_table :beta_registrations do |t|
+      t.uuid :user_uuid, null: false
+      t.string :feature, null: false
       t.timestamps null: false
     end
 
-    add_index :health_beta_registrations, [:user_uuid]
+    add_index :beta_registrations, [:user_uuid, :feature], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,6 +17,15 @@ ActiveRecord::Schema.define(version: 20170607043549) do
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
+  create_table "beta_registrations", force: :cascade do |t|
+    t.uuid     "user_uuid",  null: false
+    t.string   "feature",    null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "beta_registrations", ["user_uuid", "feature"], name: "index_beta_registrations_on_user_uuid_and_feature", unique: true, using: :btree
+
   create_table "education_benefits_claims", force: :cascade do |t|
     t.datetime "submitted_at"
     t.datetime "processed_at"
@@ -60,14 +69,6 @@ ActiveRecord::Schema.define(version: 20170607043549) do
   end
 
   add_index "evss_claims", ["user_uuid"], name: "index_evss_claims_on_user_uuid", using: :btree
-
-  create_table "health_beta_registrations", force: :cascade do |t|
-    t.uuid     "user_uuid",  null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  add_index "health_beta_registrations", ["user_uuid"], name: "index_health_beta_registrations_on_user_uuid", using: :btree
 
   create_table "in_progress_forms", force: :cascade do |t|
     t.uuid     "user_uuid",              null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 20170607043549) do
   enable_extension "uuid-ossp"
 
   create_table "beta_registrations", force: :cascade do |t|
-    t.uuid     "user_uuid",  null: false
+    t.string   "user_uuid",  null: false
     t.string   "feature",    null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 20170607043549) do
   add_index "in_progress_forms", ["user_uuid"], name: "index_in_progress_forms_on_user_uuid", using: :btree
 
   create_table "mhv_accounts", force: :cascade do |t|
-    t.uuid     "user_uuid",     null: false
+    t.string   "user_uuid",     null: false
     t.string   "account_state", null: false
     t.datetime "registered_at"
     t.datetime "upgraded_at"

--- a/lib/beta_switch.rb
+++ b/lib/beta_switch.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-module BetaSwitch 
+module BetaSwitch
   def beta_enabled?(uuid, feature_name)
     BetaRegistration.find_by(user_uuid: uuid, feature: feature_name).present?
   end

--- a/lib/beta_switch.rb
+++ b/lib/beta_switch.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module BetaSwitch 
+  def beta_enabled?(uuid, feature_name)
+    BetaRegistration.find_by(user_uuid: uuid, feature: feature_name).present?
+  end
+end

--- a/lib/health_beta.rb
+++ b/lib/health_beta.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-module HealthBeta
-  def beta_enabled?(uuid)
-    HealthBetaRegistration.find_by(user_uuid: uuid).present?
-  end
-end

--- a/spec/models/mhv_account_spec.rb
+++ b/spec/models/mhv_account_spec.rb
@@ -136,16 +136,20 @@ RSpec.describe MhvAccount, type: :model do
     context 'user with un-dashed uuid' do
       let(:nodashuser) do
         create(:loa3_user,
-          uuid: 'abcdef12345678',
-          ssn: mvi_profile.ssn,
-          first_name: mvi_profile.given_names.first,
-          last_name: mvi_profile.family_name,
-          gender: mvi_profile.gender,
-          birth_date: mvi_profile.birth_date,
-          email: 'vets.gov.user+0@gmail.com')
+               uuid: 'abcdef12345678',
+               ssn: mvi_profile.ssn,
+               first_name: mvi_profile.given_names.first,
+               last_name: mvi_profile.family_name,
+               gender: mvi_profile.gender,
+               birth_date: mvi_profile.birth_date,
+               email: 'vets.gov.user+0@gmail.com')
       end
       let(:terms) { create(:terms_and_conditions, latest: true, name: described_class::TERMS_AND_CONDITIONS_NAME) }
-      before(:each) { create(:terms_and_conditions_acceptance, terms_and_conditions: terms, user_uuid: nodashuser.uuid) }
+      before(:each) do
+        create(:terms_and_conditions_acceptance,
+               terms_and_conditions: terms,
+               user_uuid: nodashuser.uuid)
+      end
       let(:base_attributes) { { user_uuid: nodashuser.uuid, account_state: 'needs_terms_acceptance' } }
       let(:vha_facility_ids) { %w(200MH 488) }
 
@@ -232,7 +236,7 @@ RSpec.describe MhvAccount, type: :model do
         expect(subject.persisted?).to be_falsey
         VCR.use_cassette('mhv_account_creation/should_not_create_an_account_if_one_already_exists') do
           VCR.use_cassette('mhv_account_creation/account_upgrade_unknown_error', record: :none) do
-            expect { (subject.create_and_upgrade!) }.to raise_error(Common::Exceptions::BackendServiceException)
+            expect { subject.create_and_upgrade! }.to raise_error(Common::Exceptions::BackendServiceException)
             expect(subject.persisted?).to be_truthy
             expect(subject.account_state).to eq('upgrade_failed')
             expect(subject.registered_at).to be_nil

--- a/spec/models/mhv_account_spec.rb
+++ b/spec/models/mhv_account_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe MhvAccount, type: :model do
 
   before(:each) do
     stub_mvi(mvi_profile)
-    allow_any_instance_of(HealthBeta).to receive(:beta_enabled?).and_return(true)
+    allow_any_instance_of(BetaSwitch).to receive(:beta_enabled?).and_return(true)
   end
 
   it 'must have a user_uuid when initialized' do

--- a/spec/request/beta_registration_spec.rb
+++ b/spec/request/beta_registration_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe 'Beta Registration Endpoint', type: :request do
     Session.create(uuid: user.uuid, token: token)
     User.create(user)
   end
-
-  # rubocop:disable Rails/HttpPositionalArguments
   it 'returns 404 for unregistered user' do
     get '/v0/beta_registration/health_account', nil, auth_header
     expect(response).to have_http_status(:not_found)

--- a/spec/request/beta_registration_spec.rb
+++ b/spec/request/beta_registration_spec.rb
@@ -2,7 +2,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Beta Registration Endpoint', type: :request do
-
   let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
   let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
   let(:user) { build(:loa3_user) }
@@ -13,23 +12,23 @@ RSpec.describe 'Beta Registration Endpoint', type: :request do
   end
 
   it 'returns 404 for unregistered user' do
-    get '/v0/beta_registration/health_account', nil, auth_header
+    get '/v0/beta_registration/health_account', headers: auth_header
     expect(response).to have_http_status(:not_found)
   end
 
   it 'accepts register request' do
-    post '/v0/beta_registration/health_account', nil, auth_header
+    post '/v0/beta_registration/health_account', headers: auth_header
     expect(response).to be_success
     expect(response.body).to be_a(String)
-    json = JSON.parse(response.body) 
+    json = JSON.parse(response.body)
     expect(json['user']).to eq(user.email)
   end
 
   it 'accepts register request' do
-    post '/v0/beta_registration/health_account', nil, auth_header
-    get '/v0/beta_registration/health_account', nil, auth_header
+    post '/v0/beta_registration/health_account', headers: auth_header
+    get '/v0/beta_registration/health_account', headers: auth_header
     expect(response).to be_success
-    json = JSON.parse(response.body) 
+    json = JSON.parse(response.body)
     expect(json['user']).to eq(user.email)
   end
 end

--- a/spec/request/beta_registration_spec.rb
+++ b/spec/request/beta_registration_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Beta Registration Endpoint', type: :request do
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:loa3_user) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  it 'returns 404 for unregistered user' do
+    get '/v0/beta_registration/health_account', nil, auth_header
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'accepts register request' do
+    post '/v0/beta_registration/health_account', nil, auth_header
+    expect(response).to be_success
+    expect(response.body).to be_a(String)
+    json = JSON.parse(response.body) 
+    expect(json['user']).to eq(user.email)
+  end
+
+  it 'accepts register request' do
+    post '/v0/beta_registration/health_account', nil, auth_header
+    get '/v0/beta_registration/health_account', nil, auth_header
+    expect(response).to be_success
+    json = JSON.parse(response.body) 
+    expect(json['user']).to eq(user.email)
+  end
+end

--- a/spec/request/beta_registration_spec.rb
+++ b/spec/request/beta_registration_spec.rb
@@ -11,13 +11,14 @@ RSpec.describe 'Beta Registration Endpoint', type: :request do
     User.create(user)
   end
 
+  # rubocop:disable Rails/HttpPositionalArguments
   it 'returns 404 for unregistered user' do
-    get '/v0/beta_registration/health_account', headers: auth_header
+    get '/v0/beta_registration/health_account', nil, auth_header
     expect(response).to have_http_status(:not_found)
   end
 
   it 'accepts register request' do
-    post '/v0/beta_registration/health_account', headers: auth_header
+    post '/v0/beta_registration/health_account', nil, auth_header
     expect(response).to be_success
     expect(response.body).to be_a(String)
     json = JSON.parse(response.body)
@@ -25,8 +26,8 @@ RSpec.describe 'Beta Registration Endpoint', type: :request do
   end
 
   it 'accepts register request' do
-    post '/v0/beta_registration/health_account', headers: auth_header
-    get '/v0/beta_registration/health_account', headers: auth_header
+    post '/v0/beta_registration/health_account', nil, auth_header
+    get '/v0/beta_registration/health_account', nil, auth_header
     expect(response).to be_success
     json = JSON.parse(response.body)
     expect(json['user']).to eq(user.email)

--- a/spec/request/prescriptions_request_spec.rb
+++ b/spec/request/prescriptions_request_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'prescriptions', type: :request do
     let(:current_user) { build(:user) }
 
     before(:each) do
-      allow_any_instance_of(HealthBeta).to receive(:beta_enabled?).and_return(true)
+      allow_any_instance_of(BetaSwitch).to receive(:beta_enabled?).and_return(true)
     end
 
     it 'raises access denied' do
@@ -51,7 +51,7 @@ RSpec.describe 'prescriptions', type: :request do
     let(:current_user) { build(:user) }
 
     before(:each) do
-      allow_any_instance_of(HealthBeta).to receive(:beta_enabled?).and_return(true)
+      allow_any_instance_of(BetaSwitch).to receive(:beta_enabled?).and_return(true)
       allow_any_instance_of(MhvAccount).to receive(:create_and_upgrade!)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,8 +23,6 @@ unless ENV['NOCOVERAGE']
     add_filter 'lib/feature_flipper.rb'
     add_filter 'spec/support/authenticated_session_helper'
     add_filter 'spec/support/attr_encrypted_matcher'
-    add_filter 'app/models/health_beta_registration.rb'
-    add_filter 'app/controllers/v0/health_beta_registrations_controller.rb'
     add_filter 'vendor'
     SimpleCov.minimum_coverage_by_file 90
   end

--- a/spec/support/vcr_cassettes/mhv_account_creation/account_upgrade_unknown_error.yml
+++ b/spec/support/vcr_cassettes/mhv_account_creation/account_upgrade_unknown_error.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<MHV_HOST>/mhv-api/patient/v1/account/upgrade"
+    body:
+      encoding: UTF-8
+      string: '{"userId":14221465,"formSignedDateTime":"Tue, 09 May 2017 00:00:00
+        GMT","termsVersion":"v3.4"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Apptoken:
+      - "<APP_TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '143'
+      Date:
+      - Fri, 19 May 2017 14:16:16 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"errorCode":99,"developerMessage":"Error:Unknown application error",
+        "message":"MVI Unknown Issue Occurred"}'
+    http_version: 
+  recorded_at: Fri, 19 May 2017 14:16:21 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Makes beta registration mechanism generalizable for later use with appeals status (by means of addition an additional route with a fixed "feature" parameter). 

Some robustness improvements to mhv_account including adding the `failed` states. 