### PR TITLE
Add Pension and Burial claim submission endpoints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 4e588a6435507389ef7e433afc82fe6803bce7ef
+  revision: 348d450883fa946058056010b5e5d6a7eb18327d
   branch: master
   specs:
-    vets_json_schema (2.7.1)
+    vets_json_schema (3.0.12)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 

--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -67,6 +67,8 @@ module V0
       Swagger::Requests::TermsAndConditions,
       Swagger::Requests::User,
       Swagger::Requests::EducationBenefitsClaims,
+      Swagger::Requests::PensionClaims,
+      Swagger::Requests::BurialClaims,
       Swagger::Requests::HealthCareApplications,
       Swagger::Requests::Prescriptions::Prescriptions,
       Swagger::Requests::Prescriptions::Trackings,
@@ -75,6 +77,7 @@ module V0
       Swagger::Requests::Messages::Messages,
       Swagger::Requests::Messages::MessageDrafts,
       Swagger::Responses::AuthenticationError,
+      Swagger::Responses::SavedForm,
       Swagger::Schemas::Health::Prescriptions,
       Swagger::Schemas::Health::Trackings,
       Swagger::Schemas::Health::TriageTeams,
@@ -83,6 +86,7 @@ module V0
       Swagger::Schemas::Health::Meta,
       Swagger::Schemas::Health::Links,
       Swagger::Schemas::Errors,
+      Swagger::Schemas::SavedForm,
       Swagger::Schemas::TermsAndConditions,
       self
     ].freeze

--- a/app/controllers/v0/burial_claims_controller.rb
+++ b/app/controllers/v0/burial_claims_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+module V0
+  class BurialClaimsController < ApplicationController
+    skip_before_action(:authenticate)
+
+    def create
+      claim = SavedClaim::Burial.new(form: burial_claim_params[:form])
+      unless claim.save
+        validation_error = claim.errors.full_messages.join(', ')
+        log_message_to_sentry(validation_error, :error, {}, validation: 'burial_claim')
+
+        StatsD.increment("#{stats_key}.failure")
+        raise Common::Exceptions::ValidationErrors, claim
+      end
+
+      StatsD.increment("#{stats_key}.success")
+      Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{SavedClaim::Burial::FORM}"
+      render(json: claim)
+    end
+
+    private
+
+    def burial_claim_params
+      params.require(:burial_claim).permit(:form)
+    end
+
+    def stats_key
+      'api.burial_claim'
+    end
+  end
+end

--- a/app/controllers/v0/pension_claims_controller.rb
+++ b/app/controllers/v0/pension_claims_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+module V0
+  class PensionClaimsController < ApplicationController
+    skip_before_action(:authenticate)
+
+    def create
+      claim = SavedClaim::Pension.new(form: pension_claim_params[:form])
+      unless claim.save
+        validation_error = claim.errors.full_messages.join(', ')
+
+        log_message_to_sentry(validation_error, :error, {}, validation: 'pension_claim')
+
+        StatsD.increment("#{stats_key}.failure")
+        raise Common::Exceptions::ValidationErrors, claim
+      end
+
+      StatsD.increment("#{stats_key}.success")
+      Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{SavedClaim::Pension::FORM}"
+      render(json: claim)
+    end
+
+    private
+
+    def pension_claim_params
+      params.require(:pension_claim).permit(:form)
+    end
+
+    def stats_key
+      'api.pension_claim'
+    end
+  end
+end

--- a/app/models/saved_claim.rb
+++ b/app/models/saved_claim.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'attr_encrypted'
+class SavedClaim < ActiveRecord::Base
+  validates(:form, presence: true)
+  validate(:form_matches_schema)
+  validate(:form_must_be_string)
+  attr_encrypted(:form, key: Settings.db_encryption_key)
+
+  before_create do
+    self.guid = SecureRandom.uuid
+    self.form_type = self.class::FORM.upcase
+  end
+
+  def open_struct_form
+    @application ||= JSON.parse(form, object_class: OpenStruct)
+  end
+
+  def parsed_form
+    @parsed_form ||= JSON.parse(form)
+  end
+
+  def submitted_at
+    created_at
+  end
+
+  def form_is_string
+    form.is_a?(String)
+  end
+
+  def form_must_be_string
+    errors[:form] << 'must be a json string' unless form_is_string
+  end
+
+  def form_matches_schema
+    return unless form_is_string
+
+    errors[:form].concat(JSON::Validator.fully_validate(VetsJsonSchema::SCHEMAS[self.class::FORM], parsed_form))
+  end
+end

--- a/app/models/saved_claim/burial.rb
+++ b/app/models/saved_claim/burial.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class SavedClaim::Burial < SavedClaim
+  FORM = '21P-530'
+  def regional_office
+    PensionBurial::ProcessingOffice.address_for(open_struct_form.claimantAddress.postalCode)
+  end
+
+  def confirmation_number
+    "V-BUR-#{id}#{guid[0..6]}".upcase
+  end
+end

--- a/app/models/saved_claim/pension.rb
+++ b/app/models/saved_claim/pension.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class SavedClaim::Pension < SavedClaim
+  FORM = '21P-527EZ'
+  def regional_office
+    PensionBurial::ProcessingOffice.address_for(open_struct_form.veteranAddress.postalCode)
+  end
+
+  def confirmation_number
+    "V-PEN-#{id}#{guid[0..6]}".upcase
+  end
+end

--- a/app/serializers/saved_claim_serializer.rb
+++ b/app/serializers/saved_claim_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+class SavedClaimSerializer < ActiveModel::Serializer
+  attributes :id, :submitted_at, :regional_office, :confirmation_number
+  attribute :form_type, key: :form
+end

--- a/app/swagger/requests/burial_claims.rb
+++ b/app/swagger/requests/burial_claims.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Swagger
+  module Requests
+    class BurialClaims
+      include Swagger::Blocks
+
+      swagger_path '/v0/burial_claims' do
+        operation :post do
+          extend Swagger::Responses::ValidationError
+          extend Swagger::Responses::SavedForm
+
+          key :description, 'Submit a burial benefit claim'
+          key :operationId, 'addBurialClaim'
+          key :tags, %w(
+            burial
+            forms
+          )
+
+          parameter :optional_authorization
+
+          parameter do
+            key :name, :form
+            key :in, :body
+            key :description, 'Burial claim form data'
+            key :required, true
+
+            schema do
+              key :type, :string
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/swagger/requests/education_benefits_claims.rb
+++ b/app/swagger/requests/education_benefits_claims.rb
@@ -10,9 +10,10 @@ module Swagger
 
           key :description, 'Submit an education benefits claim'
           key :operationId, 'addEducationBenefitsClaim'
-          key :tags, [
-            'education_benefits'
-          ]
+          key :tags, %w(
+            education_benefits
+            forms
+          )
 
           parameter do
             key :name, :education_benefits_claim

--- a/app/swagger/requests/health_care_applications.rb
+++ b/app/swagger/requests/health_care_applications.rb
@@ -11,9 +11,10 @@ module Swagger
 
           key :description, 'Submit a health care application'
           key :operationId, 'addHealthCareApplication'
-          key :tags, [
-            'hca'
-          ]
+          key :tags, %w(
+            hca
+            forms
+          )
 
           parameter :optional_authorization
 

--- a/app/swagger/requests/in_progress_forms.rb
+++ b/app/swagger/requests/in_progress_forms.rb
@@ -10,9 +10,10 @@ module Swagger
 
           key :description, 'Get Saved Form Summaries'
           key :operationId, 'listInProgressForms'
-          key :tags, [
-            'in_progress_forms'
-          ]
+          key :tags, %w(
+            in_progress_forms
+            forms
+          )
 
           parameter :authorization
 

--- a/app/swagger/requests/pension_claims.rb
+++ b/app/swagger/requests/pension_claims.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Swagger
+  module Requests
+    class PensionClaims
+      include Swagger::Blocks
+
+      swagger_path '/v0/pension_claims' do
+        operation :post do
+          extend Swagger::Responses::ValidationError
+          extend Swagger::Responses::SavedForm
+
+          key :description, 'Submit a pension benefit claim'
+          key :operationId, 'addPensionClaim'
+          key :tags, %w(
+            pension
+            forms
+          )
+
+          parameter :optional_authorization
+
+          parameter do
+            key :name, :form
+            key :in, :body
+            key :description, 'Pension claim form data'
+            key :required, true
+
+            schema do
+              key :type, :string
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/swagger/responses/saved_form.rb
+++ b/app/swagger/responses/saved_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Responses
+    module SavedForm
+      def self.extended(base)
+        base.response 200 do
+          key :description, 'Form Submitted'
+          schema do
+            key :'$ref', :SavedForm
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/swagger/schemas/saved_form.rb
+++ b/app/swagger/schemas/saved_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Schemas
+    class SavedForm
+      include Swagger::Blocks
+      swagger_schema :SavedForm do
+        key :required, [:data]
+
+        property :data, type: :object do
+          property :id, type: :string
+          property :type, type: :string
+
+          property :attributes, type: :object do
+            property :form, type: :string
+            property :submitted_at, type: :string
+            property :regional_office, type: :array
+            property :confirmation_number, type: :string
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
         get(:healthcheck)
       end
     end
+    resource :pension_claims, only: [:create]
+    resource :burial_claims, only: [:create]
 
     resource :disability_rating, only: [:show]
 

--- a/db/migrate/20170621122611_saved_claims.rb
+++ b/db/migrate/20170621122611_saved_claims.rb
@@ -1,0 +1,11 @@
+class PensionClaim < ActiveRecord::Migration
+  def change
+     create_table(:saved_claims) do |t|
+    t.timestamps
+    t.string :encrypted_form, null: false
+    t.string :encrypted_form_iv, null: false
+    t.string :form_type
+    t.uuid :guid, null: false
+  end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170601175300) do
+ActiveRecord::Schema.define(version: 20170621122611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,15 @@ ActiveRecord::Schema.define(version: 20170601175300) do
 
   add_index "in_progress_forms", ["form_id"], name: "index_in_progress_forms_on_form_id", using: :btree
   add_index "in_progress_forms", ["user_uuid"], name: "index_in_progress_forms_on_user_uuid", using: :btree
+
+  create_table "saved_claims", force: :cascade do |t|
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "encrypted_form",    null: false
+    t.string   "encrypted_form_iv", null: false
+    t.string   "form_type"
+    t.uuid     "guid",              null: false
+  end
 
   create_table "terms_and_conditions", force: :cascade do |t|
     t.string   "name"

--- a/spec/controllers/v0/burial_claims_controller_spec.rb
+++ b/spec/controllers/v0/burial_claims_controller_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe V0::BurialClaimsController, type: :controller do
+end

--- a/spec/factories/burial_claim.rb
+++ b/spec/factories/burial_claim.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :burial_claim, class: SavedClaim::Burial do
+    form do
+      {
+        veteranFullName: {
+          first: 'Test',
+          last: 'User'
+        },
+        deathDate: '1989-12-13',
+        veteranSocialSecurityNumber: '111223333',
+        claimantAddress: {
+          country: 'USA',
+          state: 'CA',
+          postalCode: '90210',
+          street: '123 Main St',
+          city: 'Anytown'
+        }
+      }.to_json
+    end
+  end
+end

--- a/spec/factories/pension_claim.rb
+++ b/spec/factories/pension_claim.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :pension_claim, class: SavedClaim::Pension do
+    form do
+      {
+        veteranFullName: {
+          first: 'Test',
+          last: 'User'
+        },
+        gender: 'F',
+        veteranDateOfBirth: '1989-12-13',
+        veteranSocialSecurityNumber: '111223333',
+        veteranAddress: {
+          country: 'USA',
+          state: 'CA',
+          postalCode: '90210',
+          street: '123 Main St',
+          city: 'Anytown'
+        }
+      }.to_json
+    end
+  end
+end

--- a/spec/fixtures/pension/some.json
+++ b/spec/fixtures/pension/some.json
@@ -1,0 +1,16 @@
+{
+  "veteranFullName": {
+    "first": "john",
+    "middle": "middle",
+    "last": "smith",
+    "suffix": "Sr."
+  },
+  "veteranAddress": {
+    "city": "Anywhere",
+    "country": "USA",
+    "postalCode": "90210",
+    "street": "street",
+    "street2": "street2",
+    "state": "MD"
+  }
+}

--- a/spec/request/pension_claims_controller_spec.rb
+++ b/spec/request/pension_claims_controller_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'hca/service'
+
+RSpec.describe 'Pension Claim Integration', type: [:request, :serializer] do
+  let(:full_claim) do
+    build(:pension_claim).parsed_form
+  end
+
+  describe 'POST create' do
+    subject do
+      post(
+        v0_pension_claims_path,
+        params.to_json,
+        'CONTENT_TYPE' => 'application/json',
+        'HTTP_X_KEY_INFLECTION' => 'camel'
+      )
+    end
+
+    context 'with invalid params' do
+      before do
+        Settings.sentry.dsn = 'asdf'
+      end
+      after do
+        Settings.sentry.dsn = nil
+      end
+      let(:params) do
+        # JSON.parse(response.body)['errors']
+        {
+          pensionClaim: {
+            form: full_claim.merge('bankAccount' => 'just a string').to_json
+          }
+        }
+      end
+
+      it 'should show the validation errors' do
+        subject
+        expect(response.code).to eq('422')
+        expect(
+          JSON.parse(response.body)['errors'][0]['detail'].include?(
+            "The property '#/bankAccount' of type String"
+          )
+        ).to eq(true)
+      end
+
+      it 'should log the validation errors' do
+        expect(Raven).to receive(:tags_context).once.with(validation: 'pension_claim')
+        expect(Raven).to receive(:capture_message).with(/bankAccount/, level: :error)
+
+        subject
+      end
+    end
+
+    context 'with valid params' do
+      let(:params) do
+        {
+          pensionClaim: {
+            form: full_claim.to_json
+          }
+        }
+      end
+      it 'should render success' do
+        subject
+        expect(JSON.parse(response.body)['data']['attributes'].keys.sort)
+          .to eq(%w(confirmationNumber form regionalOffice submittedAt))
+      end
+    end
+  end
+end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -119,6 +119,54 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
       )
     end
 
+    it 'supports adding a pension' do
+      expect(subject).to validate(
+        :post,
+        '/v0/pension_claims',
+        200,
+        '_data' => {
+          'pension_claim' => {
+            'form' => build(:pension_claim).form
+          }
+        }
+      )
+
+      expect(subject).to validate(
+        :post,
+        '/v0/pension_claims',
+        422,
+        '_data' => {
+          'pension_claim' => {
+            'invalid-form' => { invalid: true }.to_json
+          }
+        }
+      )
+    end
+
+    it 'supports adding a burial claim' do
+      expect(subject).to validate(
+        :post,
+        '/v0/burial_claims',
+        200,
+        '_data' => {
+          'burial_claim' => {
+            'form' => build(:burial_claim).form
+          }
+        }
+      )
+
+      expect(subject).to validate(
+        :post,
+        '/v0/burial_claims',
+        422,
+        '_data' => {
+          'burial_claim' => {
+            'invalid-form' => { invalid: true }.to_json
+          }
+        }
+      )
+    end
+
     context 'HCA tests' do
       let(:test_veteran) do
         File.read(


### PR DESCRIPTION
Use a unified SavedForm model that we can maybe eventually move EDU and HCA towards using as well. Clearly some subclassing to be done with the Controllers as well.