### PR TITLE
Add MHV test users to mock MVI database

### DIFF
--- a/config/mvi_schema/mock_mvi_responses.yml.example
+++ b/config/mvi_schema/mock_mvi_responses.yml.example
@@ -1,4 +1,4 @@
-# Generated at 2017-05-24T09:12:38+00:00
+# Generated at 2017-06-21T17:07:48+00:00
 ---
 find_candidate:
   '796126859':
@@ -6,17 +6,26 @@ find_candidate:
     - Hector
     - J
     :family_name: Allen
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19320205'
     :ssn: '796126859'
-    :address:
-    :home_phone:
+    :address: !ruby/object:MVI::Models::MviProfileAddress
+      city: HOUSTON
+      state: TX
+      postal_code: '77040'
+      country: USA
+      street: "# 20140624"
+    :home_phone: "(512)543-4568"
     :icn: 1012667122V019349
     :mhv_ids:
+    - '14374039'
+    - '14370111'
     - '14221465'
     :vha_facility_ids:
     - 200ESR
+    - 200MHS
+    - 200MHS
     - 200MHS
     :edipi: '1005329660'
     :participant_id: '600043186'
@@ -25,7 +34,7 @@ find_candidate:
     - Greg
     - A
     :family_name: Anderson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19330405'
     :ssn: '796121200'
@@ -37,11 +46,13 @@ find_candidate:
       street: MILITARY ADDY 3
     :home_phone: "(333)444-5555"
     :icn: 1012666182V203559
-    :mhv_ids: []
+    :mhv_ids:
+    - '14398876'
     :vha_facility_ids:
     - '987'
     - 200ESR
     - '553'
+    - 200MHS
     :edipi: '1005079124'
     :participant_id: '600036159'
   '796127781':
@@ -49,14 +60,14 @@ find_candidate:
     - Andrea
     - L
     :family_name: Mitchell
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19591201'
     :ssn: '796127781'
     :address: !ruby/object:MVI::Models::MviProfileAddress
       city: YEREVAN
-      state:
-      postal_code:
+      state: 
+      postal_code: 
       country: ARM
       street: 22 NOR ARESH
     :home_phone: "(222)222-2222"
@@ -71,7 +82,7 @@ find_candidate:
     - Frank
     - Lee
     :family_name: Arnold
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19800220'
     :ssn: '796143510'
@@ -81,14 +92,12 @@ find_candidate:
       postal_code: '22079'
       country: USA
       street: 8131 DOVE COTTAGE CT
-    :home_phone:
+    :home_phone: 
     :icn: 1012667179V787205
-    :mhv_ids:
-    - '10713013'
+    :mhv_ids: []
     :vha_facility_ids:
     - '556'
     - '989'
-    - 200MHS
     - 200ESR
     :edipi: '1006753503'
     :participant_id: '600043216'
@@ -97,17 +106,17 @@ find_candidate:
     - Christian
     - Darnell
     :family_name: Turner
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19620615'
     :ssn: '796292881'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012830899V368969
     :mhv_ids: []
     :vha_facility_ids: []
@@ -118,17 +127,17 @@ find_candidate:
     - James
     - M
     :family_name: Beck
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19490902'
     :ssn: '796241819'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city: ANYTOWN
-      state: AK
-      postal_code: '12345'
+      city: OWENS X RDS
+      state: AL
+      postal_code: '35763'
       country: USA
-      street: ASDASD
-    :home_phone:
+      street: 110 KIRKWOOD DR SE
+    :home_phone: 
     :icn: 1012643432V477452
     :mhv_ids:
     - '10055461'
@@ -146,7 +155,7 @@ find_candidate:
     - Ray
     - Gerald
     :family_name: Bell
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19550817'
     :ssn: '796288429'
@@ -156,7 +165,7 @@ find_candidate:
       postal_code: '22033'
       country: USA
       street: INT LINE 23
-    :home_phone:
+    :home_phone: 
     :icn: 1012658910V309140
     :mhv_ids: []
     :vha_facility_ids:
@@ -170,17 +179,17 @@ find_candidate:
     - Ben
     - E
     :family_name: Weaver
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19210804'
     :ssn: '796131210'
     :address: !ruby/object:MVI::Models::MviProfileAddress
       city: MUMBAI
-      state:
-      postal_code:
+      state: 
+      postal_code: 
       country: IND
       street: '52333'
-    :home_phone:
+    :home_phone: 
     :icn: 1012848404V121721
     :mhv_ids: []
     :vha_facility_ids:
@@ -202,7 +211,7 @@ find_candidate:
       postal_code: '20171'
       country: USA
       street: ADD LINE 3 E BISHOP
-    :home_phone:
+    :home_phone: 
     :icn: 1012829228V424035
     :mhv_ids: []
     :vha_facility_ids:
@@ -214,13 +223,13 @@ find_candidate:
     - Jaime
     - Lee
     :family_name: Brooks
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19751126'
     :ssn: '796186272'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
+      city: 
+      state: 
       postal_code: '31314'
       country: USA
       street: 123 ABCDEFGHIJKLMNOP
@@ -235,16 +244,16 @@ find_candidate:
     - Jerry
     - M
     :family_name: Brooks
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19470925'
     :ssn: '796148937'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city: RICHMOND
-      state: VA
-      postal_code: '23233'
+      city: PARIS
+      state: 
+      postal_code: 
       country: USA
-      street: 123 FAKE STREET
+      street: 12 INTER DR.
     :home_phone: "(703)999-1919"
     :icn: 1012830245V504544
     :mhv_ids: []
@@ -257,7 +266,7 @@ find_candidate:
     - Allan
     - 'Null'
     :family_name: Butler
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19350615'
     :ssn: '796127023'
@@ -267,7 +276,7 @@ find_candidate:
       postal_code: '75243'
       country: USA
       street: 34343 BURNETT DRIVE
-    :home_phone:
+    :home_phone: 
     :icn: 1012829948V217207
     :mhv_ids: []
     :vha_facility_ids: []
@@ -278,7 +287,7 @@ find_candidate:
     - Jim
     - Edward
     :family_name: Byrd-ster
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19871115'
     :ssn: '796121909'
@@ -288,7 +297,7 @@ find_candidate:
       postal_code: 23322-5326
       country: USA
       street: 110 WILLIAMSBURG DR APT C2
-    :home_phone:
+    :home_phone: 
     :icn: 1012849574V585256
     :mhv_ids: []
     :vha_facility_ids:
@@ -300,7 +309,7 @@ find_candidate:
     - Eddie
     - Joseph
     :family_name: Caldwell
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19331027'
     :ssn: '796121086'
@@ -310,7 +319,7 @@ find_candidate:
       postal_code: '22309'
       country: USA
       street: WOW1
-    :home_phone:
+    :home_phone: 
     :icn: 1012666183V089914
     :mhv_ids: []
     :vha_facility_ids:
@@ -325,12 +334,12 @@ find_candidate:
     - Maurice
     - J
     :family_name: Murphy
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19730526'
     :ssn: '796265005'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012832013V553700
     :mhv_ids: []
     :vha_facility_ids: []
@@ -341,7 +350,7 @@ find_candidate:
     - Chad
     - Thomas
     :family_name: Carr
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19821016'
     :ssn: '796121207'
@@ -363,12 +372,12 @@ find_candidate:
     - Ke-lly
     - D
     :family_name: Car-roll
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19821030'
     :ssn: '796122092'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012844902V910074
     :mhv_ids: []
     :vha_facility_ids:
@@ -380,12 +389,12 @@ find_candidate:
     - Chad
     - E
     :family_name: Barrett
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19750512'
     :ssn: '796263749'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012853277V552077
     :mhv_ids: []
     :vha_facility_ids: []
@@ -396,7 +405,7 @@ find_candidate:
     - Helen
     - D
     :family_name: C-ole
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19360907'
     :ssn: '796131753'
@@ -417,12 +426,17 @@ find_candidate:
     - Travis
     - P
     :family_name: Curtis
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19460106'
     :ssn: '796127544'
-    :address:
-    :home_phone:
+    :address: !ruby/object:MVI::Models::MviProfileAddress
+      city: FAIRFAX
+      state: VA
+      postal_code: '22032'
+      country: USA
+      street: 1407 N FAIRFAX AVE
+    :home_phone: 
     :icn: 1012832612V245638
     :mhv_ids: []
     :vha_facility_ids:
@@ -434,12 +448,12 @@ find_candidate:
     - William
     - C
     :family_name: Daniels
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19370307'
     :ssn: '796127196'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012830699V134174
     :mhv_ids: []
     :vha_facility_ids:
@@ -451,12 +465,12 @@ find_candidate:
     - Kent
     - L
     :family_name: Warren
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19360714'
     :ssn: '796127160'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012662125V786396
     :mhv_ids: []
     :vha_facility_ids:
@@ -469,24 +483,24 @@ find_candidate:
     - Walter
     - Tyler
     :family_name: Davis
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19870130'
     :ssn: '796143333'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845238V805135
     :mhv_ids: []
     :vha_facility_ids:
     - 200ESR
-    :edipi:
+    :edipi: 
     :participant_id: '600043217'
   '796122400':
     :given_names:
     - Anne
     - 'Null'
     :family_name: Kurt
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19650302'
     :ssn: '796122400'
@@ -496,7 +510,7 @@ find_candidate:
       postal_code: '22033'
       country: USA
       street: 123 TEST STREET
-    :home_phone:
+    :home_phone: 
     :icn: 1012830822V023092
     :mhv_ids: []
     :vha_facility_ids:
@@ -508,7 +522,7 @@ find_candidate:
     - Tamara
     - 'Null'
     :family_name: Ellis
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19670619'
     :ssn: '796130115'
@@ -530,17 +544,17 @@ find_candidate:
     - Marcia
     - 'Null'
     :family_name: Fleming
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19381105'
     :ssn: '796126696'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012845629V054840
     :mhv_ids: []
     :vha_facility_ids: []
@@ -551,17 +565,17 @@ find_candidate:
     - Calvin
     - 'Null'
     :family_name: Fletcher
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19241219'
     :ssn: '796126777'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012829890V001762
     :mhv_ids: []
     :vha_facility_ids: []
@@ -572,7 +586,7 @@ find_candidate:
     - Martha
     - 'Null'
     :family_name: Fletcher
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19380216'
     :ssn: '796126778'
@@ -582,7 +596,7 @@ find_candidate:
       postal_code: '78259'
       country: USA
       street: 123 MAIN ST
-    :home_phone:
+    :home_phone: 
     :icn: 1012833046V189377
     :mhv_ids: []
     :vha_facility_ids:
@@ -595,7 +609,7 @@ find_candidate:
     - Wesley
     - Watson
     :family_name: Ford
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19860506'
     :ssn: '796043735'
@@ -616,7 +630,7 @@ find_candidate:
     - Marion
     - 'Null'
     :family_name: Foster
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19450213'
     :ssn: '796376250'
@@ -637,17 +651,17 @@ find_candidate:
     - Pauline
     - 'Null'
     :family_name: Foster
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19760609'
     :ssn: '796330625'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012845630V900607
     :mhv_ids: []
     :vha_facility_ids:
@@ -659,7 +673,7 @@ find_candidate:
     - Anthony
     - Joey
     :family_name: Williams
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19600203'
     :ssn: '796296387'
@@ -669,7 +683,7 @@ find_candidate:
       postal_code: '78704'
       country: USA
       street: '787'
-    :home_phone:
+    :home_phone: 
     :icn: 1012832042V458998
     :mhv_ids: []
     :vha_facility_ids: []
@@ -690,7 +704,7 @@ find_candidate:
       postal_code: '67218'
       country: USA
       street: '101'
-    :home_phone:
+    :home_phone: 
     :icn: 1012830022V956566
     :mhv_ids: []
     :vha_facility_ids:
@@ -703,12 +717,12 @@ find_candidate:
     - Melvin
     - V
     :family_name: Freeman
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19711119'
     :ssn: '796184750'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012643310V921518
     :mhv_ids:
     - '10055239'
@@ -730,7 +744,7 @@ find_candidate:
     - Russell
     - 'Null'
     :family_name: Freeman
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19691105'
     :ssn: '796149080'
@@ -740,19 +754,19 @@ find_candidate:
       postal_code: '32207'
       country: USA
       street: 100 BEACH BLVD
-    :home_phone:
+    :home_phone: 
     :icn: 1012829910V765228
     :mhv_ids: []
     :vha_facility_ids:
     - 200ESR
     :edipi: '1007481507'
-    :participant_id:
+    :participant_id: 
   '796140261':
     :given_names:
     - Olga
     - Lee
     :family_name: Fuller
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19840518'
     :ssn: '796140261'
@@ -762,18 +776,18 @@ find_candidate:
       postal_code: 78209-6015
       country: USA
       street: 1142 GARRATY RD
-    :home_phone:
+    :home_phone: 
     :icn: 1012830237V154192
     :mhv_ids: []
     :vha_facility_ids: []
     :edipi: '1006448425'
-    :participant_id:
+    :participant_id: 
   '796122369':
     :given_names:
     - Herbert
     - 'Null'
     :family_name: Gardner
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19830221'
     :ssn: '796122369'
@@ -801,11 +815,11 @@ find_candidate:
     :ssn: '796246997'
     :address: !ruby/object:MVI::Models::MviProfileAddress
       city: MANILA
-      state:
-      postal_code:
+      state: 
+      postal_code: 
       country: PHL
       street: 1201 ROXAS BOULEVARD
-    :home_phone:
+    :home_phone: 
     :icn: 1012829446V964657
     :mhv_ids: []
     :vha_facility_ids:
@@ -838,12 +852,12 @@ find_candidate:
     - Beverly
     - D
     :family_name: George
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19541028'
     :ssn: '796330165'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012856544V681033
     :mhv_ids: []
     :vha_facility_ids: []
@@ -854,7 +868,7 @@ find_candidate:
     - Denise
     - M
     :family_name: George
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19930719'
     :ssn: '796330166'
@@ -864,7 +878,7 @@ find_candidate:
       postal_code: '20171'
       country: USA
       street: 1875 WILL RD
-    :home_phone:
+    :home_phone: 
     :icn: 1012855585V634865
     :mhv_ids: []
     :vha_facility_ids: []
@@ -875,12 +889,12 @@ find_candidate:
     - Jesse
     - 'Null'
     :family_name: George
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19500313'
     :ssn: '796330163'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845632V596441
     :mhv_ids: []
     :vha_facility_ids: []
@@ -891,7 +905,7 @@ find_candidate:
     - Gerald
     - K
     :family_name: Schmidt
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19410504'
     :ssn: '796127354'
@@ -901,7 +915,7 @@ find_candidate:
       postal_code: '78259'
       country: USA
       street: 758 H AVE
-    :home_phone:
+    :home_phone: 
     :icn: 1012829895V736226
     :mhv_ids: []
     :vha_facility_ids:
@@ -914,17 +928,17 @@ find_candidate:
     - Sidney
     - 'Null'
     :family_name: Gibson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19330804'
     :ssn: '796127094'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
+      city: 
+      state: 
       postal_code: 09021
       country: USA
       street: PSC 3 BOX 4120
-    :home_phone:
+    :home_phone: 
     :icn: 1012832357V534929
     :mhv_ids: []
     :vha_facility_ids: []
@@ -935,7 +949,7 @@ find_candidate:
     - Gilbert
     - L
     :family_name: Green
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19660926'
     :ssn: '796140438'
@@ -956,7 +970,7 @@ find_candidate:
     - Glen
     - F
     :family_name: Mitchell
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19460328'
     :ssn: '796127777'
@@ -966,7 +980,7 @@ find_candidate:
       postal_code: '78259'
       country: USA
       street: 457 H STREET
-    :home_phone:
+    :home_phone: 
     :icn: 1012829925V716587
     :mhv_ids: []
     :vha_facility_ids:
@@ -978,7 +992,7 @@ find_candidate:
     :given_names:
     - Jesse
     :family_name: Gray
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19541215'
     :ssn: '796378881'
@@ -988,7 +1002,7 @@ find_candidate:
       postal_code: '75024'
       country: USA
       street: 100 MAIN STREET
-    :home_phone:
+    :home_phone: 
     :icn: 1012666073V986297
     :mhv_ids: []
     :vha_facility_ids:
@@ -1001,17 +1015,17 @@ find_candidate:
     - Marcus
     - 'Null'
     :family_name: Gregory
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19250409'
     :ssn: '796126751'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012829767V002519
     :mhv_ids: []
     :vha_facility_ids:
@@ -1023,17 +1037,17 @@ find_candidate:
     - Shirley
     - 'Null'
     :family_name: Gregory
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19710420'
     :ssn: '796126752'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012845633V224390
     :mhv_ids: []
     :vha_facility_ids:
@@ -1044,7 +1058,7 @@ find_candidate:
     :given_names:
     - Gregory
     :family_name: Wheeler
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19230730'
     :ssn: '796164129'
@@ -1054,7 +1068,7 @@ find_candidate:
       postal_code: '78259'
       country: USA
       street: 457 T STREET
-    :home_phone:
+    :home_phone: 
     :icn: 1012829891V187651
     :mhv_ids: []
     :vha_facility_ids:
@@ -1072,11 +1086,11 @@ find_candidate:
     :birth_date: '19810911'
     :ssn: '796143067'
     :address: !ruby/object:MVI::Models::MviProfileAddress
+      country: USA
+      street:
       city:
       state:
       postal_code:
-      country: USA
-      street:
     :home_phone:
     :icn: 1012830632V301660
     :mhv_ids: []
@@ -1088,7 +1102,7 @@ find_candidate:
     :given_names:
     - June
     :family_name: Harris
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19551227'
     :ssn: '796184459'
@@ -1114,12 +1128,12 @@ find_candidate:
     - Tim
     - Stephen
     :family_name: Harris
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19870427'
     :ssn: '796136798'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845502V635089
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1130,7 +1144,7 @@ find_candidate:
     - Harry
     - Y
     :family_name: Burke
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19410905'
     :ssn: '796164213'
@@ -1140,7 +1154,7 @@ find_candidate:
       postal_code: '78259'
       country: USA
       street: 754 Y AVE
-    :home_phone:
+    :home_phone: 
     :icn: 1012832249V897380
     :mhv_ids: []
     :vha_facility_ids:
@@ -1153,7 +1167,7 @@ find_candidate:
     - Bonnie
     - 'Null'
     :family_name: Hayes
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19390705'
     :ssn: '796131730'
@@ -1163,7 +1177,7 @@ find_candidate:
       postal_code: '20171'
       country: USA
       street: 4276 WILL
-    :home_phone:
+    :home_phone: 
     :icn: 1012849765V900974
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1174,7 +1188,7 @@ find_candidate:
     - Jeffery
     - 'Null'
     :family_name: Hayes
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19370925'
     :ssn: '796131729'
@@ -1184,7 +1198,7 @@ find_candidate:
       postal_code: '30062'
       country: USA
       street: 2575 VALENCIA DR NE
-    :home_phone:
+    :home_phone: 
     :icn: 1012845028V591200
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1195,12 +1209,12 @@ find_candidate:
     - Julio
     - George
     :family_name: Hendersons
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19780222'
     :ssn: '796136998'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012829610V986182
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1211,7 +1225,7 @@ find_candidate:
     - Herbert
     - F
     :family_name: George
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19611228'
     :ssn: '796156570'
@@ -1221,7 +1235,7 @@ find_candidate:
       postal_code: '22031'
       country: USA
       street: 321 NORTH SOUTH ST
-    :home_phone:
+    :home_phone: 
     :icn: 1012845754V409036
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1232,12 +1246,12 @@ find_candidate:
     - Everett
     - Avery
     :family_name: Horton
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19820423'
     :ssn: '796377148'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012826664V603033
     :mhv_ids: []
     :vha_facility_ids:
@@ -1250,7 +1264,7 @@ find_candidate:
     - Tanya
     - 'Null'
     :family_name: Horton
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19520516'
     :ssn: '796122928'
@@ -1260,7 +1274,7 @@ find_candidate:
       postal_code: '22031'
       country: USA
       street: SUITE 204
-    :home_phone:
+    :home_phone: 
     :icn: 1012667136V162744
     :mhv_ids: []
     :vha_facility_ids:
@@ -1272,12 +1286,12 @@ find_candidate:
     - Karl
     - 'Null'
     :family_name: Howard
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19610129'
     :ssn: '796123209'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845634V053289
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1288,12 +1302,12 @@ find_candidate:
     - Mathew
     - 'Null'
     :family_name: Howell
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19270118'
     :ssn: '796121275'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845636V368566
     :mhv_ids: []
     :vha_facility_ids:
@@ -1305,7 +1319,7 @@ find_candidate:
     - Julio
     - 'Null'
     :family_name: Jonesin
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19511118'
     :ssn: '796378321'
@@ -1315,7 +1329,7 @@ find_candidate:
       postal_code: '40144'
       country: USA
       street: 111 SPRING ST
-    :home_phone:
+    :home_phone: 
     :icn: 1012666072V702345
     :mhv_ids: []
     :vha_facility_ids:
@@ -1327,7 +1341,7 @@ find_candidate:
     - Rita
     - Ann
     :family_name: Jackson
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19580407'
     :ssn: '796136784'
@@ -1337,7 +1351,7 @@ find_candidate:
       postal_code: 32507-7960
       country: USA
       street: 1106 HALYARD PL
-    :home_phone:
+    :home_phone: 
     :icn: 1012846668V389995
     :mhv_ids: []
     :vha_facility_ids:
@@ -1349,7 +1363,7 @@ find_candidate:
     - Janet
     - Lynne
     :family_name: Moore
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19490506'
     :ssn: '796127677'
@@ -1378,7 +1392,7 @@ find_candidate:
     - Kimberly
     - 'Null'
     :family_name: Jenkins
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19481009'
     :ssn: '796122307'
@@ -1388,7 +1402,7 @@ find_candidate:
       postal_code: 03869-5815
       country: USA
       street: 111 WOODS RUN
-    :home_phone:
+    :home_phone: 
     :icn: 1012845637V411958
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1399,7 +1413,7 @@ find_candidate:
     - Mitchell
     - G
     :family_name: Jenkins
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19490304'
     :ssn: '796122306'
@@ -1420,7 +1434,7 @@ find_candidate:
     - Carl
     - Roger
     :family_name: Jensen
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19870327'
     :ssn: '796147571'
@@ -1430,7 +1444,7 @@ find_candidate:
       postal_code: '32514'
       country: USA
       street: 7689 HENDRIX AVE
-    :home_phone:
+    :home_phone: 
     :icn: 1012848398V967004
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1441,17 +1455,17 @@ find_candidate:
     - Manuel
     - 'Null'
     :family_name: Jensen
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19441126'
     :ssn: '796127519'
     :address: !ruby/object:MVI::Models::MviProfileAddress
       city: ALEXANDRIA
-      state:
-      postal_code:
+      state: 
+      postal_code: 
       country: BRB
       street: 4846 KENMORE AVE
-    :home_phone:
+    :home_phone: 
     :icn: 1012845234V469924
     :mhv_ids: []
     :vha_facility_ids:
@@ -1463,12 +1477,12 @@ find_candidate:
     - Jesus
     - A
     :family_name: Barrett
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19470629'
     :ssn: '796127587'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012830305V427401
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1479,17 +1493,17 @@ find_candidate:
     - Margie
     - 'Null'
     :family_name: Johnson
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19480827'
     :ssn: '796122059'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
+      city: 
+      state: 
       postal_code: '10000'
       country: USA
       street: IN DESSERT
-    :home_phone:
+    :home_phone: 
     :icn: 1012845074V891241
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1500,7 +1514,7 @@ find_candidate:
     - Oscar
     - F
     :family_name: Jones
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19481016'
     :ssn: '796122064'
@@ -1510,7 +1524,7 @@ find_candidate:
       postal_code: '03104'
       country: USA
       street: 2064 ELM ST
-    :home_phone:
+    :home_phone: 
     :icn: 1012666047V544942
     :mhv_ids: []
     :vha_facility_ids:
@@ -1522,7 +1536,7 @@ find_candidate:
     - Christopher
     - 'Null'
     :family_name: Lane
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19510710'
     :ssn: '796122633'
@@ -1532,7 +1546,7 @@ find_candidate:
       postal_code: '44102'
       country: USA
       street: 212 WEST LN
-    :home_phone:
+    :home_phone: 
     :icn: 1012829621V733243
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1543,7 +1557,7 @@ find_candidate:
     - Jean
     - Christine
     :family_name: Lane
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19920126'
     :ssn: '796295982'
@@ -1564,7 +1578,7 @@ find_candidate:
     - Wesley
     - Terrone
     :family_name: Lane
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19640525'
     :ssn: '796264319'
@@ -1574,7 +1588,7 @@ find_candidate:
       postal_code: '23233'
       country: USA
       street: 6819 Ayala Avenue
-    :home_phone:
+    :home_phone: 
     :icn: 1012855094V917428
     :mhv_ids:
     - '13877897'
@@ -1587,7 +1601,7 @@ find_candidate:
     - Brian
     - 'Null'
     :family_name: Lawrence
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19500423'
     :ssn: '796122667'
@@ -1597,7 +1611,7 @@ find_candidate:
       postal_code: '22031'
       country: USA
       street: 45 CHAIN BRIDGE RD
-    :home_phone:
+    :home_phone: 
     :icn: 1012845191V379613
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1608,17 +1622,17 @@ find_candidate:
     - Daryl
     - 'Null'
     :family_name: Lawrence
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19530215'
     :ssn: '796153447'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012829620V654328
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1629,7 +1643,7 @@ find_candidate:
     - Joanne
     - 'Null'
     :family_name: Lawrence
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19530628'
     :ssn: '796122671'
@@ -1650,7 +1664,7 @@ find_candidate:
     - Russell
     - S
     :family_name: Lawson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19581118'
     :ssn: '796220951'
@@ -1660,12 +1674,14 @@ find_candidate:
       postal_code: '30028'
       country: USA
       street: 8765 WESTBROOK LANE
-    :home_phone:
+    :home_phone: 
     :icn: 1012826601V741386
-    :mhv_ids: []
+    :mhv_ids:
+    - '14385056'
     :vha_facility_ids:
     - '987'
     - 200ESR
+    - 200MHS
     :edipi: '1045938782'
     :participant_id: '600036163'
   '796378782':
@@ -1673,7 +1689,7 @@ find_candidate:
     - Ralph
     - 'Null'
     :family_name: Lee
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19481030'
     :ssn: '796378782'
@@ -1683,7 +1699,7 @@ find_candidate:
       postal_code: '22032'
       country: USA
       street: HRB 82136
-    :home_phone:
+    :home_phone: 
     :icn: 1012667169V030190
     :mhv_ids: []
     :vha_facility_ids:
@@ -1695,7 +1711,7 @@ find_candidate:
     - Wesley
     - 'Null'
     :family_name: Lee
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19480221'
     :ssn: '796127725'
@@ -1705,7 +1721,7 @@ find_candidate:
       postal_code: '33618'
       country: USA
       street: 49 FEATHERSTONE ST
-    :home_phone:
+    :home_phone: 
     :icn: 1012845443V584332
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1716,7 +1732,7 @@ find_candidate:
     - Jon
     - J
     :family_name: Lowe
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19551120'
     :ssn: '796136639'
@@ -1726,7 +1742,7 @@ find_candidate:
       postal_code: '22033'
       country: USA
       street: 4350 FAIR LAKES CT
-    :home_phone:
+    :home_phone: 
     :icn: 1012883999V203355
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1737,7 +1753,7 @@ find_candidate:
     - Rene
     - M
     :family_name: Lowe
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19590201'
     :ssn: '796124704'
@@ -1747,18 +1763,18 @@ find_candidate:
       postal_code: '32514'
       country: USA
       street: 7689 HENDRIX AVE
-    :home_phone:
+    :home_phone: 
     :icn: 1012830303V188617
     :mhv_ids: []
     :vha_facility_ids: []
-    :edipi:
+    :edipi: 
     :participant_id: '600043181'
   '796122556':
     :given_names:
     - Marion
     - J
     :family_name: Dunn
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19500205'
     :ssn: '796122556'
@@ -1768,7 +1784,7 @@ find_candidate:
       postal_code: '33616'
       country: USA
       street: 2031 DALE MABRY
-    :home_phone:
+    :home_phone: 
     :icn: 1012830459V834803
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1779,12 +1795,12 @@ find_candidate:
     - Floyd
     - E
     :family_name: Marshall
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19651005'
     :ssn: '796147494'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012858706V701334
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1795,12 +1811,12 @@ find_candidate:
     - Rene
     - 'Null'
     :family_name: Martinez
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19800312'
     :ssn: '796122118'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012831442V629541
     :mhv_ids: []
     :vha_facility_ids:
@@ -1811,11 +1827,11 @@ find_candidate:
     :given_names:
     - Melissa
     :family_name: Vargas
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19870711'
     :ssn: '796073633'
-    :address:
+    :address: 
     :home_phone: "(412)362-7568"
     :icn: 1012585545V771188
     :mhv_ids:
@@ -1831,7 +1847,7 @@ find_candidate:
     - Randall
     - 'Null'
     :family_name: Meyer
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19540912'
     :ssn: '796150063'
@@ -1853,7 +1869,7 @@ find_candidate:
     - Norman
     - 'Null'
     :family_name: Mills
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19720108'
     :ssn: '796228919'
@@ -1863,7 +1879,7 @@ find_candidate:
       postal_code: 90807-5025
       country: USA
       street: 3170 ELM AVE
-    :home_phone:
+    :home_phone: 
     :icn: 1012845642V923610
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1874,12 +1890,12 @@ find_candidate:
     - Miriam
     - J
     :family_name: Richardson
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19740611'
     :ssn: '796127850'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012829980V308759
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1890,7 +1906,7 @@ find_candidate:
     - Terrence
     - Faustino
     :family_name: Montgomery
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19690611'
     :ssn: '796321635'
@@ -1900,7 +1916,7 @@ find_candidate:
       postal_code: 76227-3502
       country: USA
       street: 1123 BLUE JAY DR
-    :home_phone:
+    :home_phone: 
     :icn: 1012845643V859179
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1910,7 +1926,7 @@ find_candidate:
     :given_names:
     - Gladys
     :family_name: Moore
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19530329'
     :ssn: '796136776'
@@ -1928,18 +1944,18 @@ find_candidate:
     - 200ESR
     - '987'
     :edipi: '1006056896'
-    :participant_id:
+    :participant_id: 
   '796127674':
     :given_names:
     - Jon
     - 'Null'
     :family_name: Moore
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19470329'
     :ssn: '796127674'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012849931V685672
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1950,13 +1966,13 @@ find_candidate:
     - Alfredo
     - 'Null'
     :family_name: Morales
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19500114'
     :ssn: '796122472'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
+      city: 
+      state: 
       postal_code: 09157
       country: USA
       street: 100 MAIN ST
@@ -1972,17 +1988,17 @@ find_candidate:
     - Adrian
     - 'Null'
     :family_name: Andre
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19710912'
     :ssn: '796140489'
     :address: !ruby/object:MVI::Models::MviProfileAddress
       city: FLORENCE
-      state:
-      postal_code:
+      state: 
+      postal_code: 
       country: ITA
       street: APT 102
-    :home_phone:
+    :home_phone: 
     :icn: 1012831840V291348
     :mhv_ids: []
     :vha_facility_ids: []
@@ -1993,12 +2009,12 @@ find_candidate:
     - Harry
     - 'Null'
     :family_name: Olson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19690620'
     :ssn: '796136308'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012667180V621772
     :mhv_ids: []
     :vha_facility_ids:
@@ -2010,7 +2026,7 @@ find_candidate:
     - Morris
     - E
     :family_name: Ortiz
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19370322'
     :ssn: '796127109'
@@ -2020,7 +2036,7 @@ find_candidate:
       postal_code: '12312'
       country: USA
       street: APT 3011
-    :home_phone:
+    :home_phone: 
     :icn: 1012826604V590555
     :mhv_ids: []
     :vha_facility_ids:
@@ -2033,12 +2049,12 @@ find_candidate:
     - David
     - R
     :family_name: Palmer
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19390611'
     :ssn: '796127199'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845550V809717
     :mhv_ids: []
     :vha_facility_ids:
@@ -2050,7 +2066,7 @@ find_candidate:
     - Christian
     - Fitzgerald
     :family_name: Patterson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19640304'
     :ssn: '796218467'
@@ -2059,7 +2075,7 @@ find_candidate:
       state: MD
       postal_code: '20902'
       country: USA
-      street: 4576 WESTMORE STREET
+      street: TRAIL
     :home_phone: "(703)333-5544"
     :icn: 1012831012V063489
     :mhv_ids: []
@@ -2070,17 +2086,17 @@ find_candidate:
     :given_names:
     - Bob
     :family_name: Payne
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19511125'
     :ssn: '796023006'
     :address: !ruby/object:MVI::Models::MviProfileAddress
       city: Makati
-      state:
-      postal_code:
+      state: 
+      postal_code: 
       country: PHL
       street: RCBC Plaza
-    :home_phone:
+    :home_phone: 
     :icn: 1012845647V175093
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2091,7 +2107,7 @@ find_candidate:
     - Greg
     - J
     :family_name: Pena
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19550926'
     :ssn: '796002073'
@@ -2106,7 +2122,7 @@ find_candidate:
     :mhv_ids: []
     :vha_facility_ids: []
     :edipi: '1015899596'
-    :participant_id:
+    :participant_id: 
   '796231077':
     :given_names:
     - Glen
@@ -2117,11 +2133,11 @@ find_candidate:
     :birth_date: '19711208'
     :ssn: '796231077'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city: HERNDON
-      state: VA
-      postal_code: '20171'
+      city: 
+      state: 
+      postal_code: '22180'
       country: USA
-      street: 123ABC
+      street: SUITE 300
     :home_phone: "(908)765-4321"
     :icn: 1012832723V827263
     :mhv_ids: []
@@ -2144,7 +2160,7 @@ find_candidate:
       postal_code: '22031'
       country: USA
       street: 324 BAILEY LANE
-    :home_phone:
+    :home_phone: 
     :icn: 1012844916V261483
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2155,12 +2171,17 @@ find_candidate:
     - Kay
     - Danae
     :family_name: Perkins
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19820504'
     :ssn: '796064608'
-    :address:
-    :home_phone:
+    :address: !ruby/object:MVI::Models::MviProfileAddress
+      city: ORLANDO
+      state: FL
+      postal_code: '32801'
+      country: USA
+      street: 1234 PARK LN
+    :home_phone: "(404)751-1234"
     :icn: 1012830142V503884
     :mhv_ids: []
     :vha_facility_ids:
@@ -2172,12 +2193,12 @@ find_candidate:
     - Sean
     - Dennis
     :family_name: Perry
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19690926'
     :ssn: '796079042'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845655V547741
     :mhv_ids: []
     :vha_facility_ids:
@@ -2189,7 +2210,7 @@ find_candidate:
     - Jeanette
     - Mishawngwendol
     :family_name: Peters
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19820802'
     :ssn: '796070441'
@@ -2199,7 +2220,7 @@ find_candidate:
       postal_code: '22033'
       country: USA
       street: LINE3
-    :home_phone:
+    :home_phone: 
     :icn: 1012845656V205690
     :mhv_ids: []
     :vha_facility_ids:
@@ -2211,12 +2232,12 @@ find_candidate:
     - Philip
     - A
     :family_name: Horton
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19510224'
     :ssn: '796122926'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012830031V654442
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2227,12 +2248,12 @@ find_candidate:
     - Bruce
     - Allen
     :family_name: Phillips
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19910812'
     :ssn: '796023401'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845657V080189
     :mhv_ids: []
     :vha_facility_ids:
@@ -2244,12 +2265,12 @@ find_candidate:
     - Bradley
     - Thomas
     :family_name: Pierce
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19471226'
     :ssn: '796155569'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012847531V456102
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2260,7 +2281,7 @@ find_candidate:
     - Jessie
     - F
     :family_name: Price
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19340407'
     :ssn: '796126978'
@@ -2270,7 +2291,7 @@ find_candidate:
       postal_code: '33616'
       country: USA
       street: 132 N South St
-    :home_phone:
+    :home_phone: 
     :icn: 1012845658V192434
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2281,7 +2302,7 @@ find_candidate:
     - Adrian
     - J
     :family_name: Ray
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19660404'
     :ssn: '796100762'
@@ -2291,7 +2312,7 @@ find_candidate:
       postal_code: 85215-1627
       country: USA
       street: 2710 N RICARDO
-    :home_phone: 5555106274 p1
+    :home_phone: 
     :icn: 1012845659V326366
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2302,7 +2323,7 @@ find_candidate:
     - Derrick
     - L
     :family_name: Rei'd
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19760116'
     :ssn: '796229088'
@@ -2312,7 +2333,7 @@ find_candidate:
       postal_code: 28560-9458
       country: USA
       street: 110 PINE CIR
-    :home_phone:
+    :home_phone: 
     :icn: 1012845660V369114
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2322,7 +2343,7 @@ find_candidate:
     :given_names:
     - Jenny
     :family_name: Reid
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19480219'
     :ssn: '796364561'
@@ -2332,36 +2353,36 @@ find_candidate:
       postal_code: '78259'
       country: USA
       street: 47 G ST
-    :home_phone:
+    :home_phone: 
     :icn: 1012851022V753951
     :mhv_ids: []
     :vha_facility_ids:
     - '987'
     - 200ESR
-    :edipi:
+    :edipi: 
     :participant_id: '600087330'
   '796018229':
     :given_names:
     - Martin
     - R
     :family_name: Reid
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19770704'
     :ssn: '101259786'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012897042V607227
     :mhv_ids: []
     :vha_facility_ids: []
-    :edipi:
+    :edipi: 
     :participant_id: '600065659'
   '796109651':
     :given_names:
     - Mattie
     - May
     :family_name: Reid
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19640414'
     :ssn: '796109651'
@@ -2371,7 +2392,7 @@ find_candidate:
       postal_code: '33765'
       country: USA
       street: UNIT 2B
-    :home_phone:
+    :home_phone: 
     :icn: 1012845662V671308
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2382,12 +2403,12 @@ find_candidate:
     - Samantha
     - Carrie
     :family_name: Reid
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19821121'
     :ssn: '796090612'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012832350V178688
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2402,8 +2423,8 @@ find_candidate:
     :gender: M
     :birth_date: '19370617'
     :ssn: '796127085'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845079V316758
     :mhv_ids: []
     :vha_facility_ids:
@@ -2415,12 +2436,12 @@ find_candidate:
     - Vivian
     - Jesusita
     :family_name: Richardson
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19641231'
     :ssn: '796090606'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845612V245987
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2431,17 +2452,17 @@ find_candidate:
     - Andre
     - Alois
     :family_name: Richardson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19641215'
     :ssn: '796075896'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012845665V880597
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2452,12 +2473,12 @@ find_candidate:
     - Kent
     - David
     :family_name: Richardson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19820125'
     :ssn: '796092261'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845626V880077
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2468,7 +2489,7 @@ find_candidate:
     - Annette
     - K
     :family_name: Riley
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19631214'
     :ssn: '796027583'
@@ -2489,17 +2510,17 @@ find_candidate:
     - Aaron
     - Charles
     :family_name: Riley
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19701105'
     :ssn: '796081854'
     :address: !ruby/object:MVI::Models::MviProfileAddress
       city: TELI
-      state:
-      postal_code:
+      state: 
+      postal_code: 
       country: BLR
       street: 23423 BDTTE
-    :home_phone:
+    :home_phone: 
     :icn: 1012845628V226921
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2515,11 +2536,11 @@ find_candidate:
     :birth_date: '19590225'
     :ssn: '796013145'
     :address: !ruby/object:MVI::Models::MviProfileAddress
+      country: USA
+      street: 345 OCEAN LAKE DR
       city:
       state:
       postal_code: '28910'
-      country: USA
-      street: 345 OCEAN LAKE DR
     :home_phone: "(703)474-7474"
     :icn: 1012830453V141481
     :mhv_ids: []
@@ -2531,12 +2552,12 @@ find_candidate:
     - Roberto
     - Alan
     :family_name: Carpenter
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19690124'
     :ssn: '796263558'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012829859V179084
     :mhv_ids: []
     :vha_facility_ids:
@@ -2544,9 +2565,11 @@ find_candidate:
     :edipi: '1098420416'
     :participant_id: '600071398'
   '796019724':
-    :given_names: []
-    :family_name:
-    :suffix:
+    :given_names:
+    - Theodore
+    - Matthew
+    :family_name: Roberts
+    :suffix: 
     :gender: M
     :birth_date: '19860228'
     :ssn: '796019724'
@@ -2556,7 +2579,7 @@ find_candidate:
       postal_code: '70130'
       country: USA
       street: 555 CANAL STREET
-    :home_phone:
+    :home_phone: 
     :icn: 1012845672V157064
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2567,7 +2590,7 @@ find_candidate:
     - Vernon
     - W
     :family_name: Roberts
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19480719'
     :ssn: '796029838'
@@ -2577,7 +2600,7 @@ find_candidate:
       postal_code: '32987'
       country: USA
       street: APT 2H
-    :home_phone:
+    :home_phone: 
     :icn: 1012845673V335556
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2588,17 +2611,17 @@ find_candidate:
     - Clinton
     - L
     :family_name: Robertson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19471208'
     :ssn: '796059443'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
+      city: 
+      state: 
       postal_code: '12345'
       country: USA
       street: ADDRESS 3 M
-    :home_phone:
+    :home_phone: 
     :icn: 1012830862V430931
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2608,12 +2631,12 @@ find_candidate:
     :given_names:
     - Adrian
     :family_name: Rodriguez
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19470322'
     :ssn: '796014601'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845674V460918
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2624,12 +2647,12 @@ find_candidate:
     - Dean
     - Allen
     :family_name: Ruiz
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19690701'
     :ssn: '796015298'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845678V803142
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2640,13 +2663,13 @@ find_candidate:
     - Brandy
     - J
     :family_name: Ryan
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19591210'
     :ssn: '796014042'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
+      city: 
+      state: 
       postal_code: '96306'
       country: USA
       street: PSC 477 BOX 32
@@ -2661,7 +2684,7 @@ find_candidate:
     - Carole
     - N
     :family_name: Ryan
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19911123'
     :ssn: '796089399'
@@ -2671,7 +2694,7 @@ find_candidate:
       postal_code: '20189'
       country: USA
       street: 33 RESTON PLAZA
-    :home_phone:
+    :home_phone: 
     :icn: 1012845682V030899
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2703,12 +2726,12 @@ find_candidate:
     - Sergio
     - H h
     :family_name: Ryan
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19581228'
     :ssn: '796059628'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845684V316636
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2723,8 +2746,8 @@ find_candidate:
     :gender: M
     :birth_date: '19331228'
     :ssn: '796013160'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012830334V156386
     :mhv_ids: []
     :vha_facility_ids:
@@ -2738,7 +2761,7 @@ find_candidate:
     - Ruth
     - Vereen
     :family_name: Spencer
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19630629'
     :ssn: '796030711'
@@ -2759,7 +2782,7 @@ find_candidate:
     - Edith
     - Jill
     :family_name: Sanders
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19830629'
     :ssn: '796064374'
@@ -2780,16 +2803,16 @@ find_candidate:
     - Jeanne
     - E
     :family_name: Schmidt
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19510206'
     :ssn: '796164120'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
+      street: 
     :home_phone: "(301)301-3013"
     :icn: 1012829325V632209
     :mhv_ids: []
@@ -2798,14 +2821,16 @@ find_candidate:
     :edipi: '1011239230'
     :participant_id: '600052702'
   '796128746':
-    :given_names: []
-    :family_name:
-    :suffix:
+    :given_names:
+    - Jim
+    - W
+    :family_name: Scott
+    :suffix: 
     :gender: M
     :birth_date: '19590704'
     :ssn: '796128746'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012989581V442151
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2816,7 +2841,7 @@ find_candidate:
     - Penny
     - M
     :family_name: Scott
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19611222'
     :ssn: '796128750'
@@ -2826,7 +2851,7 @@ find_candidate:
       postal_code: '21211'
       country: USA
       street: 2002 CLIPPER PARK RD STE 108
-    :home_phone:
+    :home_phone: 
     :icn: 1012832046V870152
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2837,12 +2862,12 @@ find_candidate:
     - Ray
     - A
     :family_name: Scott
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19780419'
     :ssn: '796128748'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012826667V821812
     :mhv_ids: []
     :vha_facility_ids:
@@ -2853,12 +2878,12 @@ find_candidate:
     :given_names:
     - Kurt
     :family_name: Shawl
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19471012'
     :ssn: '796053371'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012833364V370552
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2869,7 +2894,7 @@ find_candidate:
     - Anne
     - R
     :family_name: Shelton
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19910106'
     :ssn: '796045393'
@@ -2890,17 +2915,17 @@ find_candidate:
     - Freddie
     - Daniel
     :family_name: Shelton
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19701103'
     :ssn: '796030111'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012833405V013211
     :mhv_ids: []
     :vha_facility_ids:
@@ -2912,17 +2937,17 @@ find_candidate:
     - Jacqueline
     - K
     :family_name: Shelton
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19920611'
     :ssn: '796075523'
     :address: !ruby/object:MVI::Models::MviProfileAddress
       city: SYDNEY
-      state:
-      postal_code:
+      state: 
+      postal_code: 
       country: USA
       street: UNIT.A
-    :home_phone:
+    :home_phone: 
     :icn: 1012833436V858693
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2933,7 +2958,7 @@ find_candidate:
     - Lois
     - A
     :family_name: Shelton
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '20010312'
     :ssn: '796041595'
@@ -2953,24 +2978,24 @@ find_candidate:
     :given_names:
     - Greg
     :family_name: Simmons
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19721014'
     :ssn: '796170170'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845059V795233
     :mhv_ids: []
     :vha_facility_ids:
     - '987'
     :edipi: '1014019258'
-    :participant_id:
+    :participant_id: 
   '796107177':
     :given_names:
     - Tom
     - J
     :family_name: Simmons
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19920916'
     :ssn: '796107177'
@@ -2980,7 +3005,7 @@ find_candidate:
       postal_code: '22031'
       country: USA
       street: 456 FUNCTION JUNCTIO
-    :home_phone:
+    :home_phone: 
     :icn: 1012833450V634386
     :mhv_ids: []
     :vha_facility_ids: []
@@ -2991,7 +3016,7 @@ find_candidate:
     - Alfred
     - James
     :family_name: Sims
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19871217'
     :ssn: '796007904'
@@ -3006,34 +3031,34 @@ find_candidate:
     :mhv_ids: []
     :vha_facility_ids: []
     :edipi: '1100470060'
-    :participant_id:
+    :participant_id: 
   '796043139':
     :given_names:
     - Marshall
     - John
     :family_name: Snyder
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19650727'
     :ssn: '796043139'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012829801V599113
     :mhv_ids: []
     :vha_facility_ids: []
     :edipi: '1099738673'
-    :participant_id:
+    :participant_id: 
   '796053469':
     :given_names:
     - Ross
     - E
     :family_name: Sotos
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19730827'
     :ssn: '796053469'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012833452V919063
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3044,7 +3069,7 @@ find_candidate:
     - Timothy
     - Hoo
     :family_name: Soto
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19460715'
     :ssn: '796038168'
@@ -3054,44 +3079,23 @@ find_candidate:
       postal_code: '29401'
       country: USA
       street: 123 Main Street
-    :home_phone:
+    :home_phone: 
     :icn: 1012833438V267437
     :mhv_ids: []
     :vha_facility_ids: []
     :edipi: '1323360622'
     :participant_id: '600076490'
-  '796083573':
-    :given_names:
-    - Dale
-    - P
-    :family_name: Soto
-    :suffix: Jr
-    :gender: M
-    :birth_date: '19320408'
-    :ssn: '796083573'
-    :address: !ruby/object:MVI::Models::MviProfileAddress
-      city: HYDERABAD
-      state:
-      postal_code:
-      country: IND
-      street: 1243 ADAMS DR
-    :home_phone:
-    :icn: 1012833451V763238
-    :mhv_ids: []
-    :vha_facility_ids: []
-    :edipi: '1010397690'
-    :participant_id: '600076495'
   '796153369':
     :given_names:
     - Dwayne
     - E
     :family_name: Spencer
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19580224'
     :ssn: '796153369'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012643250V489886
     :mhv_ids:
     - '9981379'
@@ -3115,17 +3119,17 @@ find_candidate:
     - Luke
     - J
     :family_name: Stephens
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19390820'
     :ssn: '796127242'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: BEL
       street: INTERNATIANL ADD
-    :home_phone:
+    :home_phone: 
     :icn: 1012666881V023688
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3135,7 +3139,7 @@ find_candidate:
     :given_names:
     - Herman
     :family_name: Stevens
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19461215'
     :ssn: '796049726'
@@ -3156,7 +3160,7 @@ find_candidate:
     - Derrick
     - A
     :family_name: Stewart
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19671030'
     :ssn: '796068291'
@@ -3166,7 +3170,7 @@ find_candidate:
       postal_code: '22031'
       country: USA
       street: 123 JUMP STREET
-    :home_phone:
+    :home_phone: 
     :icn: 1012592999V810903
     :mhv_ids: []
     :vha_facility_ids:
@@ -3179,12 +3183,12 @@ find_candidate:
     - Jerome
     - Allen
     :family_name: Stewart
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19790701'
     :ssn: '796098273'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845699V670513
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3195,12 +3199,12 @@ find_candidate:
     - Victor
     - Reed
     :family_name: Stewart
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19820902'
     :ssn: '796098268'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845700V116007
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3211,17 +3215,17 @@ find_candidate:
     - John
     - S
     :family_name: Robertson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19381007'
     :ssn: '796127187'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012847418V490298
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3232,12 +3236,12 @@ find_candidate:
     - Vernon
     - D
     :family_name: Wagner
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19650715'
     :ssn: '796140369'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012845702V443941
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3248,11 +3252,11 @@ find_candidate:
     - Tyrone
     - N
     :family_name: Wallace
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19741003'
     :ssn: '796122376'
-    :address:
+    :address: 
     :home_phone: 5555004134 p1
     :icn: 1012845154V366661
     :mhv_ids: []
@@ -3264,17 +3268,17 @@ find_candidate:
     - Cory
     - Joseph
     :family_name: Washington
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19490906'
     :ssn: '796122330'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012830861V355582
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3285,7 +3289,7 @@ find_candidate:
     - Darryl
     - A
     :family_name: Washington
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19680427'
     :ssn: '796199052'
@@ -3306,17 +3310,17 @@ find_candidate:
     - Rhonda
     - A
     :family_name: Washington
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19661105'
     :ssn: '796090317'
     :address: !ruby/object:MVI::Models::MviProfileAddress
-      city:
-      state:
-      postal_code:
+      city: 
+      state: 
+      postal_code: 
       country: USA
-      street:
-    :home_phone:
+      street: 
+    :home_phone: 
     :icn: 1012860875V895695
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3327,14 +3331,14 @@ find_candidate:
     - Jeff
     - Terrell
     :family_name: Watson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19680105'
     :ssn: '796246757'
     :address: !ruby/object:MVI::Models::MviProfileAddress
       city: DHAKA
-      state:
-      postal_code:
+      state: 
+      postal_code: 
       country: BGD
       street: 787 DHAKA AVE
     :home_phone: "(812)343-4346"
@@ -3348,7 +3352,7 @@ find_candidate:
     - Russell
     - Bill
     :family_name: Watson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19610902'
     :ssn: '796079018'
@@ -3358,7 +3362,7 @@ find_candidate:
       postal_code: '80044'
       country: USA
       street: 224 DUKE ST4
-    :home_phone:
+    :home_phone: 
     :icn: 1012658430V604777
     :mhv_ids: []
     :vha_facility_ids:
@@ -3373,7 +3377,7 @@ find_candidate:
     - Johnnie
     - Leonard
     :family_name: Weaver
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19560710'
     :ssn: '796123607'
@@ -3383,12 +3387,14 @@ find_candidate:
       postal_code: '20142'
       country: USA
       street: ROOM 403
-    :home_phone:
+    :home_phone: 
     :icn: 1012740600V714187
-    :mhv_ids: []
+    :mhv_ids:
+    - '14384899'
     :vha_facility_ids:
     - '989'
     - 200ESR
+    - 200MHS
     :edipi: '1005169255'
     :participant_id: '600043180'
   '796123609':
@@ -3396,7 +3402,7 @@ find_candidate:
     - Yvonne
     - L
     :family_name: Weaver
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19910706'
     :ssn: '796123609'
@@ -3444,7 +3450,7 @@ find_candidate:
     - Wallace
     - R
     :family_name: Webb
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19500913'
     :ssn: '796128064'
@@ -3454,7 +3460,7 @@ find_candidate:
       postal_code: '95102'
       country: USA
       street: 983 SHORE ST
-    :home_phone:
+    :home_phone: 
     :icn: 1012845705V991634
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3465,7 +3471,7 @@ find_candidate:
     - Claude
     - R
     :family_name: Wells
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19290104'
     :ssn: '796161553'
@@ -3486,12 +3492,12 @@ find_candidate:
     - Philip
     - Daniel
     :family_name: West
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19800606'
     :ssn: '796080135'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012593002V974767
     :mhv_ids: []
     :vha_facility_ids:
@@ -3503,12 +3509,12 @@ find_candidate:
     - Marc
     - Wade
     :family_name: West
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19871102'
     :ssn: '796052521'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012592973V765426
     :mhv_ids: []
     :vha_facility_ids:
@@ -3524,7 +3530,7 @@ find_candidate:
     - Danny
     - Derrick
     :family_name: Wheeler
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19700707'
     :ssn: '796151611'
@@ -3534,7 +3540,7 @@ find_candidate:
       postal_code: '78727'
       country: USA
       street: 905 BROADWAY AVE
-    :home_phone:
+    :home_phone: 
     :icn: 1012845384V854587
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3555,7 +3561,7 @@ find_candidate:
       postal_code: '33333'
       country: USA
       street: MIL ADDY LINE 2
-    :home_phone:
+    :home_phone: 
     :icn: 1012592963V937803
     :mhv_ids: []
     :vha_facility_ids:
@@ -3572,7 +3578,7 @@ find_candidate:
     :given_names:
     - Ryan
     :family_name: White
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19530824'
     :ssn: '796007416'
@@ -3582,18 +3588,18 @@ find_candidate:
       postal_code: 25003-9120
       country: USA
       street: 4202 COAL RIVER RD
-    :home_phone:
+    :home_phone: 
     :icn: 1012832750V262955
     :mhv_ids: []
     :vha_facility_ids: []
     :edipi: '1242992250'
-    :participant_id:
+    :participant_id: 
   '796090608':
     :given_names:
     - Roberta
     - M
     :family_name: Williamson
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19790713'
     :ssn: '796090608'
@@ -3603,7 +3609,7 @@ find_candidate:
       postal_code: '20151'
       country: USA
       street: 1234 FAIRFAX VA
-    :home_phone:
+    :home_phone: 
     :icn: 1012845709V062275
     :mhv_ids: []
     :vha_facility_ids:
@@ -3615,7 +3621,7 @@ find_candidate:
     - Sarah
     - Jean
     :family_name: Williamson
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19590513'
     :ssn: '796023436'
@@ -3636,7 +3642,7 @@ find_candidate:
     - Nicholas
     - Edward
     :family_name: Willis
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19650416'
     :ssn: '796081697'
@@ -3646,7 +3652,7 @@ find_candidate:
       postal_code: '20121'
       country: USA
       street: 212 PENN STREET
-    :home_phone:
+    :home_phone: 
     :icn: 1012845711V863651
     :mhv_ids: []
     :vha_facility_ids:
@@ -3658,7 +3664,7 @@ find_candidate:
     - Thomas
     - Paul
     :family_name: Willis
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19730807'
     :ssn: '796105732'
@@ -3679,17 +3685,17 @@ find_candidate:
     - Clifford
     - Gerard
     :family_name: Wilson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19690729'
     :ssn: '796113361'
     :address: !ruby/object:MVI::Models::MviProfileAddress
       city: FAIRFAX
       state: VA
-      postal_code:
+      postal_code: 
       country: USA
       street: 43000 FAIRLAKES
-    :home_phone:
+    :home_phone: 
     :icn: 1012845109V755759
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3700,7 +3706,7 @@ find_candidate:
     - Jeffrey
     - N
     :family_name: Wilson
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19310818'
     :ssn: '796131482'
@@ -3710,7 +3716,7 @@ find_candidate:
       postal_code: '22011'
       country: USA
       street: 1025 BRYCE DR
-    :home_phone:
+    :home_phone: 
     :icn: 1012844755V103857
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3721,7 +3727,7 @@ find_candidate:
     - Mario
     - E
     :family_name: Wright
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19540108'
     :ssn: '796123102'
@@ -3731,7 +3737,7 @@ find_candidate:
       postal_code: '22311'
       country: USA
       street: 5021 SEMINARY RD
-    :home_phone:
+    :home_phone: 
     :icn: 1012830556V118669
     :mhv_ids: []
     :vha_facility_ids:
@@ -3743,7 +3749,7 @@ find_candidate:
     - Nancy
     - Joanna-joan
     :family_name: Wright
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19560725'
     :ssn: '796123104'
@@ -3753,7 +3759,7 @@ find_candidate:
       postal_code: '22302'
       country: USA
       street: 3001 PARK CENTER DR
-    :home_phone:
+    :home_phone: 
     :icn: 1012830873V293499
     :mhv_ids: []
     :vha_facility_ids:
@@ -3768,8 +3774,8 @@ find_candidate:
     :gender: M
     :birth_date: '19650713'
     :ssn: '796192795'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012851504V621829
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3779,12 +3785,12 @@ find_candidate:
     :given_names:
     - Alana
     :family_name: Gprsresysfive
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19800602'
     :ssn: '666717635'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012872729V336966
     :mhv_ids:
     - '13492196'
@@ -3797,12 +3803,12 @@ find_candidate:
     :given_names:
     - Jerry
     :family_name: Gpktestnine
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19690407'
     :ssn: '666271152'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012827134V054550
     :mhv_ids:
     - '10894456'
@@ -3811,17 +3817,17 @@ find_candidate:
     - '979'
     - '989'
     :edipi: '1320002060'
-    :participant_id:
+    :participant_id: 
   '666360333':
     :given_names:
     - Jhun
     :family_name: Gpksysninetest
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19790605'
     :ssn: '666360333'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012870264V741864
     :mhv_ids:
     - '13408508'
@@ -3830,17 +3836,17 @@ find_candidate:
     - 200MHS
     - '989'
     :edipi: '1320002070'
-    :participant_id:
+    :participant_id: 
   '666512797':
     :given_names:
     - Sean
     :family_name: Gptestkfive
-    :suffix:
+    :suffix: 
     :gender: M
     :birth_date: '19720321'
     :ssn: '666512797'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012852978V019884
     :mhv_ids:
     - '12210827'
@@ -3854,12 +3860,12 @@ find_candidate:
     - Loretta
     - E
     :family_name: Brooks
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19640605'
     :ssn: '796184647'
-    :address:
-    :home_phone:
+    :address: 
+    :home_phone: 
     :icn: 1012830985V402307
     :mhv_ids: []
     :vha_facility_ids: []
@@ -3868,74 +3874,91 @@ find_candidate:
   '796164121':
     :given_names:
     - Vicki
-    -
+    - A
     :family_name: Schmidt
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19231224'
     :ssn: '796164121'
-    :address:
-    :home_phone:
-    :icn: '45542461134121204'
-    :mhv_ids:
-    - 96651708
+    :address: !ruby/object:MVI::Models::MviProfileAddress
+      city: Charleston
+      state: SC
+      postal_code: '29401'
+      country: USA
+      street: Shrek''s Swamp
+    :home_phone: 
+    :icn: 1012667151V535875
+    :mhv_ids: []
     :vha_facility_ids: []
-    :edipi: '8827662219'
-    :participant_id: '32417402'
+    :edipi: '1011239249'
+    :participant_id: '600052703'
   '796086306':
     :given_names:
     - Kathy
-    -
+    - Marie
     :family_name: Rogers
-    :suffix:
+    :suffix: 
     :gender: F
     :birth_date: '19860726'
     :ssn: '796086306'
-    :address:
-    :home_phone:
-    :icn: '60193550167970153'
-    :mhv_ids:
-    - 19947224
+    :address: !ruby/object:MVI::Models::MviProfileAddress
+      city: CUBA
+      state: MO
+      postal_code: 65453-1967
+      country: USA
+      street: 614 LOCUST ST
+    :home_phone: 5555328606 p1
+    :icn: 1012852803V626906
+    :mhv_ids: []
     :vha_facility_ids: []
-    :edipi: '7011062709'
-    :participant_id: '483061501'
+    :edipi: '1286162882'
+    :participant_id: '600094664'
   '796330157':
     :given_names:
     - Arthur
-    - Lee
+    - L
     :family_name: Thomas
-    :suffix:
-    :gender: M
+    :suffix: 
+    :gender: 
     :birth_date: '19570222'
     :ssn: '796330157'
-    :address:
-    :home_phone:
-    :icn: '55507491301261273'
-    :mhv_ids:
-    - 31472933
+    :address: !ruby/object:MVI::Models::MviProfileAddress
+      city: NEWINGTON
+      state: CT
+      postal_code: 06111-5413
+      country: USA
+      street: 11 KELSEY ST
+    :home_phone: 5555262765 p1
+    :icn: 1012885806V294033
+    :mhv_ids: []
     :vha_facility_ids: []
-    :edipi: '21836475'
-    :participant_id: '741716939'
+    :edipi: '1242991873'
+    :participant_id: 
   '796056674':
     :given_names:
     - Dianne
     - B
     :family_name: Scott
-    :suffix:
-    :gender: M
+    :suffix: 
+    :gender: F
     :birth_date: '19690406'
     :ssn: '796056674'
-    :address:
-    :home_phone:
-    :icn: '33991311612229264'
+    :address: 
+    :home_phone: 
+    :icn: 1012592966V272192
     :mhv_ids: []
-    :vha_facility_ids: []
-    :edipi: '5343578988'
-    :participant_id: '204225751'
+    :vha_facility_ids:
+    - '984'
+    - 200ESR
+    - '983'
+    - '668'
+    - '556'
+    :edipi: '1015218343'
+    :participant_id: '13397095'
   '796066621':
     :given_names:
-    - Gary
-    - Z
+      - Gary
+      - Z
     :family_name: Todd
     :suffix:
     :gender: M
@@ -3948,10 +3971,10 @@ find_candidate:
     :vha_facility_ids: []
     :edipi: '5343578988'
     :participant_id: '204225751'
-'301010301':
+  '301010301':
     :given_names:
-    - Jean
-    - Z
+      - Jean
+      - Z
     :family_name: Picard
     :suffix:
     :gender: M
@@ -3964,10 +3987,10 @@ find_candidate:
     :vha_facility_ids: []
     :edipi: '5343578988'
     :participant_id: '204225751'
-'796066620':
+  '796066620':
     :given_names:
-    - Srikanth
-    - Z
+      - Srikanth
+      - Z
     :family_name: Vanapalli
     :suffix:
     :gender: M
@@ -3980,3 +4003,255 @@ find_candidate:
     :vha_facility_ids: []
     :edipi: '5343578988'
     :participant_id: '204225751'
+  '666859632':
+    :given_names:
+    - Jimmy
+    :family_name: Mhvpatone
+    :suffix: 
+    :gender: M
+    :birth_date: '19690212'
+    :ssn: '666859632'
+    :address: 
+    :home_phone: 
+    :icn: 1012996209V794155
+    :mhv_ids: []
+    :vha_facility_ids:
+    - '989'
+    :edipi: 
+    :participant_id: 
+  '666741478':
+    :given_names:
+    - Burt
+    :family_name: Mhvpattwo
+    :suffix: 
+    :gender: M
+    :birth_date: '19620312'
+    :ssn: '666741478'
+    :address: 
+    :home_phone: 
+    :icn: 1012996210V640082
+    :mhv_ids: []
+    :vha_facility_ids:
+    - '989'
+    :edipi: 
+    :participant_id: 
+  '666451254':
+    :given_names:
+    - Sabrina
+    :family_name: Mhvpatthree
+    :suffix: 
+    :gender: F
+    :birth_date: '19820425'
+    :ssn: '666451254'
+    :address: 
+    :home_phone: 
+    :icn: 1012996213V894859
+    :mhv_ids: []
+    :vha_facility_ids:
+    - '989'
+    :edipi: 
+    :participant_id: 
+  '666986547':
+    :given_names:
+    - Virginia
+    :family_name: Mhvpatfour
+    :suffix: 
+    :gender: F
+    :birth_date: '19600928'
+    :ssn: '666986547'
+    :address: 
+    :home_phone: 
+    :icn: 1012996215V259676
+    :mhv_ids: []
+    :vha_facility_ids:
+    - '989'
+    :edipi: 
+    :participant_id: 
+  '666216523':
+    :given_names:
+    - Hope
+    :family_name: Mhvpatfive
+    :suffix: 
+    :gender: F
+    :birth_date: '19740701'
+    :ssn: '666216523'
+    :address: 
+    :home_phone: 
+    :icn: 1012996216V038108
+    :mhv_ids: []
+    :vha_facility_ids:
+    - '989'
+    :edipi: 
+    :participant_id: 
+  '666951239':
+    :given_names:
+    - Barney
+    :family_name: Mhvpatsix
+    :suffix: 
+    :gender: M
+    :birth_date: '19600526'
+    :ssn: '666951239'
+    :address: 
+    :home_phone: 
+    :icn: 1012996217V161423
+    :mhv_ids: []
+    :vha_facility_ids:
+    - '989'
+    :edipi: 
+    :participant_id: 
+  '666986541':
+    :given_names:
+    - Cloris
+    :family_name: Mhvpatten
+    :suffix: 
+    :gender: F
+    :birth_date: '19490315'
+    :ssn: '666986541'
+    :address: 
+    :home_phone: 
+    :icn: 1012996222V703195
+    :mhv_ids:
+    - '14391252'
+    :vha_facility_ids:
+    - '989'
+    - 200MHS
+    :edipi: 
+    :participant_id: 
+  '666977412':
+    :given_names:
+    - Morgan
+    :family_name: Mhvpattwenty
+    :suffix: 
+    :gender: M
+    :birth_date: '19600511'
+    :ssn: '666977412'
+    :address: 
+    :home_phone: 
+    :icn: 1012996345V469794
+    :mhv_ids:
+    - '14391340'
+    :vha_facility_ids:
+    - 200MHS
+    - '989'
+    :edipi: 
+    :participant_id: 
+  '666337777':
+    :given_names:
+    - Douglass
+    :family_name: Mhvpattwelve
+    :suffix: 
+    :gender: M
+    :birth_date: '19660516'
+    :ssn: '666337777'
+    :address: 
+    :home_phone: 
+    :icn: 1012996226V257050
+    :mhv_ids:
+    - '14391187'
+    :vha_facility_ids:
+    - '989'
+    - 200MHS
+    :edipi: 
+    :participant_id: 
+  '666451921':
+    :given_names:
+    - Mary
+    :family_name: Mhvpatthirteen
+    :suffix: 
+    :gender: F
+    :birth_date: '19910325'
+    :ssn: '666451921'
+    :address: 
+    :home_phone: 
+    :icn: 1012996234V981295
+    :mhv_ids:
+    - '14391216'
+    :vha_facility_ids:
+    - '989'
+    - 200MHS
+    :edipi: 
+    :participant_id: 
+  '666202525':
+    :given_names:
+    - Robert
+    :family_name: Mhvpatfourteen
+    :suffix: 
+    :gender: M
+    :birth_date: '19680816'
+    :ssn: '666202525'
+    :address: 
+    :home_phone: 
+    :icn: 1012996236V525532
+    :mhv_ids:
+    - '14391236'
+    :vha_facility_ids:
+    - '989'
+    - 200MHS
+    :edipi: 
+    :participant_id: 
+  '666087411':
+    :given_names:
+    - Sarah
+    :family_name: Mhvpatfifteen
+    :suffix: 
+    :gender: F
+    :birth_date: '19620208'
+    :ssn: '666087411'
+    :address: 
+    :home_phone: 
+    :icn: 1012996237V250961
+    :mhv_ids:
+    - '14391271'
+    :vha_facility_ids:
+    - '989'
+    - 200MHS
+    :edipi: 
+    :participant_id: 
+  '666873096':
+    :given_names:
+    - Testone
+    :family_name: Vetsez
+    :suffix: 
+    :gender: M
+    :birth_date: '19450923'
+    :ssn: '666873096'
+    :address: 
+    :home_phone: 
+    :icn: 1012996225V521261
+    :mhv_ids: []
+    :vha_facility_ids:
+    - '989'
+    :edipi: 
+    :participant_id: 
+  '666410941':
+    :given_names:
+    - Testtwo
+    :family_name: Vetsez
+    :suffix: 
+    :gender: M
+    :birth_date: '19500312'
+    :ssn: '666410941'
+    :address: 
+    :home_phone: 
+    :icn: 1012996227V035519
+    :mhv_ids: []
+    :vha_facility_ids:
+    - '989'
+    :edipi: 
+    :participant_id: 
+  '666994501':
+    :given_names:
+    - Testthree
+    :family_name: Vetsez
+    :suffix: 
+    :gender: F
+    :birth_date: '19551123'
+    :ssn: '666994501'
+    :address: 
+    :home_phone: 
+    :icn: 1012996228V160974
+    :mhv_ids: []
+    :vha_facility_ids:
+    - '989'
+    :edipi: 
+    :participant_id: 


### PR DESCRIPTION
Adds 15 MHV test accounts to mock MVI database. Also added to CSV in vets.gov-team. 

Preserves the 3 EVSS users that are not present in MVI s1a that were added by @omgitsbillryan 