### PR TITLE
Fix naming in a migration

### DIFF
--- a/db/migrate/20170621122611_saved_claims.rb
+++ b/db/migrate/20170621122611_saved_claims.rb
@@ -1,11 +1,11 @@
-class PensionClaim < ActiveRecord::Migration
+class SavedClaims < ActiveRecord::Migration
   def change
-     create_table(:saved_claims) do |t|
-    t.timestamps
-    t.string :encrypted_form, null: false
-    t.string :encrypted_form_iv, null: false
-    t.string :form_type
-    t.uuid :guid, null: false
-  end
+    create_table(:saved_claims) do |t|
+      t.timestamps
+      t.string :encrypted_form, null: false
+      t.string :encrypted_form_iv, null: false
+      t.string :form_type
+      t.uuid :guid, null: false
+    end
   end
 end


### PR DESCRIPTION
Renamed the table and filename, then used `db:setup` instead of `db:migrate` to run tests locally, so this wasn't caught.