### PR TITLE
MHV Correlation ID persistance for testing on dev

### DIFF
--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -122,7 +122,9 @@ class MhvAccount < ActiveRecord::Base
     if may_register?
       client_response = mhv_ac_client.post_register(params_for_registration)
       if client_response[:api_completion_status] == 'Successful'
-        user.va_profile.mhv_ids = [client_response[:correlation_id].to_s]
+        # TODO: Temporarily persist MHVCorrelationID on MHVAccount for convenience and debugging.
+        self.mhv_correlation_id = client_response[:correlation_id].to_s
+        user.va_profile.mhv_ids = [mhv_correlation_id]
         user.instance_variable_get(:@mvi).save
         self.registered_at = Time.current
         register!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,9 +93,14 @@ class User < Common::RedisStore
 
   delegate :edipi, to: :mvi
   delegate :icn, to: :mvi
-  delegate :mhv_correlation_id, to: :mvi
+  # delegate :mhv_correlation_id, to: :mvi
   delegate :participant_id, to: :mvi
   delegate :veteran?, to: :veteran_status
+
+  # TODO: change this back to the delegate from mvi after testing is complete
+  def mhv_correlation_id
+    mvi.mhv_correlation_id || mhv_account&.mhv_correlation_id
+  end
 
   def va_profile
     mvi.profile

--- a/db/migrate/20170621191157_add_correlation_id_to_mhv_accounts.rb
+++ b/db/migrate/20170621191157_add_correlation_id_to_mhv_accounts.rb
@@ -1,0 +1,5 @@
+class AddCorrelationIdToMhvAccounts < ActiveRecord::Migration
+  def change
+    add_column :mhv_accounts, :mhv_correlation_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170607043549) do
+ActiveRecord::Schema.define(version: 20170621191157) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,12 +84,13 @@ ActiveRecord::Schema.define(version: 20170607043549) do
   add_index "in_progress_forms", ["user_uuid"], name: "index_in_progress_forms_on_user_uuid", using: :btree
 
   create_table "mhv_accounts", force: :cascade do |t|
-    t.string   "user_uuid",     null: false
-    t.string   "account_state", null: false
+    t.string   "user_uuid",          null: false
+    t.string   "account_state",      null: false
     t.datetime "registered_at"
     t.datetime "upgraded_at"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.string   "mhv_correlation_id"
   end
 
   add_index "mhv_accounts", ["user_uuid"], name: "index_mhv_accounts_on_user_uuid", using: :btree


### PR DESCRIPTION
This PR is for consideration only. I'll list some of the advantages:

1. Persisting the mhv_correlation_id returned by MHV when we /register allows us to use this value when the mock service on dev cannot be automatically updated. On user.rb we can redefine `mhv_correlation_id` to first attempt fetching from mvi, but if it is `nil`, to reference `mhv_account`.

2. We probably don't want to use this in two different places, so the changes in user.rb would later be reverted back. But it could still prove valuable to have this MHV Correlation ID. Suppose for example that MHV creates the account, returns us a correlation ID, but for whatever reason was unable to update MVI on their end. Once the user session expires they would be in a strange / indeterminate state. But if we have this value it could possibly aid in debugging.

I'm not married to idea of having this persisted, but I think it could at the very least be helpful in testing on dev because of the mock mvi.