### PR TITLE
Fix cache update of MVI profile response with MHV ID

### DIFF
--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -128,8 +128,7 @@ class MhvAccount < ActiveRecord::Base
       if client_response[:api_completion_status] == 'Successful'
         StatsD.increment("#{STATSD_ACCOUNT_CREATION_KEY}.success")
         user.va_profile.mhv_ids = [client_response[:correlation_id].to_s]
-        mvi_response = user.instance_variable_get(:@mvi).instance_variable_get(:@mvi_response)
-        user.instance_variable_get(:@mvi).cache(user.uuid, mvi_response)
+        user.recache
         self.registered_at = Time.current
         register!
       end

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -128,7 +128,8 @@ class MhvAccount < ActiveRecord::Base
       if client_response[:api_completion_status] == 'Successful'
         StatsD.increment("#{STATSD_ACCOUNT_CREATION_KEY}.success")
         user.va_profile.mhv_ids = [client_response[:correlation_id].to_s]
-        user.instance_variable_get(:@mvi).save
+        mvi_response = user.instance_variable_get(:@mvi).instance_variable_get(:@mvi_response)
+        user.instance_variable_get(:@mvi).cache(user.uuid, mvi_response)
         self.registered_at = Time.current
         register!
       end

--- a/app/models/mvi.rb
+++ b/app/models/mvi.rb
@@ -79,11 +79,11 @@ class Mvi < Common::RedisStore
     mvi_response&.profile
   end
 
-  private
-
   def mvi_response
     @mvi_response ||= response_from_redis_or_service
   end
+
+  private
 
   def response_from_redis_or_service
     do_cached_with(key: @user.uuid) do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,6 +113,12 @@ class User < Common::RedisStore
     InProgressForm.where(user_uuid: uuid)
   end
 
+  # Re-caches the MVI response. Use in response to any local changes that
+  # have been made.
+  def recache
+    mvi.cache(uuid, mvi.mvi_response)
+  end
+
   private
 
   def mvi


### PR DESCRIPTION
Pretty gross, but necessary to update the MHV ID in redis.

`User.@mvi` is not cached directly as-is so calling `save` on it does not work. Instead you have to invoke the `cache` method of the `CacheAside` concern and provide the uuid and the response. 

I'm sure this can be refactored somehow to provide a real interface for updating, but for now this unblocks testing. 