### PR TITLE
Gracefully handle timeout exceptions

### DIFF
--- a/lib/evss/gi_bill_status/service.rb
+++ b/lib/evss/gi_bill_status/service.rb
@@ -12,6 +12,9 @@ module EVSS
       rescue Faraday::ParsingError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL })
         EVSS::GiBillStatus::GiBillStatusResponse.new(403)
+      rescue Faraday::TimeoutError => e
+        log_message_to_sentry('Timeout while connecting to GIBS service', :error, extra_context: { url: BASE_URL })
+        EVSS::GiBillStatus::GiBillStatusResponse.new(403)
       rescue Faraday::ClientError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL, body: e.response[:body] })
         EVSS::GiBillStatus::GiBillStatusResponse.new(e.response[:status])

--- a/lib/evss/gi_bill_status/service.rb
+++ b/lib/evss/gi_bill_status/service.rb
@@ -13,7 +13,7 @@ module EVSS
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL })
         EVSS::GiBillStatus::GiBillStatusResponse.new(403)
       rescue Faraday::TimeoutError
-        log_message_to_sentry('Timeout while connecting to GIBS service', :error, extra_context: { url: BASE_URL })
+        log_message_to_sentry('Timeout while connecting to GiBillStatus service', :error, extra_context: { url: BASE_URL })
         EVSS::GiBillStatus::GiBillStatusResponse.new(403)
       rescue Faraday::ClientError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL, body: e.response[:body] })

--- a/lib/evss/gi_bill_status/service.rb
+++ b/lib/evss/gi_bill_status/service.rb
@@ -12,7 +12,7 @@ module EVSS
       rescue Faraday::ParsingError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL })
         EVSS::GiBillStatus::GiBillStatusResponse.new(403)
-      rescue Faraday::TimeoutError => e
+      rescue Faraday::TimeoutError
         log_message_to_sentry('Timeout while connecting to GIBS service', :error, extra_context: { url: BASE_URL })
         EVSS::GiBillStatus::GiBillStatusResponse.new(403)
       rescue Faraday::ClientError => e

--- a/lib/evss/gi_bill_status/service.rb
+++ b/lib/evss/gi_bill_status/service.rb
@@ -13,7 +13,9 @@ module EVSS
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL })
         EVSS::GiBillStatus::GiBillStatusResponse.new(403)
       rescue Faraday::TimeoutError
-        log_message_to_sentry('Timeout while connecting to GiBillStatus service', :error, extra_context: { url: BASE_URL })
+        log_message_to_sentry(
+          'Timeout while connecting to GiBillStatus service', :error, extra_context: { url: BASE_URL }
+        )
         EVSS::GiBillStatus::GiBillStatusResponse.new(403)
       rescue Faraday::ClientError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL, body: e.response[:body] })

--- a/lib/evss/letters/service.rb
+++ b/lib/evss/letters/service.rb
@@ -17,6 +17,9 @@ module EVSS
       rescue Faraday::ParsingError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL })
         EVSS::Letters::LettersResponse.new(403)
+      rescue Faraday::TimeoutError => e
+        log_message_to_sentry('Timeout while connecting to Letters service', :error, extra_context: { url: BASE_URL })
+        EVSS::GiBillStatus::GiBillStatusResponse.new(403)
       rescue Faraday::ClientError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL, body: e.response[:body] })
         EVSS::Letters::LettersResponse.new(e.response[:status])
@@ -28,6 +31,9 @@ module EVSS
       rescue Faraday::ParsingError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL })
         EVSS::Letters::BeneficiaryResponse.new(403)
+      rescue Faraday::TimeoutError => e
+        log_message_to_sentry('Timeout while connecting to Letters service', :error, extra_context: { url: BASE_URL })
+        EVSS::GiBillStatus::GiBillStatusResponse.new(403)
       rescue Faraday::ClientError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL, body: e.response[:body] })
         EVSS::Letters::BeneficiaryResponse.new(e.response[:status])

--- a/lib/evss/letters/service.rb
+++ b/lib/evss/letters/service.rb
@@ -17,7 +17,7 @@ module EVSS
       rescue Faraday::ParsingError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL })
         EVSS::Letters::LettersResponse.new(403)
-      rescue Faraday::TimeoutError => e
+      rescue Faraday::TimeoutError
         log_message_to_sentry('Timeout while connecting to Letters service', :error, extra_context: { url: BASE_URL })
         EVSS::GiBillStatus::GiBillStatusResponse.new(403)
       rescue Faraday::ClientError => e
@@ -31,7 +31,7 @@ module EVSS
       rescue Faraday::ParsingError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: BASE_URL })
         EVSS::Letters::BeneficiaryResponse.new(403)
-      rescue Faraday::TimeoutError => e
+      rescue Faraday::TimeoutError
         log_message_to_sentry('Timeout while connecting to Letters service', :error, extra_context: { url: BASE_URL })
         EVSS::GiBillStatus::GiBillStatusResponse.new(403)
       rescue Faraday::ClientError => e

--- a/spec/lib/evss/gi_bill_status/service_spec.rb
+++ b/spec/lib/evss/gi_bill_status/service_spec.rb
@@ -62,6 +62,21 @@ describe EVSS::GiBillStatus::Service do
           end
         end
       end
+
+      context 'with an http timeout' do
+        before do
+          allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::TimeoutError)
+        end
+
+        it 'should log an error' do
+          expect(Rails.logger).to receive(:error).with(/Timeout/)
+          subject.get_gi_bill_status
+        end
+
+        it 'should not raise an exception' do
+          expect { subject.get_gi_bill_status }.to_not raise_error
+        end
+      end
     end
   end
 end

--- a/spec/lib/evss/letters/service_spec.rb
+++ b/spec/lib/evss/letters/service_spec.rb
@@ -20,6 +20,20 @@ describe EVSS::Letters::Service do
           end
         end
       end
+      context 'with an http timeout' do
+        before do
+          allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::TimeoutError)
+        end
+
+        it 'should log an error' do
+          expect(Rails.logger).to receive(:error).with(/Timeout/)
+          subject.get_letters
+        end
+
+        it 'should not raise an exception' do
+          expect { subject.get_letters }.to_not raise_error
+        end
+      end
     end
 
     describe '#get_letter_beneficiary' do
@@ -29,6 +43,20 @@ describe EVSS::Letters::Service do
           expect(response).to be_ok
           expect(response).to be_a(EVSS::Letters::BeneficiaryResponse)
           expect(response.military_service.count).to eq(2)
+        end
+      end
+      context 'with an http timeout' do
+        before do
+          allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::TimeoutError)
+        end
+
+        it 'should log an error' do
+          expect(Rails.logger).to receive(:error).with(/Timeout/)
+          subject.get_letter_beneficiary
+        end
+
+        it 'should not raise an exception' do
+          expect { subject.get_letter_beneficiary }.to_not raise_error
         end
       end
     end


### PR DESCRIPTION
`Faraday::TimeoutError` inherits from `Faraday::ClientError` ([source](http://www.rubydoc.info/gems/faraday/Faraday/TimeoutError)).  As a result, a timeout exception would be rescued by the block:
```ruby
rescue Faraday::ClientError => e
```
which would then immediately raise:
```
undefined method `[]' for nil:NilClass (NoMethodError)
```
because the `#<Faraday::TimeoutError>`, `e`, is just an empty object while we're trying to log to sentry `e.response[:status]`