### PR TITLE
Appeals status beta enablement

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,6 +74,10 @@ class User < Common::RedisStore
     edipi.present? && ssn.present? && participant_id.present?
   end
 
+  def can_access_appeals?
+    loa3? && ssn.present?
+  end
+
   def self.from_merged_attrs(existing_user, new_user)
     # we want to always use the more recent attrs so long as they exist
     attrs = new_user.attributes.map do |key, val|

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -85,6 +85,7 @@ class UserSerializer < ActiveModel::Serializer
     end
     service_list << BackendServices::EVSS_CLAIMS if object.can_access_evss?
     service_list << BackendServices::USER_PROFILE if object.can_access_user_profile?
+    service_list << BackendServices::APPEALS_STATUS if beta_enabled?(object.uuid, 'appeals_status')
     service_list
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -85,7 +85,8 @@ class UserSerializer < ActiveModel::Serializer
     end
     service_list << BackendServices::EVSS_CLAIMS if object.can_access_evss?
     service_list << BackendServices::USER_PROFILE if object.can_access_user_profile?
-    service_list << BackendServices::APPEALS_STATUS if beta_enabled?(object.uuid, 'appeals_status')
+    service_list << BackendServices::APPEALS_STATUS if beta_enabled?(object.uuid, 'appeals_status') &&
+                                                       object.can_access_appeals?
     service_list
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,8 @@ Rails.application.routes.draw do
 
     resource :beta_registrations, path: '/beta_registration/health_account', only: [:show, :create],
                                   defaults: { feature: 'health_account' }
+    resource :beta_registrations, path: '/beta_registration/appeals_status', only: [:show, :create],
+                                  defaults: { feature: 'appeals_status' }
   end
 
   root 'v0/example#index', module: 'v0'

--- a/lib/backend_services.rb
+++ b/lib/backend_services.rb
@@ -4,6 +4,7 @@ class BackendServices
   HCA = 'hca'
   EDUCATION_BENEFITS = 'edu-benefits'
   EVSS_CLAIMS = 'evss-claims'
+  APPEALS_STATUS = 'appeals-status'
   USER_PROFILE = 'user-profile'
 
   # MHV services


### PR DESCRIPTION
Proposal for enabling appeals status beta.

Should consider adding a `can_access_appeals` method to the User class if there are additional conditions for accessing appeals status (i.e. similar to how evss claims requires ssn and edipi). I'm not sure of the business logic there. 

