### PR TITLE
Nest benefit information

### DIFF
--- a/app/serializers/letter_beneficiary_serializer.rb
+++ b/app/serializers/letter_beneficiary_serializer.rb
@@ -2,11 +2,6 @@
 class LetterBeneficiarySerializer < ActiveModel::Serializer
   attribute :benefit_information
   attribute :military_service
-  attribute :has_adapted_housing
-  attribute :has_chapter35_eligibility
-  attribute :has_death_result_of_disability
-  attribute :has_individual_unemployability_granted
-  attribute :has_special_monthly_compensation
 
   def id
     nil

--- a/config/evss/mock_letters_response.yml.example
+++ b/config/evss/mock_letters_response.yml.example
@@ -42,11 +42,11 @@
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -104,11 +104,11 @@
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -166,11 +166,11 @@
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -227,11 +227,12 @@
         has_survivors_pension_award: false
         monthly_award_amount: 123.0
         service_connected_percentage: 2
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        award_effective_date: '1965-01-01T05:00:00.000+0000'
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -289,11 +290,11 @@
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -350,11 +351,12 @@
         has_survivors_pension_award: false
         monthly_award_amount: 123.0
         service_connected_percentage: 2
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        award_effective_date: '1965-01-01T05:00:00.000+0000'        
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -412,11 +414,11 @@
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -474,11 +476,11 @@
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -536,11 +538,11 @@
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -598,11 +600,11 @@
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE

--- a/config/evss/mock_letters_response.yml.example
+++ b/config/evss/mock_letters_response.yml.example
@@ -1,6 +1,6 @@
 ---
 # Mark Webb
-'796066621':
+'796104437':
   :get_letters:
     :body:
       letter_destination:
@@ -35,18 +35,18 @@
   :get_letter_beneficiary:
     :body:
       benefit_information:
-        has_non_service_connected_pension: false
-        has_service_connected_disabilities: true
-        has_survivors_indemnity_compensation_award: false
-        has_survivors_pension_award: false
-        monthly_award_amount: 123.0
-        service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
         has_adapted_housing: false
         has_chapter35_eligibility: true
         has_death_result_of_disability: false
         has_individual_unemployability_granted: false
+        has_non_service_connected_pension: false
+        has_service_connected_disabilities: true
         has_special_monthly_compensation: false
+        has_survivors_indemnity_compensation_award: false
+        has_survivors_pension_award: false
+        monthly_award_amount: 123.0
+        service_connected_percentage: 2
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -97,18 +97,18 @@
   :get_letter_beneficiary:
     :body:
       benefit_information:
-        has_non_service_connected_pension: false
-        has_service_connected_disabilities: true
-        has_survivors_indemnity_compensation_award: false
-        has_survivors_pension_award: false
-        monthly_award_amount: 123.0
-        service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
         has_adapted_housing: false
         has_chapter35_eligibility: true
         has_death_result_of_disability: false
         has_individual_unemployability_granted: false
+        has_non_service_connected_pension: false
+        has_service_connected_disabilities: true
         has_special_monthly_compensation: false
+        has_survivors_indemnity_compensation_award: false
+        has_survivors_pension_award: false
+        monthly_award_amount: 123.0
+        service_connected_percentage: 2
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -159,18 +159,18 @@
   :get_letter_beneficiary:
     :body:
       benefit_information:
-        has_non_service_connected_pension: false
-        has_service_connected_disabilities: true
-        has_survivors_indemnity_compensation_award: false
-        has_survivors_pension_award: false
-        monthly_award_amount: 123.0
-        service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
         has_adapted_housing: false
         has_chapter35_eligibility: true
         has_death_result_of_disability: false
         has_individual_unemployability_granted: false
+        has_non_service_connected_pension: false
+        has_service_connected_disabilities: true
         has_special_monthly_compensation: false
+        has_survivors_indemnity_compensation_award: false
+        has_survivors_pension_award: false
+        monthly_award_amount: 123.0
+        service_connected_percentage: 2
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -221,18 +221,18 @@
   :get_letter_beneficiary:
     :body:
       benefit_information:
-        has_non_service_connected_pension: false
-        has_service_connected_disabilities: true
-        has_survivors_indemnity_compensation_award: false
-        has_survivors_pension_award: false
-        monthly_award_amount: 123.0
-        service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
         has_adapted_housing: false
         has_chapter35_eligibility: true
         has_death_result_of_disability: false
         has_individual_unemployability_granted: false
+        has_non_service_connected_pension: false
+        has_service_connected_disabilities: true
         has_special_monthly_compensation: false
+        has_survivors_indemnity_compensation_award: false
+        has_survivors_pension_award: false
+        monthly_award_amount: 123.0
+        service_connected_percentage: 2
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -283,18 +283,18 @@
   :get_letter_beneficiary:
     :body:
       benefit_information:
-        has_non_service_connected_pension: false
-        has_service_connected_disabilities: true
-        has_survivors_indemnity_compensation_award: false
-        has_survivors_pension_award: false
-        monthly_award_amount: 123.0
-        service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
         has_adapted_housing: false
         has_chapter35_eligibility: true
         has_death_result_of_disability: false
         has_individual_unemployability_granted: false
+        has_non_service_connected_pension: false
+        has_service_connected_disabilities: true
         has_special_monthly_compensation: false
+        has_survivors_indemnity_compensation_award: false
+        has_survivors_pension_award: false
+        monthly_award_amount: 123.0
+        service_connected_percentage: 2
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -345,18 +345,18 @@
   :get_letter_beneficiary:
     :body:
       benefit_information:
-        has_non_service_connected_pension: false
-        has_service_connected_disabilities: true
-        has_survivors_indemnity_compensation_award: false
-        has_survivors_pension_award: false
-        monthly_award_amount: 123.0
-        service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'        
         has_adapted_housing: false
         has_chapter35_eligibility: true
         has_death_result_of_disability: false
         has_individual_unemployability_granted: false
+        has_non_service_connected_pension: false
+        has_service_connected_disabilities: true
         has_special_monthly_compensation: false
+        has_survivors_indemnity_compensation_award: false
+        has_survivors_pension_award: false
+        monthly_award_amount: 123.0
+        service_connected_percentage: 2
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -407,18 +407,18 @@
   :get_letter_beneficiary:
     :body:
       benefit_information:
-        has_non_service_connected_pension: false
-        has_service_connected_disabilities: true
-        has_survivors_indemnity_compensation_award: false
-        has_survivors_pension_award: false
-        monthly_award_amount: 123.0
-        service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
         has_adapted_housing: false
         has_chapter35_eligibility: true
         has_death_result_of_disability: false
         has_individual_unemployability_granted: false
+        has_non_service_connected_pension: false
+        has_service_connected_disabilities: true
         has_special_monthly_compensation: false
+        has_survivors_indemnity_compensation_award: false
+        has_survivors_pension_award: false
+        monthly_award_amount: 123.0
+        service_connected_percentage: 2
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -469,18 +469,18 @@
   :get_letter_beneficiary:
     :body:
       benefit_information:
-        has_non_service_connected_pension: false
-        has_service_connected_disabilities: true
-        has_survivors_indemnity_compensation_award: false
-        has_survivors_pension_award: false
-        monthly_award_amount: 123.0
-        service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
         has_adapted_housing: false
         has_chapter35_eligibility: true
         has_death_result_of_disability: false
         has_individual_unemployability_granted: false
+        has_non_service_connected_pension: false
+        has_service_connected_disabilities: true
         has_special_monthly_compensation: false
+        has_survivors_indemnity_compensation_award: false
+        has_survivors_pension_award: false
+        monthly_award_amount: 123.0
+        service_connected_percentage: 2
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -531,18 +531,18 @@
   :get_letter_beneficiary:
     :body:
       benefit_information:
-        has_non_service_connected_pension: false
-        has_service_connected_disabilities: true
-        has_survivors_indemnity_compensation_award: false
-        has_survivors_pension_award: false
-        monthly_award_amount: 123.0
-        service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
         has_adapted_housing: false
         has_chapter35_eligibility: true
         has_death_result_of_disability: false
         has_individual_unemployability_granted: false
+        has_non_service_connected_pension: false
+        has_service_connected_disabilities: true
         has_special_monthly_compensation: false
+        has_survivors_indemnity_compensation_award: false
+        has_survivors_pension_award: false
+        monthly_award_amount: 123.0
+        service_connected_percentage: 2
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -593,18 +593,18 @@
   :get_letter_beneficiary:
     :body:
       benefit_information:
-        has_non_service_connected_pension: false
-        has_service_connected_disabilities: true
-        has_survivors_indemnity_compensation_award: false
-        has_survivors_pension_award: false
-        monthly_award_amount: 123.0
-        service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
         has_adapted_housing: false
         has_chapter35_eligibility: true
         has_death_result_of_disability: false
         has_individual_unemployability_granted: false
+        has_non_service_connected_pension: false
+        has_service_connected_disabilities: true
         has_special_monthly_compensation: false
+        has_survivors_indemnity_compensation_award: false
+        has_survivors_pension_award: false
+        monthly_award_amount: 123.0
+        service_connected_percentage: 2
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE

--- a/lib/evss/letters/benefit_information.rb
+++ b/lib/evss/letters/benefit_information.rb
@@ -4,13 +4,18 @@ require 'common/models/base'
 module EVSS
   module Letters
     class BenefitInformation < Common::Base
+      attribute :award_effective_date, DateTime
+      attribute :has_adapted_housing, Boolean
+      attribute :has_chapter35_eligibility, Boolean
+      attribute :has_death_result_of_disability, Boolean
+      attribute :has_individual_unemployability_granted, Boolean
       attribute :has_non_service_connected_pension, Boolean
       attribute :has_service_connected_disabilities, Boolean
+      attribute :has_special_monthly_compensation, Boolean
       attribute :has_survivors_indemnity_compensation_award, Boolean
       attribute :has_survivors_pension_award, Boolean
       attribute :monthly_award_amount, Float
       attribute :service_connected_percentage, Integer
-      attribute :award_effective_date, DateTime
     end
   end
 end


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3592

@kreek This nests a bunch of fields under `benefit_information` (an update that Ian M. said he was making to INT today). Since I updated the serializers, I assume tests will fail, but right now we just need to get something to develop against, both locally and in a review instance, so leaving the tests to you if you have time tomorrow.