### PR TITLE
Specific error code for MHV account creation errors

### DIFF
--- a/app/controllers/concerns/mhv_controller_concerns.rb
+++ b/app/controllers/concerns/mhv_controller_concerns.rb
@@ -38,7 +38,7 @@ module MHVControllerConcerns
 
   def raise_something_went_wrong
     # TODO: any additional data could probably be provided in source.
-    raise Common::Exceptions::Forbidden, detail: 'Something went wrong. Please contact support'
+    raise Common::Exceptions::BackendServiceException, 'MHVAC1'
   end
 
   def authenticate_client

--- a/app/controllers/concerns/mhv_controller_concerns.rb
+++ b/app/controllers/concerns/mhv_controller_concerns.rb
@@ -37,7 +37,7 @@ module MHVControllerConcerns
   end
 
   def raise_something_went_wrong
-    # TODO: any additional data could probably be provided in source.
+    # TODO: Change this to something other than a BackendServiceException
     raise Common::Exceptions::BackendServiceException, 'MHVAC1'
   end
 

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -154,7 +154,8 @@ class MhvAccount < ActiveRecord::Base
   rescue => e
     StatsD.increment("#{STATSD_ACCOUNT_CREATION_KEY}.failure")
     fail_register!
-    log_exception_to_sentry(e)
+    extra_context = { icn: user.icn }
+    log_exception_to_sentry(e, extra_context)
     raise e
   end
 
@@ -175,7 +176,8 @@ class MhvAccount < ActiveRecord::Base
     else
       StatsD.increment("#{STATSD_ACCOUNT_UPGRADE_KEY}.failure")
       fail_upgrade!
-      log_exception_to_sentry(e)
+      extra_context = { icn: user.icn, mhv_correlation_id: user.mhv_correlation_id }
+      log_exception_to_sentry(e, extra_context)
       raise e
     end
   end

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -130,3 +130,8 @@ en:
         <<: *validation_errors
         code: 'SM152'
         detail: 'Email address is invalid'
+      MHVAC1:
+        <<: *external_defaults
+        code: 'MHV001'
+        detail: 'Failed to create or upgrade health tools account access'
+        status: 403

--- a/lib/sentry_logging.rb
+++ b/lib/sentry_logging.rb
@@ -10,8 +10,12 @@ module SentryLogging
     end
   end
 
-  def log_exception_to_sentry(exception)
-    Raven.capture_exception(exception.cause.presence || exception) if Settings.sentry.dsn.present?
+  def log_exception_to_sentry(exception, extra_context = {}, tags_context = {})
+    if Settings.sentry.dsn.present?
+      Raven.extra_context(extra_context) if non_nil_hash?(extra_context)
+      Raven.tags_context(tags_context) if non_nil_hash?(tags_context)
+      Raven.capture_exception(exception.cause.presence || exception)
+    end
     Rails.logger.error "#{exception.message}."
     Rails.logger.error exception.backtrace.join("\n") unless exception.backtrace.nil?
   end

--- a/spec/request/prescriptions_request_spec.rb
+++ b/spec/request/prescriptions_request_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'prescriptions', type: :request do
 
       expect(response).to have_http_status(:forbidden)
       expect(JSON.parse(response.body)['errors'].first['detail'])
-        .to eq('Something went wrong. Please contact support')
+        .to eq('Failed to create or upgrade health tools account access')
     end
   end
 


### PR DESCRIPTION
Also adding some extra context to sentry for account creation errors. 

Tagging @omgitsbillryan for addition of context params to log_exception_to_sentry. 