### PR TITLE
handle empty and vet not found responses for GIBS

### DIFF
--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -12,7 +12,7 @@ module V0
         log_message_to_sentry(
           'Unexpected response from EVSS GiBillStatus Service',
           :warn,
-          { evss_status: response.status }
+          evss_status: response.status
         )
         render json: { data: nil, meta: response.metadata }
       else

--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -1,14 +1,24 @@
 # frozen_string_literal: true
 module V0
   class Post911GIBillStatusesController < ApplicationController
+    include SentryLogging
+
     def show
       response = service.get_gi_bill_status
-      if response.ok?
+      if response.user_not_found?
+        # returns a standardized 404
+        raise Common::Exceptions::RecordNotFound, @current_user.email
+      elsif response.contains_no_user_info? || !response.ok?
+        log_message_to_sentry(
+          'Unexpected response from EVSS GiBillStatus Service',
+          :warn,
+          { evss_status: response.status }
+        )
+        render json: { data: nil, meta: response.metadata }
+      else
         render json: response,
                serializer: Post911GIBillStatusSerializer,
                meta: response.metadata
-      else
-        render json: { data: nil, meta: response.metadata }
       end
     end
 

--- a/lib/evss/gi_bill_status/gi_bill_status_response.rb
+++ b/lib/evss/gi_bill_status/gi_bill_status_response.rb
@@ -34,7 +34,7 @@ module EVSS
       end
 
       # EVSS partner has never heard of user
-      # response takes form:
+      # response takes the form:
       # body=
       #   {"messages"=>
       #     [{"key"=>"education.chapter33claimant.partner.service.null",

--- a/lib/evss/gi_bill_status/gi_bill_status_response.rb
+++ b/lib/evss/gi_bill_status/gi_bill_status_response.rb
@@ -5,6 +5,8 @@ require 'evss/response'
 module EVSS
   module GiBillStatus
     class GiBillStatusResponse < EVSS::Response
+      include SentryLogging
+
       attribute :first_name, String
       attribute :last_name, String
       attribute :name_suffix, String
@@ -20,8 +22,26 @@ module EVSS
       attribute :enrollments, Array[Enrollment]
 
       def initialize(status, response = nil)
+        @response = response
         attributes = response.nil? ? {} : response.body['chapter33_education_info']
         super(status, attributes)
+      end
+
+      # EVSS partner is aware of user but has no info about them
+      def contains_no_user_info?
+        @response&.body['chapter33_education_info'] == {}
+      end
+
+      # EVSS partner has never heard of user
+      # response takes form:
+      # body=
+      #   {"messages"=>
+      #     [{"key"=>"education.chapter33claimant.partner.service.null",
+      #       "severity"=>"WARN",
+      #       "text"=>"Chapter33 Claimant partner service response is invalid"}]}
+      def user_not_found?
+        @response&.body&.dig('messages', 0, 'key') == 'education.chapter33claimant.partner.service.null' &&
+          @response&.body&.dig('messages', 0, 'text') == 'Chapter33 Claimant partner service response is invalid'
       end
     end
   end

--- a/lib/evss/gi_bill_status/gi_bill_status_response.rb
+++ b/lib/evss/gi_bill_status/gi_bill_status_response.rb
@@ -29,6 +29,7 @@ module EVSS
 
       # EVSS partner is aware of user but has no info about them
       def contains_no_user_info?
+        return false if @response.nil? || !@response&.body.key?('chapter33_education_info')
         @response&.body['chapter33_education_info'] == {}
       end
 

--- a/spec/controllers/v0/post_911_gi_bill_statuses_controller_spec.rb
+++ b/spec/controllers/v0/post_911_gi_bill_statuses_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe V0::Post911GIBillStatusesController, type: :controller do
       end
       it 'logs a warning' do
         expect(Rails.logger).to receive(:warn).with(/Unexpected response from EVSS GiBillStatus/)
-         VCR.use_cassette('evss/gi_bill_status/vet_with_no_info') do
+        VCR.use_cassette('evss/gi_bill_status/vet_with_no_info') do
           request.headers['Authorization'] = "Token token=#{session.token}"
           get :show
         end

--- a/spec/controllers/v0/post_911_gi_bill_statuses_controller_spec.rb
+++ b/spec/controllers/v0/post_911_gi_bill_statuses_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe V0::Post911GIBillStatusesController, type: :controller do
   let(:user) { FactoryGirl.create(:loa3_user) }
   let(:session) { Session.create(uuid: user.uuid) }
 
-  context 'with a mocked letters response' do
+  context 'with a mocked gi bill status response' do
     let(:mock_response) do
       YAML.load_file(
         Rails.root.join('config', 'evss', 'mock_gi_bill_status_response.yml.example')
@@ -24,6 +24,38 @@ RSpec.describe V0::Post911GIBillStatusesController, type: :controller do
       get :show
       expect(response).to have_http_status(:ok)
       expect(response).to match_response_schema('post911_gi_bill_status', strict: false)
+    end
+  end
+
+  context 'without mock responses' do
+    before { Settings.evss.mock_gi_bill_status = false }
+    describe 'when EVSS has no knowledge of user' do
+      it 'responds with 404' do
+        # generated IN EVSS CI with user ssn=796066619
+        VCR.use_cassette('evss/gi_bill_status/vet_not_found') do
+          request.headers['Authorization'] = "Token token=#{session.token}"
+          get :show
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+    describe 'when EVSS has no info of user' do
+      it 'renders nil data' do
+        VCR.use_cassette('evss/gi_bill_status/vet_with_no_info') do
+          request.headers['Authorization'] = "Token token=#{session.token}"
+          get :show
+          json = JSON.parse(response.body)
+          expect(response).to have_http_status(:ok)
+          expect(json['data']).to be_nil
+        end
+      end
+      it 'logs a warning' do
+        expect(Rails.logger).to receive(:warn).with(/Unexpected response from EVSS GiBillStatus/)
+         VCR.use_cassette('evss/gi_bill_status/vet_with_no_info') do
+          request.headers['Authorization'] = "Token token=#{session.token}"
+          get :show
+        end
+      end
     end
   end
 end

--- a/spec/support/vcr_cassettes/evss/gi_bill_status/vet_not_found.yml
+++ b/spec/support/vcr_cassettes/evss/gi_bill_status/vet_not_found.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-education-services-web/rest/education/chapter33/v1"
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 28 Jun 2017 14:25:25 GMT
+      Va-Eauth-Csid:
+      - DSLogon
+      Va-Eauth-Authenticationmethod:
+      - DSLogon
+      Va-Eauth-Pnidtype:
+      - SSN
+      Va-Eauth-Assurancelevel:
+      - '3'
+      Va-Eauth-Firstname:
+      - abraham
+      Va-Eauth-Lastname:
+      - lincoln
+      Va-Eauth-Issueinstant:
+      - '2017-06-28T14:25:20Z'
+      Va-Eauth-Dodedipnid:
+      - '9121628357'
+      Va-Eauth-Pid:
+      - '5282732133'
+      Va-Eauth-Pnid:
+      - '796066619'
+      Va-Eauth-Authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796066619","edi":"9121628357","firstName":"abraham","lastName":"lincoln"}}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 28 Jun 2017 14:25:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - WSS-LETTERGENERATION-SERVICES_JSESSIONID=nZXvF64R4iurUZzfwDRIzc3PT0o63f4-xI8foPhIicpM48bDgAca!-1088566081;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages" : [ {
+            "key" : "education.chapter33claimant.partner.service.null",
+            "severity" : "WARN",
+            "text" : "Chapter33 Claimant partner service response is invalid"
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 28 Jun 2017 14:25:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/gi_bill_status/vet_with_no_info.yml
+++ b/spec/support/vcr_cassettes/evss/gi_bill_status/vet_with_no_info.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-education-services-web/rest/education/chapter33/v1"
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 28 Jun 2017 15:45:32 GMT
+      Va-Eauth-Csid:
+      - DSLogon
+      Va-Eauth-Authenticationmethod:
+      - DSLogon
+      Va-Eauth-Pnidtype:
+      - SSN
+      Va-Eauth-Assurancelevel:
+      - '3'
+      Va-Eauth-Firstname:
+      - abraham
+      Va-Eauth-Lastname:
+      - lincoln
+      Va-Eauth-Issueinstant:
+      - '2017-06-28T15:45:29Z'
+      Va-Eauth-Dodedipnid:
+      - '4868332235'
+      Va-Eauth-Pid:
+      - '9996859410'
+      Va-Eauth-Pnid:
+      - '796066622'
+      Va-Eauth-Authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796066622","edi":"4868332235","firstName":"abraham","lastName":"lincoln"}}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 28 Jun 2017 15:45:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - WSS-LETTERGENERATION-SERVICES_JSESSIONID=lDTvYQkK8aUvb_7vL90XXm8Ui1hxkGREwvUf9TuWRzguxuitfhNC!-1088566081;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "chapter33EducationInfo" : {
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 28 Jun 2017 15:45:32 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Ticket: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3297 (see bullet # 3)

This PR accomplishes
- Returns a `vets-api` standardized 404 response when EVSS tells us they have never heard of the vet
- Returns an empty response when EVSS tells us they have no data for vet