### PR TITLE
Move 5 attrs into benefit_iformation

### DIFF
--- a/app/serializers/letter_beneficiary_serializer.rb
+++ b/app/serializers/letter_beneficiary_serializer.rb
@@ -2,11 +2,6 @@
 class LetterBeneficiarySerializer < ActiveModel::Serializer
   attribute :benefit_information
   attribute :military_service
-  attribute :has_adapted_housing
-  attribute :has_chapter35_eligibility
-  attribute :has_death_result_of_disability
-  attribute :has_individual_unemployability_granted
-  attribute :has_special_monthly_compensation
 
   def id
     nil

--- a/config/evss/mock_letters_response.yml.example
+++ b/config/evss/mock_letters_response.yml.example
@@ -42,11 +42,11 @@ default:
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -104,11 +104,11 @@ default:
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -166,11 +166,11 @@ default:
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -228,11 +228,11 @@ default:
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -289,11 +289,11 @@ default:
         has_survivors_pension_award: false
         monthly_award_amount: 123.0
         service_connected_percentage: 2
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -351,11 +351,11 @@ default:
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -412,11 +412,11 @@ default:
         has_survivors_pension_award: false
         monthly_award_amount: 123.0
         service_connected_percentage: 2
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -474,11 +474,11 @@ default:
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -536,11 +536,11 @@ default:
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -598,11 +598,11 @@ default:
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -660,11 +660,11 @@ default:
         monthly_award_amount: 123.0
         service_connected_percentage: 2
         award_effective_date: '1965-01-01T05:00:00.000+0000'
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE

--- a/lib/evss/letters/beneficiary_response.rb
+++ b/lib/evss/letters/beneficiary_response.rb
@@ -6,11 +6,6 @@ module EVSS
     class BeneficiaryResponse < EVSS::Response
       attribute :benefit_information, EVSS::Letters::BenefitInformation
       attribute :military_service, Array[EVSS::Letters::MilitaryService]
-      attribute :has_adapted_housing, Boolean
-      attribute :has_chapter35_eligibility, Boolean
-      attribute :has_death_result_of_disability, Boolean
-      attribute :has_individual_unemployability_granted, Boolean
-      attribute :has_special_monthly_compensation, Boolean
 
       def initialize(status, response = nil)
         attributes = response.body if response

--- a/lib/evss/letters/benefit_information.rb
+++ b/lib/evss/letters/benefit_information.rb
@@ -11,6 +11,12 @@ module EVSS
       attribute :monthly_award_amount, Float
       attribute :service_connected_percentage, Integer
       attribute :award_effective_date, DateTime
+
+      attribute :has_adapted_housing, Boolean
+      attribute :has_chapter35_eligibility, Boolean
+      attribute :has_death_result_of_disability, Boolean
+      attribute :has_individual_unemployability_granted, Boolean
+      attribute :has_special_monthly_compensation, Boolean
     end
   end
 end

--- a/spec/support/evss/mock_letters_response.yml
+++ b/spec/support/evss/mock_letters_response.yml
@@ -39,11 +39,11 @@
         has_survivors_pension_award: false
         monthly_award_amount: 123.0
         service_connected_percentage: 2
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -98,11 +98,11 @@
         has_survivors_pension_award: false
         monthly_award_amount: 123.0
         service_connected_percentage: 2
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -157,11 +157,11 @@
         has_survivors_pension_award: false
         monthly_award_amount: 123.0
         service_connected_percentage: 2
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE
@@ -216,11 +216,11 @@ default:
         has_survivors_pension_award: false
         monthly_award_amount: 123.0
         service_connected_percentage: 2
-      has_adapted_housing: false
-      has_chapter35_eligibility: true
-      has_death_result_of_disability: false
-      has_individual_unemployability_granted: false
-      has_special_monthly_compensation: false
+        has_adapted_housing: false
+        has_chapter35_eligibility: true
+        has_death_result_of_disability: false
+        has_individual_unemployability_granted: false
+        has_special_monthly_compensation: false
       military_service:
       - branch: ARMY
         character_of_service: HONORABLE

--- a/spec/support/schemas/letter_beneficiary.json
+++ b/spec/support/schemas/letter_beneficiary.json
@@ -32,24 +32,24 @@
                 },
                 "award_effective_date": {
                   "type": "string"
+                },
+                "has_adapted_housing": {
+                  "type": ["boolean", "null"]
+                },
+                "has_chapter35_eligibility": {
+                  "type": ["boolean", "null"]
+                },
+                "has_death_result_of_disability": {
+                  "type": ["boolean", "null"]
+                },
+                "has_individual_unemployability_granted": {
+                  "type": ["boolean", "null"]
+                },
+                "has_special_monthly_compensation": {
+                  "type": ["boolean", "null"]
                 }
               },
               "type": ["object", "null"]
-            },
-            "has_adapted_housing": {
-              "type": ["boolean", "null"]
-            },
-            "has_chapter35_eligibility": {
-              "type": ["boolean", "null"]
-            },
-            "has_death_result_of_disability": {
-              "type": ["boolean", "null"]
-            },
-            "has_individual_unemployability_granted": {
-              "type": ["boolean", "null"]
-            },
-            "has_special_monthly_compensation": {
-              "type": ["boolean", "null"]
             },
             "military_service": {
               "type": ["array", "null"],

--- a/spec/support/vcr_cassettes/evss/letters/beneficiary.yml
+++ b/spec/support/vcr_cassettes/evss/letters/beneficiary.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 14 Jun 2017 21:48:53 GMT
+      - Wed, 28 Jun 2017 21:32:06 GMT
       Va-Eauth-Csid:
       - DSLogon
       Va-Eauth-Authenticationmethod:
@@ -28,7 +28,7 @@ http_interactions:
       Va-Eauth-Lastname:
       - lincoln
       Va-Eauth-Issueinstant:
-      - '2017-06-14T21:48:52Z'
+      - '2017-06-28T21:32:06Z'
       Va-Eauth-Dodedipnid:
       - '6138391549'
       Va-Eauth-Pid:
@@ -43,14 +43,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 14 Jun 2017 21:48:49 GMT
+      - Wed, 28 Jun 2017 21:32:06 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips
       Content-Type:
       - application/json
       Set-Cookie:
-      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
-      - WSS-LETTERGENERATION-SERVICES_JSESSIONID=Hs-olJiWg8WA5Z_fD2HtMzg7inHBAWR0suPhCVvs8E-tnbC16wkb!-1082478778;
+      - WLS_12.1_App1_Cluster_ROUTEID=.02; path=/
+      - WSS-LETTERGENERATION-SERVICES_JSESSIONID=ws7wnlH5vVBhWlY7Q_I4u92H2hHHgxyQnWJPptVRx2ifm0THUr0C!778538296;
         path=/; HttpOnly
       Via:
       - 1.1 csraciapp6.evss.srarad.com
@@ -61,31 +61,31 @@ http_interactions:
       string: |-
         {
           "benefitInformation" : {
+            "awardEffectiveDate" : "2013-06-06T04:00:00.000+0000",
+            "hasAdaptedHousing" : false,
+            "hasChapter35Eligibility" : true,
+            "hasDeathResultOfDisability" : false,
+            "hasIndividualUnemployabilityGranted" : false,
             "hasNonServiceConnectedPension" : false,
             "hasServiceConnectedDisabilities" : true,
+            "hasSpecialMonthlyCompensation" : false,
             "hasSurvivorsIndemnityCompensationAward" : false,
             "hasSurvivorsPensionAward" : false,
             "monthlyAwardAmount" : 123.0,
-            "serviceConnectedPercentage" : 2,
-            "awardEffectiveDate" : "1977-10-01T04:00:00.000+0000"
+            "serviceConnectedPercentage" : 2
           },
-          "hasAdaptedHousing" : false,
-          "hasChapter35Eligibility" : true,
-          "hasDeathResultOfDisability" : false,
-          "hasIndividualUnemployabilityGranted" : false,
-          "hasSpecialMonthlyCompensation" : false,
           "militaryService" : [ {
-            "branch" : "ARMY",
+            "branch" : "Army",
             "characterOfService" : "HONORABLE",
             "enteredDate" : "1965-01-01T05:00:00.000+0000",
             "releasedDate" : "1972-10-01T04:00:00.000+0000"
           }, {
-            "branch" : "ARMY",
+            "branch" : "Army",
             "characterOfService" : "UNCHARACTERIZED_ENTRY_LEVEL",
             "enteredDate" : "1973-01-01T05:00:00.000+0000",
             "releasedDate" : "1977-10-01T04:00:00.000+0000"
           } ]
         }
     http_version: 
-  recorded_at: Wed, 14 Jun 2017 21:48:53 GMT
+  recorded_at: Wed, 28 Jun 2017 21:32:06 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Regarding the EVSS `get_letter_beneficiary` API response JSON, the following 5 attributes have been out of the root (`response.body`) and into `benefit_information` (`response.body.benefit_information`):
- `has_adapted_housing`
- `has_chapter35_eligibility`
- `has_death_result_of_disability`
- `has_individual_unemployability_granted`
- `has_special_monthly_compensation`