### PR TITLE
Updating mock service

### DIFF
--- a/config/mvi_schema/mock_mvi_responses.yml.example
+++ b/config/mvi_schema/mock_mvi_responses.yml.example
@@ -4385,3 +4385,18 @@ find_candidate:
     - '648'
     :edipi: 
     :participant_id: 
+  '500500237':
+    :given_names:
+    - Burnice
+    :family_name: Upton
+    :suffix:
+    :gender: F
+    :birth_date: '19710728'
+    :ssn: '500500237'
+    :address:
+    :home_phone:
+    :icn:
+    :mhv_ids: []
+    :vha_facility_ids: []
+    :edipi:
+    :participant_id:


### PR DESCRIPTION
NOTE: this user is not in stage1a but has loa3 because of the way ID.me setup these accounts

It is needed in the mock service for testing on dev, but unclear what this will mean for testing on staging since its not available in stage1a. Technically all that is needed for appeals testing should be SSN so maybe this is OK, just a little strange having an LOA3 user that is not in MVI.