### PR TITLE
Disable SIP/Prefill for non-test accounts

### DIFF
--- a/app/controllers/v0/in_progress_forms_controller.rb
+++ b/app/controllers/v0/in_progress_forms_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module V0
   class InProgressFormsController < ApplicationController
+    before_action :check_access_denied
+
     def index
       render json: InProgressForm.where(user_uuid: @current_user.uuid)
     end
@@ -10,7 +12,7 @@ module V0
       form = InProgressForm.form_for_user(form_id, @current_user)
       if form
         render json: form.data_and_metadata
-      elsif FeatureFlipper.enable_prefill?(@current_user)
+      elsif @current_user.can_access_prefill_data?
         render json: FormProfile.for(form_id).prefill(@current_user)
       else
         head 404
@@ -28,6 +30,13 @@ module V0
       form = InProgressForm.form_for_user(params[:id], @current_user)
       form.destroy
       render json: form
+    end
+
+    private
+
+    def check_access_denied
+      return if @current_user.can_save_partial_forms?
+      raise Common::Exceptions::Unauthorized, detail: 'You do not have access to save in progress forms'
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ require 'evss/auth_headers'
 require 'saml/user_attributes'
 
 class User < Common::RedisStore
+  UNALLOCATED_SSN_PREFIX = '796' # most test accounts use this
+
   redis_store REDIS_CONFIG['user_store']['namespace']
   redis_ttl REDIS_CONFIG['user_store']['each_ttl']
   redis_key :uuid
@@ -79,11 +81,11 @@ class User < Common::RedisStore
   end
 
   def can_save_partial_forms?
-    loa3? && ssn.present? && ssn.starts_with?('796')
+    loa3? && ssn.present? && ssn.starts_with?(UNALLOCATED_SSN_PREFIX)
   end
 
   def can_access_prefill_data?
-    loa3? && ssn.present? && ssn.starts_with?('796')
+    loa3? && ssn.present? && ssn.starts_with?(UNALLOCATED_SSN_PREFIX)
   end
 
   def self.from_merged_attrs(existing_user, new_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,11 +79,11 @@ class User < Common::RedisStore
   end
 
   def can_save_partial_forms?
-    loa3?
+    loa3? && ssn.present? && ssn.starts_with?('796')
   end
 
   def can_access_prefill_data?
-    loa3?
+    loa3? && ssn.present? && ssn.starts_with?('796')
   end
 
   def self.from_merged_attrs(existing_user, new_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,6 +78,14 @@ class User < Common::RedisStore
     loa3? && ssn.present?
   end
 
+  def can_save_partial_forms?
+    loa3?
+  end
+
+  def can_access_prefill_data?
+    loa3?
+  end
+
   def self.from_merged_attrs(existing_user, new_user)
     # we want to always use the more recent attrs so long as they exist
     attrs = new_user.attributes.map do |key, val|

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -69,7 +69,7 @@ class UserSerializer < ActiveModel::Serializer
   end
 
   def prefills_available
-    FeatureFlipper.enable_prefill?(object) ? FormProfile::MAPPINGS : []
+    object.can_access_prefill_data? ? FormProfile::MAPPINGS : []
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -89,6 +89,9 @@ class UserSerializer < ActiveModel::Serializer
     service_list << BackendServices::USER_PROFILE if object.can_access_user_profile?
     service_list << BackendServices::APPEALS_STATUS if beta_enabled?(object.uuid, 'appeals_status') &&
                                                        object.can_access_appeals?
+
+    service_list << BackendServices::SAVE_IN_PROGRESS if object.can_save_partial_forms?
+    service_list << BackendServices::FORM_PREFILL if object.can_access_prefill_data?
     service_list
   end
 end

--- a/lib/backend_services.rb
+++ b/lib/backend_services.rb
@@ -12,4 +12,8 @@ class BackendServices
   MESSAGING = 'messaging'
   HEALTH_RECORDS = 'health-records'
   MHV_BASED_SERVICES = [RX, MESSAGING, HEALTH_RECORDS].freeze
+
+  # Core Form Features
+  SAVE_IN_PROGRESS = 'form-save-in-progress'
+  FORM_PREFILL = 'form-prefill'
 end

--- a/lib/feature_flipper.rb
+++ b/lib/feature_flipper.rb
@@ -7,8 +7,4 @@ module FeatureFlipper
   def self.staging_email?
     Settings.reports.server.include?('stage')
   end
-
-  def self.enable_prefill?(user)
-    (user&.ssn).present?
-  end
 end

--- a/spec/request/in_progress_forms_request_spec.rb
+++ b/spec/request/in_progress_forms_request_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe 'in progress forms', type: :request do
       end
     end
 
+    context 'when the user is not a test account' do
+      let(:user) { build(:loa3_user, ssn: '000-01-0002') }
+      it 'returns a 401' do
+        subject
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)['errors'].first['detail']).to match(/do not have access to save/)
+      end
+    end
+
     it 'returns details about saved forms' do
       subject
       items = JSON.parse(response.body)['data']

--- a/spec/request/in_progress_forms_request_spec.rb
+++ b/spec/request/in_progress_forms_request_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe 'in progress forms', type: :request do
   let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
   let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
-  let(:user) { build(:loa3_user) }
+  let(:loa3_user) { build(:loa3_user) }
+  let(:loa1_user) { build(:loa1_user) }
 
   before do
     Session.create(uuid: user.uuid, token: token)
@@ -20,10 +21,21 @@ RSpec.describe 'in progress forms', type: :request do
   end
 
   describe '#index' do
+    let(:user) { loa3_user }
     let!(:in_progress_form_edu) { FactoryGirl.create(:in_progress_form, form_id: '22-1990', user_uuid: user.uuid) }
     let!(:in_progress_form_hca) { FactoryGirl.create(:in_progress_form, form_id: '1010ez', user_uuid: user.uuid) }
+
     subject do
       get v0_in_progress_forms_url, nil, auth_header
+    end
+
+    context 'when the user is not loa3' do
+      let(:user) { loa1_user }
+      it 'returns a 401' do
+        subject
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)['errors'].first['detail']).to match(/do not have access to save/)
+      end
     end
 
     it 'returns details about saved forms' do
@@ -35,7 +47,17 @@ RSpec.describe 'in progress forms', type: :request do
   end
 
   describe '#show' do
+    let(:user) { loa3_user }
     let!(:in_progress_form) { FactoryGirl.create(:in_progress_form, user_uuid: user.uuid) }
+
+    context 'when the user is not loa3' do
+      let(:user) { loa1_user }
+      it 'returns a 401' do
+        get v0_in_progress_form_url(in_progress_form.form_id), nil, auth_header
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)['errors'].first['detail']).to match(/do not have access to save/)
+      end
+    end
 
     context 'when a form is found' do
       subject do
@@ -104,6 +126,17 @@ RSpec.describe 'in progress forms', type: :request do
   end
 
   describe '#update' do
+    let(:user) { loa3_user }
+
+    context 'when the user is not loa3' do
+      let(:user) { loa1_user }
+      it 'returns a 401' do
+        put v0_in_progress_form_url(0), {}.to_json, auth_header.merge('CONTENT_TYPE' => 'application/json')
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)['errors'].first['detail']).to match(/do not have access to save/)
+      end
+    end
+
     context 'with a new form' do
       let(:new_form) { FactoryGirl.build(:in_progress_form, user_uuid: user.uuid) }
 
@@ -152,7 +185,17 @@ RSpec.describe 'in progress forms', type: :request do
   end
 
   describe '#destroy' do
+    let(:user) { loa3_user }
     let!(:in_progress_form) { FactoryGirl.create(:in_progress_form, user_uuid: user.uuid) }
+
+    context 'when the user is not loa3' do
+      let(:user) { loa1_user }
+      it 'returns a 401' do
+        delete v0_in_progress_form_url(in_progress_form.form_id), nil, auth_header
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)['errors'].first['detail']).to match(/do not have access to save/)
+      end
+    end
 
     context 'when a form is found' do
       subject do

--- a/spec/request/messages_request_spec.rb
+++ b/spec/request/messages_request_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe 'Messages Integration', type: :request do
     let(:mhv_account) { double('mhv_account', ineligible?: true, needs_terms_acceptance?: false, upgraded?: true) }
     let(:current_user) { build(:loa1_user) }
 
-    it 'gives me a 401' do
+    it 'gives me a 403' do
       get "/v0/messaging/health/messages/#{message_id}"
 
       expect(response).not_to be_success

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe 'Fetching user data', type: :request do
           BackendServices::USER_PROFILE,
           BackendServices::RX,
           BackendServices::MESSAGING,
-          BackendServices::HEALTH_RECORDS
+          BackendServices::HEALTH_RECORDS,
+          BackendServices::FORM_PREFILL,
+          BackendServices::SAVE_IN_PROGRESS
         ].sort
       )
     end


### PR DESCRIPTION
Repurposing some work I started last night to gate things to just LOA3 to do that gate, but also add one that limits to obviously fake SSNs that we use for testing.

This is meant to disable this feature for any non-vets.gov test users, as the 796-*-* ssn pattern is not used for actual ssns.