### PR TITLE
Upload permissions before clamav scan

### DIFF
--- a/lib/shrine/plugins/validate_virus_free.rb
+++ b/lib/shrine/plugins/validate_virus_free.rb
@@ -6,7 +6,7 @@ class Shrine
         def validate_virus_free(message: nil)
           cached_path = get.download.path
           # `clamd` runs within service group, needs group read
-          File.chmod(0640, cached_path)
+          File.chmod(0o640, cached_path)
           result = ClamScan::Client.scan(location: cached_path)
           # TODO: Log a the full result to sentry
           result.safe? || add_error_msg(message || result.body)

--- a/lib/shrine/plugins/validate_virus_free.rb
+++ b/lib/shrine/plugins/validate_virus_free.rb
@@ -5,6 +5,8 @@ class Shrine
       module AttacherMethods
         def validate_virus_free(message: nil)
           cached_path = get.download.path
+          # `clamd` runs within service group, needs group read
+          File.chmod(0640, cached_path)
           result = ClamScan::Client.scan(location: cached_path)
           # TODO: Log a the full result to sentry
           result.safe? || add_error_msg(message || result.body)

--- a/spec/lib/shrine/plugins/validate_virus_free_spec.rb
+++ b/spec/lib/shrine/plugins/validate_virus_free_spec.rb
@@ -23,7 +23,7 @@ describe Shrine::Plugins::ValidateVirusFree do
       allow_any_instance_of(klass).to receive(:get)
         .and_return(instance_double('Shrine::UploadedFile', download: instance_double('File', path: 'foo/bar.jpg')))
 
-      allow(File).to receive(:chmod).with(0640, 'foo/bar.jpg').and_return(1)
+      allow(File).to receive(:chmod).with(0o640, 'foo/bar.jpg').and_return(1)
     end
 
     context 'with errors' do
@@ -82,7 +82,7 @@ describe Shrine::Plugins::ValidateVirusFree do
       allow(ClamScan::Client).to receive(:scan)
         .and_return(instance_double('ClamScan::Response', safe?: true))
 
-      expect(File).to receive(:chmod).with(0640, 'foo/bar.jpg').and_return(1)
+      expect(File).to receive(:chmod).with(0o640, 'foo/bar.jpg').and_return(1)
       instance.validate_virus_free
     end
   end

--- a/spec/lib/shrine/plugins/validate_virus_free_spec.rb
+++ b/spec/lib/shrine/plugins/validate_virus_free_spec.rb
@@ -22,6 +22,8 @@ describe Shrine::Plugins::ValidateVirusFree do
     before(:each) do
       allow_any_instance_of(klass).to receive(:get)
         .and_return(instance_double('Shrine::UploadedFile', download: instance_double('File', path: 'foo/bar.jpg')))
+
+      allow(File).to receive(:chmod).with(0640, 'foo/bar.jpg').and_return(1)
     end
 
     context 'with errors' do
@@ -74,6 +76,14 @@ describe Shrine::Plugins::ValidateVirusFree do
       expect(instance).not_to receive(:add_error_msg)
       result = instance.validate_virus_free
       expect(result).to be(true)
+    end
+
+    it 'changes group permissions of the uploaded file' do
+      allow(ClamScan::Client).to receive(:scan)
+        .and_return(instance_double('ClamScan::Response', safe?: true))
+
+      expect(File).to receive(:chmod).with(0640, 'foo/bar.jpg').and_return(1)
+      instance.validate_virus_free
     end
   end
 end


### PR DESCRIPTION
Tempfile.new is used to generate uploaded file paths, which forces permissions to `0600`. The `clamd` server needs access to these files, so we'll add the user to the `service` group and make sure these files are readable by the group as well. 

https://dsva.slack.com/archives/C4593CJRY/p1499362350438764
