### PR TITLE
Don't refer to user object since doesn't exist in logout flow

### DIFF
--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -80,7 +80,7 @@ class MhvAccount < ActiveRecord::Base
       TermsAndConditionsAcceptance.joins(:terms_and_conditions)
                                   .includes(:terms_and_conditions)
                                   .where(terms_and_conditions: { latest: true, name: TERMS_AND_CONDITIONS_NAME })
-                                  .where(user_uuid: user.uuid).limit(1).first
+                                  .where(user_uuid: user_uuid).limit(1).first
   end
 
   def address_params


### PR DESCRIPTION
See issue in Sentry here: http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/10574/

Logout flow invokes MHV logging callback which checks mhv account status. Calling user.uuid tried to do User.find, but the user was just destroyed earlier in the logout flow. Changing to user_uuid (field in this model) makes it work fine. Verified in staging.