### PR TITLE
Use correct AWS settings keys for carrierwave

### DIFF
--- a/app/uploaders/evss_claim_document_uploader.rb
+++ b/app/uploaders/evss_claim_document_uploader.rb
@@ -35,8 +35,8 @@ class EVSSClaimDocumentUploader < CarrierWave::Uploader::Base
   def set_storage_options!
     if Settings.evss.s3.uploads_enabled
       self.aws_credentials = {
-        aws_access_key_id: Settings.evss.s3.aws_access_key_id,
-        aws_secret_access_key: Settings.evss.s3.aws_secret_access_key,
+        access_key_id: Settings.evss.s3.aws_access_key_id,
+        secret_access_key: Settings.evss.s3.aws_secret_access_key,
         region: Settings.evss.s3.region
       }
       self.aws_acl = 'private'

--- a/spec/uploaders/evss_claim_document_uploader_spec.rb
+++ b/spec/uploaders/evss_claim_document_uploader_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe EVSSClaimDocumentUploader do
       it 'should set storage to fog' do
         with_settings(Settings.evss.s3, uploads_enabled: true) do
           expect(subject.class.storage).to eq(CarrierWave::Storage::AWS)
-          expect(subject.aws_credentials).to eq(aws_access_key_id: 'EVSS_S3_AWS_ACCESS_KEY_ID_XYZ',
-                                                aws_secret_access_key: 'EVSS_S3_AWS_SECRET_ACCESS_KEY_XYZ',
+          expect(subject.aws_credentials).to eq(access_key_id: 'EVSS_S3_AWS_ACCESS_KEY_ID_XYZ',
+                                                secret_access_key: 'EVSS_S3_AWS_SECRET_ACCESS_KEY_XYZ',
                                                 region: 'evss_s3_region')
           expect(subject.aws_acl).to eq('private')
           expect(subject.aws_bucket).to eq('evss_s3_bucket')


### PR DESCRIPTION
Carrierwave configures the S3 client with the credentials provided by
the `aws_credentials` attribute on the uploader instance. This hash is
passed to `AWS::S3::Client.new`, which accepts the credentials as
`access_key_id` and `secret_access_key` without the `aws_` prefix:

http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html

This caused issues with uploads logged to Sentry in
http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/10492/.

Should be deployed after
https://github.com/department-of-veterans-affairs/devops/pull/1788.