### PR TITLE
EVSS Error Handling

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -168,3 +168,9 @@ en:
         detail: 'EVSS received an error calling external service'
         code: 113
         status: 503
+    gi_bill_status:
+      <<: *defaults
+      title: External service unavailable
+      detail: 'EVSS received an error calling external service'
+      code: 113
+      status: 503

--- a/lib/evss/gi_bill_status/service.rb
+++ b/lib/evss/gi_bill_status/service.rb
@@ -10,18 +10,23 @@ module EVSS
         raw_response = get ''
         EVSS::GiBillStatus::GiBillStatusResponse.new(raw_response.status, raw_response)
       rescue Faraday::ParsingError => e
-        extra_context = { url: BASE_URL }
+        response = OpenStruct.new(e.response.to_hash)
+        content_type = response.response_headers['content-type']
+        extra_context = { response: response }
         log_exception_to_sentry(e, extra_context)
-        EVSS::GiBillStatus::GiBillStatusResponse.new(403)
+        EVSS::GiBillStatus::GiBillStatusResponse.new(response.status, response, false, content_type)
       rescue Faraday::TimeoutError
         log_message_to_sentry(
           'Timeout while connecting to GiBillStatus service', :error, extra_context: { url: BASE_URL }
         )
-        EVSS::GiBillStatus::GiBillStatusResponse.new(403)
+        EVSS::GiBillStatus::GiBillStatusResponse.new(999, nil, true)
       rescue Faraday::ClientError => e
-        extra_context = { url: BASE_URL, body: e.response[:body] }
+        # convert <Faraday::ClientError>.response hash to object to conform with a normal response
+        response = OpenStruct.new(e&.response)
+
+        extra_context = { url: BASE_URL, response: response }
         log_exception_to_sentry(e, extra_context)
-        EVSS::GiBillStatus::GiBillStatusResponse.new(e.response[:status])
+        EVSS::GiBillStatus::GiBillStatusResponse.new(response.status, response)
       end
 
       def self.breakers_service

--- a/lib/evss/gi_bill_status/service_exception.rb
+++ b/lib/evss/gi_bill_status/service_exception.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'common/exceptions/base_error'
+
+module EVSS
+  module GiBillStatus
+    class ServiceException < Common::Exceptions::BaseError
+      def initialize
+        super
+      end
+
+      def errors
+        [Common::Exceptions::SerializableError.new(i18n_data)]
+      end
+
+      def i18n_key
+        'evss.gi_bill_status'
+      end
+    end
+  end
+end

--- a/spec/controllers/v0/post_911_gi_bill_statuses_controller_spec.rb
+++ b/spec/controllers/v0/post_911_gi_bill_statuses_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe V0::Post911GIBillStatusesController, type: :controller do
       end
     end
     describe 'when EVSS has no info of user' do
-      # special EVSS CI user ssn=796066619
+      # special EVSS CI user ssn=796066622
       let(:user) { FactoryGirl.create(:loa3_user, ssn: '796066622', uuid: 'fghj3456') }
       let(:session) { Session.create(uuid: user.uuid) }
       it 'renders nil data' do
@@ -78,6 +78,19 @@ RSpec.describe V0::Post911GIBillStatusesController, type: :controller do
           request.headers['Authorization'] = "Token token=#{session.token}"
           get :show
           expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    describe 'when EVSS partners return invalid data' do
+      # special EVSS CI user ssn=301010304
+      let(:user) { FactoryGirl.create(:loa3_user, ssn: '301010304', uuid: 'aaaa1a') }
+      let(:session) { Session.create(uuid: user.uuid) }
+      it 'responds with a 422' do
+        VCR.use_cassette('evss/gi_bill_status/invalid_partner_data') do
+          request.headers['Authorization'] = "Token token=#{session.token}"
+          get :show
+          expect(response).to have_http_status(:service_unavailable)
         end
       end
     end

--- a/spec/request/post911_gi_bill_status_request_spec.rb
+++ b/spec/request/post911_gi_bill_status_request_spec.rb
@@ -27,40 +27,31 @@ RSpec.describe 'Fetching Post 911 GI Bill Status', type: :request do
   # TODO(AJD): this use case happens, 500 status but unauthorized message
   # check with evss that they shouldn't be returning 403 instead
   context 'with an 500 unauthorized response' do
-    it 'should return a not authorized response' do
+    it 'should return a forbidden response' do
       VCR.use_cassette('evss/gi_bill_status/unauthorized') do
         get v0_post911_gi_bill_status_url, nil, auth_header
-        expect(response).to have_http_status(:ok)
-        expect(response).to match_response_schema('post911_gi_bill_status')
-        expect(Oj.load(response.body).dig('meta', 'status')).to eq(
-          Common::Client::ServiceStatus::RESPONSE_STATUS[:not_authorized]
-        )
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
 
+  # TODO: - is this a real scenario?
   context 'with a 403 response' do
-    it 'should return a not authorized response' do
+    it 'should return a forbidden response' do
       VCR.use_cassette('evss/gi_bill_status/gi_bill_status_403') do
         get v0_post911_gi_bill_status_url, nil, auth_header
-        expect(response).to have_http_status(:ok)
-        expect(response).to match_response_schema('post911_gi_bill_status')
-        expect(Oj.load(response.body).dig('meta', 'status')).to eq(
-          Common::Client::ServiceStatus::RESPONSE_STATUS[:not_authorized]
-        )
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
 
-  context 'with a 500 evss response' do
-    it 'should return a not found response' do
+  # a 500 and does not contain one of the errors defined in:
+  # https://csraciapp6.evss.srarad.com/wss-education-services-web/swagger-ui/ext-docs/education-error-keys.html
+  context 'with an undefined 500 evss response' do
+    it 'should return internal server error' do
       VCR.use_cassette('evss/gi_bill_status/gi_bill_status_500') do
         get v0_post911_gi_bill_status_url, nil, auth_header
-        expect(response).to have_http_status(:ok)
-        expect(response).to match_response_schema('post911_gi_bill_status')
-        expect(Oj.load(response.body).dig('meta', 'status')).to eq(
-          Common::Client::ServiceStatus::RESPONSE_STATUS[:server_error]
-        )
+        expect(response).to have_http_status(:internal_server_error)
       end
     end
   end

--- a/spec/support/vcr_cassettes/evss/gi_bill_status/invalid_partner_data.yml
+++ b/spec/support/vcr_cassettes/evss/gi_bill_status/invalid_partner_data.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-education-services-web/rest/education/chapter33/v1"
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 17 Jul 2017 15:20:27 GMT
+      Va-Eauth-Csid:
+      - DSLogon
+      Va-Eauth-Authenticationmethod:
+      - DSLogon
+      Va-Eauth-Pnidtype:
+      - SSN
+      Va-Eauth-Assurancelevel:
+      - '3'
+      Va-Eauth-Firstname:
+      - abraham
+      Va-Eauth-Lastname:
+      - lincoln
+      Va-Eauth-Issueinstant:
+      - '2017-07-17T15:20:26Z'
+      Va-Eauth-Dodedipnid:
+      - '3499166942'
+      Va-Eauth-Pid:
+      - '2941711521'
+      Va-Eauth-Pnid:
+      - '301010304'
+      Va-Eauth-Authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"301010304","edi":"3499166942","firstName":"abraham","lastName":"lincoln"}}'
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Mon, 17 Jul 2017 15:20:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - WSS-LETTERGENERATION-SERVICES_JSESSIONID=0UxRIuc0XoTJBDf-3xo6rY27NZPT9AljzePfzktdBu6WVuaiwfW5!-2114428822;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages" : [ {
+            "key" : "education.partner.service.invalid",
+            "severity" : "FATAL",
+            "text" : "Chapter33 partner service response is invalid"
+          } ]
+        }
+    http_version: 
+  recorded_at: Mon, 17 Jul 2017 15:20:28 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Adds handling for:
- When EVSS Times out then return 504
- When EVSS returns one of their known errors then return 503
- When EVSS says invalid auth then return 403

Also adds generic catch-all 500 response for when the EVSS response
1. Does not contain any chapter33 info
& 
2. Does not match any known error response