### PR TITLE
added error handling for eoas errors

### DIFF
--- a/lib/preneeds/configuration.rb
+++ b/lib/preneeds/configuration.rb
@@ -3,6 +3,7 @@ require 'common/client/configuration/soap'
 require 'common/client/middleware/request/soap_headers'
 require 'common/client/middleware/response/soap_parser'
 require 'preneeds/middleware/response/clean_response'
+require 'preneeds/middleware/response/eoas_xml_errors'
 require 'preneeds/middleware/response/preneeds_parser'
 
 module Preneeds
@@ -26,6 +27,7 @@ module Preneeds
 
         conn.response :preneeds_parser
         conn.response :soap_parser
+        conn.response :eoas_xml_errors
         conn.response :clean_response
 
         conn.use :breakers

--- a/lib/preneeds/middleware/response/clean_response.rb
+++ b/lib/preneeds/middleware/response/clean_response.rb
@@ -6,7 +6,7 @@ module Preneeds
         def on_complete(env)
           return unless env.url.to_s == Preneeds::Configuration.url
 
-          relevant_xml = env.body&.scan(%r{<S:Envelope[^<>]*>.*</S:Envelope[^<>]*>}i)&.first
+          relevant_xml = env.body&.gsub(/[\t\n]/, ' ')&.scan(%r{<S:Envelope[^<>]*>.*</S:Envelope[^<>]*>}i)&.first
           env.body = '<?xml version="1.0" encoding="UTF-8"?>' + relevant_xml if relevant_xml.present?
         end
       end

--- a/lib/preneeds/middleware/response/eoas_xml_errors.rb
+++ b/lib/preneeds/middleware/response/eoas_xml_errors.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+module Preneeds
+  module Middleware
+    module Response
+      class EoasXmlErrors < Faraday::Response::Middleware
+        include SentryLogging
+        attr_reader :status, :fault, :code, :detail
+
+        def on_complete(env)
+          return unless env.response_headers['content-type'] =~ /\b(xml)/
+
+          @fault = fault_string(env)
+          @code = return_code(env)
+
+          return unless backend_error?(env) || status_200_error?(env)
+
+          @status = status_200_error?(env) ? return_code(env) : env.status
+          @detail = fault || return_description(env)
+
+          # strip percentages from xml because Sentry uses it for interpolation
+          extra_context = { original_status: status, original_body: env.body&.delete('%') }
+          log_message_to_sentry('Generalized XML error response from EOAS', :warn, extra_context)
+          raise Common::Exceptions::BackendServiceException.new('VA900', response_values, @status, env.body)
+        end
+
+        private
+
+        def backend_error?(env)
+          env.status != 200 && fault.present?
+        end
+
+        def status_200_error?(env)
+          env.status == 200 && code.present? && code != 200
+        end
+
+        def fault_string(env)
+          env.body&.scan(%r{<faultstring[^<>]*>(.*)</faultstring[^<>]*>}i)&.first&.first
+        end
+
+        def return_code(env)
+          env.body&.scan(%r{<returnCode[^<>]*>(.*)</returnCode[^<>]*>}i)&.first&.first&.to_i
+        end
+
+        def return_description(env)
+          env.body&.scan(%r{<returnDescription[^<>]*>(.*)</returnDescription[^<>]*>}i)&.first&.first
+        end
+
+        def response_values
+          {
+            status: status,
+            detail: detail,
+            code:   'VA900',
+            source: 'EOAS provided a general error response, check logs for original request body.'
+          }
+        end
+      end
+    end
+  end
+end
+
+Faraday::Response.register_middleware eoas_xml_errors: Preneeds::Middleware::Response::EoasXmlErrors

--- a/spec/request/preneeds/burial_forms_request_spec.rb
+++ b/spec/request/preneeds/burial_forms_request_spec.rb
@@ -32,4 +32,32 @@ RSpec.describe 'Preneeds Burial Form Integration', type: :request do
       expect(error['detail']).to match(/militaryStatus/)
     end
   end
+
+  context 'with a failed burial form submittal from EOAS' do
+    it 'returns with a VA900 error when status is 500' do
+      VCR.use_cassette('preneeds/burial_forms/burial_form_with_invalid_applicant_address2') do
+        params[:pre_need_request][:applicant][:mailing_address][:address2] = '1' * 21
+        post '/v0/preneeds/burial_forms', params
+      end
+
+      error = JSON.parse(response.body)['errors'].first
+
+      expect(error['status']).to eq('400')
+      expect(error['title']).to match(/operation failed/i)
+      expect(error['detail']).to match(/Error committing transaction/i)
+    end
+
+    it 'returns with a VA900 error when the status is 200' do
+      VCR.use_cassette('preneeds/burial_forms/burial_form_with_duplicate_tracking_number') do
+        allow_any_instance_of(Preneeds::BurialForm).to receive(:generate_tracking_number).and_return('19')
+        post '/v0/preneeds/burial_forms', params
+      end
+
+      error = JSON.parse(response.body)['errors'].first
+
+      expect(error['status']).to eq('400')
+      expect(error['title']).to match(/operation failed/i)
+      expect(error['detail']).to match(/Tracking number '19' already exists/i)
+    end
+  end
 end

--- a/spec/support/vcr_cassettes/preneeds/burial_forms/burial_form_with_duplicate_tracking_number.yml
+++ b/spec/support/vcr_cassettes/preneeds/burial_forms/burial_form_with_duplicate_tracking_number.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<PRENEEDS_HOST>/eoas_SOA/PreNeedApplicationPort"
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://service.soa.eoas.cem.va.gov/"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:receivePreNeedApplication><preNeedRequest><applicant><applicantEmail>hg@hotmail.com</applicantEmail><applicantPhoneNumber>555-555-5555
+        - 234</applicantPhoneNumber><applicantRelationshipToClaimant>Self</applicantRelationshipToClaimant><completingReason>I
+        don&#39;t know</completingReason><mailingAddress><address1>1st address line
+        1</address1><address2>2nd address line 1</address2><address3>3rd address line
+        1</address3><city>NY</city><countryCode>US</countryCode><postalZip>10000</postalZip><state>NY</state></mailingAddress><name><firstName>first_name1</firstName><lastName>last_name1</lastName><maidenName>maiden_name1</maidenName><middleName>middle_name1</middleName><suffix>Jr.</suffix></name></applicant><applicationStatus>somewhere</applicationStatus><claimant><address><address1>1st
+        address line 2</address1><address2>2nd address line 2</address2><address3>3rd
+        address line 2</address3><city>NY</city><countryCode>US</countryCode><postalZip>10000</postalZip><state>NY</state></address><dateOfBirth>2001-01-31</dateOfBirth><desiredCemetery>400</desiredCemetery><email>a@b.com</email><name><firstName>first_name2</firstName><lastName>last_name2</lastName><maidenName>maiden_name2</maidenName><middleName>middle_name2</middleName><suffix>Jr.</suffix></name><phoneNumber>1234567890</phoneNumber><relationshipToVet>1</relationshipToVet><ssn>123-45-6789</ssn></claimant><currentlyBuriedPersons><cemeteryNumber>400</cemeteryNumber><name><firstName>first_name3</firstName><lastName>last_name3</lastName><maidenName>maiden_name3</maidenName><middleName>middle_name3</middleName><suffix>Jr.</suffix></name></currentlyBuriedPersons><hasAttachments>false</hasAttachments><hasCurrentlyBuried>1</hasCurrentlyBuried><sendingApplication>vets.gov</sendingApplication><sendingCode>abc</sendingCode><sentTime>2017-07-21T04:25:47Z</sentTime><trackingNumber>19</trackingNumber><veteran><address><address1>1st
+        address line 3</address1><address2>2nd address line 3</address2><address3>3rd
+        address line 3</address3><city>NY</city><countryCode>US</countryCode><postalZip>10000</postalZip><state>NY</state></address><currentName><firstName>first_name4</firstName><lastName>last_name4</lastName><maidenName>maiden_name4</maidenName><middleName>middle_name4</middleName><suffix>Jr.</suffix></currentName><dateOfBirth>2001-01-31</dateOfBirth><dateOfDeath>2001-01-31</dateOfDeath><gender>Male</gender><isDeceased>unsure</isDeceased><maritalStatus>Married</maritalStatus><militaryServiceNumber>123456789</militaryServiceNumber><placeOfBirth>Brooklyn,
+        NY</placeOfBirth><serviceName><firstName>first_name5</firstName><lastName>last_name5</lastName><maidenName>maiden_name5</maidenName><middleName>middle_name5</middleName><suffix>Jr.</suffix></serviceName><serviceRecords><branchOfService>AF</branchOfService><dischargeType>1</dischargeType><enteredOnDutyDate>2001-01-31</enteredOnDutyDate><highestRank>GEN</highestRank><nationalGuardState>N</nationalGuardState><releaseFromDutyDate>2001-01-31</releaseFromDutyDate></serviceRecords><ssn>123-45-6789</ssn><vaClaimNumber>123456789</vaClaimNumber><militaryStatus>A</militaryStatus></veteran></preNeedRequest></tns:receivePreNeedApplication></env:Body></env:Envelope>
+    headers:
+      Accept:
+      - text/xml;charset=UTF-8
+      Content-Type:
+      - text/xml;charset=UTF-8
+      User-Agent:
+      - Vets.gov Agent
+      Date:
+      - Fri, 21 Jul 2017 04:25:47 GMT
+      Content-Length:
+      - '3456'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 21 Jul 2017 04:25:47 GMT
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - multipart/related;start="<rootpart*7120dbb5-a30a-4c52-9fd0-cfbfedf17efd@example.jaxws.sun.com>";type="application/xop+xml";boundary="uuid:7120dbb5-a30a-4c52-9fd0-cfbfedf17efd";start-info="text/xml"
+    body:
+      encoding: UTF-8
+      string: "--uuid:7120dbb5-a30a-4c52-9fd0-cfbfedf17efd\r\nContent-Id: <rootpart*7120dbb5-a30a-4c52-9fd0-cfbfedf17efd@example.jaxws.sun.com>\r\nContent-Type:
+        application/xop+xml;charset=utf-8;type=\"text/xml\"\r\nContent-Transfer-Encoding:
+        binary\r\n\r\n<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><ns2:receivePreNeedApplicationResponse
+        xmlns:ns2=\"http://service.soa.eoas.cem.va.gov/\"><return><returnCode>500</returnCode><returnDescription>Error
+        with specified tracking number: Unique Tracking Number Constraint Violation:
+        Tracking number '19' already exists.</returnDescription></return></ns2:receivePreNeedApplicationResponse></S:Body></S:Envelope>\r\n--uuid:7120dbb5-a30a-4c52-9fd0-cfbfedf17efd--"
+    http_version: 
+  recorded_at: Fri, 21 Jul 2017 04:25:47 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/preneeds/burial_forms/burial_form_with_invalid_applicant_address2.yml
+++ b/spec/support/vcr_cassettes/preneeds/burial_forms/burial_form_with_invalid_applicant_address2.yml
@@ -1,0 +1,444 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<PRENEEDS_HOST>/eoas_SOA/PreNeedApplicationPort"
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://service.soa.eoas.cem.va.gov/"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:receivePreNeedApplication><preNeedRequest><applicant><applicantEmail>hg@hotmail.com</applicantEmail><applicantPhoneNumber>555-555-5555
+        - 234</applicantPhoneNumber><applicantRelationshipToClaimant>Self</applicantRelationshipToClaimant><completingReason>I
+        don&#39;t know</completingReason><mailingAddress><address1>1st address line
+        1</address1><address2>111111111111111111111</address2><address3>3rd address
+        line 1</address3><city>NY</city><countryCode>US</countryCode><postalZip>10000</postalZip><state>NY</state></mailingAddress><name><firstName>first_name1</firstName><lastName>last_name1</lastName><maidenName>maiden_name1</maidenName><middleName>middle_name1</middleName><suffix>Jr.</suffix></name></applicant><applicationStatus>somewhere</applicationStatus><claimant><address><address1>1st
+        address line 2</address1><address2>2nd address line 2</address2><address3>3rd
+        address line 2</address3><city>NY</city><countryCode>US</countryCode><postalZip>10000</postalZip><state>NY</state></address><dateOfBirth>2001-01-31</dateOfBirth><desiredCemetery>400</desiredCemetery><email>a@b.com</email><name><firstName>first_name2</firstName><lastName>last_name2</lastName><maidenName>maiden_name2</maidenName><middleName>middle_name2</middleName><suffix>Jr.</suffix></name><phoneNumber>1234567890</phoneNumber><relationshipToVet>1</relationshipToVet><ssn>123-45-6789</ssn></claimant><currentlyBuriedPersons><cemeteryNumber>400</cemeteryNumber><name><firstName>first_name3</firstName><lastName>last_name3</lastName><maidenName>maiden_name3</maidenName><middleName>middle_name3</middleName><suffix>Jr.</suffix></name></currentlyBuriedPersons><hasAttachments>false</hasAttachments><hasCurrentlyBuried>1</hasCurrentlyBuried><sendingApplication>vets.gov</sendingApplication><sendingCode>abc</sendingCode><sentTime>2017-07-20T22:49:46Z</sentTime><trackingNumber>jTaeHz39ZZ1rzW9jZpVG</trackingNumber><veteran><address><address1>1st
+        address line 3</address1><address2>2nd address line 3</address2><address3>3rd
+        address line 3</address3><city>NY</city><countryCode>US</countryCode><postalZip>10000</postalZip><state>NY</state></address><currentName><firstName>first_name4</firstName><lastName>last_name4</lastName><maidenName>maiden_name4</maidenName><middleName>middle_name4</middleName><suffix>Jr.</suffix></currentName><dateOfBirth>2001-01-31</dateOfBirth><dateOfDeath>2001-01-31</dateOfDeath><gender>Male</gender><isDeceased>unsure</isDeceased><maritalStatus>Married</maritalStatus><militaryServiceNumber>123456789</militaryServiceNumber><placeOfBirth>Brooklyn,
+        NY</placeOfBirth><serviceName><firstName>first_name5</firstName><lastName>last_name5</lastName><maidenName>maiden_name5</maidenName><middleName>middle_name5</middleName><suffix>Jr.</suffix></serviceName><serviceRecords><branchOfService>AF</branchOfService><dischargeType>1</dischargeType><enteredOnDutyDate>2001-01-31</enteredOnDutyDate><highestRank>GEN</highestRank><nationalGuardState>N</nationalGuardState><releaseFromDutyDate>2001-01-31</releaseFromDutyDate></serviceRecords><ssn>123-45-6789</ssn><vaClaimNumber>123456789</vaClaimNumber><militaryStatus>A</militaryStatus></veteran></preNeedRequest></tns:receivePreNeedApplication></env:Body></env:Envelope>
+    headers:
+      Accept:
+      - text/xml;charset=UTF-8
+      Content-Type:
+      - text/xml;charset=UTF-8
+      User-Agent:
+      - Vets.gov Agent
+      Date:
+      - Thu, 20 Jul 2017 22:49:46 GMT
+      Content-Length:
+      - '3477'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Thu, 20 Jul 2017 22:49:47 GMT
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - multipart/related;start="<rootpart*40459b67-1374-4d13-93e9-69f35c2cd8c3@example.jaxws.sun.com>";type="application/xop+xml";boundary="uuid:40459b67-1374-4d13-93e9-69f35c2cd8c3";start-info="text/xml"
+    body:
+      encoding: UTF-8
+      string: "--uuid:40459b67-1374-4d13-93e9-69f35c2cd8c3\r\nContent-Id: <rootpart*40459b67-1374-4d13-93e9-69f35c2cd8c3@example.jaxws.sun.com>\r\nContent-Type:
+        application/xop+xml;charset=utf-8;type=\"text/xml\"\r\nContent-Transfer-Encoding:
+        binary\r\n\r\n<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><S:Fault
+        xmlns:ns4=\"http://www.w3.org/2003/05/soap-envelope\"><faultcode>S:Server</faultcode><faultstring>Error
+        committing transaction:; nested exception is: Exception [EclipseLink-4002]
+        (Eclipse Persistence Services - 2.3.1.v20111018-r10243): org.eclipse.persistence.exceptions.DatabaseException\nInternal
+        Exception: java.sql.SQLException: ORA-12899: value too large for column \"EOAS_DATA\".\"PRE_NEED_APPLICANT\".\"ADDRESS2\"
+        (actual: 21, maximum: 20)\n\nError Code: 12899\nCall: INSERT INTO eoas_data.PRE_NEED_APPLICANT
+        (pre_need_id, completing_reason, EMAIL, phone_number, relationship_cd, ADDRESS1,
+        ADDRESS2, ADDRESS3, CITY, country_code, postal_zip, STATE, first_name, last_name,
+        maiden_name, middle_name, suffix) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?)\n\tbind => [24a4e069-09e9-4ac2-acd3-f6062dbc1f4a, I don't
+        know, hg@hotmail.com, 555-555-5555 - 234, Self, 1st address line 1, 111111111111111111111,
+        3rd address line 1, NY, US, 10000, NY, first_name1, last_name1, maiden_name1,
+        middle_name1, Jr.]\nQuery: InsertObjectQuery(Applicant [Name: First Name:
+        first_name1 Middle Name: middle_name1 LastName: last_name1 Suffix: Jr. PhoneNum:
+        555-555-5555 - 234 Email: hg@hotmail.com Address: Add1: 1st address line 1
+        Add2: 111111111111111111111 Add3: 3rd address line 1 City: NY State: NY Zip:
+        10000 Country Code: US RelToClaimant: Self Reason: I don't know])</faultstring><detail><ns2:exception
+        xmlns:ns2=\"http://jax-ws.dev.java.net/\" class=\"javax.ejb.TransactionRolledbackLocalException\"
+        note=\"To disable this feature, set com.sun.xml.ws.fault.SOAPFaultBuilder.disableCaptureStackTrace
+        system property to false\"><message>Error committing transaction:; nested
+        exception is: Exception [EclipseLink-4002] (Eclipse Persistence Services -
+        2.3.1.v20111018-r10243): org.eclipse.persistence.exceptions.DatabaseException\nInternal
+        Exception: java.sql.SQLException: ORA-12899: value too large for column \"EOAS_DATA\".\"PRE_NEED_APPLICANT\".\"ADDRESS2\"
+        (actual: 21, maximum: 20)\n\nError Code: 12899\nCall: INSERT INTO eoas_data.PRE_NEED_APPLICANT
+        (pre_need_id, completing_reason, EMAIL, phone_number, relationship_cd, ADDRESS1,
+        ADDRESS2, ADDRESS3, CITY, country_code, postal_zip, STATE, first_name, last_name,
+        maiden_name, middle_name, suffix) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?)\n\tbind => [24a4e069-09e9-4ac2-acd3-f6062dbc1f4a, I don't
+        know, hg@hotmail.com, 555-555-5555 - 234, Self, 1st address line 1, 111111111111111111111,
+        3rd address line 1, NY, US, 10000, NY, first_name1, last_name1, maiden_name1,
+        middle_name1, Jr.]\nQuery: InsertObjectQuery(Applicant [Name: First Name:
+        first_name1 Middle Name: middle_name1 LastName: last_name1 Suffix: Jr. PhoneNum:
+        555-555-5555 - 234 Email: hg@hotmail.com Address: Add1: 1st address line 1
+        Add2: 111111111111111111111 Add3: 3rd address line 1 City: NY State: NY Zip:
+        10000 Country Code: US RelToClaimant: Self Reason: I don't know])</message><ns2:stackTrace><ns2:frame
+        class=\"weblogic.ejb.container.internal.EJBRuntimeUtils\" file=\"EJBRuntimeUtils.java\"
+        line=\"240\" method=\"throwTransactionRolledbackLocal\"/><ns2:frame class=\"weblogic.ejb.container.internal.EJBRuntimeUtils\"
+        file=\"EJBRuntimeUtils.java\" line=\"138\" method=\"throwEJBException\"/><ns2:frame
+        class=\"weblogic.ejb.container.internal.BaseLocalObject\" file=\"BaseLocalObject.java\"
+        line=\"650\" method=\"postInvoke1\"/><ns2:frame class=\"weblogic.ejb.container.internal.BaseLocalObject\"
+        file=\"BaseLocalObject.java\" line=\"455\" method=\"__WL_postInvokeTxRetry\"/><ns2:frame
+        class=\"weblogic.ejb.container.internal.SessionLocalMethodInvoker\" file=\"SessionLocalMethodInvoker.java\"
+        line=\"52\" method=\"invoke\"/><ns2:frame class=\"gov.va.cem.eoas.service.PreNeedApplicationServiceBean_cidpz4_PreNeedApplicationServiceImpl\"
+        line=\"unknown\" method=\"addApplication\"/><ns2:frame class=\"gov.va.cem.eoas.soa.service.PreNeedApplicationWebService\"
+        file=\"PreNeedApplicationWebService.java\" line=\"227\" method=\"receivePreNeedApplication\"/><ns2:frame
+        class=\"sun.reflect.GeneratedMethodAccessor4562\" line=\"unknown\" method=\"invoke\"/><ns2:frame
+        class=\"sun.reflect.DelegatingMethodAccessorImpl\" file=\"DelegatingMethodAccessorImpl.java\"
+        line=\"56\" method=\"invoke\"/><ns2:frame class=\"java.lang.reflect.Method\"
+        file=\"Method.java\" line=\"620\" method=\"invoke\"/><ns2:frame class=\"weblogic.wsee.jaxws.WLSInstanceResolver$WLSInvoker\"
+        file=\"WLSInstanceResolver.java\" line=\"92\" method=\"invoke\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.WLSInstanceResolver$WLSInvoker\" file=\"WLSInstanceResolver.java\"
+        line=\"74\" method=\"invoke\"/><ns2:frame class=\"com.sun.xml.ws.server.InvokerTube$2\"
+        file=\"InvokerTube.java\" line=\"151\" method=\"invoke\"/><ns2:frame class=\"com.sun.xml.ws.server.sei.EndpointMethodHandlerImpl\"
+        file=\"EndpointMethodHandlerImpl.java\" line=\"268\" method=\"invoke\"/><ns2:frame
+        class=\"com.sun.xml.ws.server.sei.SEIInvokerTube\" file=\"SEIInvokerTube.java\"
+        line=\"100\" method=\"processRequest\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"866\" method=\"__doRun\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"815\" method=\"_doRun\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"778\" method=\"doRun\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"680\" method=\"runSync\"/><ns2:frame class=\"com.sun.xml.ws.server.WSEndpointImpl$2\"
+        file=\"WSEndpointImpl.java\" line=\"403\" method=\"process\"/><ns2:frame class=\"com.sun.xml.ws.transport.http.HttpAdapter$HttpToolkit\"
+        file=\"HttpAdapter.java\" line=\"539\" method=\"handle\"/><ns2:frame class=\"com.sun.xml.ws.transport.http.HttpAdapter\"
+        file=\"HttpAdapter.java\" line=\"253\" method=\"handle\"/><ns2:frame class=\"com.sun.xml.ws.transport.http.servlet.ServletAdapter\"
+        file=\"ServletAdapter.java\" line=\"140\" method=\"handle\"/><ns2:frame class=\"weblogic.wsee.jaxws.WLSServletAdapter\"
+        file=\"WLSServletAdapter.java\" line=\"171\" method=\"handle\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.HttpServletAdapter$AuthorizedInvoke\" file=\"HttpServletAdapter.java\"
+        line=\"708\" method=\"run\"/><ns2:frame class=\"weblogic.security.acl.internal.AuthenticatedSubject\"
+        file=\"AuthenticatedSubject.java\" line=\"363\" method=\"doAs\"/><ns2:frame
+        class=\"weblogic.security.service.SecurityManager\" file=\"SecurityManager.java\"
+        line=\"146\" method=\"runAs\"/><ns2:frame class=\"weblogic.wsee.util.ServerSecurityHelper\"
+        file=\"ServerSecurityHelper.java\" line=\"103\" method=\"authenticatedInvoke\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.HttpServletAdapter$3\" file=\"HttpServletAdapter.java\"
+        line=\"311\" method=\"run\"/><ns2:frame class=\"weblogic.wsee.jaxws.HttpServletAdapter\"
+        file=\"HttpServletAdapter.java\" line=\"336\" method=\"post\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.JAXWSServlet\" file=\"JAXWSServlet.java\" line=\"99\"
+        method=\"doRequest\"/><ns2:frame class=\"weblogic.servlet.http.AbstractAsyncServlet\"
+        file=\"AbstractAsyncServlet.java\" line=\"99\" method=\"service\"/><ns2:frame
+        class=\"javax.servlet.http.HttpServlet\" file=\"HttpServlet.java\" line=\"820\"
+        method=\"service\"/><ns2:frame class=\"weblogic.servlet.internal.StubSecurityHelper$ServletServiceAction\"
+        file=\"StubSecurityHelper.java\" line=\"227\" method=\"run\"/><ns2:frame class=\"weblogic.servlet.internal.StubSecurityHelper\"
+        file=\"StubSecurityHelper.java\" line=\"125\" method=\"invokeServlet\"/><ns2:frame
+        class=\"weblogic.servlet.internal.ServletStubImpl\" file=\"ServletStubImpl.java\"
+        line=\"301\" method=\"execute\"/><ns2:frame class=\"weblogic.servlet.internal.ServletStubImpl\"
+        file=\"ServletStubImpl.java\" line=\"184\" method=\"execute\"/><ns2:frame
+        class=\"weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction\"
+        file=\"WebAppServletContext.java\" line=\"3750\" method=\"wrapRun\"/><ns2:frame
+        class=\"weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction\"
+        file=\"WebAppServletContext.java\" line=\"3714\" method=\"run\"/><ns2:frame
+        class=\"weblogic.security.acl.internal.AuthenticatedSubject\" file=\"AuthenticatedSubject.java\"
+        line=\"321\" method=\"doAs\"/><ns2:frame class=\"weblogic.security.service.SecurityManager\"
+        file=\"SecurityManager.java\" line=\"120\" method=\"runAs\"/><ns2:frame class=\"weblogic.servlet.internal.WebAppServletContext\"
+        file=\"WebAppServletContext.java\" line=\"2283\" method=\"securedExecute\"/><ns2:frame
+        class=\"weblogic.servlet.internal.WebAppServletContext\" file=\"WebAppServletContext.java\"
+        line=\"2182\" method=\"execute\"/><ns2:frame class=\"weblogic.servlet.internal.ServletRequestImpl\"
+        file=\"ServletRequestImpl.java\" line=\"1499\" method=\"run\"/><ns2:frame
+        class=\"weblogic.work.ExecuteThread\" file=\"ExecuteThread.java\" line=\"263\"
+        method=\"execute\"/><ns2:frame class=\"weblogic.work.ExecuteThread\" file=\"ExecuteThread.java\"
+        line=\"221\" method=\"run\"/></ns2:stackTrace><ns2:cause class=\"org.eclipse.persistence.exceptions.DatabaseException\"
+        note=\"To disable this feature, set com.sun.xml.ws.fault.SOAPFaultBuilder.disableCaptureStackTrace
+        system property to false\"><message>\nInternal Exception: java.sql.SQLException:
+        ORA-12899: value too large for column \"EOAS_DATA\".\"PRE_NEED_APPLICANT\".\"ADDRESS2\"
+        (actual: 21, maximum: 20)\n\nError Code: 12899\nCall: INSERT INTO eoas_data.PRE_NEED_APPLICANT
+        (pre_need_id, completing_reason, EMAIL, phone_number, relationship_cd, ADDRESS1,
+        ADDRESS2, ADDRESS3, CITY, country_code, postal_zip, STATE, first_name, last_name,
+        maiden_name, middle_name, suffix) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?)\n\tbind => [24a4e069-09e9-4ac2-acd3-f6062dbc1f4a, I don't
+        know, hg@hotmail.com, 555-555-5555 - 234, Self, 1st address line 1, 111111111111111111111,
+        3rd address line 1, NY, US, 10000, NY, first_name1, last_name1, maiden_name1,
+        middle_name1, Jr.]\nQuery: InsertObjectQuery(Applicant [Name: First Name:
+        first_name1 Middle Name: middle_name1 LastName: last_name1 Suffix: Jr. PhoneNum:
+        555-555-5555 - 234 Email: hg@hotmail.com Address: Add1: 1st address line 1
+        Add2: 111111111111111111111 Add3: 3rd address line 1 City: NY State: NY Zip:
+        10000 Country Code: US RelToClaimant: Self Reason: I don't know])</message><ns2:stackTrace><ns2:frame
+        class=\"org.eclipse.persistence.exceptions.DatabaseException\" file=\"DatabaseException.java\"
+        line=\"324\" method=\"sqlException\"/><ns2:frame class=\"org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor\"
+        file=\"DatabaseAccessor.java\" line=\"840\" method=\"executeDirectNoSelect\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor\"
+        file=\"DatabaseAccessor.java\" line=\"906\" method=\"executeNoSelect\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor\"
+        file=\"DatabaseAccessor.java\" line=\"592\" method=\"basicExecuteCall\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor\"
+        file=\"DatabaseAccessor.java\" line=\"535\" method=\"executeCall\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.AbstractSession\" file=\"AbstractSession.java\"
+        line=\"1717\" method=\"basicExecuteCall\"/><ns2:frame class=\"org.eclipse.persistence.sessions.server.ClientSession\"
+        file=\"ClientSession.java\" line=\"253\" method=\"executeCall\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism\"
+        file=\"DatasourceCallQueryMechanism.java\" line=\"207\" method=\"executeCall\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism\"
+        file=\"DatasourceCallQueryMechanism.java\" line=\"193\" method=\"executeCall\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism\"
+        file=\"DatasourceCallQueryMechanism.java\" line=\"342\" method=\"insertObject\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.StatementQueryMechanism\"
+        file=\"StatementQueryMechanism.java\" line=\"162\" method=\"insertObject\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.StatementQueryMechanism\"
+        file=\"StatementQueryMechanism.java\" line=\"177\" method=\"insertObject\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.DatabaseQueryMechanism\"
+        file=\"DatabaseQueryMechanism.java\" line=\"472\" method=\"insertObjectForWrite\"/><ns2:frame
+        class=\"org.eclipse.persistence.queries.InsertObjectQuery\" file=\"InsertObjectQuery.java\"
+        line=\"80\" method=\"executeCommit\"/><ns2:frame class=\"org.eclipse.persistence.queries.InsertObjectQuery\"
+        file=\"InsertObjectQuery.java\" line=\"90\" method=\"executeCommitWithChangeSet\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.DatabaseQueryMechanism\"
+        file=\"DatabaseQueryMechanism.java\" line=\"287\" method=\"executeWriteWithChangeSet\"/><ns2:frame
+        class=\"org.eclipse.persistence.queries.WriteObjectQuery\" file=\"WriteObjectQuery.java\"
+        line=\"58\" method=\"executeDatabaseQuery\"/><ns2:frame class=\"org.eclipse.persistence.queries.DatabaseQuery\"
+        file=\"DatabaseQuery.java\" line=\"844\" method=\"execute\"/><ns2:frame class=\"org.eclipse.persistence.queries.DatabaseQuery\"
+        file=\"DatabaseQuery.java\" line=\"743\" method=\"executeInUnitOfWork\"/><ns2:frame
+        class=\"org.eclipse.persistence.queries.ObjectLevelModifyQuery\" file=\"ObjectLevelModifyQuery.java\"
+        line=\"108\" method=\"executeInUnitOfWorkObjectLevelModifyQuery\"/><ns2:frame
+        class=\"org.eclipse.persistence.queries.ObjectLevelModifyQuery\" file=\"ObjectLevelModifyQuery.java\"
+        line=\"85\" method=\"executeInUnitOfWork\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.UnitOfWorkImpl\"
+        file=\"UnitOfWorkImpl.java\" line=\"2871\" method=\"internalExecuteQuery\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.AbstractSession\" file=\"AbstractSession.java\"
+        line=\"1516\" method=\"executeQuery\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.AbstractSession\"
+        file=\"AbstractSession.java\" line=\"1498\" method=\"executeQuery\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.AbstractSession\" file=\"AbstractSession.java\"
+        line=\"1449\" method=\"executeQuery\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.CommitManager\"
+        file=\"CommitManager.java\" line=\"224\" method=\"commitNewObjectsForClassWithChangeSet\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.CommitManager\" file=\"CommitManager.java\"
+        line=\"191\" method=\"commitAllObjectsForClassWithChangeSet\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.CommitManager\" file=\"CommitManager.java\"
+        line=\"136\" method=\"commitAllObjectsWithChangeSet\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.AbstractSession\"
+        file=\"AbstractSession.java\" line=\"3799\" method=\"writeAllObjectsWithChangeSet\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.UnitOfWorkImpl\" file=\"UnitOfWorkImpl.java\"
+        line=\"1415\" method=\"commitToDatabase\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.RepeatableWriteUnitOfWork\"
+        file=\"RepeatableWriteUnitOfWork.java\" line=\"636\" method=\"commitToDatabase\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.UnitOfWorkImpl\" file=\"UnitOfWorkImpl.java\"
+        line=\"1505\" method=\"commitToDatabaseWithChangeSet\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.UnitOfWorkImpl\"
+        file=\"UnitOfWorkImpl.java\" line=\"3143\" method=\"issueSQLbeforeCompletion\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.RepeatableWriteUnitOfWork\"
+        file=\"RepeatableWriteUnitOfWork.java\" line=\"346\" method=\"issueSQLbeforeCompletion\"/><ns2:frame
+        class=\"org.eclipse.persistence.transaction.AbstractSynchronizationListener\"
+        file=\"AbstractSynchronizationListener.java\" line=\"157\" method=\"beforeCompletion\"/><ns2:frame
+        class=\"org.eclipse.persistence.transaction.JTASynchronizationListener\" file=\"JTASynchronizationListener.java\"
+        line=\"68\" method=\"beforeCompletion\"/><ns2:frame class=\"weblogic.transaction.internal.ServerSCInfo\"
+        file=\"ServerSCInfo.java\" line=\"1244\" method=\"doBeforeCompletion\"/><ns2:frame
+        class=\"weblogic.transaction.internal.ServerSCInfo\" file=\"ServerSCInfo.java\"
+        line=\"1219\" method=\"callBeforeCompletions\"/><ns2:frame class=\"weblogic.transaction.internal.ServerSCInfo\"
+        file=\"ServerSCInfo.java\" line=\"121\" method=\"startPrePrepareAndChain\"/><ns2:frame
+        class=\"weblogic.transaction.internal.ServerTransactionImpl\" file=\"ServerTransactionImpl.java\"
+        line=\"1355\" method=\"localPrePrepareAndChain\"/><ns2:frame class=\"weblogic.transaction.internal.ServerTransactionImpl\"
+        file=\"ServerTransactionImpl.java\" line=\"2172\" method=\"globalPrePrepare\"/><ns2:frame
+        class=\"weblogic.transaction.internal.ServerTransactionImpl\" file=\"ServerTransactionImpl.java\"
+        line=\"300\" method=\"internalCommit\"/><ns2:frame class=\"weblogic.transaction.internal.ServerTransactionImpl\"
+        file=\"ServerTransactionImpl.java\" line=\"267\" method=\"commit\"/><ns2:frame
+        class=\"weblogic.ejb.container.internal.BaseLocalObject\" file=\"BaseLocalObject.java\"
+        line=\"622\" method=\"postInvoke1\"/><ns2:frame class=\"weblogic.ejb.container.internal.BaseLocalObject\"
+        file=\"BaseLocalObject.java\" line=\"455\" method=\"__WL_postInvokeTxRetry\"/><ns2:frame
+        class=\"weblogic.ejb.container.internal.SessionLocalMethodInvoker\" file=\"SessionLocalMethodInvoker.java\"
+        line=\"52\" method=\"invoke\"/><ns2:frame class=\"gov.va.cem.eoas.service.PreNeedApplicationServiceBean_cidpz4_PreNeedApplicationServiceImpl\"
+        line=\"unknown\" method=\"addApplication\"/><ns2:frame class=\"gov.va.cem.eoas.soa.service.PreNeedApplicationWebService\"
+        file=\"PreNeedApplicationWebService.java\" line=\"227\" method=\"receivePreNeedApplication\"/><ns2:frame
+        class=\"sun.reflect.GeneratedMethodAccessor4562\" line=\"unknown\" method=\"invoke\"/><ns2:frame
+        class=\"sun.reflect.DelegatingMethodAccessorImpl\" file=\"DelegatingMethodAccessorImpl.java\"
+        line=\"56\" method=\"invoke\"/><ns2:frame class=\"java.lang.reflect.Method\"
+        file=\"Method.java\" line=\"620\" method=\"invoke\"/><ns2:frame class=\"weblogic.wsee.jaxws.WLSInstanceResolver$WLSInvoker\"
+        file=\"WLSInstanceResolver.java\" line=\"92\" method=\"invoke\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.WLSInstanceResolver$WLSInvoker\" file=\"WLSInstanceResolver.java\"
+        line=\"74\" method=\"invoke\"/><ns2:frame class=\"com.sun.xml.ws.server.InvokerTube$2\"
+        file=\"InvokerTube.java\" line=\"151\" method=\"invoke\"/><ns2:frame class=\"com.sun.xml.ws.server.sei.EndpointMethodHandlerImpl\"
+        file=\"EndpointMethodHandlerImpl.java\" line=\"268\" method=\"invoke\"/><ns2:frame
+        class=\"com.sun.xml.ws.server.sei.SEIInvokerTube\" file=\"SEIInvokerTube.java\"
+        line=\"100\" method=\"processRequest\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"866\" method=\"__doRun\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"815\" method=\"_doRun\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"778\" method=\"doRun\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"680\" method=\"runSync\"/><ns2:frame class=\"com.sun.xml.ws.server.WSEndpointImpl$2\"
+        file=\"WSEndpointImpl.java\" line=\"403\" method=\"process\"/><ns2:frame class=\"com.sun.xml.ws.transport.http.HttpAdapter$HttpToolkit\"
+        file=\"HttpAdapter.java\" line=\"539\" method=\"handle\"/><ns2:frame class=\"com.sun.xml.ws.transport.http.HttpAdapter\"
+        file=\"HttpAdapter.java\" line=\"253\" method=\"handle\"/><ns2:frame class=\"com.sun.xml.ws.transport.http.servlet.ServletAdapter\"
+        file=\"ServletAdapter.java\" line=\"140\" method=\"handle\"/><ns2:frame class=\"weblogic.wsee.jaxws.WLSServletAdapter\"
+        file=\"WLSServletAdapter.java\" line=\"171\" method=\"handle\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.HttpServletAdapter$AuthorizedInvoke\" file=\"HttpServletAdapter.java\"
+        line=\"708\" method=\"run\"/><ns2:frame class=\"weblogic.security.acl.internal.AuthenticatedSubject\"
+        file=\"AuthenticatedSubject.java\" line=\"363\" method=\"doAs\"/><ns2:frame
+        class=\"weblogic.security.service.SecurityManager\" file=\"SecurityManager.java\"
+        line=\"146\" method=\"runAs\"/><ns2:frame class=\"weblogic.wsee.util.ServerSecurityHelper\"
+        file=\"ServerSecurityHelper.java\" line=\"103\" method=\"authenticatedInvoke\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.HttpServletAdapter$3\" file=\"HttpServletAdapter.java\"
+        line=\"311\" method=\"run\"/><ns2:frame class=\"weblogic.wsee.jaxws.HttpServletAdapter\"
+        file=\"HttpServletAdapter.java\" line=\"336\" method=\"post\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.JAXWSServlet\" file=\"JAXWSServlet.java\" line=\"99\"
+        method=\"doRequest\"/><ns2:frame class=\"weblogic.servlet.http.AbstractAsyncServlet\"
+        file=\"AbstractAsyncServlet.java\" line=\"99\" method=\"service\"/><ns2:frame
+        class=\"javax.servlet.http.HttpServlet\" file=\"HttpServlet.java\" line=\"820\"
+        method=\"service\"/><ns2:frame class=\"weblogic.servlet.internal.StubSecurityHelper$ServletServiceAction\"
+        file=\"StubSecurityHelper.java\" line=\"227\" method=\"run\"/><ns2:frame class=\"weblogic.servlet.internal.StubSecurityHelper\"
+        file=\"StubSecurityHelper.java\" line=\"125\" method=\"invokeServlet\"/><ns2:frame
+        class=\"weblogic.servlet.internal.ServletStubImpl\" file=\"ServletStubImpl.java\"
+        line=\"301\" method=\"execute\"/><ns2:frame class=\"weblogic.servlet.internal.ServletStubImpl\"
+        file=\"ServletStubImpl.java\" line=\"184\" method=\"execute\"/><ns2:frame
+        class=\"weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction\"
+        file=\"WebAppServletContext.java\" line=\"3750\" method=\"wrapRun\"/><ns2:frame
+        class=\"weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction\"
+        file=\"WebAppServletContext.java\" line=\"3714\" method=\"run\"/><ns2:frame
+        class=\"weblogic.security.acl.internal.AuthenticatedSubject\" file=\"AuthenticatedSubject.java\"
+        line=\"321\" method=\"doAs\"/><ns2:frame class=\"weblogic.security.service.SecurityManager\"
+        file=\"SecurityManager.java\" line=\"120\" method=\"runAs\"/><ns2:frame class=\"weblogic.servlet.internal.WebAppServletContext\"
+        file=\"WebAppServletContext.java\" line=\"2283\" method=\"securedExecute\"/><ns2:frame
+        class=\"weblogic.servlet.internal.WebAppServletContext\" file=\"WebAppServletContext.java\"
+        line=\"2182\" method=\"execute\"/><ns2:frame class=\"weblogic.servlet.internal.ServletRequestImpl\"
+        file=\"ServletRequestImpl.java\" line=\"1499\" method=\"run\"/><ns2:frame
+        class=\"weblogic.work.ExecuteThread\" file=\"ExecuteThread.java\" line=\"263\"
+        method=\"execute\"/><ns2:frame class=\"weblogic.work.ExecuteThread\" file=\"ExecuteThread.java\"
+        line=\"221\" method=\"run\"/></ns2:stackTrace><ns2:cause class=\"java.sql.SQLException\"
+        note=\"To disable this feature, set com.sun.xml.ws.fault.SOAPFaultBuilder.disableCaptureStackTrace
+        system property to false\"><message>ORA-12899: value too large for column
+        \"EOAS_DATA\".\"PRE_NEED_APPLICANT\".\"ADDRESS2\" (actual: 21, maximum: 20)\n</message><ns2:stackTrace><ns2:frame
+        class=\"oracle.jdbc.driver.T4CTTIoer\" file=\"T4CTTIoer.java\" line=\"445\"
+        method=\"processError\"/><ns2:frame class=\"oracle.jdbc.driver.T4CTTIoer\"
+        file=\"T4CTTIoer.java\" line=\"396\" method=\"processError\"/><ns2:frame class=\"oracle.jdbc.driver.T4C8Oall\"
+        file=\"T4C8Oall.java\" line=\"879\" method=\"processError\"/><ns2:frame class=\"oracle.jdbc.driver.T4CTTIfun\"
+        file=\"T4CTTIfun.java\" line=\"450\" method=\"receive\"/><ns2:frame class=\"oracle.jdbc.driver.T4CTTIfun\"
+        file=\"T4CTTIfun.java\" line=\"192\" method=\"doRPC\"/><ns2:frame class=\"oracle.jdbc.driver.T4C8Oall\"
+        file=\"T4C8Oall.java\" line=\"531\" method=\"doOALL\"/><ns2:frame class=\"oracle.jdbc.driver.T4CPreparedStatement\"
+        file=\"T4CPreparedStatement.java\" line=\"207\" method=\"doOall8\"/><ns2:frame
+        class=\"oracle.jdbc.driver.T4CPreparedStatement\" file=\"T4CPreparedStatement.java\"
+        line=\"1044\" method=\"executeForRows\"/><ns2:frame class=\"oracle.jdbc.driver.OracleStatement\"
+        file=\"OracleStatement.java\" line=\"1329\" method=\"doExecuteWithTimeout\"/><ns2:frame
+        class=\"oracle.jdbc.driver.OraclePreparedStatement\" file=\"OraclePreparedStatement.java\"
+        line=\"3593\" method=\"executeInternal\"/><ns2:frame class=\"oracle.jdbc.driver.OraclePreparedStatement\"
+        file=\"OraclePreparedStatement.java\" line=\"3674\" method=\"executeUpdate\"/><ns2:frame
+        class=\"oracle.jdbc.driver.OraclePreparedStatementWrapper\" file=\"OraclePreparedStatementWrapper.java\"
+        line=\"1354\" method=\"executeUpdate\"/><ns2:frame class=\"weblogic.jdbc.wrapper.PreparedStatement\"
+        file=\"PreparedStatement.java\" line=\"172\" method=\"executeUpdate\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor\"
+        file=\"DatabaseAccessor.java\" line=\"831\" method=\"executeDirectNoSelect\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor\"
+        file=\"DatabaseAccessor.java\" line=\"906\" method=\"executeNoSelect\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor\"
+        file=\"DatabaseAccessor.java\" line=\"592\" method=\"basicExecuteCall\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor\"
+        file=\"DatabaseAccessor.java\" line=\"535\" method=\"executeCall\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.AbstractSession\" file=\"AbstractSession.java\"
+        line=\"1717\" method=\"basicExecuteCall\"/><ns2:frame class=\"org.eclipse.persistence.sessions.server.ClientSession\"
+        file=\"ClientSession.java\" line=\"253\" method=\"executeCall\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism\"
+        file=\"DatasourceCallQueryMechanism.java\" line=\"207\" method=\"executeCall\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism\"
+        file=\"DatasourceCallQueryMechanism.java\" line=\"193\" method=\"executeCall\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism\"
+        file=\"DatasourceCallQueryMechanism.java\" line=\"342\" method=\"insertObject\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.StatementQueryMechanism\"
+        file=\"StatementQueryMechanism.java\" line=\"162\" method=\"insertObject\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.StatementQueryMechanism\"
+        file=\"StatementQueryMechanism.java\" line=\"177\" method=\"insertObject\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.DatabaseQueryMechanism\"
+        file=\"DatabaseQueryMechanism.java\" line=\"472\" method=\"insertObjectForWrite\"/><ns2:frame
+        class=\"org.eclipse.persistence.queries.InsertObjectQuery\" file=\"InsertObjectQuery.java\"
+        line=\"80\" method=\"executeCommit\"/><ns2:frame class=\"org.eclipse.persistence.queries.InsertObjectQuery\"
+        file=\"InsertObjectQuery.java\" line=\"90\" method=\"executeCommitWithChangeSet\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.queries.DatabaseQueryMechanism\"
+        file=\"DatabaseQueryMechanism.java\" line=\"287\" method=\"executeWriteWithChangeSet\"/><ns2:frame
+        class=\"org.eclipse.persistence.queries.WriteObjectQuery\" file=\"WriteObjectQuery.java\"
+        line=\"58\" method=\"executeDatabaseQuery\"/><ns2:frame class=\"org.eclipse.persistence.queries.DatabaseQuery\"
+        file=\"DatabaseQuery.java\" line=\"844\" method=\"execute\"/><ns2:frame class=\"org.eclipse.persistence.queries.DatabaseQuery\"
+        file=\"DatabaseQuery.java\" line=\"743\" method=\"executeInUnitOfWork\"/><ns2:frame
+        class=\"org.eclipse.persistence.queries.ObjectLevelModifyQuery\" file=\"ObjectLevelModifyQuery.java\"
+        line=\"108\" method=\"executeInUnitOfWorkObjectLevelModifyQuery\"/><ns2:frame
+        class=\"org.eclipse.persistence.queries.ObjectLevelModifyQuery\" file=\"ObjectLevelModifyQuery.java\"
+        line=\"85\" method=\"executeInUnitOfWork\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.UnitOfWorkImpl\"
+        file=\"UnitOfWorkImpl.java\" line=\"2871\" method=\"internalExecuteQuery\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.AbstractSession\" file=\"AbstractSession.java\"
+        line=\"1516\" method=\"executeQuery\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.AbstractSession\"
+        file=\"AbstractSession.java\" line=\"1498\" method=\"executeQuery\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.AbstractSession\" file=\"AbstractSession.java\"
+        line=\"1449\" method=\"executeQuery\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.CommitManager\"
+        file=\"CommitManager.java\" line=\"224\" method=\"commitNewObjectsForClassWithChangeSet\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.CommitManager\" file=\"CommitManager.java\"
+        line=\"191\" method=\"commitAllObjectsForClassWithChangeSet\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.CommitManager\" file=\"CommitManager.java\"
+        line=\"136\" method=\"commitAllObjectsWithChangeSet\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.AbstractSession\"
+        file=\"AbstractSession.java\" line=\"3799\" method=\"writeAllObjectsWithChangeSet\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.UnitOfWorkImpl\" file=\"UnitOfWorkImpl.java\"
+        line=\"1415\" method=\"commitToDatabase\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.RepeatableWriteUnitOfWork\"
+        file=\"RepeatableWriteUnitOfWork.java\" line=\"636\" method=\"commitToDatabase\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.UnitOfWorkImpl\" file=\"UnitOfWorkImpl.java\"
+        line=\"1505\" method=\"commitToDatabaseWithChangeSet\"/><ns2:frame class=\"org.eclipse.persistence.internal.sessions.UnitOfWorkImpl\"
+        file=\"UnitOfWorkImpl.java\" line=\"3143\" method=\"issueSQLbeforeCompletion\"/><ns2:frame
+        class=\"org.eclipse.persistence.internal.sessions.RepeatableWriteUnitOfWork\"
+        file=\"RepeatableWriteUnitOfWork.java\" line=\"346\" method=\"issueSQLbeforeCompletion\"/><ns2:frame
+        class=\"org.eclipse.persistence.transaction.AbstractSynchronizationListener\"
+        file=\"AbstractSynchronizationListener.java\" line=\"157\" method=\"beforeCompletion\"/><ns2:frame
+        class=\"org.eclipse.persistence.transaction.JTASynchronizationListener\" file=\"JTASynchronizationListener.java\"
+        line=\"68\" method=\"beforeCompletion\"/><ns2:frame class=\"weblogic.transaction.internal.ServerSCInfo\"
+        file=\"ServerSCInfo.java\" line=\"1244\" method=\"doBeforeCompletion\"/><ns2:frame
+        class=\"weblogic.transaction.internal.ServerSCInfo\" file=\"ServerSCInfo.java\"
+        line=\"1219\" method=\"callBeforeCompletions\"/><ns2:frame class=\"weblogic.transaction.internal.ServerSCInfo\"
+        file=\"ServerSCInfo.java\" line=\"121\" method=\"startPrePrepareAndChain\"/><ns2:frame
+        class=\"weblogic.transaction.internal.ServerTransactionImpl\" file=\"ServerTransactionImpl.java\"
+        line=\"1355\" method=\"localPrePrepareAndChain\"/><ns2:frame class=\"weblogic.transaction.internal.ServerTransactionImpl\"
+        file=\"ServerTransactionImpl.java\" line=\"2172\" method=\"globalPrePrepare\"/><ns2:frame
+        class=\"weblogic.transaction.internal.ServerTransactionImpl\" file=\"ServerTransactionImpl.java\"
+        line=\"300\" method=\"internalCommit\"/><ns2:frame class=\"weblogic.transaction.internal.ServerTransactionImpl\"
+        file=\"ServerTransactionImpl.java\" line=\"267\" method=\"commit\"/><ns2:frame
+        class=\"weblogic.ejb.container.internal.BaseLocalObject\" file=\"BaseLocalObject.java\"
+        line=\"622\" method=\"postInvoke1\"/><ns2:frame class=\"weblogic.ejb.container.internal.BaseLocalObject\"
+        file=\"BaseLocalObject.java\" line=\"455\" method=\"__WL_postInvokeTxRetry\"/><ns2:frame
+        class=\"weblogic.ejb.container.internal.SessionLocalMethodInvoker\" file=\"SessionLocalMethodInvoker.java\"
+        line=\"52\" method=\"invoke\"/><ns2:frame class=\"gov.va.cem.eoas.service.PreNeedApplicationServiceBean_cidpz4_PreNeedApplicationServiceImpl\"
+        line=\"unknown\" method=\"addApplication\"/><ns2:frame class=\"gov.va.cem.eoas.soa.service.PreNeedApplicationWebService\"
+        file=\"PreNeedApplicationWebService.java\" line=\"227\" method=\"receivePreNeedApplication\"/><ns2:frame
+        class=\"sun.reflect.GeneratedMethodAccessor4562\" line=\"unknown\" method=\"invoke\"/><ns2:frame
+        class=\"sun.reflect.DelegatingMethodAccessorImpl\" file=\"DelegatingMethodAccessorImpl.java\"
+        line=\"56\" method=\"invoke\"/><ns2:frame class=\"java.lang.reflect.Method\"
+        file=\"Method.java\" line=\"620\" method=\"invoke\"/><ns2:frame class=\"weblogic.wsee.jaxws.WLSInstanceResolver$WLSInvoker\"
+        file=\"WLSInstanceResolver.java\" line=\"92\" method=\"invoke\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.WLSInstanceResolver$WLSInvoker\" file=\"WLSInstanceResolver.java\"
+        line=\"74\" method=\"invoke\"/><ns2:frame class=\"com.sun.xml.ws.server.InvokerTube$2\"
+        file=\"InvokerTube.java\" line=\"151\" method=\"invoke\"/><ns2:frame class=\"com.sun.xml.ws.server.sei.EndpointMethodHandlerImpl\"
+        file=\"EndpointMethodHandlerImpl.java\" line=\"268\" method=\"invoke\"/><ns2:frame
+        class=\"com.sun.xml.ws.server.sei.SEIInvokerTube\" file=\"SEIInvokerTube.java\"
+        line=\"100\" method=\"processRequest\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"866\" method=\"__doRun\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"815\" method=\"_doRun\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"778\" method=\"doRun\"/><ns2:frame class=\"com.sun.xml.ws.api.pipe.Fiber\"
+        file=\"Fiber.java\" line=\"680\" method=\"runSync\"/><ns2:frame class=\"com.sun.xml.ws.server.WSEndpointImpl$2\"
+        file=\"WSEndpointImpl.java\" line=\"403\" method=\"process\"/><ns2:frame class=\"com.sun.xml.ws.transport.http.HttpAdapter$HttpToolkit\"
+        file=\"HttpAdapter.java\" line=\"539\" method=\"handle\"/><ns2:frame class=\"com.sun.xml.ws.transport.http.HttpAdapter\"
+        file=\"HttpAdapter.java\" line=\"253\" method=\"handle\"/><ns2:frame class=\"com.sun.xml.ws.transport.http.servlet.ServletAdapter\"
+        file=\"ServletAdapter.java\" line=\"140\" method=\"handle\"/><ns2:frame class=\"weblogic.wsee.jaxws.WLSServletAdapter\"
+        file=\"WLSServletAdapter.java\" line=\"171\" method=\"handle\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.HttpServletAdapter$AuthorizedInvoke\" file=\"HttpServletAdapter.java\"
+        line=\"708\" method=\"run\"/><ns2:frame class=\"weblogic.security.acl.internal.AuthenticatedSubject\"
+        file=\"AuthenticatedSubject.java\" line=\"363\" method=\"doAs\"/><ns2:frame
+        class=\"weblogic.security.service.SecurityManager\" file=\"SecurityManager.java\"
+        line=\"146\" method=\"runAs\"/><ns2:frame class=\"weblogic.wsee.util.ServerSecurityHelper\"
+        file=\"ServerSecurityHelper.java\" line=\"103\" method=\"authenticatedInvoke\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.HttpServletAdapter$3\" file=\"HttpServletAdapter.java\"
+        line=\"311\" method=\"run\"/><ns2:frame class=\"weblogic.wsee.jaxws.HttpServletAdapter\"
+        file=\"HttpServletAdapter.java\" line=\"336\" method=\"post\"/><ns2:frame
+        class=\"weblogic.wsee.jaxws.JAXWSServlet\" file=\"JAXWSServlet.java\" line=\"99\"
+        method=\"doRequest\"/><ns2:frame class=\"weblogic.servlet.http.AbstractAsyncServlet\"
+        file=\"AbstractAsyncServlet.java\" line=\"99\" method=\"service\"/><ns2:frame
+        class=\"javax.servlet.http.HttpServlet\" file=\"HttpServlet.java\" line=\"820\"
+        method=\"service\"/><ns2:frame class=\"weblogic.servlet.internal.StubSecurityHelper$ServletServiceAction\"
+        file=\"StubSecurityHelper.java\" line=\"227\" method=\"run\"/><ns2:frame class=\"weblogic.servlet.internal.StubSecurityHelper\"
+        file=\"StubSecurityHelper.java\" line=\"125\" method=\"invokeServlet\"/><ns2:frame
+        class=\"weblogic.servlet.internal.ServletStubImpl\" file=\"ServletStubImpl.java\"
+        line=\"301\" method=\"execute\"/><ns2:frame class=\"weblogic.servlet.internal.ServletStubImpl\"
+        file=\"ServletStubImpl.java\" line=\"184\" method=\"execute\"/><ns2:frame
+        class=\"weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction\"
+        file=\"WebAppServletContext.java\" line=\"3750\" method=\"wrapRun\"/><ns2:frame
+        class=\"weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction\"
+        file=\"WebAppServletContext.java\" line=\"3714\" method=\"run\"/><ns2:frame
+        class=\"weblogic.security.acl.internal.AuthenticatedSubject\" file=\"AuthenticatedSubject.java\"
+        line=\"321\" method=\"doAs\"/><ns2:frame class=\"weblogic.security.service.SecurityManager\"
+        file=\"SecurityManager.java\" line=\"120\" method=\"runAs\"/><ns2:frame class=\"weblogic.servlet.internal.WebAppServletContext\"
+        file=\"WebAppServletContext.java\" line=\"2283\" method=\"securedExecute\"/><ns2:frame
+        class=\"weblogic.servlet.internal.WebAppServletContext\" file=\"WebAppServletContext.java\"
+        line=\"2182\" method=\"execute\"/><ns2:frame class=\"weblogic.servlet.internal.ServletRequestImpl\"
+        file=\"ServletRequestImpl.java\" line=\"1499\" method=\"run\"/><ns2:frame
+        class=\"weblogic.work.ExecuteThread\" file=\"ExecuteThread.java\" line=\"263\"
+        method=\"execute\"/><ns2:frame class=\"weblogic.work.ExecuteThread\" file=\"ExecuteThread.java\"
+        line=\"221\" method=\"run\"/></ns2:stackTrace></ns2:cause></ns2:cause></ns2:exception></detail></S:Fault></S:Body></S:Envelope>\r\n--uuid:40459b67-1374-4d13-93e9-69f35c2cd8c3--"
+    http_version: 
+  recorded_at: Thu, 20 Jul 2017 22:49:47 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Added error handling for EOAS returned errors. Most errors from EOAS are returned with a 500 status and no minor codes. To figure out the exact nature of the error require parsing of the `<faultstring>` looking for tell-tale phrases to get more info. Also, some EOAS errors are returned with a status of 200, but a `<returnCode>500</returnCode>` in the body. This will handle both types, and return VA900.

Also stripping out tabs and newlines from body response, they affect the regexes that search for the errors. No valid EOAS response has tabs or newlines.