### PR TITLE
Statsd for GIBS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,6 @@ gem 'combine_pdf'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: :ruby
-  gem 'rb-readline'
 
   # Used to colorize output for rake tasks
   gem "rainbow"

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ gem 'combine_pdf'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: :ruby
+  gem 'rb-readline'
 
   # Used to colorize output for rake tasks
   gem "rainbow"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    rb-readline (0.5.4)
     rdoc (4.2.2)
       json (~> 1.4)
     redis (3.3.3)
@@ -494,6 +495,7 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rails-api
   rainbow
+  rb-readline
   redis
   redis-namespace
   rspec-rails (~> 3.5)
@@ -526,4 +528,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.14.6
+   1.15.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,6 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    rb-readline (0.5.4)
     rdoc (4.2.2)
       json (~> 1.4)
     redis (3.3.3)
@@ -495,7 +494,6 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rails-api
   rainbow
-  rb-readline
   redis
   redis-namespace
   rspec-rails (~> 3.5)

--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -15,8 +15,6 @@ module V0
                serializer: Post911GIBillStatusSerializer,
                meta: response.metadata
       else
-        # EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS
-        puts "BILLZ #{EVSS::GIBillStatus::GiBillStatusResponse::KNOWN_ERRORS}"
         error_type = response.error_type
         StatsD.increment(STATSD_GI_BILL_FAIL_KEY, tags: ["error:#{error_type}"])
         case error_type

--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -10,26 +10,14 @@ module V0
 
     def show
       response = service.get_gi_bill_status
-      if response.is_success?
+      if response.success?
         render json: response,
                serializer: Post911GIBillStatusSerializer,
                meta: response.metadata
       else
         error_type = response.error_type
         StatsD.increment(STATSD_GI_BILL_FAIL_KEY, tags: ["error:#{error_type}"])
-        case error_type
-        when EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS[:evss_error]
-          raise EVSS::GiBillStatus::ServiceException
-        when EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS[:vet_not_found]
-          raise Common::Exceptions::RecordNotFound, @current_user.email
-        when EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS[:timeout]
-          raise Common::Exceptions::GatewayTimeout
-        when EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS[:invalid_auth]
-          raise Common::Exceptions::Forbidden, detail: 'Missing correlation id'
-        else
-          log_message_to_sentry('Unexpected EVSS GiBillStatus Response', :error, response.to_h)
-          raise Common::Exceptions::InternalServerError
-        end
+        render_error_json(error_type)
       end
     ensure
       StatsD.increment(STATSD_GI_BILL_TOTAL_KEY)
@@ -41,6 +29,27 @@ module V0
       EVSS::GiBillStatus::ServiceFactory.get_service(
         user: @current_user, mock_service: Settings.evss.mock_gi_bill_status
       )
+    end
+
+    def render_error_json(error_type)
+      case error_type
+      when EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS[:evss_error]
+        # 503
+        raise EVSS::GiBillStatus::ServiceException
+      when EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS[:vet_not_found]
+        # 404
+        raise Common::Exceptions::RecordNotFound, @current_user.email
+      when EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS[:timeout]
+        # 504
+        raise Common::Exceptions::GatewayTimeout
+      when EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS[:invalid_auth]
+        # 403
+        raise Common::Exceptions::Forbidden, detail: 'Missing correlation id'
+      else
+        # 500
+        log_message_to_sentry('Unexpected EVSS GiBillStatus Response', :error, response.to_h)
+        raise Common::Exceptions::InternalServerError
+      end
     end
   end
 end

--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -3,6 +3,9 @@ module V0
   class Post911GIBillStatusesController < ApplicationController
     include SentryLogging
 
+    STATSD_GI_BILL_TOTAL_KEY = 'api.evss.gi_bill_status.total'
+    STATSD_GI_BILL_FAIL_KEY = 'api.evss.gi_bill_status.fail'
+
     def show
       response = service.get_gi_bill_status
       if response.contains_education_info?
@@ -12,21 +15,28 @@ module V0
                meta: response.metadata
       elsif response.evss_error?
         # 503
+        StatsD.increment(STATSD_GI_BILL_FAIL_KEY, tags: ['error:evss_error'])
         raise EVSS::GiBillStatus::ServiceException
       elsif response.vet_not_found?
         # 404
+        StatsD.increment(STATSD_GI_BILL_FAIL_KEY, tags: ['error:vet_not_found'])
         raise Common::Exceptions::RecordNotFound, @current_user.email
       elsif response.timeout?
         # 504
+        StatsD.increment(STATSD_GI_BILL_FAIL_KEY, tags: ['error:timeout'])
         raise Common::Exceptions::GatewayTimeout
       elsif response.invalid_auth?
         # 403
+        StatsD.increment(STATSD_GI_BILL_FAIL_KEY, tags: ['error:invalid_auth'])
         raise Common::Exceptions::Forbidden, detail: 'Missing correlation id'
       else
         # 500
+        StatsD.increment(STATSD_GI_BILL_FAIL_KEY, tags: ['error:unknown'])
         log_message_to_sentry('Unexpected EVSS GiBillStatus Response', :error, response.to_h)
         raise Common::Exceptions::InternalServerError
       end
+    ensure
+      StatsD.increment(STATSD_GI_BILL_TOTAL_KEY)
     end
 
     private

--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -25,12 +25,6 @@ module V0
 
     private
 
-    def service
-      EVSS::GiBillStatus::ServiceFactory.get_service(
-        user: @current_user, mock_service: Settings.evss.mock_gi_bill_status
-      )
-    end
-
     def render_error_json(error_type)
       case error_type
       when EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS[:evss_error]
@@ -50,6 +44,12 @@ module V0
         log_message_to_sentry('Unexpected EVSS GiBillStatus Response', :error, response.to_h)
         raise Common::Exceptions::InternalServerError
       end
+    end
+
+    def service
+      EVSS::GiBillStatus::ServiceFactory.get_service(
+        user: @current_user, mock_service: Settings.evss.mock_gi_bill_status
+      )
     end
   end
 end

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -16,3 +16,10 @@ StatsD.increment(V0::SessionsController::STATSD_LOGIN_FAILED_KEY, 0, tags: ['err
 SAML::AuthFailHandler::KNOWN_ERRORS.each do |known_error|
   StatsD.increment(V0::SessionsController::STATSD_LOGIN_FAILED_KEY, 0, tags: ["error:#{known_error}"])
 end
+
+# init GiBillStatus stats to 0
+StatsD.increment(V0::Post911GIBillStatusesController::STATSD_GI_BILL_TOTAL_KEY, 0)
+StatsD.increment(V0::Post911GIBillStatusesController::STATSD_GI_BILL_FAIL_KEY, 0, tags: ['error:unknown'])
+EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS.each do |_error_key, error_val|
+  StatsD.increment(V0::Post911GIBillStatusesController::STATSD_GI_BILL_FAIL_KEY, 0, tags: ["error:#{error_val}"])
+end

--- a/lib/evss/gi_bill_status/gi_bill_status_response.rb
+++ b/lib/evss/gi_bill_status/gi_bill_status_response.rb
@@ -30,7 +30,12 @@ module EVSS
         'education.service.error'
       ].freeze
 
-      ERRORS = %i(evss_error vet_not_found timeout invalid_auth).freeze
+      KNOWN_ERRORS = {
+        :evss_error => 'evss_error',
+        :vet_not_found => 'vet_not_found',
+        :timeout => 'timeout',
+        :invalid_auth => 'invalid_auth'
+      }.freeze
 
       def initialize(status, response = nil, timeout = false, content_type = 'application/json')
         @timeout = timeout
@@ -45,8 +50,8 @@ module EVSS
       end
 
       def error_type
-        ERRORS.each do |error|
-          return error if send("#{error}?")
+        KNOWN_ERRORS.each do |error_key, error_val|
+          return error_val if send("#{error_val}?")
         end
 
         'unknown'

--- a/lib/evss/gi_bill_status/gi_bill_status_response.rb
+++ b/lib/evss/gi_bill_status/gi_bill_status_response.rb
@@ -31,10 +31,10 @@ module EVSS
       ].freeze
 
       KNOWN_ERRORS = {
-        :evss_error => 'evss_error',
-        :vet_not_found => 'vet_not_found',
-        :timeout => 'timeout',
-        :invalid_auth => 'invalid_auth'
+        evss_error: 'evss_error',
+        vet_not_found: 'vet_not_found',
+        timeout: 'timeout',
+        invalid_auth: 'invalid_auth'
       }.freeze
 
       def initialize(status, response = nil, timeout = false, content_type = 'application/json')
@@ -45,12 +45,12 @@ module EVSS
         super(status, attributes)
       end
 
-      def is_success?
+      def success?
         contains_education_info?
       end
 
       def error_type
-        KNOWN_ERRORS.each do |error_key, error_val|
+        KNOWN_ERRORS.each do |_error_key, error_val|
           return error_val if send("#{error_val}?")
         end
 

--- a/lib/evss/gi_bill_status/gi_bill_status_response.rb
+++ b/lib/evss/gi_bill_status/gi_bill_status_response.rb
@@ -59,7 +59,6 @@ module EVSS
 
       private
 
-      ### ERROR types ###
       def timeout?
         @timeout
       end
@@ -78,7 +77,6 @@ module EVSS
         return false if @response.nil?
         @response&.body&.to_s&.include?('AUTH_INVALID_IDENTITY') || @response&.status == 403
       end
-      ################
 
       def contains_education_info?
         return false if @response.nil? || text_response?


### PR DESCRIPTION
- Added `StatsD` **total** & **fail** counters the latter of which has a `error_type` tag
- Refactored the `show` method:
  - No longer has each error method as public
  - Added an `error_type` public method which returns a string representation of the error