### PR TITLE
cleaning up BackendServiceException and Logging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,7 +52,7 @@ class ApplicationController < ActionController::API
         # Add additional user specific context to the logs
         extra.merge!(more_extra) if current_user.present?
         if exception.generic_error?
-          log_message_to_sentry(exception.va900_exception_message, :warn, i18n_exception_hint: exception.i18n_exception_hint)
+          log_message_to_sentry(exception.va900_message, :warn, i18n_exception_hint: exception.va900_hint)
         end
       end
       log_exception_to_sentry(exception, extra)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,8 @@ class ApplicationController < ActionController::API
       if exception.is_a?(Common::Exceptions::BackendServiceException)
         # Add additional user specific context to the logs
         if current_user.present?
-          extra.merge!(icn: current_user.icn, mhv_correlation_id: current_user.mhv_correlation_id)
+          extra[:icn] = current_user.icn
+          extra[:mhv_correlation_id] = current_user.mhv_correlation_id
         end
         # Warn about VA900 needing to be added to exception.en.yml
         if exception.generic_error?

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -4,7 +4,6 @@ require 'sentry_logging'
 
 class MhvAccount < ActiveRecord::Base
   include AASM
-  include SentryLogging
 
   STATSD_ACCOUNT_EXISTED_KEY = 'mhv.account.existed'
   STATSD_ACCOUNT_CREATION_KEY = 'mhv.account.creation'
@@ -148,7 +147,6 @@ class MhvAccount < ActiveRecord::Base
         register!
       end
     end
-  # TODO: handle/log exceptions more carefully
   rescue => e
     StatsD.increment("#{STATSD_ACCOUNT_CREATION_KEY}.failure")
     fail_register!
@@ -164,7 +162,6 @@ class MhvAccount < ActiveRecord::Base
         upgrade!
       end
     end
-  # TODO: handle/log exceptions more carefully
   rescue => e
     if e.is_a?(Common::Exceptions::BackendServiceException) && e.original_body['code'] == 155
       StatsD.increment(STATSD_ACCOUNT_EXISTED_KEY.to_s)

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -152,8 +152,6 @@ class MhvAccount < ActiveRecord::Base
   rescue => e
     StatsD.increment("#{STATSD_ACCOUNT_CREATION_KEY}.failure")
     fail_register!
-    extra_context = { icn: user.icn }
-    log_exception_to_sentry(e, extra_context)
     raise e
   end
 
@@ -174,8 +172,6 @@ class MhvAccount < ActiveRecord::Base
     else
       StatsD.increment("#{STATSD_ACCOUNT_UPGRADE_KEY}.failure")
       fail_upgrade!
-      extra_context = { icn: user.icn, mhv_correlation_id: user.mhv_correlation_id }
-      log_exception_to_sentry(e, extra_context)
       raise e
     end
   end

--- a/lib/common/exceptions/external/backend_service_exception.rb
+++ b/lib/common/exceptions/external/backend_service_exception.rb
@@ -33,6 +33,21 @@ module Common
 
       alias generic_error? va900?
 
+      def va900_message
+        "Unmapped VA900 (Backend Response: { status: #{original_status}, message: #{original_body}) }"
+      end
+
+      def va900_hint
+        <<-MESSAGE.strip_heredoc
+          Add the following to exceptions.en.yml
+          #{response_values[:code]}:
+            code: '#{response_values[:code]}'
+            detail: '#{response_values[:detail]}'
+            status: <http status code you want rendered (400, 422, etc)>
+            source: ~
+        MESSAGE
+      end
+
       private
 
       def render_overides
@@ -78,21 +93,6 @@ module Common
 
       def i18n_key
         "common.exceptions.#{code}"
-      end
-
-      def va900_message
-        "Unmapped VA900 (Backend Response: { status: #{original_status}, message: #{original_body}) }"
-      end
-
-      def va900_hint
-        <<-MESSAGE.strip_heredoc
-          Add the following to exceptions.en.yml
-          #{response_values[:code]}:
-            code: '#{response_values[:code]}'
-            detail: '#{response_values[:detail]}'
-            status: <http status code you want rendered (400, 422, etc)>
-            source: ~
-        MESSAGE
       end
     end
   end

--- a/lib/common/exceptions/external/backend_service_exception.rb
+++ b/lib/common/exceptions/external/backend_service_exception.rb
@@ -33,7 +33,7 @@ module Common
 
       alias generic_error? va900?
 
-      def va900_message
+      def va900_warning
         "Unmapped VA900 (Backend Response: { status: #{original_status}, message: #{original_body}) }"
       end
 

--- a/lib/common/exceptions/external/backend_service_exception.rb
+++ b/lib/common/exceptions/external/backend_service_exception.rb
@@ -80,11 +80,11 @@ module Common
         "common.exceptions.#{code}"
       end
 
-      def va900_exception_message
+      def va900_message
         "Unmapped VA900 (Backend Response: { status: #{original_status}, message: #{original_body}) }"
       end
 
-      def i18n_exception_hint
+      def va900_hint
         <<-MESSAGE.strip_heredoc
           Add the following to exceptions.en.yml
           #{response_values[:code]}:


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2897
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3772
Partially related to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3773

- removed icn and mhv_correlation_id logging from mhv_account.rb
- moved icn and mhv_correlation_id logging into application_controller
- removed all SentryLogging from BackendServiceException
- moved all logging for BackendServiceException into application_controller where additional context can easily be added.