### PR TITLE
Coerce User UUIDs to strings for InProgress forms

### DIFF
--- a/app/models/in_progress_form.rb
+++ b/app/models/in_progress_form.rb
@@ -1,8 +1,19 @@
 # frozen_string_literal: true
 class InProgressForm < ActiveRecord::Base
+  class CleanUUID < ActiveRecord::Type::String
+    def type_cast_for_database(value)
+      value.to_s.delete('-')
+    end
+
+    alias type_cast type_cast_for_database
+  end
+
   EXPIRES_AFTER = 60.days
+  attribute :user_uuid, CleanUUID.new
   attr_encrypted :form_data, key: Settings.db_encryption_key
   validates(:form_data, presence: true)
+  validates(:user_uuid, presence: true)
+  validate(:id_me_user_uuid)
   before_save :serialize_form_data
 
   def self.form_for_user(form_id, user)
@@ -26,6 +37,16 @@ class InProgressForm < ActiveRecord::Base
   end
 
   private
+
+  # Some IDs we get from ID.me are 22char hex strings
+  # > we started off with just 22 random hex chars (from openssl random bytes) years
+  # > ago, and switched to UUID v4 (minus dashes) later on
+  # https://dsva.slack.com/archives/C1A7KLZ9B/p1501856503336861
+  def id_me_user_uuid
+    if user_uuid && !user_uuid.length.in?([22, 32])
+      errors[:user_uuid] << "(#{user_uuid}) is not a proper length"
+    end
+  end
 
   def serialize_form_data
     self.form_data = form_data.to_json unless form_data.is_a?(String)

--- a/db/migrate/20170804151637_convert_in_progress_guid_to_string.rb
+++ b/db/migrate/20170804151637_convert_in_progress_guid_to_string.rb
@@ -1,0 +1,12 @@
+class ConvertInProgressGuidToString < ActiveRecord::Migration
+  def up
+    change_column :in_progress_forms, :user_uuid, :string, :null => false
+
+    InProgressForm.connection.schema_cache.clear!
+    InProgressForm.reset_column_information
+
+    InProgressForm.all.each { |form|
+      form.update_attribute(:user_uuid, form.user_uuid.gsub!('-', ''))
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170802173236) do
+ActiveRecord::Schema.define(version: 20170804151637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 20170802173236) do
   add_index "evss_claims", ["user_uuid"], name: "index_evss_claims_on_user_uuid", using: :btree
 
   create_table "in_progress_forms", force: :cascade do |t|
-    t.uuid     "user_uuid",              null: false
+    t.string   "user_uuid",              null: false
     t.string   "form_id",                null: false
     t.string   "encrypted_form_data",    null: false
     t.string   "encrypted_form_data_iv", null: false


### PR DESCRIPTION
Per the inline comment, some ID.me users have guids that are invalid UUIDs, and so we can't use the  PG UUID column (unless we padded the idme guid). This solution forces everything to a string, and strips all `-`s for normalization purposes.