### PR TITLE
don't memoize headers in evss service refactor

### DIFF
--- a/lib/evss/service.rb
+++ b/lib/evss/service.rb
@@ -5,10 +5,7 @@ require 'evss/auth_headers'
 module EVSS
   class Service < Common::Client::Base
     def headers_for_user(user)
-      @headers_by_user ||= Hash.new do |h, key|
-        h[key] = EVSS::AuthHeaders.new(user).to_h
-      end
-      @headers_by_user[user.uuid]
+      EVSS::AuthHeaders.new(user).to_h
     end
   end
 end


### PR DESCRIPTION
Headers include last logged in and loa level which could change vs memoized version.