### PR TITLE
pciu address set effective date in api

### DIFF
--- a/app/swagger/requests/address.rb
+++ b/app/swagger/requests/address.rb
@@ -91,7 +91,6 @@ module Swagger
                   INTERNATIONAL
                   MILITARY
                 ), example: 'DOMESTIC'
-              property :address_effective_date, type: :string, example: '1973-01-01T05:00:00.000+00:00'
               property :address_one, type: :string, example: '140 Rock Creek Church Rd NW'
               property :address_two, type: :string, example: ''
               property :address_three, type: :string, example: ''

--- a/lib/evss/pciu_address/service.rb
+++ b/lib/evss/pciu_address/service.rb
@@ -30,11 +30,9 @@ module EVSS
       def update_address(user, address)
         with_exception_handling do
           address.address_effective_date = DateTime.now.utc
-          address = address.as_json.delete_if { |_k, v| v.blank? }
           address_json = {
-            'cnpMailingAddress' => Hash[address.map { |k, v| [k.camelize(:lower), v] }]
+            'cnpMailingAddress' => Hash[address.as_json.map { |k, v| [k.camelize(:lower), v] }]
           }.to_json
-          puts address_json
           headers = headers_for_user(user).update('Content-Type' => 'application/json')
           raw_response = perform(:post, 'mailingAddress', address_json, headers)
           EVSS::PCIUAddress::AddressResponse.new(raw_response.status, raw_response)

--- a/lib/evss/pciu_address/service.rb
+++ b/lib/evss/pciu_address/service.rb
@@ -29,9 +29,12 @@ module EVSS
 
       def update_address(user, address)
         with_exception_handling do
+          address.address_effective_date = DateTime.now.utc
+          address = address.as_json.delete_if { |_k, v| v.blank? }
           address_json = {
-            'cnpMailingAddress' => Hash[address.as_json.map { |k, v| [k.camelize(:lower), v] }]
+            'cnpMailingAddress' => Hash[address.map { |k, v| [k.camelize(:lower), v] }]
           }.to_json
+          puts address_json
           headers = headers_for_user(user).update('Content-Type' => 'application/json')
           raw_response = perform(:post, 'mailingAddress', address_json, headers)
           EVSS::PCIUAddress::AddressResponse.new(raw_response.status, raw_response)

--- a/spec/lib/evss/pciu_address/service_spec.rb
+++ b/spec/lib/evss/pciu_address/service_spec.rb
@@ -45,20 +45,7 @@ describe EVSS::PCIUAddress::Service do
 
   describe '#update_address' do
     context 'with a valid address update' do
-      let(:update_address) do
-        {
-          'type' => 'DOMESTIC',
-          'addressEffectiveDate' => '2017-08-07T19:43:59.383Z',
-          'addressOne' => '225 5th St',
-          'addressTwo' => '',
-          'addressThree' => '',
-          'city' => 'Springfield',
-          'stateCode' => 'OR',
-          'countryName' => 'USA',
-          'zipCode' => '97477',
-          'zipSuffix' => ''
-        }
-      end
+      let(:update_address) { build(:pciu_domestic_address) }
 
       it 'updates and returns a users mailing address' do
         VCR.use_cassette('evss/pciu_address/address_update') do


### PR DESCRIPTION
- removes address effective date param from api/swagger
- sets address effective date before posting to EVSS address service