### PR TITLE
Updates 1990 spool file template to optionally use educationProgram

### DIFF
--- a/app/workers/education_form/forms/va1990.rb
+++ b/app/workers/education_form/forms/va1990.rb
@@ -21,6 +21,14 @@ module EducationForm::Forms
       @applicant.currentlyActiveDuty&.nonVaAssistance
     end
 
+    def school
+      @applicant.educationProgram || @applicant.school
+    end
+
+    def education_type
+      @applicant.educationProgram&.educationType || @applicant.educationType
+    end
+
     # Some descriptive text that's included near the top of the 22-1990 form. Because they can make
     # multiple selections, we have to add all the selected ones.
     def disclosures(application)

--- a/app/workers/education_form/templates/1990.erb
+++ b/app/workers/education_form/templates/1990.erb
@@ -33,7 +33,7 @@ Preferred Method of Contact: <%= @applicant.preferredContactMethod %>
                   TYPE AND PROGRAM OF EDUCATION OR TRAINING
                   -----------------------------------------
 
-Type of Education or Training: <%= @applicant.educationType&.titleize %>
+Type of Education or Training: <%= education_type&.titleize %>
 
 <%= parse_with_template_path('school') %>
 

--- a/spec/fixtures/education_benefits_claims/1990/kitchen_sink_edu_prog.json
+++ b/spec/fixtures/education_benefits_claims/1990/kitchen_sink_edu_prog.json
@@ -1,0 +1,150 @@
+{
+  "activeDutyKicker": true,
+  "additionalContributions": true,
+  "bankAccount": {
+    "accountNumber": "88888888888",
+    "accountType": "checking",
+    "bankName": "First Bank of JSON",
+    "routingNumber": "123456789"
+  },
+  "chapter1606": true,
+  "chapter33": true,
+  "chapter30": true,
+  "chapter32": true,
+  "benefitsRelinquished": "chapter1607",
+  "benefitsRelinquishedDate":"2016-12-15",
+  "currentlyActiveDuty": {
+    "nonVaAssistance": true,
+    "onTerminalLeave": true,
+    "yes": true
+  },
+  "civilianBenefitsAssistance": true,
+  "serviceAcademyGraduationYear": 2010,
+  "seniorRotc": {
+    "commissionYear": 1981,
+    "rotcScholarshipAmounts": [{
+      "year": 1999,
+      "amount": 99.99
+    },{
+      "year": 2000,
+      "amount": 199.99
+    },{
+      "year": 2001,
+      "amount": 299.99
+    }]
+  },
+  "seniorRotcScholarshipProgram": true,
+  "email": "test@sample.com",
+  "activeDutyRepayingPeriod": {
+      "from": "2012-09-09",
+      "to": "2013-10-10"
+  },
+  "preferredContactMethod": "email",
+  "educationStartDate": "1999-12-31",
+  "educationObjective": "Master’s in JSON document creation",
+  "educationProgram": {
+    "name": "\nFakeData University\n",
+    "address": {
+      "city": "Baltimore",
+      "country": "USA",
+      "postalCode": "21231",
+      "state": "MD",
+      "street": "111 Uni Drive"
+    },
+    "educationType": "flightTraining"
+  },
+  "nonMilitaryJobs": [
+    {
+      "name": "Clerk",
+      "months": 36,
+      "postMilitaryJob": false
+    },
+    {
+      "name": "Doer",
+      "licenseOrRating": "Higher Up",
+      "months": 18,
+      "postMilitaryJob": false
+    },
+    {
+      "name": "Manager",
+      "licenseOrRating": "Third Class",
+      "months": 8,
+      "postMilitaryJob": true
+    }
+  ],
+  "faaFlightCertificatesInformation": "cert1, cert2",
+  "gender": "M",
+  "highSchoolOrGedCompletionDate": "2010-06-XX",
+  "homePhone": "5551110000",
+  "reserveKicker": true,
+  "school": {
+    "educationalObjective": "...",
+    "startDate": "2016-08-29"
+  },
+  "secondaryContact": {
+    "fullName": "Sibling Olson",
+    "sameAddress": false,
+    "address": {
+      "city": "Baltimore",
+      "country": "USA",
+      "postalCode": "23131",
+      "state": "MD",
+      "street": "222 Person Drive"
+    },
+    "phone": "5550001111"
+  },
+  "serviceBefore1977": {
+    "haveDependents": true,
+    "married": true,
+    "parentDependent": false
+  },
+  "toursOfDuty": [{
+    "dateRange": {
+      "from": "2012-06-26",
+      "to": "2013-04-10"
+    },
+    "involuntarilyCalledToDuty": "no",
+    "serviceBranch": "Army Reserve",
+    "applyPeriodToSelected": false,
+    "benefitsToApplyTo": "chapter32",
+    "serviceStatus": "ACTIVE DUTY TRAINING"
+  }, {
+    "dateRange": {
+      "from": "2013-04-22",
+      "to": "2013-06-14"
+    },
+    "involuntarilyCalledToDuty": "yes",
+    "serviceBranch": "Army Reserve",
+    "applyPeriodToSelected": true,
+    "serviceStatus": "ACTIVE DUTY"
+  }],
+  "postHighSchoolTrainings": [
+    {
+      "name": "OtherCollege Name",
+      "dateRange": {
+        "from": "1999-01-01",
+        "to": "2000-01-01"
+      },
+      "city": "New York",
+      "hours": 8,
+      "hoursType": "semester",
+      "state": "NY",
+      "degreeReceived": "BA",
+      "major": "History"
+    }
+  ],
+  "veteranAddress": {
+    "city": "Milwaukee",
+    "country": "USA",
+    "postalCode": "53130",
+    "state": "WI",
+    "street": "123 Main St"
+  },
+  "veteranDateOfBirth": "1985-03-07",
+  "veteranFullName": {
+    "first": "\nMark\n",
+    "last": "\nOlson\n"
+  },
+  "veteranSocialSecurityNumber": "111223333",
+  "privacyAgreementAccepted": true
+}

--- a/spec/fixtures/education_benefits_claims/1990/kitchen_sink_edu_prog.spl
+++ b/spec/fixtures/education_benefits_claims/1990/kitchen_sink_edu_prog.spl
@@ -1,0 +1,238 @@
+*INIT*
+MARK
+
+OLSON
+111223333
+111223333
+V1990
+
+FAKEDATA UNIVERSITY
+CH1606
+*START*
+VA Form 22-1990
+DEC 2016
+
+                    APPLICATION FOR VA EDUCATION BENEFITS
+                    -------------------------------------
+
+EDUCATION BENEFIT BEING APPLIED FOR: Chapter 30
+
+******************************************************************************
+
+EDUCATION BENEFIT BEING APPLIED FOR: Chapter 1606
+
+******************************************************************************
+
+EDUCATION BENEFIT BEING APPLIED FOR: Chapter 32
+
+******************************************************************************
+
+EDUCATION BENEFIT BEING APPLIED FOR: Chapter 33 in Lieu of Chapter 1607 -
+Effective: 2016-12-15
+
+By electing Chapter 33, I acknowledge that I understand the following:
+* I may not receive more than a total of 48 months of benefits under two or
+more programs.
+* If electing chapter 33 in lieu of chapter 30, my months of entitlement under
+chapter 33 will be limited to the number of months of entitlement remaining
+under chapter 30 on the effective date of my election.
+* I will not receive a Montgomery GI Bill (Active Duty-Chapter 30 or Selected
+reserve-Chapter 1606) 'Kicker' under the Post-9/11 GI Bill, unless I was
+eligible for the kicker at the time I applied and I relinquished that benefit
+for the Post-9/11 GI Bill-Chapter 33.
+* When choosing the effective date, I understand that benefits for training
+under Chapter 33 are not payable prior to that date.
+* My election is irrevocable and may not be changed.
+
+
+
+                            APPLICANT INFORMATION
+                            ---------------------
+
+SSN: 111223333         Sex: M             Date of Birth: 1985-03-07
+
+Name:
+Mark
+
+Olson
+
+
+Address:
+123 MAIN ST
+MILWAUKEE, WI, 53130
+USA
+
+Telephone Numbers:     Primary:    5551110000
+                       Secondary:
+
+Email Address:  test@sample.com
+Preferred Method of Contact: email
+
+Direct Deposit:     Type of Account: checking
+Name of Financial Inst.: First Bank of JSON
+Routing/Transit #: 123456789   Account #: 88888888888
+
+Name, Address, & Telephone Number of Contact:
+        Sibling Olson
+        222 PERSON DRIVE
+        BALTIMORE, MD, 23131
+        USA
+        Phone: 5550001111
+
+
+                  TYPE AND PROGRAM OF EDUCATION OR TRAINING
+                  -----------------------------------------
+
+Type of Education or Training: Flight Training
+
+Name and Address of School or Training Establishment:
+
+FakeData University
+
+        111 UNI DRIVE
+        BALTIMORE, MD, 21231
+        USA
+
+Date You Started or Will Start Training: 1999-12-31
+
+Education or Career Goal: Master's in JSON document creation
+
+
+                       ACTIVE DUTY SERVICE INFORMATION
+                       -------------------------------
+
+Are You Now On Active Duty?   YES
+
+Are you Now On Terminal Leave Just Before Discharge? YES
+
+Date Entered   Date Separated     Service Component
+Active Duty    From Active Duty
+2012-06-26     2013-04-10         Army Reserve
+                         Service Status:   ACTIVE DUTY TRAINING
+                         Involuntary Call: no
+                         Benefits to Apply to: chapter32
+2013-04-22     2013-06-14         Army Reserve
+                         Service Status:   ACTIVE DUTY
+                         Involuntary Call: yes
+Benefits to Apply to: chapter33, chapter1606,
+chapter32, chapter30
+
+
+
+                    EDUCATION AND EMPLOYMENT INFORMATION
+                    ------------------------------------
+
+Date Received High School Diploma or Equivalency Certificate: 2010-06-XX
+
+FAA Flight Certificates:
+cert1, cert2
+
+      Education After High School
+      ---------------------------
+
+Name and Location of College or Training Provider:
+    OtherCollege Name
+    New York, NY
+Date of Training:     From: 1999-01-01 To: 2000-01-01
+Hours: 8 (semester)
+Degree/Diploma/Certificate: BA
+Major Field/Course of Study: History
+
+
+        Employment
+        ----------
+
+Before Entering Military Service
+        Principal Occupation: Clerk
+        Number of Months: 36
+        License or Rating:
+
+        Principal Occupation: Doer
+        Number of Months: 18
+        License or Rating: Higher Up
+
+After Leaving Military Service
+        Principal Occupation: Manager
+        Number of Months: 8
+        License or Rating: Third Class
+
+
+          ENTITLEMENT TO AND USAGE OF ADDITIONAL TYPES OF ASSISTANCE
+          ----------------------------------------------------------
+
+Did you make additional contributions (up to $600) to increase the amount
+of your monthly benefits?   YES
+
+Do you qualify for a Kicker (sometimes called a College Fund) based on
+your military service?
+
+    Active Duty Kicker:   YES
+
+    Reserve Kicker:    YES
+
+If you graduated from a military service academy, specify the year you
+graduated and received your commission: 2010
+
+ROTC Scholarship Program and Officer's Commission. Were you commissioned as
+the result of a Senior ROTC (Reserve Officers Training Corps) Scholarship
+Program?    YES
+
+        Year of Commission: 1981
+
+        Scholarship Amounts:
+            Year 1:          Amount: 99.99
+
+            Year 2:          Amount: 199.99
+
+            Year 3:          Amount: 299.99
+
+            Year 4:          Amount:
+
+            Year 5:          Amount:
+
+
+Senior ROTC Scholarship Program. Are you currently participating in a Senior
+ROTC Scholarship Program which pays for your tuition, fees, books and supplies
+under Section 2107, Title 10 U.S. Code?   YES
+
+Did you have a period of active duty that the Department of Defense counts for
+purposes of repaying an education loan?    YES
+
+        Start Date: 2012-09-09
+
+        End Date: 2013-10-10
+
+For Active Duty Claimants Only. Are you receiving or do you anticipate
+receiving any money (including but not limited to Federal Tuition Assistance)
+from the Armed Forces or Public Health Service for the course for which you
+have applied to the VA for Education Benefits?  If you receive such benefits
+during any part of your training, check 'Yes.' Note:  If you are only applying
+for Tuition Assistance Top-Up, check 'No' to this item.    YES
+
+For Civilian Employees of the U.S. Federal Government Only. Are you receiving
+or do you anticipate receiving any money from your agency (including but not
+limited to the Government Employees Training Act) for the same period for
+which you have applied to the VA for Education Benefits? If you will receive
+such benefits during any part of your training, check Yes.    YES
+
+
+                        MARITAL AND DEPENDENCY STATUS
+           (For Applicants with Military Service Before Jan 1, 1977)
+           ---------------------------------------------------------
+
+
+Married: YES
+Has Dependents: YES
+Parent Dependent: NO
+
+
+      Certification and Signature of Applicant
+Signature of Applicant                                               Date
+
+      Certification for Persons on Active Duty
+Signature/Title/Branch of Armed Forces Education Service Officer     Date
+
+Electronically Received by VA:  2017-01-17
+Confirmation #:  V-EBC-1
+
+*END*

--- a/spec/jobs/education_form/forms/va1990_spec.rb
+++ b/spec/jobs/education_form/forms/va1990_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EducationForm::Forms::VA1990, type: :model, form: :education_bene
   subject { described_class.new(application) }
 
   SAMPLE_APPLICATIONS = [
-    :simple_ch33, :kitchen_sink
+    :simple_ch33, :kitchen_sink, :kitchen_sink_edu_prog
   ].freeze
 
   # For each sample application we have, format it and compare it against a 'known good'


### PR DESCRIPTION
* Update 1990 form to optionally use educationProgram
* Add helper functions for selecting the appropriate properties to 1990 form class
* Add new fixtures to test 1990 educationProgram support
* Add new fixture to suite of specs being run

Adds support to the 1990 form for the new `educationProgram` object while maintaining backwards compatibilty with the old structure where `school` and `educationType` are expected to be in the root `@applicant` object. This is accomplished using the `education_type` and `school` helpers on the 1990 form class to select the correct available properties during rendering.

Adds an additional `kitchen_sink_edu_prog` fixture to test 1990 spool file generation with an `educationProgram` object. The fixture containing the old format should be removed once it is no longer supported.

Closes department-of-veterans-affairs/vets.gov-team#4563