### PR TITLE
correct command in make for running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,9 @@ lint: db
 security: db
 	@$(BASH_DEV) "bundle exec rake security"
 
-.PHONY: test
-test:
-	@$(BASH_TEST) "bundle exec rake test"
+.PHONY: spec
+spec:
+	@$(BASH_TEST) "bundle exec rake spec"
 
 .PHONY: up
 up: db


### PR DESCRIPTION
correct Makefile to call `spec` instead of `test`