### PR TITLE
Updates olive_branch middleware version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     oj (2.18.2)
-    olive_branch (1.2.2)
+    olive_branch (2.0.0)
       rails (>= 4.0)
     overcommit (0.37.0)
       childprocess (~> 0.5.8)


### PR DESCRIPTION
Closes department-of-veterans-affairs/vets.gov-team#3046

The 2.0.0 version of olive_branch fixes the issues seen in department-of-veterans-affairs/vets.gov-team#3046.

The issue was due to the fact that `OliveBranch::Middleware#underscore_params` was only attempting to extract and transform `POST` parameters. `GET` requests that were attempting to receive values in `camelCase` format would hit a `nil:NilClass` exception when the (non-existant) `POST` parameters were accessed for transformation. The new version of the library correctly transforms the correct parameters depending on request type.

From testing, this version of the library fixes the issues seen in department-of-veterans-affairs/vets.gov-team#3046 without any modifications to the vets-api codebase.