### PR TITLE
round average logged by benchmarking

### DIFF
--- a/lib/benchmark_request.rb
+++ b/lib/benchmark_request.rb
@@ -40,7 +40,7 @@ class BenchmarkRequest
     log_message_to_sentry(
       "Average #{@request_name} request in seconds",
       :info,
-      { average: average, count: count },
+      { average: average.round(10), count: count },
       backend_service: @request_name
     )
   end


### PR DESCRIPTION
Intention here is to relieve logging pressure as raised by [4714](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4714) until requirements around benchmarking are understood. This rounds off the logged value only.