### PR TITLE
Change recipients for reporting emails

### DIFF
--- a/app/mailers/failed_claims_report_mailer.rb
+++ b/app/mailers/failed_claims_report_mailer.rb
@@ -2,7 +2,7 @@
 class FailedClaimsReportMailer < ApplicationMailer
   RECIPIENTS = %w(
     lihan@adhocteam.us
-    mark@adhocteam.us
+    ryan.baker@adhocteam.us
     joshua.quagliaroli@va.gov
   ).freeze
 

--- a/app/mailers/year_to_date_report_mailer.rb
+++ b/app/mailers/year_to_date_report_mailer.rb
@@ -18,7 +18,7 @@ class YearToDateReportMailer < ApplicationMailer
       Anne.kainic@va.gov
       ian@adhocteam.us
       dan.hoicowitz.va@gmail.com
-      mark@adhocteam.us
+      ryan.baker@adhocteam.us
       joshua.quagliaroli@va.gov
     )
   }.freeze

--- a/spec/mailers/failed_claims_report_mailer_spec.rb
+++ b/spec/mailers/failed_claims_report_mailer_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe FailedClaimsReportMailer, type: [:mailer] do
         expect(subject.to).to eq(
           %w(
             lihan@adhocteam.us
-            mark@adhocteam.us
+            ryan.baker@adhocteam.us
             joshua.quagliaroli@va.gov
           )
         )

--- a/spec/mailers/year_to_date_report_mailer_spec.rb
+++ b/spec/mailers/year_to_date_report_mailer_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe YearToDateReportMailer, type: [:mailer, :aws_helpers] do
             Anne.kainic@va.gov
             ian@adhocteam.us
             dan.hoicowitz.va@gmail.com
-            mark@adhocteam.us
+            ryan.baker@adhocteam.us
             joshua.quagliaroli@va.gov
           )
         )


### PR DESCRIPTION
Replaces mark@adhocteam.us with ryan.baker@adhocteam.us for reporting emails and associated specs