### PR TITLE
Support 7-9 digit VA file numbers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 3e84eeca91f83f421418e086d6149965c48db773
+  revision: 6a3b3a07eec17ab06483930c8ffff2e66c0c7288
   branch: master
   specs:
-    vets_json_schema (3.2.0)
+    vets_json_schema (3.3.0)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 

--- a/lib/pdf_fill/forms/va21p530.rb
+++ b/lib/pdf_fill/forms/va21p530.rb
@@ -365,6 +365,12 @@ module PdfFill
         hash[key]
       end
 
+      def extract_va_file_number(va_file_number)
+        return va_file_number if va_file_number.blank? || va_file_number.length < 10
+
+        va_file_number.sub(/^[Cc]/, '')
+      end
+
       def expand_checkbox_as_hash(hash, key)
         value = hash.try(:[], key)
         return if value.blank?
@@ -457,6 +463,8 @@ module PdfFill
         expand_tours_of_duty(@form_data['toursOfDuty'])
 
         @form_data['previousNames'] = combine_previous_names(@form_data['previousNames'])
+
+        @form_data['vaFileNumber'] = extract_va_file_number(@form_data['vaFileNumber'])
 
         expand_burial_allowance
 

--- a/lib/pdf_fill/forms/va21p530.rb
+++ b/lib/pdf_fill/forms/va21p530.rb
@@ -365,6 +365,9 @@ module PdfFill
         hash[key]
       end
 
+      # VA file number can be up to 10 digits long; An optional leading 'c' or 'C' followed by
+      # 7-9 digits. The file number field on the 530 form has space for 9 characters so trim the
+      # potential leading 'c' to ensure the file number will fit into the form without overflow.
       def extract_va_file_number(va_file_number)
         return va_file_number if va_file_number.blank? || va_file_number.length < 10
 

--- a/spec/lib/pdf_fill/forms/va21p530_spec.rb
+++ b/spec/lib/pdf_fill/forms/va21p530_spec.rb
@@ -222,6 +222,32 @@ describe PdfFill::Forms::VA21P530 do
     end
   end
 
+  describe '#extract_va_file_number' do
+    subject do
+      new_form_class.extract_va_file_number(form_data['vaFileNumber'])
+    end
+
+    context 'longer than 9 characters containing a c' do
+      let(:form_data) do
+        { 'vaFileNumber' => 'c123456789' }
+      end
+
+      it 'should strip the leading character' do
+        expect(subject).to eq('123456789')
+      end
+    end
+
+    context 'less than 10 characters containing a c' do
+      let(:form_data) do
+        { 'vaFileNumber' => 'c12345678' }
+      end
+
+      it 'should strip the leading character' do
+        expect(subject).to eq('c12345678')
+      end
+    end
+  end
+
   describe '#extract_middle_i' do
     subject do
       described_class.new(form_data).extract_middle_i(form_data, 'veteranFullName')

--- a/spec/lib/pdf_fill/forms/va21p530_spec.rb
+++ b/spec/lib/pdf_fill/forms/va21p530_spec.rb
@@ -227,23 +227,25 @@ describe PdfFill::Forms::VA21P530 do
       new_form_class.extract_va_file_number(form_data['vaFileNumber'])
     end
 
-    context 'longer than 9 characters containing a c' do
-      let(:form_data) do
-        { 'vaFileNumber' => 'c123456789' }
+    context 'with a leading `c` character' do
+      context 'with 9 digits' do
+        let(:form_data) do
+          { 'vaFileNumber' => 'c123456789' }
+        end
+
+        it 'should strip the leading character' do
+          expect(subject).to eq('123456789')
+        end
       end
 
-      it 'should strip the leading character' do
-        expect(subject).to eq('123456789')
-      end
-    end
+      context 'with less than 9 digits' do
+        let(:form_data) do
+          { 'vaFileNumber' => 'c12345678' }
+        end
 
-    context 'less than 10 characters containing a c' do
-      let(:form_data) do
-        { 'vaFileNumber' => 'c12345678' }
-      end
-
-      it 'should strip the leading character' do
-        expect(subject).to eq('c12345678')
+        it 'should strip the leading character' do
+          expect(subject).to eq('c12345678')
+        end
       end
     end
   end

--- a/spec/lib/pdf_fill/forms/va21p530_spec.rb
+++ b/spec/lib/pdf_fill/forms/va21p530_spec.rb
@@ -243,7 +243,7 @@ describe PdfFill::Forms::VA21P530 do
           { 'vaFileNumber' => 'c12345678' }
         end
 
-        it 'should strip the leading character' do
+        it 'should leave the file number unchanged' do
           expect(subject).to eq('c12345678')
         end
       end


### PR DESCRIPTION
As of `vets_json_schema` version 3.3.0, VA file numbers can be up to 10 characters long, comprised of a 7 to 9 digit file number with an optional leading `c` or `C`. 

In order to make this value fit into the 9 character file number field on the 530 form, the leading 'c' or 'C' is stripped off if the provided file number is too long.

* Updates to `vets_json_schema` version 3.3.0
  * Contains changes to VA file number validation
* Add support to 530 form
  * Only 9 boxes to write file number
  * Strips leading `c`'s off if longer than 9 total characters
  * Adds unit tests for the `extract_va_file_number` method