### PR TITLE
Update access-to-care URLs to be https

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -73,8 +73,8 @@ locators:
   nca: https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/NCA_Facilities/FeatureServer/0
   vba: https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/VBA_Facilities/FeatureServer/0
   vc: https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/VHA_VetCenters/FeatureServer/0
-  vha_access_satisfaction: http://www.accesstoshep.va.gov/
-  vha_access_waittime: http://www.accesstopwt.va.gov/
+  vha_access_satisfaction: https://www.accesstoshep.va.gov/
+  vha_access_waittime: https://www.accesstopwt.va.gov/
 
 # Settings for MyHealthEVet
 mhv:


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4915

Noticed in Sentry, access to care site put in a 301 redirect but faraday doesn't follow by default. Could look into that but would rather configure https url anyway.