### PR TITLE
Prefill 1995, 5490, and 5495 forms with eMIS data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 6a3b3a07eec17ab06483930c8ffff2e66c0c7288
+  revision: 9a710a7dba6195e4e7906d45fe080aeebe1c6ec5
   branch: master
   specs:
-    vets_json_schema (3.3.0)
+    vets_json_schema (3.4.0)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -65,6 +65,7 @@ class FormProfile
     '22-1990N'  => ::FormProfile::VA1990n,
     '22-1995'   => ::FormProfile::VA1995,
     '22-5490'   => ::FormProfile::VA5490,
+    '22-5495'   => ::FormProfile::VA5495,
     '21P-530'   => ::FormProfile::VA21p530,
     '21P-527EZ' => ::FormProfile::VA21p527ez
   }.freeze

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -58,6 +58,16 @@ class FormProfile
   include SentryLogging
 
   MAPPINGS = Dir[Rails.root.join('config', 'form_profile_mappings', '*.yml')].map { |f| File.basename(f, '.*') }
+
+  FORM_ID_TO_CLASS = {
+    '1010EZ'    => ::FormProfile::VA1010ez,
+    '22-1990'   => ::FormProfile::VA1990,
+    '22-1990N'  => ::FormProfile::VA1990n,
+    '22-1995'   => ::FormProfile::VA1995,
+    '21P-530'   => ::FormProfile::VA21p530,
+    '21P-527EZ' => ::FormProfile::VA21p527ez
+  }.freeze
+
   attr_accessor :form_id
   include Virtus.model
 
@@ -67,20 +77,7 @@ class FormProfile
 
   def self.for(form)
     form = form.upcase
-    case form
-    when '1010EZ'
-      ::FormProfile::VA1010ez
-    when '22-1990'
-      ::FormProfile::VA1990
-    when '22-1990N'
-      ::FormProfile::VA1990n
-    when '21P-530'
-      ::FormProfile::VA21p530
-    when '21P-527EZ'
-      ::FormProfile::VA21p527ez
-    else
-      self
-    end.new(form)
+    FORM_ID_TO_CLASS.fetch(form, self).new(form)
   end
 
   def initialize(form)

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -64,6 +64,7 @@ class FormProfile
     '22-1990'   => ::FormProfile::VA1990,
     '22-1990N'  => ::FormProfile::VA1990n,
     '22-1995'   => ::FormProfile::VA1995,
+    '22-5490'   => ::FormProfile::VA5490,
     '21P-530'   => ::FormProfile::VA21p530,
     '21P-527EZ' => ::FormProfile::VA21p527ez
   }.freeze

--- a/app/models/form_profile/va1995.rb
+++ b/app/models/form_profile/va1995.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FormProfile::VA1995 < FormProfile
+  def prefill(user)
+    super
+  end
+
+  def metadata
+    {
+      version: 0,
+      prefill: true,
+      returnUrl: '/1995/applicant/information'
+    }
+  end
+end

--- a/app/models/form_profile/va5490.rb
+++ b/app/models/form_profile/va5490.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FormProfile::VA5490 < FormProfile
+  def prefill(user)
+    super
+  end
+
+  def metadata
+    {
+      version: 0,
+      prefill: true,
+      returnUrl: '/5490/applicant/information'
+    }
+  end
+end

--- a/app/models/form_profile/va5495.rb
+++ b/app/models/form_profile/va5495.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FormProfile::VA5495 < FormProfile
+  def prefill(user)
+    super
+  end
+
+  def metadata
+    {
+      version: 0,
+      prefill: true,
+      returnUrl: '/5495/applicant/information'
+    }
+  end
+end

--- a/config/form_profile_mappings/22-1995.yml
+++ b/config/form_profile_mappings/22-1995.yml
@@ -1,0 +1,1 @@
+tours_of_duty: [military_information, tours_of_duty]

--- a/config/form_profile_mappings/22-5490.yml
+++ b/config/form_profile_mappings/22-5490.yml
@@ -1,0 +1,2 @@
+tours_of_duty: [military_information, tours_of_duty]
+currently_active_duty: [military_information, currently_active_duty]

--- a/config/form_profile_mappings/22-5495.yml
+++ b/config/form_profile_mappings/22-5495.yml
@@ -1,0 +1,2 @@
+tours_of_duty: [military_information, tours_of_duty]
+currently_active_duty: [military_information, currently_active_duty]

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -52,6 +52,22 @@ RSpec.describe FormProfile, type: :model do
     }
   end
 
+  let(:v22_5490_expected) do
+    {
+      'toursOfDuty' => [
+        {
+          'service_branch' => 'Air Force',
+          'date_range' => {
+            'from' => '2007-04-01', 'to' => '2016-06-01'
+          }
+        }
+      ],
+      'currentlyActiveDuty' => {
+        'yes' => true
+      }
+    }
+  end
+
   let(:v1010ez_expected) do
     {
       'veteranFullName' => {

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -39,6 +39,19 @@ RSpec.describe FormProfile, type: :model do
     }
   end
 
+  let(:v22_1995_expected) do
+    {
+      'toursOfDuty' => [
+        {
+          'service_branch' => 'Air Force',
+          'date_range' => {
+            'from' => '2007-04-01', 'to' => '2016-06-01'
+          }
+        }
+      ]
+    }
+  end
+
   let(:v1010ez_expected) do
     {
       'veteranFullName' => {
@@ -176,6 +189,10 @@ RSpec.describe FormProfile, type: :model do
 
         it 'returns prefilled 22-1990N' do
           expect_prefilled('22-1990N')
+        end
+
+        it 'returns prefilled 22-1995' do
+          expect_prefilled('22-1995')
         end
 
         it 'returns the va profile mapped to the healthcare form' do

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -68,6 +68,22 @@ RSpec.describe FormProfile, type: :model do
     }
   end
 
+  let(:v22_5495_expected) do
+    {
+      'toursOfDuty' => [
+        {
+          'service_branch' => 'Air Force',
+          'date_range' => {
+            'from' => '2007-04-01', 'to' => '2016-06-01'
+          }
+        }
+      ],
+      'currentlyActiveDuty' => {
+        'yes' => true
+      }
+    }
+  end
+
   let(:v1010ez_expected) do
     {
       'veteranFullName' => {
@@ -213,6 +229,10 @@ RSpec.describe FormProfile, type: :model do
 
         it 'returns prefilled 22-5490' do
           expect_prefilled('22-5490')
+        end
+
+        it 'returns prefilled 22-5495' do
+          expect_prefilled('22-5495')
         end
 
         it 'returns the va profile mapped to the healthcare form' do

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -211,6 +211,10 @@ RSpec.describe FormProfile, type: :model do
           expect_prefilled('22-1995')
         end
 
+        it 'returns prefilled 22-5490' do
+          expect_prefilled('22-5490')
+        end
+
         it 'returns the va profile mapped to the healthcare form' do
           expect_prefilled('1010ez')
         end

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe 'Fetching user data', type: :request do
           '21P-527EZ',
           '22-1990',
           '22-1990N',
+          '22-1995',
           '21P-530'
         ].sort
       )

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe 'Fetching user data', type: :request do
           '22-1990N',
           '22-1995',
           '22-5490',
+          '22-5495',
           '21P-530'
         ].sort
       )

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe 'Fetching user data', type: :request do
           '22-1990',
           '22-1990N',
           '22-1995',
+          '22-5490',
           '21P-530'
         ].sort
       )


### PR DESCRIPTION
* Adds 1995, 5490, and 5495 form profile and mappings based on
  * [22-1995 JSON Schema](https://github.com/department-of-veterans-affairs/vets-json-schema/blob/master/dist/22-1995-schema.json)
  * [22-5490 JSON Schema](https://github.com/department-of-veterans-affairs/vets-json-schema/blob/master/dist/22-5490-schema.json)
  * [22-5495 JSON Schema](https://github.com/department-of-veterans-affairs/vets-json-schema/blob/master/dist/22-5495-schema.json)
* Adds 1995, 5490, and 5495 tests to specs
* Refactors switch statement to hash lookup based on linter warnings