### PR TITLE
Initialize api.auth.new_user counter to 0 on start

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -12,6 +12,7 @@ StatsD.backend = if host.present? && port.present?
 
 StatsD.increment(V0::SessionsController::STATSD_LOGIN_TOTAL_KEY, 0)
 StatsD.increment(V0::SessionsController::STATSD_LOGIN_FAILED_KEY, 0, tags: ['error:unknown'])
+StatsD.increment(V0::SessionsController::STATSD_LOGIN_NEW_USER_KEY, 0)
 
 SAML::AuthFailHandler::KNOWN_ERRORS.each do |known_error|
   StatsD.increment(V0::SessionsController::STATSD_LOGIN_FAILED_KEY, 0, tags: ["error:#{known_error}"])


### PR DESCRIPTION
Set an initial counter value for the `STATSD_LOGIN_NEW_USER_KEY` on application start so we can track a value before new sessions are generated with the application instance.