### PR TITLE
Update saml_callback stats to be tag-oriented

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -18,6 +18,13 @@ SAML::AuthFailHandler::KNOWN_ERRORS.each do |known_error|
   StatsD.increment(V0::SessionsController::STATSD_LOGIN_FAILED_KEY, 0, tags: ["error:#{known_error}"])
 end
 
+%w(success failure).each do |s|
+  StatsD.increment(V0::SessionsController::STATSD_CALLBACK_KEY, 0, tags: ["status:#{s}", 'context:unknown'])
+  V0::SessionsController::STATSD_CONTEXT_MAP.values.each do |ctx|
+    StatsD.increment(V0::SessionsController::STATSD_CALLBACK_KEY, 0, tags: ["status:#{s}", "context:#{ctx}"])
+  end
+end
+
 # init GiBillStatus stats to 0
 StatsD.increment(V0::Post911GIBillStatusesController::STATSD_GI_BILL_TOTAL_KEY, 0)
 StatsD.increment(V0::Post911GIBillStatusesController::STATSD_GI_BILL_FAIL_KEY, 0, tags: ['error:unknown'])


### PR DESCRIPTION
Will make it easier to see unified view of callback results in prometheus/grafana.