### PR TITLE
ensure multifactor policies dont persist junk to current_user

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -112,16 +112,33 @@ module V0
 
     private
 
+    def saml_user
+      binding.pry
+      @saml_user ||= SAML::User.new(@saml_response)
+    end
+
+    def new_user_from_saml
+      @new_user_from_saml ||= User.new(saml_user.to_hash)
+    end
+
     def persist_session_and_user
-      user = User.from_saml(@saml_response)
+      @session = Session.new(uuid: new_user_from_saml.uuid)
+      existing_user = User.find(@session.uuid)
 
-      # we are using an heuristic on saml_response to set the authn_context
-      @session = Session.new(uuid: user.uuid)
-      @current_user = User.find(@session.uuid)
+      @current_user =
+        # Completely new signin, both session and current user will be persisted
+        if existing_user.nil?
+          StatsD.increment(STATSD_LOGIN_NEW_USER_KEY)
+          new_user_from_saml
+        # Existing user. Updated attributes as a result of enabling multifactor
+        elsif saml_user.changing_multifactor?
+          existing_user.multifactor = saml_user.multifactor
+          existing_user
+        # Existing user. Updated attributes as a result of completing identity proof
+        else
+          User.from_merged_attrs(existing_user, new_user_from_saml)
+        end
 
-      StatsD.increment(STATSD_LOGIN_NEW_USER_KEY) if @current_user.nil?
-
-      @current_user = @current_user.nil? ? user : User.from_merged_attrs(@current_user, user)
       @session.save && @current_user.save
     end
 

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -113,7 +113,6 @@ module V0
     private
 
     def saml_user
-      binding.pry
       @saml_user ||= SAML::User.new(@saml_response)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,11 +122,6 @@ class User < Common::RedisStore
     User.new(attrs)
   end
 
-  def self.from_saml(saml_response)
-    saml_user = SAML::User.new(saml_response)
-    User.new(saml_user)
-  end
-
   delegate :edipi, to: :mvi
   delegate :icn, to: :mvi
   delegate :mhv_correlation_id, to: :mvi

--- a/lib/saml/user.rb
+++ b/lib/saml/user.rb
@@ -34,6 +34,11 @@ module SAML
       nil
     end
 
+    def changing_multifactor?
+      return false if real_authn_context.nil?
+      real_authn_context.include?('multifactor')
+    end
+
     private
 
     # returns the attributes that are defined below, could be from one of 3 distinct policies, each having different

--- a/spec/lib/saml/user_spec.rb
+++ b/spec/lib/saml/user_spec.rb
@@ -47,8 +47,35 @@ RSpec.describe SAML::User do
     it 'properly constructs a user' do
       expect(user).to be_valid
     end
-    it 'defaults loa.highest o loa.current' do
+
+    it 'defaults loa.highest to loa.current' do
       expect(user.loa[:highest]).to eq(LOA::THREE)
+    end
+  end
+
+  describe 'instance method' do
+    let(:subject) { described_class.new(saml_response) }
+    before do
+      allow(saml_response).to receive(:attributes).and_return({})
+    end
+
+    context 'changing_multifactor?' do
+      MULTIFACTORS = %w(dslogon_multifactor multifactor mhv_multifactor).freeze
+      NON_MULTIFACTORS = (%w(mhv dslogon) + LOA::MAPPING.keys + [nil]).freeze
+
+      MULTIFACTORS.each do |example|
+        it "responds as true when real_authn_context is #{example}" do
+          allow_any_instance_of(SAML::User).to receive(:real_authn_context).and_return(example)
+          expect(subject.changing_multifactor?).to be_truthy
+        end
+      end
+
+      NON_MULTIFACTORS.each do |example|
+        it "responds as false when real_authn_context is #{example}" do
+          allow_any_instance_of(SAML::User).to receive(:real_authn_context).and_return(example)
+          expect(subject.changing_multifactor?).to be_falsey
+        end
+      end
     end
   end
 


### PR DESCRIPTION
multifactor policy should only update the users multifactor attribute, absolutely nothing else should be changed.