### PR TITLE
Child to Dependent Rename/Refactor

### DIFF
--- a/lib/hca/enrollment_system.rb
+++ b/lib/hca/enrollment_system.rb
@@ -81,24 +81,6 @@ module HCA
       'Other' => 99
     }.freeze
 
-    def migrate_child_to_dependent(child)
-      {
-        'fullName' => child['childFullName'],
-        'dependentRelation' => child['childRelation'],
-        'socialSecurityNumber' => child['childSocialSecurityNumber'],
-        'becameDependent' => child['childBecameDependent'],
-        'dateOfBirth' => child['childDateOfBirth'],
-        'disabledBefore18' => child['childDisabledBefore18'],
-        'attendedSchoolLastYear' => child['childAttendedSchoolLastYear'],
-        'dependentEducationExpenses' => child['childEducationExpenses'],
-        'cohabitedLastYear' => child['childCohabitedLastYear'],
-        'receivedSupportLastYear' => child['childReceivedSupportLastYear'],
-        'grossIncome' => child['grossIncome'],
-        'netIncome' => child['netIncome'],
-        'otherIncome' => child['otherIncome']
-      }
-    end
-
     def financial_flag?(veteran)
       veteran['understandsFinancialDisclosure'] || veteran['discloseFinancialInformation']
     end
@@ -297,6 +279,26 @@ module HCA
         'attendedSchool' => dependent['attendedSchoolLastYear'].present?,
         'contributedToSupport' => dependent['receivedSupportLastYear'].present?
       }
+    end
+
+    def migrated_dependents(veteran)
+      veteran['dependents'] || veteran.fetch('children', []).map do |child|
+        {
+          'fullName' => child['childFullName'],
+          'dependentRelation' => child['childRelation'],
+          'socialSecurityNumber' => child['childSocialSecurityNumber'],
+          'becameDependent' => child['childBecameDependent'],
+          'dateOfBirth' => child['childDateOfBirth'],
+          'disabledBefore18' => child['childDisabledBefore18'],
+          'attendedSchoolLastYear' => child['childAttendedSchoolLastYear'],
+          'dependentEducationExpenses' => child['childEducationExpenses'],
+          'cohabitedLastYear' => child['childCohabitedLastYear'],
+          'receivedSupportLastYear' => child['childReceivedSupportLastYear'],
+          'grossIncome' => child['grossIncome'],
+          'netIncome' => child['netIncome'],
+          'otherIncome' => child['otherIncome']
+        }
+      end
     end
 
     def veteran_to_dependent_financials_collection(veteran)
@@ -517,11 +519,6 @@ module HCA
       end
     end
 
-    def migrated_dependents(veteran)
-      veteran['dependents'] || veteran.fetch('children', []).map do |child|
-        migrate_child_to_dependent(child)
-      end
-    end
 
     def veteran_to_association_collection(veteran)
       associations = []

--- a/lib/hca/enrollment_system.rb
+++ b/lib/hca/enrollment_system.rb
@@ -519,7 +519,6 @@ module HCA
       end
     end
 
-
     def veteran_to_association_collection(veteran)
       associations = []
 

--- a/lib/hca/enrollment_system.rb
+++ b/lib/hca/enrollment_system.rb
@@ -491,7 +491,7 @@ module HCA
           'spouseFinancialsList' => veteran_to_spouse_financials(veteran),
           'marriedLastCalendarYear' => veteran['maritalStatus'] == 'Married',
           'dependentFinancialsList' => veteran_to_dependent_financials_collection(veteran),
-          'numberOfDependents' => veteran['dependents'].size || veteran['children'].size
+          'numberOfDependentChildren' => veteran['dependents']&.size || veteran['children']&.size
         }
       }
     end

--- a/spec/lib/hca/enrollment_system_spec.rb
+++ b/spec/lib/hca/enrollment_system_spec.rb
@@ -39,25 +39,25 @@ describe HCA::EnrollmentSystem do
     "otherIncome": 91.9
   }.deep_stringify_keys
 
-  TEST_DEPENDENT = {
+  TEST_CHILD_DEPENDENT = {
     "fullName": {
-      "first": 'John',
-      "middle": 'Doe',
-      "last": 'Smith',
-      "suffix": 'Sr.'
+      "first": 'FirstChildA',
+      "middle": 'MiddleChildA',
+      "last": 'LastChildA',
+      "suffix": 'Jr.'
     },
-    "dependentRelation": 'Father',
-    "socialSecurityNumber": '111-22-9877',
-    "becameDependent": '1990-04-07',
-    "dateOfBirth": '1932-04-21',
-    "disabledBefore18": false,
-    "attendedSchoolLastYear": false,
-    "dependentEducationExpenses": 0.0,
+    "dependentRelation": 'Stepson',
+    "socialSecurityNumber": '111-22-9876',
+    "becameDependent": '1992-04-07',
+    "dateOfBirth": '1982-05-05',
+    "disabledBefore18": true,
+    "attendedSchoolLastYear": true,
+    "dependentEducationExpenses": 45.2,
     "cohabitedLastYear": true,
     "receivedSupportLastYear": false,
-    "grossIncome": 8992.9,
-    "netIncome": 8791.2,
-    "otherIncome": 891.7
+    "grossIncome": 991.9,
+    "netIncome": 981.2,
+    "otherIncome": 91.9
   }.deep_stringify_keys
 
   TEST_SPOUSE = {
@@ -477,7 +477,7 @@ describe HCA::EnrollmentSystem do
     'dependent_info',
     [
       [
-        TEST_DEPENDENT,
+        TEST_CHILD_DEPENDENT,
         {
           'dob' => '05/05/1982',
           'givenName' => 'FIRSTCHILDA',
@@ -497,7 +497,7 @@ describe HCA::EnrollmentSystem do
     'dependent_financials_info',
     [
       [
-        TEST_CHILD,
+        TEST_CHILD_DEPENDENT,
         CHILD_DEPENDENT_FINANCIALS
       ]
     ]
@@ -509,6 +509,12 @@ describe HCA::EnrollmentSystem do
     [
       [
         { 'children' => [TEST_CHILD] },
+        {
+          'dependentFinancials' => [CHILD_DEPENDENT_FINANCIALS]
+        }
+      ],
+      [
+        { 'dependents' => [TEST_CHILD_DEPENDENT] },
         {
           'dependentFinancials' => [CHILD_DEPENDENT_FINANCIALS]
         }
@@ -778,6 +784,42 @@ describe HCA::EnrollmentSystem do
             'numberOfDependentChildren' => 1
           }
         }
+      ],
+      [
+        {
+          "deductibleMedicalExpenses": 33.3,
+          "deductibleFuneralExpenses": 44.44,
+          "deductibleEducationExpenses": 77.77,
+          "veteranGrossIncome": 123.33,
+          "veteranNetIncome": 90.11,
+          "veteranOtherIncome": 10.1,
+          'dependents' => [TEST_CHILD_DEPENDENT]
+        }.merge(SPOUSE_FINANCIALS).deep_stringify_keys,
+        {
+          'incomeTest' => { 'discloseFinancialInformation' => true },
+          'financialStatement' => {
+            'expenses' => {
+              'expense' => [
+                { 'amount' => 77.77, 'expenseType' => '3' },
+                { 'amount' => 44.44, 'expenseType' => '19' },
+                { 'amount' => 33.3, 'expenseType' => '18' }
+              ]
+            },
+            'incomes' => {
+              'income' => [
+                { 'amount' => 123.33, 'type' => 7 },
+                { 'amount' => 90.11, 'type' => 13 },
+                { 'amount' => 10.1, 'type' => 10 }
+              ]
+            },
+            'spouseFinancialsList' => CONVERTED_SPOUSE_FINANCIALS,
+            'marriedLastCalendarYear' => true,
+            'dependentFinancialsList' => {
+              'dependentFinancials' => [CHILD_DEPENDENT_FINANCIALS]
+            },
+            'numberOfDependentChildren' => 1
+          }
+        }
       ]
     ]
   )
@@ -806,7 +848,7 @@ describe HCA::EnrollmentSystem do
     'dependent_to_association',
     [
       [
-        TEST_DEPENDENT,
+        TEST_CHILD_DEPENDENT,
         CONVERTED_CHILD_ASSOCIATION
       ]
     ]

--- a/spec/lib/hca/enrollment_system_spec.rb
+++ b/spec/lib/hca/enrollment_system_spec.rb
@@ -458,6 +458,21 @@ describe HCA::EnrollmentSystem do
 
   test_method(
     described_class,
+    'migrated_dependents',
+    [
+      [
+        { 'children' => [TEST_CHILD] },
+        [TEST_CHILD_DEPENDENT]
+      ],
+      [
+        { 'dependents' => [TEST_CHILD_DEPENDENT] },
+        [TEST_CHILD_DEPENDENT]
+      ]
+    ]
+  )
+
+  test_method(
+    described_class,
     'dependent_relationship_to_sds_code',
     [
       ['Spouse', 2],

--- a/spec/lib/hca/enrollment_system_spec.rb
+++ b/spec/lib/hca/enrollment_system_spec.rb
@@ -39,6 +39,27 @@ describe HCA::EnrollmentSystem do
     "otherIncome": 91.9
   }.deep_stringify_keys
 
+  TEST_DEPENDENT = {
+    "fullName": {
+      "first": 'John',
+      "middle": 'Doe',
+      "last": 'Smith',
+      "suffix": 'Sr.'
+    },
+    "dependentRelation": 'Father',
+    "socialSecurityNumber": '111-22-9877',
+    "becameDependent": '1990-04-07',
+    "dateOfBirth": '1932-04-21',
+    "disabledBefore18": false,
+    "attendedSchoolLastYear": false,
+    "dependentEducationExpenses": 0.0,
+    "cohabitedLastYear": true,
+    "receivedSupportLastYear": false,
+    "grossIncome": 8992.9,
+    "netIncome": 8791.2,
+    "otherIncome": 891.7
+  }.deep_stringify_keys
+
   TEST_SPOUSE = {
     'spouseAddress' => TEST_ADDRESS,
     'spousePhone' => '1112221234',
@@ -424,7 +445,7 @@ describe HCA::EnrollmentSystem do
     'resource_to_expense_collection',
     [
       [
-        { 'childEducationExpenses' => 1198.11 },
+        { 'dependentEducationExpenses' => 1198.11 },
         {
           'expense' => [{
             'amount' => 1198.11,
@@ -453,10 +474,10 @@ describe HCA::EnrollmentSystem do
 
   test_method(
     described_class,
-    'child_to_dependent_info',
+    'dependent_info',
     [
       [
-        TEST_CHILD,
+        TEST_DEPENDENT,
         {
           'dob' => '05/05/1982',
           'givenName' => 'FIRSTCHILDA',
@@ -473,7 +494,7 @@ describe HCA::EnrollmentSystem do
 
   test_method(
     described_class,
-    'child_to_dependent_financials_info',
+    'dependent_financials_info',
     [
       [
         TEST_CHILD,
@@ -782,10 +803,10 @@ describe HCA::EnrollmentSystem do
 
   test_method(
     described_class,
-    'child_to_association',
+    'dependent_to_association',
     [
       [
-        TEST_CHILD,
+        TEST_DEPENDENT,
         CONVERTED_CHILD_ASSOCIATION
       ]
     ]


### PR DESCRIPTION
Implemented based on updated vets-json-schema: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/150

* Creates a `migrated_dependents` helper that indexes the appropriate JSON key and migrates the object to the new format if necessary
  * New: `dependents`
  * Old: `children`
* Adds specs for `migrated_dependents` and ensuring that various components use the new format correctly
* Refactors method and variable names to reference **dependent** rather than **child**

Step 2 of department-of-veterans-affairs/vets.gov-team#4924

@lihanli I'm open to changing up how this is done if there is a better way you think this gradual switch-over to `dependents` from `children` could be managed.