### PR TITLE
Resolve incorrect routing of education forms

### DIFF
--- a/app/workers/education_form/education_facility.rb
+++ b/app/workers/education_form/education_facility.rb
@@ -101,6 +101,8 @@ module EducationForm
       end
     end
 
+    # rubocop:enable Metrics/CyclomaticComplexity
+
     def self.regional_office_for(model)
       region = region_for(model)
       address = ["#{region.to_s.capitalize} Region", 'VA Regional Office']

--- a/app/workers/education_form/education_facility.rb
+++ b/app/workers/education_form/education_facility.rb
@@ -87,10 +87,11 @@ module EducationForm
     # that the claim is relating to (either `school` or `newSchool` in our submissions)
     # or to the applicant's address (either as a relative or the veteran themselves)
     # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def self.routing_address(record, form_type:)
       case form_type.upcase
       when '1990'
-        record.school&.address || record.veteranAddress
+        record.educationProgram&.address || record.school&.address || record.veteranAddress
       when '1990N'
         record.educationProgram&.address || record.veteranAddress
       when '1990E', '5490', '5495'
@@ -99,8 +100,6 @@ module EducationForm
         record.newSchool&.address || record.veteranAddress
       end
     end
-
-    # rubocop:enable Metrics/CyclomaticComplexity
 
     def self.regional_office_for(model)
       region = region_for(model)

--- a/app/workers/education_form/education_facility.rb
+++ b/app/workers/education_form/education_facility.rb
@@ -83,7 +83,7 @@ module EducationForm
       end
     end
 
-    def education_program(record)
+    def self.education_program(record)
       record.educationProgram || record.school
     end
 

--- a/app/workers/education_form/education_facility.rb
+++ b/app/workers/education_form/education_facility.rb
@@ -83,15 +83,18 @@ module EducationForm
       end
     end
 
+    def education_program(record)
+      record.educationProgram || record.school
+    end
+
     # Claims are sent to different RPOs based first on the location of the school
     # that the claim is relating to (either `school` or `newSchool` in our submissions)
     # or to the applicant's address (either as a relative or the veteran themselves)
     # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def self.routing_address(record, form_type:)
       case form_type.upcase
       when '1990'
-        record.educationProgram&.address || record.school&.address || record.veteranAddress
+        education_program(record)&.address || record.veteranAddress
       when '1990N'
         record.educationProgram&.address || record.veteranAddress
       when '1990E', '5490', '5495'

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe EducationForm::EducationFacility do
   describe '#routing_address' do
     let(:form) { OpenStruct.new }
     context '22-1990' do
+      it 'uses educationProgram over school' do
+        form.educationProgram = school(central_address)
+        form.school = school(eastern_address)
+        form.veteranAddress = western_address
+        expect(described_class.routing_address(form, form_type: '1990').state).to eq(central_address.state)
+      end
       it 'uses school over veteranAddress' do
         form.school = school(eastern_address)
         form.veteranAddress = western_address


### PR DESCRIPTION
The error seen in department-of-veterans-affairs/vets.gov-team#5061 is caused by the facility selection code accessing the older `school` field rather than the newer `educationProgram` field. An extra case to check for the `educationProgram` address before the `school` and `veteran` address has been added.

* Adds check for `educationProgram` before school and veteran
* Adds spec to ensure `educationProgram` is used to select a facility if available