### PR TITLE
fixes letter download when 500 html response is returned

### DIFF
--- a/lib/evss/pciu_address/service.rb
+++ b/lib/evss/pciu_address/service.rb
@@ -51,7 +51,7 @@ module EVSS
         log_message_to_sentry(e.message, :error, extra_context: { url: config.base_path, body: e&.body })
         case e.status
         when 400
-          raise_backend_exception('EVSS400', e)
+          raise_backend_exception('EVSS400', 'PCIUAddress', e)
         when 403
           raise Common::Exceptions::Forbidden
         else

--- a/lib/evss/pciu_address/service.rb
+++ b/lib/evss/pciu_address/service.rb
@@ -46,7 +46,7 @@ module EVSS
         yield
       rescue Faraday::ParsingError => e
         log_exception_to_sentry(e, extra_context: { url: config.base_path })
-        raise_backend_exception('EVSS502')
+        raise_backend_exception('EVSS502', 'PCIUAddress')
       rescue Common::Client::Errors::ClientError => e
         log_message_to_sentry(e.message, :error, extra_context: { url: config.base_path, body: e&.body })
         case e.status
@@ -55,17 +55,8 @@ module EVSS
         when 403
           raise Common::Exceptions::Forbidden
         else
-          raise_backend_exception('EVSS502', e)
+          raise_backend_exception('EVSS502', 'PCIUAddress', e)
         end
-      end
-
-      def raise_backend_exception(key, error = nil)
-        raise Common::Exceptions::BackendServiceException.new(
-          key,
-          { source: 'EVSS::PCIUAddress' },
-          error&.status,
-          error&.body
-        )
       end
     end
   end

--- a/lib/evss/service.rb
+++ b/lib/evss/service.rb
@@ -7,5 +7,14 @@ module EVSS
     def headers_for_user(user)
       EVSS::AuthHeaders.new(user).to_h
     end
+
+    def raise_backend_exception(key, source, error = nil)
+      raise Common::Exceptions::BackendServiceException.new(
+        key,
+        { source: "EVSS::#{source}" },
+        error&.status,
+        error&.body
+      )
+    end
   end
 end

--- a/spec/request/letters_request_spec.rb
+++ b/spec/request/letters_request_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'letters', type: :request do
         user.va_profile.edipi = '1005079999'
         user.va_profile.participant_id = '600039999'
       end
-      it 'should raise a 404' do
+      it 'should return a 404' do
         VCR.use_cassette('evss/letters/download_404') do
           post '/v0/letters/commissary', nil, auth_header
           expect(response).to have_http_status(:not_found)
@@ -140,7 +140,7 @@ RSpec.describe 'letters', type: :request do
         user.va_profile.edipi = '1005079124'
         user.va_profile.participant_id = '600036159'
       end
-      it 'should return a not found response' do
+      it 'should return a 502' do
         VCR.use_cassette('evss/letters/download_unexpected') do
           post '/v0/letters/benefit_summary', options, auth_header
           expect(response).to have_http_status(:bad_gateway)

--- a/spec/request/letters_request_spec.rb
+++ b/spec/request/letters_request_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'letters', type: :request do
     end
 
     context 'when evss returns lettergenerator.notEligible' do
-      it 'should download a PDF' do
+      it 'should raise a 502' do
         VCR.use_cassette('evss/letters/download_not_eligible') do
           post '/v0/letters/civil_service', nil, auth_header
           expect(response).to have_http_status(:bad_gateway)

--- a/spec/support/vcr_cassettes/evss/letters/download_404.yml
+++ b/spec/support/vcr_cassettes/evss/letters/download_404.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-lettergenerator-services-web/rest/letters/v1/commissary"
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 28 Sep 2017 23:15:59 GMT
+      Va-Eauth-Csid:
+      - DSLogon
+      Va-Eauth-Authenticationmethod:
+      - DSLogon
+      Va-Eauth-Pnidtype:
+      - SSN
+      Va-Eauth-Assurancelevel:
+      - '3'
+      Va-Eauth-Firstname:
+      - John
+      Va-Eauth-Lastname:
+      - SMith
+      Va-Eauth-Issueinstant:
+      - '2017-09-28T23:15:58Z'
+      Va-Eauth-Dodedipnid:
+      - '1005079999'
+      Va-Eauth-Pid:
+      - '600039999'
+      Va-Eauth-Pnid:
+      - '7991112233'
+      Va-Eauth-Birthdate:
+      - '1973-09-22T00:00:00+00:00'
+      Va-Eauth-Authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"7991112233","edi":"1005079999","firstName":"John","lastName":"SMith","birthDate":"1973-09-22T00:00:00+00:00"}}'
+  response:
+    status:
+      code: 404
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 Sep 2017 23:15:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips
+      Content-Length:
+      - '35822'
+      Content-Type:
+      - application/pdf
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_2_ROUTEID=.02; path=/
+      - WSS-LETTERGENERATION-SERVICES_JSESSIONID=WZ_KxecejbTvvRrTvcrPyVIVsBKKYrZfZlJiVgwGgroS758E67oV!-1372799592;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [
+            {
+              "key": "string",
+              "text": "string",
+              "severity": "FATAL"
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Thu, 28 Sep 2017 23:16:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/letters/download_not_eligible.yml
+++ b/spec/support/vcr_cassettes/evss/letters/download_not_eligible.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-lettergenerator-services-web/rest/letters/v1/civil_service"
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 28 Sep 2017 22:15:29 GMT
+      Va-Eauth-Csid:
+      - DSLogon
+      Va-Eauth-Authenticationmethod:
+      - DSLogon
+      Va-Eauth-Pnidtype:
+      - SSN
+      Va-Eauth-Assurancelevel:
+      - '3'
+      Va-Eauth-Firstname:
+      - abraham
+      Va-Eauth-Lastname:
+      - lincoln
+      Va-Eauth-Issueinstant:
+      - '2017-06-23T23:32:15Z'
+      Va-Eauth-Dodedipnid:
+      - '1157667246'
+      Va-Eauth-Pid:
+      - '3585637045'
+      Va-Eauth-Pnid:
+      - '796111863'
+      Va-Eauth-Authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"1157667246","firstName":"abraham","lastName":"lincoln"}}'
+  response:
+    status:
+      code: 500
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Jun 2017 21:48:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - WSS-LETTERGENERATION-SERVICES_JSESSIONID=Hs-olJiWg8WA5Z_fD2HtMzg7inHBAWR0suPhCVvs8E-tnbC16wkb!-1082478778;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages" : [ {
+            "key" : "lettergenerator.notEligible",
+            "severity" : "ERROR",
+            "text" : "Veteran is not eligible to receive the letter"
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 14 Jun 2017 21:48:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/letters/download_unexpected.yml
+++ b/spec/support/vcr_cassettes/evss/letters/download_unexpected.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-lettergenerator-services-web/rest/letters/v1/benefit_summary/generate"
+    body:
+      encoding: UTF-8
+      string: militaryService=true&serviceConnectedDisabilities=false&serviceConnectedEvaluation=true&nonServiceConnectedPension=false&monthlyAward=true&unemployable=false&specialMonthlyCompensation=false&adaptedHousing=false&chapter35Eligibility=false&deathResultOfDisability=false&survivorsAward=false
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 28 Sep 2017 22:15:29 GMT
+      Va-Eauth-Csid:
+      - DSLogon
+      Va-Eauth-Authenticationmethod:
+      - DSLogon
+      Va-Eauth-Pnidtype:
+      - SSN
+      Va-Eauth-Assurancelevel:
+      - '3'
+      Va-Eauth-Firstname:
+      - Greg
+      Va-Eauth-Lastname:
+      - Anderson
+      Va-Eauth-Issueinstant:
+      - '2017-09-28T22:15:28Z'
+      Va-Eauth-Dodedipnid:
+      - '1005079124'
+      Va-Eauth-Pid:
+      - '600036159'
+      Va-Eauth-Pnid:
+      - '796111863'
+      Va-Eauth-Birthdate:
+      - '1947-12-05T00:00:00+00:00'
+      Va-Eauth-Authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"1005079124","firstName":"Greg","lastName":"Anderson","birthDate":"1947-12-05T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Thu, 28 Sep 2017 22:14:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips
+      Content-Length:
+      - '135'
+      Content-Type:
+      - text/html; charset=UTF-8
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_2_ROUTEID=.01; path=/
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: "\r\n<!DOCTYPE html>\r\n<html>\r\n\t<head>\r\n\t\t<title>Unexpected
+        Error</title>\r\n\t</head>\r\n\t<body>\r\n\t\tUnexpected Error\r\n\t</body>\r\n</html>\r\n\r\n\r\n\r\n"
+    http_version: 
+  recorded_at: Thu, 28 Sep 2017 22:15:29 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Returns an error response when evss returns a 500 with an html formatted error in the body
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5109 or a json response in the body https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5173

Moves/refactors raise_backend_exception from PCIU service to base EVSS service so Letters service can use it as well.

Adds letter download specs with VCR cassettes for each case above and for a 404