### PR TITLE
Fixing issue with DS Logon non-premium FICAM identity proofed users

### DIFF
--- a/lib/saml/user_attributes/dslogon.rb
+++ b/lib/saml/user_attributes/dslogon.rb
@@ -88,7 +88,7 @@ module SAML
       # NOTE: idme will always return highest attained, but for iniital non-premium this will always be 1
       # the leveling up verification step invoked by F/E will correctly capture as LOA3.
       def loa_current
-        PREMIUM_LOAS.include?(dslogon_assurance) ? 3 :  1
+        PREMIUM_LOAS.include?(dslogon_assurance) ? 3 : 1
       end
 
       # This is "highest attained" via idp

--- a/lib/saml/user_attributes/dslogon.rb
+++ b/lib/saml/user_attributes/dslogon.rb
@@ -84,9 +84,11 @@ module SAML
         attributes['level_of_assurance']&.to_i
       end
 
-      # if the dslogon_assurance PREMIUM or IDME = 3, otherwise 1
+      # if the dslogon_assurance PREMIUM, otherwise 1
+      # NOTE: idme will always return highest attained, but for iniital non-premium this will always be 1
+      # the leveling up verification step invoked by F/E will correctly capture as LOA3.
       def loa_current
-        PREMIUM_LOAS.include?(dslogon_assurance) ? 3 : (idme_loa || 1)
+        PREMIUM_LOAS.include?(dslogon_assurance) ? 3 :  1
       end
 
       # This is "highest attained" via idp

--- a/lib/saml/user_attributes/mhv.rb
+++ b/lib/saml/user_attributes/mhv.rb
@@ -64,9 +64,11 @@ module SAML
         attributes['level_of_assurance']&.to_i
       end
 
-      # if the account_type PREMIUM or IDME = 3, otherwise 1
+      # if the account_type PREMIUM, otherwise 1
+      # NOTE: idme will always return highest attained, but for iniital non-premium this will always be 1
+      # the leveling up verification step invoked by F/E will correctly capture as LOA3.
       def loa_current
-        PREMIUM_LOAS.include?(account_type) ? 3 : (idme_loa || 1)
+        PREMIUM_LOAS.include?(account_type) ? 3 : 1
       end
 
       # This is "highest attained" via idp

--- a/spec/lib/saml/dslogon_user_spec.rb
+++ b/spec/lib/saml/dslogon_user_spec.rb
@@ -15,21 +15,21 @@ RSpec.describe SAML::User do
     context 'non-premium user' do
       let(:saml_attributes) do
         OneLogin::RubySaml::Attributes.new(
-          'dslogon_status'=>[],
-          'dslogon_assurance'=>['1'],
-          'dslogon_gender'=>[],
-          'dslogon_deceased'=>[],
-          'dslogon_idtype'=>[],
-          'uuid'=>['5e7465d7c3ba47f3a388d00df1e1a982'],
-          'dslogon_uuid'=>['1606997570'],
-          'email'=>['fake.user@vets.gov'],
-          'multifactor'=>['true'],
-          'level_of_assurance'=>['3'],
-          'dslogon_birth_date'=>[],
-          'dslogon_fname'=>[],
-          'dslogon_lname'=>[],
-          'dslogon_mname'=>[],
-          'dslogon_idvalue'=>[]
+          'dslogon_status' => [],
+          'dslogon_assurance' => ['1'],
+          'dslogon_gender' => [],
+          'dslogon_deceased' => [],
+          'dslogon_idtype' => [],
+          'uuid' => ['5e7465d7c3ba47f3a388d00df1e1a982'],
+          'dslogon_uuid' => ['1606997570'],
+          'email' => ['fake.user@vets.gov'],
+          'multifactor' => ['true'],
+          'level_of_assurance' => ['3'],
+          'dslogon_birth_date' => [],
+          'dslogon_fname' => [],
+          'dslogon_lname' => [],
+          'dslogon_mname' => [],
+          'dslogon_idvalue' => []
         )
       end
 
@@ -75,21 +75,21 @@ RSpec.describe SAML::User do
     context 'premium user' do
       let(:saml_attributes) do
         OneLogin::RubySaml::Attributes.new(
-          'dslogon_status'=>['SPONSOR'],
-          'dslogon_assurance'=>['2'],
-          'dslogon_gender'=>['male'],
-          'dslogon_deceased'=>['false'],
-          'dslogon_idtype'=>['ssn'],
-          'uuid'=>['cf0f3deb1b424d3cb4f792e8346a4d71'],
-          'dslogon_uuid'=>['1016980877'],
-          'email'=>['fake.user@vets.gov'],
-          'multifactor'=>['true'],
-          'level_of_assurance'=>[],
-          'dslogon_birth_date'=>['1973-09-03'],
-          'dslogon_fname'=>['KENT'],
-          'dslogon_lname'=>['WELLS'],
-          'dslogon_mname'=>['Mayo'],
-          'dslogon_idvalue'=>['796178410']
+          'dslogon_status' => ['SPONSOR'],
+          'dslogon_assurance' => ['2'],
+          'dslogon_gender' => ['male'],
+          'dslogon_deceased' => ['false'],
+          'dslogon_idtype' => ['ssn'],
+          'uuid' => ['cf0f3deb1b424d3cb4f792e8346a4d71'],
+          'dslogon_uuid' => ['1016980877'],
+          'email' => ['fake.user@vets.gov'],
+          'multifactor' => ['true'],
+          'level_of_assurance' => [],
+          'dslogon_birth_date' => ['1973-09-03'],
+          'dslogon_fname' => ['KENT'],
+          'dslogon_lname' => ['WELLS'],
+          'dslogon_mname' => ['Mayo'],
+          'dslogon_idvalue' => ['796178410']
         )
       end
 

--- a/spec/lib/saml/dslogon_user_spec.rb
+++ b/spec/lib/saml/dslogon_user_spec.rb
@@ -4,66 +4,132 @@ require 'saml/user'
 require 'ruby-saml'
 
 RSpec.describe SAML::User do
-  let(:saml_response) do
-    instance_double(OneLogin::RubySaml::Response, attributes: saml_attributes,
-                                                  decrypted_document: decrypted_document_partial)
-  end
-  let(:decrypted_document_partial) { REXML::Document.new(dslogon_response) }
-  let(:dslogon_response) { File.read("#{::Rails.root}/spec/fixtures/files/saml_xml/dslogon_response.xml") }
-  let(:saml_attributes) do
-    OneLogin::RubySaml::Attributes.new(
-      'dslogon_status' => ['SPONSOR'],
-      'dslogon_assurance' => ['2'],
-      'dslogon_gender' => ['male'],
-      'dslogon_deceased' => ['false'],
-      'dslogon_birth_date' => ['1973-09-03'],
-      'dslogon_fname' => ['KENT'],
-      'dslogon_mname' => ['Mayo'],
-      'dslogon_lname' => ['WELLS'],
-      'dslogon_idtype' => ['ssn'],
-      'dslogon_idvalue' => ['796178410'],
-      'uuid' => ['d09ae45773f4409c943ce85f668a527d'],
-      'dslogon_uuid' => ['1016980877'],
-      'email' => ['vets.gov.user+kent.wells@gmail.com'],
-      'multifactor' => ['true'],
-      'level_of_assurance' => [3]
-    )
-  end
-  context 'LOA highest is lower than LOA current' do
-    let(:described_instance) { described_class.new(saml_response) }
-    let(:user) { User.new(described_instance) }
-    let(:frozen_time) { Time.current }
+  describe 'DS Logon' do
+    let(:saml_response) do
+      instance_double(OneLogin::RubySaml::Response, attributes: saml_attributes,
+                                                    decrypted_document: decrypted_document_partial)
+    end
+    let(:decrypted_document_partial) { REXML::Document.new(dslogon_response) }
+    let(:dslogon_response) { File.read("#{::Rails.root}/spec/fixtures/files/saml_xml/dslogon_response.xml") }
 
-    around(:each) do |example|
-      Timecop.freeze(frozen_time) do
-        example.run
+    context 'non-premium user' do
+      let(:saml_attributes) do
+        OneLogin::RubySaml::Attributes.new(
+          'dslogon_status'=>[],
+          'dslogon_assurance'=>['1'],
+          'dslogon_gender'=>[],
+          'dslogon_deceased'=>[],
+          'dslogon_idtype'=>[],
+          'uuid'=>['5e7465d7c3ba47f3a388d00df1e1a982'],
+          'dslogon_uuid'=>['1606997570'],
+          'email'=>['fake.user@vets.gov'],
+          'multifactor'=>['true'],
+          'level_of_assurance'=>['3'],
+          'dslogon_birth_date'=>[],
+          'dslogon_fname'=>[],
+          'dslogon_lname'=>[],
+          'dslogon_mname'=>[],
+          'dslogon_idvalue'=>[]
+        )
+      end
+
+      context 'LOA highest is lower than LOA current' do
+        let(:described_instance) { described_class.new(saml_response) }
+        let(:user) { User.new(described_instance) }
+        let(:frozen_time) { Time.current }
+
+        around(:each) do |example|
+          Timecop.freeze(frozen_time) do
+            example.run
+          end
+        end
+
+        it 'properly constructs a user' do
+          expect(user).to be_valid
+        end
+
+        it 'has email' do
+          expect(user.email).to be_present
+        end
+
+        it 'has various important attributes' do
+          expect(user).to have_attributes(
+            uuid: '5e7465d7c3ba47f3a388d00df1e1a982',
+            first_name: nil,
+            middle_name: nil,
+            last_name: nil,
+            gender: nil,
+            birth_date: nil,
+            zip: nil,
+            ssn: nil,
+            loa: { current: 1, highest: 3 },
+            multifactor: 'true',
+            authn_context: 'dslogon',
+            last_signed_in: frozen_time,
+            mhv_last_signed_in: nil
+          )
+        end
       end
     end
 
-    it 'properly constructs a user' do
-      expect(user).to be_valid
-    end
+    context 'premium user' do
+      let(:saml_attributes) do
+        OneLogin::RubySaml::Attributes.new(
+          'dslogon_status'=>['SPONSOR'],
+          'dslogon_assurance'=>['2'],
+          'dslogon_gender'=>['male'],
+          'dslogon_deceased'=>['false'],
+          'dslogon_idtype'=>['ssn'],
+          'uuid'=>['cf0f3deb1b424d3cb4f792e8346a4d71'],
+          'dslogon_uuid'=>['1016980877'],
+          'email'=>['fake.user@vets.gov'],
+          'multifactor'=>['true'],
+          'level_of_assurance'=>[],
+          'dslogon_birth_date'=>['1973-09-03'],
+          'dslogon_fname'=>['KENT'],
+          'dslogon_lname'=>['WELLS'],
+          'dslogon_mname'=>['Mayo'],
+          'dslogon_idvalue'=>['796178410']
+        )
+      end
 
-    it 'has email' do
-      expect(user.email).to be_present
-    end
+      context 'LOA highest is lower than LOA current' do
+        let(:described_instance) { described_class.new(saml_response) }
+        let(:user) { User.new(described_instance) }
+        let(:frozen_time) { Time.current }
 
-    it 'has various important attributes' do
-      expect(user).to have_attributes(
-        uuid: 'd09ae45773f4409c943ce85f668a527d',
-        first_name: 'KENT',
-        middle_name: 'Mayo',
-        last_name: 'WELLS',
-        gender: 'M',
-        birth_date: '1973-09-03',
-        zip: nil,
-        ssn: '796178410',
-        loa: { current: 3, highest: 3 },
-        multifactor: 'true',
-        authn_context: 'dslogon',
-        last_signed_in: frozen_time,
-        mhv_last_signed_in: nil
-      )
+        around(:each) do |example|
+          Timecop.freeze(frozen_time) do
+            example.run
+          end
+        end
+
+        it 'properly constructs a user' do
+          expect(user).to be_valid
+        end
+
+        it 'has email' do
+          expect(user.email).to be_present
+        end
+
+        it 'has various important attributes' do
+          expect(user).to have_attributes(
+            uuid: 'cf0f3deb1b424d3cb4f792e8346a4d71',
+            first_name: 'KENT',
+            middle_name: 'Mayo',
+            last_name: 'WELLS',
+            gender: 'M',
+            birth_date: '1973-09-03',
+            zip: nil,
+            ssn: '796178410',
+            loa: { current: 3, highest: 3 },
+            multifactor: 'true',
+            authn_context: 'dslogon',
+            last_signed_in: frozen_time,
+            mhv_last_signed_in: nil
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
DS Logon non-premium users that have already identity proofed at ID.me have a 2 step authentication process.

1. They sign-in as DS Logon (this is like Facebook for example). (LOA current = 1
2. If they are identity proofed (LOA highest = 3), then they go through the id.me LOA identity proofing stage to get the saml response that would have user attributes.

The backend was setting LOA current = 3 prematurely. By doing so, it was forcing the validation on user.rb when at this stage it would not have first_name, last_name and other attributes needed to persist.

- Why was this not caught in testing? On staging we identity proofed and the values for the user were persisted to redis correctly after the identity proofing flow took place. The sign-in user in the nav would correctly say Welcome, Erin. When logging out and logging back in it was peculiar that the signin user would show the email address instead of the name. However, there was no errors and everything seemed OK. And it was, you could sign-in and sign-out for 24 hours without problem. However, once the cached state of the user expired, it would trigger the errors that we've discovered in production. In short, because the user was cached correctly after `sessions/identity-proof` we didn't run into any errors in testing.