### PR TITLE
SAML Certificate Rollover

### DIFF
--- a/config/initializers/saml.rb
+++ b/config/initializers/saml.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 Settings.saml.certificate = File.read(File.expand_path(Settings.saml.cert_path))
 Settings.saml.key = File.read(File.expand_path(Settings.saml.key_path))
+Settings.saml.certificate_new = File.read(File.expand_path(Settings.saml.cert_new_path))

--- a/config/initializers/saml.rb
+++ b/config/initializers/saml.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
+def new_saml_cert_exists?
+  !Settings.saml.cert_new_path.nil? && File.file?(File.expand_path(Settings.saml.cert_new_path))
+end
+
 Settings.saml.certificate = File.read(File.expand_path(Settings.saml.cert_path))
 Settings.saml.key = File.read(File.expand_path(Settings.saml.key_path))
-Settings.saml.certificate_new = File.read(File.expand_path(Settings.saml.cert_new_path))
+Settings.saml.certificate_new = new_saml_cert_exists? ? File.read(File.expand_path(Settings.saml.cert_new_path)) : nil

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -162,6 +162,7 @@ reports:
 # Settings for SAML authentication
 saml:
   cert_path: ~/.certs/vetsgov-localhost.crt
+  cert_new_path: ~/.certs/vetsgov-localhost_new.crt
   key_path: ~/.certs/vetsgov-localhost.key
   # Loaded in `config/initializers/saml.rb`, based on `*_path` settings above
   # certificate: ~

--- a/lib/saml/settings_service.rb
+++ b/lib/saml/settings_service.rb
@@ -80,6 +80,7 @@ module SAML
         settings.private_key = Settings.saml.key
         settings.issuer = Settings.saml.issuer
         settings.assertion_consumer_service_url = Settings.saml.callback_url
+        settings.certificate_new = Settings.saml.certificate_new
 
         settings.security[:authn_requests_signed] = true
         settings.security[:logout_requests_signed] = true

--- a/spec/factories/rubysaml_settings.rb
+++ b/spec/factories/rubysaml_settings.rb
@@ -12,6 +12,10 @@ FactoryGirl.define do
     idp_slo_target_url              'https://api.idmelabs.com/saml/SingleLogoutService'
     idp_sso_target_url              'https://api.idmelabs.com/saml/SingleSignOnService'
     name_identifier_format          'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
+
+    trait :rollover_cert do
+      certificate_new Settings.saml.certificate
+    end
   end
 
   factory :settings_no_context, class: 'OneLogin::RubySaml::Settings' do

--- a/spec/request/saml_metadata_spec.rb
+++ b/spec/request/saml_metadata_spec.rb
@@ -16,4 +16,21 @@ RSpec.describe 'SAML Metadata', type: :request do
     entity_id = xml.at_xpath('//md:EntityDescriptor/@entityID', 'md' => 'urn:oasis:names:tc:SAML:2.0:metadata')
     expect(entity_id.value).to eq(Settings.saml.issuer)
   end
+
+  context 'when a new cert exists for rollover' do
+    let(:rubysaml_settings) { FactoryGirl.build(:rubysaml_settings, :rollover_cert) }
+    before(:each) do
+      allow_any_instance_of(ApplicationController).to receive(:saml_settings).and_return(rubysaml_settings)
+    end
+
+    it 'provides two certificates' do
+      get '/saml/metadata'
+      assert_response :success
+
+      xml = Nokogiri::XML(response.body)
+
+      cert_nodes = xml.xpath('//ds:X509Certificate', 'ds' => 'http://www.w3.org/2000/09/xmldsig#')
+      expect(cert_nodes.size).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
Turns our `/saml/metadata` endpoint from having 1 certificate, to 2.  Example:

```xml
<?xml version="1.0"?>
<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="_bbd79f27-f6d8-4379-b017-fe7200d31737" entityID="saml-rp.vetsgov.localhost">
  <md:SPSSODescriptor AuthnRequestsSigned="true" WantAssertionsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
    <md:KeyDescriptor use="signing">
      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
        <ds:X509Data>
          <ds:X509Certificate>
MIIDkDCCAngCCQDJs5zziPV+JDANBgkqhkiG9w0BAQsFADCBiTELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkRDMRMwEQYDVQQHEwpXYXNoaW5ndG9uMRswGQYDVQQKExJWQSBEaWdpdGFsIFNlcnZpY2UxGjAYBgNVBAMTEXZldHNnb3YubG9jYWxob3N0MR8wHQYJKoZIhvcNAQkBFhBkc3ZhQGV4YW1wbGUuZ292MB4XDTE2MDgwMzE4MTU0MVoXDTE3MDgwMzE4MTU0MVowgYkxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJEQzETMBEGA1UEBxMKV2FzaGluZ3RvbjEbMBkGA1UEChMSVkEgRGlnaXRhbCBTZXJ2aWNlMRowGAYDVQQDExF2ZXRzZ292LmxvY2FsaG9zdDEfMB0GCSqGSIb3DQEJARYQZHN2YUBleGFtcGxlLmdvdjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALdF4WSDFxSyTL36DXANlT3Akgm4lsnKJauBdb1l4Nl0Xl7vFIfFPfqYVEUxN0B57BG/GWUmpMHJFR5aXz10/DEcYcP1vlLaO2AWKoqAIyv3eF7yHo52lyYGv+jbVsI0CTl03gYIBvsh7e7778RWFOeJzQaNKr11sYm4Rvx48qyXrkd74YqRuRxFE1JlNicKy4cnDgYb7S77RzLpmD95Z07QYceV7KHwNdWgXZd3zGjfI7O8bkTvSOUcH7Bm23bwX7qrlNMYy58B4VI/YfbBSbTo9wYqCln+gdpDiOymX6db4yC4DBjUwD8tcRO249KKinSbgkwSqv+3eoq1XiTSlC8CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAmISuOhQD8SdkrkPVBWU5wwVGujF+Chm2A2rbBjESFb/f2yoNhYVNdKQhoRY9RPEJRYNypTyFLB9z+wtrQaRviHVKt/b1SfGeSFUMIkYV5/g/WFlQjD0vriyi8Um2V2BuVF5EtWat/mRYLOrHnIePbmokVh+bOS2cYTgXMB1wpAEdV0HQjUlwdNTdyPhBOw3ZiGa7DV3EbVRTq6CqD1IWRzkt3pR9g/T6nLRIlvtFaGwAM9iEi72FJK7zNqarWioCd9n7/NtspL+HdRnm3wd2/s46EbpP5me31EhrQUvEGNxw12ogXTrZ90icrfzPO3GEtc3XxYzO2Zp9LEK6IfZCAA==
</ds:X509Certificate>
        </ds:X509Data>
      </ds:KeyInfo>
    </md:KeyDescriptor>
    <md:KeyDescriptor use="signing">
      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
        <ds:X509Data>
          <ds:X509Certificate>
MIICUDCCAbmgAwIBAgIBADANBgkqhkiG9w0BAQ0FADBFMQswCQYDVQQGEwJ1czELMAkGA1UECAwCTUExFDASBgNVBAoMC0JpbGxzIEhvdXNlMRMwEQYDVQQDDApiaWxsc2hvdXNlMB4XDTE3MTAwNTE1MTU1MVoXDTE4MTAwNTE1MTU1MVowRTELMAkGA1UEBhMCdXMxCzAJBgNVBAgMAk1BMRQwEgYDVQQKDAtCaWxscyBIb3VzZTETMBEGA1UEAwwKYmlsbHNob3VzZTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA2soTM3s4bw8UWIQKuDSmmMW4wiOZwqr7xCeHgJ0DfDfOLedUy2xJ4wpeKwf222sUet7tO24gTBVvIlRRx4bEdUfNs+VgZiWb0BcR0IINvVfkGExqDDuQge36Mg3p4KdxHaioeN1rfPWfxeTskDTXrOqIaxMe+omOg0oeO5teIS0CAwEAAaNQME4wHQYDVR0OBBYEFL8OoKeIwcBB9y1NFzDt8Onuj7OoMB8GA1UdIwQYMBaAFL8OoKeIwcBB9y1NFzDt8Onuj7OoMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQENBQADgYEA0of0/s9XZsQEe9O5ggHUbh7WPd5KWCbWHlOgbqm7QwuENDst7b0RpHSsFPFG5hkxf7Y6/+i7mA3z5QKdC+tnehR51lis6OCOR19iyWMFftqyk/wGUdgxlMeAzN/JQMtiRtECMgdz+NBQ5FxTQEKB0g9hYpP3OcEOn+x7svv5MmQ=
</ds:X509Certificate>
        </ds:X509Data>
      </ds:KeyInfo>
    </md:KeyDescriptor>
    <md:NameIDFormat>
urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
</md:NameIDFormat>
    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:3000/auth/saml/callback" index="0" isDefault="true"/>
  </md:SPSSODescriptor>
</md:EntityDescriptor>
```