### PR TITLE
ensure rm doesn't fail when directories don't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,6 @@ rebuild:
 
 .PHONY: clean
 clean:
-	rm -rf data
-	$(COMPOSE_TEST) run vets-api rm -r coverage log tmp
+	rm -r data || true
+	$(COMPOSE_TEST) run vets-api rm -r coverage log tmp || true
 	$(COMPOSE_TEST) down


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5271