### PR TITLE
Fixed date bug in tracking spec

### DIFF
--- a/spec/factories/trackings.rb
+++ b/spec/factories/trackings.rb
@@ -10,5 +10,9 @@ FactoryGirl.define do
     ndc_number            '12345678910'
     shipped_date          Time.parse('Thu, 12 Oct 2016 00:00:00 EDT').in_time_zone
     delivery_service      'UPS'
+
+    trait :oldest do
+      shipped_date Time.parse('Thu, 12 Oct 2016 00:00:00 EDT').in_time_zone - 1.year
+    end
   end
 end

--- a/spec/models/tracking_spec.rb
+++ b/spec/models/tracking_spec.rb
@@ -30,7 +30,7 @@ describe Tracking do
       let(:t1) { tracking_with_prescription_id }
       let(:t2) { tracking_with_prescription_id }
       let(:t3) { described_class.new(attributes_for(:tracking, prescription_id: '2', shipped_date: Time.now.utc)) }
-      let(:t4) { described_class.new(attributes_for(:tracking, prescription_id: '3', shipped_date: 1.year.ago.utc)) }
+      let(:t4) { described_class.new(attributes_for(:tracking, :oldest, prescription_id: '3')) }
 
       subject { [t1, t2, t3, t4] }
 


### PR DESCRIPTION
Spec requires date ordered records. Bug caused the oldest date to be "newer" than the second oldest date, causing a previously passing spec to fail.