### PR TITLE
Add db as a `make spec` dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ security: db
 	@$(BASH_DEV) "bundle exec rake security"
 
 .PHONY: spec
-spec:
+spec: db
 	@$(BASH_TEST) "bundle exec rake spec"
 
 .PHONY: up
@@ -45,6 +45,7 @@ up: db
 
 .PHONY: rebuild
 rebuild:
+	@$(COMPOSE_DEV) down
 	@$(COMPOSE_DEV) build
 
 .PHONY: clean


### PR DESCRIPTION
Adding `db` as a dependency on the `spec` make task allows it to properly re-create the database when needed. Also adds `docker-compose down` as a step to for `rebuild` to rebuild networks and containers.