### PR TITLE
persistentattachment naming bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'typhoeus'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus'
 gem 'will_paginate'
+gem 'zero_downtime_migrations'
 
 group :development do
   gem 'guard-rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,6 +448,8 @@ GEM
       crack (>= 0.3.2)
       hashdiff
     will_paginate (3.1.0)
+    zero_downtime_migrations (0.0.7)
+      activerecord
 
 PLATFORMS
   ruby
@@ -542,6 +544,7 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
   will_paginate
+  zero_downtime_migrations
 
 BUNDLED WITH
    1.15.4

--- a/app/controllers/v0/claim_documents_controller.rb
+++ b/app/controllers/v0/claim_documents_controller.rb
@@ -17,7 +17,7 @@ module V0
     def klass
       case form_id
       when '21P-527EZ', '21P-530'
-        PersistentAttachment::PensionBurial
+        PersistentAttachments::PensionBurial
       end
     end
 

--- a/app/models/persistent_attachments/pension_burial.rb
+++ b/app/models/persistent_attachments/pension_burial.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class PersistentAttachment::PensionBurial < PersistentAttachment
+class PersistentAttachments::PensionBurial < PersistentAttachment
   UPLOADER_CLASS = ClaimDocumentation::PensionBurial::File
   include ::ClaimDocumentation::Uploader::Attachment.new(:file)
 end

--- a/app/models/saved_claim/burial.rb
+++ b/app/models/saved_claim/burial.rb
@@ -2,7 +2,7 @@
 class SavedClaim::Burial < SavedClaim
   FORM = '21P-530'
   CONFIRMATION = 'BUR'
-  PERSISTENT_CLASS = PersistentAttachment::PensionBurial
+  PERSISTENT_CLASS = PersistentAttachments::PensionBurial
 
   def regional_office
     PensionBurial::ProcessingOffice.address_for(open_struct_form.claimantAddress.postalCode)

--- a/app/models/saved_claim/pension.rb
+++ b/app/models/saved_claim/pension.rb
@@ -2,7 +2,7 @@
 class SavedClaim::Pension < SavedClaim
   FORM = '21P-527EZ'
   CONFIRMATION = 'PEN'
-  PERSISTENT_CLASS = PersistentAttachment::PensionBurial
+  PERSISTENT_CLASS = PersistentAttachments::PensionBurial
 
   def regional_office
     PensionBurial::ProcessingOffice.address_for(open_struct_form.veteranAddress.postalCode)

--- a/db/migrate/20171017181144_persistent_attachments_name_change.rb
+++ b/db/migrate/20171017181144_persistent_attachments_name_change.rb
@@ -1,5 +1,5 @@
 class PersistentAttachmentsNameChange < ActiveRecord::Migration
   def change
-    PersistentAttachment.where(type: 'PersistentAttachment::PensionBurial').update_all(type: 'PersistentAttachments::PensionBurial')
+    DataMigrations::PersistentAttachment.run
   end
 end

--- a/db/migrate/20171017181144_persistent_attachments_name_change.rb
+++ b/db/migrate/20171017181144_persistent_attachments_name_change.rb
@@ -1,0 +1,5 @@
+class PersistentAttachmentsNameChange < ActiveRecord::Migration
+  def change
+    PersistentAttachment.where(type: 'PersistentAttachment::PensionBurial').update_all(type: 'PersistentAttachments::PensionBurial')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170815233455) do
+ActiveRecord::Schema.define(version: 20171017181144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/data_migrations/persistent_attachment.rb
+++ b/lib/data_migrations/persistent_attachment.rb
@@ -1,9 +1,10 @@
+# TODO: delete after running
 module DataMigrations
   module PersistentAttachment
     module_function
 
     def run
-      PersistentAttachment.where(type: 'PersistentAttachment::PensionBurial').update_all(type: 'PersistentAttachments::PensionBurial')
+      ::PersistentAttachment.where(type: 'PersistentAttachment::PensionBurial').update_all(type: 'PersistentAttachments::PensionBurial')
     end
   end
 end

--- a/lib/data_migrations/persistent_attachment.rb
+++ b/lib/data_migrations/persistent_attachment.rb
@@ -1,0 +1,9 @@
+module DataMigrations
+  module PersistentAttachment
+    module_function
+
+    def run
+      PersistentAttachment.where(type: 'PersistentAttachment::PensionBurial').update_all(type: 'PersistentAttachments::PensionBurial')
+    end
+  end
+end

--- a/lib/data_migrations/persistent_attachment.rb
+++ b/lib/data_migrations/persistent_attachment.rb
@@ -1,10 +1,13 @@
+# frozen_string_literal: true
 # TODO: delete after running
 module DataMigrations
   module PersistentAttachment
     module_function
 
     def run
-      ::PersistentAttachment.where(type: 'PersistentAttachment::PensionBurial').update_all(type: 'PersistentAttachments::PensionBurial')
+      ::PersistentAttachment.where(
+        type: 'PersistentAttachment::PensionBurial'
+      ).update_all(type: 'PersistentAttachments::PensionBurial')
     end
   end
 end

--- a/rakelib/edu.rake
+++ b/rakelib/edu.rake
@@ -8,6 +8,12 @@ namespace :edu do
     puts EducationForm::Forms::Base.build(app).text
   end
 
+  # one off script for persistent attachment migrations, delete later
+  desc 'migrate persistent attachments'
+  task persistent_attachment: :environment do
+    DataMigrations::PersistentAttachment.run
+  end
+
   # one off script for spool submission report, delete later
   desc 'generate spool submissions report for last 60 days'
   task spool_report: :environment do

--- a/spec/lib/data_migrations/persistent_attachment_spec.rb
+++ b/spec/lib/data_migrations/persistent_attachment_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe DataMigrations::PersistentAttachment do
+  it 'should migrate the records' do
+    persistent_attachment = PersistentAttachment.new(file_data: 'foo')
+    persistent_attachment.type = 'PersistentAttachment::PensionBurial'
+    persistent_attachment.save(validate: false)
+
+    DataMigrations::PersistentAttachment.run
+    expect(persistent_attachment.reload.type).to eq('PersistentAttachments::PensionBurial')
+  end
+end

--- a/spec/models/persistent_attachments/pension_burial_spec.rb
+++ b/spec/models/persistent_attachments/pension_burial_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe PersistentAttachment::PensionBurial do
+RSpec.describe PersistentAttachments::PensionBurial do
   let(:file) { Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf') }
   let(:instance) { described_class.new(form_id: 'T-123') }
 

--- a/spec/request/claim_documents_spec.rb
+++ b/spec/request/claim_documents_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe 'Claim Document Attachment', type: :request do
     expect(response.status).to eq(200)
     resp = JSON.parse(response.body)
     expect(resp['data']['attributes'].keys.sort).to eq(%w(confirmation_code name size))
-    expect(PersistentAttachment.last).to be_a(PersistentAttachment::PensionBurial)
+    expect(PersistentAttachment.last).to be_a(PersistentAttachments::PensionBurial)
   end
 end


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5406
adding a rake task because there is a delay from when migrations run and the code gets updated so the migration will have to be run again after the code is updated, the code that references persistent_attachment is in a job so if the job fails it will retry for 21 days so no real problems should occur