### PR TITLE
Normalize prefilled suffix

### DIFF
--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -163,7 +163,7 @@ class FormProfile
         first: user.first_name&.capitalize,
         middle: user.middle_name&.capitalize,
         last: user.last_name&.capitalize,
-        suffix: user.va_profile&.suffix
+        suffix: user.va_profile&.normalized_suffix
       },
       date_of_birth: user.birth_date,
       gender: user.gender,

--- a/lib/mvi/models/mvi_profile.rb
+++ b/lib/mvi/models/mvi_profile.rb
@@ -38,8 +38,8 @@ module MVI
         @mhv_ids&.first
       end
 
-      def normalized_suffix(suffix)
-        case suffix
+      def normalized_suffix
+        case @suffix
         when /jr\.?/i
           'Jr.'
         when /sr\.?/i

--- a/lib/mvi/models/mvi_profile.rb
+++ b/lib/mvi/models/mvi_profile.rb
@@ -37,6 +37,21 @@ module MVI
       def mhv_correlation_id
         @mhv_ids&.first
       end
+
+      def normalized_suffix(suffix)
+        case suffix
+        when /jr\.?/i
+          'Jr.'
+        when /sr\.?/i
+          'Sr.'
+        when /iii/i
+          'III'
+        when /ii/i
+          'II'
+        when /iv/i
+          'IV'
+        end
+      end
     end
   end
 end

--- a/spec/lib/mvi/models/mvi_profile_spec.rb
+++ b/spec/lib/mvi/models/mvi_profile_spec.rb
@@ -41,4 +41,25 @@ describe MVI::Models::MviProfile do
       end
     end
   end
+
+  describe '#normalized_suffix' do
+    context 'with a non-nil suffix' do
+      cases = {
+        'Jr.' => %w(jr jr. JR JR. Jr Jr. jR jR.),
+        'Sr.' => %w(sr sr. SR SR. Sr Sr. sR sR.),
+        'II' => %w(i I).repeated_permutation(2).map(&:join),
+        'III' => %w(i I).repeated_permutation(3).map(&:join),
+        'IV' => %w(iv IV Iv iV),
+        nil => %w(i mr ms mrs md v)
+      }
+
+      cases.each do |expected_result, inputs|
+        inputs.each do |input|
+          it 'returns a properly formatted suffix' do
+            expect(build(:mvi_profile, suffix: input).normalized_suffix).to eq(expected_result)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/request/in_progress_forms_request_spec.rb
+++ b/spec/request/in_progress_forms_request_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'in progress forms', type: :request do
           'veteranFullName' => {
             'first' => user.first_name&.capitalize,
             'last' => user.last_name&.capitalize,
-            'suffix' => user.va_profile&.normalized_suffix
+            'suffix' => user.va_profile.suffix
           },
           'gender' => user.gender,
           'veteranDateOfBirth' => user.birth_date,

--- a/spec/request/in_progress_forms_request_spec.rb
+++ b/spec/request/in_progress_forms_request_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'in progress forms', type: :request do
           'veteranFullName' => {
             'first' => user.first_name&.capitalize,
             'last' => user.last_name&.capitalize,
-            'suffix' => user.va_profile.suffix
+            'suffix' => user.va_profile&.normalized_suffix
           },
           'gender' => user.gender,
           'veteranDateOfBirth' => user.birth_date,


### PR DESCRIPTION
Normalizes suffixes like so:

`jr`, `JR`, `Jr`, `jr.`, `JR.`, `Jr.` => `Jr.`
`sr`, `SR`, `Sr`, `sr.`, `SR.`, `Sr.` => `Sr.`
`ii`, `iI`, `Ii`, `II` => `II`
and so on.

This will allow suffixes to match the json schemas expectations for suffix format.