### PR TITLE
[WIP] - identity refactor version 2

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < Common::RedisStore
   redis_ttl REDIS_CONFIG['user_store']['each_ttl']
   redis_key :uuid
 
-  # id.me attributes
+  # SAML Attributes
   attribute :uuid
   attribute :email
   attribute :first_name
@@ -27,51 +27,71 @@ class User < Common::RedisStore
   attribute :zip
   attribute :ssn
   attribute :loa
-  # These attributes are fetched by SAML::User in the saml_response payload
   attribute :multifactor   # used by F/E to decision on whether or not to prompt user to add MFA
   attribute :authn_context # used by F/E to handle various identity related complexities pending refactor
-  # FIXME: if MVI were decorated on usr vs delegated to @mvi, then this might not have been necessary.
   attribute :mhv_icn # only needed by B/E not serialized in user_serializer
   attribute :mhv_uuid # this is the cannonical version of MHV Correlation ID, provided by MHV sign-in users
 
-  # vaafi attributes
-  attribute :last_signed_in, Common::UTCTime
+  # Non SAML Attributes
+  attribute :last_signed_in, Common::UTCTime # vaafi attributes
+  attribute :mhv_last_signed_in, Common::UTCTime # MHV audit logging
 
-  # mhv_last_signed_in used to determine whether we need to notify MHV audit logging
-  # This is set to Time.now when any MHV session is first created, and nulled, when logout
-  attribute :mhv_last_signed_in, Common::UTCTime
-
+  # Validations
   validates :uuid, presence: true
   validates :email, presence: true
   validates :loa, presence: true
 
-  # conditionally validate if user is LOA3
-  with_options(on: :loa3_user) do |user|
-    user.validates :first_name, presence: true
-    user.validates :last_name, presence: true
-    user.validates :birth_date, presence: true
-    user.validates :ssn, presence: true, format: /\A\d{9}\z/
-    user.validates :gender, format: /\A(M|F)\z/, allow_blank: true
+  # Getter Overrides - IMPORTANT, the source of truth should be MVI when available.
+  def first_name
+    loa3? ? va_profile.given_names.first || super : super
   end
 
-  # LOA1 no longer just means ID.me LOA1.
-  # It could also be DSLogon or MHV NON PREMIUM users who have not yet done ID.me FICAM LOA3.
-  # See also lib/saml/user_attributes/dslogon.rb
-  # See also lib/saml/user_attributes/mhv
+  def middle_name
+    loa3? ? va_profile.given_names.second || super : super
+  end
+
+  def last_name
+    loa3? ? va_profile.family_name || super : super
+  end
+
+  def gender
+    loa3? ? va_profile.gender || super : super
+  end
+
+  def birth_date
+    loa3? ? va_profile.birth_date || super : super
+  end
+
+  def zip
+    loa3? ? va_profile.address.postal_code || super : super
+  end
+
+  def ssn
+    if loa3? && va_profile.ssn == super
+      va_profile.ssn
+    else
+      # Flag for potential fraud? If so, this should probably happen at initialization
+      # Should other heuristics be considered such as birth_date?
+      nil
+    end
+  end
+
+  def mhv_correlation_id
+    loa3? ? mhv_uuid || mvi.mhv_correlation_id : nil
+  end
+
+
+  # LOA1 is not just ID.me LOA1, DSLogon or MHV "Non-Premium" users who have not done "FICAM LOA3".
   def loa1?
     loa[:current] == LOA::ONE
   end
 
+  # FIXME This method should be removed.
   def loa2?
     loa[:current] == LOA::TWO
   end
 
-  # LOA3 no longer just means ID.me FICAM LOA3.
-  # It could also be DSLogon or MHV Premium users.
-  # It could also be DSLogon or MHV NON PREMIUM users who have done ID.me FICAM LOA3.
-  # Additionally, LOA3 does not automatically mean user has opted to have MFA.
-  # See also lib/saml/user_attributes/dslogon.rb
-  # See also lib/saml/user_attributes/mhv
+  # LOA3 could be ID.me FICAM LOA3, DSLogon or MHV "Premium" users, or "Non-Premium with FICAM LOA3".
   def loa3?
     loa[:current] == LOA::THREE
   end
@@ -116,6 +136,8 @@ class User < Common::RedisStore
     false
   end
 
+  # FIXME - why is this really necessary? Shouldn't the LOA3 have everything the LOA1 has? Why can't we just
+  # expire the old and only use the new? (except maybe for multifactor) which would be cleaner / safer?
   def self.from_merged_attrs(existing_user, new_user)
     # we want to always use the more recent attrs so long as they exist
     attrs = new_user.attributes.map do |key, val|
@@ -134,10 +156,6 @@ class User < Common::RedisStore
   delegate :icn, to: :mvi
   delegate :participant_id, to: :mvi
   delegate :veteran?, to: :veteran_status
-
-  def mhv_correlation_id
-    mhv_uuid || mvi.mhv_correlation_id
-  end
 
   def va_profile
     mvi.profile


### PR DESCRIPTION
Why this approach instead of #1498 ? 

- because of the way user factory is used across all of our specs, it's an absolute disaster to try and move all of those attributes on to a new model and call it user_identity right now. All of setter and getter methods are instantly broken.

- this draws more attention to the fact that the user model is doing some data precedence, it makes sense maybe that initially we call attention to it, and then refactor and abstract that facility later when other developers are aware of this major change from the way we previously did things.

Cons

- user.rb is doing entirely way too much, not even including all of the includes for vaffi headers and other things. Those really ought to be a decorator used separately rather than added onto to this class.

- an additional band-aid until we can come up with a better abstraction. Seeing as MVI is cached independently, it follows that so should the SAML response, and any attributes related to the user should probably be cached independently of that as well.