### PR TITLE
Fix typo in generate_spool_files job

### DIFF
--- a/app/workers/education_form/generate_spool_files.rb
+++ b/app/workers/education_form/generate_spool_files.rb
@@ -73,7 +73,7 @@ module EducationForm
       regional_data = valid_records.group_by { |r| r.regional_processing_office.to_sym }
 
       raw_groups = regional_data.each do |region, v|
-        grouped_data[region] = v.map do |record|
+        regional_data[region] = v.map do |record|
           record.saved_claim.valid? && EducationForm::Forms::Base.build(record)
         end.compact
       end


### PR DESCRIPTION
Small typo we discovered last night during the cleanup. Pushing this so we don't have to make the fix again after the production deploy.