### PR TITLE
Check if latest_service_episode exists before checking end date

### DIFF
--- a/app/models/emis_redis/military_information.rb
+++ b/app/models/emis_redis/military_information.rb
@@ -72,7 +72,7 @@ module EMISRedis
 
     def currently_active_duty_hash
       {
-        yes: latest_service_episode.end_date.future?
+        yes: latest_service_episode.present? && latest_service_episode.end_date.future?
       }
     end
 


### PR DESCRIPTION
`latest_service_episode` could potentially be `nil`. This now checks if it is present before calculating if they are currently active duty.

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5831