### PR TITLE
minor refactor of saml_settings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -125,15 +125,7 @@ class ApplicationController < ActionController::API
   end
 
   def saml_settings(options = {})
-    # Make sure we're not changing the settings globally
-    base_settings = SAML::SettingsService.saml_settings.dup
-
-    options.each do |option, value|
-      next if value.nil?
-      base_settings.send("#{option}=", value)
-    end
-
-    base_settings
+    SAML::SettingsService.saml_settings(options)
   end
 
   def pagination_params

--- a/lib/saml/settings_service.rb
+++ b/lib/saml/settings_service.rb
@@ -18,7 +18,23 @@ module SAML
       OPEN_TIMEOUT = 2
       TIMEOUT = 15
 
-      def saml_settings
+      def saml_settings(options = {})
+        if options.any?
+          # Make sure we're not changing the settings globally
+          settings = base_settings.dup
+
+          options.each do |option, value|
+            next if value.nil?
+            settings.send("#{option}=", value)
+          end
+
+          settings
+        else
+          base_settings
+        end
+      end
+
+      def base_settings
         if HealthStatus.healthy?
           merged_saml_settings
         else


### PR DESCRIPTION
- this change is to support further refactor of sessions_controller
- moving persist_session_and_user into a class for better handling and testing in future PR.