### PR TITLE
GIT_REVISION added to log output

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
     end,
     proc do |_request|
       AppInfo::GIT_REVISION
-    end,
+    end
   ]
 
   # Use a different logger for distributed setups.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,10 @@ Rails.application.configure do
       else
         'unauthenticated'
       end
-    end
+    end,
+    proc do |_request|
+      AppInfo::GIT_REVISION
+    end,
   ]
 
   # Use a different logger for distributed setups.


### PR DESCRIPTION
Provide the ability to filter logs by git revision to enable faster debugging. Previously we'd need to find the server IP addresses from AWS and deployment logs, then filter log events by IPs of those
servers.

Action item from: https://github.com/department-of-veterans-affairs/vets.gov-team/pull/5679/