### PR TITLE
ID Card Announcement Subscriptions

### DIFF
--- a/app/controllers/v0/id_card_announcement_subscription_controller.rb
+++ b/app/controllers/v0/id_card_announcement_subscription_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module V0
+  class IdCardAnnouncementSubscriptionController < ApplicationController
+    skip_before_action :authenticate
+
+    def create
+      @subscription = IdCardAnnouncementSubscription.find_or_create_by(filtered_params)
+
+      if @subscription.valid?
+        render json: { status: 'OK' }, status: :accepted
+      else
+        raise Common::Exceptions::ValidationErrors, @subscription
+      end
+    end
+
+    private
+
+    def filtered_params
+      params.require(:id_card_announcement_subscription).permit(:email)
+    end
+  end
+end

--- a/app/models/id_card_announcement_subscription.rb
+++ b/app/models/id_card_announcement_subscription.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class IdCardAnnouncementSubscription < ActiveRecord::Base
+  validates :email,
+            uniqueness: true,
+            format: { with: /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/ } # Devise::email_regexp
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Rails.application.routes.draw do
 
     scope :id_card do
       resource :attributes, only: [:show], controller: 'id_card_attributes'
+      resource :announcement_subscription, only: [:create], controller: 'id_card_announcement_subscription'
     end
 
     namespace :preneeds do

--- a/db/migrate/20171203010549_create_id_card_announcement_subscriptions.rb
+++ b/db/migrate/20171203010549_create_id_card_announcement_subscriptions.rb
@@ -1,7 +1,7 @@
 class CreateIdCardAnnouncementSubscriptions < ActiveRecord::Migration
   def change
     create_table :id_card_announcement_subscriptions do |t|
-      t.string :email, null: false, unique: true
+      t.string :email, null: false
       t.timestamps null: false
     end
   end

--- a/db/migrate/20171203010549_create_id_card_announcement_subscriptions.rb
+++ b/db/migrate/20171203010549_create_id_card_announcement_subscriptions.rb
@@ -1,0 +1,8 @@
+class CreateIdCardAnnouncementSubscriptions < ActiveRecord::Migration
+  def change
+    create_table :id_card_announcement_subscriptions do |t|
+      t.string :email, null: false, unique: true
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20171203062701_add_unique_index_to_id_card_announcement_subscriptions.rb
+++ b/db/migrate/20171203062701_add_unique_index_to_id_card_announcement_subscriptions.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToIdCardAnnouncementSubscriptions < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :id_card_announcement_subscriptions, :email, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171203010549) do
+ActiveRecord::Schema.define(version: 20171203062701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,8 @@ ActiveRecord::Schema.define(version: 20171203010549) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_index "id_card_announcement_subscriptions", ["email"], name: "index_id_card_announcement_subscriptions_on_email", unique: true, using: :btree
 
   create_table "in_progress_forms", force: :cascade do |t|
     t.string   "user_uuid",              null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171108221458) do
+ActiveRecord::Schema.define(version: 20171203010549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,12 @@ ActiveRecord::Schema.define(version: 20171108221458) do
   end
 
   add_index "gibs_not_found_users", ["edipi"], name: "index_gibs_not_found_users_on_edipi", using: :btree
+
+  create_table "id_card_announcement_subscriptions", force: :cascade do |t|
+    t.string   "email",      null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "in_progress_forms", force: :cascade do |t|
     t.string   "user_uuid",              null: false

--- a/rakelib/id_card_announcement_subscriptions.rake
+++ b/rakelib/id_card_announcement_subscriptions.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :id_card_announcement_subscriptions do
+  desc 'Export distinct email addresses'
+  task export: :environment do
+    emails = IdCardAnnouncementSubscription.pluck(:email)
+    puts emails.join("\n")
+  end
+end

--- a/spec/factories/id_card_announcement_subscriptions.rb
+++ b/spec/factories/id_card_announcement_subscriptions.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :id_card_announcement_subscription do
+    email 'test@example.com'
+  end
+end

--- a/spec/models/id_card_announcement_subscription_spec.rb
+++ b/spec/models/id_card_announcement_subscription_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe IdCardAnnouncementSubscription, type: :model do
+  describe 'when validating' do
+    it 'requires a valid email address' do
+      subscription = described_class.new(email: 'invalid')
+      expect_attr_invalid(subscription, :email, 'is invalid')
+    end
+
+    it 'requires a unique email address' do
+      email = 'nonunique@example.com'
+      described_class.create(email: email)
+      subscription = described_class.new(email: email)
+      expect_attr_invalid(subscription, :email, 'has already been taken')
+    end
+  end
+end

--- a/spec/request/id_card_announcement_subscription_request_spec.rb
+++ b/spec/request/id_card_announcement_subscription_request_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Requesting ID Card Announcement Subscription', type: :request do
+  def email
+    params[:id_card_announcement_subscription][:email]
+  end
+
+  describe 'with valid params' do
+    let(:params) do
+      {
+        id_card_announcement_subscription: {
+          email: 'test@example.com'
+        }
+      }
+    end
+
+    it 'creates the subscription' do
+      post '/v0/id_card/announcement_subscription', params
+      expect(response).to have_http_status(:accepted)
+      expect(IdCardAnnouncementSubscription.find_by(email: email)).to be_present
+    end
+  end
+
+  describe 'with a non-unique address' do
+    let(:params) do
+      {
+        id_card_announcement_subscription: {
+          email: 'test@example.com'
+        }
+      }
+    end
+
+    before do
+      IdCardAnnouncementSubscription.create(email: email)
+    end
+
+    it 'creates the subscription' do
+      post '/v0/id_card/announcement_subscription', params
+      expect(response).to have_http_status(:accepted)
+    end
+  end
+
+  describe 'with invalid params' do
+    let(:params) do
+      {
+        id_card_announcement_subscription: {
+          email: 'test'
+        }
+      }
+    end
+
+    it 'responds with unprocessable entity and validation error' do
+      post '/v0/id_card/announcement_subscription', params
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to be_a(String)
+
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['title']).to eq('Email is invalid')
+    end
+  end
+
+  describe 'with missing params' do
+    it 'responds with bad request' do
+      post '/v0/id_card/announcement_subscription'
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end


### PR DESCRIPTION
Provides endpoint to record unique emails for Veterans interested in a future announcement that VIC issues have been resolved. Super interested in name suggestions.

    POST /v0/id_card_announcement_subscription
      {
        id_card_announcement_description: {
          email: test@example.com
        }
      }

creates a record in `id_card_announcement_subscriptions` with the provided email and responds with a 202 accepted. Subsequent attempts to submit the same email will result in the same response with no additional record. The response data does not include any unique identifying information:

    { result: 'OK' }

Email format validation will occur, but should also be provided on the client. Not sure if we should add support to https://github.com/department-of-veterans-affairs/vets-json-schema. I don't have much experience working with it, but will happily dive in to integrate there and gain that knowledge.

A simple rake task is provided to export a list of email addresses subscribed to the VIC ID card announcement list:

    rake id_card_announcement_subscriptions:export

ref: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/6449