### PR TITLE
VIC announcement subscription email length limit

### DIFF
--- a/app/models/id_card_announcement_subscription.rb
+++ b/app/models/id_card_announcement_subscription.rb
@@ -2,5 +2,6 @@
 class IdCardAnnouncementSubscription < ActiveRecord::Base
   validates :email,
             uniqueness: true,
+            length: { maximum: 255 },
             format: { with: /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/ } # Devise::email_regexp
 end

--- a/spec/models/id_card_announcement_subscription_spec.rb
+++ b/spec/models/id_card_announcement_subscription_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe IdCardAnnouncementSubscription, type: :model do
       expect_attr_invalid(subscription, :email, 'is invalid')
     end
 
+    it 'requires less than 255 characters in an email address' do
+      subscription = described_class.new(email: "#{'x' * 255 }@example.com")
+      expect_attr_invalid(subscription, :email, 'is too long (maximum is 255 characters)')
+    end
+
     it 'requires a unique email address' do
       email = 'nonunique@example.com'
       described_class.create(email: email)

--- a/spec/models/id_card_announcement_subscription_spec.rb
+++ b/spec/models/id_card_announcement_subscription_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe IdCardAnnouncementSubscription, type: :model do
     end
 
     it 'requires less than 255 characters in an email address' do
-      subscription = described_class.new(email: "#{'x' * 255 }@example.com")
+      email = ('x' * 255) + '@example.com'
+      subscription = described_class.new(email: email)
       expect_attr_invalid(subscription, :email, 'is too long (maximum is 255 characters)')
     end
 


### PR DESCRIPTION
Limits VIC email length to 255 characters