### PR TITLE
change preneeds timeout

### DIFF
--- a/lib/preneeds/configuration.rb
+++ b/lib/preneeds/configuration.rb
@@ -8,7 +8,7 @@ require 'preneeds/middleware/response/preneeds_parser'
 
 module Preneeds
   class Configuration < Common::Client::Configuration::SOAP
-    TIMEOUT = 15
+    TIMEOUT = 30
 
     def self.url
       "#{Settings.preneeds.host}/eoas_SOA/PreNeedApplicationPort"


### PR DESCRIPTION
http://sentry.vetsgov-internal/vets-gov/platform-api-development/issues/27907/
we're still getting timeout errors with large files