### PR TITLE
Identity Refactor Phase 4 - replace delegation with precedence

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -141,7 +141,7 @@ module V0
         StatsD.increment(STATSD_LOGIN_FAILED_KEY, tags: ["error:#{fail_handler.error}"])
         log_message_to_sentry(fail_handler.message, fail_handler.level, fail_handler.context)
       else
-        StatsD.increment(STATSD_LOGIN_FAILED_KEY, tags: ['error:validations_failed}'])
+        StatsD.increment(STATSD_LOGIN_FAILED_KEY, tags: ['error:validations_failed'])
         context = {
           uuid: @current_user.uuid,
           user:   {

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -135,13 +135,25 @@ module V0
     end
 
     def handle_login_error
-      fail_handler = SAML::AuthFailHandler.new(@saml_response, @current_user, @session)
+      fail_handler = SAML::AuthFailHandler.new(@saml_response)
       StatsD.increment(STATSD_CALLBACK_KEY, tags: ['status:failure', "context:#{context_key}"])
-      StatsD.increment(STATSD_LOGIN_FAILED_KEY, tags: ["error:#{fail_handler.error}"])
-      if fail_handler.known_error?
+      if fail_handler.errors?
+        StatsD.increment(STATSD_LOGIN_FAILED_KEY, tags: ["error:#{fail_handler.error}"])
         log_message_to_sentry(fail_handler.message, fail_handler.level, fail_handler.context)
       else
-        log_message_to_sentry(fail_handler.generic_error_message, :error)
+        StatsD.increment(STATSD_LOGIN_FAILED_KEY, tags: ['error:validations_failed}'])
+        context = {
+          uuid: @current_user.uuid,
+          user:   {
+            valid: @current_user&.valid?,
+            errors: @current_user&.errors&.full_messages
+          },
+          session:   {
+            valid: @session&.valid?,
+            errors: @session&.errors&.full_messages
+          }
+        }
+        log_message_to_sentry('Login Fail! on User/Session Validation', :error, context)
       end
     end
 

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -117,7 +117,7 @@ module V0
 
       @session = Session.new(uuid: @current_user.uuid)
       # FIXME-IDENTITY-PHASE2: the last part of this line will go away
-      @session.save && @current_user.save && user_identity.save && old_current_user.save
+      @session.save && user_identity.save && @current_user.save && old_current_user.save
     end
 
     # FIXME-IDENTITY-PHASE2: won't need to specify klass as there will only e 1

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,31 +40,35 @@ class User < Common::RedisStore
   delegate :first_name, to: :identity, allow_nil: true
 
   def first_name
-    identity.first_name || mvi&.profile&.given_names&.first
+    mhv_icn.present? ? mvi&.profile&.given_names&.first : identity.first_name
   end
 
   def middle_name
-    identity.middle_name || mvi&.profile&.given_names&.last
+    mhv_icn.present? ? mvi&.profile&.given_names&.last : identity.middle_name
   end
 
   def last_name
-    identity.last_name || mvi&.profile&.family_name
+    mhv_icn.present? ? mvi&.profile&.family_name : identity.last_name
   end
 
   def gender
-    identity.gender || mvi&.profile&.gender
+    mhv_icn.present? ? mvi&.profile&.gender : identity.gender
   end
 
   def birth_date
-    identity.birth_date || mvi&.profile&.birth_date
+    mhv_icn.present? ? mvi&.profile&.birth_date : identity.birth_date
   end
 
   def zip
-    identity.zip || mvi&.profile&.address&.postal_code
+    mhv_icn.present? ? mvi&.profile&.address&.postal_code : identity.zip
   end
 
   def ssn
-    identity.ssn || mvi&.profile&.ssn
+    mhv_icn.present? ? mvi&.profile&.ssn : identity.ssn
+  end
+
+  def mhv_correlation_id
+    mhv_uuid || mvi.mhv_correlation_id
   end
 
   delegate :loa, to: :identity, allow_nil: true
@@ -79,10 +83,6 @@ class User < Common::RedisStore
   delegate :icn, to: :mvi
   delegate :participant_id, to: :mvi
   delegate :veteran?, to: :veteran_status
-
-  def mhv_correlation_id
-    mhv_uuid || mvi.mhv_correlation_id
-  end
 
   def va_profile
     mvi.profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,12 +23,12 @@ class User < Common::RedisStore
   validates :uuid, presence: true
 
   # conditionally validate if user is LOA3
-  with_options(on: :loa3_user) do |user|
-    user.validates :first_name, presence: true
-    user.validates :last_name, presence: true
-    user.validates :birth_date, presence: true
-    user.validates :ssn, presence: true, format: /\A\d{9}\z/
-    user.validates :gender, format: /\A(M|F)\z/, allow_blank: true
+  with_options if: :loa3? do |loa3_user|
+    loa3_user.validates :first_name, presence: true
+    loa3_user.validates :last_name, presence: true
+    loa3_user.validates :birth_date, presence: true
+    loa3_user.validates :ssn, presence: true, format: /\A\d{9}\z/
+    loa3_user.validates :gender, format: /\A(M|F)\z/, allow_blank: true
   end
 
   attribute :uuid
@@ -71,7 +71,10 @@ class User < Common::RedisStore
     mhv_uuid || mvi.mhv_correlation_id
   end
 
-  delegate :loa, to: :identity, allow_nil: true
+  def loa
+    identity&.loa || {}
+  end
+
   delegate :multifactor, to: :identity, allow_nil: true
   delegate :authn_context, to: :identity, allow_nil: true
   delegate :mhv_icn, to: :identity, allow_nil: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,12 +38,35 @@ class User < Common::RedisStore
   # identity attributes, some of these will be overridden by MVI.
   delegate :email, to: :identity, allow_nil: true
   delegate :first_name, to: :identity, allow_nil: true
-  delegate :middle_name, to: :identity, allow_nil: true
-  delegate :last_name, to: :identity, allow_nil: true
-  delegate :gender, to: :identity, allow_nil: true
-  delegate :birth_date, to: :identity, allow_nil: true
-  delegate :zip, to: :identity, allow_nil: true
-  delegate :ssn, to: :identity, allow_nil: true
+
+  def first_name
+    identity.first_name || mvi&.profile&.given_names&.first
+  end
+
+  def middle_name
+    identity.middle_name || mvi&.profile&.given_names&.last
+  end
+
+  def last_name
+    identity.last_name || mvi&.profile&.family_name
+  end
+
+  def gender
+    identity.gender || mvi&.profile&.gender
+  end
+
+  def birth_date
+    identity.birth_date || mvi&.profile&.birth_date
+  end
+
+  def zip
+    identity.zip || mvi&.profile&.address&.postal_code
+  end
+
+  def ssn
+    identity.ssn || mvi&.profile&.ssn
+  end
+
   delegate :loa, to: :identity, allow_nil: true
   delegate :multifactor, to: :identity, allow_nil: true
   delegate :authn_context, to: :identity, allow_nil: true

--- a/lib/saml/auth_fail_handler.rb
+++ b/lib/saml/auth_fail_handler.rb
@@ -12,7 +12,7 @@ module SAML
     def initialize(saml_response)
       @saml_response = saml_response
       return if @saml_response.is_valid?
-      known_error? || generic_error_message
+      initialize_errors!
     end
 
     def error
@@ -23,12 +23,18 @@ module SAML
       only_one_error? ? 'unknown' : 'multiple'
     end
 
-    def known_error?
+    def errors?
+      !@message.nil? && !@level.nil?
+    end
+
+    private
+
+    def initialize_errors!
       KNOWN_ERRORS.each do |known_error|
         break if send("#{known_error}?")
       end
 
-      false
+      generic_error_message
     end
 
     def generic_error_message
@@ -40,12 +46,6 @@ module SAML
       }
       set_sentry_params('Other SAML Response Error(s)', :error, context)
     end
-
-    def errors?
-      !@message.nil? && !@level.nil?
-    end
-
-    private
 
     def clicked_deny?
       return false unless only_one_error? && @saml_response.status_message == CLICKED_DENY_MSG

--- a/lib/saml/auth_fail_handler.rb
+++ b/lib/saml/auth_fail_handler.rb
@@ -9,14 +9,10 @@ module SAML
 
     KNOWN_ERRORS = %i(clicked_deny auth_too_late auth_too_early).freeze
 
-    def initialize(saml_response, user, session)
+    def initialize(saml_response)
       @saml_response = saml_response
-      @current_user = user
-      @session = session
 
-      @message = nil
-      @level   = nil
-      @context = nil
+      known_error? || generic_error_message
     end
 
     def error
@@ -24,7 +20,7 @@ module SAML
         return known_error if send("#{known_error}?")
       end
 
-      'unknown'
+      only_one_error? ? 'unknown' : 'multiple'
     end
 
     def known_error?
@@ -32,17 +28,22 @@ module SAML
         break if send("#{known_error}?")
       end
 
-      !@message.nil? && !@level.nil?
+      false
     end
 
     def generic_error_message
-      message = <<-MESSAGE.strip_heredoc
-        SAML Login attempt failed! Reasons...
-          saml:    'valid?=#{@saml_response.is_valid?} errors=#{@saml_response.errors}'
-          user:    'valid?=#{@current_user&.valid?} errors=#{@current_user&.errors&.full_messages}'
-          session: 'valid?=#{@session&.valid?} errors=#{@session&.errors&.full_messages}'
-      MESSAGE
-      message
+      return if @saml_response.is_valid?
+      context = {
+        saml_response: {
+          status_message: @saml_response.status_message,
+          errors: @saml_response.errors
+        }
+      }
+      set_sentry_params('Other SAML Response Error(s)', :error, context)
+    end
+
+    def errors?
+      !@message.nil? && !@level.nil?
     end
 
     private

--- a/lib/saml/auth_fail_handler.rb
+++ b/lib/saml/auth_fail_handler.rb
@@ -11,7 +11,7 @@ module SAML
 
     def initialize(saml_response)
       @saml_response = saml_response
-
+      return if @saml_response.is_valid?
       known_error? || generic_error_message
     end
 
@@ -32,7 +32,6 @@ module SAML
     end
 
     def generic_error_message
-      return if @saml_response.is_valid?
       context = {
         saml_response: {
           status_message: @saml_response.status_message,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -117,7 +117,6 @@ RSpec.describe User, type: :model do
         end
 
         it 'fetches gender from mvi' do
-          expect(user.gender).not_to eq(user.identity.gender)
           expect(user.gender).to eq(mvi_profile.gender)
         end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -95,19 +95,119 @@ RSpec.describe User, type: :model do
       end
     end
 
-    describe '#mhv_correlation_id' do
-      context 'when mhv ids are nil' do
-        let(:user) { FactoryBot.build(:user) }
-        it 'has a mhv correlation id of nil' do
-          expect(user.mhv_correlation_id).to be_nil
+    describe 'getter methods' do
+      context 'when icn is available from saml data and user LOA3' do
+        let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
+        let(:user) { FactoryBot.build(:user, :loa3, mhv_icn: mvi_profile.icn) }
+        before(:each) { stub_mvi(mvi_profile) }
+
+        it 'fetches first_name from mvi' do
+          expect(user.first_name).not_to eq(user.identity.first_name)
+          expect(user.first_name).to eq(mvi_profile.given_names.first)
+        end
+
+        it 'fetches middle_name from mvi' do
+          expect(user.middle_name).not_to eq(user.identity.middle_name)
+          expect(user.middle_name).to eq(mvi_profile.given_names.last)
+        end
+
+        it 'fetches last_name from mvi' do
+          expect(user.last_name).not_to eq(user.identity.last_name)
+          expect(user.last_name).to eq(mvi_profile.family_name)
+        end
+
+        it 'fetches gender from mvi' do
+          expect(user.gender).not_to eq(user.identity.gender)
+          expect(user.gender).to eq(mvi_profile.gender)
+        end
+
+        it 'fetches birth_date from mvi' do
+          expect(user.birth_date).not_to eq(user.identity.birth_date)
+          expect(user.birth_date).to eq(mvi_profile.birth_date)
+        end
+
+        it 'fetches zip from mvi' do
+          expect(user.zip).not_to eq(user.identity.zip)
+          expect(user.zip).to eq(mvi_profile.address.postal_code)
+        end
+
+        it 'fetches ssn from mvi' do
+          expect(user.ssn).not_to eq(user.identity.ssn)
+          expect(user.ssn).to eq(mvi_profile.ssn)
         end
       end
-      context 'when there are mhv ids' do
-        let(:loa3_user) { FactoryBot.build(:user, :loa3) }
+
+      context 'when icn is available from saml data and user LOA3' do
         let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
-        it 'has a mhv correlation id' do
-          stub_mvi(mvi_profile)
-          expect(loa3_user.mhv_correlation_id).to eq(mvi_profile.mhv_ids.first)
+        let(:user) { FactoryBot.build(:user, :loa1, mhv_icn: mvi_profile.icn) }
+        before(:each) { stub_mvi(mvi_profile) }
+
+        it 'fetches first_name from mvi' do
+          expect(user.first_name).to be_nil
+        end
+
+        it 'fetches middle_name from mvi' do
+          expect(user.middle_name).to be_nil
+        end
+
+        it 'fetches last_name from mvi' do
+          expect(user.last_name).to be_nil
+        end
+
+        it 'fetches gender from mvi' do
+          expect(user.gender).to be_nil
+        end
+
+        it 'fetches birth_date from mvi' do
+          expect(user.birth_date).to be_nil
+        end
+
+        it 'fetches zip from mvi' do
+          expect(user.zip).to be_nil
+        end
+
+        it 'fetches ssn from mvi' do
+          expect(user.ssn).to be_nil
+        end
+      end
+
+      context 'when icn is not available from saml data' do
+        let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
+        let(:user) { FactoryBot.build(:user, :loa3) }
+        before(:each) { stub_mvi(mvi_profile) }
+
+        it 'fetches first_name from UserIdentity' do
+          expect(user.first_name).to eq(user.identity.first_name)
+          expect(user.first_name).not_to eq(mvi_profile.given_names.first)
+        end
+
+        it 'fetches middle_name from UserIdentity' do
+          expect(user.middle_name).to eq(user.identity.middle_name)
+          expect(user.middle_name).not_to eq(mvi_profile.given_names.last)
+        end
+
+        it 'fetches last_name from UserIdentity' do
+          expect(user.last_name).to eq(user.identity.last_name)
+          expect(user.last_name).not_to eq(mvi_profile.family_name)
+        end
+
+        it 'fetches gender from UserIdentity' do
+          expect(user.gender).to eq(user.identity.gender)
+        end
+
+        it 'fetches birth_date from UserIdentity' do
+          expect(user.birth_date).to eq(user.identity.birth_date)
+          expect(user.birth_date).not_to eq(mvi_profile.birth_date)
+        end
+
+        it 'fetches zip from UserIdentity' do
+          expect(user.zip).to eq(user.identity.zip)
+          expect(user.zip).not_to eq(mvi_profile.address.postal_code)
+        end
+
+        it 'fetches ssn from UserIdentity' do
+          expect(user.ssn).to eq(user.identity.ssn)
+          expect(user.ssn).not_to eq(mvi_profile.ssn)
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -210,6 +210,23 @@ RSpec.describe User, type: :model do
           expect(user.ssn).not_to eq(mvi_profile.ssn)
         end
       end
+
+      describe '#mhv_correlation_id' do
+        context 'when mhv ids are nil' do
+          let(:user) { FactoryBot.build(:user) }
+          it 'has a mhv correlation id of nil' do
+            expect(user.mhv_correlation_id).to be_nil
+          end
+        end
+        context 'when there are mhv ids' do
+          let(:loa3_user) { FactoryBot.build(:user, :loa3) }
+          let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
+          it 'has a mhv correlation id' do
+            stub_mvi(mvi_profile)
+            expect(loa3_user.mhv_correlation_id).to eq(mvi_profile.mhv_ids.first)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe User, type: :model do
         end
       end
 
-      context 'when icn is available from saml data and user LOA3' do
+      context 'when icn is available from saml data and user NOT LOA3' do
         let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
         let(:user) { FactoryBot.build(:user, :loa1, mhv_icn: mvi_profile.icn) }
         before(:each) { stub_mvi(mvi_profile) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe User, type: :model do
       subject(:loa1_user) { described_class.new(FactoryBot.build(:user, loa: loa_one)) }
 
       it 'should not allow a blank uuid' do
+        binding.pry
         loa1_user.uuid = ''
         expect(loa1_user.valid?).to be_falsey
         expect(loa1_user.errors[:uuid].size).to be_positive

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe User, type: :model do
       subject(:loa1_user) { described_class.new(FactoryBot.build(:user, loa: loa_one)) }
 
       it 'should not allow a blank uuid' do
-        binding.pry
         loa1_user.uuid = ''
         expect(loa1_user.valid?).to be_falsey
         expect(loa1_user.errors[:uuid].size).to be_positive

--- a/spec/request/in_progress_forms_request_spec.rb
+++ b/spec/request/in_progress_forms_request_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe V0::InProgressFormsController, type: :request do
       end
 
       context 'when the user is not a test account' do
-        let(:user) { build(:user, :loa3, ssn: '000-01-0002') }
+        let(:user) { build(:user, :loa3, ssn: '000010002') }
         it 'returns a 200' do
           subject
           expect(response).to have_http_status(:ok)

--- a/spec/request/letters_request_spec.rb
+++ b/spec/request/letters_request_spec.rb
@@ -101,7 +101,6 @@ RSpec.describe 'letters', type: :request do
         user.va_profile.participant_id = '600039999'
       end
       it 'should return a 404' do
-        binding.pry
         VCR.use_cassette('evss/letters/download_404') do
           post '/v0/letters/commissary', nil, auth_header
           expect(response).to have_http_status(:not_found)

--- a/spec/request/letters_request_spec.rb
+++ b/spec/request/letters_request_spec.rb
@@ -94,13 +94,14 @@ RSpec.describe 'letters', type: :request do
 
     context 'with a 404 evss response' do
       let(:user) do
-        build(:user, :loa3, first_name: 'John', last_name: 'SMith', birth_date: '1942-02-12', ssn: '7991112233')
+        build(:user, :loa3, first_name: 'John', last_name: 'SMith', birth_date: '1942-02-12', ssn: '799111223')
       end
       before do
         user.va_profile.edipi = '1005079999'
         user.va_profile.participant_id = '600039999'
       end
       it 'should return a 404' do
+        binding.pry
         VCR.use_cassette('evss/letters/download_404') do
           post '/v0/letters/commissary', nil, auth_header
           expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
- jumping ahead to phase 4 as don't feel comfortable removing the additional persistence yet.
- replacing user delegation to user identity with getter methods that first attempt to fetch from identity and then MVI.
- IMPORTANT, in the future we might want to reevaluate if this is the correct order. Ideally MVI would take precedence over identity and eventually this concept of a Profile and VA Profile becomes 1 thing. The F/E should have no need for two separate concepts around this.