### PR TITLE
Add cautionary note to faraday-curl in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   # TODO: switch to a version number once that version is released
   gem 'factory_bot', git: 'https://github.com/thoughtbot/factory_bot', ref: '50eeb67241ea78a6b138eea694a2a25413052f49'
+  # CAUTION: faraday_curl may not provide all headers used in the actual faraday request. Be cautious if using this to assist with debugging production issues (https://github.com/department-of-veterans-affairs/vets.gov-team/pull/6262)
   gem 'faraday_curl'
   gem 'foreman'
   gem 'guard-rspec', '~> 4.7'


### PR DESCRIPTION
While debugging issues related to the EVSS cross-account claims incident, I used faraday-curl to temporarily log requests to EVSS.  Cookie headers that were set within the adapter are not presented by this gem since they are not available in the middleware code path. This commit adds a note to the Gemfile to let others know that, while helpful, the curl output may not be completely accurate.

Action item from https://github.com/department-of-veterans-affairs/vets.gov-team/pull/6262