### PR TITLE
handle end date nil for service episodes 

### DIFF
--- a/app/models/emis_redis/military_information.rb
+++ b/app/models/emis_redis/military_information.rb
@@ -71,8 +71,16 @@ module EMISRedis
     end
 
     def currently_active_duty_hash
+      value =
+        if latest_service_episode.present?
+          end_date = latest_service_episode.end_date
+          end_date.nil? || end_date.future?
+        else
+          false
+        end
+
       {
-        yes: latest_service_episode.present? && latest_service_episode.end_date.future?
+        yes: value
       }
     end
 

--- a/spec/models/emis_redis/military_information_spec.rb
+++ b/spec/models/emis_redis/military_information_spec.rb
@@ -21,6 +21,27 @@ describe EMISRedis::MilitaryInformation, skip_emis: true do
         )
       end
     end
+
+    it 'should return true if service episode end date is in the future' do
+      allow(subject).to receive(:latest_service_episode).and_return(double(end_date: Date.today + 5.days))
+      expect(subject.currently_active_duty_hash).to eq(
+        yes: true
+      )
+    end
+
+    it 'should return true if service episode end date is nil' do
+      allow(subject).to receive(:latest_service_episode).and_return(double(end_date: nil))
+      expect(subject.currently_active_duty_hash).to eq(
+        yes: true
+      )
+    end
+
+    it 'should return false if service episode is nil' do
+      allow(subject).to receive(:latest_service_episode).and_return(nil)
+      expect(subject.currently_active_duty_hash).to eq(
+        yes: false
+      )
+    end
   end
 
   describe '#tours_of_duty' do

--- a/spec/models/emis_redis/military_information_spec.rb
+++ b/spec/models/emis_redis/military_information_spec.rb
@@ -23,7 +23,7 @@ describe EMISRedis::MilitaryInformation, skip_emis: true do
     end
 
     it 'should return true if service episode end date is in the future' do
-      allow(subject).to receive(:latest_service_episode).and_return(double(end_date: Date.today + 5.days))
+      allow(subject).to receive(:latest_service_episode).and_return(double(end_date: Date.current + 1.day))
       expect(subject.currently_active_duty_hash).to eq(
         yes: true
       )


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/6719
nil end date for service episodes means they are still on duty