### PR TITLE
Add hours/minutes/seconds to filename when uploading spool files to sftp

### DIFF
--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -70,7 +70,7 @@ module EducationForm
     def write_files(writer, structured_data:)
       structured_data.each do |region, records|
         region_id = EducationFacility.facility_for(region: region)
-        filename = "#{region_id}_#{Time.zone.today.strftime('%m%d%Y')}_vetsgov.spl"
+        filename = "#{region_id}_#{Time.zone.now.strftime('%m%d%Y_%H%M%S')}_vetsgov.spl"
         log_submissions(records, filename)
         # create the single textual spool file
         contents = records.map(&:text).join(EducationForm::WINDOWS_NOTEPAD_LINEBREAK)

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
   end
 
   context 'write_files', run_at: '2016-09-16 03:00:00 EDT' do
-    let(:filename) { '307_09162016_vetsgov.spl' }
+    let(:filename) { '307_09162016_070000_vetsgov.spl' }
     let!(:second_record) { FactoryBot.create(:va1995) }
 
     context 'in the development env' do


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5748

Currently, the timestamp will be for UTC, let me know if we want it different. Formatted it in a similar manner to the date.