### PR TITLE
Use 'uservoice' instead of 'User Feedback' label for automatically created issues

### DIFF
--- a/lib/github/github_service.rb
+++ b/lib/github/github_service.rb
@@ -12,7 +12,7 @@ module Github
           GITHUB_REPO,
           issue_title(feedback),
           issue_body(feedback),
-          assignee: 'va-bot', labels: 'User Feedback'
+          assignee: 'va-bot', labels: 'uservoice'
         )
       rescue => e
         log_exception_to_sentry(e)

--- a/spec/lib/github/github_service_spec.rb
+++ b/spec/lib/github/github_service_spec.rb
@@ -12,7 +12,7 @@ describe Github::GithubService do
         'department-of-veterans-affairs/vets.gov-team',
         feedback.description[0..40],
         feedback.description + "\n\nTarget Page: /example/page\nEmail of Author: NOT PROVIDED",
-        assignee: 'va-bot', labels: 'User Feedback'
+        assignee: 'va-bot', labels: 'uservoice'
       )
     described_class.create_issue(feedback)
   end
@@ -23,7 +23,7 @@ describe Github::GithubService do
         'department-of-veterans-affairs/vets.gov-team',
         feedback.description[0..40] + ' - Response Requested',
         feedback.description + "\n\nTarget Page: /example/page\nEmail of Author: j**********",
-        assignee: 'va-bot', labels: 'User Feedback'
+        assignee: 'va-bot', labels: 'uservoice'
       )
     described_class.create_issue(feedback_with_email)
   end


### PR DESCRIPTION
For the user-feedback API, we want the label to be `uservoice`.  When originally designed & written I made up `User Feedback`.

@rroueche i included you in this PR just as confirmation that this is desired behavior