### PR TITLE
remove -brd suffix from deploy jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,22 +50,22 @@ pipeline {
           booleanParam(name: 'release', value: false),
         ], wait: true
 
-        build job: 'deploys/vets-api-server-dev-brd', parameters: [
+        build job: 'deploys/vets-api-server-dev', parameters: [
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),
         ], wait: false
 
-        build job: 'deploys/vets-api-worker-dev-brd', parameters: [
+        build job: 'deploys/vets-api-worker-dev', parameters: [
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),
         ], wait: false
 
-        build job: 'deploys/vets-api-server-staging-brd', parameters: [
+        build job: 'deploys/vets-api-server-staging', parameters: [
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),
         ], wait: false
 
-        build job: 'deploys/vets-api-worker-staging-brd', parameters: [
+        build job: 'deploys/vets-api-worker-staging', parameters: [
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),
         ], wait: false


### PR DESCRIPTION
Resolves one of the last TODO items during transition in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5490