### PR TITLE
Make sure the same tags are always returned for api.auth.login benchm…

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -222,8 +222,8 @@ module V0
 
     def benchmark_tags(*tags)
       tags << "context:#{context_key}"
-      tags << "loa:#{@current_user.loa[:current]}" if @current_user && @current_user.identity
-      tags << "multifactor:#{@current_user.multifactor}" if @current_user && @current_user.identity
+      tags << "loa:#{@current_user && @current_user.identity ? @current_user.loa[:current] : 'none'}"
+      tags << "multifactor:#{@current_user && @current_user.identity ? @current_user.multifactor : 'none'}"
       tags
     end
   end


### PR DESCRIPTION
…arks

The way the golang prometheus client handles the conversion of statsd tags into
prometheus labels means they always need to have the same keys for a a given
metric. This is a construct that is only allowed by the golang client and the
Prometheus developers consider its use to be almost always be an anti-pattern,
so I'm not entirely sure why the statsd exported uses it.

For now this can be resolved be keeping the set of tag keys constant for given metrics.