### PR TITLE
rate limit with sidekiq enterprise

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,11 @@ gem 'carrierwave', '~> 0.11' # TODO: explanation
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc # TODO: explanation
 gem 'sidekiq-scheduler', '~> 2.0' # TODO: explanation
+# sidekiq enterprise edition
+source "https://enterprise.contribsys.com/" do
+  gem 'sidekiq-pro'
+  gem 'sidekiq-ent'
+end
 
 gem 'aasm'
 gem 'attr_encrypted'
@@ -55,9 +60,7 @@ gem 'ruby-saml'
 gem 'savon'
 gem 'sentry-raven'
 gem 'shrine'
-gem 'sidekiq'
 gem 'sidekiq-instrument'
-gem 'sidekiq-rate-limiter'
 gem 'sidekiq-unique-jobs'
 gem 'statsd-instrument'
 gem 'swagger-blocks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GIT
 
 GEM
   remote: https://rubygems.org/
+  remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.0.2)
     aasm (4.12.0)
@@ -334,8 +335,6 @@ GEM
     redis (3.3.3)
     redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
-    redis_rate_limiter (0.1.0)
-      redis
     require_all (1.4.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -403,13 +402,14 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
+    sidekiq-ent (1.6.1)
+      sidekiq (>= 4.2.9)
+      sidekiq-pro (>= 3.5.0)
     sidekiq-instrument (0.2.1)
       sidekiq (~> 4.0)
       statsd-instrument (~> 2.0, >= 2.0.4)
-    sidekiq-rate-limiter (0.1.1)
-      redis
-      redis_rate_limiter
-      sidekiq (>= 2.0, < 5.0)
+    sidekiq-pro (3.6.1)
+      sidekiq (>= 4.1.5)
     sidekiq-scheduler (2.0.19)
       hashie (~> 3.4)
       redis (~> 3)
@@ -551,9 +551,9 @@ DEPENDENCIES
   sentry-raven
   shrine
   shrine-memory
-  sidekiq
+  sidekiq-ent!
   sidekiq-instrument
-  sidekiq-rate-limiter
+  sidekiq-pro!
   sidekiq-scheduler (~> 2.0)
   sidekiq-unique-jobs
   simplecov

--- a/app/workers/github/create_issue_job.rb
+++ b/app/workers/github/create_issue_job.rb
@@ -4,7 +4,7 @@ require 'github/github_service'
 module Github
   class CreateIssueJob
     include Sidekiq::Worker
-    THROTTLE = Sidekiq::Limiter.window("prevent_feedback_spam", 4, :minute).freeze
+    THROTTLE = Sidekiq::Limiter.window('prevent_feedback_spam', 4, :minute).freeze
 
     # :nocov:
     def perform(feedback)

--- a/app/workers/github/create_issue_job.rb
+++ b/app/workers/github/create_issue_job.rb
@@ -4,21 +4,15 @@ require 'github/github_service'
 module Github
   class CreateIssueJob
     include Sidekiq::Worker
-
-    # limit the rate at which Github API calls are made
-    # so as not to trigger Github spam protections
-    sidekiq_options queue: 'low',
-                    rate: {
-                      name: 'prevent_feedback_spam',
-                      limit: 20,
-                      period: 3600, ## An hour
-                    }
+    THROTTLE = Sidekiq::Limiter.window("prevent_feedback_spam", 4, :minute).freeze
 
     # :nocov:
     def perform(feedback)
-      feedback = Feedback.new(feedback)
-      create_response = Github::GithubService.create_issue(feedback)
-      FeedbackSubmissionMailer.build(feedback, create_response&.html_url).deliver_now
+      THROTTLE.within_limit do
+        feedback = Feedback.new(feedback)
+        create_response = Github::GithubService.create_issue(feedback)
+        FeedbackSubmissionMailer.build(feedback, create_response&.html_url).deliver_now
+      end
     end
     # :nocov:
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
-require 'sidekiq-rate-limiter/version'
-require 'sidekiq-rate-limiter/fetch'
 
 Sidekiq.configure_server do |config|
-  Sidekiq.options[:fetch] = Sidekiq::RateLimiter::Fetch
   config.redis = REDIS_CONFIG['redis']
   config.on(:startup) do
     Sidekiq.schedule = YAML.load_file(File.expand_path('../../sidekiq_scheduler.yml', __FILE__))


### PR DESCRIPTION
### Work Done
- rate limiting changed to [window mode](https://github.com/mperham/sidekiq/wiki/Ent-Rate-Limiting#window) at 4 per minute
- Gemfile updated to consume sidekiq enterprise (license key config is required for this! Do not merge until we figure out how to distribute)

### Discovery Performed
[Github API rate limits](https://developer.github.com/v3/#rate-limiting)
- 5000/hour for authenticated requests (which `vets-api`---> GH API _is_)
- 60/hour for unauthenticated requests (i.e. browser ---> `vets-api`)

Sidekiq Enterprise
- Sidekiq has a [backoff algorithm](https://github.com/mperham/sidekiq/wiki/Ent-Rate-Limiting#back-off) where jobs get reschedules if the limit has already been reached

GH Spam Protections
- I created my own test repo and spammed it `5000.times { create_issue('a title', 'a body') }` and I started getting 403 responses after ~65 requests.  It locked me out of the API for ~1 minute or so.
  