### PR TITLE
add the github issue number to email subject line

### DIFF
--- a/app/mailers/feedback_submission_mailer.rb
+++ b/app/mailers/feedback_submission_mailer.rb
@@ -13,9 +13,10 @@ class FeedbackSubmissionMailer < ApplicationMailer
     nick.sullivan@adhocteam.us
   ).freeze
 
-  def build(feedback, github_link)
+  def build(feedback, github_link, github_issue_number)
     @feedback = feedback
     @github_link = github_link.presence || 'Warning: No Github link present!'
+    @github_issue_number = github_issue_number || -1
     template = File.read('app/mailers/views/feedback_report.erb')
 
     mail(
@@ -32,7 +33,7 @@ class FeedbackSubmissionMailer < ApplicationMailer
   end
 
   def subject_line
-    subject = 'Vets.gov Feedback Received'
+    subject = "#{@github_issue_number}: Vets.gov Feedback Received"
     subject += ' - Response Requested' if @feedback.owner_email.present?
     subject
   end

--- a/app/workers/github/create_issue_job.rb
+++ b/app/workers/github/create_issue_job.rb
@@ -28,7 +28,7 @@ module Github
       feedback = Feedback.new(feedback)
       THROTTLE.within_limit do
         create_response = Github::GithubService.create_issue(feedback)
-        FeedbackSubmissionMailer.build(feedback, create_response&.html_url).deliver_now
+        FeedbackSubmissionMailer.build(feedback, create_response&.html_url, create_response&.number).deliver_now
       end
     end
     # :nocov:

--- a/spec/mailers/feedback_submission_mailer_spec.rb
+++ b/spec/mailers/feedback_submission_mailer_spec.rb
@@ -6,13 +6,15 @@ RSpec.describe FeedbackSubmissionMailer, type: [:mailer] do
   let(:feedback_with_email) { build :feedback, :email_provided }
   let(:feedback_malicious) { build :feedback, :malicious_email }
   let(:github_url) { 'https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4985' }
+  let(:github_issue_number) { 4985 }
 
   subject do
-    described_class.build(feedback, github_url).deliver_now
+    described_class.build(feedback, github_url, github_issue_number).deliver_now
   end
 
   describe '#build' do
     it 'should include all info' do
+      expect(subject.subject).to include(github_issue_number.to_s)
       expect(subject.body.raw_source).to include(github_url)
       expect(subject.body.raw_source).to include(feedback.target_page)
       expect(subject.body.raw_source).to include(feedback.description)
@@ -20,7 +22,7 @@ RSpec.describe FeedbackSubmissionMailer, type: [:mailer] do
 
     context 'when malicious input injection is attempted' do
       subject do
-        described_class.build(feedback_malicious, github_url).deliver_now
+        described_class.build(feedback_malicious, github_url, github_issue_number).deliver_now
       end
       it 'should treat malicious input as string literals' do
         expect(subject.body.raw_source).to include(feedback_malicious.owner_email)
@@ -29,7 +31,7 @@ RSpec.describe FeedbackSubmissionMailer, type: [:mailer] do
 
     context 'when email is provided' do
       subject do
-        described_class.build(feedback_with_email, github_url).deliver_now
+        described_class.build(feedback_with_email, github_url, github_issue_number).deliver_now
       end
       it 'should include email in body' do
         expect(subject.body.raw_source).to include(feedback_with_email.owner_email)
@@ -41,7 +43,16 @@ RSpec.describe FeedbackSubmissionMailer, type: [:mailer] do
 
     context 'when email is not provided' do
       it 'should have the proper subject' do
-        expect(subject.subject).to eq('Vets.gov Feedback Received')
+        expect(subject.subject).to eq("#{github_issue_number}: Vets.gov Feedback Received")
+      end
+    end
+
+    context 'when issue number is not provided' do
+      subject do
+        described_class.build(feedback_with_email, github_url, nil).deliver_now
+      end
+      it 'puts -1 in the subject line' do
+        expect(subject.subject).to eq('-1: Vets.gov Feedback Received - Response Requested')
       end
     end
 
@@ -65,7 +76,7 @@ RSpec.describe FeedbackSubmissionMailer, type: [:mailer] do
 
     context 'when no github link is provided' do
       subject do
-        described_class.build(feedback_with_email, nil).deliver_now
+        described_class.build(feedback_with_email, nil, github_issue_number).deliver_now
       end
       it 'should display a warning in the email body' do
         expect(subject.body.raw_source).to include('Warning: No Github link present!')


### PR DESCRIPTION
Subject line of email will now read:

```
4968: Vets.gov Feedback Received
or
4968: Vets.gov Feedback Received  - Response Requested
```

In the event no github issue was created because of an unforeseen error, the subject line will have `-1`, e.g

```
-1: Vets.gov Feedback Received
```