### PR TITLE
WIP - increment counter when job is rate-limited

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,3 +76,7 @@ Metrics/AbcSize:
 # removing rule because get_session implies HTTP GET, and informs method
 Style/AccessorMethodName:
   Enabled: false
+
+Lint/RescueException:
+  Exclude:
+    - 'app/workers/github/create_issue_job.rb'


### PR DESCRIPTION
Need to work on testing around this (did so manually already and it does create the counters I expected), wanted to get a quick validation of approach. Would love it if someone has a better approach here, but it gets tricky when we only sometimes have exceptions available because they are defined in `sidekiq-ent`. This does work with and without rails env set to production, but we don't have mocking yet for the interaction in these jobs and I don't want to go through that if someone has a better idea.

This adds a counter to expose the number of times  we have to delay a job due to rate limit being hit.