### PR TITLE
ignore CVE-2017-8418 while we work on upgrading rubocop

### DIFF
--- a/rakelib/security.rake
+++ b/rakelib/security.rake
@@ -13,7 +13,7 @@ task :security do
 
   puts 'running bundle-audit to check for insecure dependencies...'
   exit!(1) unless ShellCommand.run('bundle-audit update')
-  audit_result = ShellCommand.run('bundle-audit check')
+  audit_result = ShellCommand.run('bundle-audit check --ignore CVE-2017-8418')
 
   puts "\n"
   if brakeman_result && audit_result


### PR DESCRIPTION
`rubocop` has a low severity CVE against it, and `bundle-audit` has decided today is the day to start failing the check. I started down the path of getting rubocop updated, but we're far enough behind that it's a decent-sized project. This change will let builds pass again until that's finished.