### PR TITLE
prevent throttling when running swagger specs

### DIFF
--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -38,11 +38,16 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
   end
   let(:mhv_user) { build(:user, :mhv) }
 
+  before(:all) do
+    Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(Redis.current)
+  end
+
   before do
     Session.create(uuid: mhv_user.uuid, token: token)
     User.create(mhv_user)
     allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
     allow(SAML::SettingsService).to receive(:saml_settings).and_return(rubysaml_settings)
+    Rack::Attack.cache.store.flushdb
   end
 
   context 'has valid paths' do
@@ -881,7 +886,8 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
       let(:missing_feedback_params) { feedback_params.except('target_page') }
 
       it 'returns 202 for valid feedback' do
-        expect(subject).to validate(:post, '/v0/feedback', 202,
+        expect(subject)
+          .to validate(:post, '/v0/feedback', 202,
                                     '_data' => { 'feedback' => feedback_params })
       end
       it 'returns 400 if a param is missing or invalid' do

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -38,16 +38,11 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
   end
   let(:mhv_user) { build(:user, :mhv) }
 
-  before(:all) do
-    Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(Redis.current)
-  end
-
   before do
     Session.create(uuid: mhv_user.uuid, token: token)
     User.create(mhv_user)
     allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
     allow(SAML::SettingsService).to receive(:saml_settings).and_return(rubysaml_settings)
-    Rack::Attack.cache.store.flushdb
   end
 
   context 'has valid paths' do
@@ -876,6 +871,12 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
     end
 
     context '#feedback' do
+      before(:all) do
+        Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(Redis.current)
+      end
+      before(:each) do
+        Rack::Attack.cache.store.flushdb
+      end
       let(:feedback_params) do
         {
           'description' => 'I liked this page',

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -886,8 +886,7 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
       let(:missing_feedback_params) { feedback_params.except('target_page') }
 
       it 'returns 202 for valid feedback' do
-        expect(subject)
-          .to validate(:post, '/v0/feedback', 202,
+        expect(subject).to validate(:post, '/v0/feedback', 202,
                                     '_data' => { 'feedback' => feedback_params })
       end
       it 'returns 400 if a param is missing or invalid' do


### PR DESCRIPTION
After running the `swagger_spec` 5+ times in one hour, it would magically start failing with:
```
Failures:

  1) the API documentation has valid paths #feedback returns 202 for valid feedback
     Failure/Error:
       expect(subject)
         .to validate(:post, '/v0/feedback', 202,
                                   '_data' => { 'feedback' => feedback_params })
     
     JSON::ParserError:
       784: unexpected token at 'Retry later
       '
     # /home/bill/.rvm/gems/ruby-2.3.0/gems/json-1.8.6/lib/json/common.rb:155:in `parse'
     # /home/bill/.rvm/gems/ruby-2.3.0/gems/json-1.8.6/lib/json/common.rb:155:in `parse'
     # /home/bill/.rvm/gems/ruby-2.3.0/gems/apivore-1.6.2/lib/apivore/validator.rb:34:in `matches?'
     # ./spec/request/swagger_spec.rb:885:in `block (4 levels) in <top (required)>'
```

Turns out `RackAttack` throttling was occuring.

This PR clears the rack_attack cache between each example in the `swagger_spec.rb`.