### PR TITLE
use redis for rackattack backend

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 class Rack::Attack
+  REDIS_CONFIG = Rails.application.config_for(:redis).freeze
+  Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(Redis.new(REDIS_CONFIG['redis']))
+
   throttle('feedback/ip', limit: 5, period: 1.hour) do |req|
     req.ip if req.path == '/v0/feedback' && req.post?
   end


### PR DESCRIPTION
Default RackAttack uses Rails.cache.store, which is not used by anything else in vets-api and is defaulting to local filesystem. Changing to Redis store so throttling is done via site-wide metrics rather than node-specific.

Part of https://github.com/department-of-veterans-affairs/vets.gov-team/issues/7063