### PR TITLE
Raise proper error on 503/504 statuses

### DIFF
--- a/lib/evss/base_service.rb
+++ b/lib/evss/base_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'common/client/middleware/response/json_parser'
 require 'evss/error_middleware'
 require 'sentry_logging'
 
@@ -57,7 +58,7 @@ module EVSS
         faraday.use      Faraday::Response::RaiseError
         faraday.response :betamocks if @use_mock
         faraday.response :snakecase, symbolize: false
-        faraday.response :json
+        faraday.response :json_parser
         faraday.use :remove_cookies
         faraday.adapter :httpclient
       end

--- a/lib/evss/base_service.rb
+++ b/lib/evss/base_service.rb
@@ -54,8 +54,8 @@ module EVSS
       @conn ||= Faraday.new(base_url, headers: @headers, ssl: ssl_options) do |faraday|
         faraday.options.timeout = timeout
         faraday.use      :breakers
-        faraday.use      EVSS::ErrorMiddleware
         faraday.use      Faraday::Response::RaiseError
+        faraday.use      EVSS::ErrorMiddleware
         faraday.response :betamocks if @use_mock
         faraday.response :snakecase, symbolize: false
         faraday.response :json_parser

--- a/lib/evss/error_middleware.rb
+++ b/lib/evss/error_middleware.rb
@@ -2,7 +2,7 @@
 module EVSS
   class ErrorMiddleware < Faraday::Response::Middleware
     class EVSSError < StandardError; end
-    class EVSSServiceError < EVSSError; end
+    class EVSSBackendServiceError < EVSSError; end
 
     def on_complete(env)
       case env[:status]
@@ -12,7 +12,7 @@ module EVSS
         raise EVSSError, resp['messages'] if resp['messages']&.find { |m| m['severity'] =~ /fatal|error/i }
       when 503, 504
         resp = env.body
-        raise EVSSServiceError, resp
+        raise EVSSBackendServiceError, resp
       end
     end
   end

--- a/lib/evss/error_middleware.rb
+++ b/lib/evss/error_middleware.rb
@@ -2,6 +2,7 @@
 module EVSS
   class ErrorMiddleware < Faraday::Response::Middleware
     class EVSSError < StandardError; end
+    class EVSSServiceError < EVSSError; end
 
     def on_complete(env)
       case env[:status]
@@ -9,6 +10,9 @@ module EVSS
         resp = env.body
         raise EVSSError, resp['messages'] if resp['success'] == false
         raise EVSSError, resp['messages'] if resp['messages']&.find { |m| m['severity'] =~ /fatal|error/i }
+      when 503, 504
+        resp = env.body
+        raise EVSSServiceError, resp
       end
     end
   end

--- a/spec/lib/evss/base_service_spec.rb
+++ b/spec/lib/evss/base_service_spec.rb
@@ -3,14 +3,6 @@ require 'rails_helper'
 require 'evss/claims_service'
 
 describe EVSS::BaseService do
-  context 'with a backend service error' do
-    it 'should raise a faraday client error on a 500 class error', run_at: 'Wed, 13 Dec 2017 23:45:40 GMT' do
-      VCR.use_cassette('evss/claims/error_504') do
-        expect { claims_service.find_claim_by_id(1) }.to raise_exception(Faraday::ClientError)
-      end
-    end
-  end
-
   context 'with an outage' do
     let(:service) { EVSS::ClaimsService.new({}) }
 

--- a/spec/lib/evss/base_service_spec.rb
+++ b/spec/lib/evss/base_service_spec.rb
@@ -3,6 +3,14 @@ require 'rails_helper'
 require 'evss/claims_service'
 
 describe EVSS::BaseService do
+  context 'with a backend service error' do
+    it 'should raise a faraday client error on a 500 class error', run_at: 'Wed, 13 Dec 2017 23:45:40 GMT' do
+      VCR.use_cassette('evss/claims/error_504') do
+        expect { claims_service.find_claim_by_id(1) }.to raise_exception(Faraday::ClientError)
+      end
+    end
+  end
+
   context 'with an outage' do
     let(:service) { EVSS::ClaimsService.new({}) }
 

--- a/spec/lib/evss/error_middleware_spec.rb
+++ b/spec/lib/evss/error_middleware_spec.rb
@@ -17,7 +17,7 @@ describe EVSS::ErrorMiddleware do
   context 'with a backend service error' do
     it 'should raise an evss service error', run_at: 'Wed, 13 Dec 2017 23:45:40 GMT' do
       VCR.use_cassette('evss/claims/error_504') do
-        expect { claims_service.find_claim_by_id(1) }.to raise_exception(described_class::EVSSServiceError)
+        expect { claims_service.find_claim_by_id(1) }.to raise_exception(described_class::EVSSBackendServiceError)
       end
     end
   end

--- a/spec/lib/evss/error_middleware_spec.rb
+++ b/spec/lib/evss/error_middleware_spec.rb
@@ -13,4 +13,12 @@ describe EVSS::ErrorMiddleware do
       expect { claims_service.find_claim_by_id 1 }.to raise_exception(described_class::EVSSError)
     end
   end
+
+  context 'with a backend service error' do
+    it 'should raise an evss service error', run_at: 'Wed, 13 Dec 2017 23:45:40 GMT' do
+      VCR.use_cassette('evss/claims/error_504') do
+        expect { claims_service.find_claim_by_id(1) }.to raise_exception(described_class::EVSSServiceError)
+      end
+    end
+  end
 end

--- a/spec/support/vcr_cassettes/evss/claims/error_504.yml
+++ b/spec/support/vcr_cassettes/evss/claims/error_504.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-claims-services-web-3.0/rest/vbaClaimStatusService/getClaimDetailById"
+    body:
+      encoding: UTF-8
+      string: '{"id":1}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 13 Dec 2017 23:45:40 GMT
+      Va-Eauth-Csid:
+      - DSLogon
+      Va-Eauth-Authenticationmethod:
+      - DSLogon
+      Va-Eauth-Pnidtype:
+      - SSN
+      Va-Eauth-Assurancelevel:
+      - '3'
+      Va-Eauth-Firstname:
+      - WESLEY
+      Va-Eauth-Lastname:
+      - FORD
+      Va-Eauth-Issueinstant:
+      - '2017-12-07T00:55:09Z'
+      Va-Eauth-Dodedipnid:
+      - '1007697216'
+      Va-Eauth-Birlsfilenumber:
+      - '796043735'
+      Va-Eauth-Pid:
+      - '600061742'
+      Va-Eauth-Pnid:
+      - '796043735'
+      Va-Eauth-Birthdate:
+      - '1986-05-06T00:00:00+00:00'
+      Va-Eauth-Authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796043735","edi":"1007697216","firstName":"WESLEY","lastName":"FORD","birthDate":"1986-05-06T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 504
+      message: OK
+    headers:
+      Date:
+      - Wed, 13 Dec 2017 23:45:40 GMT
+      Server:
+      - Apache
+      X-Wily-Servlet:
+      - Encrypt1 hR/KG2GOR16aRfvv3/q1AW0eXDaeERIVopFkOCXDj8aBMFJ3Yx6n3JU460kEeiDI+f7tx96uM7rd6Q66kG1F301pdCrOJfMsJBfCUXtpBBUC10v84zvjZZhZrTuMJwibXwrFyA6VYWhxQ0aj5bSLXKVvNWBYquJXTZ8L8ia/vdk=
+      X-Wily-Info:
+      - Clear guid=5244FC5D0AE153E03B6B6CF4D733A9E1
+      Via:
+      - 1.1 pint.ebenefits.va.gov:444
+      Vary:
+      - Accept-Encoding,User-Agent
+      Content-Encoding:
+      - gzip
+      X-Ua-Compatible:
+      - IE=Edge
+      Content-Length:
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |-
+        <html><body><h1>504 Gateway Time-out</h1> The server didn't respond in time. </body></html>
+    http_version:
+  recorded_at: Wed, 13 Dec 2017 23:46:11 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
http://sentry.vetsgov-internal/vets-gov/platform-api-production/?query=is%3Aunresolved+%22faraday%3A%3Aparsingerror%22+

Currently, 503 and 504 errors are being attempted to be parsed as JSON because the 'application/json' header is not being checked before parsing. This uses the common client middleware `:json_parser` to perform this check.

This will now raise a `Faraday::ClientError` on a 503/504 error, so I've reordered the `RaiseError`  middleware (the source of this behavior) so that we can handle 503/504 errors in `EVSS::ErrorMiddleware`. In this middleware, I've added a clause for 503 and 504 errors so that we  now raise an `EVSSBackendServiceError` rather than the `ParsingError` we were seeing.

I didn't expand on this work further because it's my understanding that this client will be replaced by the EVSS Common Client that's being implemented. Is that correct @lihanli?

@jkassemi This is where I landed on these errors. Let me know if this will work for the time being, or if you had a larger refactor in mind.