### PR TITLE
Revert "stop logging vet_not_found responses (#1591)"

### DIFF
--- a/app/models/gibs_not_found_user.rb
+++ b/app/models/gibs_not_found_user.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class GibsNotFoundUser < ActiveRecord::Base
-  # :nocov:
   attr_encrypted :ssn, key: Settings.db_encryption_key
 
   validates :edipi, presence: true, uniqueness: true
@@ -14,5 +13,4 @@ class GibsNotFoundUser < ActiveRecord::Base
       dob: user.birth_date
     ).find_or_create_by(edipi: user.edipi)
   end
-  # :nocov:
 end

--- a/spec/request/post911_gi_bill_status_request_spec.rb
+++ b/spec/request/post911_gi_bill_status_request_spec.rb
@@ -56,9 +56,34 @@ RSpec.describe 'Fetching Post 911 GI Bill Status', type: :request do
     end
   end
 
-  context 'with deprecated GibsNotFoundUser class' do
-    it 'loads the class for coverage' do
-      GibsNotFoundUser
+  context 'when evss returns not found' do
+    context 'when the user has not been logged' do
+      it 'should log the user and return a 404' do
+        VCR.use_cassette('evss/gi_bill_status/vet_not_found') do
+          expect { get v0_post911_gi_bill_status_url, nil, auth_header }.to change(GibsNotFoundUser, :count).by(1)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'when the user has been logged' do
+      before { GibsNotFoundUser.log(user) }
+      it 'should not log the user again and return a 404' do
+        VCR.use_cassette('evss/gi_bill_status/vet_not_found') do
+          expect { get v0_post911_gi_bill_status_url, nil, auth_header }.to change(GibsNotFoundUser, :count).by(0)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'when log record insertion fails' do
+      it 'should still return a 404' do
+        VCR.use_cassette('evss/gi_bill_status/vet_not_found') do
+          allow(GibsNotFoundUser).to receive(:log).and_raise(ActiveRecord::ActiveRecordError)
+          expect { get v0_post911_gi_bill_status_url, nil, auth_header }.to change(GibsNotFoundUser, :count).by(0)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We want to restart GIBS not found response logging in order to troubleshoot the latest 99% `VET_NOT_FOUND` responses.

```
This reverts commit 95fb683ef9034d45c1ab2b4210641f356829bcb8.

Conflicts:
	app/controllers/v0/post911_gi_bill_statuses_controller.rb
	spec/request/post911_gi_bill_status_request_spec.rb
```