### PR TITLE
Only download sidekiq-ent and sidekiq-pro if licence ENV is set

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,8 +120,9 @@ group :development, :test do
 end
 
 group :production do
-  # sidekiq enterprise edition
-  if ENV['BUNDLE_ENTERPRISE__CONTRIBSYS__COM']
+  # sidekiq enterprise requires a license key to download but is only required in production
+  # for local dev environments, regular sidekiq works fine
+  unless ENV['EXCLUDE_SIDEKIQ_ENTERPRISE']
     source 'https://enterprise.contribsys.com/' do
       gem 'sidekiq-ent'
       gem 'sidekiq-pro'

--- a/Gemfile
+++ b/Gemfile
@@ -121,8 +121,10 @@ end
 
 group :production do
   # sidekiq enterprise edition
-  source 'https://enterprise.contribsys.com/' do
-    gem 'sidekiq-ent'
-    gem 'sidekiq-pro'
-  end if ENV['BUNDLE_ENTERPRISE__CONTRIBSYS__COM']
+  if ENV['BUNDLE_ENTERPRISE__CONTRIBSYS__COM']
+    source 'https://enterprise.contribsys.com/' do
+      gem 'sidekiq-ent'
+      gem 'sidekiq-pro'
+    end
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -120,7 +120,7 @@ group :development, :test do
 end
 
 group :production do
-  # sidekiq enterprise requires a license key to download but is only required in production
+  # sidekiq enterprise requires a license key to download but is only required in production.
   # for local dev environments, regular sidekiq works fine
   unless ENV['EXCLUDE_SIDEKIQ_ENTERPRISE']
     source 'https://enterprise.contribsys.com/' do

--- a/Gemfile
+++ b/Gemfile
@@ -124,5 +124,5 @@ group :production do
   source 'https://enterprise.contribsys.com/' do
     gem 'sidekiq-ent'
     gem 'sidekiq-pro'
-  end
+  end if ENV['BUNDLE_ENTERPRISE__CONTRIBSYS__COM']
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,6 @@ GIT
 
 GEM
   remote: https://rubygems.org/
-  remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.0.2)
     aasm (4.12.0)
@@ -404,23 +403,18 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
-    sidekiq-ent (1.6.1)
-      sidekiq (>= 4.2.9)
-      sidekiq-pro (>= 3.5.0)
-    sidekiq-instrument (0.2.1)
-      sidekiq (~> 4.0)
+    sidekiq-instrument (0.3.0)
+      sidekiq (>= 4.2, < 6)
       statsd-instrument (~> 2.0, >= 2.0.4)
-    sidekiq-pro (3.6.1)
-      sidekiq (>= 4.1.5)
     sidekiq-scheduler (2.0.19)
       hashie (~> 3.4)
       redis (~> 3)
       rufus-scheduler (~> 3.1.8)
       sidekiq (>= 3)
       tilt (>= 1.4.0)
-    sidekiq-unique-jobs (4.0.18)
-      sidekiq (>= 2.6)
-      thor
+    sidekiq-unique-jobs (5.0.10)
+      sidekiq (>= 4.0, <= 6.0)
+      thor (~> 0)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -554,9 +548,7 @@ DEPENDENCIES
   shrine
   shrine-memory
   sidekiq
-  sidekiq-ent!
   sidekiq-instrument
-  sidekiq-pro!
   sidekiq-scheduler (~> 2.0)
   sidekiq-unique-jobs
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GIT
 
 GEM
   remote: https://rubygems.org/
+  remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.0.2)
     aasm (4.12.0)
@@ -403,9 +404,14 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
+    sidekiq-ent (1.6.1)
+      sidekiq (>= 4.2.9)
+      sidekiq-pro (>= 3.5.0)
     sidekiq-instrument (0.3.0)
       sidekiq (>= 4.2, < 6)
       statsd-instrument (~> 2.0, >= 2.0.4)
+    sidekiq-pro (3.7.0)
+      sidekiq (>= 4.1.5)
     sidekiq-scheduler (2.0.19)
       hashie (~> 3.4)
       redis (~> 3)
@@ -548,7 +554,9 @@ DEPENDENCIES
   shrine
   shrine-memory
   sidekiq
+  sidekiq-ent!
   sidekiq-instrument
+  sidekiq-pro!
   sidekiq-scheduler (~> 2.0)
   sidekiq-unique-jobs
   simplecov

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following features require additional configuration, click for details.
 - [My HealtheVet (MHV)](/docs/setup/mhv.md)
 - [Education Benefits](/docs/setup/edu_benefits.md)
 - [Master Veteran Index (MVI)](/docs/setup/mvi.md)
+- [Sidekiq Enterprise](/docs/setup/sidekiq_enterprise.md)
 
 To mock one or more of the above services see [Betamocks](/docs/setup/betamocks.md)
 

--- a/docs/setup/sidekiq_enterprise.md
+++ b/docs/setup/sidekiq_enterprise.md
@@ -1,0 +1,8 @@
+### Sidekiq Configuration
+We use [Sidekiq Enterprise (`sidekiq-ent` & `sidekiq-pro`)](https://sidekiq.org/products/enterprise.html) which requires a product license to download. Only members of the internal team have access to this license. Alternatively, you may use plain old [`sidekiq`](https://github.com/mperham/sidekiq) by setting the environment variable:
+
+```
+EXCLUDE_SIDEKIQ_ENTERPRISE=true
+```
+
+Remember to revert changes to [`Gemfile.lock`](https://github.com/department-of-veterans-affairs/vets-api/blob/master/Gemfile.lock) before merging any PR's this way!


### PR DESCRIPTION
Connects: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/7665

I went ahead and created a [`sidekiq-mock` gem](https://github.com/omgitsbillryan/sidekiq-mock) gem [based on a previous recommendation](https://github.com/department-of-veterans-affairs/vets-api/pull/1637#issuecomment-355662299), but having done so, I think it adds too much "magic" and complexity that isn't warranted.  For now, I'm comfortable with the one instance of [conditional `if Rails.env.production?` sidekiq rate-limitng](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/workers/github/create_issue_job.rb#L13). I believe it to be more explicit and easier to understand for anyone unfamiliar.