### PR TITLE
precede identity SSN over MVI whenever available

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,31 +40,31 @@ class User < Common::RedisStore
   delegate :first_name, to: :identity, allow_nil: true
 
   def first_name
-    mhv_icn.present? ? mvi&.profile&.given_names&.first : identity.first_name
+    identity.first_name || mhv_icn.present? ? mvi&.profile&.given_names&.first : nil
   end
 
   def middle_name
-    mhv_icn.present? ? mvi&.profile&.given_names&.last : identity.middle_name
+    identity.middle_name || mhv_icn.present? ? mvi&.profile&.given_names&.last : nil
   end
 
   def last_name
-    mhv_icn.present? ? mvi&.profile&.family_name : identity.last_name
+    identity.last_name || mhv_icn.present? ? mvi&.profile&.family_name : nil
   end
 
   def gender
-    mhv_icn.present? ? mvi&.profile&.gender : identity.gender
+    identity.gender || mhv_icn.present? ? mvi&.profile&.gender : nil
   end
 
   def birth_date
-    mhv_icn.present? ? mvi&.profile&.birth_date : identity.birth_date
+    identity.birth_date || mhv_icn.present? ? mvi&.profile&.birth_date : nil
   end
 
   def zip
-    mhv_icn.present? ? mvi&.profile&.address&.postal_code : identity.zip
+    identity.zip || mhv_icn.present? ? mvi&.profile&.address&.postal_code : nil
   end
 
   def ssn
-    mhv_icn.present? ? mvi&.profile&.ssn : identity.ssn
+    identity.ssn || mhv_icn.present? ? mvi&.profile&.ssn : nil
   end
 
   def mhv_correlation_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,31 +40,31 @@ class User < Common::RedisStore
   delegate :first_name, to: :identity, allow_nil: true
 
   def first_name
-    identity.first_name || mhv_icn.present? ? mvi&.profile&.given_names&.first : nil
+    identity.first_name || (mhv_icn.present? ? mvi&.profile&.given_names&.first : nil)
   end
 
   def middle_name
-    identity.middle_name || mhv_icn.present? ? mvi&.profile&.given_names&.last : nil
+    identity.middle_name || (mhv_icn.present? ? mvi&.profile&.given_names&.last : nil)
   end
 
   def last_name
-    identity.last_name || mhv_icn.present? ? mvi&.profile&.family_name : nil
+    identity.last_name || (mhv_icn.present? ? mvi&.profile&.family_name : nil)
   end
 
   def gender
-    identity.gender || mhv_icn.present? ? mvi&.profile&.gender : nil
+    identity.gender || (mhv_icn.present? ? mvi&.profile&.gender : nil)
   end
 
   def birth_date
-    identity.birth_date || mhv_icn.present? ? mvi&.profile&.birth_date : nil
+    identity.birth_date || (mhv_icn.present? ? mvi&.profile&.birth_date : nil)
   end
 
   def zip
-    identity.zip || mhv_icn.present? ? mvi&.profile&.address&.postal_code : nil
+    identity.zip || (mhv_icn.present? ? mvi&.profile&.address&.postal_code : nil)
   end
 
   def ssn
-    identity.ssn || mhv_icn.present? ? mvi&.profile&.ssn : nil
+    identity.ssn || (mhv_icn.present? ? mvi&.profile&.ssn : nil)
   end
 
   def mhv_correlation_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < Common::RedisStore
   end
 
   def middle_name
-    identity.middle_name || (mhv_icn.present? ? mvi&.profile&.given_names&.last : nil)
+    identity.middle_name || (mhv_icn.present? ? mvi&.profile&.given_names.to_a[1..-1]&.join(' ') : nil)
   end
 
   def last_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < Common::RedisStore
   end
 
   def middle_name
-    identity.middle_name || (mhv_icn.present? ? mvi&.profile&.given_names.to_a[1..-1]&.join(' ') : nil)
+    identity.middle_name || (mhv_icn.present? ? mvi&.profile&.given_names.to_a[1..-1]&.join(' ').presence : nil)
   end
 
   def last_name

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -70,6 +70,19 @@ FactoryBot.define do
       end
     end
 
+    trait :mhv_sign_in do
+      email 'abraham.lincoln@vets.gov'
+      first_name nil
+      middle_name nil
+      last_name nil
+      gender nil
+      birth_date nil
+      zip nil
+      ssn nil
+      mhv_icn '12345'
+      multifactor false
+    end
+
     trait :mhv do
       uuid 'b2fab2b5-6af0-45e1-a9e2-394347af91ef'
       last_signed_in { Faker::Time.between(2.years.ago, 1.week.ago, :all) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -200,8 +200,28 @@ RSpec.describe User, type: :model do
           expect(user.first_name).to be(user.va_profile.given_names.first)
         end
 
-        it 'fetches middle_name from MVI' do
-          expect(user.middle_name).to eq(user.va_profile.given_names.to_a[1..-1].join(' '))
+        context 'when given_names has no middle_name' do
+          let(:mvi_profile) { FactoryBot.build(:mvi_profile, given_names: ['Joe']) }
+
+          it 'fetches middle name from MVI' do
+            expect(user.middle_name).to be_nil
+          end
+        end
+
+        context 'when given_names has middle_name' do
+          let(:mvi_profile) { FactoryBot.build(:mvi_profile, given_names: %w[Joe Bob]) }
+
+          it 'fetches middle name from MVI' do
+            expect(user.middle_name).to eq('Bob')
+          end
+        end
+
+        context 'when given_names has multiple middle names' do
+          let(:mvi_profile) { FactoryBot.build(:mvi_profile, given_names: %w[Michael Joe Bob Sinclair]) }
+
+          it 'fetches middle name from MVI' do
+            expect(user.middle_name).to eq('Joe Bob Sinclair')
+          end
         end
 
         it 'fetches last_name from MVI' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe User, type: :model do
     end
 
     describe 'getter methods' do
-      context 'when saml user attributes availabled, icn is available, and user LOA3' do
+      context 'when saml user attributes available, icn is available, and user LOA3' do
         let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
         let(:user) { FactoryBot.build(:user, :loa3, middle_name: 'J', mhv_icn: mvi_profile.icn) }
         before(:each) do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -155,76 +155,106 @@ RSpec.describe User, type: :model do
     end
 
     describe 'getter methods' do
-      context 'when icn is available from saml data and user LOA3' do
+      context 'when saml user attributes availabled, icn is available, and user LOA3' do
         let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
-        let(:user) { FactoryBot.build(:user, :loa3, mhv_icn: mvi_profile.icn) }
-        before(:each) { stub_mvi(mvi_profile) }
-
-        it 'fetches first_name from mvi' do
-          expect(user.first_name).not_to eq(user.identity.first_name)
-          expect(user.first_name).to eq(mvi_profile.given_names.first)
+        let(:user) { FactoryBot.build(:user, :loa3, middle_name: 'J', mhv_icn: mvi_profile.icn) }
+        before(:each) do
+          stub_mvi(mvi_profile)
         end
 
-        it 'fetches middle_name from mvi' do
-          expect(user.middle_name).not_to eq(user.identity.middle_name)
-          expect(user.middle_name).to eq(mvi_profile.given_names.last)
+        it 'fetches first_name from IDENTITY' do
+          expect(user.first_name).to be(user.identity.first_name)
         end
 
-        it 'fetches last_name from mvi' do
-          expect(user.last_name).not_to eq(user.identity.last_name)
-          expect(user.last_name).to eq(mvi_profile.family_name)
+        it 'fetches middle_name from IDENTITY' do
+          expect(user.middle_name).to be(user.identity.middle_name)
         end
 
-        it 'fetches gender from mvi' do
-          expect(user.gender).to eq(mvi_profile.gender)
+        it 'fetches last_name from IDENTITY' do
+          expect(user.last_name).to be(user.identity.last_name)
         end
 
-        it 'fetches birth_date from mvi' do
-          expect(user.birth_date).not_to eq(user.identity.birth_date)
-          expect(user.birth_date).to eq(mvi_profile.birth_date)
+        it 'fetches gender from IDENTITY' do
+          expect(user.gender).to be(user.identity.gender)
         end
 
-        it 'fetches zip from mvi' do
-          expect(user.zip).not_to eq(user.identity.zip)
-          expect(user.zip).to eq(mvi_profile.address.postal_code)
+        it 'fetches birth_date from IDENTITY' do
+          expect(user.birth_date).to be(user.identity.birth_date)
         end
 
-        it 'fetches ssn from mvi' do
-          expect(user.ssn).not_to eq(user.identity.ssn)
-          expect(user.ssn).to eq(mvi_profile.ssn)
+        it 'fetches zip from IDENTITY' do
+          expect(user.zip).to be(user.identity.zip)
+        end
+
+        it 'fetches ssn from IDENTITY' do
+          expect(user.ssn).to be(user.identity.ssn)
         end
       end
 
-      context 'when icn is available from saml data and user NOT LOA3' do
+      context 'when saml user attributes NOT available, icn is available, and user LOA3' do
         let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
-        let(:user) { FactoryBot.build(:user, :loa1, mhv_icn: mvi_profile.icn) }
+        let(:user) { FactoryBot.build(:user, :loa3, :mhv_sign_in, mhv_icn: mvi_profile.icn) }
+        before(:each) { stub_mvi(mvi_profile)
+
+        it 'fetches first_name from MVI' do
+          expect(user.first_name).to be(user.va_profile.given_names.first)
+        end
+
+        it 'fetches middle_name from MVI' do
+          expect(user.middle_name).to be(user.va_profile.given_names.last)
+        end
+
+        it 'fetches last_name from MVI' do
+          expect(user.last_name).to be(user.va_profile.family_name)
+        end
+
+        it 'fetches gender from MVI' do
+          expect(user.gender).to be(user.va_profile.gender)
+        end
+
+        it 'fetches birth_date from MVI' do
+          expect(user.birth_date).to be(user.va_profile.birth_date)
+        end
+
+        it 'fetches zip from MVI' do
+          expect(user.zip).to be(user.va_profile.address.postal_code)
+        end
+
+        it 'fetches ssn from MVI' do
+          expect(user.ssn).to be(user.va_profile.ssn)
+        end
+      end
+
+      context 'when saml user attributes NOT available, icn is available, and user NOT LOA3' do
+        let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
+        let(:user) { FactoryBot.build(:user, :loa1, :mhv_sign_in, mhv_icn: mvi_profile.icn) }
         before(:each) { stub_mvi(mvi_profile) }
 
-        it 'fetches first_name from mvi' do
+        it 'fetches first_name from IDENTITY' do
           expect(user.first_name).to be_nil
         end
 
-        it 'fetches middle_name from mvi' do
+        it 'fetches middle_name from IDENTITY' do
           expect(user.middle_name).to be_nil
         end
 
-        it 'fetches last_name from mvi' do
+        it 'fetches last_name from IDENTITY' do
           expect(user.last_name).to be_nil
         end
 
-        it 'fetches gender from mvi' do
+        it 'fetches gender from IDENTITY' do
           expect(user.gender).to be_nil
         end
 
-        it 'fetches birth_date from mvi' do
+        it 'fetches birth_date from IDENTITY' do
           expect(user.birth_date).to be_nil
         end
 
-        it 'fetches zip from mvi' do
+        it 'fetches zip from IDENTITY' do
           expect(user.zip).to be_nil
         end
 
-        it 'fetches ssn from mvi' do
+        it 'fetches ssn from IDENTITY' do
           expect(user.ssn).to be_nil
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -194,14 +194,14 @@ RSpec.describe User, type: :model do
       context 'when saml user attributes NOT available, icn is available, and user LOA3' do
         let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
         let(:user) { FactoryBot.build(:user, :loa3, :mhv_sign_in, mhv_icn: mvi_profile.icn) }
-        before(:each) { stub_mvi(mvi_profile)
+        before(:each) { stub_mvi(mvi_profile) }
 
         it 'fetches first_name from MVI' do
           expect(user.first_name).to be(user.va_profile.given_names.first)
         end
 
         it 'fetches middle_name from MVI' do
-          expect(user.middle_name).to be(user.va_profile.given_names.last)
+          expect(user.middle_name).to eq(user.va_profile.given_names.to_a[1..-1].join(' '))
         end
 
         it 'fetches last_name from MVI' do
@@ -264,38 +264,32 @@ RSpec.describe User, type: :model do
         let(:user) { FactoryBot.build(:user, :loa3) }
         before(:each) { stub_mvi(mvi_profile) }
 
-        it 'fetches first_name from UserIdentity' do
-          expect(user.first_name).to eq(user.identity.first_name)
-          expect(user.first_name).not_to eq(mvi_profile.given_names.first)
+        it 'fetches first_name from IDENTITY' do
+          expect(user.first_name).to be(user.identity.first_name)
         end
 
-        it 'fetches middle_name from UserIdentity' do
-          expect(user.middle_name).to eq(user.identity.middle_name)
-          expect(user.middle_name).not_to eq(mvi_profile.given_names.last)
+        it 'fetches middle_name from IDENTITY' do
+          expect(user.middle_name).to be(user.identity.middle_name)
         end
 
-        it 'fetches last_name from UserIdentity' do
-          expect(user.last_name).to eq(user.identity.last_name)
-          expect(user.last_name).not_to eq(mvi_profile.family_name)
+        it 'fetches last_name from IDENTITY' do
+          expect(user.last_name).to be(user.identity.last_name)
         end
 
-        it 'fetches gender from UserIdentity' do
-          expect(user.gender).to eq(user.identity.gender)
+        it 'fetches gender from IDENTITY' do
+          expect(user.gender).to be(user.identity.gender)
         end
 
-        it 'fetches birth_date from UserIdentity' do
-          expect(user.birth_date).to eq(user.identity.birth_date)
-          expect(user.birth_date).not_to eq(mvi_profile.birth_date)
+        it 'fetches birth_date from IDENTITY' do
+          expect(user.birth_date).to be(user.identity.birth_date)
         end
 
-        it 'fetches zip from UserIdentity' do
-          expect(user.zip).to eq(user.identity.zip)
-          expect(user.zip).not_to eq(mvi_profile.address.postal_code)
+        it 'fetches zip from IDENTITY' do
+          expect(user.zip).to be(user.identity.zip)
         end
 
-        it 'fetches ssn from UserIdentity' do
-          expect(user.ssn).to eq(user.identity.ssn)
-          expect(user.ssn).not_to eq(mvi_profile.ssn)
+        it 'fetches ssn from IDENTITY' do
+          expect(user.ssn).to be(user.identity.ssn)
         end
       end
 
@@ -306,6 +300,7 @@ RSpec.describe User, type: :model do
             expect(user.mhv_correlation_id).to be_nil
           end
         end
+
         context 'when there are mhv ids' do
           let(:loa3_user) { FactoryBot.build(:user, :loa3) }
           let(:mvi_profile) { FactoryBot.build(:mvi_profile) }


### PR DESCRIPTION
Linked Issue: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/8338

Phased Changes:

1. ensure the Identity values always precede MVI ones (even for MHV-sign-in method, nil otherwise).

--- this part will be handled in a separate PR as needed.
2. add additional database level logging for when the data discrepancy issue occurs so we can better assess course of action.

Database should track:
1. uuid
2. email
3. icn
4. identity.ssn
5. mvi.ssn
6. sign-in-method (including whether it was DS Logon + FICAM LOA3, etc)
7. What else?