### PR TITLE
maintenance window nil description

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,4 @@
 # encoding: UTF-8
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/lib/pagerduty/maintenance_client.rb
+++ b/lib/pagerduty/maintenance_client.rb
@@ -42,7 +42,7 @@ module PagerDuty
             external_service: service_map[svc['id']].to_s,
             start_time: Time.iso8601(mw['start_time']),
             end_time: Time.iso8601(mw['end_time']),
-            description: mw['description']
+            description: mw['description'] ||= ''
           }
           result << window
         end

--- a/spec/lib/pagerduty/client_spec.rb
+++ b/spec/lib/pagerduty/client_spec.rb
@@ -38,6 +38,18 @@ describe PagerDuty::MaintenanceClient do
       expect(windows.first).to be_a(Hash)
       expect(windows.first.keys).to include(:pagerduty_id, :external_service, :start_time, :end_time, :description)
     end
+
+    it 'normalizes description to empty string' do
+      stub_request(:get, 'https://api.pagerduty.com/maintenance_windows')
+        .with(query: hash_including('service_ids' => %w[ABCDEF BCDEFG]))
+        .to_return(
+          status: 200,
+          headers: { 'Content-Type' => 'application/json; charset=utf-8' },
+          body: body
+        )
+      windows = subject.get_all
+      expect(windows.first[:description]).to eq('')
+    end
   end
 
   context 'with multiple pages of results' do

--- a/spec/lib/pagerduty/client_spec.rb
+++ b/spec/lib/pagerduty/client_spec.rb
@@ -49,6 +49,7 @@ describe PagerDuty::MaintenanceClient do
         )
       windows = subject.get_all
       expect(windows.first[:description]).to eq('')
+      expect(windows.last[:description]).to eq('Multi-service Window')
     end
   end
 

--- a/spec/support/pagerduty/maintenance_windows_simple.json
+++ b/spec/support/pagerduty/maintenance_windows_simple.json
@@ -9,7 +9,7 @@
       "sequence_number": 117,
       "start_time": "2017-12-25T18:59:00-05:00",
       "end_time": "2017-12-26T19:59:00-05:00",
-      "description": "Single-service Window",
+      "description": null,
       "services": [
         {
           "id": "BCDEFG",


### PR DESCRIPTION
When we don't put anything into description field in PagerDuty, it sends back a `null` value in the JSON output. This causes a `undefined method `partition' for nil:NilClass` in the worker that processes these maintenance windows.

The newline change in `db/schema.rb` comes from running `make lint` locally. It passes without, but seems to be adding that in every time I run it. Added here to avoid overhead of a PR for something so trivial.