### PR TITLE
Return an empty list if we don't even have identity data for a user

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -69,7 +69,8 @@ class UserSerializer < ActiveModel::Serializer
   end
 
   def prefills_available
-    object.can_access_prefill_data? ? FormProfile.prefill_enabled_forms : []
+    return [] unless object.identity.present? && object.can_access_prefill_data?
+    FormProfile.prefill_enabled_forms
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity


### PR DESCRIPTION
This PR will return an empty list for available prefills if we don't have identity data for a user. This will allow the frontend to determine whether to show the prefill banner or not, as described here:

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/7870

@jbalboni I figured we could do another run of tests with the MHV logins. A combination of this and 
 looking at the what the frontend receives for profile/va_profile responses while we're testing should be able to help us pin down which pieces of data are missing that are causing the MVI lookup for address to fail.