### PR TITLE
Re-enable `public-read` ACL for now

### DIFF
--- a/app/uploaders/profile_photo_attachment_uploader.rb
+++ b/app/uploaders/profile_photo_attachment_uploader.rb
@@ -20,6 +20,8 @@ class ProfilePhotoAttachmentUploader < CarrierWave::Uploader::Base
         Settings.vic.s3.bucket
       )
     end
+
+    self.aws_acl = 'public-read'
   end
 
   def extension_white_list

--- a/spec/uploaders/profile_photo_attachment_uploader_spec.rb
+++ b/spec/uploaders/profile_photo_attachment_uploader_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 
 RSpec.describe ProfilePhotoAttachmentUploader do
   context 'in production' do
-    it 'should not set aws_acl to public-read' do
+    it 'should set aws_acl to public-read' do
       expect(Rails.env).to receive(:production?).and_return(true)
       allow_any_instance_of(described_class).to receive(:set_aws_config)
       uploader = described_class.new(SecureRandom.hex(32), nil)
 
-      expect(uploader.aws_acl).not_to eq('public-read')
+      expect(uploader.aws_acl).to eq('public-read')
     end
   end
 end


### PR DESCRIPTION
After discussion with Wyatt, the reverse proxy won't be able to serve up non-public files until IAM credentials are configured for the instance. This re-enables `public-read` for e2e testing until the reverse proxy is configured for use with non-public files.