### PR TITLE
VIC photo upload metadata stripping and GET endpoint

### DIFF
--- a/app/controllers/v0/vic/profile_photo_attachments_controller.rb
+++ b/app/controllers/v0/vic/profile_photo_attachments_controller.rb
@@ -3,8 +3,6 @@
 module V0
   module VIC
     class ProfilePhotoAttachmentsController < ApplicationController
-      # include FormAttachmentCreate
-
       skip_before_action :authenticate, except: :show
 
       def create

--- a/app/controllers/v0/vic/profile_photo_attachments_controller.rb
+++ b/app/controllers/v0/vic/profile_photo_attachments_controller.rb
@@ -20,7 +20,7 @@ module V0
 
       def show
         attachment = ::VIC::ProfilePhotoAttachment.where(guid: params[:id]).first
-        render(json: JSON.parse(attachment.file_data))
+        render(json: attachment)
       end
 
       private

--- a/app/controllers/v0/vic/profile_photo_attachments_controller.rb
+++ b/app/controllers/v0/vic/profile_photo_attachments_controller.rb
@@ -15,12 +15,13 @@ module V0
           get_in_progress_form
         )
         form_attachment.save!
-        render(json: form_attachment)
+
+        render(json: form_attachment, is_anonymous_upload: @current_user.blank?)
       end
 
       def show
-        attachment = ::VIC::ProfilePhotoAttachment.where(guid: params[:id]).first
-        render(json: attachment)
+        form_attachment = ::VIC::ProfilePhotoAttachment.where(guid: params[:id]).first
+        render(json: form_attachment)
       end
 
       private

--- a/app/controllers/v0/vic/profile_photo_attachments_controller.rb
+++ b/app/controllers/v0/vic/profile_photo_attachments_controller.rb
@@ -3,7 +3,9 @@
 module V0
   module VIC
     class ProfilePhotoAttachmentsController < ApplicationController
-      include FormAttachmentCreate
+      # include FormAttachmentCreate
+
+      skip_before_action :authenticate, except: :show
 
       def create
         form_attachment = ::VIC::ProfilePhotoAttachment.new
@@ -14,6 +16,11 @@ module V0
         )
         form_attachment.save!
         render(json: form_attachment)
+      end
+
+      def show
+        attachment = ::VIC::ProfilePhotoAttachment.where(guid: params[:id]).first
+        render(json: JSON.parse(attachment.file_data))
       end
 
       private

--- a/app/serializers/profile_photo_attachment_serializer.rb
+++ b/app/serializers/profile_photo_attachment_serializer.rb
@@ -6,11 +6,11 @@ class ProfilePhotoAttachmentSerializer < ActiveModel::Serializer
   attribute :path
 
   def filename
-    parsed['filename'] unless options[:is_anonymous_upload]
+    parsed['filename'] unless @instance_options[:is_anonymous_upload]
   end
 
   def path
-    parsed['path'] unless options[:is_anonymous_upload]
+    parsed['path'] unless @instance_options[:is_anonymous_upload]
   end
 
   private

--- a/app/serializers/profile_photo_attachment_serializer.rb
+++ b/app/serializers/profile_photo_attachment_serializer.rb
@@ -6,11 +6,17 @@ class ProfilePhotoAttachmentSerializer < ActiveModel::Serializer
   attribute :path
 
   def filename
-    parsed['filename']
+    parsed['filename'] if user_uuid.present?
   end
 
   def path
-    parsed['path']
+    parsed['path'] if user_uuid.present?
+  end
+
+  private
+
+  def user_uuid
+    parsed['user_uuid']
   end
 
   def parsed

--- a/app/serializers/profile_photo_attachment_serializer.rb
+++ b/app/serializers/profile_photo_attachment_serializer.rb
@@ -6,18 +6,14 @@ class ProfilePhotoAttachmentSerializer < ActiveModel::Serializer
   attribute :path
 
   def filename
-    parsed['filename'] if user_uuid.present?
+    parsed['filename'] unless options[:is_anonymous_upload]
   end
 
   def path
-    parsed['path'] if user_uuid.present?
+    parsed['path'] unless options[:is_anonymous_upload]
   end
 
   private
-
-  def user_uuid
-    parsed['user_uuid']
-  end
 
   def parsed
     @parsed ||= JSON.parse(object.file_data)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,7 +133,7 @@ Rails.application.routes.draw do
     end
 
     namespace :vic do
-      resources :profile_photo_attachments, only: :create
+      resources :profile_photo_attachments, only: %i[create show]
       resources :supporting_documentation_attachments, only: :create
       resources :vic_submissions, only: %i[create show]
     end

--- a/spec/controllers/v0/vic/profile_photo_attachments_controller_spec.rb
+++ b/spec/controllers/v0/vic/profile_photo_attachments_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'support/authenticated_session_helper'
 
 RSpec.describe V0::VIC::ProfilePhotoAttachmentsController, type: :controller do
   describe '#show' do

--- a/spec/controllers/v0/vic/profile_photo_attachments_controller_spec.rb
+++ b/spec/controllers/v0/vic/profile_photo_attachments_controller_spec.rb
@@ -5,7 +5,6 @@ require 'support/authenticated_session_helper'
 
 RSpec.describe V0::VIC::ProfilePhotoAttachmentsController, type: :controller do
   describe '#show' do
-    let(:data) { JSON.parse(response.body) }
     let(:guid) { ::VIC::ProfilePhotoAttachment.last.guid }
 
     before do
@@ -26,14 +25,17 @@ RSpec.describe V0::VIC::ProfilePhotoAttachmentsController, type: :controller do
 
     context 'with a logged in user' do
       let(:user) { create(:user, :loa3) }
+      let(:attributes) { JSON.parse(response.body)['data']['attributes'] }
 
       before do
         expect_any_instance_of(described_class).to receive(:authenticate_token).at_least(:once).and_return(true)
+        expect_any_instance_of(described_class).to receive(:current_user).at_least(:once).and_return(user)
       end
 
       it 'allows retrieval of filename and path' do
         get(:show, id: guid)
-        puts data
+        expect(attributes['filename']).not_to be_nil
+        expect(attributes['path']).not_to be_nil
       end
     end
   end
@@ -49,7 +51,7 @@ RSpec.describe V0::VIC::ProfilePhotoAttachmentsController, type: :controller do
             file_data: fixture_file_upload('files/sm_file1.jpg')
           }
         )
-
+        puts response.body
         expect(data['filename']).to be_nil
         expect(data['path']).to be_nil
       end
@@ -72,6 +74,7 @@ RSpec.describe V0::VIC::ProfilePhotoAttachmentsController, type: :controller do
           }
         )
 
+        puts response.body
         expect(data).to have_key('filename')
         expect(data['path']).to eq "profile_photo_attachments/#{InProgressForm.last.id}"
         expect(InProgressForm.count).not_to eq(before_count)

--- a/spec/controllers/v0/vic/profile_photo_attachments_controller_spec.rb
+++ b/spec/controllers/v0/vic/profile_photo_attachments_controller_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe V0::VIC::ProfilePhotoAttachmentsController, type: :controller do
           }
         )
 
-        expect(data).to have_key('filename')
-        expect(data['path']).to eq 'profile_photo_attachments/anonymous'
+        expect(data['filename']).to be_nil
+        expect(data['path']).to be_nil
       end
     end
 

--- a/spec/controllers/v0/vic/profile_photo_attachments_controller_spec.rb
+++ b/spec/controllers/v0/vic/profile_photo_attachments_controller_spec.rb
@@ -1,9 +1,46 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/authenticated_session_helper'
 
 RSpec.describe V0::VIC::ProfilePhotoAttachmentsController, type: :controller do
+  describe '#show' do
+    let(:data) { JSON.parse(response.body) }
+    let(:guid) { ::VIC::ProfilePhotoAttachment.last.guid }
+
+    before do
+      ::VIC::ProfilePhotoAttachment.new(
+        file_data: {
+          filename: 'test.jpg',
+          path: 'anonymous'
+        }.to_json
+      ).save!
+    end
+
+    context 'with an anonymous user' do
+      it 'does not allow retrieval of filename and path' do
+        get(:show, id: guid)
+        expect(response).not_to be_success
+      end
+    end
+
+    context 'with a logged in user' do
+      let(:user) { create(:user, :loa3) }
+
+      before do
+        expect_any_instance_of(described_class).to receive(:authenticate_token).at_least(:once).and_return(true)
+      end
+
+      it 'allows retrieval of filename and path' do
+        get(:show, id: guid)
+        puts data
+      end
+    end
+  end
+
   describe '#create' do
+    let(:data) { JSON.parse(response.body)['data']['attributes'] }
+
     context 'with an anonymous user' do
       it 'uploads a profile photo attachment' do
         post(
@@ -12,8 +49,6 @@ RSpec.describe V0::VIC::ProfilePhotoAttachmentsController, type: :controller do
             file_data: fixture_file_upload('files/sm_file1.jpg')
           }
         )
-
-        data = JSON.parse(response.body)['data']['attributes']
 
         expect(data).to have_key('filename')
         expect(data['path']).to eq 'profile_photo_attachments/anonymous'
@@ -36,8 +71,6 @@ RSpec.describe V0::VIC::ProfilePhotoAttachmentsController, type: :controller do
             file_data: fixture_file_upload('files/sm_file1.jpg')
           }
         )
-
-        data = JSON.parse(response.body)['data']['attributes']
 
         expect(data).to have_key('filename')
         expect(data['path']).to eq "profile_photo_attachments/#{InProgressForm.last.id}"

--- a/spec/controllers/v0/vic/profile_photo_attachments_controller_spec.rb
+++ b/spec/controllers/v0/vic/profile_photo_attachments_controller_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe V0::VIC::ProfilePhotoAttachmentsController, type: :controller do
             file_data: fixture_file_upload('files/sm_file1.jpg')
           }
         )
-        puts response.body
         expect(data['filename']).to be_nil
         expect(data['path']).to be_nil
       end
@@ -74,7 +73,6 @@ RSpec.describe V0::VIC::ProfilePhotoAttachmentsController, type: :controller do
           }
         )
 
-        puts response.body
         expect(data).to have_key('filename')
         expect(data['path']).to eq "profile_photo_attachments/#{InProgressForm.last.id}"
         expect(InProgressForm.count).not_to eq(before_count)

--- a/spec/models/vic/profile_photo_attachment_spec.rb
+++ b/spec/models/vic/profile_photo_attachment_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe VIC::ProfilePhotoAttachment, type: :model do
     end
 
     context 'with an anonymous user' do
-      it 'should not store user uuid and form id' do
+      it 'should not store user uuid and form id or return path and filename' do
         attachment = create(:profile_photo_attachment,
                             file_path: 'spec/fixtures/files/va.gif',
                             file_type: 'image/gif')

--- a/spec/serializers/profile_photo_attachment_serializer_spec.rb
+++ b/spec/serializers/profile_photo_attachment_serializer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ProfilePhotoAttachmentSerializer, type: :serializer do
 
   subject { serialize(model, serializer_class: described_class) }
 
-  it 'should serialize only filename and path out of file_data' do
+  it 'should serialize the filename and path out of file_data' do
     expect(attributes['filename']).to eq('test.jpg')
     expect(attributes['path']).to eq('test_dir')
   end

--- a/spec/serializers/profile_photo_attachment_serializer_spec.rb
+++ b/spec/serializers/profile_photo_attachment_serializer_spec.rb
@@ -3,26 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe ProfilePhotoAttachmentSerializer, type: :serializer do
+  let(:file_data) { { filename: 'test.jpg', path: 'test_dir' } }
   let(:model) { ::VIC::ProfilePhotoAttachment.new(file_data: file_data.to_json, guid: 'abcd') }
+
   let(:attributes) { JSON.parse(subject)['data']['attributes'] }
 
-  context 'with an anonymous upload' do
-    let(:file_data) { { filename: 'test.jpg', path: 'test_dir' } }
-    subject { serialize(model, serializer_class: described_class) }
+  subject { serialize(model, serializer_class: described_class) }
 
-    it 'should not include the filename and path' do
-      expect(attributes['filename']).to be_nil
-      expect(attributes['path']).to be_nil
-    end
-  end
-
-  context 'with an authenticated upload' do
-    let(:file_data) { { filename: 'test.jpg', path: 'test_dir', user_uuid: '1234', form_id: '5678' } }
-    subject { serialize(model, serializer_class: described_class) }
-
-    it 'should include the filename and path' do
-      expect(attributes['filename']).not_to be_nil
-      expect(attributes['path']).not_to be_nil
-    end
+  it 'should serialize only filename and path out of file_data' do
+    expect(attributes['filename']).to eq('test.jpg')
+    expect(attributes['path']).to eq('test_dir')
   end
 end

--- a/spec/serializers/profile_photo_attachment_serializer_spec.rb
+++ b/spec/serializers/profile_photo_attachment_serializer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProfilePhotoAttachmentSerializer, type: :serializer do
+  let(:model) { ::VIC::ProfilePhotoAttachment.new(file_data: file_data.to_json, guid: 'abcd') }
+  let(:attributes) { JSON.parse(subject)['data']['attributes'] }
+
+  context 'with an anonymous upload' do
+    let(:file_data) { { filename: 'test.jpg', path: 'test_dir' } }
+    subject { serialize(model, serializer_class: described_class) }
+
+    it 'should not include the filename and path' do
+      expect(attributes['filename']).to be_nil
+      expect(attributes['path']).to be_nil
+    end
+  end
+
+  context 'with an authenticated upload' do
+    let(:file_data) { { filename: 'test.jpg', path: 'test_dir', user_uuid: '1234', form_id: '5678' } }
+    subject { serialize(model, serializer_class: described_class) }
+
+    it 'should include the filename and path' do
+      expect(attributes['filename']).not_to be_nil
+      expect(attributes['path']).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This PR strips `filename` and `path` from anonymous `:create` responses and also adds an authenticated endpoint:

`GET /v0/vic/profile_photo_attachments/:id`

where `:id` is the guid of the file to retrieve path information for. This will return the same form attachment response as the initial create (including path information since the user will be logged in).