### PR TITLE
Remove redundant re-encode

### DIFF
--- a/app/uploaders/reencode_images.rb
+++ b/app/uploaders/reencode_images.rb
@@ -13,7 +13,6 @@ module ReencodeImages
     unless file.content_type == 'application/pdf'
       manipulate! do |img|
         img.strip
-        img.format(img.type)
         img
       end
     end


### PR DESCRIPTION
Just calling `maniuplate!` opens/saves the image ([Carrierwave source](https://github.com/carrierwaveuploader/carrierwave/blob/d34e1210ac6af153024f61c1f5bf92ec9be66de5/lib/carrierwave/processing/mini_magick.rb#L302)), so we don't need to do it again ourselves. Should help a little bit with the load too.