### PR TITLE
introduce new redirect routing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -137,7 +137,7 @@ class ApplicationController < ActionController::API
     end
   end
 
-  attr_reader :current_user
+  attr_reader :current_user, :session
 
   def render_unauthorized
     raise Common::Exceptions::Unauthorized

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -4,6 +4,8 @@ module V0
   class SessionsController < ApplicationController
     skip_before_action :authenticate, only: %i[new authn_urls saml_callback saml_logout_callback]
 
+    REDIRECT_URLS = %w[mhv dslogon idme mfa verify slo].freeze
+
     STATSD_SSO_CALLBACK_KEY = 'api.auth.saml_callback'
     STATSD_SSO_CALLBACK_TOTAL_KEY = 'api.auth.login_callback.total'
     STATSD_SSO_CALLBACK_FAILED_KEY = 'api.auth.login_callback.failed'
@@ -21,41 +23,62 @@ module V0
     # Collection Action: no auth required
     # Returns the sign-in urls for mhv, dslogon, and ID.me (LOA1 only)
     # authn_context is the policy, connect represents the ID.me flow
+    # TODO: DEPRECATED
     def authn_urls
       render json: {
-        mhv: build_url(authn_context: 'myhealthevet', connect: 'myhealthevet'),
-        dslogon: build_url(authn_context: 'dslogon', connect: 'dslogon'),
-        idme: build_url
+        mhv: SAML::SettingsService.mhv_url,
+        dslogon: SAML::SettingsService.dslogon_url,
+        idme: SAML::SettingsService.idme_loa1_url
       }
     end
+
+    # Collection Action: auth is required for certain types of requests
+    # @type is set automatically by the routes in config/routes.rb
+    # For more details see SAML::SettingsService and SAML::URLService
+    # TODO: when deprecated routes can be removed this should be changed to use different method (ie. destroy)
+    # rubocop:disable Metrics/CyclomaticComplexity
+    def new
+      case params[:type]
+      when 'mhv'
+        redirect_to SAML::SettingsService.mhv_url
+      when 'dslogon'
+        redirect_to SAML::SettingsService.dslogon_url
+      when 'idme'
+        redirect_to SAML::SettingsService.idme_loa1_url
+      when 'mfa'
+        authenticate
+        redirect_to SAML::SettingsService.mfa_url(current_user)
+      when 'verify'
+        authenticate
+        redirect_to SAML::SettingsService.idme_loa3_url(current_user)
+      when 'slo'
+        authenticate
+        redirect_to SAML::SettingsService.slo_url(session)
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     # Member Action: auth token required
     # method is to opt in to MFA for those users who opted out
     # authn_context is the policy, connect represents the ID.me flow
+    # TODO: DEPRECATED
     def multifactor
-      policy = @current_user&.authn_context
-      authn_context = policy.present? ? "#{policy}_multifactor" : 'multifactor'
-      render json: { multifactor_url: build_url(authn_context: authn_context, connect: policy) }
+      render json: { multifactor_url: SAML::SettingsService.mfa_url(current_user) }
     end
 
     # Member Action: auth token required
     # method is to verify LOA3. It is not necessary to verify for DSLogon or MHV who are PREMIUM users.
     # These sign-in users return LOA3 from the auth_url flow.
+    # TODO: DEPRECATED
     def identity_proof
       render json: {
-        identity_proof_url: build_url(authn_context: LOA::MAPPING.invert[3], connect: @current_user&.authn_context)
+        identity_proof_url: SAML::SettingsService.idme_loa3_url(current_user)
       }
     end
 
+    # TODO: DEPRECATED
     def destroy
-      logout_request = OneLogin::RubySaml::Logoutrequest.new
-      logger.info "New SP SLO for userid '#{@session.uuid}'"
-
-      saml_settings = saml_settings(name_identifier_value: @session&.uuid)
-      # cache the request for @session.token lookup when we receive the response
-      SingleLogoutRequest.create(uuid: logout_request.uuid, token: @session.token)
-
-      render json: { logout_via_get: logout_request.create(saml_settings, saml_options) }, status: 202
+      render json: { logout_via_get: SAML::SettingsService.slo_url(session) }, status: 202
     end
 
     def saml_logout_callback
@@ -72,8 +95,8 @@ module V0
       if @sso_service.persist_authentication!
         @current_user = @sso_service.new_user
         @session = @sso_service.new_session
-        async_create_evss_account(@current_user)
-        redirect_to Settings.saml.relay + '?token=' + @session.token
+        async_create_evss_account(current_user)
+        redirect_to Settings.saml.relay + '?token=' + session.token
 
         log_persisted_session_and_warnings
         StatsD.increment(STATSD_LOGIN_NEW_USER_KEY) if @sso_service.new_login?
@@ -90,12 +113,12 @@ module V0
     private
 
     def log_persisted_session_and_warnings
-      obscure_token = Session.obscure_token(@session.token)
-      Rails.logger.info("Logged in user with id #{@session.uuid}, token #{obscure_token}")
+      obscure_token = Session.obscure_token(session.token)
+      Rails.logger.info("Logged in user with id #{session.uuid}, token #{obscure_token}")
       # We want to log when SSNs do not match between MVI and SAML Identity. And might take future
       # action if this appears to be happening frquently.
-      if @current_user.ssn_mismatch?
-        additional_context = StringHelpers.heuristics(@current_user.identity.ssn, @current_user.va_profile.ssn)
+      if current_user.ssn_mismatch?
+        additional_context = StringHelpers.heuristics(current_user.identity.ssn, current_user.va_profile.ssn)
         log_message_to_sentry('SSNS DO NOT MATCH!!', :warn, identity_compared_with_mvi: additional_context)
       end
     end
@@ -107,7 +130,7 @@ module V0
     end
 
     def handle_completed_slo
-      saml_settings = saml_settings(name_identifier_value: @session&.uuid)
+      saml_settings = saml_settings(name_identifier_value: session&.uuid)
       logout_response = OneLogin::RubySaml::Logoutresponse.new(params[:SAMLResponse], saml_settings, get_params: params)
       logout_request  = SingleLogoutRequest.find(logout_response&.in_response_to)
       session         = Session.find(logout_request&.token)
@@ -139,25 +162,10 @@ module V0
       errors
     end
 
-    def saml_options
-      Settings.review_instance_slug.blank? ? {} : { RelayState: Settings.review_instance_slug }
-    end
-
-    # Builds the urls to trigger varios sign-in, mfa, or verify flows in idme.
-    # nil authn_context and nil connect will always default to idme level 1
-    # authn_context is the policy, connect represents the ID.me specific flow.
-    def build_url(authn_context: LOA::MAPPING.invert[1], connect: nil)
-      saml_settings = saml_settings(authn_context: authn_context, name_identifier_value: @session&.uuid)
-      saml_auth_request = OneLogin::RubySaml::Authrequest.new
-      connect_param = "&connect=#{connect}"
-      link = saml_auth_request.create(saml_settings, saml_options)
-      connect.present? ? link + connect_param : link
-    end
-
     def benchmark_tags(*tags)
       tags << "context:#{context_key}"
-      tags << "loa:#{@current_user&.identity ? @current_user.loa[:current] : 'none'}"
-      tags << "multifactor:#{@current_user&.identity ? @current_user.multifactor : 'none'}"
+      tags << "loa:#{current_user&.identity ? current_user.loa[:current] : 'none'}"
+      tags << "multifactor:#{current_user&.identity ? current_user.multifactor : 'none'}"
       tags
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
   get '/saml/metadata', to: 'saml#metadata'
   get '/auth/saml/logout', to: 'v0/sessions#saml_logout_callback', as: 'saml_logout'
   post '/auth/saml/callback', to: 'v0/sessions#saml_callback', module: 'v0'
+  get '/sessions/:type/new',
+      to: 'v0/sessions#new',
+      constraints: ->(request) { V0::SessionsController::REDIRECT_URLS.include?(request.path_parameters[:type]) }
 
   namespace :v0, defaults: { format: 'json' } do
     resources :in_progress_forms, only: %i[index show update destroy]

--- a/lib/saml/settings_service.rb
+++ b/lib/saml/settings_service.rb
@@ -3,12 +3,15 @@
 require 'memoist'
 require 'sentry_logging'
 require 'saml/health_status'
+require 'saml/url_service'
 
 module SAML
   # This class is responsible for putting together a complete ruby-saml
   # SETTINGS object, meaning, our static SP settings + the IDP settings
   # which must be fetched once and only once via IDP metadata.
-  class SettingsService
+  module SettingsService
+    extend URLService
+
     class << self
       include SentryLogging
       extend Memoist

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module SAML
+  # This module is responsible for providing the URLs for the various SSO and SLO endpoints
+  module URLService
+    # SSO URLS
+    def mhv_url
+      build_sso_url(authn_context: 'myhealthevet', connect: 'myhealthevet')
+    end
+
+    def dslogon_url
+      build_sso_url(authn_context: 'dslogon', connect: 'dslogon')
+    end
+
+    def idme_loa1_url
+      build_sso_url
+    end
+
+    def idme_loa3_url(current_user)
+      build_sso_url(authn_context: LOA::MAPPING.invert[3], connect: current_user.authn_context)
+    end
+
+    def mfa_url(current_user)
+      policy = current_user.authn_context
+      authn_context = policy.present? ? "#{policy}_multifactor" : 'multifactor'
+      build_sso_url(authn_context: authn_context, connect: policy)
+    end
+
+    # SLO URLS
+    def slo_url(session)
+      build_slo_url(session)
+    end
+
+    private
+
+    # Builds the urls to trigger various SSO policies: mhv, dslogon, idme, mfa, or verify flows.
+    # nil authn_context and nil connect will always default to idme level 1
+    # authn_context is the policy, connect represents the ID.me specific flow.
+    def build_sso_url(authn_context: LOA::MAPPING.invert[1], connect: nil, session: nil)
+      url_settings = url_settings(authn_context: authn_context, name_identifier_value: session&.uuid)
+      saml_auth_request = OneLogin::RubySaml::Authrequest.new
+      connect_param = "&connect=#{connect}"
+      link = saml_auth_request.create(url_settings, saml_options)
+      connect.present? ? link + connect_param : link
+    end
+
+    # Builds the url to trigger SLO, caching the request
+    def build_slo_url(session)
+      logout_request = OneLogin::RubySaml::Logoutrequest.new
+      Rails.logger.info "New SP SLO for userid '#{session.uuid}'"
+
+      url_settings = url_settings(name_identifier_value: session.uuid)
+      # cache the request for session.token lookup when we receive the response
+      SingleLogoutRequest.create(uuid: logout_request.uuid, token: session.token)
+      logout_request.create(url_settings, saml_options)
+    end
+
+    def url_settings(options)
+      saml_settings(options)
+    end
+
+    def saml_options
+      Settings.review_instance_slug.blank? ? {} : { RelayState: Settings.review_instance_slug }
+    end
+  end
+end

--- a/spec/routing/sessions_routing_spec.rb
+++ b/spec/routing/sessions_routing_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'routes for Session', type: :routing do
+  V0::SessionsController::REDIRECT_URLS.each do |type|
+    it "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
+      expect(get("/sessions/#{type}/new")).to route_to(
+        controller: 'v0/sessions',
+        action: 'new',
+        type: type
+      )
+    end
+  end
+
+  it 'doesnt route something not matching the constraint' do
+    expect(get('/sessions/unknown/new')).to route_to(
+      controller: 'application',
+      action: 'routing_error',
+      path: 'sessions/unknown/new'
+    )
+  end
+end


### PR DESCRIPTION
This is the first part of replacing some existing routes. The goal is to make it such that the url fetched is the url to be shown in the modal immediately which will also trigger the redirect to the callback url. This has many benefits. For one, FE will no longer need to rely on promises logic or to fetch these urls up front. It can just know what the urls are and use them in the modal, and rely on HTTP redirects to take care of the rest.

This will be of particular benefit to the destroy action. We get a lot of SAML Logout failure messages currently and it is unclear as to why. It's most likely something having to do with persistence in Redis. In any case, this should help surface these types of things better. 

Eventually auth_urls and other methods like it will be replaced, but for now just introducing the new routes until the FE can be changed to stop using the deprecated routing.

Part 1:
Will introduce the new routes so that the FE can update its routes to use these instead. We will test this exhaustively for all sign-in methods and flows locally before pushing these changes to staging.

Part 2:
Replace some of the deprecated actions with new controller methods. The actual routes will stay mostly the same. We might just make the slo route a replacement of the current destroy action.
We'll also be in a position to add back in the Timer instrumentations we removed. These Timers were removed because they were mostly nonsensical in the way they were tracking things. However with the new redirect methodology they will make a lot of sense and warrant  re-introducing.