### PR TITLE
Factor in MHV correlation ID to determine accessibility to MHV services.

### DIFF
--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -74,6 +74,7 @@ class MhvAccount < ActiveRecord::Base
   end
 
   def accessible?
+    return false if mhv_correlation_id.nil? || mhv_correlation_id.empty?
     (user.loa3? || user.authn_context.include?('myhealthevet')) && (upgraded? || existing?)
   end
 
@@ -111,9 +112,13 @@ class MhvAccount < ActiveRecord::Base
     @mhv_accounts_service || MhvAccountsService.new(user)
   end
 
+  def mhv_correlation_id
+    user.mhv_correlation_id
+  end
+
   def setup
     raise StandardError, 'You must use find_or_initialize_by(user_uuid: #)' if user_uuid.nil?
-    check_eligibility unless registered? || upgraded?
+    check_eligibility unless accessible?
     check_terms_acceptance if may_check_terms_acceptance?
   end
 end

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -74,7 +74,7 @@ class MhvAccount < ActiveRecord::Base
   end
 
   def accessible?
-    return false unless mhv_correlation_id.present?
+    return false if mhv_correlation_id.blank?
     (user.loa3? || user.authn_context.include?('myhealthevet')) && (upgraded? || existing?)
   end
 

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -101,7 +101,7 @@ class MhvAccount < ActiveRecord::Base
   end
 
   def mhv_correlation_id
-    user&.mhv_correlation_id
+    user.mhv_correlation_id
   end
 
   def create_mhv_account!

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -70,11 +70,11 @@ class MhvAccount < ActiveRecord::Base
   end
 
   def preexisting_account?
-    user&.mhv_correlation_id.present? && !previously_registered?
+    mhv_correlation_id.present? && !previously_registered?
   end
 
   def accessible?
-    return false if mhv_correlation_id.nil? || mhv_correlation_id.empty?
+    return false unless mhv_correlation_id.present?
     (user.loa3? || user.authn_context.include?('myhealthevet')) && (upgraded? || existing?)
   end
 
@@ -100,6 +100,10 @@ class MhvAccount < ActiveRecord::Base
     @user ||= User.find(user_uuid)
   end
 
+  def mhv_correlation_id
+    user&.mhv_correlation_id
+  end
+
   def create_mhv_account!
     mhv_accounts_service.create
   end
@@ -110,10 +114,6 @@ class MhvAccount < ActiveRecord::Base
 
   def mhv_accounts_service
     @mhv_accounts_service || MhvAccountsService.new(user)
-  end
-
-  def mhv_correlation_id
-    user.mhv_correlation_id
   end
 
   def setup

--- a/spec/models/mhv_account_spec.rb
+++ b/spec/models/mhv_account_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe MhvAccount, type: :model do
 
           it 'a priori failed upgrade that has been registered changes to registered' do
             subject = described_class.new(
-              base_attributes.merge(registered_at: Time.current, upgraded_at: nil, account_state: :upgrade_failed)
+              base_attributes.merge(registered_at: Time.current, account_state: :upgrade_failed)
             )
             subject.send(:setup) # This gets called when object is first loaded
             expect(subject.account_state).to eq('registered')
@@ -106,15 +106,48 @@ RSpec.describe MhvAccount, type: :model do
             expect(subject.account_state).to eq('upgraded')
             expect(subject.accessible?).to be_truthy
           end
+
+          it 'is able to transition back to upgraded' do
+            subject = described_class.new(
+              base_attributes.merge(registered_at: Time.current, upgraded_at: Time.current)
+            )
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('upgraded')
+            expect(subject.eligible?).to be_truthy
+            expect(subject.terms_and_conditions_accepted?).to be_truthy
+            expect(subject.accessible?).to be_truthy
+          end
         end
 
-        it 'is able to transition back to upgraded' do
-          subject = described_class.new(base_attributes.merge(upgraded_at: Time.current))
-          subject.send(:setup) # This gets called when object is first loaded
-          expect(subject.account_state).to eq('upgraded')
-          expect(subject.eligible?).to be_truthy
-          expect(subject.terms_and_conditions_accepted?).to be_truthy
-          expect(subject.accessible?).to be_truthy
+        context 'without mhv id' do
+          it 'a priori registered account changes to registered' do
+            subject = described_class.new(
+              base_attributes.merge(registered_at: Time.current, account_state: :registered)
+            )
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('registered')
+            expect(subject.accessible?).to be_falsey
+          end
+
+          it 'a priori upgraded account changes to upgraded' do
+            subject = described_class.new(
+              base_attributes.merge(upgraded_at: Time.current, account_state: :upgraded)
+            )
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('upgraded')
+            expect(subject.accessible?).to be_falsey
+          end
+
+          it 'is able to transition back to upgraded' do
+            subject = described_class.new(
+              base_attributes.merge(registered_at: Time.current, upgraded_at: Time.current)
+            )
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('upgraded')
+            expect(subject.eligible?).to be_truthy
+            expect(subject.terms_and_conditions_accepted?).to be_truthy
+            expect(subject.accessible?).to be_falsey
+          end
         end
 
         it 'is able to transition back to registered' do
@@ -133,20 +166,6 @@ RSpec.describe MhvAccount, type: :model do
           expect(subject.eligible?).to be_truthy
           expect(subject.terms_and_conditions_accepted?).to be_truthy
           expect(subject.accessible?).to be_falsey
-        end
-
-        it 'a priori registered account stays registered' do
-          subject = described_class.new(base_attributes.merge(registered_at: nil, account_state: :registered))
-          subject.send(:setup) # This gets called when object is first loaded
-          expect(subject.account_state).to eq('registered')
-          expect(subject.accessible?).to be_falsey
-        end
-
-        it 'a priori upgraded account stays upgraded' do
-          subject = described_class.new(base_attributes.merge(upgraded_at: nil, account_state: :upgraded))
-          subject.send(:setup) # This gets called when object is first loaded
-          expect(subject.account_state).to eq('upgraded')
-          expect(subject.accessible?).to be_truthy
         end
 
         it 'a priori register_failed account changes to unknown' do


### PR DESCRIPTION
Fixes cases where a user has registered and upgraded timestamps, but no longer has an `mhv_correlation_id`, perhaps due to deleting their MHV account (just one possibility).

We were allowing users to access MHV services as long as they had those timestamps in our database, but the existence of the correlation id should take precedence. They should not be able to access those services without it.