### PR TITLE
Update rack-protection due to gem vuln

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,7 @@ GEM
     rack-attack (5.0.1)
       rack
     rack-cors (0.4.1)
-    rack-protection (1.5.3)
+    rack-protection (1.5.4)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)


### PR DESCRIPTION
Vulnerability report:

```
Name: rack-protection
Version: 1.5.3
Advisory: CVE-2018-7212
Criticality: Unknown
URL: https://github.com/sinatra/sinatra/pull/1379
Title: Path traversal is possible via backslash characters on Windows.
Solution: upgrade to >= 2.0.1, ~> 1.5.4
```