### PR TITLE
Sanitize Arrays for PII data

### DIFF
--- a/lib/sentry/processor/pii_sanitizer.rb
+++ b/lib/sentry/processor/pii_sanitizer.rb
@@ -9,10 +9,13 @@ module Sentry
 
       JSON_STARTS_WITH = ['[', '{'].freeze
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       def process(value, key = nil)
         case value
         when Hash
           !value.frozen? ? value.merge!(value) { |k, v| process v, k } : value.merge(value) { |k, v| process v, k }
+        when Array
+          !value.frozen? ? value.map! { |v| process v } : value.map { |v| process v }
         when String
           # if this string is actually a json obj, convert and sanitize
           # taken from: https://github.com/getsentry/raven-ruby/blob/master/lib/raven/processor/sanitizedata.rb#L29
@@ -25,6 +28,7 @@ module Sentry
           filter_values(key, value)
         end
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       private
 

--- a/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
+++ b/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Sentry::Processor::PIISanitizer do
           state: 'NV'
         },
         json: '{"phone": "5035551234", "postalCode": 97850}',
+        array_of_json: ['{"phone": "5035551234", "postalCode": 97850}'],
         gender: 'M',
         phone: '5035551234'
       }
@@ -38,6 +39,10 @@ RSpec.describe Sentry::Processor::PIISanitizer do
     it 'should filter json blobs' do
       expect(result[:json]).to include('FILTERED')
     end
+
+    it 'should filter arrays' do
+      expect(result[:array_of_json].first).to include('FILTERED')
+    end
   end
 
   context 'with string keys' do
@@ -51,6 +56,7 @@ RSpec.describe Sentry::Processor::PIISanitizer do
           'state' => 'OR'
         },
         'json' => '{"gender": "F"}',
+        'arrayOfJson' => ['{"phone": "5035551234", "postalCode": 97850}'],
         'gender' => 'F',
         'phone' => '5415551234'
       }
@@ -70,6 +76,10 @@ RSpec.describe Sentry::Processor::PIISanitizer do
 
     it 'should filter json blobs' do
       expect(result['json']).to include('FILTERED')
+    end
+
+    it 'should filter arrays' do
+      expect(result['arrayOfJson'].first).to include('FILTERED')
     end
   end
 end


### PR DESCRIPTION
This should cover the case we saw in Sentry where sidekiq args were being logged but not sanitized