### PR TITLE
9022 pciu primary phone endpoint

### DIFF
--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -108,6 +108,7 @@ module V0
       Swagger::Schemas::LetterBeneficiary,
       Swagger::Schemas::Letters,
       Swagger::Schemas::MaintenanceWindows,
+      Swagger::Schemas::PhoneNumber,
       Swagger::Schemas::SavedForm,
       Swagger::Schemas::States,
       Swagger::Schemas::TermsAndConditions,

--- a/app/controllers/v0/profile/primary_phones_controller.rb
+++ b/app/controllers/v0/profile/primary_phones_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V0
+  module Profile
+    class PrimaryPhonesController < ApplicationController
+      before_action { authorize :evss, :access? }
+
+      def show
+        response = service.get_primary_phone
+
+        render json: response, serializer: PhoneNumberSerializer
+      end
+
+      private
+
+      def service
+        EVSS::PCIU::Service.new @current_user
+      end
+    end
+  end
+end

--- a/app/serializers/phone_number_serializer.rb
+++ b/app/serializers/phone_number_serializer.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class PhoneNumberSerializer < ActiveModel::Serializer
+  attribute :number
+  attribute :extension
+  attribute :country_code
+
+  def id
+    nil
+  end
+
+  # Returns the phone number nested in the given object.
+  #
+  # @return [String] Phone number.  Sample `object.phone`:
+  #   {
+  #     "country_code" => "1",
+  #     "extension" => "",
+  #     "number" => "4445551212"
+  #   }
+  #
+  def number
+    object&.phone&.dig 'number'
+  end
+
+  # Returns the extension nested in the given object.
+  #
+  # @return [String] Extension.  Sample `object.phone`:
+  #   {
+  #     "country_code" => "1",
+  #     "extension" => "",
+  #     "number" => "4445551212"
+  #   }
+  #
+  def extension
+    object&.phone&.dig 'extension'
+  end
+
+  # Returns the country code nested in the given object.
+  #
+  # @return [String] Country code.  Sample `object.phone`:
+  #   {
+  #     "country_code" => "1",
+  #     "extension" => "",
+  #     "number" => "4445551212"
+  #   }
+  #
+  def country_code
+    object&.phone&.dig 'country_code'
+  end
+end

--- a/app/serializers/phone_number_serializer.rb
+++ b/app/serializers/phone_number_serializer.rb
@@ -8,43 +8,4 @@ class PhoneNumberSerializer < ActiveModel::Serializer
   def id
     nil
   end
-
-  # Returns the phone number nested in the given object.
-  #
-  # @return [String] Phone number.  Sample `object.phone`:
-  #   {
-  #     "country_code" => "1",
-  #     "extension" => "",
-  #     "number" => "4445551212"
-  #   }
-  #
-  def number
-    object&.phone&.dig 'number'
-  end
-
-  # Returns the extension nested in the given object.
-  #
-  # @return [String] Extension.  Sample `object.phone`:
-  #   {
-  #     "country_code" => "1",
-  #     "extension" => "",
-  #     "number" => "4445551212"
-  #   }
-  #
-  def extension
-    object&.phone&.dig 'extension'
-  end
-
-  # Returns the country code nested in the given object.
-  #
-  # @return [String] Country code.  Sample `object.phone`:
-  #   {
-  #     "country_code" => "1",
-  #     "extension" => "",
-  #     "number" => "4445551212"
-  #   }
-  #
-  def country_code
-    object&.phone&.dig 'country_code'
-  end
 end

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -25,6 +25,27 @@ module Swagger
           end
         end
       end
+
+      swagger_path '/v0/profile/primary_phone' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Get a users primary phone number information'
+          key :operationId, 'getPrimaryPhone'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :PhoneNumber
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/app/swagger/schemas/phone_number.rb
+++ b/app/swagger/schemas/phone_number.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Schemas
+    class PhoneNumber
+      include Swagger::Blocks
+
+      swagger_schema :PhoneNumber do
+        key :required, [:data]
+
+        property :data, type: :object do
+          key :required, [:attributes]
+          property :attributes, type: :object do
+            property :number, type: :string, example: '4445551212'
+            property :extension, type: :string, example: '101'
+            property :country_code, type: :string, example: '1'
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,7 @@ Rails.application.routes.draw do
 
     namespace :profile do
       resource :email, only: :show
+      resource :primary_phone, only: :show
     end
 
     resources :apidocs, only: [:index]

--- a/lib/evss/pciu/phone_number_response.rb
+++ b/lib/evss/pciu/phone_number_response.rb
@@ -5,12 +5,18 @@ require 'evss/response'
 module EVSS
   module PCIU
     class PhoneNumberResponse < EVSS::Response
-      attribute :phone, Hash
+      attribute :country_code, String
+      attribute :number, String
+      attribute :extension, String
 
       def initialize(status, response = nil)
-        phone = response&.body&.dig('cnp_phone')
+        attributes = {
+          country_code: response&.body&.dig('cnp_phone', 'country_code'),
+          number: response&.body&.dig('cnp_phone', 'number'),
+          extension: response&.body&.dig('cnp_phone', 'extension')
+        }
 
-        super(status, phone: phone)
+        super(status, attributes)
       end
     end
   end

--- a/lib/evss/pciu/phone_number_response.rb
+++ b/lib/evss/pciu/phone_number_response.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'evss/response'
+
+module EVSS
+  module PCIU
+    class PhoneNumberResponse < EVSS::Response
+      attribute :phone, Hash
+
+      def initialize(status, response = nil)
+        phone = response&.body&.dig('cnp_phone')
+
+        super(status, phone: phone)
+      end
+    end
+  end
+end

--- a/lib/evss/pciu/service.rb
+++ b/lib/evss/pciu/service.rb
@@ -32,6 +32,26 @@ module EVSS
       rescue StandardError => e
         handle_error(e)
       end
+
+      # Returns a response object containing the user's primary phone number,
+      # extension, and country code
+      #
+      # @return [EVSS::PCIU::PhoneNumberResponse] Sample response.phone:
+      #   {
+      #     "country_code" => "1",
+      #     "extension" => "",
+      #     "number" => "4445551212"
+      #   }
+      #
+      def get_primary_phone
+        with_monitoring do
+          raw_response = perform(:get, 'primaryPhoneNumber')
+
+          EVSS::PCIU::PhoneNumberResponse.new(raw_response.status, raw_response)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
     end
   end
 end

--- a/spec/lib/evss/pciu/service_spec.rb
+++ b/spec/lib/evss/pciu/service_spec.rb
@@ -25,4 +25,24 @@ describe EVSS::PCIU::Service do
       end
     end
   end
+
+  describe '#get_primary_phone' do
+    context 'when successful' do
+      it 'returns a status of 200' do
+        VCR.use_cassette('evss/pciu/primary_phone') do
+          response = subject.get_primary_phone
+
+          expect(response).to be_ok
+        end
+      end
+
+      it 'returns a users primary phone number, extension and country code' do
+        VCR.use_cassette('evss/pciu/primary_phone') do
+          response = subject.get_primary_phone
+
+          expect(response.phone.keys).to contain_exactly 'country_code', 'number', 'extension'
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/evss/pciu/service_spec.rb
+++ b/spec/lib/evss/pciu/service_spec.rb
@@ -40,7 +40,7 @@ describe EVSS::PCIU::Service do
         VCR.use_cassette('evss/pciu/primary_phone') do
           response = subject.get_primary_phone
 
-          expect(response.phone.keys).to contain_exactly 'country_code', 'number', 'extension'
+          expect(response.attributes.keys).to include :country_code, :number, :extension
         end
       end
     end

--- a/spec/request/primary_phone_request_spec.rb
+++ b/spec/request/primary_phone_request_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'primary phone', type: :request do
+  include SchemaMatchers
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  describe 'GET /v0/profile/primary_phone' do
+    context 'with a 200 response' do
+      it 'should match the primary phone schema' do
+        VCR.use_cassette('evss/pciu/primary_phone') do
+          get '/v0/profile/primary_phone', nil, auth_header
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('phone_number_response')
+        end
+      end
+    end
+
+    context 'with a 400 response' do
+      it 'should match the errors schema' do
+        VCR.use_cassette('evss/pciu/primary_phone_status_400') do
+          get '/v0/profile/primary_phone', nil, auth_header
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+
+    context 'with a 403 response' do
+      it 'should return a forbidden response' do
+        VCR.use_cassette('evss/pciu/primary_phone_status_403') do
+          get '/v0/profile/primary_phone', nil, auth_header
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context 'with a 500 response' do
+      it 'should match the errors schema' do
+        VCR.use_cassette('evss/pciu/primary_phone_status_500') do
+          get '/v0/profile/primary_phone', nil, auth_header
+
+          expect(response).to have_http_status(:bad_gateway)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+  end
+end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1068,6 +1068,13 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           expect(subject).to validate(:get, '/v0/profile/email', 200, auth_options)
         end
       end
+
+      it 'supports getting primary phone number data' do
+        expect(subject).to validate(:get, '/v0/profile/primary_phone', 401)
+        VCR.use_cassette('evss/pciu/primary_phone') do
+          expect(subject).to validate(:get, '/v0/profile/primary_phone', 200, auth_options)
+        end
+      end
     end
   end
 

--- a/spec/support/schemas/phone_number_response.json
+++ b/spec/support/schemas/phone_number_response.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "number": {
+              "type": "string"
+            },
+            "extension": {
+              "type": "string"
+            },
+            "country_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/vcr_cassettes/evss/pciu/primary_phone.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/primary_phone.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/primaryPhoneNumber"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-07T01:20:45Z'
+      va-eauth-dodedipnid:
+      - '7153119040'
+      va-eauth-birlsfilenumber:
+      - '4972517945'
+      va-eauth-pid:
+      - '2641765966'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1946-06-09T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"7153119040","firstName":"abraham","lastName":"lincoln","birthDate":"1946-06-09T00:00:00+00:00"}}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Mar 2018 01:20:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.02; path=/
+      - wss-pciu-services_JSESSIONID=r9b-DAr5Y-ODoCD_cGTHd-lHSHVIdD7oc5jtC4Bg27J5Dbyl4M0e!-820360796;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpPhone" : {
+            "countryCode" : "1",
+            "extension" : "",
+            "number" : "4445551212"
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 07 Mar 2018 01:20:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_400.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_400.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/primaryPhoneNumber"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-07T01:20:45Z'
+      va-eauth-dodedipnid:
+      - '7153119040'
+      va-eauth-birlsfilenumber:
+      - '4972517945'
+      va-eauth-pid:
+      - '2641765966'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1946-06-09T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"7153119040","firstName":"abraham","lastName":"lincoln","birthDate":"1946-06-09T00:00:00+00:00"}}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Wed, 07 Mar 2018 01:20:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.02; path=/
+      - wss-pciu-services_JSESSIONID=r9b-DAr5Y-ODoCD_cGTHd-lHSHVIdD7oc5jtC4Bg27J5Dbyl4M0e!-820360796;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpPhone" : {
+            "countryCode" : "1",
+            "extension" : "",
+            "number" : "4445551212"
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version:
+  recorded_at: Wed, 07 Mar 2018 01:20:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_403.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_403.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/primaryPhoneNumber"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-07T01:20:45Z'
+      va-eauth-dodedipnid:
+      - '7153119040'
+      va-eauth-birlsfilenumber:
+      - '4972517945'
+      va-eauth-pid:
+      - '2641765966'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1946-06-09T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"7153119040","firstName":"abraham","lastName":"lincoln","birthDate":"1946-06-09T00:00:00+00:00"}}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Wed, 07 Mar 2018 01:20:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.02; path=/
+      - wss-pciu-services_JSESSIONID=r9b-DAr5Y-ODoCD_cGTHd-lHSHVIdD7oc5jtC4Bg27J5Dbyl4M0e!-820360796;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpPhone" : {
+            "countryCode" : "1",
+            "extension" : "",
+            "number" : "4445551212"
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version:
+  recorded_at: Wed, 07 Mar 2018 01:20:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_500.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_500.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/primaryPhoneNumber"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-07T01:20:45Z'
+      va-eauth-dodedipnid:
+      - '7153119040'
+      va-eauth-birlsfilenumber:
+      - '4972517945'
+      va-eauth-pid:
+      - '2641765966'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1946-06-09T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"7153119040","firstName":"abraham","lastName":"lincoln","birthDate":"1946-06-09T00:00:00+00:00"}}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Wed, 07 Mar 2018 01:20:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.02; path=/
+      - wss-pciu-services_JSESSIONID=r9b-DAr5Y-ODoCD_cGTHd-lHSHVIdD7oc5jtC4Bg27J5Dbyl4M0e!-820360796;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpPhone" : {
+            "countryCode" : "1",
+            "extension" : "",
+            "number" : "4445551212"
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version:
+  recorded_at: Wed, 07 Mar 2018 01:20:57 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Background
Here are the [swagger docs](https://csraciapp6.evss.srarad.com/wss-pciu-services-web/swagger-ui/index.html?url=https://csraciapp6.evss.srarad.com/wss-pciu-services-web/rest/swagger.yaml#/) for the new PCIU Service endpoints for vets.gov to consume.

Our backend API needs to create sibling endpoints for the vets.gov frontend to consume.  The first of those endpoints was created in https://github.com/department-of-veterans-affairs/vets-api/pull/1718.

This PR will creates the `primary_phone` endpoint, following the above pattern.

## Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9022

## Screenshots

**Swagger Docs | Requests**

![image](https://user-images.githubusercontent.com/7482329/37106057-0269262e-21ee-11e8-9cb7-80aa7a49f236.png)

**Swagger Docs | Models**

![image](https://user-images.githubusercontent.com/7482329/37106218-7a9cebb2-21ee-11e8-89d3-489689fd8614.png)

## Definition of done
- [x] new `*/primary_phone` `GET` endpoint
- [x] associated specs
- [x] Yard docs
- [x] Swagger docs
- [x] Sign off by the frontend
