### PR TITLE
9161 pciu alternate phone endpoint

### DIFF
--- a/app/controllers/v0/profile/alternate_phones_controller.rb
+++ b/app/controllers/v0/profile/alternate_phones_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module V0
+  module Profile
+    class AlternatePhonesController < ApplicationController
+      before_action { authorize :evss, :access? }
+
+      def show
+        response = service.get_alternate_phone
+
+        render json: response, serializer: PhoneNumberSerializer
+      end
+
+      private
+
+      def service
+        EVSS::PCIU::Service.new @current_user
+      end
+    end
+  end
+end

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -46,6 +46,27 @@ module Swagger
           end
         end
       end
+
+      swagger_path '/v0/profile/alternate_phone' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Get a users alternate phone number information'
+          key :operationId, 'getAlternatePhone'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :PhoneNumber
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -5,6 +5,27 @@ module Swagger
     class Profile
       include Swagger::Blocks
 
+      swagger_path '/v0/profile/alternate_phone' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Get a users alternate phone number information'
+          key :operationId, 'getAlternatePhone'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :PhoneNumber
+            end
+          end
+        end
+      end
+
       swagger_path '/v0/profile/email' do
         operation :get do
           extend Swagger::Responses::AuthenticationError
@@ -32,27 +53,6 @@ module Swagger
 
           key :description, 'Get a users primary phone number information'
           key :operationId, 'getPrimaryPhone'
-          key :tags, %w[
-            profile
-          ]
-
-          parameter :authorization
-
-          response 200 do
-            key :description, 'Response is OK'
-            schema do
-              key :'$ref', :PhoneNumber
-            end
-          end
-        end
-      end
-
-      swagger_path '/v0/profile/alternate_phone' do
-        operation :get do
-          extend Swagger::Responses::AuthenticationError
-
-          key :description, 'Get a users alternate phone number information'
-          key :operationId, 'getAlternatePhone'
           key :tags, %w[
             profile
           ]

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -19,6 +19,13 @@
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: 'va_eauth_pnid'
+  # PCIU alternate phone
+  - :method: :get
+    :path: "/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"
+    :file_path: "evss/pciu/alternate_phone"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: 'va_eauth_pnid'
   # PCIUAddress
   - :method: :get
     :path: "/wss-pciu-services-web/rest/pciuServices/v1/states"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,6 +154,7 @@ Rails.application.routes.draw do
     namespace :profile do
       resource :email, only: :show
       resource :primary_phone, only: :show
+      resource :alternate_phone, only: :show
     end
 
     resources :apidocs, only: [:index]

--- a/lib/evss/pciu/service.rb
+++ b/lib/evss/pciu/service.rb
@@ -52,6 +52,26 @@ module EVSS
       rescue StandardError => e
         handle_error(e)
       end
+
+      # Returns a response object containing the user's alternate phone number,
+      # extension, and country code
+      #
+      # @return [EVSS::PCIU::PhoneNumberResponse] Sample response.phone:
+      #   {
+      #     "country_code" => "1",
+      #     "extension" => "",
+      #     "number" => "4445551212"
+      #   }
+      #
+      def get_alternate_phone
+        with_monitoring do
+          raw_response = perform(:get, 'secondaryPhoneNumber')
+
+          EVSS::PCIU::PhoneNumberResponse.new(raw_response.status, raw_response)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
     end
   end
 end

--- a/spec/lib/evss/pciu/service_spec.rb
+++ b/spec/lib/evss/pciu/service_spec.rb
@@ -45,4 +45,24 @@ describe EVSS::PCIU::Service do
       end
     end
   end
+
+  describe '#get_alternate_phone' do
+    context 'when successful' do
+      it 'returns a status of 200' do
+        VCR.use_cassette('evss/pciu/alternate_phone') do
+          response = subject.get_alternate_phone
+
+          expect(response).to be_ok
+        end
+      end
+
+      it 'returns a users alternate phone number, extension and country code' do
+        VCR.use_cassette('evss/pciu/alternate_phone') do
+          response = subject.get_alternate_phone
+
+          expect(response.attributes.keys).to include :country_code, :number, :extension
+        end
+      end
+    end
+  end
 end

--- a/spec/request/alternate_phone_request_spec.rb
+++ b/spec/request/alternate_phone_request_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'alternate phone', type: :request do
+  include SchemaMatchers
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  describe 'GET /v0/profile/alternate_phone' do
+    context 'with a 200 response' do
+      it 'should match the alternate phone schema' do
+        VCR.use_cassette('evss/pciu/alternate_phone') do
+          get '/v0/profile/alternate_phone', nil, auth_header
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('phone_number_response')
+        end
+      end
+    end
+
+    context 'with a 400 response' do
+      it 'should match the errors schema' do
+        VCR.use_cassette('evss/pciu/alternate_phone_status_400') do
+          get '/v0/profile/alternate_phone', nil, auth_header
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+
+    context 'with a 403 response' do
+      it 'should return a forbidden response' do
+        VCR.use_cassette('evss/pciu/alternate_phone_status_403') do
+          get '/v0/profile/alternate_phone', nil, auth_header
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context 'with a 500 response' do
+      it 'should match the errors schema' do
+        VCR.use_cassette('evss/pciu/alternate_phone_status_500') do
+          get '/v0/profile/alternate_phone', nil, auth_header
+
+          expect(response).to have_http_status(:bad_gateway)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+  end
+end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1075,6 +1075,13 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           expect(subject).to validate(:get, '/v0/profile/primary_phone', 200, auth_options)
         end
       end
+
+      it 'supports getting alternate phone number data' do
+        expect(subject).to validate(:get, '/v0/profile/alternate_phone', 401)
+        VCR.use_cassette('evss/pciu/alternate_phone') do
+          expect(subject).to validate(:get, '/v0/profile/alternate_phone', 200, auth_options)
+        end
+      end
     end
   end
 

--- a/spec/support/vcr_cassettes/evss/pciu/alternate_phone.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/alternate_phone.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-08T16:46:48Z'
+      va-eauth-dodedipnid:
+      - '8716670625'
+      va-eauth-birlsfilenumber:
+      - '1491411517'
+      va-eauth-pid:
+      - '4389004201'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1968-06-09T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"8716670625","firstName":"abraham","lastName":"lincoln","birthDate":"1968-06-09T00:00:00+00:00"}}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 16:46:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=hxYGgjbbL4LGjtfdAFCjaFEkf3S4Owb5UdTSV0vKMPl7_CrGCBhV!-903544307;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpPhone" : {
+            "countryCode" : "1",
+            "extension" : "",
+            "number" : ""
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 16:46:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_400.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_400.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-08T16:46:48Z'
+      va-eauth-dodedipnid:
+      - '8716670625'
+      va-eauth-birlsfilenumber:
+      - '1491411517'
+      va-eauth-pid:
+      - '4389004201'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1968-06-09T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"8716670625","firstName":"abraham","lastName":"lincoln","birthDate":"1968-06-09T00:00:00+00:00"}}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 16:46:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=hxYGgjbbL4LGjtfdAFCjaFEkf3S4Owb5UdTSV0vKMPl7_CrGCBhV!-903544307;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpPhone" : {
+            "countryCode" : "1",
+            "extension" : "",
+            "number" : ""
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version:
+  recorded_at: Thu, 08 Mar 2018 16:46:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_403.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_403.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-08T16:46:48Z'
+      va-eauth-dodedipnid:
+      - '8716670625'
+      va-eauth-birlsfilenumber:
+      - '1491411517'
+      va-eauth-pid:
+      - '4389004201'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1968-06-09T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"8716670625","firstName":"abraham","lastName":"lincoln","birthDate":"1968-06-09T00:00:00+00:00"}}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 16:46:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=hxYGgjbbL4LGjtfdAFCjaFEkf3S4Owb5UdTSV0vKMPl7_CrGCBhV!-903544307;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpPhone" : {
+            "countryCode" : "1",
+            "extension" : "",
+            "number" : ""
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version:
+  recorded_at: Thu, 08 Mar 2018 16:46:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_500.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_500.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-08T16:46:48Z'
+      va-eauth-dodedipnid:
+      - '8716670625'
+      va-eauth-birlsfilenumber:
+      - '1491411517'
+      va-eauth-pid:
+      - '4389004201'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1968-06-09T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"8716670625","firstName":"abraham","lastName":"lincoln","birthDate":"1968-06-09T00:00:00+00:00"}}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 16:46:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=hxYGgjbbL4LGjtfdAFCjaFEkf3S4Owb5UdTSV0vKMPl7_CrGCBhV!-903544307;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpPhone" : {
+            "countryCode" : "1",
+            "extension" : "",
+            "number" : ""
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version:
+  recorded_at: Thu, 08 Mar 2018 16:46:59 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Background
Here are the [swagger docs](https://csraciapp6.evss.srarad.com/wss-pciu-services-web/swagger-ui/index.html?url=https://csraciapp6.evss.srarad.com/wss-pciu-services-web/rest/swagger.yaml#/) for the new PCIU Service endpoints for vets.gov to consume.

Our backend API needs to create sibling endpoints for the vets.gov frontend to consume.  The first of those endpoints was created in https://github.com/department-of-veterans-affairs/vets-api/pull/1718.

This PR will creates the `alternate_phone` endpoint, following the above pattern.

## Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9161

**vets-api-mockdata PR**
https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/16

## Screenshots

**Swagger Docs | Requests**

![image](https://user-images.githubusercontent.com/7482329/37166686-ef4ed82a-22bc-11e8-8ba3-a3e16be5a471.png)


## Definition of done
- [x] new `*/alternate_phone` `GET` endpoint
- [x] associated specs
- [x] Yard docs
- [x] Swagger docs
- [x] Betamocks config
- [x] Sign off by the frontend
