### PR TITLE
add additional logging and ensure success url returns

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -169,6 +169,11 @@ module V0
       else
         Settings.saml.relay + '?token=' + @session.token
       end
+    rescue NoMethodError
+      Raven.user_context(user_context)
+      Raven.tags_context(tags_context)
+      log_message_to_sentry('SSO Callback Success URL', :warn)
+      Settings.saml.relay + '?token=' + @session.token
     end
 
     def benchmark_tags(*tags)


### PR DESCRIPTION
Fixes: http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/34348/

Adds additional logging to figure out why LOA is nil. Is it for a specific authn_context?