### PR TITLE
Alias for the existing address endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,8 @@ Rails.application.routes.draw do
       resource :alternate_phone, only: :show
     end
 
+    get 'profile/mailing_address', to: 'addresses#show'
+
     resources :apidocs, only: [:index]
 
     get 'terms_and_conditions', to: 'terms_and_conditions#index'

--- a/spec/routing/profile_routing_spec.rb
+++ b/spec/routing/profile_routing_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'routes for Profile', type: :routing do
+  it 'creates an alias route to the v0/addresses#show RESTful route' do
+    expect(get('/v0/profile/mailing_address')).to route_to(
+      'format' => 'json',
+      'controller' => 'v0/addresses',
+      'action' => 'show'
+    )
+  end
+end


### PR DESCRIPTION
## Background
Here are the [swagger docs](https://csraciapp6.evss.srarad.com/wss-pciu-services-web/swagger-ui/index.html?url=https://csraciapp6.evss.srarad.com/wss-pciu-services-web/rest/swagger.yaml#/) for the new PCIU Service endpoints for vets.gov to consume.

Our backend already has an existing endpoint hitting this `mailingAddress` endpoint.  The endpoint is used for letters, and we want to make sure that we can change this new one to point to Vet360 in the future.  So in order to allow us to change them independently, we’ll want a new endpoint.

This PR creates this new path aliased to the existing endpoint.

## Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9162

## Screenshot

![image](https://user-images.githubusercontent.com/7482329/37218258-1f38add4-237d-11e8-99fc-024904460aa4.png)


## Definition of done
- [x] new `profile/mailing_address` `GET` endpoint aliased to the existing `addresses#show` action
