### PR TITLE
Expose X-RateLimit-* headers through CORS

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -52,7 +52,12 @@ module VetsAPI
         origins { |source, _env| Settings.web_origin.split(',').include?(source) }
         resource '*', headers: :any,
                       methods: :any,
-                      credentials: true
+                      credentials: true,
+                      expose: [
+                        'X-RateLimit-Limit',
+                        'X-RateLimit-Remaining',
+                        'X-RateLimit-Reset'
+                      ]
       end
     end
 


### PR DESCRIPTION
Adds X-RateLimit-* headers to the list of exposed CORS headers.

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9150#issuecomment-371867532