### PR TITLE
Add missing `vic_` prefix to submission route in rate limiter

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -25,7 +25,7 @@ class Rack::Attack
   end
 
   throttle('vic_submissions/ip', limit: 10, period: 1.minute) do |req|
-    req.ip if req.path == '/v0/vic/submissions' && req.post?
+    req.ip if req.path == '/v0/vic/vic_submissions' && req.post?
   end
 
   # Source: https://github.com/kickstarter/rack-attack#x-ratelimit-headers-for-well-behaved-clients

--- a/spec/middleware/rack_attack_spec.rb
+++ b/spec/middleware/rack_attack_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Rack::Attack do
 
     context 'form submission' do
       let(:limit) { 10 }
-      let(:endpoint) { '/v0/vic/submissions' }
+      let(:endpoint) { '/v0/vic/vic_submissions' }
 
       it 'limits requests' do
         expect(last_response.status).to eq(429)


### PR DESCRIPTION
This makes it so that vic submissions will actually get rate limited.