### PR TITLE
adding raven context tag; scheduling download of facility location data

### DIFF
--- a/app/workers/facilities/facility_location_download_job.rb
+++ b/app/workers/facilities/facility_location_download_job.rb
@@ -6,6 +6,7 @@ module Facilities
 
     def perform(type)
       @type = type
+      Raven.tags_context(job: "FacilityLocationDownloadJob:#{type}")
       ActiveRecord::Base.transaction do
         process_changes
         process_deletes

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -48,6 +48,30 @@ FacilityAccessBulkUpdate:
   class: Facilities::AccessDataDownload
   description: "Download and cache facility access-to-care metric data"
 
+FacilityLocationBulkUpdateNCA:
+  cron: "35 4 * * * America/New_York"
+  class: Facilities::FacilityLocationDownloadJob
+  args: ['nca']
+  description: "Download and store facility location data"
+
+FacilityLocationBulkUpdateVBA:
+  cron: "40 4 * * * America/New_York"
+  class: Facilities::FacilityLocationDownloadJob
+  args: ['vba']
+  description: "Download and store facility location data"
+
+FacilityLocationBulkUpdateVC:
+  cron: "45 4 * * * America/New_York"
+  class: Facilities::FacilityLocationDownloadJob
+  args: ['vc']
+  description: "Download and store facility location data"
+
+FacilityLocationBulkUpdateVHA:
+  cron: "50 4 * * * America/New_York"
+  class: Facilities::FacilityLocationDownloadJob
+  args: ['vha']
+  description: "Download and store facility location data"
+
 MaintenanceWindowRefresh:
   cron: "*/5 * * * * America/New_York"
   class: PagerDuty::PollMaintenanceWindows

--- a/lib/common/client/middleware/response/facility_parser.rb
+++ b/lib/common/client/middleware/response/facility_parser.rb
@@ -62,7 +62,6 @@ module Common
 
           def clean_benefits(benefits_hash)
             benefits_hash.keys.select { |key| benefits_hash[key] == YES }
-            benefits_hash.select { |(_key, value)| value == YES }.map(&:first)
           end
 
           def strip(value)


### PR DESCRIPTION
Looking for feedback on my new raven tag and the scheduling of the jobs. 3 of 4 take < 5 seconds and the fourth takes about 15 seconds. I wanted to schedule them after the facility access download so that it picks up the latest from that information. I spaced them 5 minutes apart, but can be anything.

Note for @patrickvinograd, this still won't be live.. just starting to store the data.. next step will be modifying controllers to point to new data but we want to do a bit more verification first.