### PR TITLE
Change Pension/Burial receipt date timezone to CT

### DIFF
--- a/app/workers/submit_saved_claim_job.rb
+++ b/app/workers/submit_saved_claim_job.rb
@@ -59,12 +59,13 @@ class SubmitSavedClaimJob
     number_attachments = @attachment_paths.size
     veteran_full_name = form['veteranFullName']
     address = form['claimantAddress'] || form['veteranAddress']
+    receive_date = @claim.created_at.in_time_zone('Central Time (US & Canada)')
 
     metadata = {
       'veteranFirstName' => veteran_full_name.try(:[], 'first'),
       'veteranLastName' => veteran_full_name.try(:[], 'last'),
       'fileNumber' => form['vaFileNumber'] || form['veteranSocialSecurityNumber'],
-      'receiveDt' => @claim.created_at.utc.strftime('%Y-%m-%d %H:%M:%S'),
+      'receiveDt' => receive_date.strftime('%Y-%m-%d %H:%M:%S'),
       'zipCode' => address.try(:[], 'postalCode'),
       'uuid' => @claim.guid,
       'source' => 'vets.gov',

--- a/spec/jobs/submit_saved_claim_job_spec.rb
+++ b/spec/jobs/submit_saved_claim_job_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe SubmitSavedClaimJob, uploader_helpers: true do
           'veteranFirstName' => 'Test',
           'veteranLastName' => 'User',
           'fileNumber' => '111223333',
-          'receiveDt' => '2017-01-04 07:00:00',
+          'receiveDt' => '2017-01-04 01:00:00',
           'zipCode' => '90210',
           'uuid' => claim.guid,
           'source' => 'vets.gov',


### PR DESCRIPTION
This will adjust for CST/CDT when appropriate. ~~Waiting to hear back from stakeholder whether we should account for this or always just do CST.~~ Stakeholder has indicated they would prefer CT, which factors in daylight savings time.