### PR TITLE
9382 personal information endpoint

### DIFF
--- a/app/controllers/v0/profile/personal_informations_controller.rb
+++ b/app/controllers/v0/profile/personal_informations_controller.rb
@@ -3,7 +3,7 @@
 module V0
   module Profile
     class PersonalInformationsController < ApplicationController
-      before_action { authorize :mvi, :access? }
+      before_action { authorize :mvi, :queryable? }
 
       # Fetches the personal information for the current user.
       # Namely their gender and birth date.

--- a/app/controllers/v0/profile/personal_informations_controller.rb
+++ b/app/controllers/v0/profile/personal_informations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module V0
+  module Profile
+    class PersonalInformationsController < ApplicationController
+      # before_action { authorize :emis, :access? }
+
+      # Fetches the personal information for the current user.
+      # Namely their gender and birth date.
+      #
+      # @return [Response] Sample response.body:
+      #   {
+      #     "data" => {
+      #       "id"         => "",
+      #       "type"       => "mvi_models_mvi_profiles",
+      #       "attributes" => {
+      #         "gender"     => "M",
+      #         "birth_date" => "1949-03-04"
+      #       }
+      #     }
+      #   }
+      #
+      def show
+        response = Mvi.for_user(@current_user).profile
+
+        render json: response, serializer: PersonalInformationSerializer
+      end
+    end
+  end
+end

--- a/app/controllers/v0/profile/personal_informations_controller.rb
+++ b/app/controllers/v0/profile/personal_informations_controller.rb
@@ -3,7 +3,7 @@
 module V0
   module Profile
     class PersonalInformationsController < ApplicationController
-      # before_action { authorize :emis, :access? }
+      before_action { authorize :mvi, :access? }
 
       # Fetches the personal information for the current user.
       # Namely their gender and birth date.

--- a/app/policies/mvi_policy.rb
+++ b/app/policies/mvi_policy.rb
@@ -8,11 +8,11 @@ MviPolicy = Struct.new(:user, :mvi) do
   private
 
   def required_attrs_present?(user)
-    return if user.first_name.blank?
-    return if user.last_name.blank?
-    return if user.birth_date.blank?
-    return if user.ssn.blank?
-    return if user.gender.blank?
+    return false if user.first_name.blank?
+    return false if user.last_name.blank?
+    return false if user.birth_date.blank?
+    return false if user.ssn.blank?
+    return false if user.gender.blank?
 
     true
   end

--- a/app/policies/mvi_policy.rb
+++ b/app/policies/mvi_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-MVIPolicy = Struct.new(:user, :mvi) do
+MviPolicy = Struct.new(:user, :mvi) do
   def access?
     user.ssn.present? || user.icn.present?
   end

--- a/app/policies/mvi_policy.rb
+++ b/app/policies/mvi_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+MVIPolicy = Struct.new(:user, :mvi) do
+  def access?
+    user.ssn.present? || user.icn.present?
+  end
+end

--- a/app/policies/mvi_policy.rb
+++ b/app/policies/mvi_policy.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
 MviPolicy = Struct.new(:user, :mvi) do
-  def access?
-    user.ssn.present? || user.icn.present?
+  def queryable?
+    user.icn.present? || required_attrs_present?(user)
+  end
+
+  private
+
+  def required_attrs_present?(user)
+    return if user.first_name.blank?
+    return if user.last_name.blank?
+    return if user.birth_date.blank?
+    return if user.ssn.blank?
+    return if user.gender.blank?
+
+    true
   end
 end

--- a/app/serializers/personal_information_serializer.rb
+++ b/app/serializers/personal_information_serializer.rb
@@ -4,17 +4,10 @@ class PersonalInformationSerializer < ActiveModel::Serializer
   attribute :gender
   attribute :birth_date
 
+  delegate :gender, to: :object
+
   def id
     nil
-  end
-
-  # Returns the veteran's gender.  Object is an instance
-  # of the MVI::Models::MviProfile class.
-  #
-  # @return [String] Either 'M' or 'F'
-  #
-  def gender
-    object.gender
   end
 
   # Returns the veteran's birth date.  Object is an instance

--- a/app/serializers/personal_information_serializer.rb
+++ b/app/serializers/personal_information_serializer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class PersonalInformationSerializer < ActiveModel::Serializer
+  attribute :gender
+  attribute :birth_date
+
+  def id
+    nil
+  end
+
+  # Returns the veteran's gender.  Object is an instance
+  # of the MVI::Models::MviProfile class.
+  #
+  # @return [String] Either 'M' or 'F'
+  #
+  def gender
+    object.gender
+  end
+
+  # Returns the veteran's birth date.  Object is an instance
+  # of the MVI::Models::MviProfile class.
+  #
+  # @return [String] For example, '1949-03-04'
+  #
+  def birth_date
+    object.birth_date.to_date.to_s
+  end
+end

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -47,6 +47,35 @@ module Swagger
         end
       end
 
+      swagger_path '/v0/profile/personal_information' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Gets a users gender and birth date'
+          key :operationId, 'getPersonalInformation'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :required, [:data]
+
+              property :data, type: :object do
+                key :required, [:attributes]
+                property :attributes, type: :object do
+                  property :gender, type: :string, example: 'M'
+                  property :birth_date, type: :string, format: :date, example: '1949-03-04'
+                end
+              end
+            end
+          end
+        end
+      end
+
       swagger_path '/v0/profile/primary_phone' do
         operation :get do
           extend Swagger::Responses::AuthenticationError

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,6 +165,7 @@ Rails.application.routes.draw do
     namespace :profile do
       resource :alternate_phone, only: :show
       resource :email, only: :show
+      resource :personal_information, only: :show
       resource :primary_phone, only: :show
       resource :service_history, only: :show
     end

--- a/spec/policies/mvi_policy_spec.rb
+++ b/spec/policies/mvi_policy_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MVIPolicy do
+  subject { described_class }
+
+  permissions :access? do
+    context 'with a user who has the required mvi attributes' do
+      let(:user) { build(:user, :loa3) }
+
+      it 'grants access' do
+        expect(subject).to permit(user, :mvi)
+      end
+    end
+
+    context 'with a user who does not have the required mvi attributes' do
+      let(:user) { build(:user, :loa1, ssn: nil) }
+
+      it 'denies access' do
+        expect(subject).to_not permit(user, :mvi)
+      end
+    end
+  end
+end

--- a/spec/policies/mvi_policy_spec.rb
+++ b/spec/policies/mvi_policy_spec.rb
@@ -5,20 +5,66 @@ require 'rails_helper'
 describe MviPolicy do
   subject { described_class }
 
-  permissions :access? do
-    context 'with a user who has the required mvi attributes' do
-      let(:user) { build(:user, :loa3) }
+  permissions :queryable? do
+    let(:user) { build(:user, :loa3) }
 
-      it 'grants access' do
-        expect(subject).to permit(user, :mvi)
+    context 'with a user who has the required mvi attributes' do
+      context 'where user has an icn, but not the required personal attributes' do
+        it 'is queryable' do
+          user.identity.attributes = {
+            ssn: nil,
+            first_name: nil,
+            last_name: nil,
+            birth_date: nil,
+            gender: nil
+          }
+
+          expect(subject).to permit(user, :mvi)
+        end
+      end
+
+      context 'where user has no icn, but does have a first_name, last_name, birth_date, ssn and gender' do
+        it 'is queryable' do
+          allow(user).to receive(:icn).and_return(nil)
+
+          expect(subject).to permit(user, :mvi)
+        end
       end
     end
 
     context 'with a user who does not have the required mvi attributes' do
-      let(:user) { build(:user, :loa1, ssn: nil) }
+      context 'where user has no icn' do
+        before { allow(user).to receive(:icn).and_return(nil) }
 
-      it 'denies access' do
-        expect(subject).to_not permit(user, :mvi)
+        it 'is not queryable without a ssn' do
+          user.identity.ssn = nil
+
+          expect(subject).to_not permit(user, :mvi)
+        end
+
+        it 'is not queryable without a first_name' do
+          user.identity.first_name = nil
+
+          expect(subject).to_not permit(user, :mvi)
+        end
+
+        it 'is not queryable without a last_name' do
+          user.identity.last_name = nil
+
+          expect(subject).to_not permit(user, :mvi)
+        end
+
+        it 'is not queryable without a birth_date' do
+          user.identity.birth_date = nil
+
+          expect(subject).to_not permit(user, :mvi)
+        end
+
+        it 'is not queryable without a gender' do
+          user.identity.gender = nil
+
+          expect(subject).to_not permit(user, :mvi)
+        end
       end
     end
   end

--- a/spec/policies/mvi_policy_spec.rb
+++ b/spec/policies/mvi_policy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe MVIPolicy do
+describe MviPolicy do
   subject { described_class }
 
   permissions :access? do

--- a/spec/request/personal_information_request_spec.rb
+++ b/spec/request/personal_information_request_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'personal_information', type: :request do
+  include SchemaMatchers
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  describe 'GET /v0/profile/personal_information' do
+    context 'with a 200 response' do
+      it 'should match the personal information schema' do
+        VCR.use_cassette('mvi/find_candidate/valid') do
+          get '/v0/profile/personal_information', nil, auth_header
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('personal_information_response')
+        end
+      end
+    end
+  end
+end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1102,6 +1102,13 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           expect(subject).to validate(:get, '/v0/profile/service_history', 200, auth_options)
         end
       end
+
+      it 'supports getting personal information data' do
+        expect(subject).to validate(:get, '/v0/profile/personal_information', 401)
+        VCR.use_cassette('mvi/find_candidate/valid') do
+          expect(subject).to validate(:get, '/v0/profile/personal_information', 200, auth_options)
+        end
+      end
     end
   end
 

--- a/spec/support/schemas/personal_information_response.json
+++ b/spec/support/schemas/personal_information_response.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "gender": {
+              "type": "string"
+            },
+            "birth_date": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## Background

The new profile form has a section for **Personal Information**.  Within the section, a veteran's gender, birthday, and social security number are displayed.  

For the data source, we are repurposing the existing MVI endpoint and caching.

We do not have authorization to display the SSN at this point so we are not including that.

## Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9382

## Screenshot

**Swagger Docs | Requests**

![image](https://user-images.githubusercontent.com/7482329/37788625-88cd9594-2dc7-11e8-86db-2714af8d92fb.png)


## Definition of done

Creates the endpoint that returns the following information for the logged in end user:

- [x] new `*/personal_information` `GET` endpoint
- [x] associated specs
- [x] Pundit authorization
- [x] Yard docs
- [x] Swagger docs
- [x] Betamocks recordings
- [x] Sign off by the frontend