### PR TITLE
Disable requests to Pensions/Burial API for load testing

### DIFF
--- a/app/workers/submit_saved_claim_job.rb
+++ b/app/workers/submit_saved_claim_job.rb
@@ -22,7 +22,8 @@ class SubmitSavedClaimJob
       submission["attachment#{j}"] = to_faraday_upload(file_path)
     end
 
-    PensionBurial::Service.new.upload(submission)
+    # Disabled to do load testing without hitting 3rd party api
+    # PensionBurial::Service.new.upload(submission)
     File.delete(@pdf_path)
     @attachment_paths.each { |p| File.delete(p) }
   end

--- a/spec/jobs/submit_saved_claim_job_spec.rb
+++ b/spec/jobs/submit_saved_claim_job_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe SubmitSavedClaimJob, uploader_helpers: true do
       expect(job).to receive(:generate_metadata).and_return(
         metadata: {}
       )
-      expect_any_instance_of(PensionBurial::Service).to receive(:upload).with(
-        'metadata' => '{"metadata":{}}', 'document' => 'faraday1', 'attachment1' => 'faraday1'
-      )
+      # expect_any_instance_of(PensionBurial::Service).to receive(:upload).with(
+      #   'metadata' => '{"metadata":{}}', 'document' => 'faraday1', 'attachment1' => 'faraday1'
+      # )
 
       expect(File).to receive(:delete).with('pdf_path')
       expect(File).to receive(:delete).with('attachment_path')


### PR DESCRIPTION
We're encountering an issue on our end with the database connections, so we'd like to do some stress testing without hitting the pension/burial API.