### PR TITLE
using raw_get_params in the only instance of get_params found

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -87,7 +87,8 @@ module V0
 
     def saml_logout_callback
       saml_settings = saml_settings(name_identifier_value: session&.uuid)
-      logout_response = OneLogin::RubySaml::Logoutresponse.new(params[:SAMLResponse], saml_settings, get_params: params)
+      logout_response = OneLogin::RubySaml::Logoutresponse.new(params[:SAMLResponse], saml_settings,
+                                                               raw_get_params: params)
       logout_request  = SingleLogoutRequest.find(logout_response&.in_response_to)
       session         = Session.find(logout_request&.token)
       user            = User.find(session&.uuid)


### PR DESCRIPTION
I read the documentation here https://github.com/onelogin/ruby-saml#updating-from-150-to-160 and think I've done what we need but I'm not sure if there is a consumer of this logout response object that we can verify against. 

I had to wrap the line or rubocop complains.