### PR TITLE
Secure Message mocking

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -42,7 +42,7 @@
     # SM Folders
     - :method: :get
       :path: "/mhv-sm-api/patient/v1/folder"
-      :file_path: "mhv/secure_messaging/folder"
+      :file_path: "mhv/secure_messaging/folders"
       :cache_multiple_responses:
         :uid_location: header
         :uid_locator: 'Token'

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -32,6 +32,56 @@
       :cache_multiple_responses:
         :uid_location: url
         :uid_locator: '\/rxrefill\/(.+)'
+    # SM Session
+    - :method: :get
+      :path: "/mhv-sm-api/patient/v1/session"
+      :file_path: "mhv/session"
+      :cache_multiple_responses:
+        :uid_location: 'header'
+        :uid_locator: 'mhvCorrelationId'
+    # SM Folders
+    - :method: :get
+      :path: "/mhv-sm-api/patient/v1/folder"
+      :file_path: "mhv/folder"
+      :cache_multiple_responses:
+        :uid_location: header
+        :uid_locator: 'Token'
+    # SM Folder/*
+    - :method: :get
+      :path: "/mhv-sm-api/patient/v1/folder/*"
+      :file_path: "mhv/folder"
+      :cache_multiple_responses:
+        :uid_location: url
+        :uid_locator: '\/folder\/(.+)'
+    # SM Recipients
+    - :method: :get
+      :path: "/mhv-sm-api/patient/v1/triageteam"
+      :file_path: "mhv/triageteam"
+      :cache_multiple_responses:
+        :uid_location: header
+        :uid_locator: 'Token'
+    # SM Folder messages
+    - :method: :get
+      :path: "/mhv-sm-api/patient/v1/folder/*/message/page/*/pageSize/*"
+      :file_path: "mhv/folder_messages"
+      :cache_multiple_responses:
+        :uid_location: url
+        :uid_locator: '\/folder\/(.+)\/message'
+    # SM messages
+    - :method: :get
+      :path: "/mhv-sm-api/patient/v1/message/*/read"
+      :file_path: "mhv/messages"
+      :cache_multiple_responses:
+        :uid_location: url
+        :uid_locator: '\/message\/(.+)\/read'
+    # SM thread
+    - :method: :get
+      :path: "/mhv-sm-api/patient/v1/message/*/history"
+      :file_path: "mhv/history"
+      :cache_multiple_responses:
+        :uid_location: url
+        :uid_locator: '\/message\/(.+)\/history'
+
 
 # EVSS
 - :name: 'EVSS'

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -42,42 +42,42 @@
     # SM Folders
     - :method: :get
       :path: "/mhv-sm-api/patient/v1/folder"
-      :file_path: "mhv/folder"
+      :file_path: "mhv/secure_messaging/folder"
       :cache_multiple_responses:
         :uid_location: header
         :uid_locator: 'Token'
     # SM Folder/*
     - :method: :get
       :path: "/mhv-sm-api/patient/v1/folder/*"
-      :file_path: "mhv/folder"
+      :file_path: "mhv/secure_messaging/folder"
       :cache_multiple_responses:
         :uid_location: url
         :uid_locator: '\/folder\/(.+)'
     # SM Recipients
     - :method: :get
       :path: "/mhv-sm-api/patient/v1/triageteam"
-      :file_path: "mhv/triageteam"
+      :file_path: "mhv/secure_messaging/triageteam"
       :cache_multiple_responses:
         :uid_location: header
         :uid_locator: 'Token'
     # SM Folder messages
     - :method: :get
       :path: "/mhv-sm-api/patient/v1/folder/*/message/page/*/pageSize/*"
-      :file_path: "mhv/folder_messages"
+      :file_path: "mhv/secure_messaging/folder_messages"
       :cache_multiple_responses:
         :uid_location: url
         :uid_locator: '\/folder\/(.+)\/message'
     # SM messages
     - :method: :get
       :path: "/mhv-sm-api/patient/v1/message/*/read"
-      :file_path: "mhv/messages"
+      :file_path: "mhv/secure_messaging/messages"
       :cache_multiple_responses:
         :uid_location: url
         :uid_locator: '\/message\/(.+)\/read'
     # SM thread
     - :method: :get
       :path: "/mhv-sm-api/patient/v1/message/*/history"
-      :file_path: "mhv/history"
+      :file_path: "mhv/secure_messaging/history"
       :cache_multiple_responses:
         :uid_location: url
         :uid_locator: '\/message\/(.+)\/history'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -120,6 +120,7 @@ mhv:
   sm:
     host: https://mhv-api.example.com
     app_token: fake-app-token
+    mock: true
   bb:
     collection_caching_enabled: true
 

--- a/lib/sm/client.rb
+++ b/lib/sm/client.rb
@@ -126,14 +126,12 @@ module SM
     def get_message(id)
       path = "message/#{id}/read"
       json = perform(:get, path, nil, token_headers).body
-
       Message.new(json)
     end
 
     def get_message_history(id)
       path = "message/#{id}/history"
       json = perform(:get, path, nil, token_headers).body
-
       Common::Collection.new(Message, json)
     end
 

--- a/lib/sm/configuration.rb
+++ b/lib/sm/configuration.rb
@@ -35,6 +35,7 @@ module SM
         # conn.request(:curl, ::Logger.new(STDOUT), :warn) unless Rails.env.production?
         # conn.response(:logger, ::Logger.new(STDOUT), bodies: true) unless Rails.env.production?
 
+        conn.response :betamocks if Settings.mhv.sm.mock
         conn.response :sm_parser
         conn.response :snakecase
         conn.response :raise_error, error_prefix: service_name


### PR DESCRIPTION
Adds mocking support for secure messaging `GET` endpoints.
Closes [9239](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9239)