### PR TITLE
9507 post primary phone endpoint

### DIFF
--- a/app/controllers/v0/profile/primary_phones_controller.rb
+++ b/app/controllers/v0/profile/primary_phones_controller.rb
@@ -11,10 +11,20 @@ module V0
         render json: response, serializer: PhoneNumberSerializer
       end
 
+      def create
+        response = service.post_primary_phone(primary_phone_params)
+
+        render json: response, serializer: PhoneNumberSerializer
+      end
+
       private
 
       def service
         EVSS::PCIU::Service.new @current_user
+      end
+
+      def primary_phone_params
+        params.permit(:country_code, :number, :extension, :effective_date)
       end
     end
   end

--- a/app/controllers/v0/profile/primary_phones_controller.rb
+++ b/app/controllers/v0/profile/primary_phones_controller.rb
@@ -12,9 +12,15 @@ module V0
       end
 
       def create
-        response = service.post_primary_phone(primary_phone_params)
+        phone = EVSS::PCIU::PhoneNumber.new primary_phone_params
 
-        render json: response, serializer: PhoneNumberSerializer
+        if phone.valid?
+          response = service.post_primary_phone phone
+
+          render json: response, serializer: PhoneNumberSerializer
+        else
+          raise Common::Exceptions::ValidationErrors, phone
+        end
       end
 
       private

--- a/app/serializers/phone_number_serializer.rb
+++ b/app/serializers/phone_number_serializer.rb
@@ -4,6 +4,7 @@ class PhoneNumberSerializer < ActiveModel::Serializer
   attribute :number
   attribute :extension
   attribute :country_code
+  attribute :effective_date
 
   def id
     nil

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -99,17 +99,39 @@ module Swagger
         operation :post do
           extend Swagger::Responses::AuthenticationError
 
-          key :description, 'Creates/updates a users primar phone number information'
+          key :description, 'Creates/updates a users primary phone number information'
           key :operationId, 'postPrimaryPhone'
           key :tags, %w[
             profile
           ]
 
           parameter :authorization
+
+          parameter do
+            key :name, :number
+            key :in, :body
+            key :description, 'Telephone number. Can only contain numbers.'
+            key :required, true
+          end
+
+          parameter do
+            key :name, :extension
+            key :in, :body
+            key :description, 'Telephone extension.'
+            key :required, false
+          end
+
+          parameter do
+            key :name, :country_code
+            key :in, :body
+            key :description, "The number's country code.  Can be alphanumeric."
+            key :required, false
+          end
+
           parameter do
             key :name, :body
             key :in, :body
-            key :description, 'Attributes to create/update a phone number'
+            key :description, 'Attributes to create/update a phone number.'
             key :required, true
 
             schema do

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -95,6 +95,37 @@ module Swagger
             end
           end
         end
+
+        operation :post do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Creates/updates a users primar phone number information'
+          key :operationId, 'postPrimaryPhone'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+          parameter do
+            key :name, :body
+            key :in, :body
+            key :description, 'Attributes to create/update a phone number'
+            key :required, true
+
+            schema do
+              property :number, type: :string, example: '4445551212'
+              property :extension, type: :string, example: '101'
+              property :country_code, type: :string, example: '1'
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :PhoneNumber
+            end
+          end
+        end
       end
 
       swagger_path '/v0/profile/service_history' do

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -108,27 +108,6 @@ module Swagger
           parameter :authorization
 
           parameter do
-            key :name, :number
-            key :in, :body
-            key :description, 'Telephone number. Can only contain numbers.'
-            key :required, true
-          end
-
-          parameter do
-            key :name, :extension
-            key :in, :body
-            key :description, 'Telephone extension.'
-            key :required, false
-          end
-
-          parameter do
-            key :name, :country_code
-            key :in, :body
-            key :description, "The number's country code.  Can be alphanumeric."
-            key :required, false
-          end
-
-          parameter do
             key :name, :body
             key :in, :body
             key :description, 'Attributes to create/update a phone number.'

--- a/app/swagger/schemas/phone_number.rb
+++ b/app/swagger/schemas/phone_number.rb
@@ -14,6 +14,7 @@ module Swagger
             property :number, type: :string, example: '4445551212'
             property :extension, type: :string, example: '101'
             property :country_code, type: :string, example: '1'
+            property :effective_date, type: :string, example: '2018-03-26T15:41:37.487Z'
           end
         end
       end

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -101,6 +101,12 @@
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: 'va_eauth_pnid'
+  - :method: :post
+    :path: "/wss-pciu-services-web/rest/pciuServices/v1/primaryPhoneNumber"
+    :file_path: "evss/pciu/post_primary_phone"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: 'va_eauth_pnid'
   # PCIU alternate phone
   - :method: :get
     :path: "/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,7 +166,7 @@ Rails.application.routes.draw do
       resource :alternate_phone, only: :show
       resource :email, only: :show
       resource :personal_information, only: :show
-      resource :primary_phone, only: :show
+      resource :primary_phone, only: [:show, :create]
       resource :service_history, only: :show
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,7 +166,7 @@ Rails.application.routes.draw do
       resource :alternate_phone, only: :show
       resource :email, only: :show
       resource :personal_information, only: :show
-      resource :primary_phone, only: [:show, :create]
+      resource :primary_phone, only: %i[show create]
       resource :service_history, only: :show
     end
 

--- a/lib/evss/pciu/base_model.rb
+++ b/lib/evss/pciu/base_model.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'common/models/base'
+
+module EVSS
+  module PCIU
+    class BaseModel
+      include ActiveModel::Validations
+      include ActiveModel::Serialization
+      include Virtus.model(nullify_blank: true)
+    end
+  end
+end

--- a/lib/evss/pciu/phone_number.rb
+++ b/lib/evss/pciu/phone_number.rb
@@ -8,7 +8,8 @@ module EVSS
       attribute :extension, String
       attribute :effective_date, DateTime
 
-      validates :country_code, :number, :extension, presence: true
+      validates :number, presence: true
+      validates :number, format: { with: /\A\d+\z/, message: "Only numbers are permitted." }
     end
   end
 end

--- a/lib/evss/pciu/phone_number.rb
+++ b/lib/evss/pciu/phone_number.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module EVSS
+  module PCIU
+    class PhoneNumber < BaseModel
+      attribute :country_code, String
+      attribute :number, String
+      attribute :extension, String
+      attribute :effective_date, DateTime
+
+      validates :country_code, :number, :extension, presence: true
+    end
+  end
+end

--- a/lib/evss/pciu/phone_number.rb
+++ b/lib/evss/pciu/phone_number.rb
@@ -9,7 +9,7 @@ module EVSS
       attribute :effective_date, DateTime
 
       validates :number, presence: true
-      validates :number, format: { with: /\A\d+\z/, message: "Only numbers are permitted." }
+      validates :number, format: { with: /\A\d+\z/, message: 'Only numbers are permitted.' }
     end
   end
 end

--- a/lib/evss/pciu/phone_number_response.rb
+++ b/lib/evss/pciu/phone_number_response.rb
@@ -8,12 +8,14 @@ module EVSS
       attribute :country_code, String
       attribute :number, String
       attribute :extension, String
+      attribute :effective_date, String
 
       def initialize(status, response = nil)
         attributes = {
           country_code: response&.body&.dig('cnp_phone', 'country_code'),
           number: response&.body&.dig('cnp_phone', 'number'),
-          extension: response&.body&.dig('cnp_phone', 'extension')
+          extension: response&.body&.dig('cnp_phone', 'extension'),
+          effective_date: response&.body&.dig('cnp_phone', 'effective_date')
         }
 
         super(status, attributes)

--- a/lib/evss/pciu/request_body.rb
+++ b/lib/evss/pciu/request_body.rb
@@ -26,7 +26,7 @@ module EVSS
       # rubocop:enable Style/DateTime
 
       def remove_empty_attrs
-        request_attrs.tap { |instance| instance.as_json.delete_if { |_k, v| v.blank? } }
+        @request_attrs = request_attrs.as_json.delete_if { |_k, v| v.blank? }
       end
 
       def convert_to_json

--- a/lib/evss/pciu/request_body.rb
+++ b/lib/evss/pciu/request_body.rb
@@ -19,9 +19,11 @@ module EVSS
 
       private
 
+      # rubocop:disable Style/DateTime
       def set_effective_date
         request_attrs.tap { |instance| instance[date_attr] = DateTime.now.utc }
       end
+      # rubocop:enable Style/DateTime
 
       def remove_empty_attrs
         request_attrs.tap { |instance| instance.as_json.delete_if { |_k, v| v.blank? } }

--- a/lib/evss/pciu/request_body.rb
+++ b/lib/evss/pciu/request_body.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module EVSS
+  module PCIU
+    class RequestBody
+      attr_reader :request_attrs, :pciu_key, :date_attr
+
+      def initialize(request_attrs, pciu_key:, date_attr: 'effective_date')
+        @request_attrs = request_attrs
+        @pciu_key = pciu_key
+        @date_attr = date_attr
+      end
+
+      def set
+        set_effective_date
+        remove_empty_attrs
+        convert_to_json
+      end
+
+      private
+
+      def set_effective_date
+        request_attrs.tap { |instance| instance[date_attr] = DateTime.now.utc }
+      end
+
+      def remove_empty_attrs
+        request_attrs.tap { |instance| instance.as_json.delete_if { |_k, v| v.blank? } }
+      end
+
+      def convert_to_json
+        {
+          pciu_key => Hash[
+            request_attrs.as_json.map { |k, v| [k.camelize(:lower), v] }
+          ]
+        }.to_json
+      end
+    end
+  end
+end

--- a/lib/evss/pciu/request_body.rb
+++ b/lib/evss/pciu/request_body.rb
@@ -11,6 +11,20 @@ module EVSS
         @date_attr = date_attr
       end
 
+      # Adjusts the passed request attributes to be formatted for an EVSS
+      # POST or PUT request body.
+      #
+      # @return [String] Returns a string of JSON, nested in the passed pciu_key.
+      # @example Here is a parsed version of the returned JSON:
+      #   {
+      #     'cnpPhone' => {
+      #       'countryCode' => '1',
+      #       'number' => '4445551212',
+      #       'extension' => '101',
+      #       'effectiveDate' => '2018-04-02T16:01:50+00:00'
+      #     }
+      #   }
+      #
       def set
         set_effective_date
         remove_empty_attrs

--- a/lib/evss/pciu/service.rb
+++ b/lib/evss/pciu/service.rb
@@ -78,7 +78,7 @@ module EVSS
           raw_response = perform(
             :post,
             'primaryPhoneNumber',
-            EVSS::PCIU::RequestBody.new(phone_attrs, pciu_key: 'cnpPhone').set,
+            RequestBody.new(phone_attrs, pciu_key: 'cnpPhone').set,
             headers
           )
 

--- a/lib/evss/pciu/service.rb
+++ b/lib/evss/pciu/service.rb
@@ -40,7 +40,8 @@ module EVSS
       #   {
       #     "country_code" => "1",
       #     "extension" => "",
-      #     "number" => "4445551212"
+      #     "number" => "4445551212",
+      #     "effective_date" => "2018-02-27T14:41:32.283Z"
       #   }
       #
       def get_primary_phone
@@ -60,7 +61,8 @@ module EVSS
       #   {
       #     "country_code" => "1",
       #     "extension" => "",
-      #     "number" => "4445551212"
+      #     "number" => "4445551212",
+      #     "effective_date" => "2018-02-27T14:41:32.283Z"
       #   }
       #
       def get_alternate_phone
@@ -73,6 +75,19 @@ module EVSS
         handle_error(e)
       end
 
+      # POST's the passed phone attributes to the EVSS::PCIU service.
+      # Returns a response object containing the user's primary phone number,
+      # extension, and country code
+      #
+      # @param phone_attrs [EVSS::PCIU::PhoneNumber] A EVSS::PCIU::PhoneNumber instance
+      # @return [EVSS::PCIU::PhoneNumberResponse] Sample response.phone:
+      #   {
+      #     "country_code" => "1",
+      #     "extension" => "",
+      #     "number" => "4445551212"
+      #     "effective_date" => "2018-02-27T14:41:32.283Z"
+      #   }
+      #
       def post_primary_phone(phone_attrs)
         with_monitoring do
           raw_response = perform(

--- a/lib/evss/pciu/service.rb
+++ b/lib/evss/pciu/service.rb
@@ -72,6 +72,21 @@ module EVSS
       rescue StandardError => e
         handle_error(e)
       end
+
+      def post_primary_phone(phone_attrs)
+        with_monitoring do
+          raw_response = perform(
+            :post,
+            'primaryPhoneNumber',
+            EVSS::PCIU::RequestBody.new(phone_attrs, pciu_key: 'cnpPhone').set,
+            headers
+          )
+
+          EVSS::PCIU::PhoneNumberResponse.new(raw_response.status, raw_response)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
     end
   end
 end

--- a/lib/evss/pciu_address/service.rb
+++ b/lib/evss/pciu_address/service.rb
@@ -38,17 +38,22 @@ module EVSS
 
       def update_address(address)
         with_monitoring do
-          address.address_effective_date = DateTime.now.utc
-          address = address.as_json.delete_if { |_k, v| v.blank? }
-          address_json = {
-            'cnpMailingAddress' => Hash[address.map { |k, v| [k.camelize(:lower), v] }]
-          }.to_json
-          headers = { 'Content-Type' => 'application/json' }
-          raw_response = perform(:post, 'mailingAddress', address_json, headers)
+          raw_response = perform(:post, 'mailingAddress', request_body(address), headers)
+
           EVSS::PCIUAddress::AddressResponse.new(raw_response.status, raw_response)
         end
       rescue StandardError => e
         handle_error(e)
+      end
+
+      private
+
+      def request_body(address)
+        EVSS::PCIU::RequestBody.new(
+          address,
+          pciu_key: 'cnpMailingAddress',
+          date_attr: 'address_effective_date'
+        ).set
       end
     end
   end

--- a/lib/evss/service.rb
+++ b/lib/evss/service.rb
@@ -16,6 +16,10 @@ module EVSS
       super(method, path, body, headers)
     end
 
+    def headers
+      { 'Content-Type' => 'application/json' }
+    end
+
     private
 
     def headers_for_user(user)

--- a/spec/factories/phone_number.rb
+++ b/spec/factories/phone_number.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :phone_number, class: 'EVSS::PCIU::PhoneNumber' do
+    country_code '1'
+    number '4445551212'
+    extension '101'
+    effective_date '2017-08-07T19:43:59.383Z'
+
+    trait :nil_effective_date do
+      effective_date nil
+    end
+  end
+end

--- a/spec/lib/evss/pciu/phone_number_spec.rb
+++ b/spec/lib/evss/pciu/phone_number_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EVSS::PCIU::Service do
+  it 'should have valid factory' do
+    expect(build(:phone_number)).to be_valid
+  end
+
+  it 'should require a number', :aggregate_failures do
+    expect(build(:phone_number, number: '')).to_not be_valid
+    expect(build(:phone_number, number: nil)).to_not be_valid
+  end
+
+  it 'should not permit non-numeric characters', :aggregate_failures do
+    expect(build(:phone_number, number: '123abc')).to_not be_valid
+    expect(build(:phone_number, number: '#123')).to_not be_valid
+    expect(build(:phone_number, number: '123-456-7890')).to_not be_valid
+    expect(build(:phone_number, number: '(123) 456-7890')).to_not be_valid
+  end
+
+  it 'should be valid without a country_code or extension', :aggregate_failures do
+    expect(build(:phone_number, country_code: '')).to be_valid
+    expect(build(:phone_number, extension: '')).to be_valid
+  end
+end

--- a/spec/lib/evss/pciu/phone_number_spec.rb
+++ b/spec/lib/evss/pciu/phone_number_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe EVSS::PCIU::Service do
+describe EVSS::PCIU::PhoneNumber do
   it 'should have valid factory' do
     expect(build(:phone_number)).to be_valid
   end

--- a/spec/lib/evss/pciu/request_body_spec.rb
+++ b/spec/lib/evss/pciu/request_body_spec.rb
@@ -17,13 +17,11 @@ describe EVSS::PCIU::RequestBody do
 
       expect(results.class).to eq String
       expect(parsed).to eq(
-        {
-          'phone' => {
-            'countryCode' => '1',
-            'number' => '4445551212',
-            'extension' => '101',
-            'effectiveDate' => '2018-04-02T14:02:59.000+00:00'
-          }
+        'phone' => {
+          'countryCode' => '1',
+          'number' => '4445551212',
+          'extension' => '101',
+          'effectiveDate' => '2018-04-02T14:02:59.000+00:00'
         }
       )
       expect(parsed.keys).to include 'phone'

--- a/spec/lib/evss/pciu/request_body_spec.rb
+++ b/spec/lib/evss/pciu/request_body_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EVSS::PCIU::RequestBody do
+  let(:phone) { build(:phone_number, :nil_effective_date) }
+  let(:now) { '2018-04-02T14:02:59+00:00' }
+
+  describe '#set' do
+    before { Timecop.freeze now }
+    after { Timecop.return }
+
+    it 'returns string of JSON nested in the passed pciu_key', :aggregate_failures do
+      request_body = EVSS::PCIU::RequestBody.new(phone, pciu_key: 'phone')
+      results      = request_body.set
+      parsed       = JSON.parse results
+
+      expect(results.class).to eq String
+      expect(parsed).to eq(
+        {
+          'phone' => {
+            'countryCode' => '1',
+            'number' => '4445551212',
+            'extension' => '101',
+            'effectiveDate' => '2018-04-02T14:02:59.000+00:00'
+          }
+        }
+      )
+      expect(parsed.keys).to include 'phone'
+    end
+
+    it 'should set the passed date_attr to the current DateTime' do
+      request_body   = EVSS::PCIU::RequestBody.new(phone, pciu_key: 'phone')
+      effective_date = JSON.parse(request_body.set).dig('phone', 'effectiveDate')
+
+      expect(effective_date.to_datetime).to eq now.to_datetime
+    end
+
+    it 'should remove any empty attributes passed in the request_attrs' do
+      phone        = build :phone_number, :nil_effective_date, extension: ''
+      request_body = EVSS::PCIU::RequestBody.new(phone, pciu_key: 'phone')
+      extension    = JSON.parse(request_body.set).dig('phone', 'extension')
+
+      expect(extension).to be nil
+    end
+  end
+end

--- a/spec/lib/evss/pciu/service_spec.rb
+++ b/spec/lib/evss/pciu/service_spec.rb
@@ -86,5 +86,35 @@ describe EVSS::PCIU::Service do
         end
       end
     end
+
+    context 'with a 500 response' do
+      it 'raises a Common::Exceptions::BackendServiceException error' do
+        VCR.use_cassette('evss/pciu/post_primary_phone_status_500') do
+          expect { subject.post_primary_phone(phone) }.to raise_error(
+            Common::Exceptions::BackendServiceException
+          )
+        end
+      end
+    end
+
+    context 'with a 403 response' do
+      it 'raises a Common::Exceptions::Forbidden error' do
+        VCR.use_cassette('evss/pciu/post_primary_phone_status_403') do
+          expect { subject.post_primary_phone(phone) }.to raise_error(
+            Common::Exceptions::Forbidden
+          )
+        end
+      end
+    end
+
+    context 'with a 400 response' do
+      it 'raises a Common::Exceptions::BackendServiceException error' do
+        VCR.use_cassette('evss/pciu/post_primary_phone_status_400') do
+          expect { subject.post_primary_phone(phone) }.to raise_error(
+            Common::Exceptions::BackendServiceException
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/lib/evss/pciu/service_spec.rb
+++ b/spec/lib/evss/pciu/service_spec.rb
@@ -65,4 +65,26 @@ describe EVSS::PCIU::Service do
       end
     end
   end
+
+  describe '#post_primary_phone' do
+    let(:phone) { build(:phone_number, :nil_effective_date) }
+
+    context 'when successful' do
+      it 'returns a status of 200' do
+        VCR.use_cassette('evss/pciu/post_primary_phone') do
+          response = subject.post_primary_phone(phone)
+
+          expect(response).to be_ok
+        end
+      end
+
+      it 'returns a users primary phone number, extension and country code' do
+        VCR.use_cassette('evss/pciu/post_primary_phone') do
+          response = subject.post_primary_phone(phone)
+
+          expect(response.attributes.keys).to include :country_code, :number, :extension
+        end
+      end
+    end
+  end
 end

--- a/spec/request/primary_phone_request_spec.rb
+++ b/spec/request/primary_phone_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'primary phone', type: :request do
 
   describe 'GET /v0/profile/primary_phone' do
     context 'with a 200 response' do
-      it 'should match the primary phone schema' do
+      it 'should match the primary phone schema', :aggregate_failures do
         VCR.use_cassette('evss/pciu/primary_phone') do
           get '/v0/profile/primary_phone', nil, auth_header
 
@@ -27,7 +27,7 @@ RSpec.describe 'primary phone', type: :request do
     end
 
     context 'with a 400 response' do
-      it 'should match the errors schema' do
+      it 'should match the errors schema', :aggregate_failures do
         VCR.use_cassette('evss/pciu/primary_phone_status_400') do
           get '/v0/profile/primary_phone', nil, auth_header
 
@@ -48,7 +48,7 @@ RSpec.describe 'primary phone', type: :request do
     end
 
     context 'with a 500 response' do
-      it 'should match the errors schema' do
+      it 'should match the errors schema', :aggregate_failures do
         VCR.use_cassette('evss/pciu/primary_phone_status_500') do
           get '/v0/profile/primary_phone', nil, auth_header
 
@@ -63,7 +63,7 @@ RSpec.describe 'primary phone', type: :request do
     let(:phone) { build(:phone_number, :nil_effective_date) }
 
     context 'with a 200 response' do
-      it 'should match the primary phone schema' do
+      it 'should match the primary phone schema', :aggregate_failures do
         VCR.use_cassette('evss/pciu/post_primary_phone') do
           post(
             '/v0/profile/primary_phone',
@@ -115,5 +115,54 @@ RSpec.describe 'primary phone', type: :request do
       end
     end
 
+    context 'with a 400 response' do
+      it 'should match the errors schema', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/post_primary_phone_status_400') do
+          post(
+            '/v0/profile/primary_phone',
+            phone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+
+    context 'with a 403 response' do
+      it 'should return a forbidden response' do
+        VCR.use_cassette('evss/pciu/post_primary_phone_status_403') do
+          post(
+            '/v0/profile/primary_phone',
+            phone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context 'with a 500 response' do
+      it 'should match the errors schema', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/post_primary_phone_status_500') do
+          post(
+            '/v0/profile/primary_phone',
+            phone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:bad_gateway)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
   end
 end

--- a/spec/request/primary_phone_request_spec.rb
+++ b/spec/request/primary_phone_request_spec.rb
@@ -78,5 +78,42 @@ RSpec.describe 'primary phone', type: :request do
         end
       end
     end
+
+    context 'with a missing phone number' do
+      it 'should match the errors schema', :aggregate_failures do
+        phone = build :phone_number, :nil_effective_date, number: ''
+
+        post(
+          '/v0/profile/primary_phone',
+          phone.to_json,
+          auth_header.update(
+            'Content-Type' => 'application/json', 'Accept' => 'application/json'
+          )
+        )
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_response_schema('errors')
+        expect(errors_for response).to include "number - can't be blank", "number - Only numbers are permitted."
+      end
+    end
+
+    context 'with a number that contains non-numeric characters' do
+      it 'should match the errors schema', :aggregate_failures do
+        phone = build :phone_number, :nil_effective_date, number: '123-456-7890'
+
+        post(
+          '/v0/profile/primary_phone',
+          phone.to_json,
+          auth_header.update(
+            'Content-Type' => 'application/json', 'Accept' => 'application/json'
+          )
+        )
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_response_schema('errors')
+        expect(errors_for response).to include "number - Only numbers are permitted."
+      end
+    end
+
   end
 end

--- a/spec/request/primary_phone_request_spec.rb
+++ b/spec/request/primary_phone_request_spec.rb
@@ -58,4 +58,25 @@ RSpec.describe 'primary phone', type: :request do
       end
     end
   end
+
+  describe 'POST /v0/profile/primary_phone' do
+    let(:phone) { build(:phone_number, :nil_effective_date) }
+
+    context 'with a 200 response' do
+      it 'should match the primary phone schema' do
+        VCR.use_cassette('evss/pciu/post_primary_phone') do
+          post(
+            '/v0/profile/primary_phone',
+            phone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('phone_number_response')
+        end
+      end
+    end
+  end
 end

--- a/spec/request/primary_phone_request_spec.rb
+++ b/spec/request/primary_phone_request_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'primary phone', type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to match_response_schema('errors')
-        expect(errors_for response).to include "number - can't be blank", "number - Only numbers are permitted."
+        expect(errors_for(response)).to include "number - can't be blank", 'number - Only numbers are permitted.'
       end
     end
 
@@ -111,7 +111,7 @@ RSpec.describe 'primary phone', type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to match_response_schema('errors')
-        expect(errors_for response).to include "number - Only numbers are permitted."
+        expect(errors_for(response)).to include 'number - Only numbers are permitted.'
       end
     end
 

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1109,6 +1109,21 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           expect(subject).to validate(:get, '/v0/profile/personal_information', 200, auth_options)
         end
       end
+
+      it 'supports posting primary phone number data' do
+        expect(subject).to validate(:post, '/v0/profile/primary_phone', 401)
+
+        VCR.use_cassette('evss/pciu/post_primary_phone') do
+          phone = build(:phone_number, :nil_effective_date)
+
+          expect(subject).to validate(
+            :post,
+            '/v0/profile/primary_phone',
+            200,
+            auth_options.update(phone)
+          )
+        end
+      end
     end
   end
 

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1120,7 +1120,7 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
             :post,
             '/v0/profile/primary_phone',
             200,
-            auth_options.update(phone)
+            auth_options.merge('_data' => phone.as_json)
           )
         end
       end

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -8,6 +8,11 @@ module RequestHelper
     end
   end
 
+  # Returns an array of errors from the passed JSON
+  #
+  # @param response [String] A response as a string of JSON
+  # @return [Array] An array of error messages from the passed response
+  #
   def errors_for(response)
     parsed_body = JSON.parse response.body
 

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -7,4 +7,10 @@ module RequestHelper
       copy_session_variables!
     end
   end
+
+  def errors_for(response)
+    parsed_body = JSON.parse response.body
+
+    parsed_body['errors'].map { |error| error['detail'] }
+  end
 end

--- a/spec/support/schemas/phone_number_response.json
+++ b/spec/support/schemas/phone_number_response.json
@@ -14,6 +14,9 @@
             },
             "country_code": {
               "type": "string"
+            },
+            "effective_date": {
+              "type": "string"
             }
           },
           "type": "object"

--- a/spec/support/vcr_cassettes/evss/pciu/alternate_phone.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/alternate_phone.yml
@@ -65,7 +65,8 @@ http_interactions:
           "cnpPhone" : {
             "countryCode" : "1",
             "extension" : "",
-            "number" : ""
+            "number" : "",
+            "effectiveDate": "2018-03-26T15:41:37.487Z"
           },
           "controlInformation" : {
             "canUpdate" : true,
@@ -79,6 +80,6 @@ http_interactions:
             "notDeceasedIndicator" : true
           }
         }
-    http_version: 
+    http_version:
   recorded_at: Thu, 08 Mar 2018 16:46:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_400.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_400.yml
@@ -65,7 +65,8 @@ http_interactions:
           "cnpPhone" : {
             "countryCode" : "1",
             "extension" : "",
-            "number" : ""
+            "number" : "",
+            "effectiveDate": "2018-03-26T15:41:37.487Z"
           },
           "controlInformation" : {
             "canUpdate" : true,

--- a/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_403.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_403.yml
@@ -65,7 +65,8 @@ http_interactions:
           "cnpPhone" : {
             "countryCode" : "1",
             "extension" : "",
-            "number" : ""
+            "number" : "",
+            "effectiveDate": "2018-03-26T15:41:37.487Z"
           },
           "controlInformation" : {
             "canUpdate" : true,

--- a/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_500.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/alternate_phone_status_500.yml
@@ -65,7 +65,8 @@ http_interactions:
           "cnpPhone" : {
             "countryCode" : "1",
             "extension" : "",
-            "number" : ""
+            "number" : "",
+            "effectiveDate": "2018-03-26T15:41:37.487Z"
           },
           "controlInformation" : {
             "canUpdate" : true,

--- a/spec/support/vcr_cassettes/evss/pciu/post_primary_phone.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_primary_phone.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/primaryPhoneNumber"
+    body:
+      encoding: UTF-8
+      string: '{"cnpPhone":{"countryCode":"1","number":"4445551212","extension":"101","effectiveDate":"2018-03-29T16:20:38.301+00:00"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-29T16:20:36Z'
+      va-eauth-dodedipnid:
+      - '5106914814'
+      va-eauth-birlsfilenumber:
+      - '4879724920'
+      va-eauth-pid:
+      - '9815242068'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-11-15T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"5106914814","firstName":"abraham","lastName":"lincoln","birthDate":"1975-11-15T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Mar 2018 16:20:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=DHtyj8vsTqWV-26o6foXorEqgYBjsELLmFqEmO0bgNX6Uc6dLMBw!-1909305779;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpPhone" : {
+            "countryCode" : "1",
+            "extension" : "101",
+            "number" : "4445551212",
+            "effectiveDate": "2018-03-26T15:41:37.487Z"
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version:
+  recorded_at: Thu, 29 Mar 2018 16:20:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/post_primary_phone_status_400.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_primary_phone_status_400.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/primaryPhoneNumber"
+    body:
+      encoding: UTF-8
+      string: '{"cnpPhone":{"countryCode":"1","number":"","extension":"","effectiveDate":"2018-03-29T16:20:38.301+00:00"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-29T16:20:36Z'
+      va-eauth-dodedipnid:
+      - '5106914814'
+      va-eauth-birlsfilenumber:
+      - '4879724920'
+      va-eauth-pid:
+      - '9815242068'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-11-15T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"5106914814","firstName":"abraham","lastName":"lincoln","birthDate":"1975-11-15T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 29 Mar 2018 16:20:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=DHtyj8vsTqWV-26o6foXorEqgYBjsELLmFqEmO0bgNX6Uc6dLMBw!-1909305779;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [
+            {
+              "key": "string",
+              "text": "string",
+              "severity": "FATAL"
+            }
+          ]
+        }
+    http_version:
+  recorded_at: Thu, 29 Mar 2018 16:20:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/post_primary_phone_status_403.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_primary_phone_status_403.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/primaryPhoneNumber"
+    body:
+      encoding: UTF-8
+      string: '{"cnpPhone":{"countryCode":"1","number":"","extension":"","effectiveDate":"2018-03-29T16:20:38.301+00:00"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-29T16:20:36Z'
+      va-eauth-dodedipnid:
+      - '5106914814'
+      va-eauth-birlsfilenumber:
+      - '4879724920'
+      va-eauth-pid:
+      - '9815242068'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-11-15T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"5106914814","firstName":"abraham","lastName":"lincoln","birthDate":"1975-11-15T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Thu, 29 Mar 2018 16:20:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=DHtyj8vsTqWV-26o6foXorEqgYBjsELLmFqEmO0bgNX6Uc6dLMBw!-1909305779;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [
+            {
+              "key": "string",
+              "text": "string",
+              "severity": "FATAL"
+            }
+          ]
+        }
+    http_version:
+  recorded_at: Thu, 29 Mar 2018 16:20:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/post_primary_phone_status_500.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_primary_phone_status_500.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/primaryPhoneNumber"
+    body:
+      encoding: UTF-8
+      string: '{"cnpPhone":{"countryCode":"1","number":"","extension":"","effectiveDate":"2018-03-29T16:20:38.301+00:00"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-29T16:20:36Z'
+      va-eauth-dodedipnid:
+      - '5106914814'
+      va-eauth-birlsfilenumber:
+      - '4879724920'
+      va-eauth-pid:
+      - '9815242068'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-11-15T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"5106914814","firstName":"abraham","lastName":"lincoln","birthDate":"1975-11-15T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Thu, 29 Mar 2018 16:20:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=DHtyj8vsTqWV-26o6foXorEqgYBjsELLmFqEmO0bgNX6Uc6dLMBw!-1909305779;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [
+            {
+              "key": "string",
+              "text": "string",
+              "severity": "FATAL"
+            }
+          ]
+        }
+    http_version:
+  recorded_at: Thu, 29 Mar 2018 16:20:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/primary_phone.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/primary_phone.yml
@@ -65,7 +65,8 @@ http_interactions:
           "cnpPhone" : {
             "countryCode" : "1",
             "extension" : "",
-            "number" : "4445551212"
+            "number" : "4445551212",
+            "effectiveDate": "2018-03-26T15:41:37.487Z"
           },
           "controlInformation" : {
             "canUpdate" : true,
@@ -79,6 +80,6 @@ http_interactions:
             "notDeceasedIndicator" : true
           }
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 07 Mar 2018 01:20:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_400.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_400.yml
@@ -65,7 +65,8 @@ http_interactions:
           "cnpPhone" : {
             "countryCode" : "1",
             "extension" : "",
-            "number" : "4445551212"
+            "number" : "4445551212",
+            "effectiveDate": "2018-03-26T15:41:37.487Z"
           },
           "controlInformation" : {
             "canUpdate" : true,

--- a/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_403.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_403.yml
@@ -65,7 +65,8 @@ http_interactions:
           "cnpPhone" : {
             "countryCode" : "1",
             "extension" : "",
-            "number" : "4445551212"
+            "number" : "4445551212",
+            "effectiveDate": "2018-03-26T15:41:37.487Z"
           },
           "controlInformation" : {
             "canUpdate" : true,

--- a/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_500.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/primary_phone_status_500.yml
@@ -65,7 +65,8 @@ http_interactions:
           "cnpPhone" : {
             "countryCode" : "1",
             "extension" : "",
-            "number" : "4445551212"
+            "number" : "4445551212",
+            "effectiveDate": "2018-03-26T15:41:37.487Z"
           },
           "controlInformation" : {
             "canUpdate" : true,


### PR DESCRIPTION
## Background
Here are the [swagger docs](https://csraciapp6.evss.srarad.com/wss-pciu-services-web/swagger-ui/index.html?url=https://csraciapp6.evss.srarad.com/wss-pciu-services-web/rest/swagger.yaml#/) for the new PCIU Service endpoints for vets.gov to consume.

Our backend API needs to create sibling endpoints for the vets.gov frontend to consume.  

This PR will creates the `POST` endpoint for `primary_phone`. 

## Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9507

**vets-api-mockdata issue**

https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/25

## Screenshot

**Swagger Docs | Requests**

![image](https://user-images.githubusercontent.com/7482329/38116313-c3cbd7fa-336c-11e8-8a4f-5b3f64522350.png)

## Definition of done
- [x] new `v0/profile/primary_phone` `POST` endpoint
- [x] server side validation with sensible responses
- [x] Pundit authorization
- [x] associated specs
- [x] Yard docs
- [x] Swagger docs
- [x] Betamocks config
- [x] Betamocks recording
- [x] Sign off by the frontend
