### PR TITLE
9508 post alternate phone endpoint

### DIFF
--- a/app/controllers/v0/profile/alternate_phones_controller.rb
+++ b/app/controllers/v0/profile/alternate_phones_controller.rb
@@ -11,10 +11,26 @@ module V0
         render json: response, serializer: PhoneNumberSerializer
       end
 
+      def create
+        phone = EVSS::PCIU::PhoneNumber.new alternate_phone_params
+
+        if phone.valid?
+          response = service.post_alternate_phone phone
+
+          render json: response, serializer: PhoneNumberSerializer
+        else
+          raise Common::Exceptions::ValidationErrors, phone
+        end
+      end
+
       private
 
       def service
         EVSS::PCIU::Service.new @current_user
+      end
+
+      def alternate_phone_params
+        params.permit(:country_code, :number, :extension, :effective_date)
       end
     end
   end

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -24,6 +24,38 @@ module Swagger
             end
           end
         end
+
+        operation :post do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Creates/updates a users alternate phone number information'
+          key :operationId, 'postAlternatePhone'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          parameter do
+            key :name, :body
+            key :in, :body
+            key :description, 'Attributes to create/update a phone number.'
+            key :required, true
+
+            schema do
+              property :number, type: :string, example: '4445551212'
+              property :extension, type: :string, example: '101'
+              property :country_code, type: :string, example: '1'
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :PhoneNumber
+            end
+          end
+        end
       end
 
       swagger_path '/v0/profile/email' do

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -114,6 +114,12 @@
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: 'va_eauth_pnid'
+  - :method: :post
+    :path: "/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"
+    :file_path: "evss/pciu/alternate_phone"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: 'va_eauth_pnid'
   # PCIUAddress
   - :method: :get
     :path: "/wss-pciu-services-web/rest/pciuServices/v1/states"

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -116,7 +116,7 @@
       :uid_locator: 'va_eauth_pnid'
   - :method: :post
     :path: "/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"
-    :file_path: "evss/pciu/alternate_phone"
+    :file_path: "evss/pciu/post_alternate_phone"
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: 'va_eauth_pnid'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,7 +163,7 @@ Rails.application.routes.draw do
     end
 
     namespace :profile do
-      resource :alternate_phone, only: :show
+      resource :alternate_phone, only: %i[show create]
       resource :email, only: :show
       resource :personal_information, only: :show
       resource :primary_phone, only: %i[show create]

--- a/lib/evss/pciu/service.rb
+++ b/lib/evss/pciu/service.rb
@@ -102,6 +102,34 @@ module EVSS
       rescue StandardError => e
         handle_error(e)
       end
+
+      # POST's the passed phone attributes to the EVSS::PCIU service.
+      # Returns a response object containing the user's alternate phone number,
+      # extension, and country code
+      #
+      # @param phone_attrs [EVSS::PCIU::PhoneNumber] A EVSS::PCIU::PhoneNumber instance
+      # @return [EVSS::PCIU::PhoneNumberResponse] Sample response.phone:
+      #   {
+      #     "country_code" => "1",
+      #     "extension" => "",
+      #     "number" => "4445551212"
+      #     "effective_date" => "2018-02-27T14:41:32.283Z"
+      #   }
+      #
+      def post_alternate_phone(phone_attrs)
+        with_monitoring do
+          raw_response = perform(
+            :post,
+            'secondaryPhoneNumber',
+            RequestBody.new(phone_attrs, pciu_key: 'cnpPhone').set,
+            headers
+          )
+
+          EVSS::PCIU::PhoneNumberResponse.new(raw_response.status, raw_response)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
     end
   end
 end

--- a/spec/lib/evss/pciu/service_spec.rb
+++ b/spec/lib/evss/pciu/service_spec.rb
@@ -117,4 +117,56 @@ describe EVSS::PCIU::Service do
       end
     end
   end
+
+  describe '#post_alternate_phone' do
+    let(:phone) { build(:phone_number, :nil_effective_date) }
+
+    context 'when successful' do
+      it 'returns a status of 200' do
+        VCR.use_cassette('evss/pciu/post_alternate_phone') do
+          response = subject.post_alternate_phone(phone)
+
+          expect(response).to be_ok
+        end
+      end
+
+      it 'returns a users alternate phone number, extension and country code' do
+        VCR.use_cassette('evss/pciu/post_alternate_phone') do
+          response = subject.post_alternate_phone(phone)
+
+          expect(response.attributes.keys).to include :country_code, :number, :extension
+        end
+      end
+    end
+
+    context 'with a 500 response' do
+      it 'raises a Common::Exceptions::BackendServiceException error' do
+        VCR.use_cassette('evss/pciu/post_alternate_phone_status_500') do
+          expect { subject.post_alternate_phone(phone) }.to raise_error(
+            Common::Exceptions::BackendServiceException
+          )
+        end
+      end
+    end
+
+    context 'with a 403 response' do
+      it 'raises a Common::Exceptions::Forbidden error' do
+        VCR.use_cassette('evss/pciu/post_alternate_phone_status_403') do
+          expect { subject.post_alternate_phone(phone) }.to raise_error(
+            Common::Exceptions::Forbidden
+          )
+        end
+      end
+    end
+
+    context 'with a 400 response' do
+      it 'raises a Common::Exceptions::BackendServiceException error' do
+        VCR.use_cassette('evss/pciu/post_alternate_phone_status_400') do
+          expect { subject.post_alternate_phone(phone) }.to raise_error(
+            Common::Exceptions::BackendServiceException
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/request/alternate_phone_request_spec.rb
+++ b/spec/request/alternate_phone_request_spec.rb
@@ -58,4 +58,111 @@ RSpec.describe 'alternate phone', type: :request do
       end
     end
   end
+
+  describe 'POST /v0/profile/alternate_phone' do
+    let(:phone) { build(:phone_number, :nil_effective_date) }
+
+    context 'with a 200 response' do
+      it 'should match the phone schema', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/post_alternate_phone') do
+          post(
+            '/v0/profile/alternate_phone',
+            phone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('phone_number_response')
+        end
+      end
+    end
+
+    context 'with a missing phone number' do
+      it 'should match the errors schema', :aggregate_failures do
+        phone = build :phone_number, :nil_effective_date, number: ''
+
+        post(
+          '/v0/profile/alternate_phone',
+          phone.to_json,
+          auth_header.update(
+            'Content-Type' => 'application/json', 'Accept' => 'application/json'
+          )
+        )
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_response_schema('errors')
+        expect(errors_for(response)).to include "number - can't be blank", 'number - Only numbers are permitted.'
+      end
+    end
+
+    context 'with a number that contains non-numeric characters' do
+      it 'should match the errors schema', :aggregate_failures do
+        phone = build :phone_number, :nil_effective_date, number: '123-456-7890'
+
+        post(
+          '/v0/profile/alternate_phone',
+          phone.to_json,
+          auth_header.update(
+            'Content-Type' => 'application/json', 'Accept' => 'application/json'
+          )
+        )
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_response_schema('errors')
+        expect(errors_for(response)).to include 'number - Only numbers are permitted.'
+      end
+    end
+
+    context 'with a 400 response' do
+      it 'should match the errors schema', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/post_alternate_phone_status_400') do
+          post(
+            '/v0/profile/alternate_phone',
+            phone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+
+    context 'with a 403 response' do
+      it 'should return a forbidden response' do
+        VCR.use_cassette('evss/pciu/post_alternate_phone_status_403') do
+          post(
+            '/v0/profile/alternate_phone',
+            phone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context 'with a 500 response' do
+      it 'should match the errors schema', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/post_alternate_phone_status_500') do
+          post(
+            '/v0/profile/alternate_phone',
+            phone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:bad_gateway)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+  end
 end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1124,6 +1124,21 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           )
         end
       end
+
+      it 'supports posting alternate phone number data' do
+        expect(subject).to validate(:post, '/v0/profile/alternate_phone', 401)
+
+        VCR.use_cassette('evss/pciu/post_alternate_phone') do
+          phone = build(:phone_number, :nil_effective_date)
+
+          expect(subject).to validate(
+            :post,
+            '/v0/profile/alternate_phone',
+            200,
+            auth_options.merge('_data' => phone.as_json)
+          )
+        end
+      end
     end
   end
 

--- a/spec/support/vcr_cassettes/evss/pciu/post_alternate_phone.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_alternate_phone.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"
+    body:
+      encoding: UTF-8
+      string: '{"cnpPhone":{"countryCode":"1","number":"4445551212","extension":"101","effectiveDate":"2018-03-29T16:20:38.301+00:00"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-29T16:20:36Z'
+      va-eauth-dodedipnid:
+      - '5106914814'
+      va-eauth-birlsfilenumber:
+      - '4879724920'
+      va-eauth-pid:
+      - '9815242068'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-11-15T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"5106914814","firstName":"abraham","lastName":"lincoln","birthDate":"1975-11-15T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Mar 2018 16:20:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=DHtyj8vsTqWV-26o6foXorEqgYBjsELLmFqEmO0bgNX6Uc6dLMBw!-1909305779;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpPhone" : {
+            "countryCode" : "1",
+            "extension" : "101",
+            "number" : "4445551212",
+            "effectiveDate": "2018-03-26T15:41:37.487Z"
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version:
+  recorded_at: Thu, 29 Mar 2018 16:20:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/post_alternate_phone_status_400.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_alternate_phone_status_400.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"
+    body:
+      encoding: UTF-8
+      string: '{"cnpPhone":{"countryCode":"1","number":"","extension":"","effectiveDate":"2018-03-29T16:20:38.301+00:00"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-29T16:20:36Z'
+      va-eauth-dodedipnid:
+      - '5106914814'
+      va-eauth-birlsfilenumber:
+      - '4879724920'
+      va-eauth-pid:
+      - '9815242068'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-11-15T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"5106914814","firstName":"abraham","lastName":"lincoln","birthDate":"1975-11-15T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 29 Mar 2018 16:20:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=DHtyj8vsTqWV-26o6foXorEqgYBjsELLmFqEmO0bgNX6Uc6dLMBw!-1909305779;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [
+            {
+              "key": "string",
+              "text": "string",
+              "severity": "FATAL"
+            }
+          ]
+        }
+    http_version:
+  recorded_at: Thu, 29 Mar 2018 16:20:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/post_alternate_phone_status_403.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_alternate_phone_status_403.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"
+    body:
+      encoding: UTF-8
+      string: '{"cnpPhone":{"countryCode":"1","number":"","extension":"","effectiveDate":"2018-03-29T16:20:38.301+00:00"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-29T16:20:36Z'
+      va-eauth-dodedipnid:
+      - '5106914814'
+      va-eauth-birlsfilenumber:
+      - '4879724920'
+      va-eauth-pid:
+      - '9815242068'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-11-15T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"5106914814","firstName":"abraham","lastName":"lincoln","birthDate":"1975-11-15T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Thu, 29 Mar 2018 16:20:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=DHtyj8vsTqWV-26o6foXorEqgYBjsELLmFqEmO0bgNX6Uc6dLMBw!-1909305779;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [
+            {
+              "key": "string",
+              "text": "string",
+              "severity": "FATAL"
+            }
+          ]
+        }
+    http_version:
+  recorded_at: Thu, 29 Mar 2018 16:20:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/post_alternate_phone_status_500.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_alternate_phone_status_500.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/secondaryPhoneNumber"
+    body:
+      encoding: UTF-8
+      string: '{"cnpPhone":{"countryCode":"1","number":"","extension":"","effectiveDate":"2018-03-29T16:20:38.301+00:00"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-03-29T16:20:36Z'
+      va-eauth-dodedipnid:
+      - '5106914814'
+      va-eauth-birlsfilenumber:
+      - '4879724920'
+      va-eauth-pid:
+      - '9815242068'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-11-15T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"5106914814","firstName":"abraham","lastName":"lincoln","birthDate":"1975-11-15T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Thu, 29 Mar 2018 16:20:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - wss-pciu-services_JSESSIONID=DHtyj8vsTqWV-26o6foXorEqgYBjsELLmFqEmO0bgNX6Uc6dLMBw!-1909305779;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [
+            {
+              "key": "string",
+              "text": "string",
+              "severity": "FATAL"
+            }
+          ]
+        }
+    http_version:
+  recorded_at: Thu, 29 Mar 2018 16:20:49 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Background
Here are the [swagger docs](https://csraciapp6.evss.srarad.com/wss-pciu-services-web/swagger-ui/index.html?url=https://csraciapp6.evss.srarad.com/wss-pciu-services-web/rest/swagger.yaml#/) for the new PCIU Service endpoints for vets.gov to consume.

Our backend API needs to create sibling endpoints for the vets.gov frontend to consume.  

This PR will creates the `POST` endpoint for `alternate_phone`. 

## Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9508

**vets-api-mockdata issue**

https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/27

## Screenshot

**Swagger Docs | Requests**

![image](https://user-images.githubusercontent.com/7482329/38205946-bc0796f2-3665-11e8-9442-e73f6ace4fe8.png)

## Definition of done
- [x] new `v0/profile/alternate_phone` `POST` endpoint
- [x] server side validation with sensible responses
- [x] Pundit authorization
- [x] associated specs
- [x] Yard docs
- [x] Swagger docs
- [x] Betamocks config
- [x] Betamocks recording
- [x] Sign off by the frontend
