### PR TITLE
9509 post email endpoint

### DIFF
--- a/app/controllers/v0/profile/emails_controller.rb
+++ b/app/controllers/v0/profile/emails_controller.rb
@@ -11,10 +11,26 @@ module V0
         render json: response, serializer: EmailSerializer
       end
 
+      def create
+        email_address = EVSS::PCIU::EmailAddress.new email_params
+
+        if email_address.valid?
+          response = service.post_email_address email_address
+
+          render json: response, serializer: EmailSerializer
+        else
+          raise Common::Exceptions::ValidationErrors, email_address
+        end
+      end
+
       private
 
       def service
         EVSS::PCIU::Service.new @current_user
+      end
+
+      def email_params
+        params.permit(:email)
       end
     end
   end

--- a/app/models/messaging_preference.rb
+++ b/app/models/messaging_preference.rb
@@ -19,10 +19,13 @@ class MessagingPreference < Common::Base
 
   attribute :email_address, String
   attribute :frequency, String
-  # Always require frequency to be included in array
   validates :frequency, presence: true, inclusion: { in: FREQUENCY_UPDATE_MAP.keys }
-  # Always require valid email address
-  validates :email_address, presence: true, format: { with: /.+@.+\..+/i }, length: { maximum: 255, minimum: 6 }
+  validates(
+    :email_address,
+    presence: true,
+    format: { with: EVSS::PCIU::EmailAddress::VALID_EMAIL_REGEX },
+    length: { maximum: 255, minimum: 6 }
+  )
 
   def mhv_params
     raise Common::Exceptions::ValidationErrors, self unless valid?

--- a/app/models/prescription_preference.rb
+++ b/app/models/prescription_preference.rb
@@ -8,10 +8,13 @@ class PrescriptionPreference < Common::Base
   attribute :email_address, String
   attribute :rx_flag, Boolean
 
-  # Always validate that rx_flag is provided
   validates :rx_flag, inclusion: { in: [true, false] }
-  # Always require valid email address
-  validates :email_address, presence: true, format: { with: /.+@.+\..+/i }, length: { maximum: 255, minimum: 6 }
+  validates(
+    :email_address,
+    presence: true,
+    format: { with: EVSS::PCIU::EmailAddress::VALID_EMAIL_REGEX },
+    length: { maximum: 255, minimum: 6 }
+  )
 
   def mhv_params
     raise Common::Exceptions::ValidationErrors, self unless valid?

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -77,6 +77,36 @@ module Swagger
             end
           end
         end
+
+        operation :post do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Creates/updates a users email address'
+          key :operationId, 'postEmailAddress'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          parameter do
+            key :name, :body
+            key :in, :body
+            key :description, 'Attributes to create/update an email address.'
+            key :required, true
+
+            schema do
+              property :email, type: :string, example: 'john@example.com'
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :Email
+            end
+          end
+        end
       end
 
       swagger_path '/v0/profile/personal_information' do

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -94,6 +94,12 @@
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: 'va_eauth_pnid'
+  - :method: :post
+    :path: "/wss-pciu-services-web/rest/pciuServices/v1/emailAddress"
+    :file_path: "evss/pciu/post_email"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: 'va_eauth_pnid'
   # PCIU primary phone
   - :method: :get
     :path: "/wss-pciu-services-web/rest/pciuServices/v1/primaryPhoneNumber"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,7 +164,7 @@ Rails.application.routes.draw do
 
     namespace :profile do
       resource :alternate_phone, only: %i[show create]
-      resource :email, only: :show
+      resource :email, only: %i[show create]
       resource :personal_information, only: :show
       resource :primary_phone, only: %i[show create]
       resource :service_history, only: :show

--- a/lib/evss/pciu/email_address.rb
+++ b/lib/evss/pciu/email_address.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module EVSS
+  module PCIU
+    class EmailAddress < BaseModel
+      VALID_EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+
+      attribute :email, String
+
+      validates :email, presence: true
+      validates_format_of :email, with: VALID_EMAIL_REGEX
+    end
+  end
+end

--- a/lib/evss/pciu/email_address.rb
+++ b/lib/evss/pciu/email_address.rb
@@ -3,16 +3,16 @@
 module EVSS
   module PCIU
     class EmailAddress < BaseModel
-      # This regex comes from the `validates_format_of` Rails docs
-      #
-      # @see https://apidock.com/rails/ActiveModel/Validations/HelperMethods/validates_format_of
-      #
-      VALID_EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+      VALID_EMAIL_REGEX = /.+@.+\..+/i
 
       attribute :email, String
 
-      validates :email, presence: true
-      validates_format_of :email, with: VALID_EMAIL_REGEX
+      validates(
+        :email,
+        presence: true,
+        format: { with: VALID_EMAIL_REGEX },
+        length: { maximum: 255, minimum: 6 }
+      )
     end
   end
 end

--- a/lib/evss/pciu/email_address.rb
+++ b/lib/evss/pciu/email_address.rb
@@ -3,6 +3,10 @@
 module EVSS
   module PCIU
     class EmailAddress < BaseModel
+      # This regex comes from the `validates_format_of` Rails docs
+      #
+      # @see https://apidock.com/rails/ActiveModel/Validations/HelperMethods/validates_format_of
+      #
       VALID_EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
 
       attribute :email, String

--- a/lib/evss/pciu/service.rb
+++ b/lib/evss/pciu/service.rb
@@ -130,6 +130,31 @@ module EVSS
       rescue StandardError => e
         handle_error(e)
       end
+
+      # POST's the passed email attributes to the EVSS::PCIU service.
+      # Returns a response object containing the user's email and effective date.
+      #
+      # @param email_attrs [EVSS::PCIU::EmailAddress] A EVSS::PCIU::EmailAddress instance
+      # @return [EVSS::PCIU::EmailAddressResponse] Sample response.email_address:
+      #   {
+      #     "effective_date" => "2018-02-27T14:41:32.283Z",
+      #     "value" => "test2@test1.net"
+      #   }
+      #
+      def post_email_address(email_attrs)
+        with_monitoring do
+          raw_response = perform(
+            :post,
+            'emailAddress',
+            { value: email_attrs.email }.to_json,
+            headers
+          )
+
+          EVSS::PCIU::EmailAddressResponse.new(raw_response.status, raw_response)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
     end
   end
 end

--- a/spec/factories/email_address.rb
+++ b/spec/factories/email_address.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :email_address, class: 'EVSS::PCIU::EmailAddress' do
+    sequence(:email, 100) { |n| "person#{n}@example.com" }
+  end
+end

--- a/spec/lib/evss/pciu/email_address_spec.rb
+++ b/spec/lib/evss/pciu/email_address_spec.rb
@@ -16,6 +16,7 @@ describe EVSS::PCIU::EmailAddress do
     # Valid email formats
     expect(build(:email_address, email: 'john@gmail.com')).to be_valid
     expect(build(:email_address, email: '12john34@gmail.com')).to be_valid
+    expect(build(:email_address, email: 'john+tom@gmail.com')).to be_valid
     expect(build(:email_address, email: 'j@example.com')).to be_valid
     expect(build(:email_address, email: 'jack@anything.io')).to be_valid
     expect(build(:email_address, email: 'jack@anything.org')).to be_valid

--- a/spec/lib/evss/pciu/email_address_spec.rb
+++ b/spec/lib/evss/pciu/email_address_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EVSS::PCIU::EmailAddress do
+  it 'should have valid factory' do
+    expect(build(:email_address)).to be_valid
+  end
+
+  it 'should require an email', :aggregate_failures do
+    expect(build(:email_address, email: '')).to_not be_valid
+    expect(build(:email_address, email: nil)).to_not be_valid
+  end
+
+  it 'should be a validly formatted email', :aggregate_failures do
+    # Valid email formats
+    expect(build(:email_address, email: 'john@gmail.com')).to be_valid
+    expect(build(:email_address, email: '12john34@gmail.com')).to be_valid
+    expect(build(:email_address, email: 'j@example.com')).to be_valid
+    expect(build(:email_address, email: 'jack@anything.io')).to be_valid
+    expect(build(:email_address, email: 'jack@anything.org')).to be_valid
+    expect(build(:email_address, email: 'jack@anything.net')).to be_valid
+    expect(build(:email_address, email: 'jack@anything.whatever')).to be_valid
+
+    # Invalid email formats
+    expect(build(:email_address, email: 'johngmail.com')).to_not be_valid
+    expect(build(:email_address, email: 'john#gmail.com')).to_not be_valid
+    expect(build(:email_address, email: 'john@gmail')).to_not be_valid
+    expect(build(:email_address, email: '@example.com')).to_not be_valid
+  end
+end

--- a/spec/lib/evss/pciu/service_spec.rb
+++ b/spec/lib/evss/pciu/service_spec.rb
@@ -78,7 +78,7 @@ describe EVSS::PCIU::Service do
         end
       end
 
-      it 'returns a users primary phone number, extension and country code' do
+      it 'POSTs and returns a users primary phone number, extension and country code' do
         VCR.use_cassette('evss/pciu/post_primary_phone') do
           response = subject.post_primary_phone(phone)
 
@@ -130,7 +130,7 @@ describe EVSS::PCIU::Service do
         end
       end
 
-      it 'returns a users alternate phone number, extension and country code' do
+      it 'POSTs and returns a users alternate phone number, extension and country code' do
         VCR.use_cassette('evss/pciu/post_alternate_phone') do
           response = subject.post_alternate_phone(phone)
 
@@ -163,6 +163,58 @@ describe EVSS::PCIU::Service do
       it 'raises a Common::Exceptions::BackendServiceException error' do
         VCR.use_cassette('evss/pciu/post_alternate_phone_status_400') do
           expect { subject.post_alternate_phone(phone) }.to raise_error(
+            Common::Exceptions::BackendServiceException
+          )
+        end
+      end
+    end
+  end
+
+  describe '#post_email_address' do
+    let(:email_address) { build(:email_address) }
+
+    context 'when successful' do
+      it 'returns a status of 200' do
+        VCR.use_cassette('evss/pciu/post_email_address') do
+          response = subject.post_email_address(email_address)
+
+          expect(response).to be_ok
+        end
+      end
+
+      it 'POSTs and returns a users email address and effective_date' do
+        VCR.use_cassette('evss/pciu/post_email_address') do
+          response = subject.post_email_address(email_address)
+
+          expect(response.email_address.keys).to contain_exactly 'effective_date', 'value'
+        end
+      end
+    end
+
+    context 'with a 500 response' do
+      it 'raises a Common::Exceptions::BackendServiceException error' do
+        VCR.use_cassette('evss/pciu/post_email_address_status_500') do
+          expect { subject.post_email_address(email_address) }.to raise_error(
+            Common::Exceptions::BackendServiceException
+          )
+        end
+      end
+    end
+
+    context 'with a 403 response' do
+      it 'raises a Common::Exceptions::Forbidden error' do
+        VCR.use_cassette('evss/pciu/post_email_address_status_403') do
+          expect { subject.post_email_address(email_address) }.to raise_error(
+            Common::Exceptions::Forbidden
+          )
+        end
+      end
+    end
+
+    context 'with a 400 response' do
+      it 'raises a Common::Exceptions::BackendServiceException error' do
+        VCR.use_cassette('evss/pciu/post_email_address_status_400') do
+          expect { subject.post_email_address(email_address) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
         end

--- a/spec/request/email_request_spec.rb
+++ b/spec/request/email_request_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'email', type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to match_response_schema('errors')
-        expect(errors_for(response)).to include "email - is invalid"
+        expect(errors_for(response)).to include 'email - is invalid'
       end
     end
 

--- a/spec/request/email_request_spec.rb
+++ b/spec/request/email_request_spec.rb
@@ -58,4 +58,111 @@ RSpec.describe 'email', type: :request do
       end
     end
   end
+
+  describe 'POST /v0/profile/email' do
+    let(:email_address) { build(:email_address) }
+
+    context 'with a 200 response' do
+      it 'should match the email address schema', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/post_email_address') do
+          post(
+            '/v0/profile/email',
+            email_address.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('email_address_response')
+        end
+      end
+    end
+
+    context 'with a missing email' do
+      it 'should match the errors schema', :aggregate_failures do
+        email_address = build :email_address, email: ''
+
+        post(
+          '/v0/profile/email',
+          email_address.to_json,
+          auth_header.update(
+            'Content-Type' => 'application/json', 'Accept' => 'application/json'
+          )
+        )
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_response_schema('errors')
+        expect(errors_for(response)).to include "email - can't be blank"
+      end
+    end
+
+    context 'with an invalid email' do
+      it 'should match the errors schema', :aggregate_failures do
+        email_address = build :email_address, email: 'johngmail.com'
+
+        post(
+          '/v0/profile/email',
+          email_address.to_json,
+          auth_header.update(
+            'Content-Type' => 'application/json', 'Accept' => 'application/json'
+          )
+        )
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_response_schema('errors')
+        expect(errors_for(response)).to include "email - is invalid"
+      end
+    end
+
+    context 'with a 400 response' do
+      it 'should match the errors schema', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/post_email_address_status_400') do
+          post(
+            '/v0/profile/email',
+            email_address.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+
+    context 'with a 403 response' do
+      it 'should return a forbidden response' do
+        VCR.use_cassette('evss/pciu/post_email_address_status_403') do
+          post(
+            '/v0/profile/email',
+            email_address.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context 'with a 500 response' do
+      it 'should match the errors schema', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/post_email_address_status_500') do
+          post(
+            '/v0/profile/email',
+            email_address.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:bad_gateway)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+  end
 end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1139,6 +1139,21 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           )
         end
       end
+
+      it 'supports posting email address data' do
+        expect(subject).to validate(:post, '/v0/profile/email', 401)
+
+        VCR.use_cassette('evss/pciu/post_email_address') do
+          email_address = build(:email_address)
+
+          expect(subject).to validate(
+            :post,
+            '/v0/profile/email',
+            200,
+            auth_options.merge('_data' => email_address.as_json)
+          )
+        end
+      end
     end
   end
 

--- a/spec/support/vcr_cassettes/evss/pciu/post_email_address.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_email_address.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/emailAddress"
+    body:
+      encoding: UTF-8
+      string: '{"value":"person100@example.com"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-04-02T22:46:15Z'
+      va-eauth-dodedipnid:
+      - '4080803553'
+      va-eauth-birlsfilenumber:
+      - '5106804804'
+      va-eauth-pid:
+      - '8395915975'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-02-05T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"4080803553","firstName":"abraham","lastName":"lincoln","birthDate":"1975-02-05T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Apr 2018 22:46:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.02; path=/
+      - wss-pciu-services_JSESSIONID=l36IiktU4ATje8pd_bUFSUaifInPcDiiLaTNT1VktbcvHwmFZvIc!-1392655551;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpEmailAddress" : {
+            "effectiveDate" : "2012-04-03T04:00:00.000+0000",
+            "value" : "person100@example.com"
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 22:46:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/post_email_address_status_400.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_email_address_status_400.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/emailAddress"
+    body:
+      encoding: UTF-8
+      string: '{"value":"person100@example.com"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-04-02T22:46:15Z'
+      va-eauth-dodedipnid:
+      - '4080803553'
+      va-eauth-birlsfilenumber:
+      - '5106804804'
+      va-eauth-pid:
+      - '8395915975'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-02-05T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"4080803553","firstName":"abraham","lastName":"lincoln","birthDate":"1975-02-05T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Mon, 02 Apr 2018 22:46:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.02; path=/
+      - wss-pciu-services_JSESSIONID=l36IiktU4ATje8pd_bUFSUaifInPcDiiLaTNT1VktbcvHwmFZvIc!-1392655551;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpEmailAddress" : {
+            "effectiveDate" : "2012-04-03T04:00:00.000+0000",
+            "value" : "person100@example.com"
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version:
+  recorded_at: Mon, 02 Apr 2018 22:46:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/post_email_address_status_403.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_email_address_status_403.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/emailAddress"
+    body:
+      encoding: UTF-8
+      string: '{"value":"person100@example.com"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-04-02T22:46:15Z'
+      va-eauth-dodedipnid:
+      - '4080803553'
+      va-eauth-birlsfilenumber:
+      - '5106804804'
+      va-eauth-pid:
+      - '8395915975'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-02-05T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"4080803553","firstName":"abraham","lastName":"lincoln","birthDate":"1975-02-05T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Mon, 02 Apr 2018 22:46:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.02; path=/
+      - wss-pciu-services_JSESSIONID=l36IiktU4ATje8pd_bUFSUaifInPcDiiLaTNT1VktbcvHwmFZvIc!-1392655551;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpEmailAddress" : {
+            "effectiveDate" : "2012-04-03T04:00:00.000+0000",
+            "value" : "person100@example.com"
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version:
+  recorded_at: Mon, 02 Apr 2018 22:46:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/pciu/post_email_address_status_500.yml
+++ b/spec/support/vcr_cassettes/evss/pciu/post_email_address_status_500.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-pciu-services-web/rest/pciuServices/v1/emailAddress"
+    body:
+      encoding: UTF-8
+      string: '{"value":"person100@example.com"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - abraham
+      va-eauth-lastName:
+      - lincoln
+      va-eauth-issueinstant:
+      - '2018-04-02T22:46:15Z'
+      va-eauth-dodedipnid:
+      - '4080803553'
+      va-eauth-birlsfilenumber:
+      - '5106804804'
+      va-eauth-pid:
+      - '8395915975'
+      va-eauth-pnid:
+      - '796111863'
+      va-eauth-birthdate:
+      - '1975-02-05T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":"4080803553","firstName":"abraham","lastName":"lincoln","birthDate":"1975-02-05T00:00:00+00:00"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Mon, 02 Apr 2018 22:46:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.02; path=/
+      - wss-pciu-services_JSESSIONID=l36IiktU4ATje8pd_bUFSUaifInPcDiiLaTNT1VktbcvHwmFZvIc!-1392655551;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "cnpEmailAddress" : {
+            "effectiveDate" : "2012-04-03T04:00:00.000+0000",
+            "value" : "person100@example.com"
+          },
+          "controlInformation" : {
+            "canUpdate" : true,
+            "corpAvailIndicator" : true,
+            "corpRecFoundIndicator" : true,
+            "hasNoBDNPaymentsIndicator" : true,
+            "indentityIndicator" : true,
+            "indexIndicator" : true,
+            "isCompetentIndicator" : true,
+            "noFiduciaryAssignedIndicator" : true,
+            "notDeceasedIndicator" : true
+          }
+        }
+    http_version:
+  recorded_at: Mon, 02 Apr 2018 22:46:27 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Background
Here are the [swagger docs](https://csraciapp6.evss.srarad.com/wss-pciu-services-web/swagger-ui/index.html?url=https://csraciapp6.evss.srarad.com/wss-pciu-services-web/rest/swagger.yaml#/) for the new PCIU Service endpoints for vets.gov to consume.

Our backend API needs to create sibling endpoints for the vets.gov frontend to consume.  

This PR will creates the `POST` endpoint for `email`. 

## Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9509

**vets-api-mockdata issue**

https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/28

## Screenshot

**Swagger Docs | Requests**

![image](https://user-images.githubusercontent.com/7482329/38260614-500b78b8-3725-11e8-9b6e-c4de06cfb63d.png)

## Definition of done
- [x] new `v0/profile/email` `POST` endpoint
- [x] server side validation with sensible responses
- [x] Pundit authorization
- [x] associated specs
- [x] Yard docs
- [x] Swagger docs
- [x] Betamocks config
- [x] Betamocks recording
- [x] Sign off by the frontend
