### PR TITLE
9579 post address alias route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,6 +171,7 @@ Rails.application.routes.draw do
     end
 
     get 'profile/mailing_address', to: 'addresses#show'
+    put 'profile/mailing_address', to: 'addresses#update'
 
     resources :backend_statuses, param: :service, only: [:show]
 

--- a/spec/routing/profile_routing_spec.rb
+++ b/spec/routing/profile_routing_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe 'routes for Profile', type: :routing do
       'action' => 'show'
     )
   end
+
+  it 'creates an alias route to the v0/addresses#update RESTful route' do
+    expect(put('/v0/profile/mailing_address')).to route_to(
+      'format' => 'json',
+      'controller' => 'v0/addresses',
+      'action' => 'update'
+    )
+  end
 end


### PR DESCRIPTION
## Background
Here are the [swagger docs](https://csraciapp6.evss.srarad.com/wss-pciu-services-web/swagger-ui/index.html?url=https://csraciapp6.evss.srarad.com/wss-pciu-services-web/rest/swagger.yaml#/) for the new PCIU Service endpoints for vets.gov to consume.

Our backend already has an existing endpoint hitting this `mailingAddress` endpoint.  The endpoint is used for letters, and we want to make sure that we can change this new one to point to Vet360 in the future.  So in order to allow us to change them independently, we’ll want a new endpoint.

This PR creates this new path aliased to the existing `PUT` endpoint.

## Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9579

## Screenshot

![image](https://user-images.githubusercontent.com/7482329/38266405-d55ea7e6-3735-11e8-8b8e-ce5b164092e8.png)


## Definition of done
- [x] new `profile/mailing_address` `PUT` endpoint aliased to the existing `addresses#update` action
