### PR TITLE
Parse and expose Vet360 from MVI service

### DIFF
--- a/app/models/mvi.rb
+++ b/app/models/mvi.rb
@@ -76,6 +76,14 @@ class Mvi < Common::RedisStore
     profile&.birls_id
   end
 
+  # A Vet360 Correlation ID
+  #
+  # @return [String] the Vet360 id
+  def vet360_id
+    return nil unless @user.loa3?
+    profile&.vet360_id
+  end
+
   # A list of ICN's that the user has been identitfied by historically
   #
   # @return [Array[String]] the list of historical icns

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,6 +99,7 @@ class User < Common::RedisStore
   delegate :icn, to: :mvi
   delegate :participant_id, to: :mvi
   delegate :veteran?, to: :veteran_status
+  delegate :vet360_id, to: :mvi
 
   def va_profile
     mvi.profile

--- a/lib/mvi/models/mvi_profile.rb
+++ b/lib/mvi/models/mvi_profile.rb
@@ -34,6 +34,7 @@ module MVI
       attribute :participant_id, String
       attribute :birls_id, String
       attribute :sec_id, String
+      attribute :vet360_id, String
       attribute :historical_icns, Array[String]
 
       def mhv_correlation_id

--- a/lib/mvi/responses/id_parser.rb
+++ b/lib/mvi/responses/id_parser.rb
@@ -21,7 +21,8 @@ module MVI
           edipi: select_ids(select_extension(ids, /^\w+\^NI\^200DOD\^USDOD\^\w+$/, EDIPI_ROOT_ID))&.first,
           vba_corp_id: select_ids(select_extension(ids, /^\w+\^PI\^200CORP\^USVBA\^\w+$/, CORRELATION_ROOT_ID))&.first,
           vha_facility_ids: select_facilities(select_extension(ids, /^\w+\^PI\^\w+\^USVHA\^\w+$/, CORRELATION_ROOT_ID)),
-          birls_id: select_ids(select_extension(ids, /^\w+\^PI\^200BRLS\^USVBA\^\w+$/, CORRELATION_ROOT_ID))&.first
+          birls_id: select_ids(select_extension(ids, /^\w+\^PI\^200BRLS\^USVBA\^\w+$/, CORRELATION_ROOT_ID))&.first,
+          vet360_id: select_ids(select_extension(ids, /^\w+\^PI\^200VETS\^USDVA\^\w+$/, CORRELATION_ROOT_ID))&.first
         }
       end
 

--- a/lib/mvi/responses/profile_parser.rb
+++ b/lib/mvi/responses/profile_parser.rb
@@ -107,6 +107,7 @@ module MVI
           vha_facility_ids: correlation_ids[:vha_facility_ids],
           sec_id: correlation_ids[:sec_id],
           birls_id: correlation_ids[:birls_id],
+          vet360_id: correlation_ids[:vet360_id],
           historical_icns: MVI::Responses::HistoricalIcnParser.new(@original_body).get_icns
         )
       end

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -57,6 +57,7 @@ FactoryBot.define do
       edipi '1234'
       participant_id '12345678'
       birls_id '796122306'
+      vet360_id '123456789'
 
       trait :missing_attrs do
         given_names %w[Mitchell]
@@ -70,6 +71,7 @@ FactoryBot.define do
         vha_facility_ids ['200MHS']
         participant_id '9100792239'
         edipi nil
+        vet360_id nil
       end
 
       trait :multiple_mhvids do
@@ -86,6 +88,7 @@ FactoryBot.define do
         edipi '1122334455'
         participant_id '12345678'
         birls_id '123412345'
+        vet360_id nil
       end
 
       trait :address_austin do

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -39,6 +39,7 @@ FactoryBot.define do
     edipi { Faker::Number.number(10) }
     participant_id { Faker::Number.number(10) }
     birls_id { Faker::Number.number(10) }
+    vet360_id '123456789'
     sec_id '0001234567'
     historical_icns %w[1000123457V123456 1000123458V123456]
 

--- a/spec/lib/mvi/responses/profile_parser_spec.rb
+++ b/spec/lib/mvi/responses/profile_parser_spec.rb
@@ -154,6 +154,18 @@ describe MVI::Responses::ProfileParser do
     end
   end
 
+  context 'with a vet360 id' do
+    let(:body) { Ox.parse(File.read('spec/support/mvi/find_candidate_response.xml')) }
+
+    before(:each) do
+      allow(faraday_response).to receive(:body) { body }
+    end
+
+    it 'correctly parses a Vet360 ID' do
+      fail
+    end
+  end
+
   context 'with inactive MHV ID edge cases' do
     let(:body) { Ox.parse(File.read('spec/support/mvi/find_candidate_inactive_mhv_ids.xml')) }
 

--- a/spec/lib/mvi/responses/profile_parser_spec.rb
+++ b/spec/lib/mvi/responses/profile_parser_spec.rb
@@ -61,7 +61,7 @@ describe MVI::Responses::ProfileParser do
             birls_id: nil,
             sec_id: nil,
             historical_icns: nil,
-            vet360_id: nil,
+            vet360_id: nil
           )
         end
         it 'should set the address to nil' do

--- a/spec/lib/mvi/responses/profile_parser_spec.rb
+++ b/spec/lib/mvi/responses/profile_parser_spec.rb
@@ -60,7 +60,8 @@ describe MVI::Responses::ProfileParser do
             address: nil,
             birls_id: nil,
             sec_id: nil,
-            historical_icns: nil
+            historical_icns: nil,
+            vet360_id: nil,
           )
         end
         it 'should set the address to nil' do
@@ -156,13 +157,22 @@ describe MVI::Responses::ProfileParser do
 
   context 'with a vet360 id' do
     let(:body) { Ox.parse(File.read('spec/support/mvi/find_candidate_response.xml')) }
+    let(:mvi_profile) do
+      build(
+        :mvi_profile_response,
+        :address_austin,
+        historical_icns: nil,
+        birls_id: nil,
+        sec_id: nil
+      )
+    end
 
     before(:each) do
       allow(faraday_response).to receive(:body) { body }
     end
 
     it 'correctly parses a Vet360 ID' do
-      fail
+      expect(parser.parse).to have_deep_attributes(mvi_profile)
     end
   end
 

--- a/spec/lib/mvi/service_spec.rb
+++ b/spec/lib/mvi/service_spec.rb
@@ -65,6 +65,16 @@ describe MVI::Service do
         end
       end
 
+      it 'correctly parses vet360 id if it exists', run_at: 'Wed, 21 Feb 2018 20:19:01 GMT' do
+        allow(user).to receive(:mhv_icn).and_return('1008787551V609092^NI^200M^USVHA^P')
+
+        VCR.use_cassette('mvi/find_candidate/valid_vet360_id') do
+          response = subject.find_profile(user)
+          expect(response.status).to eq('OK')
+          expect(response.profile['vet360_id']).to eq('123456789')
+        end
+      end
+
       it 'fetches historical icns if they exist', run_at: 'Wed, 21 Feb 2018 20:19:01 GMT' do
         allow(user).to receive(:mhv_icn).and_return('1008787551V609092^NI^200M^USVHA^P')
         allow(SecureRandom).to receive(:uuid).and_return('5e819d17-ce9b-4860-929e-f9062836ebd0')

--- a/spec/models/mvi_spec.rb
+++ b/spec/models/mvi_spec.rb
@@ -73,6 +73,11 @@ describe Mvi, skip_mvi: true do
           expect(mvi.historical_icns).to eq(profile_response.profile.historical_icns)
         end
       end
+      describe '#vet360_id' do
+        it 'should match the response' do
+          expect(mvi.vet360_id).to eq(profile_response.profile.vet360_id)
+        end
+      end
     end
 
     context 'with an error response' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -189,6 +189,10 @@ RSpec.describe User, type: :model do
         it 'fetches ssn from IDENTITY' do
           expect(user.ssn).to be(user.identity.ssn)
         end
+
+        it 'has a vet360 id if one exists' do
+          binding.pry; fail
+        end
       end
 
       context 'when saml user attributes NOT available, icn is available, and user LOA3' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe User, type: :model do
         end
 
         it 'has a vet360 id if one exists' do
-          binding.pry; fail
+          expect(user.vet360_id).to be(user.va_profile.vet360_id)
         end
       end
 

--- a/spec/support/mvi/find_candidate_response.xml
+++ b/spec/support/mvi/find_candidate_response.xml
@@ -52,6 +52,7 @@
                 <id extension="123456^PI^200MHV^USVHA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="1234^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12" />
                 <id extension="12345678^PI^200CORP^USVBA^A" root="2.16.840.1.113883.4.349"/>
+                <id extension="123456789^PI^200VETS^USDVA^A" root="2.16.840.1.113883.4.349" />
                 <statusCode code="active"/>
                 <patientPerson>
                   <name use="L">

--- a/spec/support/vcr_cassettes/mvi/find_candidate/valid_vet360_id.yml
+++ b/spec/support/vcr_cassettes/mvi/find_candidate/valid_vet360_id.yml
@@ -1,0 +1,154 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<MVI_URL>"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        CjxlbnY6RW52ZWxvcGUgeG1sbnM6c29hcGVuYz0iaHR0cDovL3NjaGVtYXMu
+        eG1sc29hcC5vcmcvc29hcC9lbmNvZGluZy8iIHhtbG5zOnhzZD0iaHR0cDov
+        L3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiIHhtbG5zOmVudj0iaHR0cDov
+        L3NjaGVtYXMueG1sc29hcC5vcmcvc29hcC9lbnZlbG9wZS8iIHhtbG5zOnhz
+        aT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2Ui
+        PgogIDxlbnY6SGVhZGVyLz4KICA8ZW52OkJvZHk+CiAgICA8aWRtOlBSUEFf
+        SU4yMDEzMDVVVjAyIHhtbG5zOmlkbT0iaHR0cDovL3Zhd3cub2VkLm9pdC52
+        YS5nb3YiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxT
+        Y2hlbWHigJBpbnN0YW5jZSIgeHNpOnNjaGVtYUxvY2F0aW9uPSJ1cm46aGw3
+        4oCQb3JnOnYzIC4uLy4uL3NjaGVtYS9ITDdWMy9ORTIwMDgvbXVsdGljYWNo
+        ZXNjaGVtYXMvUFJQQV9JTjIwMTMwNVVWMDIueHNkIiB4bWxucz0idXJuOmhs
+        N+KAkG9yZzp2MyIgSVRTVmVyc2lvbj0iWE1MXzEuMCI+CiAgICAgIDxpZCBy
+        b290PSIxLjIuODQwLjExNDM1MC4xLjEzLjAuMS43LjEuMSIgZXh0ZW5zaW9u
+        PSIyMDBWR09WLTA4NTA5ZWFhLTkyM2QtNDA1NS1iZWM5LWY5ZDE4ZGU1NGVk
+        YiIvPgogICAgICA8Y3JlYXRpb25UaW1lIHZhbHVlPSIyMDE2MTAyODE1MzIx
+        MyIvPgogICAgICA8dmVyc2lvbkNvZGUgY29kZT0iMy4wIi8+CiAgICAgIDxp
+        bnRlcmFjdGlvbklkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjEuNiIgZXh0
+        ZW5zaW9uPSJQUlBBX0lOMjAxMzA1VVYwMiIvPgogICAgICA8cHJvY2Vzc2lu
+        Z0NvZGUgY29kZT0iVCIvPgogICAgICA8cHJvY2Vzc2luZ01vZGVDb2RlIGNv
+        ZGU9IlQiLz4KICAgICAgPGFjY2VwdEFja0NvZGUgY29kZT0iQUwiLz4KICAg
+        ICAgPHJlY2VpdmVyIHR5cGVDb2RlPSJSQ1YiPgogICAgICAgIDxkZXZpY2Ug
+        Y2xhc3NDb2RlPSJERVYiIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAg
+        ICAgICAgICA8aWQgcm9vdD0iMS4yLjg0MC4xMTQzNTAuMS4xMy45OTkuMjM0
+        IiBleHRlbnNpb249IjIwME0iLz4KICAgICAgICA8L2RldmljZT4KICAgICAg
+        PC9yZWNlaXZlcj4KICAgICAgPHNlbmRlciB0eXBlQ29kZT0iU05EIj4KICAg
+        ICAgICA8ZGV2aWNlIGNsYXNzQ29kZT0iREVWIiBkZXRlcm1pbmVyQ29kZT0i
+        SU5TVEFOQ0UiPgogICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEz
+        ODgzLjQuMzQ5IiBleHRlbnNpb249IjIwMFZHT1YiLz4KICAgICAgICA8L2Rl
+        dmljZT4KICAgICAgPC9zZW5kZXI+CiAgICAgIDxjb250cm9sQWN0UHJvY2Vz
+        cyBjbGFzc0NvZGU9IkNBQ1QiIG1vb2RDb2RlPSJFVk4iPgogICAgICAgIDxj
+        b2RlIGNvZGU9IlBSUEFfVEUyMDEzMDVVVjAyIiBjb2RlU3lzdGVtPSIyLjE2
+        Ljg0MC4xLjExMzg4My4xLjYiLz4KICAgICAgICA8ZGF0YUVudGVyZXIgdHlw
+        ZUNvZGU9IkVOVCIgY29udGV4dENvbnRyb2xDb2RlPSJBUCI+CiAgICAgICAg
+        ICA8YXNzaWduZWRQZXJzb24gY2xhc3NDb2RlPSJBU1NJR05FRCI+CiAgICAg
+        ICAgICAgIDxpZCBleHRlbnNpb249Ijc5NjEyMjMwNiIgcm9vdD0iMi4xNi44
+        NDAuMS4xMTM4ODMuNzc3Ljk5OSIvPgogICAgICAgICAgICA8YXNzaWduZWRQ
+        ZXJzb24gY2xhc3NDb2RlPSJQU04iIGRldGVybWluZXJDb2RlPSJJTlNUQU5D
+        RSI+CiAgICAgICAgICAgICAgPG5hbWU+CiAgICAgICAgICAgICAgICA8Z2l2
+        ZW4+TWl0Y2hlbGw8L2dpdmVuPgogICAgICAgICAgICAgICAgPGdpdmVuPkc8
+        L2dpdmVuPgogICAgICAgICAgICAgICAgPGZhbWlseT5KZW5raW5zPC9mYW1p
+        bHk+CiAgICAgICAgICAgICAgPC9uYW1lPgogICAgICAgICAgICA8L2Fzc2ln
+        bmVkUGVyc29uPgogICAgICAgICAgPC9hc3NpZ25lZFBlcnNvbj4KICAgICAg
+        ICA8L2RhdGFFbnRlcmVyPgogICAgICAgIDxxdWVyeUJ5UGFyYW1ldGVyPgog
+        ICAgICAgICAgPHF1ZXJ5SWQgcm9vdD0iMS4yLjg0MC4xMTQzNTAuMS4xMy4y
+        OC4xLjE4LjUuOTk5IiBleHRlbnNpb249IjE4MjA0Ii8+CiAgICAgICAgICA8
+        c3RhdHVzQ29kZSBjb2RlPSJuZXciLz4KICAgICAgICAgIDxtb2RpZnlDb2Rl
+        IGNvZGU9Ik1WSS5DT01QMSIvPgogICAgICAgICAgPGluaXRpYWxRdWFudGl0
+        eSB2YWx1ZT0iMSIvPgogICAgICAgICAgPHBhcmFtZXRlckxpc3Q+CiAgICAg
+        ICAgICAgIDxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+CiAg
+        ICAgICAgICAgICAgPHZhbHVlIGNvZGU9Ik0iLz4KICAgICAgICAgICAgICA8
+        c2VtYW50aWNzVGV4dD5HZW5kZXI8L3NlbWFudGljc1RleHQ+CiAgICAgICAg
+        ICAgIDwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPgogICAg
+        ICAgICAgICA8bGl2aW5nU3ViamVjdEJpcnRoVGltZT4KICAgICAgICAgICAg
+        ICA8dmFsdWUgdmFsdWU9IjE5NDkwMzA0Ii8+CiAgICAgICAgICAgICAgPHNl
+        bWFudGljc1RleHQ+RGF0ZSBvZiBCaXJ0aDwvc2VtYW50aWNzVGV4dD4KICAg
+        ICAgICAgICAgPC9saXZpbmdTdWJqZWN0QmlydGhUaW1lPgogICAgICAgICAg
+        ICA8bGl2aW5nU3ViamVjdElkPgogICAgICAgICAgICAgIDx2YWx1ZSByb290
+        PSIyLjE2Ljg0MC4xLjExMzg4My40LjEiIGV4dGVuc2lvbj0iNzk2MTIyMzA2
+        Ii8+CiAgICAgICAgICAgICAgPHNlbWFudGljc1RleHQ+U1NOPC9zZW1hbnRp
+        Y3NUZXh0PgogICAgICAgICAgICA8L2xpdmluZ1N1YmplY3RJZD4KICAgICAg
+        ICAgICAgPGxpdmluZ1N1YmplY3ROYW1lPgogICAgICAgICAgICAgIDx2YWx1
+        ZSB1c2U9IkwiPgogICAgICAgICAgICAgICAgPGdpdmVuPk1pdGNoZWxsPC9n
+        aXZlbj4KICAgICAgICAgICAgICAgIDxnaXZlbj5HPC9naXZlbj4KICAgICAg
+        ICAgICAgICAgIDxmYW1pbHk+SmVua2luczwvZmFtaWx5PgogICAgICAgICAg
+        ICAgIDwvdmFsdWU+CiAgICAgICAgICAgICAgPHNlbWFudGljc1RleHQ+TGVn
+        YWwgTmFtZTwvc2VtYW50aWNzVGV4dD4KICAgICAgICAgICAgPC9saXZpbmdT
+        dWJqZWN0TmFtZT4KICAgICAgICAgIDwvcGFyYW1ldGVyTGlzdD4KICAgICAg
+        ICA8L3F1ZXJ5QnlQYXJhbWV0ZXI+CiAgICAgIDwvY29udHJvbEFjdFByb2Nl
+        c3M+CiAgICA8L2lkbTpQUlBBX0lOMjAxMzA1VVYwMj4KICA8L2VudjpCb2R5
+        Pgo8L2VudjpFbnZlbG9wZT4K
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Date:
+      - Fri, 28 Oct 2016 15:32:13 GMT
+      Content-Length:
+      - '3123'
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Soapaction:
+      - PRPA_IN201305UV02
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Oct 2016 15:12:01 GMT
+      Content-Length:
+      - '4018'
+      Content-Type:
+      - text/xml
+      Set-Cookie:
+      - JSESSIONID=w7RgYTqBYV2hMcQyLQVMZPl0X5yMFP2NXx8sDDtVdyQpLnTdxLSk!1604350384;
+        path=/; HttpOnly
+      X-Powered-By:
+      - Servlet/2.5 JSP/2.1
+    body:
+      encoding: UTF-8
+      string: <env:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><env:Header/><env:Body><idm:PRPA_IN201306UV02
+        xmlns="urn:hl7-org:v3" xmlns:idm="http://vaww.oed.oit.va.gov" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        ITSVersion="XML_1.0" xsi:schemaLocation="urn:hl7-org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/PRPA_IN201306UV02.xsd"><id
+        extension="WSDOC1610281012015841158653421" root="2.16.840.1.113883.4.349"/><creationTime
+        value="20161028101201"/><versionCode code="3.0"/><interactionId extension="PRPA_IN201306UV02"
+        root="2.16.840.1.113883.1.6"/><processingCode code="T"/><processingModeCode
+        code="T"/><acceptAckCode code="NE"/><receiver typeCode="RCV"><device determinerCode="INSTANCE"
+        classCode="DEV"><id extension="200VGOV" root="2.16.840.1.113883.4.349"/></device></receiver><sender
+        typeCode="SND"><device determinerCode="INSTANCE" classCode="DEV"><id extension="200M"
+        root="2.16.840.1.113883.4.349"/></device></sender><acknowledgement><typeCode
+        code="AA"/><targetMessage><id extension="200VGOV-08509eaa-923d-4055-bec9-f9d18de54edb"
+        root="1.2.840.114350.1.13.0.1.7.1.1"/></targetMessage><acknowledgementDetail><code
+        codeSystemName="MVI" code="132" displayName="IMT"/><text>Identity Match Threshold</text></acknowledgementDetail><acknowledgementDetail><code
+        codeSystemName="MVI" code="120" displayName="PDT"/><text>Potential Duplicate
+        Threshold</text></acknowledgementDetail></acknowledgement><controlActProcess
+        classCode="CACT" moodCode="EVN"><code codeSystem="2.16.840.1.113883.1.6" code="PRPA_TE201306UV02"/><subject
+        typeCode="SUBJ"><registrationEvent classCode="REG" moodCode="EVN"><id nullFlavor="NA"/><statusCode
+        code="active"/><subject1 typeCode="SBJ"><patient classCode="PAT"><id extension="1008714701V416111^NI^200M^USVHA^P"
+        root="2.16.840.1.113883.4.349"/><id extension="123456789^PI^200VETS^USDVA^A"
+        root="2.16.840.1.113883.4.349"/><id extension="796122306^PI^200BRLS^USVBA^A"
+        root="2.16.840.1.113883.4.349"/><id extension="9100792239^PI^200CORP^USVBA^A"
+        root="2.16.840.1.113883.4.349"/><statusCode code="active"/><patientPerson><name
+        use="L"><given>MITCHELL</given><given>G</given><family>JENKINS</family></name><administrativeGenderCode
+        code="M"/><birthTime value="19490304"/><addr use="PHYS"><streetAddressLine>121
+        A St</streetAddressLine><city>Austin</city><state>TX</state><postalCode>78772</postalCode><country>USA</country></addr><asOtherIDs
+        classCode="SSN"><id extension="796122306" root="2.16.840.1.113883.4.1"/><scopingOrganization
+        determinerCode="INSTANCE" classCode="ORG"><id root="1.2.840.114350.1.13.99997.2.3412"/></scopingOrganization></asOtherIDs></patientPerson><subjectOf1><queryMatchObservation
+        classCode="COND" moodCode="EVN"><code code="IHE_PDQ"/><value value="169" xsi:type="INT"/></queryMatchObservation></subjectOf1></patient></subject1><custodian
+        typeCode="CST"><assignedEntity classCode="ASSIGNED"><id root="2.16.840.1.113883.4.349"/></assignedEntity></custodian></registrationEvent></subject><queryAck><queryId
+        extension="18204" root="1.2.840.114350.1.13.28.1.18.5.999"/><queryResponseCode
+        code="OK"/><resultCurrentQuantity value="1"/></queryAck><queryByParameter><queryId
+        extension="18204" root="1.2.840.114350.1.13.28.1.18.5.999"/><statusCode code="new"/><modifyCode
+        code="MVI.COMP1"/><initialQuantity value="1"/><parameterList><livingSubjectAdministrativeGender><value
+        code="M"/><semanticsText>Gender</semanticsText></livingSubjectAdministrativeGender><livingSubjectBirthTime><value
+        value="19490304"/><semanticsText>Date of Birth</semanticsText></livingSubjectBirthTime><livingSubjectId><value
+        extension="796122306" root="2.16.840.1.113883.4.1"/><semanticsText>SSN</semanticsText></livingSubjectId><livingSubjectName><value
+        use="L"><given>Mitchell</given><given>G</given><family>Jenkins</family></value><semanticsText>Legal
+        Name</semanticsText></livingSubjectName></parameterList></queryByParameter></controlActProcess></idm:PRPA_IN201306UV02></env:Body></env:Envelope>
+    http_version:
+  recorded_at: Fri, 28 Oct 2016 15:32:14 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Ticket: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9164

This PR adds support for retrieving the Vet360 id from MVI, similar to how we parse other correlation id's. The `vet360_id` is then exposed in the MVI facade model and delegated to by the user model. 

This will allow us to look up users in Vet360 under the following conditions:
1) User is logged in and loa3 `AND`
2) User exists in MVI `AND`
3) User has a correlated Vet360 id in MVI

Our next steps will be to find staging MVI users with real Vet360 id's and record them for betamocks usage. This work is part of https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9653