### PR TITLE
9584 get full name endpoint

### DIFF
--- a/app/controllers/v0/profile/full_names_controller.rb
+++ b/app/controllers/v0/profile/full_names_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module V0
+  module Profile
+    class FullNamesController < ApplicationController
+      before_action { authorize :mvi, :queryable? }
+
+      # Fetches the full name details for the current user.
+      # Namely their first/middle/last name, and suffix.
+      #
+      # @return [Response] Sample response.body:
+      #   {
+      #     "data" => {
+      #       "id"         => "",
+      #       "type"       => "hashes",
+      #       "attributes" => {
+      #         "first"  => "Jack",
+      #         "middle" => "Robert",
+      #         "last"   => "Smith",
+      #         "suffix" => "Jr."
+      #       }
+      #     }
+      #   }
+      #
+      def show
+        render(
+          json: @current_user.full_name_normalized,
+          serializer: FullNameSerializer
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/v0/profile/full_names_controller.rb
+++ b/app/controllers/v0/profile/full_names_controller.rb
@@ -3,8 +3,6 @@
 module V0
   module Profile
     class FullNamesController < ApplicationController
-      before_action { authorize :mvi, :queryable? }
-
       # Fetches the full name details for the current user.
       # Namely their first/middle/last name, and suffix.
       #

--- a/app/serializers/full_name_serializer.rb
+++ b/app/serializers/full_name_serializer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class FullNameSerializer < ActiveModel::Serializer
+  attribute :first
+  attribute :middle
+  attribute :last
+  attribute :suffix
+
+  def id
+    nil
+  end
+
+  def first
+    object[:first]
+  end
+
+  def middle
+    object[:middle]
+  end
+
+  def last
+    object[:last]
+  end
+
+  def suffix
+    object[:suffix]
+  end
+end

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -109,6 +109,37 @@ module Swagger
         end
       end
 
+      swagger_path '/v0/profile/full_name' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Gets a users full name with suffix'
+          key :operationId, 'getFullName'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :required, [:data]
+
+              property :data, type: :object do
+                key :required, [:attributes]
+                property :attributes, type: :object do
+                  property :first, type: :string, example: 'Jack'
+                  property :middle, type: :string, example: 'Robert'
+                  property :last, type: :string, example: 'Smith'
+                  property :suffix, type: :string, example: 'Jr.'
+                end
+              end
+            end
+          end
+        end
+      end
+
       swagger_path '/v0/profile/personal_information' do
         operation :get do
           extend Swagger::Responses::AuthenticationError

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,6 +165,7 @@ Rails.application.routes.draw do
     namespace :profile do
       resource :alternate_phone, only: %i[show create]
       resource :email, only: %i[show create]
+      resource :full_name, only: :show
       resource :personal_information, only: :show
       resource :primary_phone, only: %i[show create]
       resource :service_history, only: :show

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -70,6 +70,26 @@ FactoryBot.define do
       end
     end
 
+    factory :user_with_suffix, traits: [:loa3] do
+      first_name('Jack')
+      middle_name('Robert')
+      last_name('Smith')
+      last_signed_in(Time.zone.parse('2017-12-07T00:55:09Z'))
+      ssn('796043735')
+
+      after(:build) do
+        stub_mvi(
+          build(
+            :mvi_profile_response,
+            edipi: '1007697216',
+            birls_id: '796043735',
+            participant_id: '600061742',
+            birth_date: '1986-05-06T00:00:00+00:00'.to_date.to_s
+          )
+        )
+      end
+    end
+
     trait :mhv_sign_in do
       email 'abraham.lincoln@vets.gov'
       first_name nil

--- a/spec/request/full_name_request_spec.rb
+++ b/spec/request/full_name_request_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'full_name', type: :request do
+  include SchemaMatchers
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user_with_suffix, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  describe 'GET /v0/profile/full_name' do
+    context 'with a 200 response' do
+      it 'should match the full name schema' do
+        get '/v0/profile/full_name', nil, auth_header
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to match_response_schema('full_name_response')
+      end
+    end
+  end
+end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1154,6 +1154,16 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           )
         end
       end
+
+      it 'supports getting full name data' do
+        expect(subject).to validate(:get, '/v0/profile/full_name', 401)
+
+        user = build(:user_with_suffix, :loa3)
+        Session.create(uuid: user.uuid, token: token)
+        User.create(user)
+
+        expect(subject).to validate(:get, '/v0/profile/full_name', 200, auth_options)
+      end
     end
   end
 

--- a/spec/support/schemas/full_name_response.json
+++ b/spec/support/schemas/full_name_response.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "middle": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "suffix": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## Background

The new profile form needs a direct endpoint to consume a user's full name information.  

## Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9584

## Screenshot

**Swagger Docs | Requests**

![image](https://user-images.githubusercontent.com/7482329/38313366-1bab98a2-37e1-11e8-9608-12c3c2851ac9.png)

## Definition of done
- [x] new `v0/profile/full_name` `GET` endpoint
- [x] associated specs
- [x] Yard docs
- [x] Swagger docs
- [x] Sign off by the frontend