### PR TITLE
Pass the exclude sidekiq flag to the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM centos:6
 
 ARG sidekiq_license
 ENV BUNDLE_ENTERPRISE__CONTRIBSYS__COM=$sidekiq_license
+ARG exclude_sidekiq_ent
+ENV EXCLUDE_SIDEKIQ_ENTERPRISE=$exclude_sidekiq_ent
 
 # Match the jenkins uid/gid on the host (504)
 RUN groupadd -r vets-api && \

--- a/Gemfile
+++ b/Gemfile
@@ -128,7 +128,7 @@ end
 group :production do
   # sidekiq enterprise requires a license key to download but is only required in production.
   # for local dev environments, regular sidekiq works fine
-  unless ENV['EXCLUDE_SIDEKIQ_ENTERPRISE']
+  unless ENV['EXCLUDE_SIDEKIQ_ENTERPRISE'] == 'true'
     source 'https://enterprise.contribsys.com/' do
       gem 'sidekiq-ent'
       gem 'sidekiq-pro'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     build:
       context: .
       args:
+        exclude_sidekiq_ent: "${EXCLUDE_SIDEKIQ_ENTERPRISE:-false}"
         sidekiq_license: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
     image: "vets-api:${BUILD_TAG:-latest}"
     volumes:


### PR DESCRIPTION
Lets sidekiq enterprise be excluded from the bundle in a Docker container with an argument. This changes behaviour so `EXCLUDE_SIDEKIQ_ENTERPRISE` must be set to `true` instead of just being set generally.