### PR TITLE
Delete unnecessary migration

### DIFF
--- a/app/workers/sentry_job.rb
+++ b/app/workers/sentry_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SentryJob
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'tasker'
+
+  def perform(event)
+    Raven.send_event(event)
+  end
+end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -9,4 +9,7 @@ Raven.configure do |config|
   config.processors << Sentry::Processor::PIISanitizer
 
   config.excluded_exceptions += ['Sentry::IgnoredError']
+  config.async = lambda { |event|
+    SentryJob.perform_async(event)
+  }
 end

--- a/db/migrate/20171017181144_persistent_attachments_name_change.rb
+++ b/db/migrate/20171017181144_persistent_attachments_name_change.rb
@@ -1,5 +1,0 @@
-class PersistentAttachmentsNameChange < ActiveRecord::Migration
-  def change
-    DataMigrations::PersistentAttachment.run
-  end
-end

--- a/spec/jobs/sentry_job_spec.rb
+++ b/spec/jobs/sentry_job_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SentryJob do
+  describe '#perform' do
+    it 'should call Raven.send_event' do
+      expect(Raven).to receive(:send_event)
+      SentryJob.new.perform('my' => 'event')
+    end
+  end
+end


### PR DESCRIPTION
This migration references `DataMigrations::PersistentAttachment`, which was deleted in [this commit](https://github.com/department-of-veterans-affairs/vets-api/commit/e1c09345d42765479687)


