### PR TITLE
strip chars from branch name that are invalid for docker name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,8 @@
 pipeline {
+  environment {
+    DOCKER_IMAGE = env.BUILD_TAG.replaceAll(/[%\/]/, '')
+  }
+
   options {
     buildDiscarder(logRotator(daysToKeepStr: '60'))
   }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,7 +12,7 @@ services:
       context: .
       args:
         sidekiq_license: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
-    image: "vets-api:${BUILD_TAG:-latest}"
+    image: "vets-api:${DOCKER_IMAGE:-latest}"
     volumes:
       - ".:/src/vets-api"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       args:
         exclude_sidekiq_ent: "${EXCLUDE_SIDEKIQ_ENTERPRISE:-false}"
         sidekiq_license: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
-    image: "vets-api:${BUILD_TAG:-latest}"
+    image: "vets-api:${DOCKER_IMAGE:-latest}"
     volumes:
       - ".:/src/vets-api"
       - "../vets-api-mockdata:/cache"


### PR DESCRIPTION
Builds of branches with a slash in the name were failing in Jenkins because Docker Compose was trying to use the BUILD_TAG (which would escape the slashes) in the image name which was invalid. This adds a more direct `DOCKER_IMAGE` env var, with those characters stripped. It's not terribly defensive, I'm not sure if there's a valid reason to be more defensive here than this approach.