### PR TITLE
GET Vet360 Telephone transaction status

### DIFF
--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -69,11 +69,11 @@ module Vet360
 
       private
 
-      def get_transaction_status(route, klass)
+      def get_transaction_status(route, response_class)
         with_monitoring do
           raw_response = perform(:get, route)
 
-          klass.new(raw_response.status, raw_response)
+          response_class.new(raw_response.status, raw_response)
         end
       rescue StandardError => e
         handle_error(e)

--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -52,7 +52,7 @@ module Vet360
       end
 
       # GET's the status of a transaction id from the Vet360 api
-      # @params transaction [Vet360::Models::Transaction] the transaction check
+      # @params transaction [Vet360::Models::Transaction] the transaction to check
       # @returns [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
       def get_email_transaction_status(transaction)
         route = "#{@user.vet360_id}/emails/status/#{transaction.id}"

--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -17,7 +17,7 @@ module Vet360
           # TODO: guard clause in case there is no vet360_id
           raw_response = perform(:get, @user.vet360_id)
 
-          Vet360::ContactInformation::PersonResponse.new(raw_response.status, raw_response)
+          PersonResponse.new(raw_response.status, raw_response)
         end
       rescue StandardError => e
         handle_error(e)
@@ -61,10 +61,10 @@ module Vet360
 
       # GET's the status of a transaction id from the Vet360 api
       # @params transaction [Vet360::Models::Transaction] the transaction to check
-      # @returns [Vet360::ContactInformation::AddressTransactionResponse] response wrapper around a transaction object
-      def get_address_transaction_status(transaction)
-        route = "#{@user.vet360_id}/addresses/status/#{transaction.id}"
-        get_transaction_status(route, AddressTransactionResponse)
+      # @returns [Vet360::ContactInformation::TelephoneTransactionResponse] response wrapper around a transaction object
+      def get_telephone_transaction_status(transaction)
+        route = "#{@user.vet360_id}/telephones/status/#{transaction.id}"
+        get_transaction_status(route, TelephoneTransactionResponse)
       end
 
       private
@@ -82,7 +82,7 @@ module Vet360
       def post_or_put_email(method, email)
         with_monitoring do
           raw = perform(method, 'emails', email.in_json)
-          Vet360::ContactInformation::EmailTransactionResponse.new(raw.status, raw)
+          EmailTransactionResponse.new(raw.status, raw)
         end
       rescue StandardError => e
         handle_error(e)
@@ -91,7 +91,7 @@ module Vet360
       def post_or_put_address(method, address)
         with_monitoring do
           raw = perform(method, 'addresses', address.in_json)
-          Vet360::ContactInformation::AddressTransactionResponse.new(raw.status, raw)
+          AddressTransactionResponse.new(raw.status, raw)
         end
       rescue StandardError => e
         handle_error(e)

--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -37,20 +37,6 @@ module Vet360
         post_or_put_email(:put, email)
       end
 
-      # GET's the status of a transaction id from the Vet360 api
-      # @params address [Vet360::Models::Transaction] the email to update
-      # @returns [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
-      def get_email_transaction_status(transaction)
-        with_monitoring do
-          route = "#{@user.vet360_id}/emails/status/#{transaction.id}"
-          raw_response = perform(:get, route)
-
-          Vet360::ContactInformation::EmailTransactionResponse.new(raw_response.status, raw_response)
-        end
-      rescue StandardError => e
-        handle_error(e)
-      end
-
       # POSTs a new address to the vet360 API
       # @params address [Vet360::Models::Address] the address to send
       # @returns [Vet360::ContactInformation::AddressTransactionResponse] response wrapper around an transaction object
@@ -65,7 +51,33 @@ module Vet360
         post_or_put_address(:put, address)
       end
 
+      # GET's the status of a transaction id from the Vet360 api
+      # @params transaction [Vet360::Models::Transaction] the transaction check
+      # @returns [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
+      def get_email_transaction_status(transaction)
+        route = "#{@user.vet360_id}/emails/status/#{transaction.id}"
+        get_transaction_status(route, EmailTransactionResponse)
+      end
+
+      # GET's the status of a transaction id from the Vet360 api
+      # @params transaction [Vet360::Models::Transaction] the transaction to check
+      # @returns [Vet360::ContactInformation::AddressTransactionResponse] response wrapper around a transaction object
+      def get_address_transaction_status(transaction)
+        route = "#{@user.vet360_id}/addresses/status/#{transaction.id}"
+        get_transaction_status(route, AddressTransactionResponse)
+      end
+
       private
+
+      def get_transaction_status(route, klass)
+        with_monitoring do
+          raw_response = perform(:get, route)
+
+          klass.new(raw_response.status, raw_response)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
 
       def post_or_put_email(method, email)
         with_monitoring do

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -28,7 +28,6 @@ describe Vet360::ContactInformation::Service do
             expect(e).to be_a(Common::Exceptions::BackendServiceException)
             expect(e.status_code).to eq(404)
             expect(e.errors.first.code).to eq('VET360_CORE103')
-            expect(e.errors.first.title).to eq('Not Found')
           end
         end
       end
@@ -57,7 +56,6 @@ describe Vet360::ContactInformation::Service do
             expect(e).to be_a(Common::Exceptions::BackendServiceException)
             expect(e.status_code).to eq(400)
             expect(e.errors.first.code).to eq('VET360_EMAIL301')
-            expect(e.errors.first.title).to eq('Email Address Already Exists')
           end
         end
       end
@@ -114,7 +112,6 @@ describe Vet360::ContactInformation::Service do
             expect(e).to be_a(Common::Exceptions::BackendServiceException)
             expect(e.status_code).to eq(404)
             expect(e.errors.first.code).to eq('VET360_CORE103')
-            expect(e.errors.first.title).to eq('Not Found')
           end
         end
       end
@@ -142,7 +139,6 @@ describe Vet360::ContactInformation::Service do
             expect(e).to be_a(Common::Exceptions::BackendServiceException)
             expect(e.status_code).to eq(404)
             expect(e.errors.first.code).to eq('VET360_CORE103')
-            expect(e.errors.first.title).to eq('Not Found')
           end
         end
       end

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -93,6 +93,34 @@ describe Vet360::ContactInformation::Service do
     end
   end
 
+  describe '#get_telephone_transaction_status' do
+    let(:transaction_id) { 'd47b3d96-9ddd-42be-ac57-8e564aa38029' }
+    let(:transaction) { Vet360::Models::Transaction.new(id: transaction_id) }
+
+    context 'when successful' do
+      it 'returns a status of 200' do
+        VCR.use_cassette('vet360/contact_information/telephone_transaction_status', VCR::MATCH_EVERYTHING) do
+          response = subject.get_telephone_transaction_status(transaction)
+          expect(response).to be_ok
+          expect(response.transaction).to be_a(Vet360::Models::Transaction)
+        end
+      end
+    end
+
+    context 'when not successful' do
+      it 'returns a status of 404' do
+        VCR.use_cassette('vet360/contact_information/telephone_transaction_status_error', VCR::MATCH_EVERYTHING) do
+          expect { subject.get_telephone_transaction_status(transaction) }.to raise_error do |e|
+            expect(e).to be_a(Common::Exceptions::BackendServiceException)
+            expect(e.status_code).to eq(404)
+            expect(e.errors.first.code).to eq('VET360_CORE103')
+            expect(e.errors.first.title).to eq('Not Found')
+          end
+        end
+      end
+    end
+  end
+
   describe '#get_email_transaction_status' do
     let(:transaction_id) { 'd47b3d96-9ddd-42be-ac57-8e564aa38029' }
     let(:transaction) { Vet360::Models::Transaction.new(id: transaction_id) }

--- a/spec/support/vcr_cassettes/vet360/contact_information/telephone_transaction_status.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/telephone_transaction_status.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/1/emails/status/d47b3d96-9ddd-42be-ac57-8e564aa38029
+    uri: https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/1/telephones/status/d47b3d96-9ddd-42be-ac57-8e564aa38029
     body:
       encoding: US-ASCII
       string: ''
@@ -19,8 +19,8 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
     headers:
       X-Application-Context:
       - edge-gateway:ENV-INT-DEV:8766
@@ -50,16 +50,16 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "messages": [
-            {
-              "code": "CORE103",
-              "key": "_CUF_NOT_FOUND",
-              "severity": "ERROR",
-              "text": ""
-            }
-          ],
+          "messages": [],
+          "status": "COMPLETED_SUCCESS",
           "txAuditId": "d47b3d96-9ddd-42be-ac57-8e564aa38029",
-          "status": "REJECTED"
+          "txInteractionType": "string",
+          "txMessages": [],
+          "txOutput": [],
+          "txPullInput": "string",
+          "txPushInput": {},
+          "txStatus": "COMPLETED_SUCCESS",
+          "txType": "string"
         }
     http_version:
   recorded_at: Thu, 22 Feb 2018 23:58:38 GMT

--- a/spec/support/vcr_cassettes/vet360/contact_information/telephone_transaction_status_error.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/telephone_transaction_status_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/1/emails/status/d47b3d96-9ddd-42be-ac57-8e564aa38029
+    uri: https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/1/telephones/status/d47b3d96-9ddd-42be-ac57-8e564aa38029
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Adds support for the GET Telephone transaction status call to the Vet360 service. This will allow us to retrieve the status of updates to veteran email addresses. This also adds some refactoring to add a helper method for calling transaction status endpoints.

* Adds `get_telephone_transaction_status` call
* Adds cassettes for successful and 404 cases
* No new error codes added (already covered by existing list)
* YARD Docs updated

Closes department-of-veterans-affairs/vets.gov-team#9710