### PR TITLE
GET Vet360 Address transaction status

### DIFF
--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -30,11 +30,19 @@ module Vet360
         post_or_put_data(:post, address, 'addresses', AddressTransactionResponse)
       end
 
-      # PUTs a new address to the vet360 API
+      # PUTs an updated address to the vet360 API
       # @params address [Vet360::Models::Address] the address to update
       # @returns [Vet360::ContactInformation::AddressTransactionResponse] response wrapper around a transaction object
       def put_address(address)
         post_or_put_data(:put, address, 'addresses', AddressTransactionResponse)
+      end
+
+      # GET's the status of an address transaction from the Vet360 api
+      # @params transaction [Vet360::Models::Transaction] the transaction to check
+      # @returns [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
+      def get_address_transaction_status(transaction)
+        route = "#{@user.vet360_id}/addresses/status/#{transaction.id}"
+        get_transaction_status(route, AddressTransactionResponse)
       end
 
       # POSTs a new address to the vet360 API
@@ -44,14 +52,14 @@ module Vet360
         post_or_put_data(:post, email, 'emails', EmailTransactionResponse)
       end
 
-      # PUTs a new address to the vet360 API
+      # PUTs an updated address to the vet360 API
       # @params email [Vet360::Models::Email] the email to update
       # @returns [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
       def put_email(email)
         post_or_put_data(:put, email, 'emails', EmailTransactionResponse)
       end
 
-      # GET's the status of a transaction id from the Vet360 api
+      # GET's the status of an email transaction from the Vet360 api
       # @params transaction [Vet360::Models::Transaction] the transaction to check
       # @returns [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
       def get_email_transaction_status(transaction)
@@ -61,19 +69,19 @@ module Vet360
 
       # POSTs a new telephone to the vet360 API
       # @params telephone [Vet360::Models::Telephone] the telephone to send
-      # @returns [Vet360::ContactInformation::TelephoneUpdateResponse] response wrapper around an transaction object
+      # @returns [Vet360::ContactInformation::TelephoneUpdateResponse] response wrapper around a transaction object
       def post_telephone(telephone)
         post_or_put_data(:post, telephone, 'telephones', TelephoneTransactionResponse)
       end
 
-      # PUTs a new telephone to the vet360 API
+      # PUTs an updated telephone to the vet360 API
       # @params telephone [Vet360::Models::Telephone] the telephone to update
       # @returns [Vet360::ContactInformation::TelephoneUpdateResponse] response wrapper around a transaction object
       def put_telephone(telephone)
         post_or_put_data(:put, telephone, 'telephones', TelephoneTransactionResponse)
       end
 
-      # GET's the status of a transaction id from the Vet360 api
+      # GET's the status of a telephone transaction from the Vet360 api
       # @params transaction [Vet360::Models::Transaction] the transaction to check
       # @returns [Vet360::ContactInformation::TelephoneTransactionResponse] response wrapper around a transaction object
       def get_telephone_transaction_status(transaction)

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -101,6 +101,7 @@ describe Vet360::ContactInformation::Service do
           response = subject.get_telephone_transaction_status(transaction)
           expect(response).to be_ok
           expect(response.transaction).to be_a(Vet360::Models::Transaction)
+          expect(response.transaction.id).to eq(transaction_id)
         end
       end
     end
@@ -128,6 +129,7 @@ describe Vet360::ContactInformation::Service do
           response = subject.get_email_transaction_status(transaction)
           expect(response).to be_ok
           expect(response.transaction).to be_a(Vet360::Models::Transaction)
+          expect(response.transaction.id).to eq(transaction_id)
         end
       end
     end

--- a/spec/support/vcr_cassettes/vet360/contact_information/address_transaction_status.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/address_transaction_status.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/1/addresses/status/d47b3d96-9ddd-42be-ac57-8e564aa38029
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Cufsystemname:
+      - VETSGOV
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Application-Context:
+      - edge-gateway:ENV-INT-DEV:8766
+      Date:
+      - Fri, 13 Apr 2018 21:07:24 GMT
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Ua-Compatible:
+      - IE-edge,chrome=1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [],
+          "status": "COMPLETED_SUCCESS",
+          "txAuditId": "d47b3d96-9ddd-42be-ac57-8e564aa38029",
+          "txInteractionType": "string",
+          "txMessages": [],
+          "txOutput": [],
+          "txPullInput": "string",
+          "txPushInput": {},
+          "txStatus": "COMPLETED_SUCCESS",
+          "txType": "string"
+        }
+    http_version:
+  recorded_at: Thu, 22 Feb 2018 23:58:38 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/vet360/contact_information/address_transaction_status_error.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/address_transaction_status_error.yml
@@ -25,7 +25,7 @@ http_interactions:
       X-Application-Context:
       - edge-gateway:ENV-INT-DEV:8766
       Date:
-      - Fri, 13 Apr 2018 21:07:24 GMT
+      - Mon, 23 Apr 2018 17:35:12 GMT
       Expires:
       - '0'
       X-Content-Type-Options:
@@ -55,12 +55,12 @@ http_interactions:
               "code": "CORE103",
               "key": "_CUF_NOT_FOUND",
               "severity": "ERROR",
-              "text": ""
+              "text": "The tx for id/criteria d47b3d96-9ddd-42be-ac57-8e564aa38029 could not be found. Please correct your request and try again!"
             }
           ],
           "txAuditId": "d47b3d96-9ddd-42be-ac57-8e564aa38029",
-          "status": "REJECTED"
+          "status": "COMPLETED_FAILURE"
         }
     http_version:
-  recorded_at: Thu, 22 Feb 2018 23:58:38 GMT
+  recorded_at: Mon, 23 Apr 2018 17:35:12 GMT
 recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/vet360/contact_information/address_transaction_status_error.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/address_transaction_status_error.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/1/addresses/status/d47b3d96-9ddd-42be-ac57-8e564aa38029
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Cufsystemname:
+      - VETSGOV
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Application-Context:
+      - edge-gateway:ENV-INT-DEV:8766
+      Date:
+      - Fri, 13 Apr 2018 21:07:24 GMT
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Ua-Compatible:
+      - IE-edge,chrome=1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [
+            {
+              "code": "CORE103",
+              "key": "_CUF_NOT_FOUND",
+              "severity": "ERROR",
+              "text": ""
+            }
+          ],
+          "txAuditId": "d47b3d96-9ddd-42be-ac57-8e564aa38029",
+          "status": "REJECTED"
+        }
+    http_version:
+  recorded_at: Thu, 22 Feb 2018 23:58:38 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Adds support for the GET Address transaction status call to the Vet360 service. This will allow us to retrieve the status of updates to veteran addresses.

* Adds `get_address_transaction_status` call
* Adds hand-crafted cassettes for successful and 404 cases
* No new error codes added (already covered by existing list)
* YARD Docs updated

Closes department-of-veterans-affairs/vets.gov-team#9775