### PR TITLE
Fix rake loading in prod; fix upload scan scheduling

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ Dir[Rails.root.join('lib', 'tasks', 'support', '**', '*.rb')].each { |f| require
 
 Rails.application.load_tasks
 
-if !Rails.env.production?
+unless Rails.env.production?
   require 'rspec/core/rake_task'
   task(:spec).clear
   RSpec::Core::RakeTask.new(:spec) do |t|

--- a/Rakefile
+++ b/Rakefile
@@ -4,15 +4,17 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
-require 'rspec/core/rake_task'
 
 # Load rake support files
 Dir[Rails.root.join('lib', 'tasks', 'support', '**', '*.rb')].each { |f| require f }
 
 Rails.application.load_tasks
 
-task(:spec).clear
-RSpec::Core::RakeTask.new(:spec) do |t|
-  t.pattern = Dir.glob(['spec/**/*_spec.rb', 'modules/vba_documents/spec/**/*_spec.rb'])
-  t.verbose = false
+if !Rails.env.production?
+  require 'rspec/core/rake_task'
+  task(:spec).clear
+  RSpec::Core::RakeTask.new(:spec) do |t|
+    t.pattern = Dir.glob(['spec/**/*_spec.rb', 'modules/vba_documents/spec/**/*_spec.rb'])
+    t.verbose = false
+  end
 end

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -83,6 +83,6 @@ MaintenanceWindowRefresh:
   description: "Poll PagerDuty API for maintenance window information"
 
 VBADocuments::UploadScanner:
-  cron: "*/30 * * * * * America/New_York"
+  cron: "0,30 * * * * * America/New_York"
   class: VBADocuments::UploadScanner
   description: "Poll upload bucket for unprocessed uploads"


### PR DESCRIPTION
The Rakefile fix is awkward - need to revisit that - but otherwise it prevented db:migrate from working when RAILS_ENV=prod.

We will eventually get rid of the need to redefine this spec task redefinition but for now it's necessary to get spec + coverage working with the additional rails engine in place. 

The scheduler change seems to avoid double-scheduling in local testing. Sidekiq unique jobs might be worthwhile, but I might instead spend that time working on the SNS alternative to this scanner job. I did observe the potential for multiple jobs to schedule on cold-startup of sidekiq locally, but that shouldn't be an issue in AWS envs.