### PR TITLE
rake task for deletion of legacy Pension and Burial Claim database records.

### DIFF
--- a/rakelib/pension_burial.rake
+++ b/rakelib/pension_burial.rake
@@ -23,6 +23,7 @@ namespace :pension_burial do
 
   desc 'Delete old claims'
   task delete_pre_central_mail: :environment do
+    Rails.application.eager_load!
     scs = SavedClaim.where(type: ['SavedClaim::Burial', 'SavedClaim::Pension']).where(
       'created_at < ?', Date.parse('2018-04-01')
     )
@@ -32,6 +33,5 @@ namespace :pension_burial do
     end
 
     scs.delete_all
-
   end
 end

--- a/rakelib/pension_burial.rake
+++ b/rakelib/pension_burial.rake
@@ -23,8 +23,15 @@ namespace :pension_burial do
 
   desc 'Delete old claims'
   task delete_pre_central_mail: :environment do
-    SavedClaim.where(type: ['SavedClaim::Burial', 'SavedClaim::Pension']).where(
+    scs = SavedClaim.where(type: ['SavedClaim::Burial', 'SavedClaim::Pension']).where(
       'created_at < ?', Date.parse('2018-04-01')
-    ).destroy_all
+    )
+
+    scs.find_each do |sc|
+      sc.persistent_attachments.delete_all
+    end
+
+    scs.delete_all
+    
   end
 end

--- a/rakelib/pension_burial.rake
+++ b/rakelib/pension_burial.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 namespace :pension_burial do
   desc 'retry failed pension burial jobs'
   task retry_jobs: :environment do
@@ -22,8 +23,8 @@ namespace :pension_burial do
 
   desc 'Delete old claims'
   task delete_pre_central_mail: :environment do
-    SavedClaim.where(type: ["SavedClaim::Burial", "SavedClaim::Pension"]).where(
-      'created_at < ?', Date.parse("2018-04-01")
+    SavedClaim.where(type: ['SavedClaim::Burial', 'SavedClaim::Pension']).where(
+      'created_at < ?', Date.parse('2018-04-01')
     ).destroy_all
   end
 end

--- a/rakelib/pension_burial.rake
+++ b/rakelib/pension_burial.rake
@@ -32,6 +32,6 @@ namespace :pension_burial do
     end
 
     scs.delete_all
-    
+
   end
 end

--- a/rakelib/pension_burial.rake
+++ b/rakelib/pension_burial.rake
@@ -1,21 +1,29 @@
 # frozen_string_literal: true
+namespace :pension_burial do
+  desc 'retry failed pension burial jobs'
+  task retry_jobs: :environment do
+    # JIDS up to date as of Dec 4, 2017 2:40:39 PM UTC
+    # TODO: might need to run this again if all these jobs haven't failed yet
+    JIDS = %w[bb2894d2445beeaaf8c0e28d fe0a9e359d0f61b0766c7ef4 b893a455044bfc5b46dae93e].freeze
+    Rails.application.eager_load!
 
-desc 'retry failed pension burial jobs'
-task pension_burial_retry_jobs: :environment do
-  # JIDS up to date as of Dec 4, 2017 2:40:39 PM UTC
-  # TODO: might need to run this again if all these jobs haven't failed yet
-  JIDS = %w[bb2894d2445beeaaf8c0e28d fe0a9e359d0f61b0766c7ef4 b893a455044bfc5b46dae93e].freeze
-  Rails.application.eager_load!
+    Sidekiq::DeadSet.new.each do |job|
+      jid = job.jid
 
-  Sidekiq::DeadSet.new.each do |job|
-    jid = job.jid
-
-    if JIDS.include?(jid)
-      guid = job.args[1]['internal']['history'][0]['user_args']['guid']
-      persistent_attachment = PersistentAttachment.find_by(guid: guid)
-      raise if persistent_attachment.completed_at.present?
-      persistent_attachment.process
-      puts "#{jid} rerun"
+      if JIDS.include?(jid)
+        guid = job.args[1]['internal']['history'][0]['user_args']['guid']
+        persistent_attachment = PersistentAttachment.find_by(guid: guid)
+        raise if persistent_attachment.completed_at.present?
+        persistent_attachment.process
+        puts "#{jid} rerun"
+      end
     end
+  end
+
+  desc 'Delete old claims'
+  task delete_pre_central_mail: :environment do
+    SavedClaim.where(type: ["SavedClaim::Burial", "SavedClaim::Pension"]).where(
+      'created_at < ?', Date.parse("2018-04-01")
+    ).destroy_all
   end
 end

--- a/spec/models/saved_claims/pension_spec.rb
+++ b/spec/models/saved_claims/pension_spec.rb
@@ -8,13 +8,15 @@ RSpec.describe SavedClaim::Pension, uploader_helpers: true do
   let(:instance) { FactoryBot.build(:pension_claim) }
 
   it_should_behave_like 'saved_claim_with_confirmation_number'
-  
-  context 'saved claims w/ attachments' do
-      stub_virus_scan
-      let!(:attachment1) { FactoryBot.create(:pension_burial, saved_claim_id: nil) }
-      let!(:attachment2) { FactoryBot.create(:pension_burial, saved_claim_id: nil) }
 
-      let(:claim) { FactoryBot.create(
+  context 'saved claims w/ attachments' do
+    stub_virus_scan
+
+    let!(:attachment1) { FactoryBot.create(:pension_burial, saved_claim_id: nil) }
+    let!(:attachment2) { FactoryBot.create(:pension_burial, saved_claim_id: nil) }
+
+    let(:claim) do
+      FactoryBot.create(
         :pension_claim,
         form: {
           privacyAgreementAccepted: true,
@@ -42,7 +44,8 @@ RSpec.describe SavedClaim::Pension, uploader_helpers: true do
             city: 'Anytown'
           }
         }.to_json
-      )}
+      )
+    end
 
     describe '#process_attachments!' do
       it 'should set the attachments saved_claim_id' do


### PR DESCRIPTION
add rake task for one-time deletion of legacy Pension and Burial Claim database records.

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/10081