### PR TITLE
bug/pciu-service-no-method-error

### DIFF
--- a/lib/common/client/base.rb
+++ b/lib/common/client/base.rb
@@ -47,6 +47,7 @@ module Common
 
       def request(method, path, params = {}, headers = {})
         sanitize_headers!(headers)
+        sanitize_headers!(headers) if Settings.vet360.contact_information.enabled
         raise_not_authenticated if headers.keys.include?('Token') && headers['Token'].nil?
         connection.send(method.to_sym, path, params) { |request| request.headers.update(headers) }.env
       rescue Timeout::Error, Faraday::TimeoutError

--- a/lib/common/client/base.rb
+++ b/lib/common/client/base.rb
@@ -45,11 +45,12 @@ module Common
         send(method, path, params || {}, headers || {})
       end
 
+      # rubocop:disable Metrics/MethodLength
       def request(method, path, params = {}, headers = {})
         log_message_to_sentry(
           'nil headers bug',
           :info,
-          headers: headers, method: method, path: path, params: params, client: self.inspect,
+          headers: headers, method: method, path: path, params: params, client: inspect,
           profile: 'pciu_profile'
         )
         sanitize_headers!(headers) if Settings.vet360.contact_information.enabled
@@ -74,6 +75,7 @@ module Common
         client_error = error_class.new(e.message, response_hash&.dig(:status), response_hash&.dig(:body))
         raise client_error
       end
+      # rubocop:enable Metrics/MethodLength
 
       def sanitize_headers!(headers)
         headers.transform_keys!(&:to_s)

--- a/lib/common/client/base.rb
+++ b/lib/common/client/base.rb
@@ -46,8 +46,14 @@ module Common
       end
 
       def request(method, path, params = {}, headers = {})
-        sanitize_headers!(headers)
+        log_message_to_sentry(
+          'nil headers bug',
+          :info,
+          headers: headers, method: method, path: path, params: params, client: self.inspect,
+          profile: 'pciu_profile'
+        )
         sanitize_headers!(headers) if Settings.vet360.contact_information.enabled
+
         raise_not_authenticated if headers.keys.include?('Token') && headers['Token'].nil?
         connection.send(method.to_sym, path, params) { |request| request.headers.update(headers) }.env
       rescue Timeout::Error, Faraday::TimeoutError

--- a/lib/sentry/processor/pii_sanitizer.rb
+++ b/lib/sentry/processor/pii_sanitizer.rb
@@ -4,7 +4,7 @@ module Sentry
   module Processor
     class PIISanitizer < Raven::Processor
       SANITIZED_FIELDS = Set.new(
-        %w[city country gender phone postalCode zipCode fileNumber state street]
+        %w[city country gender phone postalCode zipCode fileNumber state street vaEauthPnid vaEauthBirthdate]
       )
 
       JSON_STARTS_WITH = ['[', '{'].freeze

--- a/spec/lib/common/client/base_spec.rb
+++ b/spec/lib/common/client/base_spec.rb
@@ -20,4 +20,36 @@ describe Common::Client::Base do
       expect { TestService2.new.send(:request, :get, '', nil) }.to raise_error(Common::Client::SecurityError)
     end
   end
+
+  describe '#sanitize_headers!' do
+    context 'where headers have symbol hash keys' do
+      it 'should permanently set any nil values to an empty string' do
+        symbolized_hash = { foo: nil, bar: 'baz' }
+
+        TestService2.new.send('sanitize_headers!', symbolized_hash)
+
+        expect(symbolized_hash).to eq({'foo' => '', 'bar' => 'baz'})
+      end
+    end
+
+    context 'where headers have string hash keys' do
+      it 'should permanently set any nil values to an empty string' do
+        string_hash = { 'foo' => nil, 'bar' => 'baz' }
+
+        TestService2.new.send('sanitize_headers!', string_hash)
+
+        expect(string_hash).to eq({'foo' => '', 'bar' => 'baz'})
+      end
+    end
+
+    context 'where header is an empty hash' do
+      it 'should return an empty hash' do
+        empty_hash = {}
+
+        TestService2.new.send('sanitize_headers!', empty_hash)
+
+        expect(empty_hash).to eq({})
+      end
+    end
+  end
 end

--- a/spec/lib/common/client/base_spec.rb
+++ b/spec/lib/common/client/base_spec.rb
@@ -26,7 +26,7 @@ describe Common::Client::Base do
       it 'should permanently set any nil values to an empty string' do
         symbolized_hash = { foo: nil, bar: 'baz' }
 
-        TestService2.new.send('sanitize_headers!', symbolized_hash)
+        TestService2.new.send('sanitize_headers!', :request, :get, '', symbolized_hash)
 
         expect(symbolized_hash).to eq('foo' => '', 'bar' => 'baz')
       end
@@ -36,7 +36,7 @@ describe Common::Client::Base do
       it 'should permanently set any nil values to an empty string' do
         string_hash = { 'foo' => nil, 'bar' => 'baz' }
 
-        TestService2.new.send('sanitize_headers!', string_hash)
+        TestService2.new.send('sanitize_headers!', :request, :get, '', string_hash)
 
         expect(string_hash).to eq('foo' => '', 'bar' => 'baz')
       end
@@ -46,7 +46,7 @@ describe Common::Client::Base do
       it 'should return an empty hash' do
         empty_hash = {}
 
-        TestService2.new.send('sanitize_headers!', empty_hash)
+        TestService2.new.send('sanitize_headers!', :request, :get, '', empty_hash)
 
         expect(empty_hash).to eq({})
       end

--- a/spec/lib/common/client/base_spec.rb
+++ b/spec/lib/common/client/base_spec.rb
@@ -28,7 +28,7 @@ describe Common::Client::Base do
 
         TestService2.new.send('sanitize_headers!', symbolized_hash)
 
-        expect(symbolized_hash).to eq({'foo' => '', 'bar' => 'baz'})
+        expect(symbolized_hash).to eq('foo' => '', 'bar' => 'baz')
       end
     end
 
@@ -38,7 +38,7 @@ describe Common::Client::Base do
 
         TestService2.new.send('sanitize_headers!', string_hash)
 
-        expect(string_hash).to eq({'foo' => '', 'bar' => 'baz'})
+        expect(string_hash).to eq('foo' => '', 'bar' => 'baz')
       end
     end
 

--- a/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
+++ b/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Sentry::Processor::PIISanitizer do
         json: '{"phone": "5035551234", "postalCode": 97850}',
         array_of_json: ['{"phone": "5035551234", "postalCode": 97850}'],
         gender: 'M',
-        phone: '5035551234'
+        phone: '5035551234',
+        va_eauth_birthdate: '1945-02-13T00:00:00+00:00',
+        va_eauth_pnid: '796375555'
       }
     end
 
@@ -53,6 +55,14 @@ RSpec.describe Sentry::Processor::PIISanitizer do
     it 'should filter arrays' do
       expect(result[:array_of_json].first).to include('FILTERED')
     end
+
+    it 'should filter EVSS va_eauth_birthdate data' do
+      expect(result[:va_eauth_birthdate]).to eq('FILTERED')
+    end
+
+    it 'should filter EVSS va_eauth_pnid data' do
+      expect(result[:va_eauth_pnid]).to eq('FILTERED')
+    end
   end
 
   context 'with string keys' do
@@ -68,7 +78,9 @@ RSpec.describe Sentry::Processor::PIISanitizer do
         'json' => '{"gender": "F"}',
         'arrayOfJson' => ['{"phone": "5035551234", "postalCode": 97850}'],
         'gender' => 'F',
-        'phone' => '5415551234'
+        'phone' => '5415551234',
+        'va_eauth_birthdate' => '1945-02-13T00:00:00+00:00',
+        'va_eauth_pnid' => '796375555'
       }
     end
 
@@ -90,6 +102,14 @@ RSpec.describe Sentry::Processor::PIISanitizer do
 
     it 'should filter arrays' do
       expect(result['arrayOfJson'].first).to include('FILTERED')
+    end
+
+    it 'should filter EVSS va_eauth_birthdate data' do
+      expect(result['va_eauth_birthdate']).to eq('FILTERED')
+    end
+
+    it 'should filter EVSS va_eauth_pnid data' do
+      expect(result['va_eauth_pnid']).to eq('FILTERED')
     end
   end
 end


### PR DESCRIPTION
## Background

We started getting these errors in Sentry logging for production two days ago:

```
NoMethodErrorlib/common/client/middleware/request/immutable_headers.rb in call at line 66
```

Coming from this sentry issue:

http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/37304/

Here is an associated issue in the Faraday repo:  

https://github.com/lostisland/faraday/issues/727

As it turns out, under the hood, the file `net/http/header.rb` calls `value = value.strip`.  If `value` is `nil`, this errors with `NoMethodError: undefined method 'strip' for nil:NilClass`.

## Definition of done

- [x] Set any `nil` header values to `''`
- [x] Leave any non-`nil` header values as is
- [x] Leave empty header hashes empty
- [x] Spec coverage
