### PR TITLE
letters config has unique url from evss

### DIFF
--- a/lib/evss/letters/configuration.rb
+++ b/lib/evss/letters/configuration.rb
@@ -6,8 +6,7 @@ module EVSS
       self.read_timeout = Settings.evss.letters.timeout || 55
 
       def base_path
-        base = Settings.evss.letters.url || Settings.evss.url
-        "#{base}/wss-lettergenerator-services-web/rest/letters/v1"
+        "#{Settings.evss.letters.url}/wss-lettergenerator-services-web/rest/letters/v1"
       end
 
       def service_name


### PR DESCRIPTION
Letters will timeout if `Settings.evss.letters.url` is not set for an environment as it will fall back to the setting defined in `config/settings.yml` (and the config's `|| Settings.evss.url` never gets called)