### PR TITLE
nil EVSS headers

### DIFF
--- a/lib/evss/auth_headers.rb
+++ b/lib/evss/auth_headers.rb
@@ -17,10 +17,10 @@ module EVSS
         'va_eauth_firstName' => @user.first_name,
         'va_eauth_lastName' => @user.last_name,
         'va_eauth_issueinstant' => @user.last_signed_in.iso8601,
-        'va_eauth_dodedipnid' => @user.edipi,
+        'va_eauth_dodedipnid' => (@user.edipi || ''),
         'va_eauth_birlsfilenumber' => (@user.birls_id || ''),
         'va_eauth_pid' => @user.participant_id,
-        'va_eauth_pnid' => @user.ssn,
+        'va_eauth_pnid' => (@user.ssn || ''),
         'va_eauth_birthdate' => iso8601_birth_date,
         'va_eauth_authorization' => eauth_json
       }

--- a/lib/evss/auth_headers.rb
+++ b/lib/evss/auth_headers.rb
@@ -7,7 +7,7 @@ module EVSS
     end
 
     def to_h
-      @headers ||= {
+      @headers ||= sanitize(
         'va_eauth_csid' => 'DSLogon',
         # TODO: Change va_eauth_authenticationmethod to vets.gov
         # once the EVSS team is ready for us to use it
@@ -17,16 +17,22 @@ module EVSS
         'va_eauth_firstName' => @user.first_name,
         'va_eauth_lastName' => @user.last_name,
         'va_eauth_issueinstant' => @user.last_signed_in.iso8601,
-        'va_eauth_dodedipnid' => (@user.edipi || ''),
-        'va_eauth_birlsfilenumber' => (@user.birls_id || ''),
+        'va_eauth_dodedipnid' => @user.edipi,
+        'va_eauth_birlsfilenumber' => @user.birls_id,
         'va_eauth_pid' => @user.participant_id,
-        'va_eauth_pnid' => (@user.ssn || ''),
+        'va_eauth_pnid' => @user.ssn,
         'va_eauth_birthdate' => iso8601_birth_date,
         'va_eauth_authorization' => eauth_json
-      }
+      )
     end
 
     private
+
+    def sanitize(headers)
+      headers.transform_values! do |value|
+        value.nil? ? '' : value
+      end
+    end
 
     def eauth_json
       {

--- a/spec/lib/evss/auth_headers_spec.rb
+++ b/spec/lib/evss/auth_headers_spec.rb
@@ -30,4 +30,29 @@ describe EVSS::AuthHeaders do
       expect(subject.to_h['va_eauth_assurancelevel']).to eq '1'
     end
   end
+
+  describe '#to_h' do
+    let(:current_user) { FactoryBot.build(:user, :loa3) }
+
+    before do
+      allow(current_user).to receive(:ssn).and_return(nil)
+      allow(current_user).to receive(:edipi).and_return(nil)
+    end
+
+    let(:headers) { subject.to_h }
+
+    it 'will not return nil header values' do
+      expect(headers.values.include?(nil)).to eq false
+    end
+
+    it 'sets any nil headers values to an empty string', :aggregate_failures do
+      expect(headers['va_eauth_dodedipnid']).to eq ''
+      expect(headers['va_eauth_pnid']).to eq ''
+    end
+
+    it 'does not modify non-nil header values', :aggregate_failures do
+      expect(headers['va_eauth_firstName']).to eq current_user.first_name
+      expect(headers['va_eauth_lastName']).to eq current_user.last_name
+    end
+  end
 end


### PR DESCRIPTION
## Background

I shipped this PR that that sought to fix and report on the `nil` header issue:

https://github.com/department-of-veterans-affairs/vets-api/pull/1894

This PR only applies the fix to dev and staging, not prod.  After testing in staging, here is sample logging when there is a `nil` header present:

http://sentry.vetsgov-internal/vets-gov/platform-api-staging/issues/37624/events/937254/

The salient logging in sentry were these **unmodified headers**:

```ruby
{
  va_eauth_assurancelevel: [Filtered], 
  va_eauth_authenticationmethod: [Filtered], 
  va_eauth_authorization: [Filtered], 
  va_eauth_birlsfilenumber: [Filtered], 
  va_eauth_birthdate: [Filtered], 
  va_eauth_csid: [Filtered], 
  va_eauth_dodedipnid: None, 
  va_eauth_firstName: [Filtered], 
  va_eauth_issueinstant: [Filtered], 
  va_eauth_lastName: [Filtered], 
  va_eauth_pid: None, 
  va_eauth_pnid: [Filtered], 
  va_eauth_pnidtype: [Filtered]
}
```

You'll note `va_eauth_dodedipnid: None` and `va_eauth_pid: None`.  After testing in local dev, there are times when some users will have `nil` values for these two attrs:

- https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/evss/auth_headers.rb#L20
- https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/evss/auth_headers.rb#L23

## Definition of done

- [x] Set the two EVSS `nil` header values to `''`

