### PR TITLE
ignore not found for GIBS

### DIFF
--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -4,6 +4,7 @@ require 'evss/gi_bill_status/gi_bill_status_response'
 
 module V0
   class Post911GIBillStatusesController < ApplicationController
+    include IgnoreNotFound
     include SentryLogging
 
     before_action { authorize :evss, :access? }


### PR DESCRIPTION
This has been a [long-standing entry in `Sentry`](http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/37402/) and doesnt belong there.  For better or worse, I've used this prometheus link to aggregate GIBS stats:

http://prometheus-prod.vetsgov-internal:9090/prometheus/graph?g0.range_input=1h&g0.expr=sum(api_evss_gi_bill_status_total)&g0.tab=1&g1.range_input=1h&g1.expr=sum(api_evss_gi_bill_status_fail)+by+(error)&g1.tab=1

This is related to item # 4 in : https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9997#issuecomment-382917392