### PR TITLE
Vet360 update telephone endpoints

### DIFF
--- a/app/controllers/v0/profile/addresses_controller.rb
+++ b/app/controllers/v0/profile/addresses_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module V0
+  module Profile
+    class AddressesController < ApplicationController
+      before_action { authorize :vet360, :access? }
+
+      def create
+        address = Vet360::Models::Address.with_defaults(@current_user, address_params)
+
+        if address.valid?
+          response    = service.post_address address
+          transaction = AsyncTransaction::Vet360::AddressTransaction.start(@current_user, response)
+
+          render json: transaction, serializer: AsyncTransaction::BaseSerializer
+        else
+          raise Common::Exceptions::ValidationErrors, address
+        end
+      end
+
+      def update
+        address = Vet360::Models::Address.with_defaults(@current_user, address_params)
+
+        if address.valid?
+          response    = service.put_address address
+          transaction = AsyncTransaction::Vet360::AddressTransaction.start @current_user, response
+
+          render json: transaction, serializer: AsyncTransaction::BaseSerializer
+        else
+          raise Common::Exceptions::ValidationErrors, address
+        end
+      end
+
+      private
+
+      def service
+        Vet360::ContactInformation::Service.new @current_user
+      end
+
+      def address_params
+        params.permit(
+          :address_line1,
+          :address_line2,
+          :address_line3,
+          :address_pou,
+          :address_type,
+          :city,
+          :country,
+          :country_code_iso2,
+          :country_code_iso3,
+          :county_code,
+          :county_name,
+          :effective_end_date,
+          :effective_start_date,
+          :id,
+          :international_postal_code,
+          :province,
+          :source_date,
+          :state_abbr,
+          :transaction_id,
+          :vet360_id,
+          :zip_code,
+          :zip_code_suffix
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/v0/profile/addresses_controller.rb
+++ b/app/controllers/v0/profile/addresses_controller.rb
@@ -37,6 +37,7 @@ module V0
         Vet360::ContactInformation::Service.new @current_user
       end
 
+      # rubocop:disable Metrics/MethodLength
       def address_params
         params.permit(
           :address_line1,
@@ -63,6 +64,7 @@ module V0
           :zip_code_suffix
         )
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/app/controllers/v0/profile/telephones_controller.rb
+++ b/app/controllers/v0/profile/telephones_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module V0
+  module Profile
+    class TelephonesController < ApplicationController
+      before_action { authorize :vet360, :access? }
+
+      def create
+        telephone = Vet360::Models::Telephone.with_defaults(@current_user, telephone_params)
+
+        if telephone.valid?
+          response    = service.post_telephone telephone
+          transaction = AsyncTransaction::Vet360::TelephoneTransaction.start(@current_user, response)
+
+          render json: transaction, serializer: AsyncTransaction::BaseSerializer
+        else
+          raise Common::Exceptions::ValidationErrors, telephone
+        end
+      end
+
+      def update
+        telephone = Vet360::Models::Telephone.with_defaults(@current_user, telephone_params)
+
+        if telephone.valid?
+          response    = service.put_telephone telephone
+          transaction = AsyncTransaction::Vet360::TelephoneTransaction.start @current_user, response
+
+          render json: transaction, serializer: AsyncTransaction::BaseSerializer
+        else
+          raise Common::Exceptions::ValidationErrors, telephone
+        end
+      end
+
+      private
+
+      def service
+        Vet360::ContactInformation::Service.new @current_user
+      end
+
+      def telephone_params
+        params.permit(
+          :area_code,
+          :country_code,
+          :extension,
+          :effective_end_date,
+          :effective_start_date,
+          :id,
+          :is_international,
+          :is_textable,
+          :is_text_permitted,
+          :is_tty,
+          :is_voicemailable,
+          :phone_number,
+          :phone_type,
+          :source_date,
+          :transaction_id,
+          :vet360_id
+        )
+      end
+    end
+  end
+end

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -154,7 +154,7 @@ module Swagger
           parameter do
             key :name, :body
             key :in, :body
-            key :description, 'Attributes to create an email address.'
+            key :description, 'Attributes to update an email address.'
             key :required, true
 
             schema do
@@ -317,6 +317,89 @@ module Swagger
                   end
                 end
               end
+            end
+          end
+        end
+      end
+
+      swagger_path '/v0/profile/telephones' do
+        operation :post do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Creates a users Vet360 telephone'
+          key :operationId, 'postVet360Telephone'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          parameter do
+            key :name, :body
+            key :in, :body
+            key :description, 'Attributes to create a telephone.'
+            key :required, true
+
+            schema do
+              key :'$ref', :Telephone
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              property :phone_number, type: :string, example: '5551212'
+              property :area_code, type: :string, example: '303'
+              property :extension, type: :string, example: '101'
+              property :phone_type, type: :string, enum:
+                %w[
+                  MOBILE
+                  HOME
+                  WORK
+                  FAX
+                  TEMPORARY
+                ], example: 'MOBILE'
+            end
+          end
+        end
+
+        operation :put do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Updates a users existing telephone'
+          key :operationId, 'putVet360Telephone'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          parameter do
+            key :name, :body
+            key :in, :body
+            key :description, 'Attributes to update a telephone'
+            key :required, true
+
+            schema do
+              property :id, type: :integer, example: 1
+              property :phone_number, type: :string, example: '5551212'
+              property :area_code, type: :string, example: '303'
+              property :extension, type: :string, example: '101'
+              property :phone_type, type: :string, enum:
+                %w[
+                  MOBILE
+                  HOME
+                  WORK
+                  FAX
+                  TEMPORARY
+                ], example: 'MOBILE'
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :AsyncTransactionVet360
             end
           end
         end

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 module Swagger
   module Requests
     class Profile
@@ -500,3 +501,4 @@ module Swagger
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -5,6 +5,99 @@ module Swagger
     class Profile
       include Swagger::Blocks
 
+      swagger_path '/v0/profile/addresses' do
+        operation :post do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Creates a users Vet360 address'
+          key :operationId, 'postVet360Address'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          parameter do
+            key :name, :body
+            key :in, :body
+            key :description, 'Attributes to create an address.'
+            key :required, true
+
+            schema do
+              property :address_line1, type: :string, example: '1493 Martin Luther King Rd'
+              property :address_pou, type: :string, enum:
+                %w[
+                  RESIDENCE/CHOICE
+                  CORRESPONDENCE
+                ], example: 'RESIDENCE/CHOICE'
+              property :address_type, type: :string, enum:
+                %w[
+                  domestic
+                  international
+                  military overseas
+                ], example: 'domestic'
+              property :city, type: :string, example: 'Fulton'
+              property :country, type: :string, example: 'USA'
+              property :state_abbr, type: :string, example: 'MS'
+              property :zip_code, type: :string, example: '38843'
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :AsyncTransactionVet360
+            end
+          end
+        end
+
+        operation :put do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Updates a users existing Vet360 address'
+          key :operationId, 'putVet360Address'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          parameter do
+            key :name, :body
+            key :in, :body
+            key :description, 'Attributes to update an address.'
+            key :required, true
+
+            schema do
+              property :id, type: :integer, example: 1
+              property :address_line1, type: :string, example: '1493 Martin Luther King Rd'
+              property :address_pou, type: :string, enum:
+                %w[
+                  RESIDENCE/CHOICE
+                  CORRESPONDENCE
+                ], example: 'RESIDENCE/CHOICE'
+              property :address_type, type: :string, enum:
+                %w[
+                  domestic
+                  international
+                  military overseas
+                ], example: 'domestic'
+              property :city, type: :string, example: 'Fulton'
+              property :country, type: :string, example: 'USA'
+              property :state_abbr, type: :string, example: 'MS'
+              property :zip_code, type: :string, example: '38843'
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :AsyncTransactionVet360
+            end
+          end
+        end
+      end
+
       swagger_path '/v0/profile/alternate_phone' do
         operation :get do
           extend Swagger::Responses::AuthenticationError

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,7 @@ Rails.application.routes.draw do
     end
 
     namespace :profile do
+      resource :addresses, only: %i[create update]
       resource :alternate_phone, only: %i[show create]
       resource :email, only: %i[show create]
       resource :email_addresses, only: %i[create update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,6 +171,7 @@ Rails.application.routes.draw do
       resource :personal_information, only: :show
       resource :primary_phone, only: %i[show create]
       resource :service_history, only: :show
+      resource :telephones, only: %i[create update]
     end
 
     get 'profile/mailing_address', to: 'addresses#show'

--- a/spec/factories/vet360/addresses.rb
+++ b/spec/factories/vet360/addresses.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
     country 'USA'
     state_abbr 'MS'
     zip_code '38843'
-    sequence(:id) { |n| n }
     sequence(:transaction_id, 100) { |n| "c2fab2b5-6af0-45e1-a9e2-394347af9#{n}" }
     source_date          '2018-04-09T11:52:03-06:00'
     created_at           '2017-04-09T11:52:03-06:00'

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1233,6 +1233,36 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           )
         end
       end
+
+      it 'supports posting vet360 telephone data' do
+        expect(subject).to validate(:post, '/v0/profile/telephones', 401)
+
+        VCR.use_cassette('vet360/contact_information/post_telephone_success') do
+          telephone = build(:telephone)
+
+          expect(subject).to validate(
+            :post,
+            '/v0/profile/telephones',
+            200,
+            auth_options.merge('_data' => telephone.as_json)
+          )
+        end
+      end
+
+      it 'supports putting vet360 telephone data' do
+        expect(subject).to validate(:put, '/v0/profile/telephones', 401)
+
+        VCR.use_cassette('vet360/contact_information/put_telephone_success') do
+          telephone = build(:telephone, id: 42)
+
+          expect(subject).to validate(
+            :put,
+            '/v0/profile/telephones',
+            200,
+            auth_options.merge('_data' => telephone.as_json)
+          )
+        end
+      end
     end
   end
 

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1263,6 +1263,36 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           )
         end
       end
+
+      it 'supports posting vet360 address data' do
+        expect(subject).to validate(:post, '/v0/profile/addresses', 401)
+
+        VCR.use_cassette('vet360/contact_information/post_address_success') do
+          address = build(:vet360_address)
+
+          expect(subject).to validate(
+            :post,
+            '/v0/profile/addresses',
+            200,
+            auth_options.merge('_data' => address.as_json)
+          )
+        end
+      end
+
+      it 'supports putting vet360 address data' do
+        expect(subject).to validate(:put, '/v0/profile/addresses', 401)
+
+        VCR.use_cassette('vet360/contact_information/put_address_success') do
+          address = build(:vet360_address, id: 42)
+
+          expect(subject).to validate(
+            :put,
+            '/v0/profile/addresses',
+            200,
+            auth_options.merge('_data' => address.as_json)
+          )
+        end
+      end
     end
   end
 

--- a/spec/request/vet360/address_request_spec.rb
+++ b/spec/request/vet360/address_request_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'address', type: :request do
+  include SchemaMatchers
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  describe 'POST /v0/profile/addresses' do
+    let(:address) { build(:vet360_address, vet360_id: user.vet360_id) }
+
+    context 'with a 200 response' do
+      it 'should match the address schema', :aggregate_failures do
+        VCR.use_cassette('vet360/contact_information/post_address_success') do
+          post(
+            '/v0/profile/addresses',
+            address.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('vet360/transaction_response')
+        end
+      end
+
+      it 'creates a new AsyncTransaction::Vet360::AddressTransaction db record' do
+        VCR.use_cassette('vet360/contact_information/post_address_success') do
+          expect do
+            post(
+              '/v0/profile/addresses',
+              address.to_json,
+              auth_header.update(
+                'Content-Type' => 'application/json', 'Accept' => 'application/json'
+              )
+            )
+          end.to change(AsyncTransaction::Vet360::AddressTransaction, :count).from(0).to(1)
+        end
+      end
+    end
+
+    context 'with a 400 response' do
+      it 'should match the errors schema', :aggregate_failures do
+        VCR.use_cassette('vet360/contact_information/post_address_w_id_error') do
+          post(
+            '/v0/profile/addresses',
+            address.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+
+    context 'with a 403 response' do
+      it 'should return a forbidden response' do
+        VCR.use_cassette('vet360/contact_information/post_address_status_403') do
+          post(
+            '/v0/profile/addresses',
+            address.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context 'with a validtion issue' do
+      it 'should match the errors schema', :aggregate_failures do
+        address.address_pou = ''
+
+        post(
+          '/v0/profile/addresses',
+          address.to_json,
+          auth_header.update(
+            'Content-Type' => 'application/json', 'Accept' => 'application/json'
+          )
+        )
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_response_schema('errors')
+        expect(errors_for(response)).to include "address-pou - can't be blank"
+      end
+    end
+  end
+
+  describe 'PUT /v0/profile/addresses' do
+    let(:address) { build(:vet360_address, vet360_id: user.vet360_id) }
+
+    context 'with a 200 response' do
+      it 'should match the email address schema', :aggregate_failures do
+        VCR.use_cassette('vet360/contact_information/put_address_success') do
+          put(
+            '/v0/profile/addresses',
+            address.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('vet360/transaction_response')
+        end
+      end
+
+      it 'creates a new AsyncTransaction::Vet360::AddressTransaction db record' do
+        VCR.use_cassette('vet360/contact_information/put_address_success') do
+          expect do
+            put(
+              '/v0/profile/addresses',
+              address.to_json,
+              auth_header.update(
+                'Content-Type' => 'application/json', 'Accept' => 'application/json'
+              )
+            )
+          end.to change(AsyncTransaction::Vet360::AddressTransaction, :count).from(0).to(1)
+        end
+      end
+    end
+
+    context 'with a validtion issue' do
+      it 'should match the errors schema', :aggregate_failures do
+        address.address_pou = ''
+
+        put(
+          '/v0/profile/addresses',
+          address.to_json,
+          auth_header.update(
+            'Content-Type' => 'application/json', 'Accept' => 'application/json'
+          )
+        )
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_response_schema('errors')
+        expect(errors_for(response)).to include "address-pou - can't be blank"
+      end
+    end
+  end
+end

--- a/spec/request/vet360/address_request_spec.rb
+++ b/spec/request/vet360/address_request_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'address', type: :request do
       end
     end
 
-    context 'with a validtion issue' do
+    context 'with a validation issue' do
       it 'should match the errors schema', :aggregate_failures do
         address.address_pou = ''
 
@@ -134,7 +134,7 @@ RSpec.describe 'address', type: :request do
       end
     end
 
-    context 'with a validtion issue' do
+    context 'with a validation issue' do
       it 'should match the errors schema', :aggregate_failures do
         address.address_pou = ''
 

--- a/spec/request/vet360/telephone_request_spec.rb
+++ b/spec/request/vet360/telephone_request_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'telephone', type: :request do
 
       it 'creates a new AsyncTransaction::Vet360::TelephoneTransaction db record' do
         VCR.use_cassette('vet360/contact_information/post_telephone_success') do
-          expect {
+          expect do
             post(
               '/v0/profile/telephones',
               telephone.to_json,
@@ -43,7 +43,7 @@ RSpec.describe 'telephone', type: :request do
                 'Content-Type' => 'application/json', 'Accept' => 'application/json'
               )
             )
-          }.to change(AsyncTransaction::Vet360::TelephoneTransaction, :count).from(0).to(1)
+          end.to change(AsyncTransaction::Vet360::TelephoneTransaction, :count).from(0).to(1)
         end
       end
     end
@@ -125,7 +125,7 @@ RSpec.describe 'telephone', type: :request do
 
       it 'creates a new AsyncTransaction::Vet360::TelephoneTransaction db record' do
         VCR.use_cassette('vet360/contact_information/put_telephone_success') do
-          expect {
+          expect do
             put(
               '/v0/profile/telephones',
               telephone.to_json,
@@ -133,7 +133,7 @@ RSpec.describe 'telephone', type: :request do
                 'Content-Type' => 'application/json', 'Accept' => 'application/json'
               )
             )
-          }.to change(AsyncTransaction::Vet360::TelephoneTransaction, :count).from(0).to(1)
+          end.to change(AsyncTransaction::Vet360::TelephoneTransaction, :count).from(0).to(1)
         end
       end
     end

--- a/spec/request/vet360/telephone_request_spec.rb
+++ b/spec/request/vet360/telephone_request_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'telephone', type: :request do
+  include SchemaMatchers
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  describe 'POST /v0/profile/telephones' do
+    let(:telephone) { build(:telephone, vet360_id: user.vet360_id) }
+
+    context 'with a 200 response' do
+      it 'should match the telephone schema', :aggregate_failures do
+        VCR.use_cassette('vet360/contact_information/post_telephone_success') do
+          post(
+            '/v0/profile/telephones',
+            telephone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('vet360/transaction_response')
+        end
+      end
+
+      it 'creates a new AsyncTransaction::Vet360::TelephoneTransaction db record' do
+        VCR.use_cassette('vet360/contact_information/post_telephone_success') do
+          expect {
+            post(
+              '/v0/profile/telephones',
+              telephone.to_json,
+              auth_header.update(
+                'Content-Type' => 'application/json', 'Accept' => 'application/json'
+              )
+            )
+          }.to change(AsyncTransaction::Vet360::TelephoneTransaction, :count).from(0).to(1)
+        end
+      end
+    end
+
+    context 'with a 400 response' do
+      it 'should match the errors schema', :aggregate_failures do
+        telephone.id = 42
+
+        VCR.use_cassette('vet360/contact_information/post_telephone_w_id_error') do
+          post(
+            '/v0/profile/telephones',
+            telephone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+
+    context 'with a 403 response' do
+      it 'should return a forbidden response' do
+        VCR.use_cassette('vet360/contact_information/post_telephone_status_403') do
+          post(
+            '/v0/profile/telephones',
+            telephone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context 'with a validtion issue' do
+      it 'should match the errors schema', :aggregate_failures do
+        telephone.phone_number = ''
+
+        post(
+          '/v0/profile/telephones',
+          telephone.to_json,
+          auth_header.update(
+            'Content-Type' => 'application/json', 'Accept' => 'application/json'
+          )
+        )
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_response_schema('errors')
+        expect(errors_for(response)).to include "phone-number - can't be blank"
+      end
+    end
+  end
+
+  describe 'PUT /v0/profile/telephones' do
+    let(:telephone) { build(:telephone, vet360_id: user.vet360_id) }
+
+    before { telephone.id = 42 }
+
+    context 'with a 200 response' do
+      it 'should match the telephone schema', :aggregate_failures do
+        VCR.use_cassette('vet360/contact_information/put_telephone_success') do
+          put(
+            '/v0/profile/telephones',
+            telephone.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('vet360/transaction_response')
+        end
+      end
+
+      it 'creates a new AsyncTransaction::Vet360::TelephoneTransaction db record' do
+        VCR.use_cassette('vet360/contact_information/put_telephone_success') do
+          expect {
+            put(
+              '/v0/profile/telephones',
+              telephone.to_json,
+              auth_header.update(
+                'Content-Type' => 'application/json', 'Accept' => 'application/json'
+              )
+            )
+          }.to change(AsyncTransaction::Vet360::TelephoneTransaction, :count).from(0).to(1)
+        end
+      end
+    end
+
+    context 'with a validtion issue' do
+      it 'should match the errors schema', :aggregate_failures do
+        telephone.phone_number = ''
+
+        put(
+          '/v0/profile/telephones',
+          telephone.to_json,
+          auth_header.update(
+            'Content-Type' => 'application/json', 'Accept' => 'application/json'
+          )
+        )
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_response_schema('errors')
+        expect(errors_for(response)).to include "phone-number - can't be blank"
+      end
+    end
+  end
+end

--- a/spec/request/vet360/telephone_request_spec.rb
+++ b/spec/request/vet360/telephone_request_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'telephone', type: :request do
       end
     end
 
-    context 'with a validtion issue' do
+    context 'with a validation issue' do
       it 'should match the errors schema', :aggregate_failures do
         telephone.phone_number = ''
 
@@ -138,7 +138,7 @@ RSpec.describe 'telephone', type: :request do
       end
     end
 
-    context 'with a validtion issue' do
+    context 'with a validation issue' do
       it 'should match the errors schema', :aggregate_failures do
         telephone.phone_number = ''
 

--- a/spec/support/vcr_cassettes/vet360/contact_information/post_address_status_403.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/post_address_status_403.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/addresses
+    body:
+      encoding: UTF-8
+      string: '{"bio":{"addressId":42,"addressLine1":"1493 Martin Luther King Rd","addressLine2":null,"addressLine3":null,"addressPOU":"RESIDENCE/CHOICE","addressType":"domestic","cityName":"Fulton","countryCodeISO2":null,"countryCodeISO3":null,"countryName":"USA","county":{"countyCode":null,"countyName":null},"intPostalCode":null,"provinceName":null,"stateCode":"MS","zipCode4":"38843","zipCode5":null,"originatingSourceSystem":"VETSGOV","sourceDate":"2018-04-09T11:52:03.000-06:00","vet360Id":"1"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Cufsystemname:
+      - VETSGOV
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Wed, 25 Apr 2018 16:49:36 GMT
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      X-Ua-Compatible:
+      - IE-edge,chrome=1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"code":"ADDR200","key":"addressId.Null","severity":"ERROR","text":"must
+        be null"}],"txAuditId":"5b450492-b1cc-4beb-94d0-a49176fc6c44","status":"REJECTED"}'
+    http_version:
+  recorded_at: Wed, 25 Apr 2018 16:49:36 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/vet360/contact_information/post_telephone_status_403.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/post_telephone_status_403.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/telephones
+    body:
+      encoding: UTF-8
+      string: '{"bio":{"areaCode":"303","countryCode":"1","internationalIndicator":false,"originatingSourceSystem":"VETSGOV","phoneNumber":"5551234","phoneNumberExt":null,"phoneType":"MOBILE","sourceDate":"2018-04-09T11:52:03.000-06:00","telephoneId":42,"ttyInd":true,"vet360Id":"1","voiceMailAcceptableInd":true}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Cufsystemname:
+      - VETSGOV
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Wed, 25 Apr 2018 17:01:25 GMT
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      X-Ua-Compatible:
+      - IE-edge,chrome=1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"code":"PHON124","key":"telephoneId.Null","severity":"ERROR","text":"must
+        be null"}],"txAuditId":"e7d665e4-2d84-4bce-8d58-09072fc99de4","status":"REJECTED"}'
+    http_version:
+  recorded_at: Wed, 25 Apr 2018 17:01:24 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Background

These endpoints will be used to update the telephone numbers of a logged-in user. We will need endpoints for both POST and PUT. PUT requests must include the attribute id so that we can update the correct attribute. POST requests must not include an attribute id, since they are being newly created.

When a user submits an update to the backend, we will:
1. Construct an instance of the Vet360 Telephone model
2. Validate model and return any errors
3. Call the vet360 service with the validated telephone model
4. Create a record in the db with the relevant transaction info
5. Return the transaction info to the FE

## Definition of done

- [x] Swagger docs
- [x] Front-end sign-off on api spec
- [x] Route declared for endpoint (POST/PUT `/v0/profile/telephones`)
- [x] Request specs
- [x] Endpoint controller built
- [x] Controller persists instance of `TelephoneTransaction` model after service call
~- [ ] Controller returns instance of `TelephoneTransaction` model to FE~
- [x] Controller returns relevant transaction details to FE (i.e. status, transaction_id and type)
- [x] Validation of the service model being `POST`/`PUT` to Vet360
- [x] Pundit auth (checking for Vet360 id)
- [x] Go through [punch list](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/vets-api-endpoint-punch-list.md)