### PR TITLE
remove places where sentry gets logged to twice

### DIFF
--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -36,7 +36,7 @@ module V0
     private
 
     def skip_sentry_exception_types
-      super + [Common::Exceptions::GatewayTimeout]
+      super + [Common::Exceptions::GatewayTimeout, Common::Exceptions::BackendServiceException]
     end
 
     def validate!(form)

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -18,8 +18,6 @@ module V0
       result = begin
         HCA::Service.new(current_user).submit_form(form)
       rescue Common::Client::Errors::ClientError => e
-        log_exception_to_sentry(e)
-
         raise Common::Exceptions::BackendServiceException.new(
           nil, detail: e.message
         )

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -18,6 +18,7 @@ module V0
       result = begin
         HCA::Service.new(current_user).submit_form(form)
       rescue Common::Client::Errors::ClientError => e
+        log_exception_to_sentry(e)
         raise Common::Exceptions::BackendServiceException.new(
           nil, detail: e.message
         )

--- a/app/controllers/v0/id_card_attributes_controller.rb
+++ b/app/controllers/v0/id_card_attributes_controller.rb
@@ -12,9 +12,6 @@ module V0
       signed_attributes = ::VIC::URLHelper.generate(id_attributes)
       render json: signed_attributes
     rescue => e
-      # Catch all potential errors looking up military service history
-      # Monitor sentry to make sure this is not catching more general errors
-      log_exception_to_sentry(e)
       raise ::VIC::IDCardAttributeError, status: 502, code: 'VIC011',
                                          detail: 'Could not verify military service attributes'
     end
@@ -34,8 +31,6 @@ module V0
                                              detail: 'Not eligible for a Veteran ID Card'
         end
       rescue => e
-        # current_user.veteran? above may raise an error if user was not found or backend service was unavailable
-        log_exception_to_sentry(e)
         raise ::VIC::IDCardAttributeError, status: 403, code: 'VIC010',
                                            detail: 'Could not verify Veteran status'
       end

--- a/app/controllers/v0/id_card_attributes_controller.rb
+++ b/app/controllers/v0/id_card_attributes_controller.rb
@@ -11,7 +11,7 @@ module V0
       id_attributes = IdCardAttributes.for_user(current_user)
       signed_attributes = ::VIC::URLHelper.generate(id_attributes)
       render json: signed_attributes
-    rescue => e
+    rescue
       raise ::VIC::IDCardAttributeError, status: 502, code: 'VIC011',
                                          detail: 'Could not verify military service attributes'
     end
@@ -30,7 +30,7 @@ module V0
           raise ::VIC::IDCardAttributeError, status: 403, code: 'VIC003',
                                              detail: 'Not eligible for a Veteran ID Card'
         end
-      rescue => e
+      rescue
         raise ::VIC::IDCardAttributeError, status: 403, code: 'VIC010',
                                            detail: 'Could not verify Veteran status'
       end

--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -41,7 +41,6 @@ module V0
         raise Common::Exceptions::UnexpectedForbidden, detail: 'Missing correlation id'
       else
         # 500
-        log_message_to_sentry('Unexpected EVSS GiBillStatus Response', :error, response.to_h)
         raise Common::Exceptions::InternalServerError
       end
     end

--- a/lib/evss/gi_bill_status/service.rb
+++ b/lib/evss/gi_bill_status/service.rb
@@ -39,7 +39,6 @@ module EVSS
         response = OpenStruct.new(status: e.status, body: e.body)
 
         extra_context = { url: config.base_path, response: response }
-        log_exception_to_sentry(e, extra_context)
         EVSS::GiBillStatus::GiBillStatusResponse.new(response.status, response)
       end
     end

--- a/lib/evss/gi_bill_status/service.rb
+++ b/lib/evss/gi_bill_status/service.rb
@@ -37,8 +37,6 @@ module EVSS
         EVSS::GiBillStatus::GiBillStatusResponse.new(raw_response.status, raw_response)
       rescue Common::Client::Errors::ClientError => e
         response = OpenStruct.new(status: e.status, body: e.body)
-
-        extra_context = { url: config.base_path, response: response }
         EVSS::GiBillStatus::GiBillStatusResponse.new(response.status, response)
       end
     end

--- a/spec/request/health_care_applications_request_spec.rb
+++ b/spec/request/health_care_applications_request_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
         end
 
         it 'should render error message' do
-          expect(Raven).to receive(:capture_exception).with(error, level: 'error').twice
+          expect(Raven).to receive(:capture_exception).with(error, level: 'error').once
 
           subject
 


### PR DESCRIPTION
In reference to [item #2 in this list](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9997#issuecomment-382917392)

These are places where I believe we have been logging to Sentry twice for the same event.  These exceptions bubble all the way to `application_controller` which logs (almost) everything to Sentry.