### PR TITLE
Makes nil header fix available in prod

### DIFF
--- a/lib/common/client/base.rb
+++ b/lib/common/client/base.rb
@@ -46,7 +46,7 @@ module Common
       end
 
       def request(method, path, params = {}, headers = {})
-        sanitize_headers!(method, path, params, headers) if Settings.vet360.contact_information.enabled
+        sanitize_headers!(method, path, params, headers)
         raise_not_authenticated if headers.keys.include?('Token') && headers['Token'].nil?
         connection.send(method.to_sym, path, params) { |request| request.headers.update(headers) }.env
       rescue Timeout::Error, Faraday::TimeoutError


### PR DESCRIPTION
## Background

We were getting this error in production:

http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/37304/

These two PR's have been implemented to fix it:

- https://github.com/department-of-veterans-affairs/vets-api/pull/1894
- https://github.com/department-of-veterans-affairs/vets-api/pull/1904

They have both been successfully tested in staging.  The test user that was passing `nil` headers from EVSS is no longer doing so.

## Definition of done

- [x] Make these changes available in production