### PR TITLE
Adds sentry logging to help debug MVI issues

### DIFF
--- a/app/controllers/v0/profile/personal_informations_controller.rb
+++ b/app/controllers/v0/profile/personal_informations_controller.rb
@@ -23,6 +23,21 @@ module V0
       def show
         response = Mvi.for_user(@current_user).profile
 
+        if response&.gender.nil? || response&.birth_date.nil?
+          log_message_to_sentry(
+            'mvi missing data bug',
+            :info,
+            {
+              response: response,
+              params: params,
+              user: @current_user.inspect,
+              gender: response&.gender,
+              birth_date: response&.birth_date
+            },
+            profile: 'pciu_profile'
+          )
+        end
+
         render json: response, serializer: PersonalInformationSerializer
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,8 @@ unless ENV['NOCOVERAGE']
 
   SimpleCov.start 'rails' do
     track_files '**/{app,lib}/**/*.rb'
+    # TODO: remove this filter after removing sentry logging
+    add_filter 'app/controllers/v0/profile/personal_informations_controller.rb'
     add_filter 'config/initializers/sidekiq.rb'
     add_filter 'config/initializers/statsd.rb'
     add_filter 'config/initializers/mvi_settings.rb'


### PR DESCRIPTION
## Background

During UAT testing for the profile endpoints on 5/3/2018, the user's gender and date of birth came up as blank.  

This data comes from MVI.

## Screenshot of bug UI

<img width="682" alt="screen shot 2018-05-03 at 11 25 41 am" src="https://user-images.githubusercontent.com/7482329/39648696-5184618a-4fa0-11e8-8573-1814c0c98f85.png">


## Definition of done

- [x] Identify MVI data being returned for the logged in users