### PR TITLE
Adds temporary logging to debug Profile UAT issues in prod

### DIFF
--- a/app/controllers/concerns/vet360/writeable.rb
+++ b/app/controllers/concerns/vet360/writeable.rb
@@ -22,6 +22,22 @@ module Vet360
       render_new_transaction!(type, response)
     end
 
+    # Temporary method for debugging during UAT
+    #
+    def log_profile_data_to_sentry(response)
+      log_message_to_sentry(
+        'Profile controller bug',
+        :info,
+        {
+          controller: self.class.to_s,
+          response: response,
+          params: params,
+          user: @current_user.inspect
+        },
+        profile: 'pciu_profile'
+      )
+    end
+
     private
 
     def build_record(type, params)

--- a/app/controllers/v0/addresses_controller.rb
+++ b/app/controllers/v0/addresses_controller.rb
@@ -2,10 +2,15 @@
 
 module V0
   class AddressesController < ApplicationController
+    include Vet360::Writeable
+
     before_action { authorize :evss, :access? }
 
     def show
       response = service.get_address
+
+      log_profile_data_to_sentry(response) if response&.address&.address_one.blank?
+
       render json: response,
              serializer: AddressSerializer
     end
@@ -14,6 +19,9 @@ module V0
       address = EVSS::PCIUAddress::Address.build_address(params)
       raise Common::Exceptions::ValidationErrors, address unless address.valid?
       response = service.update_address(address)
+
+      log_profile_data_to_sentry(response) if response&.address&.address_one.blank?
+
       render json: response,
              serializer: AddressSerializer
     end

--- a/app/controllers/v0/profile/alternate_phones_controller.rb
+++ b/app/controllers/v0/profile/alternate_phones_controller.rb
@@ -3,10 +3,14 @@
 module V0
   module Profile
     class AlternatePhonesController < ApplicationController
+      include Vet360::Writeable
+
       before_action { authorize :evss, :access? }
 
       def show
         response = service.get_alternate_phone
+
+        log_profile_data_to_sentry(response) if response&.number.blank?
 
         render json: response, serializer: PhoneNumberSerializer
       end
@@ -16,6 +20,8 @@ module V0
 
         if phone.valid?
           response = service.post_alternate_phone phone
+
+          log_profile_data_to_sentry(response) if response&.number.blank?
 
           render json: response, serializer: PhoneNumberSerializer
         else

--- a/app/controllers/v0/profile/emails_controller.rb
+++ b/app/controllers/v0/profile/emails_controller.rb
@@ -3,10 +3,14 @@
 module V0
   module Profile
     class EmailsController < ApplicationController
+      include Vet360::Writeable
+
       before_action { authorize :evss, :access? }
 
       def show
         response = service.get_email_address
+
+        log_profile_data_to_sentry(response) if response&.email.blank?
 
         render json: response, serializer: EmailSerializer
       end
@@ -16,6 +20,8 @@ module V0
 
         if email_address.valid?
           response = service.post_email_address email_address
+
+          log_profile_data_to_sentry(response) if response&.email.blank?
 
           render json: response, serializer: EmailSerializer
         else

--- a/app/controllers/v0/profile/full_names_controller.rb
+++ b/app/controllers/v0/profile/full_names_controller.rb
@@ -3,6 +3,8 @@
 module V0
   module Profile
     class FullNamesController < ApplicationController
+      include Vet360::Writeable
+
       # Fetches the full name details for the current user.
       # Namely their first/middle/last name, and suffix.
       #
@@ -21,6 +23,8 @@ module V0
       #   }
       #
       def show
+        log_profile_data_to_sentry('') if @current_user&.full_name_normalized.blank?
+
         render(
           json: @current_user.full_name_normalized,
           serializer: FullNameSerializer

--- a/app/controllers/v0/profile/primary_phones_controller.rb
+++ b/app/controllers/v0/profile/primary_phones_controller.rb
@@ -3,10 +3,14 @@
 module V0
   module Profile
     class PrimaryPhonesController < ApplicationController
+      include Vet360::Writeable
+
       before_action { authorize :evss, :access? }
 
       def show
         response = service.get_primary_phone
+
+        log_profile_data_to_sentry(response) if response&.number.blank?
 
         render json: response, serializer: PhoneNumberSerializer
       end
@@ -16,6 +20,8 @@ module V0
 
         if phone.valid?
           response = service.post_primary_phone phone
+
+          log_profile_data_to_sentry(response) if response&.number.blank?
 
           render json: response, serializer: PhoneNumberSerializer
         else

--- a/app/controllers/v0/profile/service_histories_controller.rb
+++ b/app/controllers/v0/profile/service_histories_controller.rb
@@ -3,6 +3,8 @@
 module V0
   module Profile
     class ServiceHistoriesController < ApplicationController
+      include Vet360::Writeable
+
       before_action { authorize :emis, :access? }
 
       # Fetches the service history for the current user.
@@ -27,6 +29,8 @@ module V0
       #
       def show
         response = EMISRedis::MilitaryInformation.for_user(@current_user).service_history
+
+        log_profile_data_to_sentry(response) if response.try(:first).try(:dig, :branch_of_service).blank?
 
         render json: response, serializer: ServiceHistorySerializer
       end

--- a/app/policies/evss_policy.rb
+++ b/app/policies/evss_policy.rb
@@ -1,7 +1,26 @@
 # frozen_string_literal: true
 
 EVSSPolicy = Struct.new(:user, :evss) do
+  include SentryLogging
+
   def access?
-    user.edipi.present? && user.ssn.present? && user.participant_id.present?
+    if user.edipi.present? && user.ssn.present? && user.participant_id.present?
+      true
+    else
+      log_message_to_sentry(
+        'EVSS Pundit Policy bug',
+        :info,
+        {
+          edipi_present: user.edipi.present?,
+          ssn_present: user.ssn.present?,
+          participant_id_present: user.participant_id.present?,
+          user_loa: user&.loa,
+          user: user.inspect
+        },
+        profile: 'pciu_profile'
+      )
+
+      false
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ unless ENV['NOCOVERAGE']
   SimpleCov.start 'rails' do
     track_files '**/{app,lib}/**/*.rb'
     # TODO: remove this filter after removing sentry logging
-    add_filter 'app/controllers/v0/profile/personal_informations_controller.rb'
+    add_filter 'app/controllers/v0/profile'
     add_filter 'config/initializers/sidekiq.rb'
     add_filter 'config/initializers/statsd.rb'
     add_filter 'config/initializers/mvi_settings.rb'


### PR DESCRIPTION
## Background

During UAT testing for the profile endpoints on 5/7/2018, the user's service history came up as blank.  

This data comes from eMIS.

## Screenshot of bug UI

<img width="390" alt="screen shot 2018-05-07 at 4 37 57 pm" src="https://user-images.githubusercontent.com/7482329/39728164-f1aaa9d4-5212-11e8-91df-bd788e87c117.png">

We are also seeing intermittent issues with other profile endpoints.  For example:

- http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/37509/
- http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/35301/ 

## Definition of done

This is all **temporary** logging, and will be removed once issues are resolved.

- [x] Identify eMIS data being returned for the logged in users
- [x] Adds comprehensive logging for the profile endpoints