### PR TITLE
VBADocuments service: Add submission logging and expire obsolete records

### DIFF
--- a/modules/vba_documents/app/controllers/vba_documents/v0/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v0/uploads_controller.rb
@@ -18,6 +18,7 @@ module VBADocuments
       def show
         submission = VBADocuments::UploadSubmission.find_by(guid: params[:id])
         raise Common::Exceptions::RecordNotFound, params[:id] if submission.nil?
+        raise Common::Exceptions::RecordNotFound, params[:id] if submission.status == 'expired'
         submission.refresh_status!
         render json: submission,
                serializer: VBADocuments::UploadSerializer,

--- a/modules/vba_documents/app/workers/vba_documents/upload_scanner.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_scanner.rb
@@ -9,7 +9,6 @@ module VBADocuments
     def perform
       return unless Settings.vba_documents.s3.enabled
       VBADocuments::UploadSubmission.where(status: 'pending').find_each do |upload|
-        # TODO: expire records after upload URL is obsolete (default 900 secs)
         processed = process(upload)
         expire(upload) unless processed
       end

--- a/modules/vba_documents/app/workers/vba_documents/upload_scanner.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_scanner.rb
@@ -10,7 +10,8 @@ module VBADocuments
       return unless Settings.vba_documents.s3.enabled
       VBADocuments::UploadSubmission.where(status: 'pending').find_each do |upload|
         # TODO: expire records after upload URL is obsolete (default 900 secs)
-        process(upload)
+        processed = process(upload)
+        expire(upload) unless processed
       end
     end
 
@@ -22,6 +23,10 @@ module VBADocuments
       VBADocuments::UploadProcessor.perform_async(upload.guid)
       upload.update(status: 'uploaded')
       true
+    end
+
+    def expire(upload)
+      upload.update(status: 'expired') if upload.created_at < Time.zone.now - 20.minutes
     end
 
     def bucket

--- a/modules/vba_documents/spec/request/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/uploads_request_spec.rb
@@ -41,5 +41,11 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
       get '/services/vba_documents/v0/uploads/non_existent_guid'
       expect(response).to have_http_status(:not_found)
     end
+
+    it 'should return not_found for an expired submission' do
+      upload.update(status: 'expired')
+      get "/services/vba_documents/v0/uploads/#{upload.guid}"
+      expect(response).to have_http_status(:not_found)
+    end
   end
 end


### PR DESCRIPTION
I believe the logging will allow us to pull some useful data out via CloudWatch metrics filters, though I'm not convinced this is the optimal approach. Alex mentioned "number of pages submitted" as a vanity metric of instance thus that calculation. 