### PR TITLE
Update swagger docs for `/v0/user` to include Vet360 attributes

### DIFF
--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -175,6 +175,7 @@ module V0
       Swagger::Schemas::Vet360::Address,
       Swagger::Schemas::Vet360::Email,
       Swagger::Schemas::Vet360::Telephone,
+      Swagger::Schemas::Vet360::ContactInformation,
       self
     ].freeze
 

--- a/app/swagger/requests/user.rb
+++ b/app/swagger/requests/user.rb
@@ -27,44 +27,51 @@ module Swagger
       end
 
       swagger_schema :UserData, required: [:data] do
-        property :data, type: :object do
-          property :id, type: :string
-          property :type, type: :string
-          property :attributes, type: :object do
-            property :services, type: :array do
-              items do
-                key :type, :string
-              end
-            end
-            property :in_progress_forms
-            property :profile, type: :object do
-              property :email, type: :string
-              property :first_name, type: :string
-              property :last_name, type: :string
-              property :birth_date, type: :string
-              property :gender, type: :string
-              property :zip, type: :string
-              property :last_signed_in, type: :string
-              property :loa, type: :object do
-                property :current, type: :integer, format: :int32
-                property :highest, type: :integer, format: :int32
-              end
-            end
-            property :va_profile, type: :object do
-              property :status, type: :string
-              property :birthdate, type: :string
-              property :family_name, type: :string
-              property :gender, type: :string
-              property :given_names, type: :array do
-                items do
-                  key :type, :string
+        allOf do
+          schema do
+            key :'$ref', :Vet360ContactInformation
+          end
+          schema do
+            property :data, type: :object do
+              property :id, type: :string
+              property :type, type: :string
+              property :attributes, type: :object do
+                property :services, type: :array do
+                  items do
+                    key :type, :string
+                  end
+                end
+                property :in_progress_forms
+                property :profile, type: :object do
+                  property :email, type: :string
+                  property :first_name, type: :string
+                  property :last_name, type: :string
+                  property :birth_date, type: :string
+                  property :gender, type: :string
+                  property :zip, type: :string
+                  property :last_signed_in, type: :string
+                  property :loa, type: :object do
+                    property :current, type: :integer, format: :int32
+                    property :highest, type: :integer, format: :int32
+                  end
+                end
+                property :va_profile, type: :object do
+                  property :status, type: :string
+                  property :birthdate, type: :string
+                  property :family_name, type: :string
+                  property :gender, type: :string
+                  property :given_names, type: :array do
+                    items do
+                      key :type, :string
+                    end
+                  end
+                end
+                property :veteran_status, type: :object do
+                  key :required, [:status]
+                  property :is_veteran, type: :boolean, example: true
+                  property :status, type: :string, enum: %w[OK NOT_AUTHORIZED NOT_FOUND SERVER_ERROR], example: 'OK'
                 end
               end
-            end
-            property :veteran_status, type: :object do
-              key :required, [:status]
-              property :is_veteran, type: :boolean, example: true
-              property :status, type: :string, enum: %w[OK NOT_AUTHORIZED NOT_FOUND SERVER_ERROR], example: 'OK'
             end
           end
         end

--- a/app/swagger/schemas/vet360/contact_information.rb
+++ b/app/swagger/schemas/vet360/contact_information.rb
@@ -16,25 +16,25 @@ module Swagger
                   property :id, type: :integer, example: 323
                   property :email_address, type: :string, example: 'john@example.com'
                   property :created_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_end_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_start_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :source_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :updated_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                 end
 
                 property :residential_address, type: :object do
@@ -43,9 +43,9 @@ module Swagger
                   property :address_line3, type: :string
                   property :address_pou, type: :string, example: ::Vet360::Models::Address::RESIDENCE
                   property :address_type,
-                    type: :string,
-                    enum: ::Vet360::Models::Address::ADDRESS_TYPES,
-                    example: ::Vet360::Models::Address::DOMESTIC
+                           type: :string,
+                           enum: ::Vet360::Models::Address::ADDRESS_TYPES,
+                           example: ::Vet360::Models::Address::DOMESTIC
                   property :city, type: :string, example: 'Fulton'
                   property :country, type: :string, example: 'United States of America'
                   property :country_code_iso2, type: :string, example: 'US'
@@ -58,25 +58,25 @@ module Swagger
                   property :zip_code, type: :string, example: '97062'
                   property :zip_code_suffix, type: :string, example: '1234'
                   property :created_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_end_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_start_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :source_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :updated_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                 end
 
                 property :mailing_address, type: :object do
@@ -84,12 +84,12 @@ module Swagger
                   property :address_line2, type: :string
                   property :address_line3, type: :string
                   property :address_pou,
-                    type: :string,
-                    example: ::Vet360::Models::Address::CORRESPONDENCE
+                           type: :string,
+                           example: ::Vet360::Models::Address::CORRESPONDENCE
                   property :address_type,
-                    type: :string,
-                    enum: ::Vet360::Models::Address::ADDRESS_TYPES,
-                    example: ::Vet360::Models::Address::DOMESTIC
+                           type: :string,
+                           enum: ::Vet360::Models::Address::ADDRESS_TYPES,
+                           example: ::Vet360::Models::Address::DOMESTIC
                   property :city, type: :string, example: 'Fulton'
                   property :country, type: :string, example: 'United States of America'
                   property :country_code_iso2, type: :string, example: 'US'
@@ -102,25 +102,25 @@ module Swagger
                   property :zip_code, type: :string, example: '97062'
                   property :zip_code_suffix, type: :string, example: '1234'
                   property :created_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_end_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_start_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :source_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :updated_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                 end
 
                 property :mobile_phone, type: :object do
@@ -136,25 +136,25 @@ module Swagger
                   property :phone_number, type: :string, example: '5551234'
                   property :phone_type, type: :string, example: ::Vet360::Models::Telephone::MOBILE
                   property :created_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_end_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_start_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :source_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :updated_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                 end
 
                 property :home_phone, type: :object do
@@ -170,25 +170,25 @@ module Swagger
                   property :phone_number, type: :string, example: '5551234'
                   property :phone_type, type: :string, example: ::Vet360::Models::Telephone::HOME
                   property :created_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_end_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_start_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :source_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :updated_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                 end
 
                 property :work_phone, type: :object do
@@ -204,25 +204,25 @@ module Swagger
                   property :phone_number, type: :string, example: '5551234'
                   property :phone_type, type: :string, example: ::Vet360::Models::Telephone::WORK
                   property :created_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_end_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_start_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :source_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :updated_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                 end
 
                 property :temporary_phone, type: :object do
@@ -238,25 +238,25 @@ module Swagger
                   property :phone_number, type: :string, example: '5551234'
                   property :phone_type, type: :string, example: ::Vet360::Models::Telephone::TEMPORARY
                   property :created_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_end_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_start_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :source_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :updated_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                 end
 
                 property :fax_number, type: :object do
@@ -272,25 +272,25 @@ module Swagger
                   property :phone_number, type: :string, example: '5551234'
                   property :phone_type, type: :string, example: ::Vet360::Models::Telephone::FAX
                   property :created_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_end_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :effective_start_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :source_date,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                   property :updated_at,
-                    type: :string,
-                    format: 'date-time',
-                    example: '2018-04-21T20:09:50Z'
+                           type: :string,
+                           format: 'date-time',
+                           example: '2018-04-21T20:09:50Z'
                 end
               end
             end

--- a/app/swagger/schemas/vet360/contact_information.rb
+++ b/app/swagger/schemas/vet360/contact_information.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Schemas
+    module Vet360
+      class ContactInformation
+        include Swagger::Blocks
+
+        swagger_schema :Vet360ContactInformation do
+          property :data, type: :object do
+            property :id, type: :string
+            property :type, type: :string
+            property :attributes, type: :object do
+              property :vet360_contact_information, type: :object do
+                property :email, type: :object do
+                  property :id, type: :integer, example: 323
+                  property :email_address, type: :string, example: 'john@example.com'
+                  property :created_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_end_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_start_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :source_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :updated_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                end
+
+                property :residential_address, type: :object do
+                  property :address_line1, type: :string, example: '1493 Martin Luther King Rd'
+                  property :address_line2, type: :string
+                  property :address_line3, type: :string
+                  property :address_pou, type: :string, example: ::Vet360::Models::Address::RESIDENCE
+                  property :address_type,
+                    type: :string,
+                    enum: ::Vet360::Models::Address::ADDRESS_TYPES,
+                    example: ::Vet360::Models::Address::DOMESTIC
+                  property :city, type: :string, example: 'Fulton'
+                  property :country, type: :string, example: 'United States of America'
+                  property :country_code_iso2, type: :string, example: 'US'
+                  property :country_code_iso3, type: :string, example: 'USA'
+                  property :country_code_fips, type: :string, example: 'US'
+                  property :id, type: :integer, example: 123
+                  property :international_postal_code, type: :string, example: '54321'
+                  property :province, type: :string
+                  property :state_abbr, type: :string, example: 'NY'
+                  property :zip_code, type: :string, example: '97062'
+                  property :zip_code_suffix, type: :string, example: '1234'
+                  property :created_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_end_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_start_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :source_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :updated_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                end
+
+                property :mailing_address, type: :object do
+                  property :address_line1, type: :string, example: '1493 Martin Luther King Rd'
+                  property :address_line2, type: :string
+                  property :address_line3, type: :string
+                  property :address_pou,
+                    type: :string,
+                    example: ::Vet360::Models::Address::CORRESPONDENCE
+                  property :address_type,
+                    type: :string,
+                    enum: ::Vet360::Models::Address::ADDRESS_TYPES,
+                    example: ::Vet360::Models::Address::DOMESTIC
+                  property :city, type: :string, example: 'Fulton'
+                  property :country, type: :string, example: 'United States of America'
+                  property :country_code_iso2, type: :string, example: 'US'
+                  property :country_code_iso3, type: :string, example: 'USA'
+                  property :country_code_fips, type: :string, example: 'US'
+                  property :id, type: :integer, example: 123
+                  property :international_postal_code, type: :string, example: '54321'
+                  property :province, type: :string
+                  property :state_abbr, type: :string, example: 'NY'
+                  property :zip_code, type: :string, example: '97062'
+                  property :zip_code_suffix, type: :string, example: '1234'
+                  property :created_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_end_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_start_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :source_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :updated_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                end
+
+                property :mobile_phone, type: :object do
+                  property :area_code, type: :string, example: '503'
+                  property :country_code, type: :string, example: '1'
+                  property :extension, type: :string
+                  property :id, type: :integer, example: 123
+                  property :is_international, type: :boolean
+                  property :is_textable, type: :boolean
+                  property :is_text_permitted, type: :boolean
+                  property :is_tty, type: :boolean
+                  property :is_voicemailable, type: :boolean
+                  property :phone_number, type: :string, example: '5551234'
+                  property :phone_type, type: :string, example: ::Vet360::Models::Telephone::MOBILE
+                  property :created_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_end_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_start_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :source_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :updated_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                end
+
+                property :home_phone, type: :object do
+                  property :area_code, type: :string, example: '503'
+                  property :country_code, type: :string, example: '1'
+                  property :extension, type: :string
+                  property :id, type: :integer, example: 123
+                  property :is_international, type: :boolean
+                  property :is_textable, type: :boolean
+                  property :is_text_permitted, type: :boolean
+                  property :is_tty, type: :boolean
+                  property :is_voicemailable, type: :boolean
+                  property :phone_number, type: :string, example: '5551234'
+                  property :phone_type, type: :string, example: ::Vet360::Models::Telephone::HOME
+                  property :created_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_end_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_start_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :source_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :updated_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                end
+
+                property :work_phone, type: :object do
+                  property :area_code, type: :string, example: '503'
+                  property :country_code, type: :string, example: '1'
+                  property :extension, type: :string
+                  property :id, type: :integer, example: 123
+                  property :is_international, type: :boolean
+                  property :is_textable, type: :boolean
+                  property :is_text_permitted, type: :boolean
+                  property :is_tty, type: :boolean
+                  property :is_voicemailable, type: :boolean
+                  property :phone_number, type: :string, example: '5551234'
+                  property :phone_type, type: :string, example: ::Vet360::Models::Telephone::WORK
+                  property :created_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_end_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_start_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :source_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :updated_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                end
+
+                property :temporary_phone, type: :object do
+                  property :area_code, type: :string, example: '503'
+                  property :country_code, type: :string, example: '1'
+                  property :extension, type: :string
+                  property :id, type: :integer, example: 123
+                  property :is_international, type: :boolean
+                  property :is_textable, type: :boolean
+                  property :is_text_permitted, type: :boolean
+                  property :is_tty, type: :boolean
+                  property :is_voicemailable, type: :boolean
+                  property :phone_number, type: :string, example: '5551234'
+                  property :phone_type, type: :string, example: ::Vet360::Models::Telephone::TEMPORARY
+                  property :created_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_end_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_start_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :source_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :updated_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                end
+
+                property :fax_number, type: :object do
+                  property :area_code, type: :string, example: '503'
+                  property :country_code, type: :string, example: '1'
+                  property :extension, type: :string
+                  property :id, type: :integer, example: 123
+                  property :is_international, type: :boolean
+                  property :is_textable, type: :boolean
+                  property :is_text_permitted, type: :boolean
+                  property :is_tty, type: :boolean
+                  property :is_voicemailable, type: :boolean
+                  property :phone_number, type: :string, example: '5551234'
+                  property :phone_type, type: :string, example: ::Vet360::Models::Telephone::FAX
+                  property :created_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_end_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :effective_start_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :source_date,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                  property :updated_at,
+                    type: :string,
+                    format: 'date-time',
+                    example: '2018-04-21T20:09:50Z'
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the full user attributes that will be populated by Vet360 to the swagger docs. This will help drive discussion with the frontend and design team so they are aware what attributes are available to read.

I have excluded some fields that don't have any real value in the context of reads such as the transaction ids and Vet360 ID.

Example:
<img width="1161" alt="screen shot 2018-05-10 at 10 09 31 am" src="https://user-images.githubusercontent.com/967417/39882950-41bb0ca6-543a-11e8-9d0f-4d4debd6f2b3.png">
