### PR TITLE
Vet360 error code coverage

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -330,6 +330,12 @@ en:
         code: 'VET360_ADDR112'
         detail: 'Size must be between 0 and 100.'
         status: 400
+      VET360_ADDR115:
+        <<: *external_defaults
+        title: Bad address indicator size
+        code: 'VET360_ADDR115'
+        detail: 'Bad address indicator size must be between 0 and 35.'
+        status: 400
       VET360_ADDR118:
         <<: *external_defaults
         title: City Name Size
@@ -390,6 +396,18 @@ en:
         code: 'VET360_ADDR131'
         detail: 'Country name pattern must match "^[a-zA-Z]+$"'
         status: 400
+      VET360_ADDR132:
+        <<: *external_defaults
+        title: Country code FIPS size
+        code: 'VET360_ADDR132'
+        detail: 'Country code FIPS size must be between 0 and 3.'
+        status: 400
+      VET360_ADDR133:
+        <<: *external_defaults
+        title: Country code FIPS pattern
+        code: 'VET360_ADDR133'
+        detail: 'Country code FIPS pattern must match "^[a-zA-Z]+$"'
+        status: 400
       VET360_ADDR134:
         <<: *external_defaults
         title: County Code ISO2 Size
@@ -413,6 +431,24 @@ en:
         title: County Code ISO3 Pattern
         code: 'VET360_ADDR137'
         detail: 'County code pattern must match "^[a-zA-Z]+$"'
+        status: 400
+      VET360_ADDR138:
+        <<: *external_defaults
+        title: Latitude size
+        code: 'VET360_ADDR138'
+        detail: 'Latitude size must be between 0 and 35.'
+        status: 400
+      VET360_ADDR140:
+        <<: *external_defaults
+        title: Longitude size
+        code: 'VET360_ADDR140'
+        detail: 'Longitude size must be between 0 and 35.'
+        status: 400
+      VET360_ADDR142:
+        <<: *external_defaults
+        title: Geocode precision size
+        code: 'VET360_ADDR142'
+        detail: 'Geocode precision size must be between 0 and 35.'
         status: 400
       VET360_ADDR146:
         <<: *external_defaults
@@ -462,11 +498,23 @@ en:
         code: 'VET360_CORE101'
         detail: 'You do not have access to perform the requested operation'
         status: 400
+      VET360_CORE102:
+        <<: *external_defaults
+        title: Data integrity violation
+        code: 'VET360_CORE102'
+        detail: 'The operation could not be fulfilled due to a data integrity violation.'
+        status: 400
       VET360_CORE103:
         <<: *external_defaults
         title: Not Found
         code: 'VET360_CORE103'
         detail: 'The Vet360 id could not be found'
+        status: 404
+      VET360_CORE104:
+        <<: *external_defaults
+        title: No changes detected
+        code: 'VET360_CORE104'
+        detail: 'Your request was received and processed without error, however no differences were detected between current data and the data you sent. This message is informational only, please verify your request if you believe you sent actual changes that should be applied.'
         status: 404
       VET360_CORE105:
         <<: *external_defaults
@@ -480,17 +528,35 @@ en:
         code: 'VET360_CORE106'
         detail: 'The request cannot be null'
         status: 400
+      VET360_CORE107:
+        <<: *external_defaults
+        title: Invalid txAuditId key
+        code: 'VET360_CORE107'
+        detail: 'The operation could not be completed due to invalid txAuditId.'
+        status: 400
       VET360_CORE109:
         <<: *external_defaults
         title: Incorrect Result Size
         code: 'VET360_CORE109'
         detail: 'Incorrect Result Set Size' # TODO: Update this error message once we have more info
         status: 500
+      VET360_CORE110:
+        <<: *external_defaults
+        title: Source date version violation
+        code: 'VET360_CORE110'
+        detail: 'Source dates are invalid for Type {0} with a ID of {1}. Previous source date was {2} but received new source date of {3}. Source dates may not be null, and new must be greater than the previous. Please correct your request and try again!'
+        status: 400
       VET360_CORE111:
         <<: *external_defaults
         title: Check Address Line
         code: 'VET360_CORE111'
         detail: 'Required data set missing.'
+        status: 400
+      VET360_CORE300:
+        <<: *external_defaults
+        title: Bio not null
+        code: 'VET360_CORE300'
+        detail: 'The submitted person contact bio is invalid/null and cannot be.'
         status: 400
       VET360_CORE302:
         <<: *external_defaults
@@ -503,6 +569,24 @@ en:
         title: Null Transaction Audit ID
         code: 'VET360_CORE303'
         detail: 'The transaction audit id may not be null'
+        status: 400
+      VET360_CORE500:
+        <<: *external_defaults
+        title: Source date not null
+        code: 'VET360_CORE500'
+        detail: 'Source date may not be null'
+        status: 400
+      VET360_CORE501:
+        <<: *external_defaults
+        title: Originating source system size
+        code: 'VET360_CORE501'
+        detail: 'Originating source system size must be between 0 and 255.'
+        status: 400
+      VET360_CORE502:
+        <<: *external_defaults
+        title: Source system user size
+        code: 'VET360_CORE502'
+        detail: 'Source system user size must be between 0 and 255.'
         status: 400
       VET360_EMAIL101:
         <<: *external_defaults
@@ -534,6 +618,12 @@ en:
         code: 'VET360_EMAIL302'
         detail: 'Email address text must be between 1 and 255'
         status: 400
+      VET360_EMAIL303:
+        <<: *external_defaults
+        title: Check email local part
+        code: 'VET360_EMAIL303'
+        detail: 'AlphaNumeric LocalPart of email must be <= 64 Characters.'
+        status: 400
       VET360_EMAIL304:
         <<: *external_defaults
         title: Check Email Domain
@@ -557,6 +647,90 @@ en:
         title: Email Inactive
         code: 'VET360_EMAIL307'
         detail: "Cannot modify an existing inactive record."
+        status: 400
+      VET360_MVI100:
+        <<: *external_defaults
+        title: MVI identifier invalid
+        code: 'VET360_MVI100'
+        detail: 'MVI invalid request identifier.'
+        status: 400
+      VET360_MVI101:
+        <<: *external_defaults
+        title: MVI identifier mismatch
+        code: 'VET360_MVI101'
+        detail: 'The person was found in MVI but the vet360Id returned did not match the submitted vet360Id.'
+        status: 400
+      VET360_MVI200:
+        <<: *external_defaults
+        title: MVI error
+        code: 'VET360_MVI200'
+        detail: 'The MVI Service returned an error.'
+        status: 400
+      VET360_MVI201:
+        <<: *external_defaults
+        title: MVI not found
+        code: 'VET360_MVI201'
+        detail: 'The person with the identifier requested was not found in MVI.'
+        status: 400
+      VET360_MVI202:
+        <<: *external_defaults
+        title: MVI duplicate correlations
+        code: 'VET360_MVI202'
+        detail: 'The MVI Service returned duplicate correlations for the requested identifier.'
+        status: 400
+      VET360_MVI203:
+        <<: *external_defaults
+        title: MVI response error
+        code: 'VET360_MVI203'
+        detail: 'The MVI Service returned an error response for the requested identifier.'
+        status: 400
+      VET360_MVI300:
+        <<: *external_defaults
+        title: MVI person deceased
+        code: 'VET360_MVI300'
+        detail: 'The MVI Service returned that the requested veteran is deceased.'
+        status: 400
+      VET360_PERS100:
+        <<: *external_defaults
+        title: vet360Id must match
+        code: 'VET360_PERS100'
+        detail: 'The vet360Id in the person contact sub-bio(s) must match the vet360Id in the Person bio.'
+        status: 400
+      VET360_PERS101:
+        <<: *external_defaults
+        title: vet360Id not null
+        code: 'VET360_PERS101'
+        detail: 'The vet360Id cannot be null.'
+        status: 400
+      VET360_PERS200:
+        <<: *external_defaults
+        title: Duplicate create veteran
+        code: 'VET360_PERS200'
+        detail: 'The veteran with the id requested has already been created.'
+        status: 400
+      VET360_PERS300:
+        <<: *external_defaults
+        title: Check EffectiveStartDate
+        code: 'VET360_PERS300'
+        detail: 'EffectiveStartDate can not be more than 6 months after current date.'
+        status: 400
+      VET360_PERS301:
+        <<: *external_defaults
+        title: Check EffectiveEndDate
+        code: 'VET360_PERS301'
+        detail: 'EffectiveEndDate must be after EffectiveStartDate.'
+        status: 400
+      VET360_PERS302:
+        <<: *external_defaults
+        title: confirmationDate past
+        code: 'VET360_PERS302'
+        detail: 'confirmationDate cannot be in the future.'
+        status: 400
+      VET360_PERS304:
+        <<: *external_defaults
+        title: Check confirmationDate
+        code: 'VET360_PERS304'
+        detail: 'ConfirmationDate can not be greater than sourceDate.'
         status: 400
       VET360_PHON100:
         <<: *external_defaults

--- a/spec/lib/vet360/service_spec.rb
+++ b/spec/lib/vet360/service_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'csv'
+
+describe Vet360::Service do
+  let(:user)    { build(:user, :loa3) }
+  let(:status)  { 400 }
+  let(:message) { 'the server responded with status 400' }
+  let(:file)    { Rails.root.join('spec', 'support', 'vet360', 'api_response_error_messages.csv') }
+  subject       { described_class.new(user) }
+
+  describe '#handle_error' do
+    before do
+      allow_any_instance_of(Common::Client::Base).to receive_message_chain(:config, :base_path) { '' }
+    end
+
+    it 'maps the error codes returned from Vet360 to the appropriate vets-api error message', :aggregate_failures do
+      CSV.foreach(file, headers: true) do |row|
+        error = Common::Client::Errors::ClientError.new(message, status, body_for(row))
+        code  = row['Message Code']
+
+        expect { subject.send('handle_error', error) }.to raise_error do |e|
+          p "Failing code: #{code}" if e.errors.first.code != "VET360_#{code}"
+
+          expect(e.errors.first.code).to eq("VET360_#{code}")
+          expect(e).to be_a(Common::Exceptions::BackendServiceException)
+        end
+      end
+    end
+  end
+end
+
+def body_for(row)
+  {
+    'messages' => [
+      {
+        'code'     => row['Message Code'].to_s,
+        'key'      => row['Message Key'].to_s,
+        'severity' => 'ERROR',
+        'text'     => row['Message Description'].to_s
+      }
+    ],
+    'tx_audit_id' => '3773cd41-0958-4bbe-a035-16ae353cde03',
+    'status'      => 'REJECTED'
+  }
+end

--- a/spec/support/vet360/api_response_error_messages.csv
+++ b/spec/support/vet360/api_response_error_messages.csv
@@ -1,0 +1,94 @@
+Message Key,Message Code,Message Description
+addressType.Size,ADDR101,size must be between 0 and 35
+addressLine1.Size,ADDR108,size must be between 0 and 100
+addressLine2.Size,ADDR110,size must be between 0 and 100
+addressLine3.Size,ADDR112,size must be between 0 and 100
+badAddressIndicator.Size,ADDR115,size must be between 0 and 35
+cityName.Size,ADDR118,size must be between 0 and 100
+stateCode.Size,ADDR120,size must be between 2 and 2
+stateCode.Pattern,ADDR121,"must match ""^[a-zA-Z]+$"""
+zipCode5.Size,ADDR122,size must be between 0 and 5
+zipCode4.Size,ADDR124,size must be between 0 and 4
+zipCode4.Pattern,ADDR125,"must match ""[0-9]+"""
+provinceName.Size,ADDR126,size must be between 0 and 100
+intPostalCode.Size,ADDR128,size must be between 0 and 100
+countryName.Size,ADDR130,size must be between 0 and 35
+countryName.Pattern,ADDR131,"must match ""^[a-zA-Z ]+$"""
+countryCodeFIPS.Size,ADDR132,size must be between 0 and 3
+countryCodeFIPS.Pattern,ADDR133,"must match ""^[a-zA-Z]+$"""
+countryCodeISO2.Size,ADDR134,size must be between 0 and 3
+countryCodeISO2.Pattern,ADDR135,"must match ""^[a-zA-Z]+$"""
+countryCodeISO3.Size,ADDR136,size must be between 0 and 3
+countryCodeISO3.Pattern,ADDR137,"must match ""^[a-zA-Z]+$"""
+latitude.Size,ADDR138,size must be between 0 and 35
+longitude.Size,ADDR140,size must be between 0 and 35
+geocodePrecision.Size,ADDR142,size must be between 0 and 35
+addressPOU.NotNull,ADDR146,may not be null
+addressId.Null,ADDR200,must be null
+addressId.NotNull,ADDR201,may not be null
+AddressInactive,ADDR300,Cannot modify an existing inactive record.
+AddressPOU,ADDR301,Can not insert a record for an address POU that already exists. Pull the address record and update it using the addressId provided.
+DuplicateAddressPOU,ADDR304,Cannot accept a request with multiple addresses of the same POU.
+_CUF_UNEXPECTED_ERROR,CORE100,"There was an error encountered processing the Request. Please retry. If problem persists, please contact support with a copy of the Response."
+_CUF_ACCESS_DENIED,CORE101,"You do not have access to perform the requested operation. Please correct your request before trying again! If you believe you have received this access denied error incorrect, please contact your system administrator."
+_CUF_DATA_INTEGRITY_VIOLATION,CORE102,The operation could not be fulfilled due to a data integrity violation.
+_CUF_NOT_FOUND,CORE103,The {0} for id/criteria {1} could not be found. Please correct your request and try again!
+_CUF_NO_CHANGES_DETECTED,CORE104,"Your request was received and processed without error, however no differences were detected between current data and the data you sent. This message is informational only, please verify your request if you believe you sent actual changes that should be applied."
+_CUF_REQUEST_MALFORMED,CORE105,The request was malformed and could not be processed. Please correct your request before trying again!
+_CUF_REQUEST_NULL,CORE106,The request cannot be null. Please correct your request and try again.
+_CUF_INVALID_TX_AUDIT_ID_KEY,CORE107,The operation could not be completed due to invalid txAuditId.
+_CUF_INCORRECT_RESULTSET_SIZE,CORE109,Expected {0} of {1} for id/criteria {2} but found > {0}. Please correct your request and try again!
+_CUF_SOURCE_DATE_VERSION_VIOLATION,CORE110,"Source dates are invalid for Type {0} with a ID of {1}. Previous source date was {2} but received new source date of {3}. Source dates may not be null, and new must be greater than the previous. Please correct your request and try again!"
+CheckAddressLine,CORE111,Required data set missing.
+bio.NotNull,CORE300,The submitted person contact bio is invalid/null and can not be.
+pullByExampleBio.NotNull,CORE302,may not be null
+txAuditId.NotNull,CORE303,may not be null
+sourceDate.NotNull,CORE500,may not be null
+originatingSourceSystem.Size,CORE501,size must be between 0 and 255
+sourceSystemUser.Size,CORE502,size must be between 0 and 255
+emailAddressText.NotNull,EMAIL101,may not be null
+emailId.Null,EMAIL200,must be null
+emailId.NotNull,EMAIL201,may not be null
+EmailAddressType,EMAIL301,Can not insert a record for an email address that already exists. Pull the email record and update it using the emailId provided.
+emailAddressText.Size,EMAIL302,size must be between 1 and 255
+CheckEmailLocalPart,EMAIL303,AlphaNumeric LocalPart of email must be <= 64 Characters.
+CheckEmailDomain,EMAIL304,AlphaNumeric ToplevelDomainName must be <= 63 Characters.
+CheckEmailAddress,EMAIL305,"EmailAddressText cannot have 2 @ symbols, must have at least one period '.' after the @ character, and cannot have '.%' or '%.' or '%..%' or "" ( ) , : ; < > @ [ ] or space unless in a quoted string in the local part."
+CheckEmailEndDate,EMAIL306,EffectiveEndDate must be null or in the past for email.
+DuplicateEmailAddress,EMAIL306,Cannot accept a request with multiple emailAddress records.
+CheckEmailEndDate,EMAIL306,EffectiveEndDate must be null or in the past for email.
+DuplicateEmailAddress,EMAIL306,Cannot accept a request with multiple emailAddress records.
+EmailInactive,EMAIL307,Cannot modify an existing inactive record.
+MviIdentifierInvalid,MVI100,Invalid request identifier.
+MviIdentifierMismatch,MVI101,The person was found in MVI but the vet360Id returned did not match the submitted vet360Id.
+MviError,MVI200,The MVI Service returned an error.
+MviNotFound,MVI201,The person with the identifier requested was not found in MVI.
+MviDuplicateCorrelations,MVI202,The MVI Service returned duplicate correlations for the requested identifier.
+MviResponseError,MVI203,The MVI Service returned an error response for the requested identifier.
+MviPersonDeceased,MVI300,The MVI Service returned that the requested veteran is deceased.
+vet360Id.MustMatch,PERS100,The vet360Id in the person contact sub-bio(s) must match the vet360Id in the Person bio.
+vet360Id.NotNull,PERS101,
+DuplicateCreateVeteran,PERS200,The veteran with the id requested has already been created.
+CheckEffectiveStartDate,PERS300,EffectiveStartDate can not be more than 6 months after current date.
+CheckEffectiveEndDate,PERS301,EffectiveEndDate must be after EffectiveStartDate.
+confirmationDate.Past,PERS302,Can not be in the future.
+CheckConfirmationDate,PERS304,ConfirmationDate can not be greater than sourceDate.
+internationalIndicator.NotNull,PHON100,may not be null
+areaCode.Size,PHON104,size must be between 3 and 3
+phoneNumber.NotNull,PHON105,may not be null
+phoneNumber.Pattern,PHON106,"must match ""[^a-zA-Z]+"""
+phoneNumber.Size,PHON107,size must be between 1 and 14
+phoneNumberExt.Pattern,PHON108,"must match ""^[a-zA-Z0-9]+$"""
+phoneType.NotNull,PHON109,may not be null
+phoneNumberExt.Size,PHON110,size must be between 1 and 10
+telephoneId.Null,PHON124,must be null
+telephoneId.NotNull,PHON125,may not be null
+areaCode.Pattern,PHON126,"must match ""[0-9]+"""
+CheckDomesticPhoneNumber,PHON207,"Domestic phone number size must be 7 characters, and can not start with a 0 or 1."
+CheckInternationalPhoneNumber,PHON208,International phone number must have 12 characters or less.
+CheckPhoneNumberDomesticIndicated,PHON209,Domestic numbers must have an area code and country code must be 1.
+CheckPhoneNumberInternationalIndicated,PHON210,"International numbers must have a valid country code that is not 1, and no area code."
+PhoneInactive,PHON300,Cannot modify an existing inactive record.
+TelephoneType,PHON301,Can not insert a record for a phone type that already exists. Pull the phone record and update it using the telphoneId provided.
+CheckPhoneEndDate,PHON303,"EffectiveEndDate cannot be present when adding a non temporary phone, and must be present for a temporary phone."
+DuplicateTelephoneType,PHON304,Cannot accept a request with multiple phones of the same type.


### PR DESCRIPTION
## Background

There are 104 error messages that we can potentially receive from Vet360 during normal interaction. We would like to ensure that we appropriately handle the full range of errors we may get.

## Definition of Done

- [x] Implement support file that contains all Vet360 error codes we may reasonably encounter
- [x] Implement spec to test handling of error codes.  Spec should:
  - [x] Loops over support file
  - [x] Generates an error for the specified scenario
  - [x] Checks that our implementation renders the error code as expected
- [x] Add any missing exceptions to `config/locales/exceptions.en.yml`