### PR TITLE
10519 profile error handling for emis and mvi

### DIFF
--- a/app/controllers/v0/profile/personal_informations_controller.rb
+++ b/app/controllers/v0/profile/personal_informations_controller.rb
@@ -39,7 +39,7 @@ module V0
       def raise_error!
         raise Common::Exceptions::BackendServiceException.new(
           'MVI_BD502',
-          { source: self.class.to_s }
+          source: self.class.to_s
         )
       end
 

--- a/app/controllers/v0/profile/personal_informations_controller.rb
+++ b/app/controllers/v0/profile/personal_informations_controller.rb
@@ -23,6 +23,27 @@ module V0
       def show
         response = Mvi.for_user(@current_user).profile
 
+        handle_errors!(response)
+
+        render json: response, serializer: PersonalInformationSerializer
+      end
+
+      private
+
+      def handle_errors!(response)
+        raise_error! if response&.gender.blank? && response&.birth_date.blank?
+
+        log_errors_for(response)
+      end
+
+      def raise_error!
+        raise Common::Exceptions::BackendServiceException.new(
+          'MVI_BD502',
+          { source: self.class.to_s }
+        )
+      end
+
+      def log_errors_for(response)
         if response&.gender.nil? || response&.birth_date.nil?
           log_message_to_sentry(
             'mvi missing data bug',
@@ -30,15 +51,12 @@ module V0
             {
               response: response,
               params: params,
-              user: @current_user.inspect,
               gender: response&.gender,
               birth_date: response&.birth_date
             },
             profile: 'pciu_profile'
           )
         end
-
-        render json: response, serializer: PersonalInformationSerializer
       end
     end
   end

--- a/app/controllers/v0/profile/service_histories_controller.rb
+++ b/app/controllers/v0/profile/service_histories_controller.rb
@@ -46,7 +46,7 @@ module V0
       def raise_error!
         raise Common::Exceptions::BackendServiceException.new(
           'EMIS_HIST502',
-          { source: self.class.to_s }
+          source: self.class.to_s
         )
       end
     end

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -363,6 +363,27 @@ module Swagger
               end
             end
           end
+
+          response 502 do
+            key :description, 'Unexpected response body'
+            schema do
+              key :required, [:errors]
+
+              property :errors do
+                key :type, :array
+                items do
+                  key :required, %i[title detail code status source]
+                  property :title, type: :string, example: 'Unexpected response body'
+                  property :detail,
+                           type: :string,
+                           example: 'MVI service responded without a birthday or a gender.'
+                  property :code, type: :string, example: 'MVI_BD502'
+                  property :status, type: :string, example: '502'
+                  property :source, type: :string, example: 'V0::Profile::PersonalInformationsController'
+                end
+              end
+            end
+          end
         end
       end
 
@@ -463,6 +484,27 @@ module Swagger
                       property :end_date, type: :string, format: :date, example: '2016-06-01'
                     end
                   end
+                end
+              end
+            end
+          end
+
+          response 502 do
+            key :description, 'Unexpected response body'
+            schema do
+              key :required, [:errors]
+
+              property :errors do
+                key :type, :array
+                items do
+                  key :required, %i[title detail code status source]
+                  property :title, type: :string, example: 'Unexpected response body'
+                  property :detail,
+                           type: :string,
+                           example: 'EMIS service responded with something other than the expected array of service history hashes.'
+                  property :code, type: :string, example: 'EMIS_HIST502'
+                  property :status, type: :string, example: '502'
+                  property :source, type: :string, example: 'V0::Profile::ServiceHistoriesController'
                 end
               end
             end

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/ClassLength
+# rubocop:disable Metrics/LineLength
 module Swagger
   module Requests
     class Profile
@@ -627,3 +628,4 @@ module Swagger
   end
 end
 # rubocop:enable Metrics/ClassLength
+# rubocop:enable Metrics/LineLength

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -852,6 +852,12 @@ en:
         code: 'EMIS_HIST502'
         detail: EMIS service responded with something other than the expected array of service history hashes.
         status: 502
+      MVI_BD502:
+        <<: *external_defaults
+        title: Unexpected response body
+        code: 'MVI_BD502'
+        detail: MVI service responded without a birthday or a gender.
+        status: 502
 
   evss:
     external_service_unavailable:

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -846,6 +846,12 @@ en:
         code: 'VET36_PHON304'
         detail: Cannot accept a request with multiple phones of the same type.
         status: 400
+      EMIS_HIST502:
+        <<: *external_defaults
+        title: Unexpected response body
+        code: 'EMIS_HIST502'
+        detail: EMIS service responded with something other than the expected array of service history hashes.
+        status: 502
 
   evss:
     external_service_unavailable:

--- a/spec/request/email_request_spec.rb
+++ b/spec/request/email_request_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe 'email', type: :request do
       it 'should include the missing values in the response detail', :aggregate_failures do
         get '/v0/profile/email', nil, auth_header
 
-        expect(details_for(response)).to include 'corp_id'
-        expect(details_for(response)).to include 'edipi'
+        expect(error_details_for(response)).to include 'corp_id'
+        expect(error_details_for(response)).to include 'edipi'
       end
     end
   end
@@ -218,8 +218,8 @@ RSpec.describe 'email', type: :request do
           )
         )
 
-        expect(details_for(response)).to include 'corp_id'
-        expect(details_for(response)).to include 'edipi'
+        expect(error_details_for(response)).to include 'corp_id'
+        expect(error_details_for(response)).to include 'edipi'
       end
     end
   end

--- a/spec/request/email_request_spec.rb
+++ b/spec/request/email_request_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/error_details'
 
 RSpec.describe 'email', type: :request do
   include SchemaMatchers
+  include ErrorDetails
 
   let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
   let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
@@ -75,8 +77,8 @@ RSpec.describe 'email', type: :request do
       it 'should include the missing values in the response detail', :aggregate_failures do
         get '/v0/profile/email', nil, auth_header
 
-        expect(detail_for(response)).to include 'corp_id'
-        expect(detail_for(response)).to include 'edipi'
+        expect(details_for(response)).to include 'corp_id'
+        expect(details_for(response)).to include 'edipi'
       end
     end
   end
@@ -216,13 +218,9 @@ RSpec.describe 'email', type: :request do
           )
         )
 
-        expect(detail_for(response)).to include 'corp_id'
-        expect(detail_for(response)).to include 'edipi'
+        expect(details_for(response)).to include 'corp_id'
+        expect(details_for(response)).to include 'edipi'
       end
     end
   end
-end
-
-def detail_for(response)
-  JSON.parse(response.body)['errors'].first['detail']
 end

--- a/spec/request/personal_information_request_spec.rb
+++ b/spec/request/personal_information_request_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/error_details'
 
 RSpec.describe 'personal_information', type: :request do
   include SchemaMatchers
+  include ErrorDetails
 
   let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
   let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
@@ -40,13 +42,9 @@ RSpec.describe 'personal_information', type: :request do
         VCR.use_cassette('mvi/find_candidate/missing_birthday_and_gender') do
           get '/v0/profile/personal_information', nil, auth_header
 
-          expect(detail_for(response)).to eq 'MVI_BD502'
+          expect(details_for(response, key: 'code')).to eq 'MVI_BD502'
         end
       end
     end
   end
-end
-
-def detail_for(response)
-  JSON.parse(response.body)['errors'].first['code']
 end

--- a/spec/request/personal_information_request_spec.rb
+++ b/spec/request/personal_information_request_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'personal_information', type: :request do
         VCR.use_cassette('mvi/find_candidate/missing_birthday_and_gender') do
           get '/v0/profile/personal_information', nil, auth_header
 
-          expect(details_for(response, key: 'code')).to eq 'MVI_BD502'
+          expect(error_details_for(response, key: 'code')).to eq 'MVI_BD502'
         end
       end
     end

--- a/spec/request/service_history_request_spec.rb
+++ b/spec/request/service_history_request_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/error_details'
 
 RSpec.describe 'service_history', type: :request, skip_emis: true do
   include SchemaMatchers
+  include ErrorDetails
 
   let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
   let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
@@ -54,12 +56,8 @@ RSpec.describe 'service_history', type: :request, skip_emis: true do
       it 'should include the correct error code' do
         get '/v0/profile/service_history', nil, auth_header
 
-        expect(detail_for(response)).to eq 'EMIS_HIST502'
+        expect(details_for(response, key: 'code')).to eq 'EMIS_HIST502'
       end
     end
   end
-end
-
-def detail_for(response)
-  JSON.parse(response.body)['errors'].first['code']
 end

--- a/spec/request/service_history_request_spec.rb
+++ b/spec/request/service_history_request_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'service_history', type: :request, skip_emis: true do
       it 'should include the correct error code' do
         get '/v0/profile/service_history', nil, auth_header
 
-        expect(details_for(response, key: 'code')).to eq 'EMIS_HIST502'
+        expect(error_details_for(response, key: 'code')).to eq 'EMIS_HIST502'
       end
     end
   end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1366,6 +1366,25 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
         expect(subject).to validate(:post, '/v0/profile/alternate_phone', 403, auth_options)
       end
     end
+
+    describe 'when MVI returns an unexpected response body' do
+      it 'supports returning a custom 502 response' do
+        allow_any_instance_of(MVI::Models::MviProfile).to receive(:gender).and_return(nil)
+        allow_any_instance_of(MVI::Models::MviProfile).to receive(:birth_date).and_return(nil)
+
+        VCR.use_cassette('mvi/find_candidate/missing_birthday_and_gender') do
+          expect(subject).to validate(:get, '/v0/profile/personal_information', 502, auth_options)
+        end
+      end
+    end
+
+    describe 'when EMIS returns an unexpected response body' do
+      it 'supports returning a custom 502 response' do
+        allow(EMISRedis::MilitaryInformation).to receive_message_chain(:for_user, :service_history) { nil }
+
+        expect(subject).to validate(:get, '/v0/profile/service_history', 502, auth_options)
+      end
+    end
   end
 
   context 'and' do

--- a/spec/support/error_details.rb
+++ b/spec/support/error_details.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ErrorDetails
+  def details_for(response, key: 'detail')
+    JSON.parse(response.body)['errors'].first[key]
+  end
+end

--- a/spec/support/error_details.rb
+++ b/spec/support/error_details.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ErrorDetails
-  def details_for(response, key: 'detail')
+  def error_details_for(response, key: 'detail')
     JSON.parse(response.body)['errors'].first[key]
   end
 end

--- a/spec/support/vcr_cassettes/mvi/find_candidate/missing_birthday_and_gender.yml
+++ b/spec/support/vcr_cassettes/mvi/find_candidate/missing_birthday_and_gender.yml
@@ -1,0 +1,153 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<MVI_URL>"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        CjxlbnY6RW52ZWxvcGUgeG1sbnM6c29hcGVuYz0iaHR0cDovL3NjaGVtYXMu
+        eG1sc29hcC5vcmcvc29hcC9lbmNvZGluZy8iIHhtbG5zOnhzZD0iaHR0cDov
+        L3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiIHhtbG5zOmVudj0iaHR0cDov
+        L3NjaGVtYXMueG1sc29hcC5vcmcvc29hcC9lbnZlbG9wZS8iIHhtbG5zOnhz
+        aT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2Ui
+        PgogIDxlbnY6SGVhZGVyLz4KICA8ZW52OkJvZHk+CiAgICA8aWRtOlBSUEFf
+        SU4yMDEzMDVVVjAyIHhtbG5zOmlkbT0iaHR0cDovL3Zhd3cub2VkLm9pdC52
+        YS5nb3YiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxT
+        Y2hlbWHigJBpbnN0YW5jZSIgeHNpOnNjaGVtYUxvY2F0aW9uPSJ1cm46aGw3
+        4oCQb3JnOnYzIC4uLy4uL3NjaGVtYS9ITDdWMy9ORTIwMDgvbXVsdGljYWNo
+        ZXNjaGVtYXMvUFJQQV9JTjIwMTMwNVVWMDIueHNkIiB4bWxucz0idXJuOmhs
+        N+KAkG9yZzp2MyIgSVRTVmVyc2lvbj0iWE1MXzEuMCI+CiAgICAgIDxpZCBy
+        b290PSIxLjIuODQwLjExNDM1MC4xLjEzLjAuMS43LjEuMSIgZXh0ZW5zaW9u
+        PSIyMDBWR09WLTA4NTA5ZWFhLTkyM2QtNDA1NS1iZWM5LWY5ZDE4ZGU1NGVk
+        YiIvPgogICAgICA8Y3JlYXRpb25UaW1lIHZhbHVlPSIyMDE2MTAyODE1MzIx
+        MyIvPgogICAgICA8dmVyc2lvbkNvZGUgY29kZT0iMy4wIi8+CiAgICAgIDxp
+        bnRlcmFjdGlvbklkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjEuNiIgZXh0
+        ZW5zaW9uPSJQUlBBX0lOMjAxMzA1VVYwMiIvPgogICAgICA8cHJvY2Vzc2lu
+        Z0NvZGUgY29kZT0iVCIvPgogICAgICA8cHJvY2Vzc2luZ01vZGVDb2RlIGNv
+        ZGU9IlQiLz4KICAgICAgPGFjY2VwdEFja0NvZGUgY29kZT0iQUwiLz4KICAg
+        ICAgPHJlY2VpdmVyIHR5cGVDb2RlPSJSQ1YiPgogICAgICAgIDxkZXZpY2Ug
+        Y2xhc3NDb2RlPSJERVYiIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAg
+        ICAgICAgICA8aWQgcm9vdD0iMS4yLjg0MC4xMTQzNTAuMS4xMy45OTkuMjM0
+        IiBleHRlbnNpb249IjIwME0iLz4KICAgICAgICA8L2RldmljZT4KICAgICAg
+        PC9yZWNlaXZlcj4KICAgICAgPHNlbmRlciB0eXBlQ29kZT0iU05EIj4KICAg
+        ICAgICA8ZGV2aWNlIGNsYXNzQ29kZT0iREVWIiBkZXRlcm1pbmVyQ29kZT0i
+        SU5TVEFOQ0UiPgogICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEz
+        ODgzLjQuMzQ5IiBleHRlbnNpb249IjIwMFZHT1YiLz4KICAgICAgICA8L2Rl
+        dmljZT4KICAgICAgPC9zZW5kZXI+CiAgICAgIDxjb250cm9sQWN0UHJvY2Vz
+        cyBjbGFzc0NvZGU9IkNBQ1QiIG1vb2RDb2RlPSJFVk4iPgogICAgICAgIDxj
+        b2RlIGNvZGU9IlBSUEFfVEUyMDEzMDVVVjAyIiBjb2RlU3lzdGVtPSIyLjE2
+        Ljg0MC4xLjExMzg4My4xLjYiLz4KICAgICAgICA8ZGF0YUVudGVyZXIgdHlw
+        ZUNvZGU9IkVOVCIgY29udGV4dENvbnRyb2xDb2RlPSJBUCI+CiAgICAgICAg
+        ICA8YXNzaWduZWRQZXJzb24gY2xhc3NDb2RlPSJBU1NJR05FRCI+CiAgICAg
+        ICAgICAgIDxpZCBleHRlbnNpb249Ijc5NjEyMjMwNiIgcm9vdD0iMi4xNi44
+        NDAuMS4xMTM4ODMuNzc3Ljk5OSIvPgogICAgICAgICAgICA8YXNzaWduZWRQ
+        ZXJzb24gY2xhc3NDb2RlPSJQU04iIGRldGVybWluZXJDb2RlPSJJTlNUQU5D
+        RSI+CiAgICAgICAgICAgICAgPG5hbWU+CiAgICAgICAgICAgICAgICA8Z2l2
+        ZW4+TWl0Y2hlbGw8L2dpdmVuPgogICAgICAgICAgICAgICAgPGdpdmVuPkc8
+        L2dpdmVuPgogICAgICAgICAgICAgICAgPGZhbWlseT5KZW5raW5zPC9mYW1p
+        bHk+CiAgICAgICAgICAgICAgPC9uYW1lPgogICAgICAgICAgICA8L2Fzc2ln
+        bmVkUGVyc29uPgogICAgICAgICAgPC9hc3NpZ25lZFBlcnNvbj4KICAgICAg
+        ICA8L2RhdGFFbnRlcmVyPgogICAgICAgIDxxdWVyeUJ5UGFyYW1ldGVyPgog
+        ICAgICAgICAgPHF1ZXJ5SWQgcm9vdD0iMS4yLjg0MC4xMTQzNTAuMS4xMy4y
+        OC4xLjE4LjUuOTk5IiBleHRlbnNpb249IjE4MjA0Ii8+CiAgICAgICAgICA8
+        c3RhdHVzQ29kZSBjb2RlPSJuZXciLz4KICAgICAgICAgIDxtb2RpZnlDb2Rl
+        IGNvZGU9Ik1WSS5DT01QMSIvPgogICAgICAgICAgPGluaXRpYWxRdWFudGl0
+        eSB2YWx1ZT0iMSIvPgogICAgICAgICAgPHBhcmFtZXRlckxpc3Q+CiAgICAg
+        ICAgICAgIDxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+CiAg
+        ICAgICAgICAgICAgPHZhbHVlIGNvZGU9Ik0iLz4KICAgICAgICAgICAgICA8
+        c2VtYW50aWNzVGV4dD5HZW5kZXI8L3NlbWFudGljc1RleHQ+CiAgICAgICAg
+        ICAgIDwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPgogICAg
+        ICAgICAgICA8bGl2aW5nU3ViamVjdEJpcnRoVGltZT4KICAgICAgICAgICAg
+        ICA8dmFsdWUgdmFsdWU9IjE5NDkwMzA0Ii8+CiAgICAgICAgICAgICAgPHNl
+        bWFudGljc1RleHQ+RGF0ZSBvZiBCaXJ0aDwvc2VtYW50aWNzVGV4dD4KICAg
+        ICAgICAgICAgPC9saXZpbmdTdWJqZWN0QmlydGhUaW1lPgogICAgICAgICAg
+        ICA8bGl2aW5nU3ViamVjdElkPgogICAgICAgICAgICAgIDx2YWx1ZSByb290
+        PSIyLjE2Ljg0MC4xLjExMzg4My40LjEiIGV4dGVuc2lvbj0iNzk2MTIyMzA2
+        Ii8+CiAgICAgICAgICAgICAgPHNlbWFudGljc1RleHQ+U1NOPC9zZW1hbnRp
+        Y3NUZXh0PgogICAgICAgICAgICA8L2xpdmluZ1N1YmplY3RJZD4KICAgICAg
+        ICAgICAgPGxpdmluZ1N1YmplY3ROYW1lPgogICAgICAgICAgICAgIDx2YWx1
+        ZSB1c2U9IkwiPgogICAgICAgICAgICAgICAgPGdpdmVuPk1pdGNoZWxsPC9n
+        aXZlbj4KICAgICAgICAgICAgICAgIDxnaXZlbj5HPC9naXZlbj4KICAgICAg
+        ICAgICAgICAgIDxmYW1pbHk+SmVua2luczwvZmFtaWx5PgogICAgICAgICAg
+        ICAgIDwvdmFsdWU+CiAgICAgICAgICAgICAgPHNlbWFudGljc1RleHQ+TGVn
+        YWwgTmFtZTwvc2VtYW50aWNzVGV4dD4KICAgICAgICAgICAgPC9saXZpbmdT
+        dWJqZWN0TmFtZT4KICAgICAgICAgIDwvcGFyYW1ldGVyTGlzdD4KICAgICAg
+        ICA8L3F1ZXJ5QnlQYXJhbWV0ZXI+CiAgICAgIDwvY29udHJvbEFjdFByb2Nl
+        c3M+CiAgICA8L2lkbTpQUlBBX0lOMjAxMzA1VVYwMj4KICA8L2VudjpCb2R5
+        Pgo8L2VudjpFbnZlbG9wZT4K
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Date:
+      - Fri, 28 Oct 2016 15:32:13 GMT
+      Content-Length:
+      - '3123'
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Soapaction:
+      - PRPA_IN201305UV02
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Oct 2016 15:12:01 GMT
+      Content-Length:
+      - '4018'
+      Content-Type:
+      - text/xml
+      Set-Cookie:
+      - JSESSIONID=w7RgYTqBYV2hMcQyLQVMZPl0X5yMFP2NXx8sDDtVdyQpLnTdxLSk!1604350384;
+        path=/; HttpOnly
+      X-Powered-By:
+      - Servlet/2.5 JSP/2.1
+    body:
+      encoding: UTF-8
+      string: <env:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><env:Header/><env:Body><idm:PRPA_IN201306UV02
+        xmlns="urn:hl7-org:v3" xmlns:idm="http://vaww.oed.oit.va.gov" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        ITSVersion="XML_1.0" xsi:schemaLocation="urn:hl7-org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/PRPA_IN201306UV02.xsd"><id
+        extension="WSDOC1610281012015841158653421" root="2.16.840.1.113883.4.349"/><creationTime
+        value="20161028101201"/><versionCode code="3.0"/><interactionId extension="PRPA_IN201306UV02"
+        root="2.16.840.1.113883.1.6"/><processingCode code="T"/><processingModeCode
+        code="T"/><acceptAckCode code="NE"/><receiver typeCode="RCV"><device determinerCode="INSTANCE"
+        classCode="DEV"><id extension="200VGOV" root="2.16.840.1.113883.4.349"/></device></receiver><sender
+        typeCode="SND"><device determinerCode="INSTANCE" classCode="DEV"><id extension="200M"
+        root="2.16.840.1.113883.4.349"/></device></sender><acknowledgement><typeCode
+        code="AA"/><targetMessage><id extension="200VGOV-08509eaa-923d-4055-bec9-f9d18de54edb"
+        root="1.2.840.114350.1.13.0.1.7.1.1"/></targetMessage><acknowledgementDetail><code
+        codeSystemName="MVI" code="132" displayName="IMT"/><text>Identity Match Threshold</text></acknowledgementDetail><acknowledgementDetail><code
+        codeSystemName="MVI" code="120" displayName="PDT"/><text>Potential Duplicate
+        Threshold</text></acknowledgementDetail></acknowledgement><controlActProcess
+        classCode="CACT" moodCode="EVN"><code codeSystem="2.16.840.1.113883.1.6" code="PRPA_TE201306UV02"/><subject
+        typeCode="SUBJ"><registrationEvent classCode="REG" moodCode="EVN"><id nullFlavor="NA"/><statusCode
+        code="active"/><subject1 typeCode="SBJ"><patient classCode="PAT"><id extension="1008714701V416111^NI^200M^USVHA^P"
+        root="2.16.840.1.113883.4.349"/><id extension="796122306^PI^200BRLS^USVBA^A"
+        root="2.16.840.1.113883.4.349"/><id extension="9100792239^PI^200CORP^USVBA^A"
+        root="2.16.840.1.113883.4.349"/><statusCode code="active"/><patientPerson><name
+        use="L"><given>MITCHELL</given><given>G</given><family>JENKINS</family></name><administrativeGenderCode
+        code=""/><birthTime value=""/><addr use="PHYS"><streetAddressLine>121
+        A St</streetAddressLine><city>Austin</city><state>TX</state><postalCode>78772</postalCode><country>USA</country></addr><asOtherIDs
+        classCode="SSN"><id extension="796122306" root="2.16.840.1.113883.4.1"/><scopingOrganization
+        determinerCode="INSTANCE" classCode="ORG"><id root="1.2.840.114350.1.13.99997.2.3412"/></scopingOrganization></asOtherIDs></patientPerson><subjectOf1><queryMatchObservation
+        classCode="COND" moodCode="EVN"><code code="IHE_PDQ"/><value value="169" xsi:type="INT"/></queryMatchObservation></subjectOf1></patient></subject1><custodian
+        typeCode="CST"><assignedEntity classCode="ASSIGNED"><id root="2.16.840.1.113883.4.349"/></assignedEntity></custodian></registrationEvent></subject><queryAck><queryId
+        extension="18204" root="1.2.840.114350.1.13.28.1.18.5.999"/><queryResponseCode
+        code="OK"/><resultCurrentQuantity value="1"/></queryAck><queryByParameter><queryId
+        extension="18204" root="1.2.840.114350.1.13.28.1.18.5.999"/><statusCode code="new"/><modifyCode
+        code="MVI.COMP1"/><initialQuantity value="1"/><parameterList><livingSubjectAdministrativeGender><value
+        code=""/><semanticsText>Gender</semanticsText></livingSubjectAdministrativeGender><livingSubjectBirthTime><value
+        value=""/><semanticsText>Date of Birth</semanticsText></livingSubjectBirthTime><livingSubjectId><value
+        extension="" root="2.16.840.1.113883.4.1"/><semanticsText>SSN</semanticsText></livingSubjectId><livingSubjectName><value
+        use="L"><given>Mitchell</given><given>G</given><family>Jenkins</family></value><semanticsText>Legal
+        Name</semanticsText></livingSubjectName></parameterList></queryByParameter></controlActProcess></idm:PRPA_IN201306UV02></env:Body></env:Envelope>
+    http_version:
+  recorded_at: Fri, 28 Oct 2016 15:32:14 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Background

We are sporadically seeing issues when calling the EMIS and MVI services.  EMIS provides us service history for a veteran, and MVI is providing us with a veterans gender and birthday.

Here is a sample log for the EMIS issue:

http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/38205/events/996315/

You'll note the response is a handful of empty tags.  Similar things happen with MVI, randomly.

## Definition of done

- [x] custom error handling for when EMIS does not respond with the expected payload
- [x] custom error handling for when MVI does not respond with the expected payload
- [x] collaborate with the FE on the response API
- [x] update swagger docs with new customer errors
- [x] spec coverage