### PR TITLE
WIP - 10358 vet360 cache invalidation

### DIFF
--- a/app/controllers/v0/profile/transactions_controller.rb
+++ b/app/controllers/v0/profile/transactions_controller.rb
@@ -17,6 +17,9 @@ module V0
 
       def statuses
         transactions = AsyncTransaction::Vet360::Base.refresh_transaction_statuses(@current_user, service)
+
+        Vet360Redis::Cache.invalidate(@current_user) if transactions.present?
+
         render json: transactions, each_serializer: AsyncTransaction::BaseSerializer
       end
 

--- a/app/models/vet360_redis/cache.rb
+++ b/app/models/vet360_redis/cache.rb
@@ -1,0 +1,7 @@
+module Vet360Redis
+  class Cache
+    def self.invalidate(user)
+      user.vet360_contact_info&.destroy
+    end
+  end
+end

--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -107,6 +107,7 @@ module Vet360
 
         with_monitoring do
           raw_response = perform(method, path, model.in_json)
+          Vet360Redis::Cache.invalidate(@user)
 
           response_class.from(raw_response)
         end

--- a/spec/models/vet360_redis/cache_spec.rb
+++ b/spec/models/vet360_redis/cache_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'common/exceptions'
+
+describe Vet360Redis::Cache do
+  let(:user) { build :user, :loa3 }
+  let(:contact_info) { Vet360Redis::ContactInformation.for_user(user) }
+
+  describe '.invalidate' do
+    it 'invalidates the vet360-contact-info-response cache' do
+      contact_info.cache(user.uuid, 'cache data')
+
+      expect_any_instance_of(Common::RedisStore).to receive(:destroy)
+
+      Vet360Redis::Cache.invalidate(user)
+    end
+  end
+end

--- a/spec/request/profile_status_spec.rb
+++ b/spec/request/profile_status_spec.rb
@@ -98,5 +98,35 @@ RSpec.describe 'profile_status', type: :request do
         end
       end
     end
+
+    context 'cache invalidation' do
+      context 'when transactions exist' do
+        it 'invalidates the cache for the vet360-contact-info-response Redis key' do
+          allow(AsyncTransaction::Vet360::Base).to receive(:refresh_transaction_statuses).and_return(['a transaction'])
+
+          expect_any_instance_of(Common::RedisStore).to receive(:destroy)
+
+          get(
+            '/v0/profile/status/',
+            nil,
+            auth_header
+          )
+        end
+      end
+
+      context 'when transactions do not exist' do
+        it 'does not invalidate the cache for the vet360-contact-info-response Redis key' do
+          allow(AsyncTransaction::Vet360::Base).to receive(:refresh_transaction_statuses).and_return([])
+
+          expect_any_instance_of(Common::RedisStore).to_not receive(:destroy)
+
+          get(
+            '/v0/profile/status/',
+            nil,
+            auth_header
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/request/vet360/email_address_request_spec.rb
+++ b/spec/request/vet360/email_address_request_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe 'email_address', type: :request do
           end.to change(AsyncTransaction::Vet360::EmailTransaction, :count).from(0).to(1)
         end
       end
+
+      it 'invalidates the cache for the vet360-contact-info-response Redis key' do
+        VCR.use_cassette('vet360/contact_information/post_email_success') do
+          expect_any_instance_of(Common::RedisStore).to receive(:destroy)
+
+          post(
+            '/v0/profile/email_addresses',
+            { email_address: 'test@example.com' }.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+        end
+      end
     end
 
     context 'with a 400 response' do
@@ -128,6 +142,20 @@ RSpec.describe 'email_address', type: :request do
               )
             )
           end.to change(AsyncTransaction::Vet360::EmailTransaction, :count).from(0).to(1)
+        end
+      end
+
+      it 'invalidates the cache for the vet360-contact-info-response Redis key' do
+        VCR.use_cassette('vet360/contact_information/put_email_success') do
+          expect_any_instance_of(Common::RedisStore).to receive(:destroy)
+
+          put(
+            '/v0/profile/email_addresses',
+            { id: 42, email_address: 'person42@example.com' }.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
         end
       end
     end


### PR DESCRIPTION
## Background
We currently collect v360 user profile data as part of the `/v0/user` request. This data gets cached in Redis for 60 seconds (but this may change in the future). We're adding support for modifying some of that profile information: address(s), email, telephone(s). So the question is how those updates should interact with the Redis caching.

## Definition of Done
- [ ] Decide when and which endpoints will trigger a cache invalidation
- [ ] Implement in vets-api
- [ ] Specs to ensure caching is being invalidated as designed