### PR TITLE
Logs to sentry in the nil case

### DIFF
--- a/app/models/async_transaction/vet360/base.rb
+++ b/app/models/async_transaction/vet360/base.rb
@@ -35,10 +35,10 @@ module AsyncTransaction
       end
 
       # Updates the status and transaction_status with fresh API data
-      # @params user [User] the user whose tx data is being updated
-      # @params service [Vet360::ContactInformation::Service] an initialized vet360 client
-      # @params tx_id [int] the transaction_id
-      # @returns [AsyncTransaction::Vet360::Base]
+      # @param user [User] the user whose tx data is being updated
+      # @param service [Vet360::ContactInformation::Service] an initialized vet360 client
+      # @param tx_id [int] the transaction_id
+      # @return [AsyncTransaction::Vet360::Base]
       def self.refresh_transaction_status(user, service, tx_id = nil)
         transaction_record = find_transaction!(user.uuid, tx_id)
         return transaction_record if transaction_record.finished?
@@ -47,10 +47,10 @@ module AsyncTransaction
       end
 
       # Requests a transaction from vet360 for an app transaction
-      # @params user [User] the user whose tx data is being updated
-      # @params transaction_record [AsyncTransaction::Vet360::Base] the tx record to be checked
-      # @params service [Vet360::ContactInformation::Service] an initialized vet360 client
-      # @returns [Vet360::Models::Transaction]
+      # @param user [User] the user whose tx data is being updated
+      # @param transaction_record [AsyncTransaction::Vet360::Base] the tx record to be checked
+      # @param service [Vet360::ContactInformation::Service] an initialized vet360 client
+      # @return [Vet360::Models::Transaction]
       def self.fetch_transaction(transaction_record, service)
         case transaction_record
         when AsyncTransaction::Vet360::AddressTransaction
@@ -66,9 +66,9 @@ module AsyncTransaction
       end
 
       # Finds a transaction by transaction_id for a user
-      # @params user_uuid [String] the user's UUID
-      # @params transaction_id [String] the transaction UUID
-      # @returns [AddressTransaction, EmailTransaction, TelephoneTransaction]
+      # @param user_uuid [String] the user's UUID
+      # @param transaction_id [String] the transaction UUID
+      # @return [AddressTransaction, EmailTransaction, TelephoneTransaction]
       def self.find_transaction!(user_uuid, transaction_id)
         Base.find_by!(user_uuid: user_uuid, transaction_id: transaction_id)
       end
@@ -91,7 +91,7 @@ module AsyncTransaction
       # Wrapper for .refresh_transaction_status which finds any outstanding transactions
       #   for a user and refreshes them
       # @param user [User] the user whose transactions we're checking
-      # @params service [Vet360::ContactInformation::Service] an initialized vet360 client
+      # @param service [Vet360::ContactInformation::Service] an initialized vet360 client
       # @return [Array] An array with any outstanding transactions refreshed. Empty if none.
       def self.refresh_transaction_statuses(user, service)
         last_ongoing_transactions_for_user(user).each_with_object([]) do |transaction, array|

--- a/app/models/vet360_redis/cache.rb
+++ b/app/models/vet360_redis/cache.rb
@@ -1,14 +1,24 @@
 # frozen_string_literal: true
 
+require 'sentry_logging'
+
 module Vet360Redis
   class Cache
+    include SentryLogging
+
     # Invalidates the cache set in Vet360Redis::ContactInformation through
     # our Common::RedisStore#destroy method.
     #
-    # @param url [User] The current user
+    # @param user [User] The current user
     #
     def self.invalidate(user)
-      user.vet360_contact_info&.destroy
+      contact_info = user.vet360_contact_info
+
+      if contact_info.present?
+        contact_info.destroy
+      else
+        new.log_message_to_sentry('Vet360: Cannot invalidate a nil response cache', :info)
+      end
     end
   end
 end

--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -12,7 +12,7 @@ module Vet360
 
       # GET's a Person bio from the Vet360 API
       # If a user is not found in Vet360, an empty PersonResponse with a 404 status will be returned
-      # @returns [Vet360::ContactInformation::PersonResponse] response wrapper around an person object
+      # @return [Vet360::ContactInformation::PersonResponse] response wrapper around an person object
       def get_person
         with_monitoring do
           raw_response = perform(:get, @user.vet360_id)
@@ -27,21 +27,21 @@ module Vet360
 
       # POSTs a new address to the vet360 API
       # @param address [Vet360::Models::Address] the address to create
-      # @returns [Vet360::ContactInformation::AddressTransactionResponse] response wrapper around an transaction object
+      # @return [Vet360::ContactInformation::AddressTransactionResponse] response wrapper around an transaction object
       def post_address(address)
         post_or_put_data(:post, address, 'addresses', AddressTransactionResponse)
       end
 
       # PUTs an updated address to the vet360 API
       # @param address [Vet360::Models::Address] the address to update
-      # @returns [Vet360::ContactInformation::AddressTransactionResponse] response wrapper around a transaction object
+      # @return [Vet360::ContactInformation::AddressTransactionResponse] response wrapper around a transaction object
       def put_address(address)
         post_or_put_data(:put, address, 'addresses', AddressTransactionResponse)
       end
 
       # GET's the status of an address transaction from the Vet360 api
       # @param transaction_id [int] the transaction_id to check
-      # @returns [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
+      # @return [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
       def get_address_transaction_status(transaction_id)
         route = "#{@user.vet360_id}/addresses/status/#{transaction_id}"
         get_transaction_status(route, AddressTransactionResponse)
@@ -49,21 +49,21 @@ module Vet360
 
       # POSTs a new address to the vet360 API
       # @param email [Vet360::Models::Email] the email to create
-      # @returns [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around an transaction object
+      # @return [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around an transaction object
       def post_email(email)
         post_or_put_data(:post, email, 'emails', EmailTransactionResponse)
       end
 
       # PUTs an updated address to the vet360 API
       # @param email [Vet360::Models::Email] the email to update
-      # @returns [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
+      # @return [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
       def put_email(email)
         post_or_put_data(:put, email, 'emails', EmailTransactionResponse)
       end
 
       # GET's the status of an email transaction from the Vet360 api
       # @param transaction_id [int] the transaction_id to check
-      # @returns [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
+      # @return [Vet360::ContactInformation::EmailTransactionResponse] response wrapper around a transaction object
       def get_email_transaction_status(transaction_id)
         route = "#{@user.vet360_id}/emails/status/#{transaction_id}"
         get_transaction_status(route, EmailTransactionResponse)
@@ -71,21 +71,21 @@ module Vet360
 
       # POSTs a new telephone to the vet360 API
       # @param telephone [Vet360::Models::Telephone] the telephone to create
-      # @returns [Vet360::ContactInformation::TelephoneUpdateResponse] response wrapper around a transaction object
+      # @return [Vet360::ContactInformation::TelephoneUpdateResponse] response wrapper around a transaction object
       def post_telephone(telephone)
         post_or_put_data(:post, telephone, 'telephones', TelephoneTransactionResponse)
       end
 
       # PUTs an updated telephone to the vet360 API
       # @param telephone [Vet360::Models::Telephone] the telephone to update
-      # @returns [Vet360::ContactInformation::TelephoneUpdateResponse] response wrapper around a transaction object
+      # @return [Vet360::ContactInformation::TelephoneUpdateResponse] response wrapper around a transaction object
       def put_telephone(telephone)
         post_or_put_data(:put, telephone, 'telephones', TelephoneTransactionResponse)
       end
 
       # GET's the status of a telephone transaction from the Vet360 api
       # @param transaction_id [int] the transaction_id to check
-      # @returns [Vet360::ContactInformation::TelephoneTransactionResponse] response wrapper around a transaction object
+      # @return [Vet360::ContactInformation::TelephoneTransactionResponse] response wrapper around a transaction object
       def get_telephone_transaction_status(transaction_id)
         route = "#{@user.vet360_id}/telephones/status/#{transaction_id}"
         get_transaction_status(route, TelephoneTransactionResponse)

--- a/lib/vet360/models/address.rb
+++ b/lib/vet360/models/address.rb
@@ -113,7 +113,7 @@ module Vet360
       end
 
       # Converts a decoded JSON response from Vet360 to an instance of the Address model
-      # @params body [Hash] the decoded response body from Vet360
+      # @param body [Hash] the decoded response body from Vet360
       # @return [Vet360::Models::Address] the model built from the response body
       # rubocop:disable Metrics/MethodLength
       def in_json
@@ -147,7 +147,7 @@ module Vet360
       # rubocop:enable Metrics/MethodLength
 
       # Converts a decoded JSON response from Vet360 to an instance of the Address model
-      # @params body [Hash] the decoded response body from Vet360
+      # @param body [Hash] the decoded response body from Vet360
       # @return [Vet360::Models::Address] the model built from the response body
       # rubocop:disable Metrics/MethodLength
       def self.build_from(body)

--- a/lib/vet360/models/email.rb
+++ b/lib/vet360/models/email.rb
@@ -39,7 +39,7 @@ module Vet360
       end
 
       # Converts a decoded JSON response from Vet360 to an instance of the Email model
-      # @params body [Hash] the decoded response body from Vet360
+      # @param body [Hash] the decoded response body from Vet360
       # @return [Vet360::Models::Email] the model built from the response body
       def self.build_from(body)
         Vet360::Models::Email.new(

--- a/lib/vet360/models/message.rb
+++ b/lib/vet360/models/message.rb
@@ -23,7 +23,7 @@ module Vet360
       )
 
       # Converts a decoded JSON response from Vet360 to an instance of the Message model
-      # @params body [Hash] the decoded response body from Vet360
+      # @param body [Hash] the decoded response body from Vet360
       # @return [Vet360::Models::Message] the model built from the response body
       def self.build_from(body)
         Vet360::Models::Message.new(

--- a/lib/vet360/models/person.rb
+++ b/lib/vet360/models/person.rb
@@ -13,7 +13,7 @@ module Vet360
       attribute :vet360_id, String
 
       # Converts a decoded JSON response from Vet360 to an instance of the Person model
-      # @params body [Hash] the decoded response body from Vet360
+      # @param body [Hash] the decoded response body from Vet360
       # @return [Vet360::Models::Person] the model built from the response body
       def self.build_from(body)
         addresses = body['addresses']&.map { |a| Vet360::Models::Address.build_from(a) }

--- a/lib/vet360/models/telephone.rb
+++ b/lib/vet360/models/telephone.rb
@@ -84,7 +84,7 @@ module Vet360
       end
 
       # Converts a decoded JSON response from Vet360 to an instance of the Telephone model
-      # @params body [Hash] the decoded response body from Vet360
+      # @param body [Hash] the decoded response body from Vet360
       # @return [Vet360::Models::Telephone] the model built from the response body
       def self.build_from(body)
         Vet360::Models::Telephone.new(

--- a/lib/vet360/models/transaction.rb
+++ b/lib/vet360/models/transaction.rb
@@ -18,7 +18,7 @@ module Vet360
       attribute :status, String
 
       # Converts a decoded JSON response from Vet360 to an instance of the Transaction model
-      # @params body [Hash] the decoded response body from Vet360
+      # @param body [Hash] the decoded response body from Vet360
       # @return [Vet360::Models::Transaction] the model built from the response body
       def self.build_from(body)
         messages = body['tx_messages']&.map { |m| Vet360::Models::Message.build_from(m) }

--- a/spec/models/vet360_redis/cache_spec.rb
+++ b/spec/models/vet360_redis/cache_spec.rb
@@ -8,12 +8,32 @@ describe Vet360Redis::Cache do
   let(:contact_info) { Vet360Redis::ContactInformation.for_user(user) }
 
   describe '.invalidate' do
-    it 'invalidates the vet360-contact-info-response cache' do
-      contact_info.cache(user.uuid, 'cache data')
+    context 'when user.vet360_contact_info is present' do
+      it 'invalidates the vet360-contact-info-response cache' do
+        contact_info.cache(user.uuid, 'cache data')
 
-      expect_any_instance_of(Common::RedisStore).to receive(:destroy)
+        expect_any_instance_of(Common::RedisStore).to receive(:destroy)
 
-      Vet360Redis::Cache.invalidate(user)
+        Vet360Redis::Cache.invalidate(user)
+      end
+    end
+
+    context 'when user.vet360_contact_info is nil' do
+      before do
+        allow(user).to receive(:vet360_contact_info).and_return(nil)
+      end
+
+      it 'does not call #destroy' do
+        expect_any_instance_of(Common::RedisStore).to_not receive(:destroy)
+
+        Vet360Redis::Cache.invalidate(user)
+      end
+
+      it 'logs to sentry' do
+        expect_any_instance_of(described_class).to receive(:log_message_to_sentry)
+
+        Vet360Redis::Cache.invalidate(user)
+      end
     end
   end
 end


### PR DESCRIPTION
## Background

Theoretically the `user.vet360_contact_info` call could resolve to `nil` when invalidating the Redis cache.

## Definition of done

- [x] Adds sentry logging for the `nil` case