### PR TITLE
Add appeals logging recording the first id returned by caseflow

### DIFF
--- a/lib/appeals/configuration.rb
+++ b/lib/appeals/configuration.rb
@@ -27,6 +27,7 @@ module Appeals
         faraday.use Faraday::Response::RaiseError
         faraday.request :json
         faraday.response :betamocks if mock_enabled?
+        faraday.response :json
         faraday.adapter Faraday.default_adapter
       end
     end

--- a/lib/appeals/service.rb
+++ b/lib/appeals/service.rb
@@ -12,9 +12,9 @@ module Appeals
 
     STATSD_KEY_PREFIX = 'api.appeals'
 
-    def get_appeals(user)
+    def get_appeals(user, additional_headers = {})
       with_monitoring do
-        response = perform(:get, '', {}, request_headers(user))
+        response = perform(:get, '', {}, request_headers(user, additional_headers))
         Appeals::Responses::Appeals.new(response.body, response.status)
       end
     rescue Common::Client::Errors::ClientError => error
@@ -23,11 +23,11 @@ module Appeals
 
     private
 
-    def request_headers(user)
+    def request_headers(user, additional_headers)
       {
         'ssn' => user.ssn,
         'Authorization' => "Token token=#{Settings.appeals.app_token}"
-      }
+      }.merge(additional_headers)
     end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/docs/v0/api_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/docs/v0/api_controller.rb
@@ -7,7 +7,7 @@ module AppealsApi
         skip_before_action(:authenticate)
 
         def index
-          swagger = YAML.safe_load(File.read(VBADocuments::Engine.root.join('README.yml')))
+          swagger = YAML.safe_load(File.read(AppealsApi::Engine.root.join('README.yml')))
           render json: swagger
         end
       end

--- a/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
@@ -9,7 +9,10 @@ module AppealsApi
 
       def index
         log_request
-        appeals_response = Appeals::Service.new.get_appeals(user)
+        appeals_response = Appeals::Service.new.get_appeals(
+          user,
+          'X-Consumer-Username' => request.headers['X-Consumer-Username']
+        )
         log_response(appeals_response)
         render(
           json: appeals_response.body

--- a/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
@@ -25,7 +25,7 @@ module AppealsApi
         hashed_ssn = Digest::SHA2.hexdigest ssn
         Rails.logger.info('Caseflow Request',
                           'consumer' => consumer,
-                          'request_identifier' => hashed_ssn)
+                          'lookup_identifier' => hashed_ssn)
       end
 
       def log_response(appeals_response)

--- a/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
@@ -11,12 +11,19 @@ module AppealsApi
 
       def index
         appeals_response = Appeals::Service.new.get_appeals(user)
+        log_response(appeals_response)
         render(
           json: appeals_response.body
         )
       end
 
       private
+
+      def log_response(appeals_response)
+        consumer = request.headers['X-Consumer-Username']
+        first_appeals_id = appeals_response.body['data'][0]['id']
+        Rails.logger.info("Caseflow request by #{consumer} retrieved #{first_appeals_id}")
+      end
 
       def user
         ssn = request.headers[VA_SSN_HEADER]

--- a/modules/appeals_api/spec/requests/appeals_request_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_request_spec.rb
@@ -21,7 +21,14 @@ RSpec.describe 'Claim Appeals API endpoint', type: :request do
         allow(Rails.logger).to receive(:info)
         get '/services/appeals/v0/appeals', nil,
             'X-VA-SSN' => '111223333', 'X-Consumer-Username' => 'TestConsumer'
-        expect(Rails.logger).to have_received(:info).with(/TestConsumer/)
+        hash = Digest::SHA2.hexdigest '111223333'
+        expect(Rails.logger).to have_received(:info).with('Caseflow Request',
+                                                          'consumer' => 'TestConsumer',
+                                                          'request_identifier' => hash)
+        expect(Rails.logger).to have_received(:info).with('Caseflow Response',
+                                                          'consumer' => 'TestConsumer',
+                                                          'first_appeal_id' => '1196201',
+                                                          'appeal_count' => 3)
       end
     end
   end

--- a/modules/appeals_api/spec/requests/appeals_request_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_request_spec.rb
@@ -8,10 +8,8 @@ RSpec.describe 'Claim Appeals API endpoint', type: :request do
   context 'with the X-VA-SSN header supplied ' do
     it 'returns a successful response' do
       VCR.use_cassette('appeals/appeals') do
-        get '/services/appeals/v0/appeals', nil, {
-              'X-VA-SSN' => '111223333',
-              'X-Consumer-Username' => 'TestConsumer'
-            }
+        get '/services/appeals/v0/appeals', nil,
+            'X-VA-SSN' => '111223333', 'X-Consumer-Username' => 'TestConsumer'
         expect(response).to have_http_status(:ok)
         expect(response.body).to be_a(String)
         expect(response).to match_response_schema('appeals')
@@ -21,10 +19,8 @@ RSpec.describe 'Claim Appeals API endpoint', type: :request do
     it 'should log the consumer name' do
       VCR.use_cassette('appeals/appeals') do
         allow(Rails.logger).to receive(:info)
-        get '/services/appeals/v0/appeals', nil, {
-              'X-VA-SSN' => '111223333',
-              'X-Consumer-Username' => 'TestConsumer'
-            }
+        get '/services/appeals/v0/appeals', nil,
+            'X-VA-SSN' => '111223333', 'X-Consumer-Username' => 'TestConsumer'
         expect(Rails.logger).to have_received(:info).with(/TestConsumer/)
       end
     end

--- a/modules/appeals_api/spec/requests/appeals_request_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_request_spec.rb
@@ -8,10 +8,24 @@ RSpec.describe 'Claim Appeals API endpoint', type: :request do
   context 'with the X-VA-SSN header supplied ' do
     it 'returns a successful response' do
       VCR.use_cassette('appeals/appeals') do
-        get '/services/appeals/v0/appeals', nil, 'X-VA-SSN' => '111223333'
+        get '/services/appeals/v0/appeals', nil, {
+              'X-VA-SSN' => '111223333',
+              'X-Consumer-Username' => 'TestConsumer'
+            }
         expect(response).to have_http_status(:ok)
         expect(response.body).to be_a(String)
         expect(response).to match_response_schema('appeals')
+      end
+    end
+
+    it 'should log the consumer name' do
+      VCR.use_cassette('appeals/appeals') do
+        allow(Rails.logger).to receive(:info)
+        get '/services/appeals/v0/appeals', nil, {
+              'X-VA-SSN' => '111223333',
+              'X-Consumer-Username' => 'TestConsumer'
+            }
+        expect(Rails.logger).to have_received(:info).with(/TestConsumer/)
       end
     end
   end

--- a/modules/appeals_api/spec/requests/appeals_request_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_request_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Claim Appeals API endpoint', type: :request do
         hash = Digest::SHA2.hexdigest '111223333'
         expect(Rails.logger).to have_received(:info).with('Caseflow Request',
                                                           'consumer' => 'TestConsumer',
-                                                          'request_identifier' => hash)
+                                                          'lookup_identifier' => hash)
         expect(Rails.logger).to have_received(:info).with('Caseflow Response',
                                                           'consumer' => 'TestConsumer',
                                                           'first_appeal_id' => '1196201',


### PR DESCRIPTION
Logs the Kong Username and the first record returned so we can later audit to
see if a call center inappropriately accessed records. This is just one way of
doing it. we have also talked about logging the request itself with a hash of
the ssn.