### PR TITLE
Logging to determine user success/failure access rate

### DIFF
--- a/app/policies/evss_policy.rb
+++ b/app/policies/evss_policy.rb
@@ -5,19 +5,23 @@ EVSSPolicy = Struct.new(:user, :evss) do
 
   def access?
     if user.edipi.present? && user.ssn.present? && user.participant_id.present?
+      log_message_to_sentry('EVSS Pundit success log', :info) if user.loa3?
+
       true
     else
-      log_message_to_sentry(
-        'EVSS Pundit Policy bug',
-        :info,
-        {
-          edipi_present: user.edipi.present?,
-          ssn_present: user.ssn.present?,
-          participant_id_present: user.participant_id.present?,
-          user_loa: user&.loa
-        },
-        profile: 'pciu_profile'
-      )
+      if user.loa3?
+        log_message_to_sentry(
+          'EVSS Pundit failure log',
+          :info,
+          {
+            edipi_present: user.edipi.present?,
+            ssn_present: user.ssn.present?,
+            participant_id_present: user.participant_id.present?,
+            user_loa: user&.loa
+          },
+          profile: 'pciu_profile'
+        )
+      end
 
       false
     end

--- a/app/policies/evss_policy.rb
+++ b/app/policies/evss_policy.rb
@@ -5,11 +5,13 @@ EVSSPolicy = Struct.new(:user, :evss) do
 
   def access?
     if user.edipi.present? && user.ssn.present? && user.participant_id.present?
-      log_message_to_sentry('EVSS Pundit success log', :info) if user.loa3?
+      StatsD.increment('api.evss.policy.success') if user.loa3?
 
       true
     else
       if user.loa3?
+        StatsD.increment('api.evss.policy.failure')
+
         log_message_to_sentry(
           'EVSS Pundit failure log',
           :info,

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -51,6 +51,8 @@ StatsD.increment("#{EVSS::Service::STATSD_KEY_PREFIX}.get_address.total", 0)
 StatsD.increment("#{EVSS::Service::STATSD_KEY_PREFIX}.get_address.fail", 0)
 StatsD.increment("#{EVSS::Service::STATSD_KEY_PREFIX}.update_address.total", 0)
 StatsD.increment("#{EVSS::Service::STATSD_KEY_PREFIX}.update_address.fail", 0)
+StatsD.increment("#{EVSS::Service::STATSD_KEY_PREFIX}.policy.success", 0)
+StatsD.increment("#{EVSS::Service::STATSD_KEY_PREFIX}.policy.failure", 0)
 
 # init appeals
 StatsD.increment("#{Appeals::Service::STATSD_KEY_PREFIX}.get_appeals.total", 0)

--- a/spec/policies/evss_policy_spec.rb
+++ b/spec/policies/evss_policy_spec.rb
@@ -12,6 +12,10 @@ describe EVSSPolicy do
       it 'grants access' do
         expect(subject).to permit(user, :evss)
       end
+
+      it 'increments the StatsD success counter' do
+        expect { EVSSPolicy.new(user, :evss).access? }.to trigger_statsd_increment('api.evss.policy.success')
+      end
     end
 
     context 'with a user who does not have the required evss attributes' do
@@ -19,6 +23,10 @@ describe EVSSPolicy do
 
       it 'denies access' do
         expect(subject).to_not permit(user, :evss)
+      end
+
+      it 'increments the StatsD failure counter' do
+        expect { EVSSPolicy.new(user, :evss).access? }.to trigger_statsd_increment('api.evss.policy.failure')
       end
     end
   end

--- a/spec/policies/evss_policy_spec.rb
+++ b/spec/policies/evss_policy_spec.rb
@@ -15,7 +15,7 @@ describe EVSSPolicy do
     end
 
     context 'with a user who does not have the required evss attributes' do
-      let(:user) { build(:user, :loa1) }
+      let(:user) { build(:unauthorized_evss_user, :loa3) }
 
       it 'denies access' do
         expect(subject).to_not permit(user, :evss)


### PR DESCRIPTION
## Background

Background is outlined in detail in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/10478

## Definition of done

- [x] Logging to determine the success/failure percentages for the EVSS Pundit policy being met