### PR TITLE
Vet360: Attempt to parse tx_status before status

### DIFF
--- a/lib/vet360/models/transaction.rb
+++ b/lib/vet360/models/transaction.rb
@@ -25,7 +25,7 @@ module Vet360
         Vet360::Models::Transaction.new(
           messages: messages || [],
           id: body['tx_audit_id'],
-          status: body['status']
+          status: body['tx_status'] || body['status']
         )
       end
     end


### PR DESCRIPTION
This PR sets up the Vet360 service model for transactions to attempt to parse `tx_status` before status. This allows us to handle the following scenarios:

1) Response from POST / PUT contains `status`
2) Response from GET transaction status contains `tx_status` and `status`, the former being the one we are interested in. `tx_status` is the status of the transaction, while the `status` field in this case is the state of the actual GET request for the transaction status. 

This fallback behavior will allow us to capture both scenarios correctly without any modifications to application layer code.