### PR TITLE
Vet360 Improve isInternational field handling and docs

### DIFF
--- a/app/swagger/schemas/vet360/telephone.rb
+++ b/app/swagger/schemas/vet360/telephone.rb
@@ -7,7 +7,7 @@ module Swagger
         include Swagger::Blocks
 
         swagger_schema :PostVet360Telephone do
-          key :required, %i[is_international phone_number area_code phone_type]
+          key :required, %i[phone_number area_code phone_type]
           property :is_international,
                    type: :boolean,
                    example: false
@@ -37,7 +37,7 @@ module Swagger
         end
 
         swagger_schema :PutVet360Telephone do
-          key :required, %i[id is_international phone_number area_code phone_type]
+          key :required, %i[id phone_number area_code phone_type]
           property :id, type: :integer, example: 1
           property :is_international,
                    type: :boolean,

--- a/app/swagger/schemas/vet360/telephone.rb
+++ b/app/swagger/schemas/vet360/telephone.rb
@@ -7,7 +7,13 @@ module Swagger
         include Swagger::Blocks
 
         swagger_schema :PostVet360Telephone do
-          key :required, %i[phone_number area_code phone_type]
+          key :required, %i[is_international phone_number area_code phone_type]
+          property :is_international,
+                   type: :boolean,
+                   example: false
+          property :country_code,
+                   type: :string,
+                   example: '1'
           property :phone_number,
                    type: :string,
                    example: '5551212',
@@ -31,8 +37,14 @@ module Swagger
         end
 
         swagger_schema :PutVet360Telephone do
-          key :required, %i[id phone_number area_code phone_type]
+          key :required, %i[id is_international phone_number area_code phone_type]
           property :id, type: :integer, example: 1
+          property :is_international,
+                   type: :boolean,
+                   example: false
+          property :country_code,
+                   type: :string,
+                   example: '1'
           property :phone_number,
                    type: :string,
                    example: '5551212',

--- a/lib/vet360/models/telephone.rb
+++ b/lib/vet360/models/telephone.rb
@@ -22,7 +22,7 @@ module Vet360
       attribute :effective_end_date, Common::ISO8601Time
       attribute :effective_start_date, Common::ISO8601Time
       attribute :id, Integer
-      attribute :is_international, Boolean
+      attribute :is_international, Boolean, default: false
       attribute :is_textable, Boolean
       attribute :is_text_permitted, Boolean
       attribute :is_tty, Boolean
@@ -59,12 +59,18 @@ module Vet360
         inclusion: { in: PHONE_TYPES }
       )
 
+      validates(
+        :is_international,
+        inclusion: { in: [true, false] },
+        exclusion: { in: [nil] }
+      )
+
       # Converts an instance of the Telphone model to a JSON encoded string suitable for
       # use in the body of a request to Vet360
       # @return [String] JSON-encoded string suitable for requests to Vet360
       def in_json
         # Determine international flag if not set
-        @is_international ||= @country_code.present? && @country_code != '1'
+        # @is_international ||= @country_code.present? && @country_code != '1'
 
         {
           bio: {

--- a/lib/vet360/models/telephone.rb
+++ b/lib/vet360/models/telephone.rb
@@ -59,6 +59,11 @@ module Vet360
         inclusion: { in: PHONE_TYPES }
       )
 
+      validates(
+        :is_international,
+        presence: true
+      )
+
       # Converts an instance of the Telphone model to a JSON encoded string suitable for
       # use in the body of a request to Vet360
       # @return [String] JSON-encoded string suitable for requests to Vet360

--- a/lib/vet360/models/telephone.rb
+++ b/lib/vet360/models/telephone.rb
@@ -63,6 +63,9 @@ module Vet360
       # use in the body of a request to Vet360
       # @return [String] JSON-encoded string suitable for requests to Vet360
       def in_json
+        # Determine international flag if not set
+        @is_international ||= @country_code.present? && @country_code != '1'
+
         {
           bio: {
             areaCode: @area_code,

--- a/lib/vet360/models/telephone.rb
+++ b/lib/vet360/models/telephone.rb
@@ -70,7 +70,7 @@ module Vet360
       # @return [String] JSON-encoded string suitable for requests to Vet360
       def in_json
         # Determine international flag if not set
-        # @is_international ||= @country_code.present? && @country_code != '1'
+        @is_international ||= @country_code.present? && @country_code != '1'
 
         {
           bio: {

--- a/lib/vet360/models/telephone.rb
+++ b/lib/vet360/models/telephone.rb
@@ -59,11 +59,6 @@ module Vet360
         inclusion: { in: PHONE_TYPES }
       )
 
-      validates(
-        :is_international,
-        presence: true
-      )
-
       # Converts an instance of the Telphone model to a JSON encoded string suitable for
       # use in the body of a request to Vet360
       # @return [String] JSON-encoded string suitable for requests to Vet360

--- a/spec/lib/vet360/models/telephone_spec.rb
+++ b/spec/lib/vet360/models/telephone_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Vet360::Models::Telephone do
+  describe 'is_international' do
+    let(:data) { JSON.parse(telephone.in_json) }
+    let(:is_international) { data['bio']['internationalIndicator'] }
+
+    context 'when explicitly set' do
+      let(:telephone) { build(:telephone, is_international: true) }
+
+      it 'equals the input value' do
+        expect(is_international).to eq(true)
+      end
+    end
+
+    context 'when nil' do
+      context 'when country_code is nil' do
+        let(:telephone) { build(:telephone, is_international: nil, country_code: nil) }
+
+        it 'defaults to false' do
+          expect(is_international).to eq(false)
+        end
+      end
+
+      context 'when country_code is domestic' do
+        let(:telephone) { build(:telephone, is_international: nil, country_code: '1') }
+        it 'is false' do
+          expect(is_international).to eq(false)
+        end
+      end
+
+      context 'when country_code is international' do
+        let(:telephone) { build(:telephone, is_international: nil, country_code: '44') }
+        it 'is true' do
+          expect(is_international).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR ensures that isInternational is included in the swagger docs for Vet360 endpoints. This is required by Vet360 when we perform telephone address updates.