### PR TITLE
VBADocuments: Return data object for non-existent results

### DIFF
--- a/modules/vba_documents/README.yml
+++ b/modules/vba_documents/README.yml
@@ -234,10 +234,7 @@ paths:
       responses:
         '200':
           description: |
-            Upload status report retrieved successfully. Any invalid or
-            unknown GUIDs will be omitted from the response, so the length
-            of the response list may not match the length of the 
-            requested GUID list.
+            Upload status report retrieved successfully.
           content:
             application/json:
               schema:

--- a/modules/vba_documents/README.yml
+++ b/modules/vba_documents/README.yml
@@ -394,6 +394,7 @@ components:
             * `DOC102` - Invalid metadata - not parseable as JSON, incorrect fields, etc.
             * `DOC103` - Invalid content - not parseable as PDF. Detail field will indicate which document or attachment part was affected.
             * `DOC104` - Upload rejected by downstream system. Detail field will indicate nature of rejection.
+            * `DOC105` - Invalid or unknown id
             * `DOC201` - Upload server error.
             * `DOC202` - Error during processing by downstream system. Processing failed and could not be retried. Detail field will provide additional details where available.
           type: string

--- a/modules/vba_documents/app/controllers/vba_documents/v0/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v0/uploads_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency 'vba_documents/application_controller'
+require_dependency 'vba_documents/upload_error'
 
 module VBADocuments
   module V0
@@ -17,12 +18,17 @@ module VBADocuments
 
       def show
         submission = VBADocuments::UploadSubmission.find_by(guid: params[:id])
-        raise Common::Exceptions::RecordNotFound, params[:id] if submission.nil?
-        raise Common::Exceptions::RecordNotFound, params[:id] if submission.status == 'expired'
-        submission.refresh_status!
-        render json: submission,
-               serializer: VBADocuments::UploadSerializer,
-               render_location: false
+        if submission.nil? || submission.status == 'expired'
+          render status: :not_found,
+                 json: VBADocuments::UploadSubmission.fake_status(params[:id]),
+                 serializer: VBADocuments::UploadSerializer,
+                 render_location: false
+        else
+          submission.refresh_status!
+          render json: submission,
+                 serializer: VBADocuments::UploadSerializer,
+                 render_location: false
+        end
       end
     end
   end

--- a/modules/vba_documents/app/models/vba_documents/upload_submission.rb
+++ b/modules/vba_documents/app/models/vba_documents/upload_submission.rb
@@ -22,7 +22,7 @@ module VBADocuments
                                         detail: VBADocuments::UploadError::DOC105,
                                         location: nil)
       def empty_submission.read_attribute_for_serialization(attr)
-        self.send(attr)
+        send(attr)
       end
       empty_submission
     end

--- a/modules/vba_documents/app/models/vba_documents/upload_submission.rb
+++ b/modules/vba_documents/app/models/vba_documents/upload_submission.rb
@@ -11,7 +11,20 @@ module VBADocuments
       submissions = where(guid: guids)
       in_flights = submissions.select { |sub| sub.send(:status_in_flight?) }
       refresh_statuses!(in_flights)
-      submissions.to_a
+      missing = guids - submissions.map(&:guid)
+      submissions.to_a + missing.map { |id| fake_status(id) }
+    end
+
+    def self.fake_status(guid)
+      empty_submission = OpenStruct.new(guid: guid,
+                                        status: 'error',
+                                        code: 'DOC105',
+                                        detail: VBADocuments::UploadError::DOC105,
+                                        location: nil)
+      def empty_submission.read_attribute_for_serialization(attr)
+        self.send(attr)
+      end
+      empty_submission
     end
 
     def self.refresh_statuses!(submissions)

--- a/modules/vba_documents/lib/vba_documents/upload_error.rb
+++ b/modules/vba_documents/lib/vba_documents/upload_error.rb
@@ -10,6 +10,7 @@ module VBADocuments
     DOC102 = 'Invalid metadata part'
     DOC103 = 'Invalid content part'
     DOC104 = 'Upload rejected by downstream system'
+    DOC105 = 'Invalid or unknown id'
 
     # DOC2xx errors: server errors either local or downstream
     # not unambiguously related to submitted content

--- a/modules/vba_documents/spec/jobs/upload_remover_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_remover_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe VBADocuments::UploadRemover, type: :job do
 
       it 'should do nothing' do
         with_settings(Settings.vba_documents.s3, 'enabled': true) do
-          expect(@object).to_not receive(:delete).with(upload.guid)
+          expect(@objstore).to_not receive(:delete).with(upload.guid)
           described_class.new.perform
           upload.reload
           expect(upload.s3_deleted).to be_falsy

--- a/modules/vba_documents/spec/request/reports_request_spec.rb
+++ b/modules/vba_documents/spec/request/reports_request_spec.rb
@@ -108,12 +108,16 @@ RSpec.describe 'VBA Document Uploads Report Endpoint', type: :request do
         expect(ids).to include(upload.guid)
       end
 
-      it 'should omit results for non-existent submission' do
+      it 'should present error result for non-existent submission' do
         post '/services/vba_documents/v0/uploads/report', ids: ['fake-1234']
         expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
         expect(json['data']).to be_an(Array)
-        expect(json['data']).to be_empty
+        expect(json['data'].size).to eq(1)
+        status = json['data'][0]
+        expect(status['id']).to eq('fake-1234')
+        expect(status['attributes']['guid']).to eq('fake-1234')
+        expect(status['attributes']['code']).to eq('DOC105')
       end
     end
 

--- a/modules/vba_documents/spec/request/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/uploads_request_spec.rb
@@ -43,9 +43,12 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
       expect(json['data']['attributes']['location']).to be_nil
     end
 
-    it 'should return not_found for a non-existent submission' do
+    it 'should return not_found with data for a non-existent submission' do
       get '/services/vba_documents/v0/uploads/non_existent_guid'
       expect(response).to have_http_status(:not_found)
+      json = JSON.parse(response.body)
+      expect(json['data']['attributes']['guid']).to eq('non_existent_guid')
+      expect(json['data']['attributes']['status']).to eq('error')
     end
 
     it 'should return not_found for an expired submission' do


### PR DESCRIPTION
See forwarded email thread for context. 

Goals were twofold:
- Make nonexistent submission IDs return something (instead of being omitted) in the bulk status operation.
- Make the bulk status and single status operations more similar in the nonexistent case.

So single status nonexistent now returns a 404 status but with a JSON API `data` element instead of an `errors` element. Somewhat of a divergence from the rest of our API but I'm comfortable with it.

Some messiness needed to render these objects with potentially invalid UUIDs because ActiveRecord prevents you from setting the guid accordingly. So I had to fake out some objects. I would expect that consumers are invoking the API with semantically valid but non-existent UUIDs, but I didn't want to fork the API even more for "existent", "non-existent but valid" and "non-existent and invalid" UUID possibilities. 