### PR TITLE
add logging for dslogon status of DEPENDENT or DECEASED

### DIFF
--- a/app/models/user_identity.rb
+++ b/app/models/user_identity.rb
@@ -9,6 +9,9 @@ class UserIdentity < Common::RedisStore
   redis_ttl REDIS_CONFIG['user_identity_store']['each_ttl']
   redis_key :uuid
 
+  after_initialize :dslogon_logging
+  DSLOGON_LOGGING_STATUS_TYPES = %w[DEPENDENT DECEASED]
+
   # identity attributes
   attribute :uuid
   attribute :email
@@ -25,8 +28,26 @@ class UserIdentity < Common::RedisStore
   attribute :mhv_icn # only needed by B/E not serialized in user_serializer
   attribute :mhv_correlation_id # this is the cannonical version of MHV Correlation ID, provided by MHV sign-in users
   attribute :mhv_account_type # this is only available for MHV sign-in users
+  attribute :dslogon_edipi # this is only available for DS Logon sign-in users
+  attribute :dslogon_status # this is only available for DS Logon sign-in users
+  attribute :dslogon_deceased # this is only available for DS Logon sign-in users
 
   validates :uuid, presence: true
   validates :email, presence: true
   validates :loa, presence: true
+
+  def dslogon_logging
+    return if persisted? # only log it once when first initialized
+    return unless DSLOGON_LOGGING_STATUS_TYPES.includes?(dslogon_status.upcase)
+    logger.info("DSLogon #{dslogon_status} Logging",
+                uuid: uuid,
+                loa: loa,
+                email: email,
+                first_name: first_name,
+                dslogon_edipi: dslogon_edipi,
+                dslogon_status: dslogon_status,
+                dslogon_deceased: dslogon_deceased,
+                ssn_exists: ssn.present?
+              )
+  end
 end


### PR DESCRIPTION
@jkassemi what do you think about this approach?

NOTE: this wont tell us if the user has a record in MVI because i'm logging it in UserIdentity vs User, but I could probably just as easily do it in User and get additional information from there.

Some of what is being logged here could also be characterized as PII maybe?