### PR TITLE
10550 rake initialize vet360

### DIFF
--- a/lib/mvi/responses/id_parser.rb
+++ b/lib/mvi/responses/id_parser.rb
@@ -6,6 +6,7 @@ module MVI
       CORRELATION_ROOT_ID = '2.16.840.1.113883.4.349'
       EDIPI_ROOT_ID = '2.16.840.1.113883.3.42.10001.100001.12'
       ICN_REGEX = /^\w+\^NI\^\w+\^\w+\^\w+$/
+      VET360_ASSIGNING_AUTHORITY_ID = '^NI^200M^USVHA^P'
 
       # MVI correlation id source id relationships:
       # {source id}^{id type}^{assigning facility}^{assigning authority}^{id status}

--- a/lib/vet360/person/service.rb
+++ b/lib/vet360/person/service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'common/client/base'
+require 'vet360/contact_information/transaction_response'
+
+module Vet360
+  module Person
+    class Service < Vet360::Service
+      include Common::Client::Monitoring
+
+      OID = MVI::Responses::IdParser::CORRELATION_ROOT_ID
+      AAID = MVI::Responses::IdParser::VET360_ASSIGNING_AUTHORITY_ID
+
+      configuration Vet360::ContactInformation::Configuration
+
+      def init_vet360_id(icn)
+        with_monitoring do
+          raw_response = perform(:post, encoded_uri_for(icn), empty_body, skip_vet360_id: true)
+
+          Vet360::ContactInformation::PersonResponse.from(raw_response)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      private
+
+      # rubocop:disable Lint/UriEscapeUnescape
+      def encoded_uri_for(icn, oid: OID, aaid: AAID)
+        URI.encode("#{oid}/#{icn}#{aaid}")
+      end
+      # rubocop:enable Lint/UriEscapeUnescape
+
+      def empty_body
+        {
+          bio: {
+            sourceDate: Time.zone.now.iso8601
+          }
+        }.to_json
+      end
+    end
+  end
+end

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -10,8 +10,8 @@ module Vet360
       @user = user
     end
 
-    def perform(method, path, body = nil, headers = {})
-      vet360_id_present!
+    def perform(method, path, body = nil, headers = {}, skip_vet360_id: false)
+      vet360_id_present! unless skip_vet360_id
 
       config.base_request_headers.merge(headers)
       response = super(method, path, body, headers)

--- a/rakelib/vet360.rake
+++ b/rakelib/vet360.rake
@@ -199,17 +199,17 @@ namespace :vet360 do
     pp trx.to_h
   end
 
-  desc <<-EOD
-Initializes a vet360_id for the passed in ICNs.
+  desc <<~DESCRIPTION
+    Initializes a vet360_id for the passed in ICNs.
 
-Takes a comma-separated list of ICNs as an argument.  Prints an array of hash results.
+    Takes a comma-separated list of ICNs as an argument.  Prints an array of hash results.
 
-Sample way to call this rake task:
+    Sample way to call this rake task:
 
-rake vet360:init_vet360_id[123456,1312312,134234234,4234234]'
+    rake vet360:init_vet360_id[123456,1312312,134234234,4234234]'
 
-Note: There *cannot* be any spaces around the commas (i.e. [123456, 1312312, 134234234, 4234234])
-  EOD
+    Note: There *cannot* be any spaces around the commas (i.e. [123456, 1312312, 134234234, 4234234])
+  DESCRIPTION
   task :init_vet360_id, [:icns] => [:environment] do |_, args|
     service = Vet360::Person::Service.new('rake_user')
     icns    = args.extras.prepend(args[:icns])
@@ -223,7 +223,7 @@ Note: There *cannot* be any spaces around the commas (i.e. [123456, 1312312, 134
         vet360_id = response&.person&.vet360_id
 
         results << { icn: icn, vet360_id: vet360_id }
-      rescue => e
+      rescue StandardError => e
         results << { icn: icn, vet360_id: e.message }
       end
     end

--- a/rakelib/vet360.rake
+++ b/rakelib/vet360.rake
@@ -199,6 +199,38 @@ namespace :vet360 do
     pp trx.to_h
   end
 
+  desc <<-EOD
+Initializes a vet360_id for the passed in ICNs.
+
+Takes a comma-separated list of ICNs as an argument.  Prints an array of hash results.
+
+Sample way to call this rake task:
+
+rake vet360:init_vet360_id[123456,1312312,134234234,4234234]'
+
+Note: There *cannot* be any spaces around the commas (i.e. [123456, 1312312, 134234234, 4234234])
+  EOD
+  task :init_vet360_id, [:icns] => [:environment] do |_, args|
+    service = Vet360::Person::Service.new('rake_user')
+    icns    = args.extras.prepend(args[:icns])
+    results = []
+
+    p "#{icns.size} to be initialized"
+
+    icns.each do |icn|
+      begin
+        response  = service.init_vet360_id(icn)
+        vet360_id = response&.person&.vet360_id
+
+        results << { icn: icn, vet360_id: vet360_id }
+      rescue => e
+        results << { icn: icn, vet360_id: e.message }
+      end
+    end
+
+    puts "Results:\n\n#{results}"
+  end
+
   def ensure_data_var
     abort "Env var: #{ENV_VAR_NAME} not set" if ENV[ENV_VAR_NAME].blank?
   end

--- a/spec/lib/vet360/person/service_spec.rb
+++ b/spec/lib/vet360/person/service_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Vet360::Person::Service, skip_vet360: true do
+  let(:user) { 'rake_user' }
+  let(:icn)  { '1012852978V019884' }
+  subject    { described_class.new(user) }
+
+  before { Timecop.freeze('2018-04-09T17:52:03Z') }
+  after  { Timecop.return }
+
+  describe '#init_vet360_id' do
+    context 'when successful' do
+      it 'returns a status of 200', :aggregate_failures do
+        VCR.use_cassette('vet360/person/init_vet360_id_success', VCR::MATCH_EVERYTHING) do
+          response = subject.init_vet360_id(icn)
+
+          expect(response).to be_ok
+          expect(response.person).to be_a(Vet360::Models::Person)
+        end
+      end
+
+      it 'initializes a vet360_id' do
+        VCR.use_cassette('vet360/person/init_vet360_id_success', VCR::MATCH_EVERYTHING) do
+          response = subject.init_vet360_id(icn)
+
+          expect(response.person.vet360_id).to eq '323'
+        end
+      end
+    end
+
+    context 'with a 400 response' do
+      it 'raises an exception' do
+        VCR.use_cassette('vet360/person/init_vet360_id_status_400', VCR::MATCH_EVERYTHING) do
+          expect { subject.init_vet360_id(icn) }.to raise_error do |e|
+            expect(e).to be_a(Common::Exceptions::BackendServiceException)
+            expect(e.status_code).to eq(400)
+            expect(e.errors.first.code).to eq('VET360_PERS101')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/vcr_cassettes/vet360/person/init_vet360_id_status_400.yml
+++ b/spec/support/vcr_cassettes/vet360/person/init_vet360_id_status_400.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/2.16.840.1.113883.4.349/1012852978V019884%5ENI%5E200M%5EUSVHA%5EP"
+    body:
+      encoding: UTF-8
+      string: '{"bio":{"sourceDate":"2018-04-09T17:52:03Z"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Cufsystemname:
+      - VETSGOV
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Date:
+      - Wed, 25 Apr 2018 17:17:07 GMT
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      X-Ua-Compatible:
+      - IE-edge,chrome=1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+        "messages": [
+          {
+            "code":"PERS101",
+            "key":"vet360Id.NotNull",
+            "severity":"ERROR",
+            "text":"The vet360Id cannot be null."
+          }
+        ],
+        "txAuditId":"3773cd41-0958-4bbe-a035-16ae353cde03",
+        "status":"REJECTED"
+      }'
+    http_version:
+  recorded_at: Wed, 25 Apr 2018 17:17:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/vet360/person/init_vet360_id_success.yml
+++ b/spec/support/vcr_cassettes/vet360/person/init_vet360_id_success.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/2.16.840.1.113883.4.349/1012852978V019884%5ENI%5E200M%5EUSVHA%5EP"
+    body:
+      encoding: UTF-8
+      string: '{"bio":{"sourceDate":"2018-04-09T17:52:03Z"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Cufsystemname:
+      - VETSGOV
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Wed, 25 Apr 2018 17:17:07 GMT
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      X-Ua-Compatible:
+      - IE-edge,chrome=1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+        "bio":{
+          "vet360Id":323,
+          "addresses":[],
+          "telephones":[],
+          "emails":[],
+          "sourceSystem":"VET360-TEST-PARTNER",
+          "sourceDate":"2018-04-21T19:51:43Z"
+        }
+      }'
+    http_version:
+  recorded_at: Wed, 25 Apr 2018 17:17:06 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Background

Our Vet360 endpoints require a user's `vet360_id` to be included as part of the request.  The Vet360 group is intending to bulk update veteran's with this new `vet360_id`; however, this will take place over time, and there is always a possibility that any given user might have not have one.

In addition to that, during our smoke testing, and UAT, there is also a possibility that a given user might not have one.

The Vet360 team offers an endpoint to initialize a `vet360_id` for a given user:

```
POST /cuf/person/contact-information/v1/{oid}/{idWithAaid}
```

The `oid` is an organizational ID obtained from MVI, and the `idWithAaid` is the ICN with the `assigningauthorityid`, also obtained from MVI.

A sample request would look something like this:

```
POST /cuf/person/contact-information/v1/2.16.840.1.113883.4.349/124V123^NI^200M^USVHA
```

## Definition of done

- [x] Rake task that can initialize a user's `vet360_id`
- [x] Service object that calls Vet360 endpoint
- [x] Rake task should call the logic, not encapsulate it, so that this logic can be re-purposed elsewhere (i.e. from the new profile page, if needs be)
- [ ] new recorded cassette of hitting the Vet360 POST endpoint
- [x] spec coverage