### PR TITLE
10748 initialize vet360 id 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,6 +113,7 @@ class User < Common::RedisStore
   delegate :birls_id, to: :mvi
   delegate :edipi, to: :mvi
   delegate :icn, to: :mvi
+  delegate :icn_with_aaid, to: :mvi
   delegate :participant_id, to: :mvi
   delegate :veteran?, to: :veteran_status
   delegate :vet360_id, to: :mvi

--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -15,7 +15,9 @@ module Vet360
       # @return [Vet360::ContactInformation::PersonResponse] response wrapper around an person object
       def get_person
         with_monitoring do
+          vet360_id_present!
           raw_response = perform(:get, @user.vet360_id)
+
           PersonResponse.from(raw_response)
         end
       rescue Common::Client::Errors::ClientError => error
@@ -102,10 +104,15 @@ module Vet360
         end
       end
 
+      def vet360_id_present!
+        raise 'User does not have a vet360_id' if @user&.vet360_id.blank?
+      end
+
       def post_or_put_data(method, model, path, response_class)
         temporary_short_circuit!
 
         with_monitoring do
+          vet360_id_present!
           raw_response = perform(method, path, model.in_json)
 
           response_class.from(raw_response)
@@ -118,6 +125,7 @@ module Vet360
         temporary_short_circuit!
 
         with_monitoring do
+          vet360_id_present!
           raw_response = perform(:get, path)
 
           response_class.from(raw_response)

--- a/lib/vet360/contact_information/transaction_response.rb
+++ b/lib/vet360/contact_information/transaction_response.rb
@@ -21,6 +21,7 @@ module Vet360
 
     class AddressTransactionResponse < TransactionResponse; end
     class EmailTransactionResponse < TransactionResponse; end
+    class PersonTransactionResponse < TransactionResponse; end
     class TelephoneTransactionResponse < TransactionResponse; end
   end
 end

--- a/lib/vet360/person/service.rb
+++ b/lib/vet360/person/service.rb
@@ -15,7 +15,7 @@ module Vet360
 
       def init_vet360_id(icn)
         with_monitoring do
-          raw_response = perform(:post, encoded_uri_for(icn), empty_body, skip_vet360_id: true)
+          raw_response = perform(:post, encoded_uri_for(icn), empty_body)
 
           Vet360::ContactInformation::PersonResponse.from(raw_response)
         end

--- a/lib/vet360/person/service.rb
+++ b/lib/vet360/person/service.rb
@@ -8,16 +8,16 @@ module Vet360
     class Service < Vet360::Service
       include Common::Client::Monitoring
 
-      OID = MVI::Responses::IdParser::CORRELATION_ROOT_ID
       AAID = MVI::Responses::IdParser::VET360_ASSIGNING_AUTHORITY_ID
+      OID  = MVI::Responses::IdParser::CORRELATION_ROOT_ID
 
       configuration Vet360::ContactInformation::Configuration
 
-      def init_vet360_id(icn)
+      def init_vet360_id(icn = nil)
         with_monitoring do
-          raw_response = perform(:post, encoded_uri_for(icn), empty_body)
+          raw_response = perform(:post, encode_uri!(icn), empty_body)
 
-          Vet360::ContactInformation::PersonResponse.from(raw_response)
+          Vet360::ContactInformation::PersonTransactionResponse.from(raw_response)
         end
       rescue StandardError => e
         handle_error(e)
@@ -26,10 +26,20 @@ module Vet360
       private
 
       # rubocop:disable Lint/UriEscapeUnescape
-      def encoded_uri_for(icn, oid: OID, aaid: AAID)
-        URI.encode("#{oid}/#{icn}#{aaid}")
+      def encode_uri!(icn)
+        URI.encode("#{OID}/#{build_icn_with_aaid!(icn)}")
       end
       # rubocop:enable Lint/UriEscapeUnescape
+
+      def build_icn_with_aaid!(icn)
+        if icn.present?
+          "#{icn}#{AAID}"
+        elsif @user&.icn_with_aaid.present?
+          @user.icn_with_aaid
+        else
+          raise 'User does not have an ICN with an Assigning Authority ID'
+        end
+      end
 
       def empty_body
         {

--- a/lib/vet360/person/service.rb
+++ b/lib/vet360/person/service.rb
@@ -7,6 +7,7 @@ module Vet360
   module Person
     class Service < Vet360::Service
       include Common::Client::Monitoring
+      include ERB::Util
 
       AAID = MVI::Responses::IdParser::VET360_ASSIGNING_AUTHORITY_ID
       OID  = MVI::Responses::IdParser::CORRELATION_ROOT_ID
@@ -22,7 +23,7 @@ module Vet360
       #
       def init_vet360_id(icn = nil)
         with_monitoring do
-          raw_response = perform(:post, encode_uri!(icn), empty_body)
+          raw_response = perform(:post, encode_url!(icn), empty_body)
 
           Vet360::ContactInformation::PersonTransactionResponse.from(raw_response)
         end
@@ -32,11 +33,13 @@ module Vet360
 
       private
 
-      # rubocop:disable Lint/UriEscapeUnescape
-      def encode_uri!(icn)
-        URI.encode("#{OID}/#{build_icn_with_aaid!(icn)}")
+      # @see https://ruby-doc.org/stdlib-2.3.0/libdoc/erb/rdoc/ERB/Util.html
+      #
+      def encode_url!(icn)
+        encoded_icn_with_aaid = url_encode(build_icn_with_aaid!(icn))
+
+        "#{OID}/#{encoded_icn_with_aaid}"
       end
-      # rubocop:enable Lint/UriEscapeUnescape
 
       def build_icn_with_aaid!(icn)
         if icn.present?

--- a/lib/vet360/person/service.rb
+++ b/lib/vet360/person/service.rb
@@ -13,6 +13,13 @@ module Vet360
 
       configuration Vet360::ContactInformation::Configuration
 
+      # Initializes a vet360_id for a user that does not have one. Can be used when a current user
+      # is present, or through a rake task when no user is present (through passing in their ICN).
+      # This is an asynchronous process for Vet360, so it returns Vet360 transaction information.
+      #
+      # @param icn [String] A users ICN. Only required when current user is absent.  Intended to be used in a rake task.
+      # @return [Vet360::ContactInformation::PersonTransactionResponse] response wrapper around a transaction object
+      #
       def init_vet360_id(icn = nil)
         with_monitoring do
           raw_response = perform(:post, encode_uri!(icn), empty_body)

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -10,9 +10,7 @@ module Vet360
       @user = user
     end
 
-    def perform(method, path, body = nil, headers = {}, skip_vet360_id: false)
-      vet360_id_present! unless skip_vet360_id
-
+    def perform(method, path, body = nil, headers = {})
       config.base_request_headers.merge(headers)
       response = super(method, path, body, headers)
       log_to_sentry(response)
@@ -25,10 +23,6 @@ module Vet360
     end
 
     private
-
-    def vet360_id_present!
-      raise 'User does not have a vet360_id' if @user&.vet360_id.blank?
-    end
 
     def handle_error(error)
       case error

--- a/spec/lib/vet360/person/service_spec.rb
+++ b/spec/lib/vet360/person/service_spec.rb
@@ -3,36 +3,61 @@
 require 'rails_helper'
 
 describe Vet360::Person::Service, skip_vet360: true do
-
   before { Timecop.freeze('2018-04-09T17:52:03Z') }
   after  { Timecop.return }
 
   describe '#init_vet360_id' do
-    context 'when successful' do
     let(:user) { build(:user_with_suffix, :loa3) }
     subject { described_class.new(user) }
+
+    context 'with a user present, that has a icn_with_aaid, and no passed in ICN' do
+      it 'returns a status of 200', :aggregate_failures do
+        VCR.use_cassette('vet360/person/init_vet360_id_success', VCR::MATCH_EVERYTHING) do
+          response = subject.init_vet360_id
+
+          expect(response).to be_ok
+          expect(response).to be_a(Vet360::ContactInformation::PersonTransactionResponse)
+        end
+      end
+
+      it 'initiates an asynchronous Vet360 transaction', :aggregate_failures do
+        VCR.use_cassette('vet360/person/init_vet360_id_success', VCR::MATCH_EVERYTHING) do
+          response = subject.init_vet360_id
+
+          expect(response.transaction.id).to be_present
+          expect(response.transaction.status).to be_present
+        end
+      end
+    end
+
+    context 'with a passed in ICN' do
+      let(:icn) { '1000123456V123456' }
+      let(:rake_user) { 'rake_user' }
+      subject { described_class.new(rake_user) }
+
       it 'returns a status of 200', :aggregate_failures do
         VCR.use_cassette('vet360/person/init_vet360_id_success', VCR::MATCH_EVERYTHING) do
           response = subject.init_vet360_id(icn)
 
           expect(response).to be_ok
-          expect(response.person).to be_a(Vet360::Models::Person)
+          expect(response).to be_a(Vet360::ContactInformation::PersonTransactionResponse)
         end
       end
 
-      it 'initializes a vet360_id' do
+      it 'initiates an asynchronous Vet360 transaction', :aggregate_failures do
         VCR.use_cassette('vet360/person/init_vet360_id_success', VCR::MATCH_EVERYTHING) do
           response = subject.init_vet360_id(icn)
 
-          expect(response.person.vet360_id).to eq '323'
+          expect(response.transaction.id).to be_present
+          expect(response.transaction.status).to be_present
         end
       end
     end
 
     context 'with a 400 response' do
-      it 'raises an exception' do
+      it 'raises an exception', :aggregate_failures do
         VCR.use_cassette('vet360/person/init_vet360_id_status_400', VCR::MATCH_EVERYTHING) do
-          expect { subject.init_vet360_id(icn) }.to raise_error do |e|
+          expect { subject.init_vet360_id }.to raise_error do |e|
             expect(e).to be_a(Common::Exceptions::BackendServiceException)
             expect(e.status_code).to eq(400)
             expect(e.errors.first.code).to eq('VET360_PERS101')

--- a/spec/lib/vet360/person/service_spec.rb
+++ b/spec/lib/vet360/person/service_spec.rb
@@ -3,15 +3,14 @@
 require 'rails_helper'
 
 describe Vet360::Person::Service, skip_vet360: true do
-  let(:user) { 'rake_user' }
-  let(:icn)  { '1012852978V019884' }
-  subject    { described_class.new(user) }
 
   before { Timecop.freeze('2018-04-09T17:52:03Z') }
   after  { Timecop.return }
 
   describe '#init_vet360_id' do
     context 'when successful' do
+    let(:user) { build(:user_with_suffix, :loa3) }
+    subject { described_class.new(user) }
       it 'returns a status of 200', :aggregate_failures do
         VCR.use_cassette('vet360/person/init_vet360_id_success', VCR::MATCH_EVERYTHING) do
           response = subject.init_vet360_id(icn)

--- a/spec/support/vcr_cassettes/vet360/person/init_vet360_id_status_400.yml
+++ b/spec/support/vcr_cassettes/vet360/person/init_vet360_id_status_400.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/2.16.840.1.113883.4.349/1012852978V019884%5ENI%5E200M%5EUSVHA%5EP"
+    uri: "https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/2.16.840.1.113883.4.349/1000123456V123456%5ENI%5E200M%5EUSVHA%5EP"
     body:
       encoding: UTF-8
       string: '{"bio":{"sourceDate":"2018-04-09T17:52:03Z"}}'

--- a/spec/support/vcr_cassettes/vet360/person/init_vet360_id_success.yml
+++ b/spec/support/vcr_cassettes/vet360/person/init_vet360_id_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/2.16.840.1.113883.4.349/1012852978V019884%5ENI%5E200M%5EUSVHA%5EP"
+    uri: "https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/2.16.840.1.113883.4.349/1000123456V123456%5ENI%5E200M%5EUSVHA%5EP"
     body:
       encoding: UTF-8
       string: '{"bio":{"sourceDate":"2018-04-09T17:52:03Z"}}'
@@ -44,16 +44,7 @@ http_interactions:
       - chunked
     body:
       encoding: UTF-8
-      string: '{
-        "bio":{
-          "vet360Id":323,
-          "addresses":[],
-          "telephones":[],
-          "emails":[],
-          "sourceSystem":"VET360-TEST-PARTNER",
-          "sourceDate":"2018-04-21T19:51:43Z"
-        }
-      }'
+      string: '{"txAuditId":"786efe0e-fd20-4da2-9019-0c00540dba4d","status":"RECEIVED"}'
     http_version:
   recorded_at: Wed, 25 Apr 2018 17:17:06 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Background

Initialization of a Vet360 user is a 2-step process, first requiring a POST, and then a follow up GET to check for any errors. This PR represents the implementation of the first step, performing a POST to `/cuf/person/contact-information/v1/maintenance/{oid}/{idWithAaid}` using a user's ICN.

## Definition of done 

- [x] Refactor `skip_vet360_id` parameter (if necessary)
- [x] Build service call to `/cuf/person/contact-information/v1/maintenance/{oid}/{idWithAaid}`
- [x] Returns an instance of `Vet360::Models::Transaction` rather than a Person
- [ ] Cassettes recorded
- [x] Specs