### PR TITLE
10764 get person status

### DIFF
--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -93,6 +93,12 @@ module Vet360
         get_transaction_status(route, TelephoneTransactionResponse)
       end
 
+      # GET's the status of a person transaction from the Vet360 api. Does not validate the presence of
+      # a vet360_id before making the service call, as POSTing a person initializes a vet360_id.
+      #
+      # @param transaction_id [String] the transaction_id to check
+      # @return [Vet360::ContactInformation::PersonTransactionResponse] response wrapper around a transaction object
+      #
       def get_person_transaction_status(transaction_id)
         with_monitoring do
           raw_response = perform(:get, "status/#{transaction_id}")

--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -93,6 +93,16 @@ module Vet360
         get_transaction_status(route, TelephoneTransactionResponse)
       end
 
+      def get_person_transaction_status(transaction_id)
+        with_monitoring do
+          raw_response = perform(:get, "status/#{transaction_id}")
+
+          Vet360::ContactInformation::PersonTransactionResponse.from(raw_response)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
+
       private
 
       # This method acts as a beta flag, and is temporarily in place until Vet360

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -275,4 +275,34 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
       end
     end
   end
+
+  describe '#get_person_transaction_status' do
+    context 'when successful' do
+      let(:transaction_id) { '786efe0e-fd20-4da2-9019-0c00540dba4d' }
+
+      it 'returns a status of 200', :aggregate_failures do
+        VCR.use_cassette('vet360/contact_information/person_transaction_status', VCR::MATCH_EVERYTHING) do
+          response = subject.get_person_transaction_status(transaction_id)
+
+          expect(response).to be_ok
+          expect(response.transaction).to be_a(Vet360::Models::Transaction)
+          expect(response.transaction.id).to eq(transaction_id)
+        end
+      end
+    end
+
+    context 'when not successful' do
+      let(:transaction_id) { 'd47b3d96-9ddd-42be-ac57-8e564aa38029' }
+
+      it 'returns a status of 400', :aggregate_failures do
+        VCR.use_cassette('vet360/contact_information/person_transaction_status_error', VCR::MATCH_EVERYTHING) do
+          expect { subject.get_person_transaction_status(transaction_id) }.to raise_error do |e|
+            expect(e).to be_a(Common::Exceptions::BackendServiceException)
+            expect(e.status_code).to eq(400)
+            expect(e.errors.first.code).to eq('VET360_PERS200')
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/support/vcr_cassettes/vet360/contact_information/person_transaction_status.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/person_transaction_status.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/status/786efe0e-fd20-4da2-9019-0c00540dba4d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Cufsystemname:
+      - VETSGOV
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Wed, 25 Apr 2018 17:22:19 GMT
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      X-Ua-Compatible:
+      - IE-edge,chrome=1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "txAuditId": "786efe0e-fd20-4da2-9019-0c00540dba4d",
+          "status": "COMPLETED_SUCCESS",
+          "txStatus": "COMPLETED_SUCCESS",
+          "txType": "PUSH",
+          "txInteractionType": "ATTENDED",
+          "txPushInput": {
+            "sourceDate": "2018-04-09T17:52:03Z",
+            "originatingSourceSystem": "VETSGOV"
+          },
+          "txOutput": [
+            {
+              "vet360Id": 1,
+              "txAuditId": "786efe0e-fd20-4da2-9019-0c00540dba4d",
+              "sourceSystem": "VETSGOV",
+              "sourceDate": "2018-04-09T17:52:03Z",
+              "originatingSourceSystem": "VETSGOV"
+            }
+          ]
+        }
+    http_version:
+  recorded_at: Wed, 25 Apr 2018 17:22:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/vet360/contact_information/person_transaction_status_error.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/person_transaction_status_error.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/status/d47b3d96-9ddd-42be-ac57-8e564aa38029
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Cufsystemname:
+      - VETSGOV
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Date:
+      - Wed, 25 Apr 2018 17:22:19 GMT
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      X-Ua-Compatible:
+      - IE-edge,chrome=1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [
+            {
+              "code": "PERS200",
+              "key": "_CUF_NOT_FOUND",
+              "severity": "ERROR",
+              "text": "The veteran with the id requested has already been created."
+            }
+          ],
+          "status": "COMPLETED_FAILURE"
+        }
+    http_version:
+  recorded_at: Wed, 25 Apr 2018 17:22:18 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Background

Initialization of a Vet360 user is a 2-step process, first requiring a POST, and then a follow up GET to check for any errors. This PR represents the implementation of the second step, a performing a GET to `/cuf/person/contact-information/v1/status/{txAuditId}` to check if there were any issues initializing a user in Vet360.

This follows the precedence that has been set when POSTing/PUTting an email, telephone, etc. and checking its status.

## Definition of done 

- [x] Build service call to `/cuf/person/contact-information/v1/status/{txAuditId}`
- [x] Returns an instance of `Vet360::Models::Transaction` rather than a Person
- [ ] Cassettes recorded
- [x] Specs