### PR TITLE
10749 initialize vet360 id endpoint

### DIFF
--- a/app/controllers/v0/profile/persons_controller.rb
+++ b/app/controllers/v0/profile/persons_controller.rb
@@ -3,15 +3,19 @@
 module V0
   module Profile
     class PersonsController < ApplicationController
-      include Vet360::Writeable
-
-      after_action :invalidate_cache
+      after_action :invalidate_mvi_cache
 
       def initialize_vet360_id
         response    = Vet360::Person::Service.new(@current_user).init_vet360_id
         transaction = AsyncTransaction::Vet360::InitializePersonTransaction.start(@current_user, response)
 
         render json: transaction, serializer: AsyncTransaction::BaseSerializer
+      end
+
+      private
+
+      def invalidate_mvi_cache
+        @current_user.mvi&.destroy
       end
     end
   end

--- a/app/controllers/v0/profile/persons_controller.rb
+++ b/app/controllers/v0/profile/persons_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V0
+  module Profile
+    class PersonsController < ApplicationController
+      include Vet360::Writeable
+
+      after_action :invalidate_cache
+
+      def initialize_vet360_id
+        response    = Vet360::Person::Service.new(@current_user).init_vet360_id
+        transaction = AsyncTransaction::Vet360::InitializePersonTransaction.start(@current_user, response)
+
+        render json: transaction, serializer: AsyncTransaction::BaseSerializer
+      end
+    end
+  end
+end

--- a/app/models/async_transaction/base.rb
+++ b/app/models/async_transaction/base.rb
@@ -20,8 +20,15 @@ module AsyncTransaction
     end
 
     validates :id, uniqueness: true
-    validates :user_uuid, :source_id, :source, :status, :transaction_id, presence: true
+    validates :user_uuid, :source, :status, :transaction_id, presence: true
+    validates :source_id, presence: true, unless: :initialize_person?
     validates :transaction_id,
               uniqueness: { scope: :source, message: 'Transaction ID must be unique within a source.' }
+
+    private
+
+    def initialize_person?
+      type&.constantize == AsyncTransaction::Vet360::InitializePersonTransaction
+    end
   end
 end

--- a/app/models/async_transaction/vet360/initialize_person_transaction.rb
+++ b/app/models/async_transaction/vet360/initialize_person_transaction.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AsyncTransaction
+  module Vet360
+    class InitializePersonTransaction < AsyncTransaction::Vet360::Base; end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -235,11 +235,11 @@ class User < Common::RedisStore
     @vet360_contact_info ||= Vet360Redis::ContactInformation.for_user(self)
   end
 
-  private
-
   def mvi
     @mvi ||= Mvi.for_user(self)
   end
+
+  private
 
   def pciu
     @pciu ||= EVSS::PCIU::Service.new self

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -338,6 +338,27 @@ module Swagger
         end
       end
 
+      swagger_path '/v0/profile/initialize_vet360_id' do
+        operation :post do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Initializes a vet360_id for the current user'
+          key :operationId, 'initializeVet360Id'
+          key :tags, %w[
+            profile
+          ]
+
+          parameter :authorization
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :AsyncTransactionVet360
+            end
+          end
+        end
+      end
+
       swagger_path '/v0/profile/personal_information' do
         operation :get do
           extend Swagger::Responses::AuthenticationError

--- a/app/swagger/schemas/async_transaction/vet360.rb
+++ b/app/swagger/schemas/async_transaction/vet360.rb
@@ -27,6 +27,7 @@ module Swagger
                 %w[
                   AsyncTransaction::Vet360::AddressTransaction
                   AsyncTransaction::Vet360::EmailTransaction
+                  AsyncTransaction::Vet360::InitializePersonTransaction
                   AsyncTransaction::Vet360::TelephoneTransaction
                 ], example: 'AsyncTransaction::Vet360::EmailTransaction'
               property :metadata, type: :array do
@@ -63,6 +64,7 @@ module Swagger
                   %w[
                     AsyncTransaction::Vet360::AddressTransaction
                     AsyncTransaction::Vet360::EmailTransaction
+                    AsyncTransaction::Vet360::InitializePersonTransaction
                     AsyncTransaction::Vet360::TelephoneTransaction
                   ], example: 'AsyncTransaction::Vet360::EmailTransaction'
                 property :metadata, type: :array do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,6 +180,7 @@ Rails.application.routes.draw do
       resource :addresses, only: %i[create update]
       resource :email_addresses, only: %i[create update]
       resource :telephones, only: %i[create update]
+      post 'initialize_vet360_id', to: 'persons#initialize_vet360_id'
       get 'status/:transaction_id', to: 'transactions#status'
       get 'status', to: 'transactions#statuses'
     end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1319,6 +1319,19 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           )
         end
       end
+
+      it 'supports posting to initialize a vet360_id' do
+        expect(subject).to validate(:post, '/v0/profile/initialize_vet360_id', 401)
+
+        VCR.use_cassette('vet360/person/init_vet360_id_success') do
+          expect(subject).to validate(
+            :post,
+            '/v0/profile/initialize_vet360_id',
+            200,
+            auth_options.merge('_data' => {})
+          )
+        end
+      end
     end
 
     describe 'profile/status' do

--- a/spec/request/vet360/person_request_spec.rb
+++ b/spec/request/vet360/person_request_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'person', type: :request do
+  include SchemaMatchers
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user_with_suffix, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  describe 'POST /v0/profile/initialize_vet360_id' do
+    before do
+      allow_any_instance_of(User).to receive(:vet360_id).and_return(nil)
+    end
+
+    context 'with a user that has an icn_with_aaid' do
+      it 'should match the transaction response schema', :aggregate_failures do
+        VCR.use_cassette('vet360/person/init_vet360_id_success') do
+          post(
+            '/v0/profile/initialize_vet360_id',
+            {},
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('vet360/transaction_response')
+        end
+      end
+
+      it 'should create a new AsyncTransaction::Vet360::InitializePersonTransaction', :aggregate_failures do
+        VCR.use_cassette('vet360/person/init_vet360_id_success') do
+          expect do
+            post(
+              '/v0/profile/initialize_vet360_id',
+              {},
+              auth_header.update(
+                'Content-Type' => 'application/json', 'Accept' => 'application/json'
+              )
+            )
+          end.to change { AsyncTransaction::Vet360::InitializePersonTransaction.count }.from(0).to(1)
+        end
+      end
+    end
+
+    context 'with an error response' do
+      it 'should match the transaction response schema', :aggregate_failures do
+        VCR.use_cassette('vet360/person/init_vet360_id_status_400') do
+          post(
+            '/v0/profile/initialize_vet360_id',
+            {},
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+  end
+end

--- a/spec/request/vet360/person_request_spec.rb
+++ b/spec/request/vet360/person_request_spec.rb
@@ -10,21 +10,32 @@ RSpec.describe 'person', type: :request do
   let(:user) { build(:user_with_suffix, :loa3) }
 
   before do
+    Timecop.freeze('2018-04-09T17:52:03Z')
     Session.create(uuid: user.uuid, token: token)
     User.create(user)
   end
 
+  after { Timecop.return }
+
   describe 'POST /v0/profile/initialize_vet360_id' do
+    let(:empty_body) do
+      {
+        bio: {
+          sourceDate: Time.zone.now.iso8601
+        }
+      }.to_json
+    end
+
     before do
       allow_any_instance_of(User).to receive(:vet360_id).and_return(nil)
     end
 
     context 'with a user that has an icn_with_aaid' do
       it 'should match the transaction response schema', :aggregate_failures do
-        VCR.use_cassette('vet360/person/init_vet360_id_success') do
+        VCR.use_cassette('vet360/person/init_vet360_id_success', VCR::MATCH_EVERYTHING) do
           post(
             '/v0/profile/initialize_vet360_id',
-            {},
+            empty_body,
             auth_header.update(
               'Content-Type' => 'application/json', 'Accept' => 'application/json'
             )
@@ -36,11 +47,11 @@ RSpec.describe 'person', type: :request do
       end
 
       it 'should create a new AsyncTransaction::Vet360::InitializePersonTransaction', :aggregate_failures do
-        VCR.use_cassette('vet360/person/init_vet360_id_success') do
+        VCR.use_cassette('vet360/person/init_vet360_id_success', VCR::MATCH_EVERYTHING) do
           expect do
             post(
               '/v0/profile/initialize_vet360_id',
-              {},
+              empty_body,
               auth_header.update(
                 'Content-Type' => 'application/json', 'Accept' => 'application/json'
               )
@@ -52,10 +63,10 @@ RSpec.describe 'person', type: :request do
 
     context 'with an error response' do
       it 'should match the transaction response schema', :aggregate_failures do
-        VCR.use_cassette('vet360/person/init_vet360_id_status_400') do
+        VCR.use_cassette('vet360/person/init_vet360_id_status_400', VCR::MATCH_EVERYTHING) do
           post(
             '/v0/profile/initialize_vet360_id',
-            {},
+            empty_body,
             auth_header.update(
               'Content-Type' => 'application/json', 'Accept' => 'application/json'
             )

--- a/spec/request/vet360/person_request_spec.rb
+++ b/spec/request/vet360/person_request_spec.rb
@@ -59,6 +59,20 @@ RSpec.describe 'person', type: :request do
           end.to change { AsyncTransaction::Vet360::InitializePersonTransaction.count }.from(0).to(1)
         end
       end
+
+      it 'invalidates the cache for the mvi-profile-response Redis key' do
+        VCR.use_cassette('vet360/person/init_vet360_id_success', VCR::MATCH_EVERYTHING) do
+          expect_any_instance_of(Common::RedisStore).to receive(:destroy)
+
+          post(
+            '/v0/profile/initialize_vet360_id',
+            empty_body,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+        end
+      end
     end
 
     context 'with an error response' do

--- a/spec/request/vet360/transactions_request_spec.rb
+++ b/spec/request/vet360/transactions_request_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe 'transactions', type: :request do
   end
 
   describe 'GET /v0/profile/status/:transaction_id' do
-    let(:address) { build(:vet360_address, source_id: '1', transaction_status: 'RECEIVED') }
-
     context 'when the requested transaction exists' do
       it 'it responds with a serialized transaction', :aggregate_failures do
         transaction = create(
@@ -46,7 +44,6 @@ RSpec.describe 'transactions', type: :request do
       end
     end
 
-    let(:email) { build(:email, source_id: '1', transaction_status: 'RECEIVED') }
     context 'when the transaction has messages' do
       it 'messages are serialiezd in the metadata property', :aggregate_failures do
         transaction = create(


### PR DESCRIPTION
## Background

In order to initialize Vets.gov users in Vet360, two actions must be performed due to the async nature of the service call. This PR represents the first step, implemented as an endpoint which will allow the FE to start the process of initializing a user in Vet360.

## Definition of done 

- [x] Implement `POST /v0/profile/initialize_vet360_id` endpoint
- [x] New subclass of AsyncTransaction for Person initialization
- [x] Persist instance of AsyncTransaction subclass after service call
- [x] Invalidate MVI cache
- [x] Specs
- [x] Swagger docs