### PR TITLE
526 remove prefill banking info

### DIFF
--- a/app/models/form_profiles/va526ez.rb
+++ b/app/models/form_profiles/va526ez.rb
@@ -25,21 +25,6 @@ module VA526ez
     attribute :rated_disabilities, Array[FormRatedDisability]
   end
 
-  class FormPaymentAccountInformation
-    include Virtus.model
-
-    attribute :account_type, String
-    attribute :account_number, String
-    attribute :routing_number, String
-    attribute :bank_name, String
-  end
-
-  class FormPaymentInformation
-    include Virtus.model
-
-    attribute :payment_account, FormPaymentAccountInformation
-  end
-
   class FormAddress
     include Virtus.model
 
@@ -72,12 +57,10 @@ end
 
 class FormProfiles::VA526ez < FormProfile
   attribute :rated_disabilities_information, VA526ez::FormRatedDisabilities
-  attribute :payment_information, VA526ez::FormPaymentInformation
   attribute :veteran_contact_information, VA526ez::FormContactInformation
 
   def prefill(user)
     @rated_disabilities_information = initialize_rated_disabilities_information(user)
-    @payment_information = initialize_payment_information(user)
     @veteran_contact_information = initialize_veteran_contact_information(user)
     super(user)
   end
@@ -119,31 +102,6 @@ class FormProfiles::VA526ez < FormProfile
     VA526ez::FormRatedDisabilities.new(
       rated_disabilities: response.rated_disabilities
     )
-  rescue StandardError
-    {}
-  end
-
-  def initialize_payment_information(user)
-    return {} unless user.authorize :evss, :access?
-
-    service = EVSS::PPIU::Service.new(user)
-    response = service.get_payment_information
-    raw_account = response.responses.first&.payment_account
-
-    if raw_account
-      account = VA526ez::FormPaymentAccountInformation.new(
-        account_type: raw_account&.account_type&.upcase,
-        account_number: raw_account&.account_number,
-        routing_number: raw_account&.financial_institution_routing_number,
-        bank_name: raw_account&.financial_institution_name
-      )
-
-      VA526ez::FormPaymentInformation.new(
-        payment_account: account
-      )
-    else
-      {}
-    end
   rescue StandardError
     {}
   end

--- a/config/form_profile_mappings/21-526EZ.yml
+++ b/config/form_profile_mappings/21-526EZ.yml
@@ -1,4 +1,3 @@
 veteran: [veteran_contact_information, veteran]
-directDeposit: [payment_information, payment_account]
 disabilities: [rated_disabilities_information, rated_disabilities]
 servicePeriods: [military_information, service_periods]

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -310,12 +310,6 @@ RSpec.describe FormProfile, type: :model do
 
   let(:v21_526_ez_expected) do
     {
-      'directDeposit' => {
-        'accountType' => 'CHECKING',
-        'accountNumber' => '9876543211234',
-        'routingNumber' => '042102115',
-        'bankName' => 'Comerica'
-      },
       'disabilities' => [
         {
           'diagnosticCode' => 5238,
@@ -506,15 +500,13 @@ RSpec.describe FormProfile, type: :model do
 
         context 'with a user that can prefill evss' do
           before do
-            expect(user).to receive(:authorize).with(:evss, :access?).exactly(3).times.and_return(true)
+            expect(user).to receive(:authorize).with(:evss, :access?).exactly(2).times.and_return(true)
           end
 
           it 'returns prefilled 21-526EZ' do
             VCR.use_cassette('evss/pciu_address/address_domestic') do
-              VCR.use_cassette('evss/ppiu/payment_information') do
-                VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
-                  expect_prefilled('21-526EZ')
-                end
+              VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
+                expect_prefilled('21-526EZ')
               end
             end
           end


### PR DESCRIPTION
Form 526 will no longer be pulling payment information via prefill. This will be moved to an endpoint call (for display purposes only for the veteran). The actual `directDeposit` field for the form will be spliced in when the form is being submitted.