### PR TITLE
pass Rails logger to GovDelivery::TMS::Client instance

### DIFF
--- a/app/workers/hca/submission_failure_email_analytics_job.rb
+++ b/app/workers/hca/submission_failure_email_analytics_job.rb
@@ -59,7 +59,8 @@ module HCA
     def govdelivery_client
       @govdelivery_client ||= GovDelivery::TMS::Client.new(
         Settings.reports.token,
-        api_root: "https://#{Settings.reports.server}"
+        api_root: "https://#{Settings.reports.server}",
+        logger: logger
       )
     end
 


### PR DESCRIPTION
If you don't provide a logger, the client defaults to STDOUT