### PR TITLE
10765 check vet360 id status endpoint

### DIFF
--- a/app/controllers/concerns/vet360/transactionable.rb
+++ b/app/controllers/concerns/vet360/transactionable.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Vet360
+  module Transactionable
+    extend ActiveSupport::Concern
+
+    def check_transaction_status!
+      transaction = AsyncTransaction::Vet360::Base.refresh_transaction_status(
+        @current_user,
+        service,
+        params[:transaction_id]
+      )
+
+      raise Common::Exceptions::RecordNotFound, transaction unless transaction
+
+      render json: transaction, serializer: AsyncTransaction::BaseSerializer
+    end
+
+    private
+
+    def service
+      Vet360::ContactInformation::Service.new @current_user
+    end
+  end
+end

--- a/app/controllers/v0/profile/persons_controller.rb
+++ b/app/controllers/v0/profile/persons_controller.rb
@@ -3,6 +3,8 @@
 module V0
   module Profile
     class PersonsController < ApplicationController
+      include Vet360::Transactionable
+
       after_action :invalidate_mvi_cache
 
       def initialize_vet360_id
@@ -10,6 +12,10 @@ module V0
         transaction = AsyncTransaction::Vet360::InitializePersonTransaction.start(@current_user, response)
 
         render json: transaction, serializer: AsyncTransaction::BaseSerializer
+      end
+
+      def status
+        check_transaction_status!
       end
 
       private

--- a/app/controllers/v0/profile/transactions_controller.rb
+++ b/app/controllers/v0/profile/transactions_controller.rb
@@ -3,21 +3,14 @@
 module V0
   module Profile
     class TransactionsController < ApplicationController
+      include Vet360::Transactionable
       include Vet360::Writeable
 
       before_action { authorize :vet360, :access? }
       after_action :invalidate_cache
 
       def status
-        transaction = AsyncTransaction::Vet360::Base.refresh_transaction_status(
-          @current_user,
-          service,
-          transaction_params[:transaction_id]
-        )
-
-        raise Common::Exceptions::RecordNotFound, transaction unless transaction
-
-        render json: transaction, serializer: AsyncTransaction::BaseSerializer
+        check_transaction_status!
       end
 
       def statuses

--- a/app/models/async_transaction/vet360/base.rb
+++ b/app/models/async_transaction/vet360/base.rb
@@ -59,6 +59,8 @@ module AsyncTransaction
           service.get_email_transaction_status(transaction_record.transaction_id)
         when AsyncTransaction::Vet360::TelephoneTransaction
           service.get_telephone_transaction_status(transaction_record.transaction_id)
+        when AsyncTransaction::Vet360::InitializePersonTransaction
+          service.get_person_transaction_status(transaction_record.transaction_id)
         else
           # Unexpected transaction type means something went sideways
           raise

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -359,6 +359,32 @@ module Swagger
         end
       end
 
+      swagger_path '/v0/profile/person/status/{transaction_id}' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Gets an updated person transaction by ID'
+          key :operationId, 'getPersonTransactionStatusById'
+          key :tags, %w[profile]
+
+          parameter :authorization
+          parameter do
+            key :name, :transaction_id
+            key :in, :path
+            key :description, 'ID of transaction'
+            key :required, true
+            key :type, :string
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :AsyncTransactionVet360
+            end
+          end
+        end
+      end
+
       swagger_path '/v0/profile/personal_information' do
         operation :get do
           extend Swagger::Responses::AuthenticationError

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,6 +181,7 @@ Rails.application.routes.draw do
       resource :email_addresses, only: %i[create update]
       resource :telephones, only: %i[create update]
       post 'initialize_vet360_id', to: 'persons#initialize_vet360_id'
+      get 'person/status/:transaction_id', to: 'persons#status', as: 'person/status'
       get 'status/:transaction_id', to: 'transactions#status'
       get 'status', to: 'transactions#statuses'
     end

--- a/spec/factories/async_transactions.rb
+++ b/spec/factories/async_transactions.rb
@@ -17,5 +17,11 @@ FactoryBot.define do
 
     factory :telephone_transaction, class: AsyncTransaction::Vet360::TelephoneTransaction do
     end
+
+    factory :initialize_person_transaction, class: AsyncTransaction::Vet360::InitializePersonTransaction do
+      trait :init_vet360_id do
+        source_id nil
+      end
+    end
   end
 end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1407,12 +1407,17 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           transaction_id: transaction_id
         )
 
-        expect(subject).to validate(:get, "/v0/profile/person/status/{transaction_id}", 401, 'transaction_id' => transaction.transaction_id)
+        expect(subject).to validate(
+          :get,
+          '/v0/profile/person/status/{transaction_id}',
+          401,
+          'transaction_id' => transaction.transaction_id
+        )
 
         VCR.use_cassette('vet360/contact_information/person_transaction_status') do
           expect(subject).to validate(
             :get,
-            "/v0/profile/person/status/{transaction_id}",
+            '/v0/profile/person/status/{transaction_id}',
             200,
             auth_options.merge('transaction_id' => transaction.transaction_id)
           )

--- a/spec/request/vet360/person_request_spec.rb
+++ b/spec/request/vet360/person_request_spec.rb
@@ -98,11 +98,11 @@ RSpec.describe 'person', type: :request do
   describe 'GET /v0/profile/person/status/:transaction_id' do
     it 'responds with a serialized transaction', :aggregate_failures do
       transaction = create(
-          :initialize_person_transaction,
-          :init_vet360_id,
-          user_uuid: user.uuid,
-          transaction_id: '786efe0e-fd20-4da2-9019-0c00540dba4d'
-        )
+        :initialize_person_transaction,
+        :init_vet360_id,
+        user_uuid: user.uuid,
+        transaction_id: '786efe0e-fd20-4da2-9019-0c00540dba4d'
+      )
 
       VCR.use_cassette('vet360/contact_information/person_transaction_status') do
         get(
@@ -119,11 +119,11 @@ RSpec.describe 'person', type: :request do
     context 'with an error response' do
       it 'should match the errors response schema', :aggregate_failures do
         transaction = create(
-            :initialize_person_transaction,
-            :init_vet360_id,
-            user_uuid: user.uuid,
-            transaction_id: 'd47b3d96-9ddd-42be-ac57-8e564aa38029'
-          )
+          :initialize_person_transaction,
+          :init_vet360_id,
+          user_uuid: user.uuid,
+          transaction_id: 'd47b3d96-9ddd-42be-ac57-8e564aa38029'
+        )
 
         VCR.use_cassette('vet360/contact_information/person_transaction_status_error', VCR::MATCH_EVERYTHING) do
           get(

--- a/spec/request/vet360/person_request_spec.rb
+++ b/spec/request/vet360/person_request_spec.rb
@@ -57,6 +57,8 @@ RSpec.describe 'person', type: :request do
               )
             )
           end.to change { AsyncTransaction::Vet360::InitializePersonTransaction.count }.from(0).to(1)
+
+          expect(AsyncTransaction::Vet360::InitializePersonTransaction.first).to be_valid
         end
       end
 
@@ -76,7 +78,7 @@ RSpec.describe 'person', type: :request do
     end
 
     context 'with an error response' do
-      it 'should match the transaction response schema', :aggregate_failures do
+      it 'should match the errors response schema', :aggregate_failures do
         VCR.use_cassette('vet360/person/init_vet360_id_status_400', VCR::MATCH_EVERYTHING) do
           post(
             '/v0/profile/initialize_vet360_id',
@@ -84,6 +86,50 @@ RSpec.describe 'person', type: :request do
             auth_header.update(
               'Content-Type' => 'application/json', 'Accept' => 'application/json'
             )
+          )
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+  end
+
+  describe 'GET /v0/profile/person/status/:transaction_id' do
+    it 'responds with a serialized transaction', :aggregate_failures do
+      transaction = create(
+          :initialize_person_transaction,
+          :init_vet360_id,
+          user_uuid: user.uuid,
+          transaction_id: '786efe0e-fd20-4da2-9019-0c00540dba4d'
+        )
+
+      VCR.use_cassette('vet360/contact_information/person_transaction_status') do
+        get(
+          "/v0/profile/person/status/#{transaction.transaction_id}",
+          nil,
+          auth_header
+        )
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to match_response_schema('vet360/transaction_response')
+      end
+    end
+
+    context 'with an error response' do
+      it 'should match the errors response schema', :aggregate_failures do
+        transaction = create(
+            :initialize_person_transaction,
+            :init_vet360_id,
+            user_uuid: user.uuid,
+            transaction_id: 'd47b3d96-9ddd-42be-ac57-8e564aa38029'
+          )
+
+        VCR.use_cassette('vet360/contact_information/person_transaction_status_error', VCR::MATCH_EVERYTHING) do
+          get(
+            "/v0/profile/person/status/#{transaction.transaction_id}",
+            nil,
+            auth_header
           )
 
           expect(response).to have_http_status(:bad_request)


### PR DESCRIPTION
## Background

In order to initialize Vets.gov users in Vet360, two actions must be performed due to the async nature of the service call. This PR represents the second step, implemented as an endpoint which will allow the FE to check the status of initialization.

## Definition of done 

- [x] AsyncTransaction support for person initialization
- [x] Invalidate MVI cache
- [x] Specs
- [x] Swagger doc updates