### PR TITLE
Add X-VA-User header to appeals status service api

### DIFF
--- a/modules/appeals_api/README.yml
+++ b/modules/appeals_api/README.yml
@@ -31,6 +31,7 @@ info:
 
     1. Client Request: GET https://api.vets.gov/services/appeals/v0/appeals
         * Provide the Veteran's SSN as the X-VA-SSN header
+        * Provide the VA username of the person requesting the appeals status as the X-VA-User header
     
     2. Service Response: A JSON API object with the current status of appeals
           
@@ -65,7 +66,13 @@ paths:
           required: true
           schema:
             type: string
-          description: SSN of Veteran to retrieve appeals statuses for 
+          description: SSN of Veteran to retrieve appeals statuses for
+        - in: header
+          name: X-VA-User
+          required: true
+          schema:
+            type: string
+          description: VA username of the person making the request
       responses:
         '200':
           description: Appeals retrieved successfully

--- a/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
@@ -11,7 +11,8 @@ module AppealsApi
         log_request
         appeals_response = Appeals::Service.new.get_appeals(
           user,
-          'X-Consumer-Username' => request.headers['X-Consumer-Username']
+          'Consumer-Username' => consumer
+          'VA-User' => requesting_user
         )
         log_response(appeals_response)
         render(
@@ -25,6 +26,7 @@ module AppealsApi
         hashed_ssn = Digest::SHA2.hexdigest ssn
         Rails.logger.info('Caseflow Request',
                           'consumer' => consumer,
+                          'requested_by' => requesting_user,
                           'lookup_identifier' => hashed_ssn)
       end
 
@@ -33,6 +35,7 @@ module AppealsApi
         count = appeals_response.body['data'].length
         Rails.logger.info('Caseflow Response',
                           'consumer' => consumer,
+                          'requested_by' => requesting_user,
                           'first_appeal_id' => first_appeal_id,
                           'appeal_count' => count)
       end
@@ -45,6 +48,12 @@ module AppealsApi
         ssn = request.headers['X-VA-SSN']
         raise Common::Exceptions::ParameterMissing, 'X-VA-SSN' unless ssn
         ssn
+      end
+
+      def requesting_user
+        user = request.headers['X-VA-User']
+        raise Common::Exceptions::ParameterMissing, 'X-VA-User' unless user
+        user
       end
 
       def user

--- a/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
@@ -10,9 +10,9 @@ module AppealsApi
       def index
         log_request
         appeals_response = Appeals::Service.new.get_appeals(
-          user,
-          'Consumer-Username' => consumer
-          'VA-User' => requesting_user
+          target_veteran,
+          'Consumer' => consumer,
+          'VA-User' => requesting_va_user
         )
         log_response(appeals_response)
         render(
@@ -26,7 +26,7 @@ module AppealsApi
         hashed_ssn = Digest::SHA2.hexdigest ssn
         Rails.logger.info('Caseflow Request',
                           'consumer' => consumer,
-                          'requested_by' => requesting_user,
+                          'va_user' => requesting_va_user,
                           'lookup_identifier' => hashed_ssn)
       end
 
@@ -35,7 +35,7 @@ module AppealsApi
         count = appeals_response.body['data'].length
         Rails.logger.info('Caseflow Response',
                           'consumer' => consumer,
-                          'requested_by' => requesting_user,
+                          'va_user' => requesting_va_user,
                           'first_appeal_id' => first_appeal_id,
                           'appeal_count' => count)
       end
@@ -50,13 +50,13 @@ module AppealsApi
         ssn
       end
 
-      def requesting_user
-        user = request.headers['X-VA-User']
-        raise Common::Exceptions::ParameterMissing, 'X-VA-User' unless user
-        user
+      def requesting_va_user
+        va_user = request.headers['X-VA-User']
+        raise Common::Exceptions::ParameterMissing, 'X-VA-User' unless va_user
+        va_user
       end
 
-      def user
+      def target_veteran
         veteran = OpenStruct.new
         veteran.ssn = ssn
         veteran

--- a/modules/appeals_api/spec/requests/appeals_request_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_request_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe 'Claim Appeals API endpoint', type: :request do
   include SchemaMatchers
 
-  context 'with the X-VA-SSN header supplied ' do
+  context 'with the X-VA-SSN and X-VA-User header supplied ' do
     it 'returns a successful response' do
       VCR.use_cassette('appeals/appeals') do
         get '/services/appeals/v0/appeals', nil,
-            'X-VA-SSN' => '111223333', 'X-Consumer-Username' => 'TestConsumer'
+            'X-VA-SSN' => '111223333',
+            'X-Consumer-Username' => 'TestConsumer',
+            'X-VA-User' => 'adhoc.test.user'
         expect(response).to have_http_status(:ok)
         expect(response.body).to be_a(String)
         expect(response).to match_response_schema('appeals')
@@ -20,23 +22,40 @@ RSpec.describe 'Claim Appeals API endpoint', type: :request do
       VCR.use_cassette('appeals/appeals') do
         allow(Rails.logger).to receive(:info)
         get '/services/appeals/v0/appeals', nil,
-            'X-VA-SSN' => '111223333', 'X-Consumer-Username' => 'TestConsumer'
+            'X-VA-SSN' => '111223333',
+            'X-Consumer-Username' => 'TestConsumer',
+            'X-VA-User' => 'adhoc.test.user'
         hash = Digest::SHA2.hexdigest '111223333'
         expect(Rails.logger).to have_received(:info).with('Caseflow Request',
                                                           'consumer' => 'TestConsumer',
+                                                          'requested_by' => 'adhoc.test.user',
                                                           'lookup_identifier' => hash)
         expect(Rails.logger).to have_received(:info).with('Caseflow Response',
                                                           'consumer' => 'TestConsumer',
+                                                          'requested_by' => 'adhoc.test.user',
                                                           'first_appeal_id' => '1196201',
                                                           'appeal_count' => 3)
       end
     end
   end
 
-  context 'without the X-VA-SSN header supplied ' do
+  context 'without the X-VA-User header supplied' do
     it 'returns a successful response' do
       VCR.use_cassette('appeals/appeals') do
-        get '/services/appeals/v0/appeals'
+        get '/services/appeals/v0/appeals', nil,
+            'X-VA-SSN' => '111223333',
+            'X-Consumer-Username' => 'TestConsumer'
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+
+  context 'without the X-VA-SSN header supplied' do
+    it 'returns a successful response' do
+      VCR.use_cassette('appeals/appeals') do
+        get '/services/appeals/v0/appeals', nil,
+            'X-Consumer-Username' => 'TestConsumer',
+            'X-VA-User' => 'adhoc.test.user'
         expect(response).to have_http_status(:bad_request)
       end
     end

--- a/modules/appeals_api/spec/requests/appeals_request_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_request_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe 'Claim Appeals API endpoint', type: :request do
         hash = Digest::SHA2.hexdigest '111223333'
         expect(Rails.logger).to have_received(:info).with('Caseflow Request',
                                                           'consumer' => 'TestConsumer',
-                                                          'requested_by' => 'adhoc.test.user',
+                                                          'va_user' => 'adhoc.test.user',
                                                           'lookup_identifier' => hash)
         expect(Rails.logger).to have_received(:info).with('Caseflow Response',
                                                           'consumer' => 'TestConsumer',
-                                                          'requested_by' => 'adhoc.test.user',
+                                                          'va_user' => 'adhoc.test.user',
                                                           'first_appeal_id' => '1196201',
                                                           'appeal_count' => 3)
       end


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets-contrib#169

We are passing a 'consumer' and 'va-user' header onto caseflow.

* The 'consumer' header is the username assigned to the api key in Kong and represents the application making the request
* The 'va-user' header is the username of the person making the request to caseflow. It will be logged to CorpDB by caseflow. 