### PR TITLE
Vet360 Reference Data Endpoints

### DIFF
--- a/app/controllers/v0/addresses_controller.rb
+++ b/app/controllers/v0/addresses_controller.rb
@@ -28,6 +28,7 @@ module V0
 
     def countries
       response = strategy.cache_or_service(:countries) { service.get_countries }
+      binding.pry
       render json: response,
              serializer: CountriesSerializer
     end

--- a/app/controllers/v0/addresses_controller.rb
+++ b/app/controllers/v0/addresses_controller.rb
@@ -28,7 +28,6 @@ module V0
 
     def countries
       response = strategy.cache_or_service(:countries) { service.get_countries }
-      binding.pry
       render json: response,
              serializer: CountriesSerializer
     end

--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -179,6 +179,9 @@ module V0
       Swagger::Schemas::Vet360::Email,
       Swagger::Schemas::Vet360::Telephone,
       Swagger::Schemas::Vet360::ContactInformation,
+      Swagger::Schemas::Vet360::Countries,
+      Swagger::Schemas::Vet360::States,
+      Swagger::Schemas::Vet360::Zipcodes,
       self
     ].freeze
 

--- a/app/controllers/v0/profile/reference_data_controller.rb
+++ b/app/controllers/v0/profile/reference_data_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module V0
+  module Profile
+    class ReferenceDataController < ApplicationController
+      def countries
+        render json: service.countries,
+               serializer: CountriesSerializer
+      end
+
+      def states
+        render json: service.states,
+               serializer: StatesSerializer
+      end
+
+      def zipcodes
+        render json: service.zipcodes,
+               serializer: ZipcodesSerializer
+      end
+
+      private
+
+      def service
+        @service ||= Vet360Redis::ReferenceData.new
+      end
+    end
+  end
+end

--- a/app/models/vet360_redis/reference_data.rb
+++ b/app/models/vet360_redis/reference_data.rb
@@ -14,26 +14,20 @@ module Vet360Redis
     # Redis settings for ttl and namespacing reside in config/redis.yml
     redis_config_key :vet360_reference_data_response
 
-    # Vet360 country reference data
-    # [{ "country_name": "Afghanistan",
-    #    "country_code_iso2": "AF",
-    #    "country_code_iso3": "AFG",
-    #    "country_code_fips": "AF" }, ...]
-    # @return [Array[Hash]] List of countries Vet360 recognizes as valid
+    # List of valid Vet360 countries
+    # @return [Vet360::ReferenceData::CountriesResponse]
     def countries
       response_from_redis_or_service(:countries)
     end
 
-    # Vet360 state reference data
-    # [{ "state_name": "Ohio", "state_code": "OH" }, ...]
-    # @return [Array[Hash]] List of states Vet360 recognizes as valid
+    # List of valid Vet360 states
+    # @return [Vet360::ReferenceData::StatesResponse]
     def states
       response_from_redis_or_service(:states)
     end
 
-    # Vet360 zipcode reference data
-    # [{ "zip_code": "12345" }, ...]
-    # @return [Array[Hash]] List of zipcodes Vet360 recognizes as valid
+    # List of valid Vet360 zipcodes
+    # @return [Vet360::ReferenceData::ZipcodesResponse]
     def zipcodes
       response_from_redis_or_service(:zipcodes)
     end

--- a/app/models/vet360_redis/reference_data.rb
+++ b/app/models/vet360_redis/reference_data.rb
@@ -21,21 +21,21 @@ module Vet360Redis
     #    "country_code_fips": "AF" }, ...]
     # @return [Array[Hash]] List of countries Vet360 recognizes as valid
     def countries
-      response_from_redis_or_service(:countries).reference_data
+      response_from_redis_or_service(:countries)
     end
 
     # Vet360 state reference data
     # [{ "state_name": "Ohio", "state_code": "OH" }, ...]
     # @return [Array[Hash]] List of states Vet360 recognizes as valid
     def states
-      response_from_redis_or_service(:states).reference_data
+      response_from_redis_or_service(:states)
     end
 
     # Vet360 zipcode reference data
     # [{ "zip_code": "12345" }, ...]
     # @return [Array[Hash]] List of zipcodes Vet360 recognizes as valid
     def zipcodes
-      response_from_redis_or_service(:zipcodes).reference_data
+      response_from_redis_or_service(:zipcodes)
     end
 
     private

--- a/app/serializers/zipcodes_serializer.rb
+++ b/app/serializers/zipcodes_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ZipcodesSerializer < ActiveModel::Serializer
+  attribute :zipcodes
+
+  def id
+    nil
+  end
+end

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -652,9 +652,7 @@ module Swagger
 
           key :description, 'GET Vet360 Country reference data'
           key :operationId, 'getVet360ReferenceDataCountries'
-          key :tags, [
-            'user'
-          ]
+          key :tags, ['profile']
 
           parameter :authorization
 
@@ -673,9 +671,7 @@ module Swagger
 
           key :description, 'GET Vet360 State reference data'
           key :operationId, 'getVet360ReferenceDataStates'
-          key :tags, [
-            'user'
-          ]
+          key :tags, ['profile']
 
           parameter :authorization
 
@@ -688,15 +684,13 @@ module Swagger
         end
       end
 
-      swagger_path '/v0/profile/reference_data/countries' do
+      swagger_path '/v0/profile/reference_data/zipcodes' do
         operation :get do
           extend Swagger::Responses::AuthenticationError
 
           key :description, 'GET Vet360 Zipcode reference data'
           key :operationId, 'getVet360ReferenceDataZipcodes'
-          key :tags, [
-            'user'
-          ]
+          key :tags, ['profile']
 
           parameter :authorization
 

--- a/app/swagger/requests/profile.rb
+++ b/app/swagger/requests/profile.rb
@@ -645,6 +645,69 @@ module Swagger
           end
         end
       end
+
+      swagger_path '/v0/profile/reference_data/countries' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'GET Vet360 Country reference data'
+          key :operationId, 'getVet360ReferenceDataCountries'
+          key :tags, [
+            'user'
+          ]
+
+          parameter :authorization
+
+          response 200 do
+            key :description, 'List of valid Vet360 countries'
+            schema do
+              key :'$ref', :Vet360Countries
+            end
+          end
+        end
+      end
+
+      swagger_path '/v0/profile/reference_data/states' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'GET Vet360 State reference data'
+          key :operationId, 'getVet360ReferenceDataStates'
+          key :tags, [
+            'user'
+          ]
+
+          parameter :authorization
+
+          response 200 do
+            key :description, 'List of valid Vet360 states'
+            schema do
+              key :'$ref', :Vet360States
+            end
+          end
+        end
+      end
+
+      swagger_path '/v0/profile/reference_data/countries' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'GET Vet360 Zipcode reference data'
+          key :operationId, 'getVet360ReferenceDataZipcodes'
+          key :tags, [
+            'user'
+          ]
+
+          parameter :authorization
+
+          response 200 do
+            key :description, 'List of valid Vet360 zipcodes'
+            schema do
+              key :'$ref', :Vet360Zipcodes
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/app/swagger/schemas/vet360/countries.rb
+++ b/app/swagger/schemas/vet360/countries.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Schemas
+    class Countries
+      include Swagger::Blocks
+
+      swagger_schema :Vet360Countries do
+        key :required, [:data]
+
+        property :data, type: :object do
+          key :required, [:attributes]
+          property :attributes, type: :object do
+            key :required, [:countries]
+            property :countries do
+              key :type, :array
+              items do
+                property :country_name, type: :string, example: 'Italy'
+                property :country_code_iso3, type: :string, example: 'ITA'
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/swagger/schemas/vet360/countries.rb
+++ b/app/swagger/schemas/vet360/countries.rb
@@ -2,21 +2,23 @@
 
 module Swagger
   module Schemas
-    class Countries
-      include Swagger::Blocks
+    module Vet360
+      class Countries
+        include Swagger::Blocks
 
-      swagger_schema :Vet360Countries do
-        key :required, [:data]
+        swagger_schema :Vet360Countries do
+          key :required, [:data]
 
-        property :data, type: :object do
-          key :required, [:attributes]
-          property :attributes, type: :object do
-            key :required, [:countries]
-            property :countries do
-              key :type, :array
-              items do
-                property :country_name, type: :string, example: 'Italy'
-                property :country_code_iso3, type: :string, example: 'ITA'
+          property :data, type: :object do
+            key :required, [:attributes]
+            property :attributes, type: :object do
+              key :required, [:countries]
+              property :countries do
+                key :type, :array
+                items do
+                  property :country_name, type: :string, example: 'Italy'
+                  property :country_code_iso3, type: :string, example: 'ITA'
+                end
               end
             end
           end

--- a/app/swagger/schemas/vet360/states.rb
+++ b/app/swagger/schemas/vet360/states.rb
@@ -2,21 +2,23 @@
 
 module Swagger
   module Schemas
-    class States
-      include Swagger::Blocks
+    module Vet360
+      class States
+        include Swagger::Blocks
 
-      swagger_schema :Vet360States do
-        key :required, [:data]
+        swagger_schema :Vet360States do
+          key :required, [:data]
 
-        property :data, type: :object do
-          key :required, [:attributes]
-          property :attributes, type: :object do
-            key :required, [:states]
-            property :states do
-              key :type, :array
-              items do
-                property :state_name, type: :string, example: 'Oregon'
-                property :state_code, type: :string, example: 'OR'
+          property :data, type: :object do
+            key :required, [:attributes]
+            property :attributes, type: :object do
+              key :required, [:states]
+              property :states do
+                key :type, :array
+                items do
+                  property :state_name, type: :string, example: 'Oregon'
+                  property :state_code, type: :string, example: 'OR'
+                end
               end
             end
           end

--- a/app/swagger/schemas/vet360/states.rb
+++ b/app/swagger/schemas/vet360/states.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Schemas
+    class States
+      include Swagger::Blocks
+
+      swagger_schema :Vet360States do
+        key :required, [:data]
+
+        property :data, type: :object do
+          key :required, [:attributes]
+          property :attributes, type: :object do
+            key :required, [:states]
+            property :states do
+              key :type, :array
+              items do
+                property :state_name, type: :string, example: 'Oregon'
+                property :state_code, type: :string, example: 'OR'
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/swagger/schemas/vet360/zipcodes.rb
+++ b/app/swagger/schemas/vet360/zipcodes.rb
@@ -16,7 +16,7 @@ module Swagger
               property :zipcodes do
                 key :type, :array
                 items do
-                  property :zipcode, type: :string, example: '97062'
+                  property :zip_code, type: :string, example: '97062'
                 end
               end
             end

--- a/app/swagger/schemas/vet360/zipcodes.rb
+++ b/app/swagger/schemas/vet360/zipcodes.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Schemas
+    class Countries
+      include Swagger::Blocks
+
+      swagger_schema :Vet360Zipcodes do
+        key :required, [:data]
+
+        property :data, type: :object do
+          key :required, [:attributes]
+          property :attributes, type: :object do
+            key :required, [:zipcodes]
+            property :zipcodes do
+              key :type, :array
+              items do
+                property :zipcode, type: :string, example: '97062'
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/swagger/schemas/vet360/zipcodes.rb
+++ b/app/swagger/schemas/vet360/zipcodes.rb
@@ -2,20 +2,22 @@
 
 module Swagger
   module Schemas
-    class Countries
-      include Swagger::Blocks
+    module Vet360
+      class Zipcodes
+        include Swagger::Blocks
 
-      swagger_schema :Vet360Zipcodes do
-        key :required, [:data]
+        swagger_schema :Vet360Zipcodes do
+          key :required, [:data]
 
-        property :data, type: :object do
-          key :required, [:attributes]
-          property :attributes, type: :object do
-            key :required, [:zipcodes]
-            property :zipcodes do
-              key :type, :array
-              items do
-                property :zipcode, type: :string, example: '97062'
+          property :data, type: :object do
+            key :required, [:attributes]
+            property :attributes, type: :object do
+              key :required, [:zipcodes]
+              property :zipcodes do
+                key :type, :array
+                items do
+                  property :zipcode, type: :string, example: '97062'
+                end
               end
             end
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,14 @@ Rails.application.routes.draw do
       post 'initialize_vet360_id', to: 'persons#initialize_vet360_id'
       get 'status/:transaction_id', to: 'transactions#status'
       get 'status', to: 'transactions#statuses'
+
+      resource :reference_data, only: %i[show] do
+        collection do
+          get 'countries', to: 'reference_data#countries'
+          get 'states', to: 'reference_data#states'
+          get 'zipcodes', to: 'reference_data#zipcodes'
+        end
+      end
     end
 
     get 'profile/mailing_address', to: 'addresses#show'

--- a/lib/vet360/reference_data/countries_response.rb
+++ b/lib/vet360/reference_data/countries_response.rb
@@ -17,25 +17,5 @@ module Vet360
         new(response.status, countries: data)
       end
     end
-
-    class StatesResponse < Response
-      attribute :states, Array[Hash]
-
-      def self.from(response)
-        new(response.status, states: response.body['state_list'])
-      end
-    end
-
-    class ZipcodesResponse < Response
-      attribute :zipcodes, Array[Hash]
-
-      def self.from(response)
-        data = response.body['zip_code5_list'].map do |z|
-          { 'zip_code' => z['zip_code5'] }
-        end
-
-        new(response.status, zipcodes: data)
-      end
-    end
   end
 end

--- a/lib/vet360/reference_data/response.rb
+++ b/lib/vet360/reference_data/response.rb
@@ -4,11 +4,31 @@ require 'vet360/response'
 
 module Vet360
   module ReferenceData
-    class Response < Vet360::Response
-      attribute :reference_data, Array[Hash]
+    class CountriesResponse < Response
+      attribute :countries, Array[Hash]
 
-      def self.from(response, key)
-        new(response.status, reference_data: response.body[key])
+      def self.from(response)
+        new(response.status, countries: response.body['country_list'])
+      end
+    end
+
+    class StatesResponse < Response
+      attribute :states, Array[Hash]
+
+      def self.from(response)
+        new(response.status, states: response.body['state_list'])
+      end
+    end
+
+    class ZipcodesResponse < Response
+      attribute :zipcodes, Array[Hash]
+
+      def self.from(response)
+        data = response.body['zip_code5_list'].map do |z|
+          { 'zip_code' => z['zip_code5'] }
+        end
+
+        new(response.status, zipcodes: data)
       end
     end
   end

--- a/lib/vet360/reference_data/response.rb
+++ b/lib/vet360/reference_data/response.rb
@@ -8,7 +8,13 @@ module Vet360
       attribute :countries, Array[Hash]
 
       def self.from(response)
-        new(response.status, countries: response.body['country_list'])
+        data = response.body['country_list'].map do |c|
+          {
+            'country_name' => c['country_name'],
+            'country_code_iso3' => c['country_code_iso3']
+          }
+        end
+        new(response.status, countries: data)
       end
     end
 

--- a/lib/vet360/reference_data/service.rb
+++ b/lib/vet360/reference_data/service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'common/client/base'
+require 'vet360/reference_data/response'
 
 module Vet360
   module ReferenceData
@@ -14,43 +15,40 @@ module Vet360
       end
 
       # GETs a the list of valid countries from Vet360
-      # List of countries is available under the reference_data property with the structure
+      # List of countries is available under the countries property with the structure
       # { "country_name": "Afghanistan",
       #   "country_code_iso2": "AF",
       #   "country_code_iso3": "AFG",
       #   "country_code_fips": "AF" }
-      # @return [Vet360::ReferenceData::Response] response wrapper around array of countries
+      # @return [Vet360::ReferenceData::CountriesResponse] response wrapper around array of countries
       def countries
-        get_reference_data('countries', 'country_list')
+        with_monitoring do
+          Vet360::ReferenceData::CountriesResponse.from(perform(:get, 'countries'))
+        end
+      rescue StandardError => e
+        handle_error(e)
       end
 
       # GETs a the list of valid states from Vet360
-      # List of states is available under the reference_data property with the strutcture
+      # List of states is available under the states property with the strutcture
       # { "state_name": "Ohio", "state_code": "OH" }
-      # @return [Vet360::ReferenceData::Response] response wrapper around array of states
+      # @return [Vet360::ReferenceData::StatesResponse] response wrapper around array of states
       def states
-        get_reference_data('states', 'state_list')
+        with_monitoring do
+          Vet360::ReferenceData::StatesResponse.from(perform(:get, 'states'))
+        end
+      rescue StandardError => e
+        handle_error(e)
       end
 
       # GETs a the list of valid zipcodes from Vet360
-      # List of zipcodes is available under the reference_data property with the structure
+      # List of zipcodes is available under the zipcodes property with the structure
       # { "zip_code": "12345" }
-      # @return [Vet360::ReferenceData::Response] response wrapper around array of states
+      # @return [Vet360::ReferenceData::ZipcodesResponse] response wrapper around array of states
       def zipcodes
-        get_reference_data('zipcode5', 'zip_code5_list').tap do |resp|
-          zipcodes = resp.reference_data.map do |data|
-            { 'zip_code' => data['zip_code5'] }
-          end
-
-          resp.reference_data = zipcodes
+        with_monitoring do
+          Vet360::ReferenceData::ZipcodesResponse.from(perform(:get, 'zipcode5'))
         end
-      end
-
-      private
-
-      def get_reference_data(route, key)
-        response = perform(:get, route)
-        Vet360::ReferenceData::Response.from(response, key)
       rescue StandardError => e
         handle_error(e)
       end

--- a/lib/vet360/reference_data/service.rb
+++ b/lib/vet360/reference_data/service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'common/client/base'
-require 'vet360/reference_data/response'
 
 module Vet360
   module ReferenceData

--- a/lib/vet360/reference_data/states_response.rb
+++ b/lib/vet360/reference_data/states_response.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'vet360/response'
+
+module Vet360
+  module ReferenceData
+    class StatesResponse < Response
+      attribute :states, Array[Hash]
+
+      def self.from(response)
+        new(response.status, states: response.body['state_list'])
+      end
+    end
+  end
+end

--- a/lib/vet360/reference_data/zipcodes_response.rb
+++ b/lib/vet360/reference_data/zipcodes_response.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'vet360/response'
+
+module Vet360
+  module ReferenceData
+    class ZipcodesResponse < Response
+      attribute :zipcodes, Array[Hash]
+
+      def self.from(response)
+        data = response.body['zip_code5_list'].map do |z|
+          { 'zip_code' => z['zip_code5'] }
+        end
+
+        new(response.status, zipcodes: data)
+      end
+    end
+  end
+end

--- a/spec/lib/vet360/reference_data/service_spec.rb
+++ b/spec/lib/vet360/reference_data/service_spec.rb
@@ -19,9 +19,7 @@ describe Vet360::ReferenceData::Service, skip_vet360: true do
 
           data = response.countries.first
           expect(data).to have_key('country_name')
-          expect(data).to have_key('country_code_iso2')
           expect(data).to have_key('country_code_iso3')
-          expect(data).to have_key('country_code_fips')
         end
       end
     end

--- a/spec/lib/vet360/reference_data/service_spec.rb
+++ b/spec/lib/vet360/reference_data/service_spec.rb
@@ -15,9 +15,9 @@ describe Vet360::ReferenceData::Service, skip_vet360: true do
           response = subject.countries
 
           expect(response).to be_ok
-          expect(response.reference_data).to be_a(Array)
+          expect(response.countries).to be_a(Array)
 
-          data = response.reference_data.first
+          data = response.countries.first
           expect(data).to have_key('country_name')
           expect(data).to have_key('country_code_iso2')
           expect(data).to have_key('country_code_iso3')
@@ -34,9 +34,9 @@ describe Vet360::ReferenceData::Service, skip_vet360: true do
           response = subject.states
 
           expect(response).to be_ok
-          expect(response.reference_data).to be_a(Array)
+          expect(response.states).to be_a(Array)
 
-          data = response.reference_data.first
+          data = response.states.first
           expect(data).to have_key('state_name')
           expect(data).to have_key('state_code')
         end
@@ -51,9 +51,9 @@ describe Vet360::ReferenceData::Service, skip_vet360: true do
           response = subject.zipcodes
 
           expect(response).to be_ok
-          expect(response.reference_data).to be_a(Array)
+          expect(response.zipcodes).to be_a(Array)
 
-          data = response.reference_data.first
+          data = response.zipcodes.first
           expect(data).to have_key('zip_code')
         end
       end

--- a/spec/models/vet360_redis/reference_data_spec.rb
+++ b/spec/models/vet360_redis/reference_data_spec.rb
@@ -2,7 +2,6 @@
 
 require 'rails_helper'
 require 'common/exceptions'
-require 'vet360/reference_data/response'
 
 describe Vet360Redis::ReferenceData do
   subject { Vet360Redis::ReferenceData.new }

--- a/spec/models/vet360_redis/reference_data_spec.rb
+++ b/spec/models/vet360_redis/reference_data_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'common/exceptions'
+require 'vet360/reference_data/response'
 
 describe Vet360Redis::ReferenceData do
   subject { Vet360Redis::ReferenceData.new }
@@ -13,20 +14,23 @@ describe Vet360Redis::ReferenceData do
           it 'should cache and return the response', :aggregate_failures do
             VCR.use_cassette("vet360/reference_data/#{method}", VCR::MATCH_EVERYTHING) do
               expect(subject.redis_namespace).to receive(:set).once
-              expect(subject.public_send(method)).to be_a(Array)
+              response = subject.public_send(method)
+              expect(response.public_send(method)).to be_a(Array)
             end
           end
         end
 
         context 'when there is cached data' do
           it 'returns the cached data', :aggregate_failures do
+            response_type = "Vet360::ReferenceData::#{method.to_s.titleize}Response".constantize
+
             subject.cache(
               "vet360_reference_data_#{method}",
-              Vet360::ReferenceData::Response.new(200, reference_data: [])
+              response_type.new(200, reference_data: [])
             )
 
             expect_any_instance_of(Vet360::ReferenceData::Service).to_not receive(method)
-            expect(subject.public_send(method)).to be_a(Array)
+            expect(subject.public_send(method)).to be_a(response_type)
           end
         end
       end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1349,10 +1349,10 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
         end
       end
 
-      it 'supports getting vet360 state reference data' do
+      it 'supports getting vet360 zipcode reference data' do
         expect(subject).to validate(:get, '/v0/profile/reference_data/zipcodes', 401)
 
-        VCR.use_cassette('vet360/reference_data/states') do
+        VCR.use_cassette('vet360/reference_data/zipcodes') do
           expect(subject).to validate(:get, '/v0/profile/reference_data/zipcodes', 200, auth_options)
         end
       end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1332,6 +1332,30 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           )
         end
       end
+
+      it 'supports getting vet360 country reference data' do
+        expect(subject).to validate(:get, '/v0/profile/reference_data/countries', 401)
+
+        VCR.use_cassette('vet360/reference_data/countries') do
+          expect(subject).to validate(:get, '/v0/profile/reference_data/countries', 200, auth_options)
+        end
+      end
+
+      it 'supports getting vet360 state reference data' do
+        expect(subject).to validate(:get, '/v0/profile/reference_data/states', 401)
+
+        VCR.use_cassette('vet360/reference_data/states') do
+          expect(subject).to validate(:get, '/v0/profile/reference_data/states', 200, auth_options)
+        end
+      end
+
+      it 'supports getting vet360 state reference data' do
+        expect(subject).to validate(:get, '/v0/profile/reference_data/zipcodes', 401)
+
+        VCR.use_cassette('vet360/reference_data/states') do
+          expect(subject).to validate(:get, '/v0/profile/reference_data/zipcodes', 200, auth_options)
+        end
+      end
     end
 
     describe 'profile/status' do

--- a/spec/request/vet360/reference_data_spec.rb
+++ b/spec/request/vet360/reference_data_spec.rb
@@ -14,13 +14,14 @@ RSpec.describe 'profile reference data', type: :request do
     User.create(user)
   end
 
-  describe 'GET /v0/profile/reference_data/countries' do
-    it 'should match the schema' do
-      VCR.use_cassette('vet360/reference_data/countries') do
-        get('/v0/profile/reference_data/countries', nil, auth_header)
-        binding.pry
-        expect(response).to have_http_status(:ok)
-        expect(response).to match_response_schema('vet360/countries')
+  %i[countries states zipcodes].each do |endpoint|
+    describe "GET /v0/profile/reference_data/#{endpoint}" do
+      it 'should match the schema' do
+        VCR.use_cassette("vet360/reference_data/#{endpoint}") do
+          get("/v0/profile/reference_data/#{endpoint}", nil, auth_header)
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema("vet360/#{endpoint}")
+        end
       end
     end
   end

--- a/spec/request/vet360/reference_data_spec.rb
+++ b/spec/request/vet360/reference_data_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'profile reference data', type: :request do
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  describe 'GET /v0/profile/reference_data/countries' do
+    it 'should match the schema' do
+      VCR.use_cassette('vet360/reference_data/countries') do
+        get('/v0/profile/reference_data/countries', nil, auth_header)
+        binding.pry
+        expect(response).to have_http_status(:ok)
+        # expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/request/vet360/reference_data_spec.rb
+++ b/spec/request/vet360/reference_data_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'profile reference data', type: :request do
+  include SchemaMatchers
+
   let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
   let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
   let(:user) { build(:user, :loa3) }
@@ -18,7 +20,7 @@ RSpec.describe 'profile reference data', type: :request do
         get('/v0/profile/reference_data/countries', nil, auth_header)
         binding.pry
         expect(response).to have_http_status(:ok)
-        # expect(response).to have_http_status(:ok)
+        expect(response).to match_response_schema('vet360/countries')
       end
     end
   end

--- a/spec/support/schemas/vet360/countries.json
+++ b/spec/support/schemas/vet360/countries.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "countries": {
+              "description": "Array of countries",
+              "items": {
+                "type": "object",
+                "properties": {
+                    "country_name": {},
+                    "country_code_iso3": { "type": "string" }
+                }
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas/vet360/countries.json
+++ b/spec/support/schemas/vet360/countries.json
@@ -11,7 +11,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                    "country_name": {},
+                    "country_name": { "type": "string" },
                     "country_code_iso3": { "type": "string" }
                 }
               },

--- a/spec/support/schemas/vet360/states.json
+++ b/spec/support/schemas/vet360/states.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "states": {
+              "description": "Array of states",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas/vet360/states.json
+++ b/spec/support/schemas/vet360/states.json
@@ -9,7 +9,11 @@
             "states": {
               "description": "Array of states",
               "items": {
-                "type": "string"
+                "type": "object",
+                "properties": {
+                    "state_name": { "type": "string" },
+                    "state_code": { "type": "string" }
+                }
               },
               "type": "array"
             }

--- a/spec/support/schemas/vet360/zipcodes.json
+++ b/spec/support/schemas/vet360/zipcodes.json
@@ -6,10 +6,13 @@
       "properties": {
         "attributes": {
           "properties": {
-            "countries": {
-              "description": "Array of countries",
+            "zipcodes": {
+              "description": "Array of zipcodes",
               "items": {
-                "type": "string"
+                "type": "object",
+                "properties": {
+                    "zip_code": { "type": "string" }
+                }
               },
               "type": "array"
             }

--- a/spec/support/schemas/vet360/zipcodes.json
+++ b/spec/support/schemas/vet360/zipcodes.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "countries": {
+              "description": "Array of countries",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This PR implements 3 new endpoints, all of which provide cached reference data from Vet360. I also performed refactor of the underlying service and it's handling of response data. This make is Serializer-compatible with the EVSS reference data service, of which it there is some overlap. This should make centralization on a single data source easier in the future.

- `/v0/profile/reference_data/countries`
- `/v0/profile/reference_data/states`
- `/v0/profile/reference_data/zipcodes`


### /v0/profile/reference_data/countries

<img width="806" alt="countries" src="https://user-images.githubusercontent.com/967417/41260758-ac04a772-6d8d-11e8-8fb6-b3930dd6b8ad.png">

### /v0/profile/reference_data/states

<img width="808" alt="states" src="https://user-images.githubusercontent.com/967417/41260761-b14179ea-6d8d-11e8-9b92-782c8204114b.png">

### /v0/profile/reference_data/zipcodes

<img width="800" alt="zipcodes" src="https://user-images.githubusercontent.com/967417/41260768-b577b132-6d8d-11e8-8dd6-780142d8e7e2.png">


## Tasks

- [x] Implement reference data endpoints for countries, states, and zipcodes
- [x] Swagger docs
- [x] Specs