### PR TITLE
10819 - Handle non-json response bodies in Vet360 `handle_error`

### DIFF
--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -32,6 +32,7 @@ module Vet360
       when Common::Client::Errors::ClientError
         log_message_to_sentry(error.message, :error, extra_context: { url: config.base_path, body: error.body })
         raise Common::Exceptions::Forbidden if error.status == 403
+        raise_invalid_body(error, self.class) unless error.body.is_a?(Hash)
         message = parse_messages(error)&.first
         raise_backend_exception("VET360_#{message['code']}", self.class, error) if message.present?
         raise_backend_exception('VET360_502', self.class, error)
@@ -64,6 +65,15 @@ module Vet360
           response: { status: response.status, body: response.body }
         )
       end
+    end
+
+    def raise_invalid_body(error, source)
+      raise Common::Exceptions::BackendServiceException.new(
+        'VET360_502',
+        { source: source.to_s },
+        502,
+        error.body
+      )
     end
   end
 end


### PR DESCRIPTION
## Background

Our `handle_error` method currently assumes there is a valid json body with a `messages` field. This is not always the case, as we've saw a 503 with an html response body. The error handling logic will blow up unless we support the case where `error.body` is a string.

## Definition of done

- [x] Custom error handling when `error.body` is not a `Hash`