### PR TITLE
10948 remove id status from icn with aaid

### DIFF
--- a/lib/mvi/responses/icn_with_aaid_parser.rb
+++ b/lib/mvi/responses/icn_with_aaid_parser.rb
@@ -5,7 +5,7 @@ module MVI
     # This class takes a valid ICN with an Assigning Authority ID, and
     # an ID status, and parses it to meet Vet360's icn_with_aaid design constraints.
     #
-    class IcnWithAaidParser
+    class ICNWithAAIDParser
       INVALID_ID_STATUSES = %w[H PCE].freeze
 
       attr_reader :extension

--- a/lib/mvi/responses/icn_with_aaid_parser.rb
+++ b/lib/mvi/responses/icn_with_aaid_parser.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module MVI
+  module Responses
+    # This class takes a valid ICN with an Assigning Authority ID, and
+    # an ID status, and parses it to meet Vet360's icn_with_aaid design constraints.
+    #
+    class IcnWithAaidParser
+      INVALID_ID_STATUSES = %w[H PCE].freeze
+
+      attr_reader :extension
+
+      # @param extension [String] A full ICN with an Assigning Authority ID,
+      #   and an ID status (i.e. '12345678901234567^NI^200M^USVHA^P').
+      #   This structure of five sections is enforced by the IdParser::ICN_REGEX.
+      #   The five sections are: ID^TYPE^SOURCE^ISSUER^IDSTATUS
+      #
+      def initialize(extension)
+        @extension = extension
+      end
+
+      # Starts with a full icn_with_aaid with an ID status. For valid ID statuses, returns
+      # the icn_with_aaid with the ID status removed. For invalid ID statuses, returns nil.
+      #
+      # @return [String] For valid case, an icn_with_aaid with the ID status removed.
+      #   For example, '12345678901234567^NI^200M^USVHA'
+      # @return [Nil]
+      #
+      def without_id_status
+        return if extension.nil?
+        return if invalid_id_status?
+
+        trim_id_status
+      end
+
+      private
+
+      def invalid_id_status?
+        INVALID_ID_STATUSES.include? id_status
+      end
+
+      def id_status
+        identifiers.last
+      end
+
+      def identifiers
+        extension.split('^')
+      end
+
+      def trim_id_status
+        identifiers.take(4).join('^')
+      end
+    end
+  end
+end

--- a/lib/mvi/responses/id_parser.rb
+++ b/lib/mvi/responses/id_parser.rb
@@ -24,7 +24,7 @@ module MVI
           vha_facility_ids: select_facilities(select_extension(ids, /^\w+\^PI\^\w+\^USVHA\^\w+$/, CORRELATION_ROOT_ID)),
           birls_id: select_ids(select_extension(ids, /^\w+\^PI\^200BRLS\^USVBA\^\w+$/, CORRELATION_ROOT_ID))&.first,
           vet360_id: select_ids(select_extension(ids, /^\w+\^PI\^200VETS\^USDVA\^\w+$/, CORRELATION_ROOT_ID))&.first,
-          icn_with_aaid: select_extension(ids, ICN_REGEX, CORRELATION_ROOT_ID)&.first&.dig(:extension)
+          icn_with_aaid: IcnWithAaidParser.new(full_icn_with_aaid(ids)).without_id_status
         }
       end
 
@@ -48,6 +48,10 @@ module MVI
         ids.select do |id|
           id[:extension] =~ pattern && id[:root] == root
         end
+      end
+
+      def full_icn_with_aaid(ids)
+        select_extension(ids, ICN_REGEX, CORRELATION_ROOT_ID)&.first&.dig(:extension)
       end
     end
   end

--- a/lib/mvi/responses/id_parser.rb
+++ b/lib/mvi/responses/id_parser.rb
@@ -6,7 +6,7 @@ module MVI
       CORRELATION_ROOT_ID = '2.16.840.1.113883.4.349'
       EDIPI_ROOT_ID = '2.16.840.1.113883.3.42.10001.100001.12'
       ICN_REGEX = /^\w+\^NI\^\w+\^\w+\^\w+$/
-      VET360_ASSIGNING_AUTHORITY_ID = '^NI^200M^USVHA^P'
+      VET360_ASSIGNING_AUTHORITY_ID = '^NI^200M^USVHA'
 
       # MVI correlation id source id relationships:
       # {source id}^{id type}^{assigning facility}^{assigning authority}^{id status}

--- a/lib/mvi/responses/id_parser.rb
+++ b/lib/mvi/responses/id_parser.rb
@@ -24,7 +24,7 @@ module MVI
           vha_facility_ids: select_facilities(select_extension(ids, /^\w+\^PI\^\w+\^USVHA\^\w+$/, CORRELATION_ROOT_ID)),
           birls_id: select_ids(select_extension(ids, /^\w+\^PI\^200BRLS\^USVBA\^\w+$/, CORRELATION_ROOT_ID))&.first,
           vet360_id: select_ids(select_extension(ids, /^\w+\^PI\^200VETS\^USDVA\^\w+$/, CORRELATION_ROOT_ID))&.first,
-          icn_with_aaid: IcnWithAaidParser.new(full_icn_with_aaid(ids)).without_id_status
+          icn_with_aaid: ICNWithAAIDParser.new(full_icn_with_aaid(ids)).without_id_status
         }
       end
 

--- a/lib/vet360/person/service.rb
+++ b/lib/vet360/person/service.rb
@@ -47,7 +47,7 @@ module Vet360
         elsif @user&.icn_with_aaid.present?
           @user.icn_with_aaid
         else
-          raise 'User does not have an ICN with an Assigning Authority ID'
+          raise 'User does not have a valid ICN with an Assigning Authority ID'
         end
       end
 

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
     address { build(:mvi_profile_address) }
     home_phone { Faker::PhoneNumber.phone_number }
     icn { Faker::Number.number(17) }
-    icn_with_aaid { '1000123456V123456^NI^200M^USVHA^P' }
+    icn_with_aaid { '1000123456V123456^NI^200M^USVHA' }
     mhv_ids { Array.new(2) { Faker::Number.number(11) } }
     edipi { Faker::Number.number(10) }
     participant_id { Faker::Number.number(10) }

--- a/spec/lib/mvi/responses/icn_with_aaid_parser_spec.rb
+++ b/spec/lib/mvi/responses/icn_with_aaid_parser_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe MVI::Responses::IcnWithAaidParser do
+describe MVI::Responses::ICNWithAAIDParser do
   describe '#without_id_status' do
     context 'when initialized with a valid ICN and Assigning Authority ID' do
       context 'with a valid ID status' do
@@ -46,7 +46,7 @@ describe MVI::Responses::IcnWithAaidParser do
 end
 
 def expect_correct_response_from_without_id_status(full_icn, expected_return_value)
-  results = MVI::Responses::IcnWithAaidParser.new(full_icn).without_id_status
+  results = MVI::Responses::ICNWithAAIDParser.new(full_icn).without_id_status
 
   expect(results).to eq expected_return_value
 end

--- a/spec/lib/mvi/responses/icn_with_aaid_parser_spec.rb
+++ b/spec/lib/mvi/responses/icn_with_aaid_parser_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MVI::Responses::IcnWithAaidParser do
+  describe '#without_id_status' do
+    context 'when initialized with a valid ICN and Assigning Authority ID' do
+      context 'with a valid ID status' do
+        it 'returns the icn_with_aaid, trimming off the ID status', :aggregate_failures do
+          expect_correct_response_from_without_id_status(
+            '12345678901234567^NI^200M^USVHA^P',
+            '12345678901234567^NI^200M^USVHA'
+          )
+
+          expect_correct_response_from_without_id_status(
+            '12345678901234567^NI^200M^USVHA^A',
+            '12345678901234567^NI^200M^USVHA'
+          )
+        end
+      end
+
+      context 'with an invalid ID status' do
+        it 'returns nil', :aggregate_failures do
+          expect_correct_response_from_without_id_status(
+            '12345678901234567^NI^200M^USVHA^PCE',
+            nil
+          )
+
+          expect_correct_response_from_without_id_status(
+            '12345678901234567^NI^200M^USVHA^H',
+            nil
+          )
+        end
+      end
+    end
+
+    context 'when initialized with nil' do
+      it 'returns nil' do
+        expect_correct_response_from_without_id_status(
+          nil,
+          nil
+        )
+      end
+    end
+  end
+end
+
+def expect_correct_response_from_without_id_status(full_icn, expected_return_value)
+  results = MVI::Responses::IcnWithAaidParser.new(full_icn).without_id_status
+
+  expect(results).to eq expected_return_value
+end

--- a/spec/lib/mvi/responses/profile_parser_spec.rb
+++ b/spec/lib/mvi/responses/profile_parser_spec.rb
@@ -71,7 +71,7 @@ describe MVI::Responses::ProfileParser do
       end
 
       context 'with no middle name, missing and alternate correlation ids, multiple other_ids' do
-        let(:icn_with_aaid) { '1008714701V416111^NI^200M^USVHA^P' }
+        let(:icn_with_aaid) { '1008714701V416111^NI^200M^USVHA' }
         let(:body) { Ox.parse(File.read('spec/support/mvi/find_candidate_missing_attrs.xml')) }
         let(:mvi_profile) do
           build(
@@ -146,7 +146,7 @@ describe MVI::Responses::ProfileParser do
   end
 
   context 'with multiple MHV IDs' do
-    let(:icn_with_aaid) { '12345678901234567^NI^200M^USVHA^P' }
+    let(:icn_with_aaid) { '12345678901234567^NI^200M^USVHA' }
     let(:body) { Ox.parse(File.read('spec/support/mvi/find_candidate_multiple_mhv_response.xml')) }
     let(:mvi_profile) do
       build(:mvi_profile_response, :multiple_mhvids, historical_icns: nil, icn_with_aaid: icn_with_aaid)

--- a/spec/lib/mvi/service_spec.rb
+++ b/spec/lib/mvi/service_spec.rb
@@ -16,7 +16,7 @@ describe MVI::Service do
   end
 
   let(:user) { build(:user, :loa3, user_hash) }
-  let(:icn_with_aaid) { '1008714701V416111^NI^200M^USVHA^P' }
+  let(:icn_with_aaid) { '1008714701V416111^NI^200M^USVHA' }
 
   let(:mvi_profile) do
     build(

--- a/spec/support/vcr_cassettes/vet360/person/init_vet360_id_status_400.yml
+++ b/spec/support/vcr_cassettes/vet360/person/init_vet360_id_status_400.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/2.16.840.1.113883.4.349/1000123456V123456%5ENI%5E200M%5EUSVHA%5EP"
+    uri: "https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/2.16.840.1.113883.4.349/1000123456V123456%5ENI%5E200M%5EUSVHA"
     body:
       encoding: UTF-8
       string: '{"bio":{"sourceDate":"2018-04-09T17:52:03Z"}}'

--- a/spec/support/vcr_cassettes/vet360/person/init_vet360_id_success.yml
+++ b/spec/support/vcr_cassettes/vet360/person/init_vet360_id_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/2.16.840.1.113883.4.349/1000123456V123456%5ENI%5E200M%5EUSVHA%5EP"
+    uri: "https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/2.16.840.1.113883.4.349/1000123456V123456%5ENI%5E200M%5EUSVHA"
     body:
       encoding: UTF-8
       string: '{"bio":{"sourceDate":"2018-04-09T17:52:03Z"}}'


### PR DESCRIPTION
## Background

Per Josh Lindsey, Vet360 is checking:

> two things:  #1 - that the date of death is not set.  #2 - that IDStatus matches active criteria. 

Vet360 cannot process an `icn_with_aaid` that contains an ID status.  Additionally, they cannot process an ID that has an invalid ID status.  Sample ID statuses are:

```
^P
^A
^H
^PCE
```

An invalid ID status is one that contains either `^H` or `^PCE`.  

## Definition of done

- [x] the `icn_with_aaid` value should be stripped of its ID status
- [x] calls to initialize a Vet360 ID, or POST a person should be short circuited if the ID status is invalid