### PR TITLE
10886 vet360 StatsD reporting

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -61,3 +61,13 @@ StatsD.increment("#{Appeals::Service::STATSD_KEY_PREFIX}.get_appeals.fail", 0)
 # init  mvi
 StatsD.increment("#{MVI::Service::STATSD_KEY_PREFIX}.find_profile.total", 0)
 StatsD.increment("#{MVI::Service::STATSD_KEY_PREFIX}.find_profile.fail", 0)
+
+# init Vet360
+Vet360::Stats.exception_keys.each do |key|
+  StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.exceptions.#{key}", 0)
+end
+StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.total_operations", 0)
+StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.posts_and_puts.success", 0)
+StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.posts_and_puts.failure", 0)
+StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.init_vet360_id.success", 0)
+StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.init_vet360_id.failure", 0)

--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -102,6 +102,7 @@ module Vet360
       def get_person_transaction_status(transaction_id)
         with_monitoring do
           raw_response = perform(:get, "status/#{transaction_id}")
+          Vet360::Stats.increment_transaction_results(raw_response, 'init_vet360_id')
 
           Vet360::ContactInformation::PersonTransactionResponse.from(raw_response)
         end

--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -143,6 +143,7 @@ module Vet360
         with_monitoring do
           vet360_id_present!
           raw_response = perform(:get, path)
+          Vet360::Stats.increment_transaction_results(raw_response)
 
           response_class.from(raw_response)
         end

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -47,6 +47,8 @@ module Vet360
     end
 
     def raise_backend_exception(key, source, error = nil)
+      Vet360::Stats.increment('exceptions', key)
+
       raise Common::Exceptions::BackendServiceException.new(
         key,
         { source: source.to_s },
@@ -73,11 +75,13 @@ module Vet360
     end
 
     def raise_invalid_body(error, source)
+      Vet360::Stats.increment('exceptions', 'VET360_502')
+
       raise Common::Exceptions::BackendServiceException.new(
         'VET360_502',
         { source: source.to_s },
         502,
-        error.body
+        error&.body
       )
     end
   end

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -13,7 +13,7 @@ module Vet360
     def perform(method, path, body = nil, headers = {})
       config.base_request_headers.merge(headers)
       response = super(method, path, body, headers)
-      log_to_sentry(response)
+      report(response)
 
       response
     end
@@ -53,6 +53,11 @@ module Vet360
         error&.status,
         error&.body
       )
+    end
+
+    def report(response)
+      log_to_sentry(response)
+      Vet360::Stats.increment('total_operations')
     end
 
     def log_to_sentry(response)

--- a/lib/vet360/stats.rb
+++ b/lib/vet360/stats.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Vet360
+  class Stats
+    FINAL_SUCCESS = %w[COMPLETED_SUCCESS COMPLETED_NO_CHANGES_DETECTED].freeze
+    FINAL_FAILURE = %w[REJECTED COMPLETED_FAILURE].freeze
+
+    class << self
+      def exception_keys
+        exceptions_file
+          .dig('en', 'common', 'exceptions')
+          .keys
+          .select { |exception| exception.include? 'VET360_' }
+          .sort
+          .map(&:downcase)
+      end
+
+      def increment(*args)
+        buckets = args.map(&:downcase).join('.')
+
+        StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.#{buckets}")
+      end
+
+      def increment_transaction_results(response, bucket1 = 'posts_and_puts')
+        status = status_in(response)
+
+        return unless final_status?(status)
+
+        increment(bucket1, bucket_for(status))
+      end
+
+      private
+
+      def exceptions_file
+        config = Rails.root + 'config/locales/exceptions.en.yml'
+
+        YAML.load_file(config)
+      end
+
+      def status_in(response)
+        response&.body&.dig('tx_status')&.upcase
+      end
+
+      def final_status?(status)
+        status.present? && success?(status) || failure?(status)
+      end
+
+      def success?(status)
+        FINAL_SUCCESS.include? status
+      end
+
+      def failure?(status)
+        FINAL_FAILURE.include? status
+      end
+
+      def bucket_for(status)
+        if success?(status)
+          'success'
+        elsif failure?(status)
+          'failure'
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -343,6 +343,18 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
           end
         end
       end
+
+      context 'for initializing a vet360_id' do
+        it 'increments the StatsD Vet360 init_vet360_id counters' do
+          transaction_id = '786efe0e-fd20-4da2-9019-0c00540dba4d'
+
+          VCR.use_cassette('vet360/contact_information/person_transaction_status') do
+            expect { subject.get_person_transaction_status(transaction_id) }.to trigger_statsd_increment(
+              "#{Vet360::Service::STATSD_KEY_PREFIX}.init_vet360_id.success"
+            )
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -305,4 +305,44 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
       end
     end
   end
+
+  context 'When reporting StatsD statistics' do
+    context 'when checking transaction status' do
+      context 'for emails' do
+        it 'increments the StatsD Vet360 posts_and_puts counters' do
+          transaction_id = '786efe0e-fd20-4da2-9019-0c00540dba4d'
+
+          VCR.use_cassette('vet360/contact_information/email_transaction_status') do
+            expect { subject.get_email_transaction_status(transaction_id) }.to trigger_statsd_increment(
+              "#{Vet360::Service::STATSD_KEY_PREFIX}.posts_and_puts.success"
+            )
+          end
+        end
+      end
+
+      context 'for telephones' do
+        it 'increments the StatsD Vet360 posts_and_puts counters' do
+          transaction_id = 'a50193df-f4d5-4b6a-b53d-36fed2db1a15'
+
+          VCR.use_cassette('vet360/contact_information/telephone_transaction_status') do
+            expect { subject.get_telephone_transaction_status(transaction_id) }.to trigger_statsd_increment(
+              "#{Vet360::Service::STATSD_KEY_PREFIX}.posts_and_puts.success"
+            )
+          end
+        end
+      end
+
+      context 'for addresses' do
+        it 'increments the StatsD Vet360 posts_and_puts counters' do
+          transaction_id = '0faf342f-5966-4d3f-8b10-5e9f911d07d2'
+
+          VCR.use_cassette('vet360/contact_information/address_transaction_status') do
+            expect { subject.get_address_transaction_status(transaction_id) }.to trigger_statsd_increment(
+              "#{Vet360::Service::STATSD_KEY_PREFIX}.posts_and_puts.success"
+            )
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/vet360/service_spec.rb
+++ b/spec/lib/vet360/service_spec.rb
@@ -44,6 +44,33 @@ describe Vet360::Service do
       end
     end
   end
+
+  describe '#raise_backend_exception' do
+    context 'regarding its reporting' do
+      it 'increments the StatsD error counter', :aggregate_failures do
+        error_key = 'VET360_ADDR133'
+
+        expect(Vet360::Stats).to receive(:increment).with('exceptions', error_key)
+        expect { subject.send('raise_backend_exception', error_key, 'test') }.to raise_error(
+          Common::Exceptions::BackendServiceException
+        )
+      end
+    end
+  end
+
+  describe '#raise_invalid_body' do
+    context 'regarding its reporting' do
+      it 'increments the StatsD error counter', :aggregate_failures do
+        error_key = 'VET360_502'
+
+        expect(Vet360::Stats).to receive(:increment).with('exceptions', error_key)
+        expect { subject.send('raise_invalid_body', nil, 'test') }.to raise_error(
+          Common::Exceptions::BackendServiceException
+        )
+      end
+    end
+  end
+
   describe '#perform' do
     context 'regarding its reporting' do
       before do

--- a/spec/lib/vet360/service_spec.rb
+++ b/spec/lib/vet360/service_spec.rb
@@ -44,6 +44,20 @@ describe Vet360::Service do
       end
     end
   end
+  describe '#perform' do
+    context 'regarding its reporting' do
+      before do
+        allow_any_instance_of(Vet360::Service).to receive_message_chain(:config, :base_request_headers, :merge) { '' }
+        allow_any_instance_of(Common::Client::Base).to receive(:perform).and_return(nil)
+      end
+
+      it 'increments the StatsD Vet360 total_operations counter' do
+        expect { subject.perform(:get, 'some_path') }.to trigger_statsd_increment(
+          "#{Vet360::Service::STATSD_KEY_PREFIX}.total_operations"
+        )
+      end
+    end
+  end
 end
 
 def body_for(row)

--- a/spec/lib/vet360/stats_spec.rb
+++ b/spec/lib/vet360/stats_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Vet360::Stats do
+  let(:statsd_prefix) { Vet360::Service::STATSD_KEY_PREFIX }
+
+  describe '.exception_keys' do
+    subject { described_class.exception_keys }
+
+    it 'returns an array of Vet360 exception keys' do
+      expect(subject).to be_a Array
+    end
+
+    it 'contains only downcased, Vet360 exception keys' do
+      total_key_count  = subject.size
+      keys_with_vet360 = subject.select { |key| key.include? 'vet360_' }.size
+
+      expect(total_key_count).to eq keys_with_vet360
+    end
+  end
+
+  describe '.increment' do
+    it 'increments the StatsD Vet360 counter' do
+      bucket1 = 'exceptions'
+      bucket2 = 'VET360_ADDR133'
+
+      expect { described_class.increment(bucket1, bucket2) }.to trigger_statsd_increment(
+        "#{statsd_prefix}.#{bucket1}.#{bucket2.downcase}"
+      )
+    end
+
+    it 'increments the StatsD Vet360 counter with a variable number of buckets passed' do
+      bucket1 = 'bucket1'
+      bucket2 = 'bucket2'
+      bucket3 = 'bucket3'
+      bucket4 = 'bucket4'
+
+      expect { described_class.increment(bucket1, bucket2, bucket3, bucket4) }.to trigger_statsd_increment(
+        "#{statsd_prefix}.#{bucket1}.#{bucket2}.#{bucket3}.#{bucket4}"
+      )
+    end
+  end
+
+  describe '.increment_transaction_results' do
+    let(:success_status) { described_class::FINAL_SUCCESS.first }
+    let(:failure_status) { described_class::FINAL_FAILURE.first }
+
+    context 'when response contains a final success status' do
+      it 'increments the StatsD Vet360 posts_and_puts success counter' do
+        response = raw_vet360_transaction_response(success_status)
+
+        expect { described_class.increment_transaction_results(response) }.to trigger_statsd_increment(
+          "#{statsd_prefix}.posts_and_puts.success"
+        )
+      end
+    end
+
+    context 'when response contains a final failure status' do
+      it 'increments the StatsD Vet360 posts_and_puts failure counter' do
+        response = raw_vet360_transaction_response(failure_status)
+
+        expect { described_class.increment_transaction_results(response) }.to trigger_statsd_increment(
+          "#{statsd_prefix}.posts_and_puts.failure"
+        )
+      end
+    end
+
+    context 'when response is neither a success nor failure status' do
+      it 'does not increment the StatsD Vet360 posts_and_puts counters', :aggregate_failures do
+        response = raw_vet360_transaction_response('RECEIVED')
+
+        expect { described_class.increment_transaction_results(response) }.to_not trigger_statsd_increment(
+          "#{statsd_prefix}.posts_and_puts.success"
+        )
+        expect { described_class.increment_transaction_results(response) }.to_not trigger_statsd_increment(
+          "#{statsd_prefix}.posts_and_puts.failure"
+        )
+      end
+    end
+
+    context 'when response body is nil' do
+      it 'does not increment the StatsD Vet360 posts_and_puts counters', :aggregate_failures do
+        expect { described_class.increment_transaction_results(nil) }.to_not trigger_statsd_increment(
+          "#{statsd_prefix}.posts_and_puts.success"
+        )
+        expect { described_class.increment_transaction_results(nil) }.to_not trigger_statsd_increment(
+          "#{statsd_prefix}.posts_and_puts.failure"
+        )
+      end
+    end
+
+    context 'when bucket1 is provided as init_vet360_id' do
+      let(:init_vet360) { 'init_vet360_id' }
+
+      it 'increments the StatsD Vet360 init_vet360_id success counter' do
+        response = raw_vet360_transaction_response(success_status)
+
+        expect { described_class.increment_transaction_results(response, init_vet360) }.to trigger_statsd_increment(
+          "#{statsd_prefix}.#{init_vet360}.success"
+        )
+      end
+
+      it 'increments the StatsD Vet360 init_vet360_id failure counter' do
+        response = raw_vet360_transaction_response(failure_status)
+
+        expect { described_class.increment_transaction_results(response, init_vet360) }.to trigger_statsd_increment(
+          "#{statsd_prefix}.#{init_vet360}.failure"
+        )
+      end
+    end
+  end
+end
+
+def raw_vet360_transaction_response(tx_status)
+  OpenStruct.new(body: { 'tx_status' => tx_status })
+end

--- a/spec/support/vcr_cassettes/vet360/contact_information/person_transaction_status.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/person_transaction_status.yml
@@ -52,16 +52,16 @@ http_interactions:
           "txType": "PUSH",
           "txInteractionType": "ATTENDED",
           "txPushInput": {
-            "sourceDate": "2018-04-09T17:52:03Z",
-            "originatingSourceSystem": "VETSGOV"
+            "sourceDate": "2018-04-09T17:52:03Z"
           },
           "txOutput": [
             {
               "vet360Id": 1,
               "txAuditId": "786efe0e-fd20-4da2-9019-0c00540dba4d",
               "sourceSystem": "VETSGOV",
-              "sourceDate": "2018-04-09T17:52:03Z",
-              "originatingSourceSystem": "VETSGOV"
+              "createDate": "2018-04-09T17:52:03Z",
+              "updateDate": "2018-04-09T17:52:03Z",
+              "sourceDate": "2018-04-09T17:52:03Z"
             }
           ]
         }


### PR DESCRIPTION
## Background 

We'll want to know how our users are doing once we launch Vet360

## Definition of done

StatsD reporting for:

- [x] count of all Vet360 operations
- [x] count of successful `POST/PUT` address/email/telephone transactions
- [x] count of failed `POST/PUT` address/email/telephone transactions 
- [x] count of successful `vet360_id` initialization transactions
- [x] count of failed `vet360_id` initialization transactions
- [x] count of each instance an exception is raised, per Vet360 exception key
- [x] spec coverage
- [x] yard docs