### PR TITLE
GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,5 @@
 - [ ] _Replace this line with individual tasks unique to your PR_
 - [ ] Appropriate test coverage & logging
 - [ ] Swagger docs have been updated, if applicable
+- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
 - [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Background
+<!-- What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary -->
+
+## Definition of Done
+
+- [ ] _Replace this line with individual "To-Do's" unique to your PR_
+- [ ] Appropriate test coverage & logging
+- [ ] Swagger docs have been updated, if applicable
+- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 
 ## Definition of Done
 
-- [ ] _Replace this line with individual "To-Do's" unique to your PR_
+- [ ] _Replace this line with individual tasks unique to your PR_
 - [ ] Appropriate test coverage & logging
 - [ ] Swagger docs have been updated, if applicable
 - [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)


### PR DESCRIPTION
## Background

In a recent engineering meeting, we discussed creating a PR template that encourages the inclusion of important information related to that PR. Things like screenshots, security checks, etc. 

Most of that information is mentioned in our code review norms doc: https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Code%20Review%20Norms.md

## Definition of Done

- [x] Create a default GitHub PR template for the Vets-API repo
- [x] Collaborate with many Vets-API contributors to finalize the first release of the template