### PR TITLE
10886 known vet360 exception keys

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -63,7 +63,7 @@ StatsD.increment("#{MVI::Service::STATSD_KEY_PREFIX}.find_profile.total", 0)
 StatsD.increment("#{MVI::Service::STATSD_KEY_PREFIX}.find_profile.fail", 0)
 
 # init Vet360
-Vet360::Stats.exception_keys.each do |key|
+Vet360::Exceptions.instance.known_keys.each do |key|
   StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.exceptions.#{key}", 0)
 end
 StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.total_operations", 0)

--- a/lib/vet360/exceptions.rb
+++ b/lib/vet360/exceptions.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'singleton'
+
+module Vet360
+  class Exceptions
+    include Singleton
+
+    attr_reader :keys
+
+    def initialize
+      @keys = nil
+    end
+
+    def known_keys
+      @keys = exception_keys
+    end
+
+    private
+
+    # Parses our exceptions file and returns all of the Vet360 exception keys.
+    #
+    # @return [Array] An array of lowercased, alphabetized, Vet360 exception keys
+    #
+    def exception_keys
+      exceptions_file
+        .dig('en', 'common', 'exceptions')
+        .keys
+        .select { |exception| exception.include? 'VET360_' }
+        .sort
+        .map(&:downcase)
+    end
+
+    def exceptions_file
+      config = Rails.root + 'config/locales/exceptions.en.yml'
+
+      YAML.load_file(config)
+    end
+  end
+end

--- a/lib/vet360/exceptions.rb
+++ b/lib/vet360/exceptions.rb
@@ -3,17 +3,22 @@
 require 'singleton'
 
 module Vet360
+  # This class parses all of the Vet360 exception keys from config/locales/exceptions.en.yml
+  # and saves them to an instance variable.  For performance reasons, the Singleton Pattern
+  # is used.  This allows the file system to be hit one time, when a server instance is
+  # initialized.  From that point forward, the exception keys are saved to an instance
+  # variable in this class, thereby eliminating the need for the file system to be hit repeatedly.
+  #
   class Exceptions
     include Singleton
 
-    attr_reader :keys
-
-    def initialize
-      @keys = nil
-    end
-
+    # Parses our exceptions file and returns all of the Vet360 exception keys.  Memoizes this
+    # value by setting it equal to the @keys instance variable.
+    #
+    # @return [Array] An array of lowercased, alphabetized, Vet360 exception keys
+    #
     def known_keys
-      @keys = exception_keys
+      @keys ||= exception_keys
     end
 
     # Checks if the passed exception key is present in the exceptions_file
@@ -23,15 +28,11 @@ module Vet360
     # @return [Boolean]
     #
     def known?(exception_key)
-      keys.include? exception_key.downcase
+      known_keys.include? exception_key.downcase
     end
 
     private
 
-    # Parses our exceptions file and returns all of the Vet360 exception keys.
-    #
-    # @return [Array] An array of lowercased, alphabetized, Vet360 exception keys
-    #
     def exception_keys
       exceptions_file
         .dig('en', 'common', 'exceptions')

--- a/lib/vet360/exceptions.rb
+++ b/lib/vet360/exceptions.rb
@@ -16,6 +16,16 @@ module Vet360
       @keys = exception_keys
     end
 
+    # Checks if the passed exception key is present in the exceptions_file
+    #
+    # @param exception_key [String] A Vet360 exception key from config/locales/exceptions.en.yml
+    #   For example, 'VET360_ADDR133'
+    # @return [Boolean]
+    #
+    def known?(exception_key)
+      keys.include? exception_key.downcase
+    end
+
     private
 
     # Parses our exceptions file and returns all of the Vet360 exception keys.

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -47,7 +47,7 @@ module Vet360
     end
 
     def raise_backend_exception(key, source, error = nil)
-      Vet360::Stats.increment('exceptions', key)
+      report_stats_on(key)
 
       raise Common::Exceptions::BackendServiceException.new(
         key,
@@ -83,6 +83,14 @@ module Vet360
         502,
         error&.body
       )
+    end
+
+    def report_stats_on(exception_key)
+      if Vet360::Exceptions.instance.keys.include?(exception_key)
+        Vet360::Stats.increment('exceptions', exception_key)
+      else
+        log_message_to_sentry('New Vet360 Exceptions Key', :info, key: exception_key)
+      end
     end
   end
 end

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -86,7 +86,7 @@ module Vet360
     end
 
     def report_stats_on(exception_key)
-      if Vet360::Exceptions.instance.keys.include?(exception_key)
+      if Vet360::Exceptions.instance.known?(exception_key)
         Vet360::Stats.increment('exceptions', exception_key)
       else
         log_message_to_sentry('New Vet360 Exceptions Key', :info, key: exception_key)

--- a/lib/vet360/stats.rb
+++ b/lib/vet360/stats.rb
@@ -6,19 +6,6 @@ module Vet360
     FINAL_FAILURE = %w[REJECTED COMPLETED_FAILURE].freeze
 
     class << self
-      # Parses our exceptions file and returns all of the Vet360 exception keys.
-      #
-      # @return [Array] An array of lowercased, alphabetized, Vet360 exception keys
-      #
-      def exception_keys
-        exceptions_file
-          .dig('en', 'common', 'exceptions')
-          .keys
-          .select { |exception| exception.include? 'VET360_' }
-          .sort
-          .map(&:downcase)
-      end
-
       # Triggers the associated StatsD.increment method for the Vet360 buckets that are
       # initialized in the config/initializers/statsd.rb file.
       #
@@ -49,12 +36,6 @@ module Vet360
       end
 
       private
-
-      def exceptions_file
-        config = Rails.root + 'config/locales/exceptions.en.yml'
-
-        YAML.load_file(config)
-      end
 
       def status_in(response)
         response&.body&.dig('tx_status')&.upcase

--- a/spec/lib/vet360/exceptions_spec.rb
+++ b/spec/lib/vet360/exceptions_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Vet360::Exceptions do
+  describe '.known_keys' do
+    subject { described_class.instance.known_keys }
+
+    it 'returns an array of Vet360 exception keys' do
+      expect(subject).to be_a Array
+    end
+
+    it 'contains only downcased, Vet360 exception keys' do
+      total_key_count  = subject.size
+      keys_with_vet360 = subject.select { |key| key.include? 'vet360_' }.size
+
+      expect(total_key_count).to eq keys_with_vet360
+    end
+  end
+end

--- a/spec/lib/vet360/exceptions_spec.rb
+++ b/spec/lib/vet360/exceptions_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Vet360::Exceptions do
-  describe '.known_keys' do
+  describe '#known_keys' do
     subject { described_class.instance.known_keys }
 
     it 'returns an array of Vet360 exception keys' do
@@ -15,6 +15,20 @@ describe Vet360::Exceptions do
       keys_with_vet360 = subject.select { |key| key.include? 'vet360_' }.size
 
       expect(total_key_count).to eq keys_with_vet360
+    end
+  end
+
+  describe '#known?' do
+    let(:known_key) { 'VET360_ADDR133' }
+    let(:unknown_key) { 'VET360_some_key' }
+    subject { described_class.instance }
+
+    it 'returns true if the passed Vet360 exception key is present in the exception_keys' do
+      expect(subject.known?(known_key)).to be true
+    end
+
+    it 'returns false if the passed Vet360 exception key is not present in the exception_keys' do
+      expect(subject.known?(unknown_key)).to be false
     end
   end
 end

--- a/spec/lib/vet360/stats_spec.rb
+++ b/spec/lib/vet360/stats_spec.rb
@@ -5,21 +5,6 @@ require 'rails_helper'
 describe Vet360::Stats do
   let(:statsd_prefix) { Vet360::Service::STATSD_KEY_PREFIX }
 
-  describe '.exception_keys' do
-    subject { described_class.exception_keys }
-
-    it 'returns an array of Vet360 exception keys' do
-      expect(subject).to be_a Array
-    end
-
-    it 'contains only downcased, Vet360 exception keys' do
-      total_key_count  = subject.size
-      keys_with_vet360 = subject.select { |key| key.include? 'vet360_' }.size
-
-      expect(total_key_count).to eq keys_with_vet360
-    end
-  end
-
   describe '.increment' do
     it 'increments the StatsD Vet360 counter' do
       bucket1 = 'exceptions'


### PR DESCRIPTION
## Background

We have captured all of the current, known Vet360 exception keys in our [locales.exceptions file](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/locales/exceptions.en.yml).  These are the same exception keys that we are creating StatsD buckets for.

If Vet360 were to release a new exception key, without it being in our locales.exceptions file, this could cause Prometheus to get a request for a bucket that it does not know about.

## Definition of Done

- [x] Ensure that the dynamic exception keys coming from Vet360 is accounted for in our StatsD logging to Prometheus
- [x] Do not continuously hit the file system in order to check for the returned exception key being known/unknown 