### PR TITLE
11038 do not accept international phones

### DIFF
--- a/app/swagger/schemas/vet360/telephone.rb
+++ b/app/swagger/schemas/vet360/telephone.rb
@@ -7,12 +7,14 @@ module Swagger
         include Swagger::Blocks
 
         swagger_schema :PostVet360Telephone do
-          key :required, %i[phone_number area_code phone_type]
+          key :required, %i[phone_number area_code phone_type is_international country_code]
           property :is_international,
                    type: :boolean,
+                   enum: [false],
                    example: false
           property :country_code,
                    type: :string,
+                   enum: ['1'],
                    example: '1'
           property :phone_number,
                    type: :string,
@@ -37,13 +39,15 @@ module Swagger
         end
 
         swagger_schema :PutVet360Telephone do
-          key :required, %i[id phone_number area_code phone_type]
+          key :required, %i[id phone_number area_code phone_type is_international country_code]
           property :id, type: :integer, example: 1
           property :is_international,
                    type: :boolean,
+                   enum: [false],
                    example: false
           property :country_code,
                    type: :string,
+                   enum: ['1'],
                    example: '1'
           property :phone_number,
                    type: :string,

--- a/lib/vet360/models/telephone.rb
+++ b/lib/vet360/models/telephone.rb
@@ -62,17 +62,21 @@ module Vet360
 
       validates(
         :is_international,
-        inclusion: { in: [true, false] },
-        exclusion: { in: [nil] }
+        inclusion: { in: [false] }
+      )
+
+      validates(
+        :country_code,
+        presence: true,
+        inclusion: { in: ['1'] }
       )
 
       # Converts an instance of the Telphone model to a JSON encoded string suitable for
       # use in the body of a request to Vet360
+      #
       # @return [String] JSON-encoded string suitable for requests to Vet360
+      #
       def in_json
-        # Determine international flag if not set
-        @is_international ||= @country_code.present? && @country_code != '1'
-
         {
           bio: {
             areaCode: @area_code,

--- a/spec/lib/vet360/models/telephone_spec.rb
+++ b/spec/lib/vet360/models/telephone_spec.rb
@@ -3,39 +3,56 @@
 require 'rails_helper'
 
 describe Vet360::Models::Telephone do
-  describe 'is_international' do
-    let(:data) { JSON.parse(telephone.in_json) }
-    let(:is_international) { data['bio']['internationalIndicator'] }
+  describe 'validations' do
+    it 'we have a valid factory in place' do
+      expect(build(:telephone)).to be_valid
+    end
 
-    context 'when explicitly set' do
-      let(:telephone) { build(:telephone, is_international: true) }
+    context 'is_international' do
+      it 'is valid when set to false' do
+        phone = build(:telephone, is_international: false)
 
-      it 'equals the input value' do
-        expect(is_international).to eq(true)
+        expect(phone).to be_valid
+      end
+
+      it 'is not valid when set to true' do
+        phone = build(:telephone, is_international: true)
+
+        expect(phone).to_not be_valid
+      end
+
+      it 'is not valid when nil' do
+        phone = build(:telephone, is_international: nil)
+
+        expect(phone).to_not be_valid
       end
     end
 
-    context 'when nil' do
-      context 'when country_code is nil' do
-        let(:telephone) { build(:telephone, is_international: nil, country_code: nil) }
+    context 'country_code' do
+      it 'is valid when set to "1" or 1', :aggregate_failures do
+        valid_country_codes = ['1', 1]
 
-        it 'defaults to false' do
-          expect(is_international).to eq(false)
+        valid_country_codes.each do |valid_country_code|
+          phone = build(:telephone, country_code: valid_country_code)
+
+          expect(phone).to be_valid
         end
       end
 
-      context 'when country_code is domestic' do
-        let(:telephone) { build(:telephone, is_international: nil, country_code: '1') }
-        it 'is false' do
-          expect(is_international).to eq(false)
+      it 'is not valid when set to anything other than "1"', :aggregate_failures do
+        invalid_country_codes = ['2', '15', 'abc', '01']
+
+        invalid_country_codes.each do |invalid_country_code|
+          phone = build(:telephone, country_code: invalid_country_code)
+
+          expect(phone).to_not be_valid
         end
       end
 
-      context 'when country_code is international' do
-        let(:telephone) { build(:telephone, is_international: nil, country_code: '44') }
-        it 'is true' do
-          expect(is_international).to eq(true)
-        end
+      it 'is not valid when nil' do
+        phone = build(:telephone, country_code: nil)
+
+        expect(phone).to_not be_valid
       end
     end
   end

--- a/spec/lib/vet360/models/telephone_spec.rb
+++ b/spec/lib/vet360/models/telephone_spec.rb
@@ -40,7 +40,7 @@ describe Vet360::Models::Telephone do
       end
 
       it 'is not valid when set to anything other than "1"', :aggregate_failures do
-        invalid_country_codes = ['2', '15', 'abc', '01']
+        invalid_country_codes = %w[2 15 abc 01]
 
         invalid_country_codes.each do |invalid_country_code|
           phone = build(:telephone, country_code: invalid_country_code)


### PR DESCRIPTION
## Background

Vet360 will not be supporting international phone numbers for the foreseeable future. 

## Screenshots

Updated swagger docs (`PUT` endpoint has same updated validations present)

![image](https://user-images.githubusercontent.com/7482329/41608057-cfd61a7e-73a4-11e8-9ac6-8146c516a24e.png)


## Definition of Done

- [x] Validate that `country_code` is `"1"`
- [x] Validate that `is_international` is `false`
- [x] Update any existing telephone validations in keeping with this new policy
- [x] Update swagger docs
- [x] Update specs 