### PR TITLE
11039 low confidence vet360 error code

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -486,6 +486,12 @@ en:
         code: 'VET360_ADDR304'
         detail: 'Cannot accept a request with multiple addresses of the same POU.'
         status: 400
+      VET360_ADDR306:
+        <<: *external_defaults
+        title: Low confidence score
+        code: 'VET360_ADDR306'
+        detail: 'Confidence Score less than 80.'
+        status: 400
       VET360_CORE100:
         <<: *external_defaults
         title: Unexpected Error

--- a/spec/request/vet360/address_request_spec.rb
+++ b/spec/request/vet360/address_request_spec.rb
@@ -70,6 +70,27 @@ RSpec.describe 'address', type: :request do
       end
     end
 
+    context 'with a low confidence error' do
+      it 'returns the low confidence error error code', :aggregate_failures do
+        VCR.use_cassette('vet360/contact_information/post_address_w_low_confidence_error') do
+          low_confidence_error = 'VET360_ADDR306'
+
+          post(
+            '/v0/profile/addresses',
+            address.to_json,
+            auth_header.update(
+              'Content-Type' => 'application/json', 'Accept' => 'application/json'
+            )
+          )
+
+          body = JSON.parse response.body
+          expect(body['errors'].first['code']).to eq low_confidence_error
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+
     context 'with a 403 response' do
       it 'should return a forbidden response' do
         VCR.use_cassette('vet360/contact_information/post_address_status_403') do

--- a/spec/support/vcr_cassettes/vet360/contact_information/post_address_w_low_confidence_error.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/post_address_w_low_confidence_error.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://int.vet360.va.gov/person-mdm-cuf-person-hub/cuf/person/contact-information/v1/addresses
+    body:
+      encoding: UTF-8
+      string: '{"bio":{"addressId":42,"addressLine1":"1493 Martin Luther King Rd","addressLine2":null,"addressLine3":null,"addressPOU":"RESIDENCE/CHOICE","addressType":"DOMESTIC","cityName":"Fulton","countryCodeISO2":null,"countryCodeISO3":null,"countryName":"USA","county":{"countyCode":null,"countyName":null},"intPostalCode":null,"provinceName":null,"stateCode":"MS","zipCode4":"38843","zipCode5":null,"originatingSourceSystem":"VETSGOV","sourceSystemUser":"1234","sourceDate":"2018-04-09T11:52:03.000-06:00","vet360Id":"1","effectiveStartDate":null,"effectiveEndDate":null}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Cufsystemname:
+      - VETSGOV
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Date:
+      - Wed, 25 Apr 2018 16:49:36 GMT
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      X-Ua-Compatible:
+      - IE-edge,chrome=1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"code":"ADDR306","key":"addressBio.lowConfidenceScore","severity":"ERROR","text":"Confidence Score less than 80"}],"txAuditId":"5b450492-b1cc-4beb-94d0-a49176fc6c44","status":"REJECTED"}'
+    http_version:
+  recorded_at: Wed, 25 Apr 2018 16:49:36 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vet360/api_response_error_messages.csv
+++ b/spec/support/vet360/api_response_error_messages.csv
@@ -29,6 +29,7 @@ addressId.NotNull,ADDR201,may not be null
 AddressInactive,ADDR300,Cannot modify an existing inactive record.
 AddressPOU,ADDR301,Can not insert a record for an address POU that already exists. Pull the address record and update it using the addressId provided.
 DuplicateAddressPOU,ADDR304,Cannot accept a request with multiple addresses of the same POU.
+addressBio.lowConfidenceScore,ADDR306,Confidence Score less than 80.
 _CUF_UNEXPECTED_ERROR,CORE100,"There was an error encountered processing the Request. Please retry. If problem persists, please contact support with a copy of the Response."
 _CUF_ACCESS_DENIED,CORE101,"You do not have access to perform the requested operation. Please correct your request before trying again! If you believe you have received this access denied error incorrect, please contact your system administrator."
 _CUF_DATA_INTEGRITY_VIOLATION,CORE102,The operation could not be fulfilled due to a data integrity violation.


### PR DESCRIPTION
## Background

There is a Vet360 error code when an address is `POST/PUT` where the address can be rejected due to a low confidence score.  Per Amy Rosenthal from Vet360:

> should be ADDR306 Confidence Score less than 80
> addresses[#].lowConfidenceScore

## Definition of Done

- [x] Low confidence error code added to our `locales.exceptions` file
- [x] Spec in place that exercises the new error code
- [x] Confirmation with the FE team on the error message that is returned 