### PR TITLE
Add Vet360 to list of user Backend Services

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,7 +237,7 @@ class User < Common::RedisStore
 
   def can_access_vet360?
     loa3? && icn.present? && vet360_id.present?
-  rescue StandardError # Default to false for any veteran_status error
+  rescue StandardError # Default to false for any error
     false
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -235,6 +235,13 @@ class User < Common::RedisStore
     @vet360_contact_info ||= Vet360Redis::ContactInformation.for_user(self)
   end
 
+  def can_access_vet360?
+    loa3? && icn.present? && vet360_id.present?
+  rescue StandardError # Default to false for any veteran_status error
+    false
+  end
+
+
   def mvi
     @mvi ||= Mvi.for_user(self)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -241,7 +241,6 @@ class User < Common::RedisStore
     false
   end
 
-
   def mvi
     @mvi ||= Mvi.for_user(self)
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -108,6 +108,7 @@ class UserSerializer < ActiveModel::Serializer
     service_list << BackendServices::FORM_PREFILL if object.can_access_prefill_data?
     service_list << BackendServices::ID_CARD if object.can_access_id_card?
     service_list << BackendServices::IDENTITY_PROOFED if object.identity_proofed?
+    service_list << BackendServices::VET360 if object.can_access_vet360?
     service_list += BetaRegistration.where(user_uuid: object.uuid).pluck(:feature) || []
     service_list
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -90,7 +90,7 @@ class UserSerializer < ActiveModel::Serializer
     FormProfile.prefill_enabled_forms
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
   def services
     service_list = [
       BackendServices::FACILITIES,
@@ -112,5 +112,5 @@ class UserSerializer < ActiveModel::Serializer
     service_list += BetaRegistration.where(user_uuid: object.uuid).pluck(:feature) || []
     service_list
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
 end

--- a/lib/backend_services.rb
+++ b/lib/backend_services.rb
@@ -19,6 +19,7 @@ class BackendServices
   USER_PROFILE = 'user-profile'
   ID_CARD = 'id-card'
   IDENTITY_PROOFED = 'identity-proofed'
+  VET360 = 'vet360'
 
   # MHV services
   RX = 'rx'

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe 'Fetching user data', type: :request do
           BackendServices::FORM_PREFILL,
           BackendServices::SAVE_IN_PROGRESS,
           BackendServices::APPEALS_STATUS,
-          BackendServices::IDENTITY_PROOFED
+          BackendServices::IDENTITY_PROOFED,
+          BackendServices::VET360
         ].sort
       )
     end


### PR DESCRIPTION
This PR adds `vet360` to the potential list of backend services a user is able to access. This will allow the frontend to more easily check if a user is able to query Vet360 without having to do null checks.

### Tasks
- [x] Create new backend service listing for Vet360
- [x] Add helper method for checking attributes required to query Vet360
- [x] Add support to serializer to render the new backend service value
- [x] Update specs to ensure value is in list