### PR TITLE
Prep Vet360 service for production deployment

### DIFF
--- a/lib/vet360/configuration.rb
+++ b/lib/vet360/configuration.rb
@@ -13,10 +13,6 @@ module Vet360
         faraday.use      :breakers
         faraday.use      Faraday::Response::RaiseError
 
-        # @TODO Remove for production...
-        # (This is really helpful for setting up cassettes)
-        # faraday.response :logger, ::Logger.new(STDOUT), bodies: true
-
         faraday.response :betamocks if mock_enabled?
         faraday.response :snakecase, symbolize: false
         faraday.response :json, content_type: /\bjson/ # ensures only json content types parsed

--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -112,21 +112,11 @@ module Vet360
 
       private
 
-      def enabled?
-        Settings.vet360.contact_information.enabled
-      end
-
-      def raise_if_disabled!
-        raise 'Vet360 service is disabled in this environment' unless enabled?
-      end
-
       def vet360_id_present!
         raise 'User does not have a vet360_id' if @user&.vet360_id.blank?
       end
 
       def post_or_put_data(method, model, path, response_class)
-        raise_if_disabled!
-
         with_monitoring do
           vet360_id_present!
           raw_response = perform(method, path, model.in_json)
@@ -138,8 +128,6 @@ module Vet360
       end
 
       def get_transaction_status(path, response_class)
-        raise_if_disabled!
-
         with_monitoring do
           vet360_id_present!
           raw_response = perform(:get, path)

--- a/lib/vet360/contact_information/service.rb
+++ b/lib/vet360/contact_information/service.rb
@@ -112,13 +112,12 @@ module Vet360
 
       private
 
-      # This method acts as a beta flag, and is temporarily in place until Vet360
-      # is ready to be released and activated in production
-      #
-      def temporary_short_circuit!
-        unless Settings.vet360.contact_information.enabled
-          raise 'Vet360 service has not been fully integrated into production'
-        end
+      def enabled?
+        Settings.vet360.contact_information.enabled
+      end
+
+      def raise_if_disabled!
+        raise 'Vet360 service is disabled in this environment' unless enabled?
       end
 
       def vet360_id_present!
@@ -126,7 +125,7 @@ module Vet360
       end
 
       def post_or_put_data(method, model, path, response_class)
-        temporary_short_circuit!
+        raise_if_disabled!
 
         with_monitoring do
           vet360_id_present!
@@ -139,7 +138,7 @@ module Vet360
       end
 
       def get_transaction_status(path, response_class)
-        temporary_short_circuit!
+        raise_if_disabled!
 
         with_monitoring do
           vet360_id_present!

--- a/lib/vet360/models/email.rb
+++ b/lib/vet360/models/email.rb
@@ -31,7 +31,6 @@ module Vet360
           bio: {
             emailAddressText: @email_address,
             emailId: @id,
-            # emailPermInd: true, # @TODO ??
             originatingSourceSystem: SOURCE_SYSTEM,
             sourceSystemUser: @source_system_user,
             sourceDate: @source_date,

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -11,9 +11,10 @@ module Vet360
     end
 
     def perform(method, path, body = nil, headers = {})
+      increment_total
+
       config.base_request_headers.merge(headers)
       response = super(method, path, body, headers)
-      Vet360::Stats.increment('total_operations')
 
       response
     end
@@ -74,6 +75,10 @@ module Vet360
       else
         log_message_to_sentry('New Vet360 Exceptions Key', :info, key: exception_key)
       end
+    end
+
+    def increment_total
+      Vet360::Stats.increment('total_operations')
     end
   end
 end

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -13,7 +13,7 @@ module Vet360
     def perform(method, path, body = nil, headers = {})
       config.base_request_headers.merge(headers)
       response = super(method, path, body, headers)
-      report(response)
+      Vet360::Stats.increment('total_operations')
 
       response
     end
@@ -26,7 +26,7 @@ module Vet360
 
     def handle_error(error)
       case error
-      when Common::Client::Errors::ParsingError
+      when Common::Client::Errors::ParsingError # Vet360 sent a non-JSON response
         log_message_to_sentry(error.message, :error, extra_context: { url: config.base_path })
         raise_backend_exception('VET360_502', self.class)
       when Common::Client::Errors::ClientError
@@ -55,23 +55,6 @@ module Vet360
         error&.status,
         error&.body
       )
-    end
-
-    def report(response)
-      log_to_sentry(response)
-      Vet360::Stats.increment('total_operations')
-    end
-
-    def log_to_sentry(response)
-      # TODO: Disable when we're ready to enable in production
-      if Rails.env.production?
-        log_message_to_sentry(
-          'Vet360 Request',
-          :info,
-          request: { headers: response.request_headers },
-          response: { status: response.status, body: response.body }
-        )
-      end
     end
 
     def raise_invalid_body(error, source)

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -11,8 +11,7 @@ module Vet360
     end
 
     def perform(method, path, body = nil, headers = {})
-      increment_total
-
+      Vet360::Stats.increment('total_operations')
       config.base_request_headers.merge(headers)
       response = super(method, path, body, headers)
 
@@ -75,10 +74,6 @@ module Vet360
       else
         log_message_to_sentry('New Vet360 Exceptions Key', :info, key: exception_key)
       end
-    end
-
-    def increment_total
-      Vet360::Stats.increment('total_operations')
     end
   end
 end


### PR DESCRIPTION
This PR will be used to prep changes that need to be in place before Vet360 calls are turned on in production. So far, this mostly removes logging calls for success paths. We'll be meeting on 2018-06-25 to review any outstanding items.

This originally was a much larger set of changes, but I decided that we probably shouldn't do any logging on success calls, even restricted subsets of data, since they don't provide us much useful information. Instead we'll just stick with Statsd metrics until we need something specific.