### PR TITLE
Add consumer id to upload submission

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -304,6 +304,7 @@ ActiveRecord::Schema.define(version: 20180709214011) do
     t.datetime "updated_at",                        null: false
     t.boolean  "s3_deleted"
     t.string   "consumer_name"
+    t.uuid     "consumer_id"
   end
 
   add_index "vba_documents_upload_submissions", ["guid"], name: "index_vba_documents_upload_submissions_on_guid", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20180709214011) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"

--- a/modules/vba_documents/db/migrate/20180626141145_add_consumer_id_to_upload_submission.rb
+++ b/modules/vba_documents/db/migrate/20180626141145_add_consumer_id_to_upload_submission.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddConsumerIdToUploadSubmission < ActiveRecord::Migration
+  def change
+    add_column :vba_documents_upload_submissions, :consumer_id, :uuid
+  end
+end


### PR DESCRIPTION
Add the consumer id to upload submission this helps us both better track where benefits intake submissions are coming from, the username could change in kong, but the id shouldn't. And makes it easier for us to log submission success/errors for future metrics.