### PR TITLE
Add service information in post submit

### DIFF
--- a/app/models/emis_redis/military_information.rb
+++ b/app/models/emis_redis/military_information.rb
@@ -128,7 +128,7 @@ module EMISRedis
     # rubocop:enable Metrics/CyclomaticComplexity
 
     def service_periods
-      military_service_episodes.map do |military_service_episode|
+      service_episodes_by_date.map do |military_service_episode|
         # avoid prefilling if service branch is 'other' as this breaks validation
         return {} if military_service_episode.hca_branch_of_service == 'other'
 

--- a/config/form_profile_mappings/21-526EZ.yml
+++ b/config/form_profile_mappings/21-526EZ.yml
@@ -1,3 +1,4 @@
 veteran: [veteran_contact_information, veteran]
 disabilities: [rated_disabilities_information, rated_disabilities]
 servicePeriods: [military_information, service_periods]
+servedInCombatZone: [military_information, post_nov111998_combat]

--- a/spec/lib/evss/disability_compensation_form/data_translation_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_spec.rb
@@ -17,13 +17,14 @@ describe EVSS::DisabilityCompensationForm::DataTranslation do
   describe '#translate' do
     before do
       create(:in_progress_form, form_id: VA526ez::FORM_ID, user_uuid: user.uuid)
-      allow_any_instance_of(EMISRedis::MilitaryInformation).to receive(:service_episodes_by_date).and_return([])
     end
 
     it 'should return correctly formatted json to send to EVSS' do
       VCR.use_cassette('evss/ppiu/payment_information') do
         VCR.use_cassette('evss/intent_to_file/active_compensation') do
-          expect(JSON.parse(subject.translate)).to eq JSON.parse(evss_json)
+          VCR.use_cassette('emis/get_military_service_episodes/valid', allow_playback_repeats: true) do
+            expect(JSON.parse(subject.translate)).to eq JSON.parse(evss_json)
+          end
         end
       end
     end

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -338,6 +338,7 @@ RSpec.describe FormProfile, type: :model do
           ]
         }
       ],
+      'servedInCombatZone' => true,
       'servicePeriods' => [
         {
           'serviceBranch' => 'Air Force Reserve',

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -67,91 +67,79 @@ RSpec.describe 'Disability compensation form', type: :request do
   end
 
   describe 'Get /v0/disability_compensation_form/submit' do
+    before(:each) do
+      VCR.insert_cassette('emis/get_military_service_episodes/valid', allow_playback_repeats: true)
+      VCR.insert_cassette('evss/ppiu/payment_information')
+      VCR.insert_cassette('evss/intent_to_file/active_compensation')
+    end
+
+    after(:each) do
+      VCR.eject_cassette('emis/get_military_service_episodes/valid')
+      VCR.eject_cassette('evss/ppiu/payment_information')
+      VCR.eject_cassette('evss/intent_to_file/active_compensation')
+    end
+
     context 'with a valid 200 evss response' do
       let(:valid_form_content) { File.read 'spec/support/disability_compensation_form/front_end_submission.json' }
       let(:jid) { "JID-#{SecureRandom.base64}" }
 
       before(:each) { allow(EVSS::DisabilityCompensationForm::SubmitUploads).to receive(:start).and_return(jid) }
+
       before do
         create(:in_progress_form, form_id: VA526ez::FORM_ID, user_uuid: user.uuid)
-        allow_any_instance_of(EMISRedis::MilitaryInformation).to receive(:service_episodes_by_date).and_return([])
       end
 
       it 'should match the rated disabilities schema' do
-        VCR.use_cassette('evss/ppiu/payment_information') do
-          VCR.use_cassette('evss/intent_to_file/active_compensation') do
-            VCR.use_cassette('evss/disability_compensation_form/submit_form') do
-              post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
-              expect(response).to have_http_status(:ok)
-              expect(response).to match_response_schema('submit_disability_form')
-            end
-          end
+        VCR.use_cassette('evss/disability_compensation_form/submit_form') do
+          post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('submit_disability_form')
         end
       end
 
       it 'should start the uploads job' do
-        VCR.use_cassette('evss/ppiu/payment_information') do
-          VCR.use_cassette('evss/intent_to_file/active_compensation') do
-            VCR.use_cassette('evss/disability_compensation_form/submit_form') do
-              expect(EVSS::DisabilityCompensationForm::SubmitUploads).to receive(:start).once
-              post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
-            end
-          end
+        VCR.use_cassette('evss/disability_compensation_form/submit_form') do
+          expect(EVSS::DisabilityCompensationForm::SubmitUploads).to receive(:start).once
+          post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
         end
       end
 
       context 'with a 500 response' do
         it 'should return a bad gateway response' do
-          VCR.use_cassette('evss/ppiu/payment_information') do
-            VCR.use_cassette('evss/intent_to_file/active_compensation') do
-              VCR.use_cassette('evss/disability_compensation_form/submit_500') do
-                post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
-                expect(response).to have_http_status(:bad_gateway)
-                expect(response).to match_response_schema('evss_errors', strict: false)
-              end
-            end
+          VCR.use_cassette('evss/disability_compensation_form/submit_500') do
+            post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
+            expect(response).to have_http_status(:bad_gateway)
+            expect(response).to match_response_schema('evss_errors', strict: false)
           end
         end
       end
 
       context 'with a 403 unauthorized response' do
         it 'should return a not authorized response' do
-          VCR.use_cassette('evss/ppiu/payment_information') do
-            VCR.use_cassette('evss/intent_to_file/active_compensation') do
-              VCR.use_cassette('evss/disability_compensation_form/submit_403') do
-                post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
-                expect(response).to have_http_status(:forbidden)
-                expect(response).to match_response_schema('evss_errors', strict: false)
-              end
-            end
+          VCR.use_cassette('evss/disability_compensation_form/submit_403') do
+            post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
+            expect(response).to have_http_status(:forbidden)
+            expect(response).to match_response_schema('evss_errors', strict: false)
           end
         end
       end
 
       context 'with a generic 400 response' do
         it 'should return a bad request response' do
-          VCR.use_cassette('evss/ppiu/payment_information') do
-            VCR.use_cassette('evss/intent_to_file/active_compensation') do
-              VCR.use_cassette('evss/disability_compensation_form/submit_400') do
-                post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
-                expect(response).to have_http_status(:bad_request)
-                expect(response).to match_response_schema('evss_errors', strict: false)
-              end
-            end
+          VCR.use_cassette('evss/disability_compensation_form/submit_400') do
+            post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
+            expect(response).to have_http_status(:bad_request)
+            expect(response).to match_response_schema('evss_errors', strict: false)
           end
         end
       end
 
       context 'with a 401 response' do
         it 'should return a bad gateway response' do
-          VCR.use_cassette('evss/ppiu/payment_information') do
-            VCR.use_cassette('evss/intent_to_file/active_compensation') do
-              VCR.use_cassette('evss/disability_compensation_form/submit_401') do
-                post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
-                expect(response).to have_http_status(:bad_gateway)
-                expect(response).to match_response_schema('evss_errors', strict: false)
-              end
-            end
+          VCR.use_cassette('evss/disability_compensation_form/submit_401') do
+            post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
+            expect(response).to have_http_status(:bad_gateway)
+            expect(response).to match_response_schema('evss_errors', strict: false)
           end
         end
       end

--- a/spec/support/disability_compensation_form/evss_submission.json
+++ b/spec/support/disability_compensation_form/evss_submission.json
@@ -52,41 +52,12 @@
     "serviceInformation": {
       "servicePeriods": [
         {
-          "serviceBranch": "National Oceanic &amp; Atmospheric Administration",
-          "activeDutyBeginDate": "2018-03-29T18:50:03.015Z",
-          "activeDutyEndDate": "2018-03-29T18:50:03.015Z"
+          "serviceBranch": "Air Force Reserve",
+          "activeDutyBeginDate": "2007-04-01T00:00:00Z",
+          "activeDutyEndDate": "2016-06-01T00:00:00Z"
         }
       ],
-      "reservesNationalGuardService": {
-        "title10Activation": {
-          "title10ActivationDate": "2018-03-29T18:50:03.015Z",
-          "anticipatedSeparationDate": "2018-03-29T18:50:03.015Z"
-        },
-        "obligationTermOfServiceFromDate": "2018-03-29T18:50:03.015Z",
-        "obligationTermOfServiceToDate": "2018-03-29T18:50:03.015Z",
-        "unitName": "string",
-        "unitPhone": {
-          "areaCode": "202",
-          "phoneNumber": "4561111"
-        }
-      },
-      "servedInCombatZone": true,
-      "separationLocationName": "OTHER",
-      "separationLocationCode": "SOME VALUE",
-      "alternateNames": [
-        {
-          "firstName": "string",
-          "middleName": "string",
-          "lastName": "string"
-        }
-      ],
-      "confinements": [
-        {
-          "confinementBeginDate": "2018-03-29T18:50:03.015Z",
-          "confinementEndDate": "2018-03-29T18:50:03.015Z",
-          "verifiedIndicator": false
-        }
-      ]
+      "servedInCombatZone": false
     },
     "disabilities": [
       {

--- a/spec/support/disability_compensation_form/front_end_submission.json
+++ b/spec/support/disability_compensation_form/front_end_submission.json
@@ -34,48 +34,6 @@
       "payments": [],
       "receiveCompensationInLieuOfRetired": false
     },
-    "serviceInformation": {
-      "servicePeriods": [
-        {
-          "serviceBranch": "NOAA",
-          "dateRange": {
-            "from": "2018-03-29T18:50:03.015Z",
-            "to": "2018-03-29T18:50:03.015Z"
-          }
-        }
-      ],
-      "reservesNationalGuardService": {
-        "title10Activation": {
-          "title10ActivationDate": "2018-03-29T18:50:03.015Z",
-          "anticipatedSeparationDate": "2018-03-29T18:50:03.015Z"
-        },
-        "obligationTermOfServiceDateRange": {
-          "from": "2018-03-29T18:50:03.015Z",
-          "to": "2018-03-29T18:50:03.015Z"
-        },
-        "unitName": "string",
-        "unitPhone": "2024561111"
-      },
-      "servedInCombatZone": true,
-      "separationLocationName": "OTHER",
-      "separationLocationCode": "SOME VALUE",
-      "alternateNames": [
-        {
-          "first": "string",
-          "middle": "string",
-          "last": "string"
-        }
-      ],
-      "confinements": [
-        {
-          "confinementDateRange": {
-            "from": "2018-03-29T18:50:03.015Z",
-            "to": "2018-03-29T18:50:03.015Z"
-          },
-          "verifiedIndicator": false
-        }
-      ]
-    },
     "disabilities": [
       {
         "name": "Diabetes mellitus",


### PR DESCRIPTION
The `serviceInformation` block in form 526 is being made non-editable by the user. This requires that the back end fill in these details in the post submit stage before sending the request to EVSS submission endpoint. Also, EVSS has made the `treatments` section of the form `optional` which means this has to be accounted for in the data translation as well.

*Note 1*: `servedInCombatZone` has been added into the prefill section along side `servicePeriods`. This is not an ideal solution. A future change will include moving these data points to be callable via an endpoint on vets-api and removing them from prefill entirely.

*Note 2*: Many fields have been removed from the submission (`confinements`, `alternateNames`, and everything within `reservesNationalGuardService`). This is because they are not _required_ by evss for submission but mainly because there is no correlating EMIS data for any of this information (besides some reserves data... but its missing fields like `unitName`, `unitPhone` and `title10Activation`). For 526 increase this shouldn't be a big deal, however, this data needs to be available when work on the actual 526 compensation is being done.