### PR TITLE
Disable Vet360 caching in staging

### DIFF
--- a/app/models/vet360_redis/contact_information.rb
+++ b/app/models/vet360_redis/contact_information.rb
@@ -155,6 +155,8 @@ module Vet360Redis
     end
 
     def response_from_redis_or_service
+      return contact_info_service.get_person unless Settings.vet360.contact_information.cache_enabled
+
       do_cached_with(key: @user.uuid) do
         contact_info_service.get_person
       end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,6 +49,7 @@ pension_burial:
 vet360:
   url: "https://int.vet360.va.gov"
   contact_information:
+    cache_enabled: false
     enabled: true
     timeout: 30
     mock: false

--- a/spec/models/vet360_redis/contact_information_spec.rb
+++ b/spec/models/vet360_redis/contact_information_spec.rb
@@ -40,7 +40,7 @@ describe Vet360Redis::ContactInformation do
           Vet360::ContactInformation::Service
         ).to receive(:get_person).and_return(person_response)
 
-        expect(contact_info.redis_namespace).to receive(:set).once
+        expect(contact_info.redis_namespace).to receive(:set).once if Settings.vet360.contact_information.cache_enabled
         expect_any_instance_of(Vet360::ContactInformation::Service).to receive(:get_person).once
         expect(contact_info.status).to eq 200
         expect(contact_info.response.person).to have_deep_attributes(person)


### PR DESCRIPTION
This PR allows us to toggle whether Vet360 caches a response or not. This will allow us to debug an issue we're seeing, but not disable caching in every environment.