### PR TITLE
Generic error message for GIDS record not found

### DIFF
--- a/app/swagger/schemas/gibct/institutions.rb
+++ b/app/swagger/schemas/gibct/institutions.rb
@@ -135,17 +135,6 @@ module Swagger
                 property :transcript_by_ope_id_do_not_sum, type: :integer
                 property :other_by_ope_id_do_not_sum, type: :integer
               end
-              property :yellow_ribbon_programs, type: :array do
-                items do
-                  key :type, :object
-                  key :required, %i[degree_level division_professional_school number_of_students contribution_amount]
-
-                  property :degree_level, type: :string, description: 'Program applies to this degree level', example: 'All (Nursing School)'
-                  property :division_professional_school, type: :string, description: 'Program applies to this division of or school within institution', example: 'College of Medicine'
-                  property :number_of_students, type: :integer, description: 'Number of students who can receive Yellow Ribbon for the given degree level/program combination', example: 2000
-                  property :contribution_amount, type: :number, format: :currency, description: 'Yellow Ribbon amount from school per year', example: 5000.00
-                end
-              end
             end
           end
 

--- a/app/swagger/schemas/gibct/institutions.rb
+++ b/app/swagger/schemas/gibct/institutions.rb
@@ -135,6 +135,17 @@ module Swagger
                 property :transcript_by_ope_id_do_not_sum, type: :integer
                 property :other_by_ope_id_do_not_sum, type: :integer
               end
+              property :yellow_ribbon_programs, type: :array do
+                items do
+                  key :type, :object
+                  key :required, %i[degree_level division_professional_school number_of_students contribution_amount]
+
+                  property :degree_level, type: :string, description: 'Program applies to this degree level', example: 'All (Nursing School)'
+                  property :division_professional_school, type: :string, description: 'Program applies to this division of or school within institution', example: 'College of Medicine'
+                  property :number_of_students, type: :integer, description: 'Number of students who can receive Yellow Ribbon for the given degree level/program combination', example: 2000
+                  property :contribution_amount, type: :number, format: :currency, description: 'Yellow Ribbon amount from school per year', example: 5000.00
+                end
+              end
             end
           end
 

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -286,9 +286,9 @@ en:
         status: 404
       GI404:
         <<: *external_defaults
-        title: 'Institution not found'
+        title: 'Record not found'
         code: 'GI404'
-        detail: 'Institution with the specified code was not found'
+        detail: 'Record with the specified code was not found'
         status: 404
       EVSS400:
         <<: *external_defaults

--- a/spec/lib/common/client/middleware/response/gids_response_middleware_spec.rb
+++ b/spec/lib/common/client/middleware/response/gids_response_middleware_spec.rb
@@ -31,8 +31,8 @@ describe 'GIDS Response Middleware' do
     expect { gi_client.get('not-found') }
       .to raise_error do |error|
         expect(error).to be_a(Common::Exceptions::BackendServiceException)
-        expect(error.errors.first[:title]).to eq('Institution not found')
-        expect(error.errors.first[:detail]).to eq('Institution with the specified code was not found')
+        expect(error.errors.first[:title]).to eq('Record not found')
+        expect(error.errors.first[:detail]).to eq('Record with the specified code was not found')
         expect(error.errors.first[:code]).to eq('GI404')
       end
   end

--- a/spec/request/gi/zipcode_rates_request_spec.rb
+++ b/spec/request/gi/zipcode_rates_request_spec.rb
@@ -14,4 +14,17 @@ RSpec.describe 'zipcode_rates', type: :request do
     expect(response.body).to be_a(String)
     expect(response).to match_response_schema('gi/zipcode_rate')
   end
+
+  it 'responds with appropriate not found' do
+    VCR.use_cassette('gi_client/gets_zip_code_rate_error') do
+      get '/v0/gi/zipcode_rates/splunge'
+    end
+
+    expect(response).to have_http_status(:not_found)
+
+    json = JSON.parse(response.body)
+    expect(json['errors'].length).to eq(1)
+    expect(json['errors'][0]['title']).to eq('Record not found')
+    expect(json['errors'][0]['detail']).to eq('Record with the specified code was not found')
+  end
 end

--- a/spec/support/vcr_cassettes/gi_client/gets_zip_code_rate_error.yml
+++ b/spec/support/vcr_cassettes/gi_client/gets_zip_code_rate_error.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<GIDS_URL>/v0/zipcode_rates/splunge"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 31 Jul 2017 18:12:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 3c33860f-6adf-40e0-a45f-fc3c992c5e1e
+      X-Runtime:
+      - '0.011183'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Set-Cookie:
+      - TS0108eb76=01c8917e48f2f47fab2de82aca0d643611e90ec39aa0105811532845b482a9d216ad4c5786c70374e88062df5091040af0461c2934;
+        Max-Age=900; Path=/
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":[{"title":"Record not found","detail":"The record identified
+        by splunge could not be found","code":"404","status":"404"}]}'
+    http_version: 
+  recorded_at: Mon, 31 Jul 2017 18:12:17 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Previous error message included mention of an Institution, but we're
supporting both Institutions and Zip Code Rates now, so making a change
to the language of the message to make it more generic.