### PR TITLE
Fix bug in CacheAside that made it impossible to invalidate cache

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -44,9 +44,6 @@ development: &defaults
   intent_to_file_response:
     namespace: intent-to-file-response
     each_ttl: 86400
-  planet_express:
-    namespace: planet-express
-    each_ttl: 86400
 
 test:
   <<: *defaults

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -44,6 +44,9 @@ development: &defaults
   intent_to_file_response:
     namespace: intent-to-file-response
     each_ttl: 86400
+  planet_express:
+    namespace: planet-express
+    each_ttl: 86400
 
 test:
   <<: *defaults

--- a/lib/common/models/concerns/cache_aside.rb
+++ b/lib/common/models/concerns/cache_aside.rb
@@ -28,7 +28,11 @@ module Common
 
     def do_cached_with(key:)
       cached = self.class.find(key)
-      return cached.response if cached
+      if cached
+        set_attributes(key, cached.response)
+        return cached.response
+      end
+
       response = yield
       raise NoMethodError, 'The response class being cached must implement #cache?' unless response.respond_to?(:cache?)
       cache(key, response) if response.cache?
@@ -36,8 +40,14 @@ module Common
     end
 
     def cache(key, response)
-      self.attributes = { uuid: key, response: response }
+      set_attributes(key, response)
       save
+    end
+
+    private
+
+    def set_attributes(key, response)
+      self.attributes = { uuid: key, response: response }
     end
   end
 end

--- a/spec/lib/common/models/concerns/cache_aside_spec.rb
+++ b/spec/lib/common/models/concerns/cache_aside_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'common/models/concerns/cache_aside'
+
+describe Common::CacheAside do
+  let(:user) { build :user, :loa3 }
+  let(:person) { build :person }
+
+  before do
+    allow(Vet360::Models::Person).to receive(:build_from).and_return(person)
+  end
+
+  describe '#do_cached_with' do
+    let(:person_response) do
+      Vet360::ContactInformation::PersonResponse.from(
+        OpenStruct.new(status: 200, body: { 'bio' => person.to_hash })
+      )
+    end
+
+    it 'sets the attributes needed to perform redis actions', :aggregate_failures do
+      instance1 = Vet360Redis::ContactInformation.for_user(user)
+      instance1.do_cached_with(key: 'test') { person_response }
+      expect(instance1.attributes[:uuid]).not_to be(nil)
+      expect(instance1.attributes[:response]).not_to be(nil)
+
+      instance2 = Vet360Redis::ContactInformation.for_user(user)
+      instance2.do_cached_with(key: 'test') { person_response }
+      expect(instance2.attributes[:uuid]).not_to be(nil)
+      expect(instance2.attributes[:response]).not_to be(nil)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes an issue with the `CacheAside` concern.

The issue was that the attributes that are set when caching a value, `uuid` and `response`, are not also set when retrieving a cached value. This makes it impossible to perform any actions on the cached value, including invalidating it. This has not been an issue until now because we've not needed to invalidate caches for read-only services.