### PR TITLE
Fixed typo in sidekiq scheduler

### DIFF
--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -105,7 +105,7 @@ HCA::SubmissionFailureEmailAnalyticsJob:
   description: "posts HCA Submission Failure email sends and failures to Google Analytics"
 
 DeleteOldTransactionsJob:
-  cron: "0 3 * * * * America/New_York" # Daily @ 3am Eastern
+  cron: "0 3 * * * America/New_York" # Daily @ 3am Eastern
   description: "Deletes old, completed AsyncTransaction records"
 
 MHV::AccountStatisticsJob:

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -105,7 +105,7 @@ HCA::SubmissionFailureEmailAnalyticsJob:
   description: "posts HCA Submission Failure email sends and failures to Google Analytics"
 
 DeleteOldTransactionsJob:
-  cron: "0 3 * * * America/New_york" # Daily @ 3am Eastern
+  cron: "0 3 * * * * America/New_York" # Daily @ 3am Eastern
   description: "Deletes old, completed AsyncTransaction records"
 
 MHV::AccountStatisticsJob:


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11305

Fixed a typo in the timezone that was causing the scheduler to choke.