### PR TITLE
StatsD reporting on Vet360 exception error keys

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -64,7 +64,7 @@ StatsD.increment("#{MVI::Service::STATSD_KEY_PREFIX}.find_profile.fail", 0)
 
 # init Vet360
 Vet360::Exceptions::Parser.instance.known_keys.each do |key|
-  StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.exceptions.#{key}", 0)
+  StatsD.increment(Vet360::Service::STATSD_KEY_PREFIX, 0, tags: ["exceptions:#{key}"])
 end
 StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.total_operations", 0)
 StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.posts_and_puts.success", 0)

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -64,7 +64,7 @@ StatsD.increment("#{MVI::Service::STATSD_KEY_PREFIX}.find_profile.fail", 0)
 
 # init Vet360
 Vet360::Exceptions::Parser.instance.known_keys.each do |key|
-  StatsD.increment(Vet360::Service::STATSD_KEY_PREFIX, 0, tags: ["exceptions:#{key}"])
+  StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.exceptions", 0, tags: ["exception:#{key}"])
 end
 StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.total_operations", 0)
 StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.posts_and_puts.success", 0)

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -58,7 +58,7 @@ module Vet360
     end
 
     def raise_invalid_body(error, source)
-      Vet360::Stats.increment('exceptions', 'VET360_502')
+      Vet360::Stats.increment_exception('VET360_502')
 
       raise Common::Exceptions::BackendServiceException.new(
         'VET360_502',
@@ -70,7 +70,7 @@ module Vet360
 
     def report_stats_on(exception_key)
       if Vet360::Exceptions::Parser.instance.known?(exception_key)
-        Vet360::Stats.increment('exceptions', exception_key)
+        Vet360::Stats.increment_exception(exception_key)
       else
         log_message_to_sentry('New Vet360 Exceptions Key', :info, key: exception_key)
       end

--- a/lib/vet360/stats.rb
+++ b/lib/vet360/stats.rb
@@ -35,6 +35,10 @@ module Vet360
         increment(bucket1, bucket_for(status))
       end
 
+      def increment_exception(key)
+        StatsD.increment(Vet360::Service::STATSD_KEY_PREFIX, tags: ["exceptions:#{key.downcase}"])
+      end
+
       private
 
       def status_in(response)

--- a/lib/vet360/stats.rb
+++ b/lib/vet360/stats.rb
@@ -35,6 +35,11 @@ module Vet360
         increment(bucket1, bucket_for(status))
       end
 
+      # Increments the associated StatsD bucket with the passed in exception error key.
+      #
+      # @param key [String] A Vet360 exception key from the locales/exceptions file
+      #   For example, 'VET360_ADDR133'.
+      #
       def increment_exception(key)
         StatsD.increment(Vet360::Service::STATSD_KEY_PREFIX, tags: ["exceptions:#{key.downcase}"])
       end

--- a/lib/vet360/stats.rb
+++ b/lib/vet360/stats.rb
@@ -41,7 +41,7 @@ module Vet360
       #   For example, 'VET360_ADDR133'.
       #
       def increment_exception(key)
-        StatsD.increment(Vet360::Service::STATSD_KEY_PREFIX, tags: ["exceptions:#{key.downcase}"])
+        StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.exceptions", tags: ["exception:#{key.downcase}"])
       end
 
       private

--- a/spec/lib/vet360/service_spec.rb
+++ b/spec/lib/vet360/service_spec.rb
@@ -53,7 +53,7 @@ describe Vet360::Service do
       it 'increments the StatsD error counter', :aggregate_failures do
         error_key = 'VET360_ADDR133'
 
-        expect(Vet360::Stats).to receive(:increment).with('exceptions', error_key)
+        expect(Vet360::Stats).to receive(:increment_exception).with(error_key)
         expect { subject.send('raise_backend_exception', error_key, 'test') }.to raise_error(
           Common::Exceptions::BackendServiceException
         )
@@ -66,7 +66,7 @@ describe Vet360::Service do
       it 'increments the StatsD error counter', :aggregate_failures do
         error_key = 'VET360_502'
 
-        expect(Vet360::Stats).to receive(:increment).with('exceptions', error_key)
+        expect(Vet360::Stats).to receive(:increment_exception).with(error_key)
         expect { subject.send('raise_invalid_body', nil, 'test') }.to raise_error(
           Common::Exceptions::BackendServiceException
         )

--- a/spec/lib/vet360/stats_spec.rb
+++ b/spec/lib/vet360/stats_spec.rb
@@ -95,6 +95,16 @@ describe Vet360::Stats do
       end
     end
   end
+
+  describe '.increment_exception' do
+    it 'increments the StatsD Vet360 counter' do
+      tag = 'VET360_ADDR133'
+
+      expect { described_class.increment_exception(tag) }.to trigger_statsd_increment(
+        "#{statsd_prefix}"
+      )
+    end
+  end
 end
 
 def raw_vet360_transaction_response(tx_status)

--- a/spec/lib/vet360/stats_spec.rb
+++ b/spec/lib/vet360/stats_spec.rb
@@ -97,11 +97,11 @@ describe Vet360::Stats do
   end
 
   describe '.increment_exception' do
-    it 'increments the StatsD Vet360 counter' do
+    it 'increments the StatsD Vet360 exceptions counter' do
       tag = 'VET360_ADDR133'
 
       expect { described_class.increment_exception(tag) }.to trigger_statsd_increment(
-        statsd_prefix
+        "#{statsd_prefix}.exceptions"
       )
     end
   end

--- a/spec/lib/vet360/stats_spec.rb
+++ b/spec/lib/vet360/stats_spec.rb
@@ -101,7 +101,7 @@ describe Vet360::Stats do
       tag = 'VET360_ADDR133'
 
       expect { described_class.increment_exception(tag) }.to trigger_statsd_increment(
-        "#{statsd_prefix}"
+        statsd_prefix
       )
     end
   end


### PR DESCRIPTION
## Background

The work that was completed in https://github.com/department-of-veterans-affairs/vets-api/pull/2041 associated with exception keys needs to be refactored to use StatsD tags options.  Creating individual buckets for each exception key does not scale well for the reporting we'll need in Grafana.

## Definition of Done

- [x] Initialize StatsD reporting using tags instead of individual buckets
- [x] When exceptions occur, trigger the reporting based on tags, not buckets
- [x] Refactor associated specs