### PR TITLE
Create service information endpoint

### DIFF
--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -140,6 +140,7 @@ module V0
       Swagger::Requests::Prescriptions::Prescriptions,
       Swagger::Requests::Prescriptions::Trackings,
       Swagger::Requests::Profile,
+      Swagger::Requests::ServiceInformation,
       Swagger::Requests::Sessions,
       Swagger::Requests::TermsAndConditions,
       Swagger::Requests::UploadSupportingEvidence,

--- a/app/controllers/v0/service_informations_controller.rb
+++ b/app/controllers/v0/service_informations_controller.rb
@@ -2,10 +2,7 @@
 
 module V0
   class ServiceInformationsController < ApplicationController
-    before_action do
-      authorize :emis, :access?
-      authorize :evss, :access?
-    end
+    before_action { authorize :evss, :access? }
 
     def show
       response = {

--- a/app/controllers/v0/service_informations_controller.rb
+++ b/app/controllers/v0/service_informations_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V0
+  class ServiceInformationsController < ApplicationController
+    before_action do
+      authorize :emis, :access?
+      authorize :evss, :access?
+    end
+
+    def show
+      response = {
+        service_periods: @current_user.military_information.service_periods,
+        served_in_combat_zone: @current_user.military_information.post_nov111998_combat
+      }
+      render json: response, serializer: ServiceInformationSerializer
+    end
+  end
+end

--- a/app/serializers/service_information_serializer.rb
+++ b/app/serializers/service_information_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ServiceInformationSerializer < ActiveModel::Serializer
+  attribute :service_periods
+  attribute :served_in_combat_zone
+
+  def id
+    nil
+  end
+
+  def service_periods
+    object[:service_periods]
+  end
+
+  def served_in_combat_zone
+    object[:served_in_combat_zone]
+  end
+end

--- a/app/swagger/requests/service_information.rb
+++ b/app/swagger/requests/service_information.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Requests
+    class ServiceInformation
+      include Swagger::Blocks
+
+      swagger_path '/v0/service_information' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Get a list of all service periods and whether
+                             they have served in a combat zone for the user'
+          key :operationId, 'getServiceInformation'
+          key :tags, %w[form_526]
+
+          parameter :authorization
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :ServiceInfo
+            end
+          end
+        end
+      end
+
+      swagger_schema :ServiceInfo do
+        key :required, %i[data]
+        property :data, type: :object do
+          key :required, %i[attributes]
+          property :id, type: :string
+          property :type, type: :string
+          property :attributes, type: :object do
+            key :required, %i[service_periods served_in_combat_zone]
+            property :served_in_combat_zone, type: :boolean, example: true
+            property :service_periods, type: :array do
+              items do
+                key :required, %i[service_branch date_range]
+                property :service_branch, type: :string, example: 'Air Force Reserve'
+                property :date_range, type: :object do
+                  key :required, %i[from to]
+                  property :from, type: :string, example: '2007-04-01'
+                  property :to, type: :string, example: '2016-06-01'
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/form_profile_mappings/21-526EZ.yml
+++ b/config/form_profile_mappings/21-526EZ.yml
@@ -1,4 +1,2 @@
 veteran: [veteran_contact_information, veteran]
 disabilities: [rated_disabilities_information, rated_disabilities]
-servicePeriods: [military_information, service_periods]
-servedInCombatZone: [military_information, post_nov111998_combat]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,8 @@ Rails.application.routes.draw do
       resources :documents, only: [:create]
     end
 
+    resource :service_information, only: [:show]
+
     get 'intent_to_file', to: 'intent_to_files#index'
     get 'intent_to_file/:type/active', to: 'intent_to_files#active'
     post 'intent_to_file/:type', to: 'intent_to_files#submit'

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -338,16 +338,6 @@ RSpec.describe FormProfile, type: :model do
           ]
         }
       ],
-      'servedInCombatZone' => true,
-      'servicePeriods' => [
-        {
-          'serviceBranch' => 'Air Force Reserve',
-          'dateRange' => {
-            'from' => '2007-04-01',
-            'to' => '2016-06-01'
-          }
-        }
-      ],
       'veteran' => {
         'mailingAddress' => {
           'country' => 'USA',

--- a/spec/request/service_informations_request_spec.rb
+++ b/spec/request/service_informations_request_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'service_information', type: :request, skip_emis: true do
+  include SchemaMatchers
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  describe 'GET /v0/service_information' do
+    context 'with a 200 response' do
+      context 'with one military service episode' do
+        it 'should match the service information schema' do
+          VCR.use_cassette('emis/get_deployment/valid') do
+            VCR.use_cassette('emis/get_military_service_episodes/valid') do
+              get '/v0/service_information', nil, auth_header
+
+              expect(response).to have_http_status(:ok)
+              expect(response).to match_response_schema('service_information_response')
+            end
+          end
+        end
+      end
+
+      context 'with multiple military service episodes' do
+        it 'should match the service information schema' do
+          VCR.use_cassette('emis/get_deployment/valid') do
+            VCR.use_cassette('emis/get_military_service_episodes/valid_multiple_episodes') do
+              get '/v0/service_information', nil, auth_header
+
+              expect(response).to have_http_status(:ok)
+              expect(response).to match_response_schema('service_information_response')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -354,6 +354,17 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
       end
     end
 
+    describe 'service information' do
+      it 'supports getting service information' do
+        expect(subject).to validate(:get, '/v0/service_information', 401)
+        VCR.use_cassette('emis/get_deployment/valid') do
+          VCR.use_cassette('emis/get_military_service_episodes/valid') do
+            expect(subject).to validate(:get, '/v0/service_information', 200, auth_options)
+          end
+        end
+      end
+    end
+
     describe 'intent to file' do
       it 'supports getting all intent to file' do
         expect(subject).to validate(:get, '/v0/intent_to_file', 401)

--- a/spec/support/schemas/service_information_response.json
+++ b/spec/support/schemas/service_information_response.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "service_periods": {
+              "description": "Array of service periods hashes",
+              "items": {
+                "type": "hash"
+              },
+              "properties": {
+                "service_branch": {
+                  "type": "string"
+                },
+                "date_range": {
+                  "type": "hash",
+                  "properties": {
+                    "from": {
+                      "type": "string"
+                    },
+                    "to": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "type": "array"
+            },
+            "served_in_combat_zone": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Form526 required an endpoint that serves the users service information (periods of service and whether they have served in a post911 combat zone). 

This includes:
* A service information controller + route
* A service information serializer
* Swagger documentation
* Tests

_Note_: There is a current endpoint defined under `profile` that contains a veterans service history. The reason it was not used is because it uses the `SERVICE_BRANCHS` list of service branches where as this endpoint uses the `HCA_SERVICE_BRANCHES`. On top of that, the profiles endpoint does not include the `served_in_combat_zone` field. @rlbaker has been included in this PR to see if there may be a possibility to have vet360 adopt this and make this endpoint redundant. 

Relevant profile controller: https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/controllers/v0/profile/service_histories_controller.rb