### PR TITLE
Aligns military type with Vet360’s return type

### DIFF
--- a/lib/vet360/models/address.rb
+++ b/lib/vet360/models/address.rb
@@ -13,7 +13,7 @@ module Vet360
       ADDRESS_POUS   = [RESIDENCE, CORRESPONDENCE].freeze
       DOMESTIC       = 'DOMESTIC'
       INTERNATIONAL  = 'INTERNATIONAL'
-      MILITARY       = 'MILITARY OVERSEAS'
+      MILITARY       = 'OVERSEAS MILITARY'
       ADDRESS_TYPES  = [DOMESTIC, INTERNATIONAL, MILITARY].freeze
 
       attribute :address_line1, String


### PR DESCRIPTION
## Background

@bshyong discovered that the API is returning address type: address_type: "OVERSEAS MILITARY" , while the Swagger docs say to create military addresses with type "address_type": "MILITARY OVERSEAS"

## Definition of Done

- [x] Correct military address type