### PR TITLE
remove cve ignore that is no longer needed

### DIFF
--- a/rakelib/security.rake
+++ b/rakelib/security.rake
@@ -14,7 +14,7 @@ task :security do
 
   puts 'running bundle-audit to check for insecure dependencies...'
   exit!(1) unless ShellCommand.run('bundle-audit update')
-  audit_result = ShellCommand.run('bundle-audit check --ignore CVE-2016-10545')
+  audit_result = ShellCommand.run('bundle-audit check')
 
   puts "\n"
   if brakeman_result && audit_result


### PR DESCRIPTION
We added an exception in the security check for this CVE when it was added to ruby advisory db yesterday. The CVE has since been rejected, and vulnerability removed. This cleans up by removing the unnecessary ignore rule.

https://github.com/department-of-veterans-affairs/vets-api/pull/2099

https://github.com/erikhuda/thor/issues/514