### PR TITLE
11369 emis error tracking

### DIFF
--- a/app/controllers/v0/profile/service_histories_controller.rb
+++ b/app/controllers/v0/profile/service_histories_controller.rb
@@ -31,6 +31,7 @@ module V0
         response = EMISRedis::MilitaryInformation.for_user(@current_user).service_history
 
         handle_errors!(response)
+        report_results(response)
 
         render json: response, serializer: ServiceHistorySerializer
       end
@@ -48,6 +49,14 @@ module V0
           'EMIS_HIST502',
           source: self.class.to_s
         )
+      end
+
+      def report_results(response)
+        if response.present?
+          StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history.present")
+        else
+          StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history.empty")
+        end
       end
     end
   end

--- a/app/controllers/v0/profile/service_histories_controller.rb
+++ b/app/controllers/v0/profile/service_histories_controller.rb
@@ -53,9 +53,9 @@ module V0
 
       def report_results(response)
         if response.present?
-          StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history.present")
+          StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.has_service_history", tags: ['true'])
         else
-          StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history.empty")
+          StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.has_service_history", tags: ['false'])
         end
       end
     end

--- a/app/controllers/v0/profile/service_histories_controller.rb
+++ b/app/controllers/v0/profile/service_histories_controller.rb
@@ -53,9 +53,9 @@ module V0
 
       def report_results(response)
         if response.present?
-          StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.has_service_history", tags: ['true'])
+          StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history", tags: ['present:true'])
         else
-          StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.has_service_history", tags: ['false'])
+          StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history", tags: ['present:false'])
         end
       end
     end

--- a/app/policies/emis_policy.rb
+++ b/app/policies/emis_policy.rb
@@ -2,6 +2,12 @@
 
 EMISPolicy = Struct.new(:user, :emis) do
   def access?
-    user.edipi.present?
+    if user.edipi.present?
+      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi.success")
+      true
+    else
+      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi.failure")
+      false
+    end
   end
 end

--- a/app/policies/emis_policy.rb
+++ b/app/policies/emis_policy.rb
@@ -3,10 +3,10 @@
 EMISPolicy = Struct.new(:user, :emis) do
   def access?
     if user.edipi.present?
-      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi.success")
+      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", tags: ['success'])
       true
     else
-      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi.failure")
+      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", tags: ['failure'])
       false
     end
   end

--- a/app/policies/emis_policy.rb
+++ b/app/policies/emis_policy.rb
@@ -3,10 +3,10 @@
 EMISPolicy = Struct.new(:user, :emis) do
   def access?
     if user.edipi.present?
-      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", tags: ['success'])
+      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", tags: ['present:true'])
       true
     else
-      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", tags: ['failure'])
+      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", tags: ['present:false'])
       false
     end
   end

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -71,3 +71,9 @@ StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.posts_and_puts.success",
 StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.posts_and_puts.failure", 0)
 StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.init_vet360_id.success", 0)
 StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.init_vet360_id.failure", 0)
+
+# init eMIS
+StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi.success", 0)
+StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi.failure", 0)
+StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history.present", 0)
+StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history.empty", 0)

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -73,5 +73,5 @@ StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.init_vet360_id.success",
 StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.init_vet360_id.failure", 0)
 
 # init eMIS
-StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", 0, tags: %w[success failure])
-StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.has_service_history", 0, tags: %w[true false])
+StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", 0, tags: ['present:true', 'present:false'])
+StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history", 0, tags: ['present:true', 'present:false'])

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -73,7 +73,5 @@ StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.init_vet360_id.success",
 StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.init_vet360_id.failure", 0)
 
 # init eMIS
-StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi.success", 0)
-StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi.failure", 0)
-StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history.present", 0)
-StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history.empty", 0)
+StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", 0, tags: ['success', 'failure'])
+StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.has_service_history", 0, tags: ['true', 'false'])

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -73,5 +73,5 @@ StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.init_vet360_id.success",
 StatsD.increment("#{Vet360::Service::STATSD_KEY_PREFIX}.init_vet360_id.failure", 0)
 
 # init eMIS
-StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", 0, tags: ['success', 'failure'])
-StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.has_service_history", 0, tags: ['true', 'false'])
+StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", 0, tags: %w[success failure])
+StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.has_service_history", 0, tags: %w[true false])

--- a/lib/emis/service.rb
+++ b/lib/emis/service.rb
@@ -9,6 +9,8 @@ require 'common/client/middleware/response/soap_parser'
 
 module EMIS
   class Service < Common::Client::Base
+    STATSD_KEY_PREFIX = 'api.emis'
+
     def self.create_endpoints(endpoints)
       endpoints.each do |endpoint|
         operation = nil

--- a/spec/policies/emis_policy_spec.rb
+++ b/spec/policies/emis_policy_spec.rb
@@ -14,7 +14,7 @@ describe EMISPolicy do
       end
 
       it 'increments the StatsD success counter' do
-        expect { EMISPolicy.new(user, :emis).access? }.to trigger_statsd_increment('api.emis.edipi.success')
+        expect { EMISPolicy.new(user, :emis).access? }.to trigger_statsd_increment('api.emis.edipi')
       end
     end
 
@@ -26,7 +26,7 @@ describe EMISPolicy do
       end
 
       it 'increments the StatsD failure counter' do
-        expect { EMISPolicy.new(user, :emis).access? }.to trigger_statsd_increment('api.emis.edipi.failure')
+        expect { EMISPolicy.new(user, :emis).access? }.to trigger_statsd_increment('api.emis.edipi')
       end
     end
   end

--- a/spec/policies/emis_policy_spec.rb
+++ b/spec/policies/emis_policy_spec.rb
@@ -12,6 +12,10 @@ describe EMISPolicy do
       it 'grants access' do
         expect(subject).to permit(user, :emis)
       end
+
+      it 'increments the StatsD success counter' do
+        expect { EMISPolicy.new(user, :emis).access? }.to trigger_statsd_increment('api.emis.edipi.success')
+      end
     end
 
     context 'with a user who does not have the required emis attributes' do
@@ -19,6 +23,10 @@ describe EMISPolicy do
 
       it 'denies access' do
         expect(subject).to_not permit(user, :emis)
+      end
+
+      it 'increments the StatsD failure counter' do
+        expect { EMISPolicy.new(user, :emis).access? }.to trigger_statsd_increment('api.emis.edipi.failure')
       end
     end
   end

--- a/spec/request/service_history_request_spec.rb
+++ b/spec/request/service_history_request_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'service_history', type: :request, skip_emis: true do
           VCR.use_cassette('emis/get_military_service_episodes/valid') do
             expect do
               get '/v0/profile/service_history', nil, auth_header
-            end.to trigger_statsd_increment('api.emis.service_history.present')
+            end.to trigger_statsd_increment('api.emis.has_service_history')
           end
         end
       end
@@ -76,7 +76,7 @@ RSpec.describe 'service_history', type: :request, skip_emis: true do
       it 'increments the StatsD empty counter' do
         expect do
           get '/v0/profile/service_history', nil, auth_header
-        end.to trigger_statsd_increment('api.emis.service_history.empty')
+        end.to trigger_statsd_increment('api.emis.has_service_history')
       end
     end
   end

--- a/spec/request/service_history_request_spec.rb
+++ b/spec/request/service_history_request_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'service_history', type: :request, skip_emis: true do
           VCR.use_cassette('emis/get_military_service_episodes/valid') do
             expect do
               get '/v0/profile/service_history', nil, auth_header
-            end.to trigger_statsd_increment('api.emis.has_service_history')
+            end.to trigger_statsd_increment('api.emis.service_history')
           end
         end
       end
@@ -76,7 +76,7 @@ RSpec.describe 'service_history', type: :request, skip_emis: true do
       it 'increments the StatsD empty counter' do
         expect do
           get '/v0/profile/service_history', nil, auth_header
-        end.to trigger_statsd_increment('api.emis.has_service_history')
+        end.to trigger_statsd_increment('api.emis.service_history')
       end
     end
   end

--- a/spec/request/service_history_request_spec.rb
+++ b/spec/request/service_history_request_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe 'service_history', type: :request, skip_emis: true do
             expect(response).to match_response_schema('service_history_response')
           end
         end
+
+        it 'increments the StatsD presence counter' do
+          VCR.use_cassette('emis/get_military_service_episodes/valid') do
+            expect do
+              get '/v0/profile/service_history', nil, auth_header
+            end.to trigger_statsd_increment('api.emis.service_history.present')
+          end
+        end
       end
 
       context 'with multiple military service episodes' do
@@ -57,6 +65,18 @@ RSpec.describe 'service_history', type: :request, skip_emis: true do
         get '/v0/profile/service_history', nil, auth_header
 
         expect(error_details_for(response, key: 'code')).to eq 'EMIS_HIST502'
+      end
+    end
+
+    context 'when service history is empty' do
+      before do
+        allow(EMISRedis::MilitaryInformation).to receive_message_chain(:for_user, :service_history) { [] }
+      end
+
+      it 'increments the StatsD empty counter' do
+        expect do
+          get '/v0/profile/service_history', nil, auth_header
+        end.to trigger_statsd_increment('api.emis.service_history.empty')
       end
     end
   end


### PR DESCRIPTION
## Background

For the new profile form, we need more insight into why a user's service history is not present.  Service history comes from eMIS, and requires that a user have an EDIPI.

## Definition of Done

- [x] StatsD reporting for when a user does/does not have an EDIPI
- [x] StatsD reporting for when a user does/does not have a service history
