### PR TITLE
Add reserves guard to prefill

### DIFF
--- a/app/models/emis_redis/military_information.rb
+++ b/app/models/emis_redis/military_information.rb
@@ -267,9 +267,9 @@ module EMISRedis
     end
 
     def guard_reserve_service_by_date
-      @guard_reserve_service_by_date ||= lambda do
+      @guard_reserve_service_by_date ||= begin
         guard_reserve_service_periods.sort_by { |per| per.end_date || Time.zone.today + 3650 }.reverse
-      end.call
+      end
     end
 
     def guard_reserve_service_history

--- a/app/models/emis_redis/military_information.rb
+++ b/app/models/emis_redis/military_information.rb
@@ -38,6 +38,8 @@ module EMISRedis
       service_branches
       va_compensation_type
       service_periods
+      guard_reserve_service_history
+      latest_guard_reserve_service_period
     ].freeze
 
     LOWER_DISABILITY_RATINGS = [10, 20, 30, 40].freeze
@@ -258,6 +260,29 @@ module EMISRedis
           end_date: episode.end_date
         }
       end
+    end
+
+    def guard_reserve_service_periods
+      @guard_reserve_service_periods ||= items_from_response('get_guard_reserve_service_periods')
+    end
+
+    def guard_reserve_service_by_date
+      @guard_reserve_service_by_date ||= lambda do
+        guard_reserve_service_periods.sort_by { |per| per.end_date || Time.zone.today + 3650 }.reverse
+      end.call
+    end
+
+    def guard_reserve_service_history
+      guard_reserve_service_by_date.map do |period|
+        {
+          from: period.begin_date,
+          to: period.end_date
+        }
+      end
+    end
+
+    def latest_guard_reserve_service_period
+      guard_reserve_service_history.try(:[], 0)
     end
   end
 end

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -10,6 +10,13 @@ class FormFullName
   attribute :suffix, String
 end
 
+class FormDate
+  include Virtus.model
+
+  attribute :from, Date
+  attribute :to, Date
+end
+
 class FormMilitaryInformation
   include Virtus.model
 
@@ -30,6 +37,8 @@ class FormMilitaryInformation
   attribute :vic_verified, Boolean
   attribute :service_branches, Array[String]
   attribute :service_periods, Array
+  attribute :guard_reserve_service_history, Array[FormDate]
+  attribute :latest_guard_reserve_service_period, FormDate
 end
 
 class FormAddress

--- a/config/form_profile_mappings/21-526EZ.yml
+++ b/config/form_profile_mappings/21-526EZ.yml
@@ -2,3 +2,5 @@ veteran: [veteran_contact_information, veteran]
 disabilities: [rated_disabilities_information, rated_disabilities]
 servicePeriods: [military_information, service_periods]
 servedInCombatZone: [military_information, post_nov111998_combat]
+reservesNationalGuardService:
+  obligationTermOfServiceDateRange: [military_information, latest_guard_reserve_service_period]

--- a/lib/evss/claims_service.rb
+++ b/lib/evss/claims_service.rb
@@ -22,7 +22,9 @@ module EVSS
     end
 
     def find_claim_by_id(claim_id)
-      post 'vbaClaimStatusService/getClaimDetailById', { id: claim_id }.to_json
+      rescue_evss_errors(%w[EVSS_10021]) do
+        post 'vbaClaimStatusService/getClaimDetailById', { id: claim_id }.to_json
+      end
     end
 
     def request_decision(claim_id)

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -433,7 +433,6 @@ RSpec.describe FormProfile, type: :model do
         )
         expect(errors.empty?).to eq(true), "schema errors: #{errors}"
       end
-      byebug
       expect(prefilled_data).to eq(
         form_profile.send(:clean!, public_send("v#{form_id.underscore}_expected"))
       )

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -348,6 +348,12 @@ RSpec.describe FormProfile, type: :model do
           }
         }
       ],
+      'reservesNationalGuardService' => {
+        'obligationTermOfServiceDateRange' => {
+          'from' => '2007-04-01',
+          'to' => '2016-06-01'
+        }
+      },
       'veteran' => {
         'mailingAddress' => {
           'country' => 'USA',
@@ -427,6 +433,7 @@ RSpec.describe FormProfile, type: :model do
         )
         expect(errors.empty?).to eq(true), "schema errors: #{errors}"
       end
+      byebug
       expect(prefilled_data).to eq(
         form_profile.send(:clean!, public_send("v#{form_id.underscore}_expected"))
       )
@@ -466,6 +473,13 @@ RSpec.describe FormProfile, type: :model do
         expect(user).to receive(:can_access_id_card?).and_return(true)
         expect(military_information).to receive(:service_periods).and_return(
           [{ service_branch: 'Air Force Reserve', date_range: { from: '2007-04-01', to: '2016-06-01' } }]
+        )
+        expect(military_information).to receive(:guard_reserve_service_history).and_return(
+          [{ from: '2007-04-01', to: '2016-06-01' }, { from: '2002-02-14', to: '2007-01-01' }]
+        )
+        expect(military_information).to receive(:latest_guard_reserve_service_period).and_return(
+          from: '2007-04-01',
+          to: '2016-06-01'
         )
       end
 

--- a/spec/support/vcr_cassettes/emis/get_guard_reserve_service_periods/valid_no_end_date.yml
+++ b/spec/support/vcr_cassettes/emis/get_guard_reserve_service_periods/valid_no_end_date.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://vaausvrsapp81.aac.va.gov/VIERSService/eMIS/v1/MilitaryInformationService
+    body:
+      encoding: ASCII-8BIT
+      string: |2
+
+        <soap:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:v1="http://viers.va.gov/cdi/CDI/commonService/v1" xmlns:v12="http://viers.va.gov/cdi/eMIS/RequestResponse/v1" xmlns:v13="http://viers.va.gov/cdi/eMIS/commonService/v1" xmlns:v11="http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v1">
+          <soap:Header>
+            <v1:inputHeaderInfo>
+              <v1:userId>vets.gov</v1:userId>
+              <v1:sourceSystemName>vets.gov</v1:sourceSystemName>
+              <v1:transactionId>ea823f51-deb0-47f8-b452-d2a58da2ce18</v1:transactionId>
+            </v1:inputHeaderInfo>
+          </soap:Header>
+          <soap:Body>
+            <v11:eMISguardReserveServicePeriodsRequest>
+              <v12:edipiORicn>
+                <v13:edipiORicnValue>1607472595</v13:edipiORicnValue>
+                <v13:inputType>EDIPI</v13:inputType>
+              </v12:edipiORicn>
+            </v11:eMISguardReserveServicePeriodsRequest>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Accept:
+      - text/xml;charset=UTF-8
+      Content-Type:
+      - text/xml;charset=UTF-8
+      User-Agent:
+      - Vets.gov Agent
+      Soapaction:
+      - http://viers.va.gov/cdi/eMIS/getGuardReserveServicePeriods/v1
+      Date:
+      - Wed, 19 Apr 2017 19:17:24 GMT
+      Content-Length:
+      - '973'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Apr 2017 19:17:20 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Set-Cookie:
+      - BlueStripe.PVN=8f7b047d0000000b; path=/
+      Content-Length:
+      - '2059'
+      Cache-Control:
+      - max-age=0, no-store
+      Connection:
+      - close
+      Content-Type:
+      - application/soap+xml;charset=utf-8
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><NS1:Envelope xmlns:NS1="http://www.w3.org/2003/05/soap-envelope"><NS1:Header><NS2:essResponseCode
+        xmlns:NS2="http://va.gov/ess/message/v1">Success</NS2:essResponseCode><NS3:inputHeaderInfo
+        xmlns:NS3="http://viers.va.gov/cdi/CDI/commonService/v1"><NS3:userId>vets.gov</NS3:userId><NS3:sourceSystemName>vets.gov</NS3:sourceSystemName><NS3:transactionId>ea823f51-deb0-47f8-b452-d2a58da2ce18</NS3:transactionId></NS3:inputHeaderInfo></NS1:Header><NS1:Body><NS4:eMISguardReserveServicePeriodsResponse
+        xmlns:NS4="http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v1"><NS5:guardReserveServicePeriods
+        xmlns:NS5="http://viers.va.gov/cdi/eMIS/RequestResponse/v1"><NS6:edipi xmlns:NS6="http://viers.va.gov/cdi/eMIS/commonService/v1">1607472595</NS6:edipi><NS7:keyData
+        xmlns:NS7="http://viers.va.gov/cdi/eMIS/commonService/v1"><NS7:personnelOrganizationCode>41</NS7:personnelOrganizationCode><NS7:personnelCategoryTypeCode>V</NS7:personnelCategoryTypeCode><NS7:personnelSegmentIdentifier>1</NS7:personnelSegmentIdentifier></NS7:keyData><NS8:guardReserveServicePeriodsData
+        xmlns:NS8="http://viers.va.gov/cdi/eMIS/commonService/v1"><NS8:guardReserveSegmentIdentifier>3</NS8:guardReserveSegmentIdentifier><NS8:guardReservePeriodStartDate>2007-05-22</NS8:guardReservePeriodStartDate><NS8:guardReservePeriodTerminationReason>C</NS8:guardReservePeriodTerminationReason><NS8:guardReservePeriodCharacterOfServiceCode>H</NS8:guardReservePeriodCharacterOfServiceCode><NS8:narrativeReasonForSeparationCode>999</NS8:narrativeReasonForSeparationCode><NS8:guardReservePeriodStatuteCode>C</NS8:guardReservePeriodStatuteCode><NS8:guardReservePeriodProjectCode>9GF</NS8:guardReservePeriodProjectCode><NS8:post911GIBilLossCategoryCode>06</NS8:post911GIBilLossCategoryCode><NS8:trainingIndicatorCode>N</NS8:trainingIndicatorCode></NS8:guardReserveServicePeriodsData></NS5:guardReserveServicePeriods></NS4:eMISguardReserveServicePeriodsResponse></NS1:Body></NS1:Envelope>
+    http_version:
+  recorded_at: Wed, 19 Apr 2017 19:17:25 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Since we are allowing the veteran to edit their service information within the form we can prefill as much reserves/guard data that we have available. Currently this is only the service dates.