### PR TITLE
Removed VET360_ADDRVAL104

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -752,12 +752,6 @@ en:
         code: VET360_ADDRVAL103
         detail: The country lookup service returned an error
         status: 400
-      VET360_ADDRVAL104:
-        <<: *external_defaults
-        title: Address Validation Service Error
-        code: VET360_ADDRVAL104
-        detail: The address validation service returned an error
-        status: 400
       VET360_ADDRVAL105:
         <<: *external_defaults
         title: Invalid Request Error


### PR DESCRIPTION
VET360_ADDRVAL104 is deprecated and cannot happen anymore...

From Jason Ginnow via Steve:
> AddressValidationServiceError   ADDRVAL104     Vet360 Address Validation Service Error
> -> This error is deprecated and will not show up. I apologize for that; we'll remove it from the documentation.

