### PR TITLE
prepend va_eauth to gender header

### DIFF
--- a/lib/evss/disability_compensation_auth_headers.rb
+++ b/lib/evss/disability_compensation_auth_headers.rb
@@ -3,7 +3,7 @@
 module EVSS
   class DisabilityCompensationAuthHeaders
     def self.add_headers(auth_headers, user)
-      auth_headers.merge('gender' => gender(user))
+      auth_headers.merge('va_eauth_gender' => gender(user))
     end
 
     def self.gender(user)

--- a/spec/lib/evss/disability_compensation_auth_headers_spec.rb
+++ b/spec/lib/evss/disability_compensation_auth_headers_spec.rb
@@ -9,7 +9,7 @@ describe EVSS::DisabilityCompensationAuthHeaders do
 
   it 'includes gender in the headers' do
     user = build(:user)
-    expect(subject.add_headers(auth_headers, user)).to eq('foo' => 'bar', 'gender' => 'MALE')
+    expect(subject.add_headers(auth_headers, user)).to eq('foo' => 'bar', 'va_eauth_gender' => 'MALE')
   end
 
   it 'raises an error if gender is not included' do


### PR DESCRIPTION
The added header for `gender` was missing a prepend to it.