### PR TITLE
fixes 526 submit validation error handling

### DIFF
--- a/lib/evss/disability_compensation_form/service_exception.rb
+++ b/lib/evss/disability_compensation_form/service_exception.rb
@@ -28,6 +28,20 @@ module EVSS
         treatments: 'common.exceptions.validation_errors',
         veteran: 'common.exceptions.validation_errors'
       }.freeze
+
+      def errors
+        Array(
+          Common::Exceptions::SerializableError.new(
+            i18n_data.merge(source: 'EVSS::DisabilityCompensationForm::Service', meta: { messages: @messages })
+          )
+        )
+      end
+
+      private
+
+      def i18n_key
+        @key
+      end
     end
   end
 end

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -124,12 +124,34 @@ RSpec.describe 'Disability compensation form', type: :request do
         end
       end
 
-      context 'with a generic 400 response' do
+      context 'with a 400 response' do
+        let(:validation_array) do
+          [
+            {
+              'key' => 'form526.serviceInformation.ConfinementPastActiveDutyDate',
+              'severity' => 'ERROR',
+              'text' => 'The confinement start date is too far in the past'
+            },
+            {
+              'key' => 'form526.serviceInformation.ConfinementWithInServicePeriod',
+              'severity' => 'ERROR',
+              'text' => 'Your period of confinement must be within a single period of service'
+            },
+            {
+              'key' => 'form526.veteran.homelessness.pointOfContact.pointOfContactName.Pattern',
+              'severity' => 'ERROR',
+              'text' => 'must match "([a-zA-Z0-9-/]+( ?))*$"'
+            }
+          ]
+        end
+
         it 'should return a bad request response' do
           VCR.use_cassette('evss/disability_compensation_form/submit_400') do
             post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
-            expect(response).to have_http_status(:bad_request)
+            expect(response).to have_http_status(:unprocessable_entity)
             expect(response).to match_response_schema('evss_errors', strict: false)
+            meta = JSON.parse(response.body).dig('errors').first.dig('meta', 'messages')
+            expect(meta).to match_array(validation_array)
           end
         end
       end

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'Disability compensation form', type: :request do
           ]
         end
 
-        it 'should return a bad request response' do
+        it 'should return a unprocessable_entity response' do
           VCR.use_cassette('evss/disability_compensation_form/submit_400') do
             post '/v0/disability_compensation_form/submit', valid_form_content, auth_header
             expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/support/vcr_cassettes/evss/disability_compensation_form/submit_400.yml
+++ b/spec/support/vcr_cassettes/evss/disability_compensation_form/submit_400.yml
@@ -66,6 +66,25 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |-
-    http_version: 
+        {
+          "messages": [
+            {
+              "key": "form526.serviceInformation.ConfinementPastActiveDutyDate",
+              "severity": "ERROR",
+              "text": "The confinement start date is too far in the past"
+            },
+            {
+              "key": "form526.serviceInformation.ConfinementWithInServicePeriod",
+              "severity": "ERROR",
+              "text": "Your period of confinement must be within a single period of service"
+            },
+            {
+              "key": "form526.veteran.homelessness.pointOfContact.pointOfContactName.Pattern",
+              "severity": "ERROR",
+              "text": "must match \"([a-zA-Z0-9-/]+( ?))*$\""
+            }
+          ]
+        }
+    http_version:
   recorded_at: Mon, 02 Apr 2018 22:46:34 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Fixes the `EVSS::DisabilityCompensationForm::ServiceException` (must implement errors) and updates the spec to ensure vets-api returns a 422 with details in the response meta.