### PR TITLE
WIP - rename breakers metrics

### DIFF
--- a/lib/breakers/statsd_plugin.rb
+++ b/lib/breakers/statsd_plugin.rb
@@ -2,8 +2,8 @@
 
 module Breakers
   class StatsdPlugin
-    def get_tags(request)
-      tags = []
+    def get_tags(request, status, service_name)
+      tags = ["status:#{status}", "service:#{service_name}"]
       if request
         if request.url&.path
           # replace identifiers with 'xxx'
@@ -34,11 +34,11 @@ module Breakers
     end
 
     def send_metric(status, service, request_env, response_env)
-      tags = get_tags(request_env)
-      metric_base = "api.external_http_request.#{service.name}."
-      StatsD.increment(metric_base + status, 1, tags: tags)
+      tags = get_tags(request_env, status, service.name)
+      metric_name = 'api.external_http_request'
+      StatsD.increment(metric_name, 1, tags: tags)
       if response_env && response_env[:duration]
-        StatsD.measure(metric_base + 'time', response_env[:duration], tags: tags)
+        StatsD.measure(metric_name + '.duration_seconds', response_env[:duration], tags: tags)
       end
     end
   end

--- a/spec/lib/breakers/statsd_plugin_spec.rb
+++ b/spec/lib/breakers/statsd_plugin_spec.rb
@@ -10,40 +10,50 @@ describe Breakers::StatsdPlugin do
     context 'request is sent' do
       it 'adds method tag when available' do
         request.method = :get
-        expect(subject.get_tags(request)).to include('method:get')
+        expect(subject.get_tags(request, 'success', 'foo')).to include('method:get')
       end
 
       it 'returns endpoint tag' do
         request.url = URI(test_host + '/foo')
-        expect(subject.get_tags(request)).to include('endpoint:/foo')
+        expect(subject.get_tags(request, 'success', 'Foo')).to include('endpoint:/foo')
+      end
+
+      it 'includes service name tag' do
+        request.url = URI(test_host + '/foo')
+        expect(subject.get_tags(request, 'success', 'foo')).to include('service:foo')
+      end
+
+      it 'includes status tag' do
+        request.url = URI(test_host + '/foo')
+        expect(subject.get_tags(request, 'success', 'foo')).to include('status:success')
       end
     end
 
     context 'request is made with id' do
       it 'returns endpoint tag with id replaced' do
         request.url = URI(test_host + '/v1/foo/12345')
-        expect(subject.get_tags(request)).to include('endpoint:/v1/foo/xxx')
+        expect(subject.get_tags(request, 'success', 'foo')).to include('endpoint:/v1/foo/xxx')
 
         request.url = URI(test_host + '/page/1/foo/12345')
-        expect(subject.get_tags(request)).to include('endpoint:/page/xxx/foo/xxx')
+        expect(subject.get_tags(request, 'success', 'foo')).to include('endpoint:/page/xxx/foo/xxx')
 
         request.url = URI(test_host + '/foo/25D05EEE-187A-4332-86BF-BED70E10B6B7')
-        expect(subject.get_tags(request)).to include('endpoint:/foo/xxx')
+        expect(subject.get_tags(request, 'success', 'foo')).to include('endpoint:/foo/xxx')
 
         request.url = URI(test_host + '/foo/25d05eee-187a-4332-86bf-bed70e10b6b7/test')
-        expect(subject.get_tags(request)).to include('endpoint:/foo/xxx/test')
+        expect(subject.get_tags(request, 'success', 'foo')).to include('endpoint:/foo/xxx/test')
 
         request.url = URI(test_host + '/foo/25d05eee187a433286bfbed70e10b6b7/')
-        expect(subject.get_tags(request)).to include('endpoint:/foo/xxx/')
+        expect(subject.get_tags(request, 'success', 'foo')).to include('endpoint:/foo/xxx/')
 
         request.url = URI(test_host + '/foo/111A2222')
-        expect(subject.get_tags(request)).to include('endpoint:/foo/xxx')
+        expect(subject.get_tags(request, 'success', 'foo')).to include('endpoint:/foo/xxx')
 
         request.url = URI(test_host + '/foo/aaaaaaaa/11A22222')
-        expect(subject.get_tags(request)).to include('endpoint:/foo/aaaaaaaa/xxx')
+        expect(subject.get_tags(request, 'success', 'foo')).to include('endpoint:/foo/aaaaaaaa/xxx')
 
         request.url = URI(test_host + '/foo/-1')
-        expect(subject.get_tags(request)).to include('endpoint:/foo/xxx')
+        expect(subject.get_tags(request, 'success', 'foo')).to include('endpoint:/foo/xxx')
       end
     end
   end

--- a/spec/request/breakers_integration_spec.rb
+++ b/spec/request/breakers_integration_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'breakers', type: :request do
 
       expect do
         get '/v0/prescriptions'
-      end.to trigger_statsd_increment('api.external_http_request.Rx.skipped', times: 1, value: 1)
+      end.to trigger_statsd_increment('api.external_http_request', times: 1, value: 1)
 
       response = get '/v0/prescriptions'
       expect(response).to eq(503)
@@ -75,20 +75,21 @@ RSpec.describe 'breakers', type: :request do
       stub_varx_request(:get, 'mhv-api/patient/v1/prescription/gethistoryrx', history_rxs, status_code: 200)
       expect do
         get '/v0/prescriptions'
-      end.to trigger_statsd_increment('api.external_http_request.Rx.success', times: 1, value: 1)
+      end.to trigger_statsd_increment('api.external_http_request', times: 1, value: 1)
     end
 
     it 'increments errors' do
       stub_varx_request(:get, 'mhv-api/patient/v1/prescription/gethistoryrx', history_rxs, status_code: 500)
       expect do
         get '/v0/prescriptions'
-      end.to trigger_statsd_increment('api.external_http_request.Rx.failed', times: 1, value: 1)
+      end.to trigger_statsd_increment('api.external_http_request', times: 1, value: 1)
     end
 
     it 'measures request times' do
       path = 'mhv-api/patient/v1/prescription/gethistoryrx'
+      metric = 'api.external_http_request.duration_seconds'
       stub_varx_request(:get, path, history_rxs, status_code: 200, tags: ['endpoint:/' + path])
-      expect { get '/v0/prescriptions' }.to trigger_statsd_measure('api.external_http_request.Rx.time', times: 1)
+      expect { get '/v0/prescriptions' }.to trigger_statsd_measure(metric, times: 1)
     end
   end
 end


### PR DESCRIPTION
Rename the metrics created by breakers plugin and use tags instead. I also renamed the request duration measurement to remove the name translation in the StatsD exporter config.