### PR TITLE
Add eMIS properties to the user serializer for veteran status

### DIFF
--- a/app/models/emis_redis/veteran_status.rb
+++ b/app/models/emis_redis/veteran_status.rb
@@ -3,6 +3,17 @@
 require 'emis/veteran_status_service'
 
 module EMISRedis
+  # Much of this class depends on the Title 38 Status codes, which are:
+  #
+  # V1 = Title 38 Veteran
+  # V2 = VA Beneficiary
+  # V3 = Military Person, not Title 38 Veteran, NOT DoD-Affiliated
+  # V4 = Non-military person
+  # V5 = EDI PI Not Found in VADIR (service response only not stored in table)
+  # V6 = Military Person, not Title 38 Veteran, DoD-Affiliated
+  #
+  # @see https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/SiP-Prefill/Prefill/eMIS_Integration/eMIS_Documents/MIS%20Service%20Description%20Document.docx
+  #
   class VeteranStatus < Model
     CLASS_NAME = 'VeteranStatusService'
 
@@ -30,6 +41,15 @@ module EMISRedis
     #
     def post_911_combat_deployment?
       coerce(validated_response&.post911_deployment_indicator)
+    end
+
+    # Returns boolean for user being/not being considered a military person, by eMIS,
+    # based on their Title 38 Status Code.
+    #
+    # @return [Boolean]
+    #
+    def military_person?
+      title38_status == 'V3' || title38_status == 'V6'
     end
 
     class NotAuthorized < StandardError

--- a/app/models/emis_redis/veteran_status.rb
+++ b/app/models/emis_redis/veteran_status.rb
@@ -25,24 +25,6 @@ module EMISRedis
       validated_response&.title38_status_code
     end
 
-    # Returns boolean for user having/not having pre-911 combat deployment.
-    #
-    # @return [Boolean] If 'Y' or 'N' is returned from eMIS, returns associated boolean
-    # @return [NilClass] If anything other than 'Y' or 'N' is returned from eMIS, returns nil
-    #
-    def pre_911_combat_deployment?
-      coerce(validated_response&.pre911_deployment_indicator)
-    end
-
-    # Returns boolean for user having/not having ppost-911 combat deployment.
-    #
-    # @return [Boolean] If 'Y' or 'N' is returned from eMIS, returns associated boolean
-    # @return [NilClass] If anything other than 'Y' or 'N' is returned from eMIS, returns nil
-    #
-    def post_911_combat_deployment?
-      coerce(validated_response&.post911_deployment_indicator)
-    end
-
     # Returns boolean for user being/not being considered a military person, by eMIS,
     # based on their Title 38 Status Code.
     #
@@ -66,19 +48,6 @@ module EMISRedis
 
       raise VeteranStatus::RecordNotFound if response.empty?
       response.items.first
-    end
-
-    def coerce(y_or_n)
-      value = y_or_n&.upcase
-
-      return value if value.nil?
-
-      case value
-      when 'Y'
-        true
-      when 'N'
-        false
-      end
     end
   end
 end

--- a/app/models/emis_redis/veteran_status.rb
+++ b/app/models/emis_redis/veteran_status.rb
@@ -11,16 +11,56 @@ module EMISRedis
     end
 
     def title38_status
-      raise VeteranStatus::NotAuthorized unless @user.loa3?
-      response = emis_response('get_veteran_status')
-      raise VeteranStatus::RecordNotFound if response.empty?
-      response.items.first&.title38_status_code
+      validated_response&.title38_status_code
+    end
+
+    # Returns boolean for user having/not having pre-911 combat deployment.
+    #
+    # @return [Boolean] If 'Y' or 'N' is returned from eMIS, returns associated boolean
+    # @return [NilClass] If anything other than 'Y' or 'N' is returned from eMIS, returns nil
+    #
+    def pre_911_combat_deployment?
+      coerce(validated_response&.pre911_deployment_indicator)
+    end
+
+    # Returns boolean for user having/not having ppost-911 combat deployment.
+    #
+    # @return [Boolean] If 'Y' or 'N' is returned from eMIS, returns associated boolean
+    # @return [NilClass] If anything other than 'Y' or 'N' is returned from eMIS, returns nil
+    #
+    def post_911_combat_deployment?
+      coerce(validated_response&.post911_deployment_indicator)
     end
 
     class NotAuthorized < StandardError
     end
 
     class RecordNotFound < StandardError
+    end
+
+    private
+
+    def validated_response
+      raise VeteranStatus::NotAuthorized unless @user.loa3?
+      response = emis_response('get_veteran_status')
+
+      raise VeteranStatus::RecordNotFound if response.empty?
+      response.items.first
+    end
+
+    def coerce(y_or_n)
+      value = y_or_n&.upcase
+
+      return value if value.nil?
+
+      case value
+      when 'Y'
+        true
+      when 'N'
+        false
+      else
+        nil
+      end
     end
   end
 end

--- a/app/models/emis_redis/veteran_status.rb
+++ b/app/models/emis_redis/veteran_status.rb
@@ -78,8 +78,6 @@ module EMISRedis
         true
       when 'N'
         false
-      else
-        nil
       end
     end
   end

--- a/app/models/emis_redis/veteran_status.rb
+++ b/app/models/emis_redis/veteran_status.rb
@@ -42,6 +42,20 @@ module EMISRedis
 
     private
 
+    # The emis_response call in this method returns an instance of the
+    # EMIS::Responses::GetVeteranStatusResponse class. This response's `items`
+    # is an array of one hash.  For example:
+    #   [
+    #     {
+    #       :title38_status_code          => "V1",
+    #       :post911_deployment_indicator => "Y",
+    #       :post911_combat_indicator     => "N",
+    #       :pre911_deployment_indicator  => "N"
+    #     }
+    #   ]
+    #
+    # @return [Hash] A hash of veteran status properties
+    #
     def validated_response
       raise VeteranStatus::NotAuthorized unless @user.loa3?
       response = emis_response('get_veteran_status')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -245,6 +245,16 @@ class User < Common::RedisStore
     @mvi ||= Mvi.for_user(self)
   end
 
+  # A user can have served in the military without being a veteran.  For example,
+  # someone can be ex-military by having a discharge status higher than
+  # 'Other Than Honorable'.
+  #
+  # @return [Boolean]
+  #
+  def served_in_military?
+    edipi.present? && veteran? || military_person?
+  end
+
   private
 
   def pciu

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,8 +119,6 @@ class User < Common::RedisStore
 
   # emis attributes
   delegate :military_person?, to: :veteran_status
-  delegate :post_911_combat_deployment?, to: :veteran_status
-  delegate :pre_911_combat_deployment?, to: :veteran_status
   delegate :veteran?, to: :veteran_status
 
   def va_profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,8 +115,13 @@ class User < Common::RedisStore
   delegate :icn, to: :mvi
   delegate :icn_with_aaid, to: :mvi
   delegate :participant_id, to: :mvi
-  delegate :veteran?, to: :veteran_status
   delegate :vet360_id, to: :mvi
+
+  # emis attributes
+  delegate :military_person?, to: :veteran_status
+  delegate :post_911_combat_deployment?, to: :veteran_status
+  delegate :pre_911_combat_deployment?, to: :veteran_status
+  delegate :veteran?, to: :veteran_status
 
   def va_profile
     mvi.profile

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -62,8 +62,6 @@ class UserSerializer < ActiveModel::Serializer
     {
       status: RESPONSE_STATUS[:ok],
       is_veteran: object.veteran?,
-      post_911_combat_deployment: object.post_911_combat_deployment?,
-      pre_911_combat_deployment: object.pre_911_combat_deployment?,
       served_in_military: object.served_in_military?
     }
   rescue EMISRedis::VeteranStatus::NotAuthorized

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -61,7 +61,10 @@ class UserSerializer < ActiveModel::Serializer
   def veteran_status
     {
       status: RESPONSE_STATUS[:ok],
-      is_veteran: object.veteran?
+      is_veteran: object.veteran?,
+      post_911_combat_deployment: object.post_911_combat_deployment?,
+      pre_911_combat_deployment: object.pre_911_combat_deployment?,
+      served_in_military: object.served_in_military?
     }
   rescue EMISRedis::VeteranStatus::NotAuthorized
     { status: RESPONSE_STATUS[:not_authorized] }

--- a/app/swagger/requests/user.rb
+++ b/app/swagger/requests/user.rb
@@ -70,8 +70,6 @@ module Swagger
                   key :required, [:status]
                   property :is_veteran, type: :boolean, example: true
                   property :status, type: :string, enum: %w[OK NOT_AUTHORIZED NOT_FOUND SERVER_ERROR], example: 'OK'
-                  property :post_911_combat_deployment, type: :boolean, enum: [true, false, 'nil'], example: true
-                  property :pre_911_combat_deployment, type: :boolean, enum: [true, false, 'nil'], example: false
                   property :served_in_military, type: :boolean, example: true
                 end
               end

--- a/app/swagger/requests/user.rb
+++ b/app/swagger/requests/user.rb
@@ -70,6 +70,9 @@ module Swagger
                   key :required, [:status]
                   property :is_veteran, type: :boolean, example: true
                   property :status, type: :string, enum: %w[OK NOT_AUTHORIZED NOT_FOUND SERVER_ERROR], example: 'OK'
+                  property :post_911_combat_deployment, type: :boolean, enum: [true, false, 'nil'], example: true
+                  property :pre_911_combat_deployment, type: :boolean, enum: [true, false, 'nil'], example: false
+                  property :served_in_military, type: :boolean, example: true
                 end
               end
             end

--- a/spec/models/emis_redis/veteran_status_spec.rb
+++ b/spec/models/emis_redis/veteran_status_spec.rb
@@ -61,4 +61,44 @@ describe EMISRedis::VeteranStatus, skip_emis: true do
       end
     end
   end
+
+  describe 'pre_911_combat_deployment?' do
+    context 'with a response of "N"' do
+      it 'returns false' do
+        VCR.use_cassette('emis/get_veteran_status/valid') do
+          expect(subject.pre_911_combat_deployment?).to eq false
+        end
+      end
+    end
+
+    context 'with an empty response' do
+      before do
+        allow(subject).to receive_message_chain(:validated_response, :pre911_deployment_indicator) { nil }
+      end
+
+      it 'returns nil' do
+        expect(subject.pre_911_combat_deployment?).to be_nil
+      end
+    end
+
+    context 'with an unexpected response' do
+      before do
+        allow(subject).to receive_message_chain(:validated_response, :pre911_deployment_indicator) { 'random' }
+      end
+
+      it 'returns nil' do
+        expect(subject.pre_911_combat_deployment?).to be_nil
+      end
+    end
+  end
+
+  describe 'post_911_combat_deployment?' do
+    context 'with a response of "Y"' do
+      it 'returns true' do
+        VCR.use_cassette('emis/get_veteran_status/valid') do
+          expect(subject.post_911_combat_deployment?).to eq true
+        end
+      end
+    end
+  end
 end

--- a/spec/models/emis_redis/veteran_status_spec.rb
+++ b/spec/models/emis_redis/veteran_status_spec.rb
@@ -61,44 +61,4 @@ describe EMISRedis::VeteranStatus, skip_emis: true do
       end
     end
   end
-
-  describe 'pre_911_combat_deployment?' do
-    context 'with a response of "N"' do
-      it 'returns false' do
-        VCR.use_cassette('emis/get_veteran_status/valid') do
-          expect(subject.pre_911_combat_deployment?).to eq false
-        end
-      end
-    end
-
-    context 'with an empty response' do
-      before do
-        allow(subject).to receive_message_chain(:validated_response, :pre911_deployment_indicator) { nil }
-      end
-
-      it 'returns nil' do
-        expect(subject.pre_911_combat_deployment?).to be_nil
-      end
-    end
-
-    context 'with an unexpected response' do
-      before do
-        allow(subject).to receive_message_chain(:validated_response, :pre911_deployment_indicator) { 'random' }
-      end
-
-      it 'returns nil' do
-        expect(subject.pre_911_combat_deployment?).to be_nil
-      end
-    end
-  end
-
-  describe 'post_911_combat_deployment?' do
-    context 'with a response of "Y"' do
-      it 'returns true' do
-        VCR.use_cassette('emis/get_veteran_status/valid') do
-          expect(subject.post_911_combat_deployment?).to eq true
-        end
-      end
-    end
-  end
 end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -121,6 +121,18 @@ RSpec.describe UserSerializer, type: :serializer do
       it 'should include status' do
         expect(veteran_status['status']).to eq('OK')
       end
+
+      it 'should include post_911_combat_deployment' do
+        expect(veteran_status['post_911_combat_deployment']).to eq(user.post_911_combat_deployment?)
+      end
+
+      it 'should include pre_911_combat_deployment' do
+        expect(veteran_status['pre_911_combat_deployment']).to eq(user.pre_911_combat_deployment?)
+      end
+
+      it 'should include served_in_military' do
+        expect(veteran_status['served_in_military']).to eq(user.served_in_military?)
+      end
     end
 
     context 'when a veteran status is not found' do

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -122,14 +122,6 @@ RSpec.describe UserSerializer, type: :serializer do
         expect(veteran_status['status']).to eq('OK')
       end
 
-      it 'should include post_911_combat_deployment' do
-        expect(veteran_status['post_911_combat_deployment']).to eq(user.post_911_combat_deployment?)
-      end
-
-      it 'should include pre_911_combat_deployment' do
-        expect(veteran_status['pre_911_combat_deployment']).to eq(user.pre_911_combat_deployment?)
-      end
-
       it 'should include served_in_military' do
         expect(veteran_status['served_in_military']).to eq(user.served_in_military?)
       end

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -100,6 +100,9 @@
                 {
                   "properties": {
                     "is_veteran": { "type": "boolean" },
+                    "post_911_combat_deployment": { "type": "boolean" },
+                    "pre_911_combat_deployment": { "type": "boolean" },
+                    "served_in_military": { "type": "boolean" },
                     "status": { "type": "string"  }
                   }
                 }

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -100,8 +100,6 @@
                 {
                   "properties": {
                     "is_veteran": { "type": "boolean" },
-                    "post_911_combat_deployment": { "type": "boolean" },
-                    "pre_911_combat_deployment": { "type": "boolean" },
                     "served_in_military": { "type": "boolean" },
                     "status": { "type": "string"  }
                   }

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -101,8 +101,6 @@
                 {
                   "properties": {
                     "is_veteran": { "type": "boolean" },
-                    "post_911_combat_deployment": { "type": "boolean" },
-                    "pre_911_combat_deployment": { "type": "boolean" },
                     "served_in_military": { "type": "boolean" },
                     "status": { "type": "string"  }
                   }

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -101,6 +101,9 @@
                 {
                   "properties": {
                     "is_veteran": { "type": "boolean" },
+                    "post_911_combat_deployment": { "type": "boolean" },
+                    "pre_911_combat_deployment": { "type": "boolean" },
+                    "served_in_military": { "type": "boolean" },
                     "status": { "type": "string"  }
                   }
                 }

--- a/spec/support/stub_emis.rb
+++ b/spec/support/stub_emis.rb
@@ -2,5 +2,8 @@
 
 def stub_emis
   allow_any_instance_of(EMISRedis::VeteranStatus).to receive(:veteran?).and_return(true)
+  allow_any_instance_of(EMISRedis::VeteranStatus).to receive(:post_911_combat_deployment?).and_return(true)
+  allow_any_instance_of(EMISRedis::VeteranStatus).to receive(:pre_911_combat_deployment?).and_return(false)
+  allow_any_instance_of(EMISRedis::VeteranStatus).to receive(:military_person?).and_return(true)
   allow_any_instance_of(FormProfile).to receive(:initialize_military_information).and_return({})
 end

--- a/spec/support/stub_emis.rb
+++ b/spec/support/stub_emis.rb
@@ -2,8 +2,6 @@
 
 def stub_emis
   allow_any_instance_of(EMISRedis::VeteranStatus).to receive(:veteran?).and_return(true)
-  allow_any_instance_of(EMISRedis::VeteranStatus).to receive(:post_911_combat_deployment?).and_return(true)
-  allow_any_instance_of(EMISRedis::VeteranStatus).to receive(:pre_911_combat_deployment?).and_return(false)
   allow_any_instance_of(EMISRedis::VeteranStatus).to receive(:military_person?).and_return(true)
   allow_any_instance_of(FormProfile).to receive(:initialize_military_information).and_return({})
 end


### PR DESCRIPTION
## Background

We are trying to uncover reasons why a user's service history would/would not be present.

In the [`/v0/user`](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/user/getUser) response we are currently returning a boolean value for `is_veteran`.

In addition to that, we need to also know if the person is a title 38 Veteran with a pre- or post-911 combat deployment.  This way we would know that the user absolutely should have a service history, and would allow us to message the end user accordingly.

## Definition of Done

Add the following data to `/v0/user` response, within the `veteran_status` property:

- [x] a boolean for `"served_in_military"`

#### Before

```
  "veteran_status": {
    "is_veteran": true,
    "status": "OK"
  }
}
```

#### After
```
  "veteran_status": {
    "is_veteran": true,
    "status": "OK",
    "served_in_military": true
  }
}
```
