### PR TITLE
remove the itf type error check

### DIFF
--- a/lib/evss/intent_to_file/intent_to_file.rb
+++ b/lib/evss/intent_to_file/intent_to_file.rb
@@ -14,12 +14,6 @@ module EVSS
         incomplete
       ].freeze
 
-      ITF_TYPE = %w[
-        compensation
-        pension
-        survivor
-      ].freeze
-
       attribute :id, String
       attribute :creation_date, DateTime
       attribute :expiration_date, DateTime
@@ -30,7 +24,6 @@ module EVSS
 
       def initialize(args)
         raise ArgumentError, "invalid status type: #{args['status']}" unless STATUS_TYPES.include? args['status']
-        raise ArgumentError, "invalid type: #{args['type']}" unless ITF_TYPE.include? args['type']
         super(args)
       end
 


### PR DESCRIPTION
EVSS treats the `type` field as an enum but, since the data for the field is not guaranteed, we actually *can't* treat it like an enum at all.