### PR TITLE
override idp metadata to use name_id 'unspecified'

### DIFF
--- a/lib/saml/settings_service.rb
+++ b/lib/saml/settings_service.rb
@@ -102,6 +102,8 @@ module SAML
         settings.assertion_consumer_service_url = Settings.saml.callback_url
         settings.certificate_new = Settings.saml.certificate_new
 
+        settings.name_identifier_format = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
+
         settings.security[:authn_requests_signed] = true
         settings.security[:logout_requests_signed] = true
         settings.security[:embed_sign] = false

--- a/spec/lib/saml/saml_settings_service_spec.rb
+++ b/spec/lib/saml/saml_settings_service_spec.rb
@@ -11,19 +11,19 @@ RSpec.describe SAML::SettingsService do
   end
 
   describe '.saml_settings' do
-    context 'with a 200 response' do
+    context 'with a 200 response', vcr: { cassette_name: 'saml/idp_metadata' } do
       it 'should only ever make 1 external web call' do
-        VCR.use_cassette('saml/idp_metadata') do
-          SAML::SettingsService.merged_saml_settings(true)
-          SAML::SettingsService.saml_settings
-          SAML::SettingsService.saml_settings
-          expect(a_request(:get, Settings.saml.metadata_url)).to have_been_made.at_most_once
-        end
+        SAML::SettingsService.merged_saml_settings(true)
+        SAML::SettingsService.saml_settings
+        SAML::SettingsService.saml_settings
+        expect(a_request(:get, Settings.saml.metadata_url)).to have_been_made.at_most_once
       end
       it 'returns a settings instance' do
-        VCR.use_cassette('saml/idp_metadata') do
-          expect(SAML::SettingsService.merged_saml_settings(true)).to be_an_instance_of(OneLogin::RubySaml::Settings)
-        end
+        expect(SAML::SettingsService.merged_saml_settings(true)).to be_an_instance_of(OneLogin::RubySaml::Settings)
+      end
+      it 'overrides name-id to be "unspecified"' do
+        expect(SAML::SettingsService.merged_saml_settings(true).name_identifier_format)
+          .to eq('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified')
       end
     end
     context 'with metadata 500 responses' do


### PR DESCRIPTION
ID.me recently modified their [IDP metadata XML](https://api.id.me/saml/metadata/provider) such that `"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"` went from being the _first_ `md:NameIDFormat ` to the _second_.  When fetching IDP metadata, [`ruby-saml` simply return's the `.first` one found](https://github.com/onelogin/ruby-saml/blob/master/lib/onelogin/ruby-saml/idp_metadata_parser.rb#L191-L198).  Therefore, `AuthnRequest`'s from Vets.gov were showing `emailAddress` as the nameID.  This is incorrect and ID.me has instructed us to continue using `unspecified`.

This PR hardcodes our `name_identifier_format` to `'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'`.

For more context [see slack thread](https://dsva.slack.com/archives/C6WGBD0SW/p1531508771000440)