### PR TITLE
VBADocuments: Add source to failed submission log entry

### DIFF
--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -30,6 +30,7 @@ module VBADocuments
         upload.update(status: 'error', code: e.code, detail: e.detail)
         Rails.logger.info('VBADocuments: Submission failure',
                           'uuid' => guid,
+                          'source' => "#{upload.consumer_name} via VA API",
                           'code' => e.code,
                           'detail' => e.detail)
       ensure


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets-contrib/issues/216

While playing with ElasticSearch, observed that we couldn't log failed submissions by source. This adds the same source info to the failed submission log entry.

Though it occurs to me that we may want to knock off the "via Vets API" part from both the success and failed cases (i.e. just log `upload.consumer_name` for possible cross-correlation with other log entries where we just have the consumer_name. Happy to make that change here if you agree.