### PR TITLE
vets360 prefill bug

### DIFF
--- a/app/models/form_profiles/va1990.rb
+++ b/app/models/form_profiles/va1990.rb
@@ -7,7 +7,7 @@ class FormProfiles::VA1990 < FormProfile
     # TODO: temporary solution for vets360 testing, move code to `FormContactInformation` in the future
     return_val = super
 
-    if Settings.vet360.prefill
+    if Settings.vet360.prefill && user.vet360_id.present?
       form_data = return_val[:form_data]
       contact_information = Vet360Redis::ContactInformation.for_user(user)
       email = contact_information.email&.email_address


### PR DESCRIPTION
## Background
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11529
this pr fixes the errors in production caused by trying to lookup a user's vets360 information when the user doesnt have a vets360 id

## Definition of Done

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
