### PR TITLE
Treatments empty list fix

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation.rb
+++ b/lib/evss/disability_compensation_form/data_translation.rb
@@ -185,7 +185,11 @@ module EVSS
       end
 
       def translate_treatments
-        return if form['treatments'].blank?
+        if form['treatments'].blank?
+          form.delete('treatments')
+          return
+        end
+
         form['treatments'].map! do |treatment|
           treatment['center'] = {
             'name' => treatment['treatmentCenterName'],

--- a/spec/lib/evss/disability_compensation_form/data_translation_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_spec.rb
@@ -170,6 +170,25 @@ describe EVSS::DisabilityCompensationForm::DataTranslation do
     end
   end
 
+  describe '#translate_treatments' do
+    context 'when the veteran gives no treatment centers' do
+      before do
+        subject.instance_variable_set(
+          :@form_content,
+          'form526' => {
+            'treatments' => []
+          }
+        )
+      end
+      it 'should delete the "treatments" key' do
+        subject.send(:translate_treatments)
+        expect(
+          subject.instance_variable_get(:@form_content).dig('form526', 'treatments')
+        ).to eq nil
+      end
+    end
+  end
+
   describe '#translate_homelessness' do
     context 'when the veteran is not homeless' do
       before do


### PR DESCRIPTION
## Background
Fix for the `treatments` key in the form526 submission being an empty list (instead of a `nil` value or the key not existing at all)

## Definition of Done

- [x] delete `treatments` hash key if it contains an empty list
- [x] Appropriate test coverage & logging
