### PR TITLE
Revert changes for name substitution/truncation in disabilities prefill

### DIFF
--- a/app/models/form_profiles/va526ez.rb
+++ b/app/models/form_profiles/va526ez.rb
@@ -19,10 +19,6 @@ module VA526ez
     attribute :rating_decision_id, String
     attribute :diagnostic_code, Integer
     attribute :rating_percentage, Integer
-
-    def name=(value)
-      super value.gsub(/[()]/, '').tr('/', ' ').truncate(250)
-    end
   end
 
   class FormRatedDisabilities


### PR DESCRIPTION
## Background
Revert changes to `name` field on va526 form prefill due to requirement changes.
