### PR TITLE
Add a service config entry for 526 form submit endpoint

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -198,6 +198,12 @@
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: 'va_eauth_pnid'
+  - :method: :post
+    :path: "/wss-form526-services-web/rest/form526/v1/submit"
+    :file_path: "evss/disability_form/submit"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: 'va_eauth_pnid'
 
   # Letters
   - :method: :get


### PR DESCRIPTION
## Background
For local testing, the submit endpoint for form 526 needs to have a configuration entry for betamocks.
