### PR TITLE
Shorten 526ez addresses in specs to match max length changes to schema.

### DIFF
--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -360,7 +360,7 @@ RSpec.describe FormProfile, type: :model do
           'city' => 'Washington',
           'state' => 'DC',
           'zipCode' => '20011',
-          'addressLine1' => '140 Rock Creek Church Rd NW'
+          'addressLine1' => '140 Rock Creek Rd'
         },
         'primaryPhone' => '4445551212',
         'emailAddress' => 'test2@test1.net'

--- a/spec/support/vcr_cassettes/evss/pciu_address/address_domestic.yml
+++ b/spec/support/vcr_cassettes/evss/pciu_address/address_domestic.yml
@@ -62,7 +62,7 @@ http_interactions:
         {
           "cnpMailingAddress" : {
             "addressEffectiveDate" : "2012-04-03T04:00:00.000+0000",
-            "addressOne" : "140 Rock Creek Church Rd NW",
+            "addressOne" : "140 Rock Creek Rd",
             "addressThree" : "",
             "addressTwo" : "",
             "city" : "Washington",


### PR DESCRIPTION
## Background
[A schema update](https://github.com/department-of-veterans-affairs/vets-json-schema/commit/8814cd9d73e3eda8daab363716f57c9f9ea43054) shortened the allowed length of addresses for form 526EZ, causing some specs to fail in vets-api.

## Definition of Done

- [x] Appropriate test coverage & logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
