### PR TITLE
Iteration of the GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,12 @@
 
 ## Definition of Done
 
+#### Unique to this PR
+
 - [ ] _Replace this line with individual tasks unique to your PR_
+
+#### Applies to all PRs
+
 - [ ] Appropriate test coverage & logging
 - [ ] Swagger docs have been updated, if applicable
 - [ ] Provide link to originating GitHub issue, or connected to it via ZenHub


### PR DESCRIPTION
## Background

The new [GitHub PR template](https://github.com/department-of-veterans-affairs/vets-api/blob/update-pr-template/.github/PULL_REQUEST_TEMPLATE.md) was just released, and after seeing it in use, I am already seeing an opportunity for improvement.

Regarding the "Definition of Done" section, we want to be sure that the recurring reminder tasks that apply to all new PRs do not drown out, or compete with, the important tasks that are unique to the given PR in question.

For example, a code reviewer should not have to work hard to discern the tasks that are unique to this PR, that they need to be aware of, versus the tasks that apply to every PR, that globally need to be on the author's radar.

## Definition of Done

- [x] Creates a visual delineation between the tasks that are **unique to this PR** vs the tasks that **apply to all PRs**

## Screenshot

Here is how the template would now look:

![image](https://user-images.githubusercontent.com/7482329/42908601-9d160b56-8a9e-11e8-9360-be14f225132d.png)



