### PR TITLE
setup-osx:  remove mvi mock responses

### DIFF
--- a/bin/setup-osx
+++ b/bin/setup-osx
@@ -138,8 +138,6 @@ bundle exec overcommit --install --sign
 
 rake db:create db:setup db:seed
 
-cp config/mvi_schema/mock_mvi_responses.yml.example config/mvi_schema/mock_mvi_responses.yml
-
 # Run a test to make sure things are working after setup
 
 rake


### PR DESCRIPTION
## Background
<!-- What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary -->

## Definition of Done

- [x] remove line that was made invalid by [previous commit](git push --set-upstream origin setup-osx-betamocks)
- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
