### PR TITLE
526 remove special issues

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation.rb
+++ b/lib/evss/disability_compensation_form/data_translation.rb
@@ -16,6 +16,7 @@ module EVSS
         translate_service_info
         translate_veteran
         translate_treatments
+        translate_disabilities
 
         @form_content.compact.to_json
       end
@@ -32,6 +33,10 @@ module EVSS
 
       def veteran
         form['veteran']
+      end
+
+      def disabilities
+        form['disabilities']
       end
 
       def translate_service_info
@@ -205,6 +210,12 @@ module EVSS
             'treatmentCenterType'
           ).compact
         end
+      end
+
+      def translate_disabilities
+        # The EVSS API does not support `specialIssues` currently. Including it in
+        # the submission will trigger an error response.
+        disabilities.each { |d| d.delete('specialIssues') }
       end
 
       def application_expiration_date

--- a/spec/lib/evss/disability_compensation_form/data_translation_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_spec.rb
@@ -189,6 +189,29 @@ describe EVSS::DisabilityCompensationForm::DataTranslation do
     end
   end
 
+  describe '#translate_disabilities' do
+    context 'there are special issues' do
+      before do
+        subject.instance_variable_set(
+          :@form_content,
+          'form526' => {
+            'disabilities' => [
+              {
+                'specialIssues' => [{ 'code' => 'TRM' }]
+              }
+            ]
+          }
+        )
+      end
+      it 'should delete the "specialIssues" key' do
+        subject.send(:translate_disabilities)
+        expect(
+          subject.instance_variable_get(:@form_content).dig('form526', 'disabilities', 0, 'specialIssues')
+        ).to eq nil
+      end
+    end
+  end
+
   describe '#translate_homelessness' do
     context 'when the veteran is not homeless' do
       before do

--- a/spec/support/disability_compensation_form/evss_submission.json
+++ b/spec/support/disability_compensation_form/evss_submission.json
@@ -91,12 +91,6 @@
         "name": "Diabetes mellitus",
         "classificationCode": "string",
         "disabilityActionType": "INCREASE",
-        "specialIssues": [
-          {
-            "code": "TRM",
-            "name": "Personal Trauma PTSD"
-          }
-        ],
         "ratedDisabilityId": "0",
         "diagnosticCode": 5235,
         "secondaryDisabilities": [


### PR DESCRIPTION
## Background
Special issues are not supported on evss submission currently. Therefore this needs to be stripped out of the submission payload otherwise EVSS will throw an error.

## Definition of Done

- [x] Strip out `specialIssues` for `disabilities` in data_translation
- [x] Appropriate test coverage & logging
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
