### PR TITLE
Scopes EDIPI presence counter to service history endpoint

### DIFF
--- a/app/policies/emis_policy.rb
+++ b/app/policies/emis_policy.rb
@@ -2,12 +2,6 @@
 
 EMISPolicy = Struct.new(:user, :emis) do
   def access?
-    if user.edipi.present?
-      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", tags: ['present:true'])
-      true
-    else
-      StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.edipi", tags: ['present:false'])
-      false
-    end
+    user.edipi.present?
   end
 end

--- a/spec/policies/emis_policy_spec.rb
+++ b/spec/policies/emis_policy_spec.rb
@@ -12,10 +12,6 @@ describe EMISPolicy do
       it 'grants access' do
         expect(subject).to permit(user, :emis)
       end
-
-      it 'increments the StatsD success counter' do
-        expect { EMISPolicy.new(user, :emis).access? }.to trigger_statsd_increment('api.emis.edipi')
-      end
     end
 
     context 'with a user who does not have the required emis attributes' do
@@ -23,10 +19,6 @@ describe EMISPolicy do
 
       it 'denies access' do
         expect(subject).to_not permit(user, :emis)
-      end
-
-      it 'increments the StatsD failure counter' do
-        expect { EMISPolicy.new(user, :emis).access? }.to trigger_statsd_increment('api.emis.edipi')
       end
     end
   end

--- a/spec/request/service_history_request_spec.rb
+++ b/spec/request/service_history_request_spec.rb
@@ -28,11 +28,19 @@ RSpec.describe 'service_history', type: :request, skip_emis: true do
           end
         end
 
-        it 'increments the StatsD presence counter' do
+        it 'increments the StatsD service_history presence counter' do
           VCR.use_cassette('emis/get_military_service_episodes/valid') do
             expect do
               get '/v0/profile/service_history', nil, auth_header
             end.to trigger_statsd_increment('api.emis.service_history')
+          end
+        end
+
+        it 'increments the StatsD EDIPI presence counter' do
+          VCR.use_cassette('emis/get_military_service_episodes/valid') do
+            expect do
+              get '/v0/profile/service_history', nil, auth_header
+            end.to trigger_statsd_increment('api.emis.edipi')
           end
         end
       end
@@ -73,10 +81,22 @@ RSpec.describe 'service_history', type: :request, skip_emis: true do
         allow(EMISRedis::MilitaryInformation).to receive_message_chain(:for_user, :service_history) { [] }
       end
 
-      it 'increments the StatsD empty counter' do
+      it 'increments the StatsD service_history empty counter' do
         expect do
           get '/v0/profile/service_history', nil, auth_header
         end.to trigger_statsd_increment('api.emis.service_history')
+      end
+    end
+
+    context 'when user does not have an EDIPI present' do
+      before do
+        allow_any_instance_of(User).to receive(:edipi).and_return(nil)
+      end
+
+      it 'increments the StatsD EDIPI empty counter' do
+        expect do
+          get '/v0/profile/service_history', nil, auth_header
+        end.to trigger_statsd_increment('api.emis.edipi')
       end
     end
   end


### PR DESCRIPTION
## Background
<!-- What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary -->

In https://github.com/department-of-veterans-affairs/vets-api/pull/2104 we are counting when an EDIPI is/is not present; however, that is based on the Pundit policy.

We need it to be scoped to when the `/v0/profile/service_history` endpoint is being requested.

## Definition of Done

- [x] scope EDIPI presence to the `/v0/profile/service_history` endpoint
- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
