### PR TITLE
Add zip for military address

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation.rb
+++ b/lib/evss/disability_compensation_form/data_translation.rb
@@ -154,17 +154,16 @@ module EVSS
       end
 
       def translate_mailing_address(address)
-        pciu_address = { 'country' => address['country'],
-                         'addressLine1' => address['addressLine1'],
-                         'addressLine2' => address['addressLine2'],
-                         'addressLine3' => address['addressLine3'],
-                         'effectiveDate' => address['effectiveDate'] }
+        pciu_address = { 'effectiveDate' => address['effectiveDate'], 'country' => address['country'],
+                         'addressLine1' => address['addressLine1'], 'addressLine2' => address['addressLine2'],
+                         'addressLine3' => address['addressLine3'] }
 
         pciu_address['type'] = get_address_type(address)
 
+        zip_code = split_zip_code(address['zipCode']) if address['zipCode']
+
         case pciu_address['type']
         when 'DOMESTIC'
-          zip_code = split_zip_code(address['zipCode'])
           pciu_address['city'] = address['city']
           pciu_address['state'] = address['state']
           pciu_address['zipFirstFive'] = zip_code.first
@@ -172,6 +171,8 @@ module EVSS
         when 'MILITARY'
           pciu_address['militaryPostOfficeTypeCode'] = address['city']
           pciu_address['militaryStateCode'] = address['state']
+          pciu_address['zipFirstFive'] = zip_code.first
+          pciu_address['zipLastFour'] = zip_code.last
         when 'INTERNATIONAL'
           pciu_address['city'] = address['city']
         end

--- a/spec/lib/evss/disability_compensation_form/data_translation_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_spec.rb
@@ -107,7 +107,8 @@ describe EVSS::DisabilityCompensationForm::DataTranslation do
           'country' => 'USA',
           'addressLine1' => '123 South Frampington St.',
           'state' => 'AA',
-          'city' => 'ASO'
+          'city' => 'ASO',
+          'zipCode' => '12345-6789'
         }
       end
 
@@ -117,7 +118,9 @@ describe EVSS::DisabilityCompensationForm::DataTranslation do
           'country' => 'USA',
           'addressLine1' => '123 South Frampington St.',
           'militaryPostOfficeTypeCode' => 'ASO',
-          'militaryStateCode' => 'AA'
+          'militaryStateCode' => 'AA',
+          'zipFirstFive' => '12345',
+          'zipLastFour' => '6789'
         }
         expect(subject.send(:translate_mailing_address, address)).to eq result_hash
       end

--- a/spec/support/disability_compensation_form/evss_submission.json
+++ b/spec/support/disability_compensation_form/evss_submission.json
@@ -18,6 +18,8 @@
         "militaryStateCode": "AA",
         "militaryPostOfficeTypeCode": "APO",
         "type": "MILITARY",
+        "zipFirstFive": "12345",
+        "zipLastFour": "6789",
         "addressLine1": "1234 de Buen Tono Calle",
         "addressLine2": "Apartamento 567",
         "effectiveDate": "2018-03-29T18:50:03.014Z"

--- a/spec/support/disability_compensation_form/front_end_submission.json
+++ b/spec/support/disability_compensation_form/front_end_submission.json
@@ -17,6 +17,7 @@
         "state": "AA",
         "city": "APO",
         "country": "USA",
+        "zipCode": "12345-6789",
         "effectiveDate": "2018-03-29T18:50:03.014Z"
       },
       "primaryPhone": "2024561111",


### PR DESCRIPTION
## Background
The zip code field(s) were missing for the military addresses. They have been added in.

## Definition of Done

- [x] add zip code parsing for military addresses
- [x] Appropriate test coverage & logging
