### PR TITLE
Update document and zipcode error messages

### DIFF
--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -245,6 +245,29 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
     xit 'sets error status for unexpected attachment part names' do
     end
 
+    it 'sets error status for downstream zip code validation' do
+      allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
+      allow(CentralMail::Service).to receive(:new) { client_stub }
+      allow(faraday_response).to receive(:status).and_return(412)
+      allow(faraday_response).to receive(:body).and_return("Metadata Field Error - Missing zipCode [uuid: #{upload.guid}] ")
+      allow(faraday_response).to receive(:success?).and_return(false)
+      capture_body = nil
+      expect(client_stub).to receive(:upload) { |arg|
+        capture_body = arg
+        faraday_response
+      }
+      described_class.new.perform(upload.guid)
+      expect(capture_body).to be_a(Hash)
+      expect(capture_body).to have_key('metadata')
+      expect(capture_body).to have_key('document')
+      metadata = JSON.parse(capture_body['metadata'])
+      expect(metadata['uuid']).to eq(upload.guid)
+      updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
+      expect(updated.status).to eq('error')
+      expect(updated.code).to eq('DOC104')
+      expect(updated.detail).to eq('Downstream status: 412 - Missing ZIP Code. ZIP Code must be 5 digits, or 9 digits in XXXXX-XXXX format. Specify \'00000\' for non-US addresses.')
+    end
+
     it 'sets error status for downstream server error' do
       allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
       allow(CentralMail::Service).to receive(:new) { client_stub }


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets-contrib#210

## Background
Since Vet Pro passes on error message directly from our API to uses we want to make sure the messages returned for the two most common errors  are as clear as possible

## Definition of Done

#### Unique to this PR

- [ ] Update error messages with the ones discussed in department-of-veterans-affairs/vets-contrib#210

#### Applies to all PRs

- [ ] Appropriate test coverage & logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
