### PR TITLE
Add disability rating service endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'appeals_api', path: 'modules/appeals_api'
 gem 'va_facilities', path: 'modules/va_facilities'
 gem 'vba_documents', path: 'modules/vba_documents'
+gem 'veteran_verification', path: 'modules/veteran_verification'
 
 # Anchored versions, do not change
 gem 'puma', '~> 2.16.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,12 @@ PATH
       rails (~> 4.2.7.1)
       sidekiq
 
+PATH
+  remote: modules/veteran_verification
+  specs:
+    veteran_verification (0.0.1)
+      rails (~> 4.2.7.1)
+
 GEM
   remote: https://rubygems.org/
   remote: https://enterprise.contribsys.com/
@@ -1163,6 +1169,7 @@ DEPENDENCIES
   va_facilities!
   vba_documents!
   vcr
+  veteran_verification!
   vets_json_schema!
   virtus
   web-console (~> 2.0)

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,8 @@ unless Rails.env.production?
         'spec/**/*_spec.rb',
         'modules/vba_documents/spec/**/*_spec.rb',
         'modules/appeals_api/spec/**/*_spec.rb',
-        'modules/va_facilities/spec/**/*_spec.rb'
+        'modules/va_facilities/spec/**/*_spec.rb',
+        'modules/veteran_verification/spec/**/*_spec.rb'
       ]
     )
     t.verbose = false

--- a/app/models/emis_redis/military_information.rb
+++ b/app/models/emis_redis/military_information.rb
@@ -13,6 +13,19 @@ module EMISRedis
       'K' => 'dishonorable'
     }.freeze
 
+    EXTERNAL_DISCHARGE_TYPES = {
+      'A' => 'honorable',
+      'B' => 'general',
+      'D' => 'bad-conduct',
+      'E' => 'other-than-honorable',
+      'F' => 'dishonorable',
+      'H' => 'honorable-absence-of-negative-report',
+      'J' => 'honorable-for-va-purposes',
+      'K' => 'dishonorable-for-va-purposes',
+      'Y' => 'uncharacterized',
+      'Z' => 'unknown'
+    }.freeze
+
     PREFILL_METHODS = %i[
       hca_last_service_branch
       last_service_branch

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,7 @@ Rails.application.routes.draw do
     mount VBADocuments::Engine, at: '/vba_documents'
     mount AppealsApi::Engine, at: '/appeals'
     mount VaFacilities::Engine, at: '/va_facilities'
+    mount VeteranVerification::Engine, at: '/veteran_verification'
   end
 
   if Rails.env.development? || Settings.sidekiq_admin_panel

--- a/lib/evss/disability_compensation_form/rated_disabilities.rb
+++ b/lib/evss/disability_compensation_form/rated_disabilities.rb
@@ -6,6 +6,7 @@ require 'evss/disability_compensation_form/special_issue'
 module EVSS
   module DisabilityCompensationForm
     class RatedDisability
+      include ActiveModel::Serialization
       include Virtus.model
 
       attribute :decision_code, String
@@ -24,6 +25,10 @@ module EVSS
       def initialize(attrs)
         super(attrs)
         self.name = attrs['diagnostic_text']
+      end
+
+      def id
+        rated_disability_id
       end
     end
   end

--- a/modules/appeals_api/appeals_api.gemspec
+++ b/modules/appeals_api/appeals_api.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://api.vets.gov/services/appeals/docs/v0'
   s.summary     = 'Caseflow appeals status'
   s.description = 'Caseflow appeals status API'
-  s.license     = 'MIT'
+  s.license     = 'CC0'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['spec/**/*']

--- a/modules/va_facilities/va_facilities.gemspec
+++ b/modules/va_facilities/va_facilities.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://api.vets.gov/services/facilities/docs/v0'
   s.summary     = 'VA Facilities'
   s.description = 'VA Facilities API'
-  s.license     = 'MIT'
+  s.license     = 'CC0'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile']
   s.test_files = Dir['spec/**/*']

--- a/modules/vba_documents/vba_documents.gemspec
+++ b/modules/vba_documents/vba_documents.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://api.vets.gov/services/vba_documents/docs/v0'
   s.summary     = 'VBA Documents Upload'
   s.description = 'VBA Documents Upload API'
-  s.license     = 'MIT'
+  s.license     = 'CC0'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile']
   s.test_files = Dir['spec/**/*']

--- a/modules/veteran_verification/.gitignore
+++ b/modules/veteran_verification/.gitignore
@@ -1,0 +1,3 @@
+.bundle/
+log/*.log
+pkg/

--- a/modules/veteran_verification/.rspec
+++ b/modules/veteran_verification/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/modules/veteran_verification/.rubocop.yml
+++ b/modules/veteran_verification/.rubocop.yml
@@ -1,0 +1,14 @@
+inherit_from:
+  - ../../.rubocop.yml
+
+AllCops:
+  Exclude:
+    - 'bin/*'
+    - bin/rails
+    - db/migrate/*.rb
+    - 'spec/dummy/**/*'
+    - spec/dummy/db/schema.rb
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*.rb

--- a/modules/veteran_verification/DISABILITY_RATING.yml
+++ b/modules/veteran_verification/DISABILITY_RATING.yml
@@ -7,28 +7,19 @@ info:
 
     ## Backgroun
 
-    This API is provided as a proof of concept for a general-purpose VA
-    API that allows Veterans to provide authorization to a third-party to access
-    information on their behalf. The use-case of this API is to allow third-parties
-    to access the service history of a Veteran after receiving authorization to
-    do so using an Open ID Connect flow.
+    This API is provided as a proof of concept for a general-purpose VA API that allows Veterans to provide authorization to a third-party to access information on their behalf. The use-case of this API is to allow third-parties to access the service history of a Veteran after receiving authorization to do so using an Open ID Connect flow.
 
-    The Disability Rating API passes requests through to eMIS, the Enterprise
-    Military Information Service, and formats the response into consumable data.
+    The Disability Rating API passes requests through to EVSS, the Electronic Veterans Self Service, and formats the response into consumable data.
 
     ## Design
 
     ### Authorization
 
-    API requests are authorized using a Bearer token issued through an OpenID
-    Connect service to permit access to Veteran information to third-party
-    applications. The token should be submitted as an `Authorization` header
-    in the form `Bearer <token>`.
+    API requests are authorized using a Bearer token issued through an OpenID Connect service to permit access to Veteran information to third-party applications. The token should be submitted as an `Authorization` header in the form `Bearer <token>`.
 
     ### Disability Rating Request
 
-    Allows a third-party application to request a Veteran's disability rating with
-    the authorization of the Veteran.
+    Allows a third-party application to request a Veteran's disability rating with the authorization of the Veteran.
 
     1. Client Request: GET https://api.vets.gov/services/veteran_verification/v0/diability_rating
        *  Provide the Bearer token as a header: `Authorization: Bearer <token>`
@@ -59,7 +50,7 @@ paths:
       summary: Retrieve disability rating of authorized Veteran
       operationId: getDisabilityRating
       security:
-        - bearer_token: []
+        - bearerAuth: []
       responses:
         '200':
           description: Disability Rating retrieved successfully
@@ -73,10 +64,53 @@ paths:
                     $ref: '#/components/schemas/DisabilityRating'
         '404':
           description: No disability ratings found
-                
-
-
-    
-
-
-    
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: token
+  schemas:
+    DisabilityRating:
+      description: |
+        The disability rating percentage applied to the Veteran.
+      required:
+        - id
+        - type
+        - atttributes
+      properties:
+        id:
+          description: JSON API identifier
+          type: string
+          format: uuid
+          example: 6d8433c1-cd55-4c24-affd-f592287a7572
+        type:
+          description: JSON API type specification
+          type: string
+          example: 'document_upload'
+        attributes:
+          $ref: '#/components/schemas/RatingAttributes'
+    RatingAttributes:
+      description: |
+        Body of the disability rating response
+      required:
+        - decision
+        - effective_date
+        - rating_percentage
+      properties:
+        decision:
+          description: Whether the disability is service connected or not
+          type: string
+          example: 'Service Connected'
+        effective_date:
+          description: When the Veteran could begin claiming benefits related to this disability
+          type: string
+          format: datetime
+          example: "2018-03-27T21:00:41.000+0000"
+        rating_percentage:
+          description: Amount the Veteran is disability from this particular disability. Used to calculate disability pay and benefits
+          type: number
+          example: 50
+          
+      
+          

--- a/modules/veteran_verification/DISABILITY_RATING.yml
+++ b/modules/veteran_verification/DISABILITY_RATING.yml
@@ -1,0 +1,82 @@
+openapi: '3.0.0'
+info:
+  version: 0.0.1
+  title: Disability Rating
+  description: |
+    Veteran Verification - Disability Rating
+
+    ## Backgroun
+
+    This API is provided as a proof of concept for a general-purpose VA
+    API that allows Veterans to provide authorization to a third-party to access
+    information on their behalf. The use-case of this API is to allow third-parties
+    to access the service history of a Veteran after receiving authorization to
+    do so using an Open ID Connect flow.
+
+    The Disability Rating API passes requests through to eMIS, the Enterprise
+    Military Information Service, and formats the response into consumable data.
+
+    ## Design
+
+    ### Authorization
+
+    API requests are authorized using a Bearer token issued through an OpenID
+    Connect service to permit access to Veteran information to third-party
+    applications. The token should be submitted as an `Authorization` header
+    in the form `Bearer <token>`.
+
+    ### Disability Rating Request
+
+    Allows a third-party application to request a Veteran's disability rating with
+    the authorization of the Veteran.
+
+    1. Client Request: GET https://api.vets.gov/services/veteran_verification/v0/diability_rating
+       *  Provide the Bearer token as a header: `Authorization: Bearer <token>`
+
+    2. Service Response: A JSON API object with the Veteran's disability rating
+
+    ## Reference
+
+    Raw Open API Spec: https://dev-api.vets.gov/services/appeals/docs/v0/api
+
+  termsOfService: ''
+  contact:
+    name: Vets.gov
+tags:
+  - name: disability_rating
+    description: Veteran Verification - Disability Rating
+servers:
+  - url: https://dev-api.vets.gov/services/veteran_verification/{version}
+    description: Vets.gov API development environment
+    variables:
+      version:
+        default: v0
+paths:
+  /disability_rating:
+    get:
+      tags:
+        - disability_rating
+      summary: Retrieve disability rating of authorized Veteran
+      operationId: getDisabilityRating
+      security:
+        - bearer_token: []
+      responses:
+        '200':
+          description: Disability Rating retrieved successfully
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                propertiesw:
+                  data:
+                    $ref: '#/components/schemas/DisabilityRating'
+        '404':
+          description: No disability ratings found
+                
+
+
+    
+
+
+    

--- a/modules/veteran_verification/DISABILITY_RATING.yml
+++ b/modules/veteran_verification/DISABILITY_RATING.yml
@@ -82,8 +82,7 @@ components:
         id:
           description: JSON API identifier
           type: string
-          format: uuid
-          example: 6d8433c1-cd55-4c24-affd-f592287a7572
+          example: 12303
         type:
           description: JSON API type specification
           type: string

--- a/modules/veteran_verification/DISABILITY_RATING.yml
+++ b/modules/veteran_verification/DISABILITY_RATING.yml
@@ -5,7 +5,7 @@ info:
   description: |
     Veteran Verification - Disability Rating
 
-    ## Backgroun
+    ## Background
 
     This API is provided as a proof of concept for a general-purpose VA API that allows Veterans to provide authorization to a third-party to access information on their behalf. The use-case of this API is to allow third-parties to access the service history of a Veteran after receiving authorization to do so using an Open ID Connect flow.
 
@@ -107,7 +107,7 @@ components:
           format: datetime
           example: "2018-03-27T21:00:41.000+0000"
         rating_percentage:
-          description: Amount the VA has determine a Veteran is disabled from this particular disability. Used to calculate disability pay and benefits
+          description: Severity rating determined by VA that indicates how disabling an illness or injury is for the Veteran. Used to help determine disability compensation (pay) and related benefits.
           type: number
           example: 50
           

--- a/modules/veteran_verification/DISABILITY_RATING.yml
+++ b/modules/veteran_verification/DISABILITY_RATING.yml
@@ -98,7 +98,7 @@ components:
         - rating_percentage
       properties:
         decision:
-          description: Whether the disability is service connected or not
+          description: Whether the disability is service connected or not. 
           type: string
           example: 'Service Connected'
         effective_date:
@@ -107,7 +107,7 @@ components:
           format: datetime
           example: "2018-03-27T21:00:41.000+0000"
         rating_percentage:
-          description: Amount the Veteran is disability from this particular disability. Used to calculate disability pay and benefits
+          description: Amount the VA has determine a Veteran is disabled from this particular disability. Used to calculate disability pay and benefits
           type: number
           example: 50
           

--- a/modules/veteran_verification/Gemfile
+++ b/modules/veteran_verification/Gemfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Declare your gem's dependencies in veteran_verification.gemspec.
+# Bundler will treat runtime dependencies like base dependencies, and
+# development dependencies will be added by default to the :development group.
+gemspec
+
+# Declare any dependencies that are still in development here instead of in
+# your gemspec. These might include edge Rails or gems from your path or
+# Git. Remember to move these dependencies to your gemspec before releasing
+# your gem to rubygems.org.
+
+# To use a debugger
+# gem 'byebug', group: [:development, :test]

--- a/modules/veteran_verification/MIT-LICENSE
+++ b/modules/veteran_verification/MIT-LICENSE
@@ -1,0 +1,20 @@
+Copyright 2018 
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/modules/veteran_verification/README.rdoc
+++ b/modules/veteran_verification/README.rdoc
@@ -1,0 +1,3 @@
+= VeteranVerification
+
+This project rocks and uses MIT-LICENSE.

--- a/modules/veteran_verification/Rakefile
+++ b/modules/veteran_verification/Rakefile
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+require 'rdoc/task'
+
+RDoc::Task.new(:rdoc) do |rdoc|
+  rdoc.rdoc_dir = 'rdoc'
+  rdoc.title    = 'VeteranVerification'
+  rdoc.options << '--line-numbers'
+  rdoc.rdoc_files.include('README.rdoc')
+  rdoc.rdoc_files.include('lib/**/*.rb')
+end
+
+load 'rails/tasks/statistics.rake'
+
+Bundler::GemHelper.install_tasks

--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -1,0 +1,142 @@
+openapi: '3.0.0'
+info:
+  version: 0.0.1
+  title: Service History
+  description: |
+    Veteran Verification - Service History
+
+    ## Background
+
+    This API is provide provided as a proof of concept for a general-purpose VA
+    API that allows Veterans to provide authorization to a third-party to access
+    information on their behalf. The use-case of this API is to allow third-parties
+    to access the service history of a Veteran after receiving authorization to
+    do so using an Open ID Connect flow.
+
+    The Service History API passes requests through to eMIS, the Enterprise
+    Military Information Service, and formats the response into consumable data.
+
+    ## Design
+
+    ### Authorization
+
+    API requests are authorized using a Bearer token issued through an OpenID
+    Connect service to allow third-party applications. The token should be
+    submitted as an `Authorization` header in the form `Bearer <toekn>`.
+
+    ### Service History Request
+
+    Allows a third-party application to request service history with the authorization
+    of a Veteran.
+
+    1. Client Request: GET https://api.vets.gov/services/veteran_verification/v0/service_history
+       * Provide the Bearer token as a header: `Authorization: Bearer <token>`
+
+    2. Service Response: A JSON API object with the Veteran's complete service history
+
+    ## Reference
+
+    Raw Open API Spec: http://dev-api.vets.gov/services/appeals/docs/v0/api
+
+  termsOfService: ''
+  contact:
+    name: Vets.gov
+tags:
+  - name: service_history
+    description: Veteran Verification - Service History
+servers:
+  - url: .vets.gov/services/veteran_verification/{version}
+    description: Vets.gov API development environment
+    variables:
+      version:
+        default: v0
+paths:
+  /service_history:
+    get:
+      tags:
+        - service_history
+      summary: Retrieve service history of authorized Veteran
+      operationId: getServiceHistory
+      security:
+        - bearer_token: []
+      resposnes:
+        '200':
+          description: Service History retrieved successfully
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/components/schemas/ServiceHistoryEpisode'
+        '404':
+          description: No service history found
+components:
+  securitySchemes:
+    bearer_token:
+      type: http
+      scheme: bearer
+  schemas:
+    ServiceHistoryEpisode:
+      description: |
+        Service History for authorized Veteran
+      type: object
+      properties:
+        id:
+          type: string
+          description: Service History Episode ID from eMIS
+          example: "12312AASDf"
+        type:
+          type: string
+          example: service-history-episodes
+        attributes:
+          type: object
+          properties:
+            start_date:
+              type: string
+              format: date
+              description: start date of a service history episode (YYYY-mm-dd)
+              example: '1948-04-08'
+            end_date:
+              type: string
+              format: date
+              description: end date of a service history episode (YYYY-mm-dd)
+              example: '1950-05-10'
+            branch:
+              type: string
+              description: Branch of military including National Guard or Reserve status
+              example: "Air Force"
+            discharge_status:
+              type: string
+              description: status level of discharge from service history episode
+              enum:
+                - honorable
+                - general
+                - bad-conduct
+                - dishonorable
+                - other
+              example: honorable
+            deployments:
+              type: array
+              items:
+                $ref: #/components/schemas/Deployment
+    Deployment:
+      description: |
+        Deployment during a service history episode
+      type: object
+      properties:
+        start_date:
+          type: string
+          format: date
+          description: beginning of deployment (YYYY-mm-dd)
+          example: '1948-10-10'
+        end_date:
+          type: string
+          format: date
+          description: end of deployment (YYYY-mm-dd)
+          example: '1949-10-09'
+        location:
+          type: string
+          description: Three letter ISO country code of deployment location
+          example: KOR

--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -7,7 +7,7 @@ info:
 
     ## Background
 
-    This API is provide provided as a proof of concept for a general-purpose VA
+    This API is provided as a proof of concept for a general-purpose VA
     API that allows Veterans to provide authorization to a third-party to access
     information on their behalf. The use-case of this API is to allow third-parties
     to access the service history of a Veteran after receiving authorization to
@@ -45,7 +45,7 @@ tags:
   - name: service_history
     description: Veteran Verification - Service History
 servers:
-  - url: .vets.gov/services/veteran_verification/{version}
+  - url: https://dev-api.vets.gov/services/veteran_verification/{version}
     description: Vets.gov API development environment
     variables:
       version:
@@ -59,7 +59,7 @@ paths:
       operationId: getServiceHistory
       security:
         - bearer_token: []
-      resposnes:
+      responses:
         '200':
           description: Service History retrieved successfully
           content:

--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -109,7 +109,8 @@ components:
               example: "Air Force"
             discharge_status:
               type: string
-              description: status level of discharge from service history episode
+              description: |
+                Character of discharge from service episode. These are derived from the following eMIS status codes. A becomes 'honorable'. B is 'general'. D is 'bad-conduct'. F is 'dishonorable'. J was originally a 'bad-conduct' or 'dishonorable', but has been changed to 'honorable' (as reported by this API) via an administrative decision. K was originally a 'bad-conduct' or 'dishonorable' and was determined to still be after an administrative hearing (reported as 'dishonorable' by this API). 
               enum:
                 - honorable
                 - general

--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -110,13 +110,20 @@ components:
             discharge_status:
               type: string
               description: |
-                Character of discharge from service episode. These are derived from the following eMIS status codes. A becomes 'honorable'. B is 'general'. D is 'bad-conduct'. F is 'dishonorable'. J was originally a 'bad-conduct' or 'dishonorable', but has been changed to 'honorable' (as reported by this API) via an administrative decision. K was originally a 'bad-conduct' or 'dishonorable' and was determined to still be after an administrative hearing (reported as 'dishonorable' by this API). 
+                Character of discharge from service episode. Possible values are:
+
+                Both "honorable-for-va-purposes" and "dishonorable-for-va-purposes" represent a change in character of discharge based on an administrative decision, for purposes of VA benefits administration. The original character of discharge for other purposes was either "bad-conduct" or "other-than-honorable". "honorable-absence-of-negative-report" represents a an unreported character of service that DoD classifies as honorable.
               enum:
                 - honorable
                 - general
                 - bad-conduct
+                - other-than-honorable
                 - dishonorable
-                - other
+                - honorable-absence-of-negative-report
+                - honorable-for-va-purposes
+                - dishonorable-for-va-purposes
+                - uncharacterized
+                - unknown
               example: honorable
             deployments:
               type: array

--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -85,7 +85,7 @@ components:
       properties:
         id:
           type: string
-          description: Service History Episode ID from eMIS
+          description: Service History Episode ID
           example: "12312AASDf"
         type:
           type: string

--- a/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module VeteranVerification
+  class ApplicationController < ::ApplicationController
+    skip_before_action :set_tags_and_extra_content
+  end
+end

--- a/modules/veteran_verification/app/controllers/veteran_verification/docs/v0/api_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/docs/v0/api_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module VeteranVerification
+  module Docs
+    module V0
+      class ApiController < ApplicationController
+        skip_before_action(:authenticate)
+
+        def history
+          swagger = YAML.safe_load(File.read(VeteranVerification::Engine.root.join('SERVICE_HISTORY.yml')))
+          render json: swagger
+        end
+      end
+    end
+  end
+end

--- a/modules/veteran_verification/app/controllers/veteran_verification/docs/v0/api_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/docs/v0/api_controller.rb
@@ -10,6 +10,11 @@ module VeteranVerification
           swagger = YAML.safe_load(File.read(VeteranVerification::Engine.root.join('SERVICE_HISTORY.yml')))
           render json: swagger
         end
+
+        def rating
+          swagger = YAML.safe_load(File.read(VeteranVerification::Engine.root.join('DISABILITY_RATING.yml')))
+          render json: swagger
+        end
       end
     end
   end

--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/disability_rating_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/disability_rating_controller.rb
@@ -1,0 +1,9 @@
+module VeteranVerification
+  module V0
+    class DisabilityRatingController < ApplicationController
+      def index
+        render json: {}
+      end
+    end
+  end
+end

--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/disability_rating_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/disability_rating_controller.rb
@@ -1,8 +1,20 @@
+# frozen_string_literal: true
+
 module VeteranVerification
   module V0
     class DisabilityRatingController < ApplicationController
+      before_action { authorize :evss, :access? }
+
       def index
-        render json: {}
+        response = service.get_rated_disabilities
+        render json: response.rated_disabilities,
+               each_serializer: VeteranVerification::DisabilityRatingSerializer
+      end
+
+      private
+
+      def service
+        EVSS::DisabilityCompensationForm::Service.new(@current_user)
       end
     end
   end

--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/disability_rating_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/disability_rating_controller.rb
@@ -18,7 +18,8 @@ module VeteranVerification
       end
 
       def auth_headers
-        EVSS::DisabilityCompensationAuthHeaders.new(@current_user).add_headers(EVSS::AuthHeaders.new(@current_user).to_h)
+        EVSS::DisabilityCompensationAuthHeaders.new(@current_user)
+          .add_headers(EVSS::AuthHeaders.new(@current_user).to_h)
       end
     end
   end

--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/disability_rating_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/disability_rating_controller.rb
@@ -18,8 +18,8 @@ module VeteranVerification
       end
 
       def auth_headers
-        EVSS::DisabilityCompensationAuthHeaders.new(@current_user)
-          .add_headers(EVSS::AuthHeaders.new(@current_user).to_h)
+        headers = EVSS::DisabilityCompensationAuthHeaders.new(@current_user)
+        headers.add_headers(EVSS::AuthHeaders.new(@current_user).to_h)
       end
     end
   end

--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/disability_rating_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/disability_rating_controller.rb
@@ -14,7 +14,11 @@ module VeteranVerification
       private
 
       def service
-        EVSS::DisabilityCompensationForm::Service.new(@current_user)
+        EVSS::DisabilityCompensationForm::Service.new(auth_headers)
+      end
+
+      def auth_headers
+        EVSS::DisabilityCompensationAuthHeaders.new(@current_user).add_headers(EVSS::AuthHeaders.new(@current_user).to_h)
       end
     end
   end

--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/service_history_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/service_history_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module VeteranVerification
+  module V0
+    class ServiceHistoryController < ApplicationController
+      before_action { authorize :emis, :access? }
+
+      def index
+        response = ServiceHistoryEpisode.for_user(@current_user)
+
+        render json: response, each_serializer: VeteranVerification::ServiceHistorySerializer
+      end
+    end
+  end
+end

--- a/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
+++ b/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/digest/uuid'
+
+module VeteranVerification
+  class ServiceHistoryEpisode
+    include ActiveModel::Serialization
+    include Virtus.model
+
+    attribute :id, String
+    attribute :branch_of_service, String
+    attribute :end_date, Date
+    attribute :deployments, Array
+    attribute :discharge_type, String
+    attribute :start_date, Date
+
+    def self.for_user(user)
+      emis = EMISRedis::MilitaryInformation.for_user(user)
+      handle_errors!(emis)
+      episodes(emis, user)
+    end
+
+    def self.handle_errors!(emis)
+      raise_error! unless emis.service_history.is_a?(Array)
+    end
+
+    def self.raise_error!
+      raise Common::Exceptions::BackendServiceException.new(
+        'EMIS_HIST502',
+        source: self.class.to_s
+      )
+    end
+
+    def self.episodes(emis, user)
+      emis.service_episodes_by_date.map do |episode|
+        ServiceHistoryEpisode.new(
+          id: episode_identifier(episode, user),
+          branch_of_service: emis.build_service_branch(episode),
+          end_date: episode.end_date,
+          deployments: deployments(emis, episode),
+          discharge_type: episode.discharge_character_of_service_code,
+          start_date: episode.begin_date
+        )
+      end
+    end
+
+    def self.episode_identifier(episode, user)
+      Digest::UUID.uuid_v5(
+        'gov.vets.service-history-episodes',
+        "#{user.uuid}-#{episode.begin_date}-#{episode.end_date}"
+      )
+    end
+
+    def self.deployments(emis, episode)
+      deployments_for_episode = emis.deployments.select do |dep|
+        (dep.begin_date >= episode.begin_date) && (dep.end_date <= episode.end_date)
+      end
+
+      deployments_for_episode.map do |dep|
+        {
+          start_date: dep.begin_date,
+          end_date: dep.end_date,
+          location: dep.locations[0].iso_alpha3_country
+        }
+      end
+    end
+
+    def discharge_status
+      EMISRedis::MilitaryInformation::DISCHARGE_TYPES[discharge_type] || 'other'
+    end
+  end
+end

--- a/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
+++ b/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
@@ -66,7 +66,7 @@ module VeteranVerification
     end
 
     def discharge_status
-      EMISRedis::MilitaryInformation::DISCHARGE_TYPES[discharge_type] || 'other'
+      EMISRedis::MilitaryInformation::EXTERNAL_DISCHARGE_TYPES[discharge_type] || 'unknown'
     end
   end
 end

--- a/modules/veteran_verification/app/serializers/veteran_verification/disability_rating_serializer.rb
+++ b/modules/veteran_verification/app/serializers/veteran_verification/disability_rating_serializer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module VeteranVerification
+  class DisabilityRatingSerializer < ActiveModel::Serializer
+    attributes :rating_percentage, :effective_date, :decision
+    type 'disability_ratings'
+
+    def decision
+      object.decision_text
+    end
+  end
+end

--- a/modules/veteran_verification/app/serializers/veteran_verification/service_history_serializer.rb
+++ b/modules/veteran_verification/app/serializers/veteran_verification/service_history_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module VeteranVerification
+  class ServiceHistorySerializer < ActiveModel::Serializer
+    attributes :branch_of_service, :start_date, :end_date, :discharge_status, :deployments
+    type 'service_history_episodes'
+  end
+end

--- a/modules/veteran_verification/bin/rails
+++ b/modules/veteran_verification/bin/rails
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+ENGINE_ROOT = File.expand_path('../..', __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/veteran_verification/engine', __FILE__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails/all'
+require 'rails/engine/commands'

--- a/modules/veteran_verification/config/routes.rb
+++ b/modules/veteran_verification/config/routes.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+VeteranVerification::Engine.routes.draw do
+  match '/v0/*path', to: 'application#cors_preflight', via: [:options]
+
+  namespace :v0, defaults: { format: 'json' } do
+    resources :service_history, only: [:index]
+  end
+
+  namespace :docs do
+    namespace :v0, defaults: { format: 'json' } do
+      get 'service_history', to: 'api#history'
+    end
+  end
+end

--- a/modules/veteran_verification/config/routes.rb
+++ b/modules/veteran_verification/config/routes.rb
@@ -5,11 +5,13 @@ VeteranVerification::Engine.routes.draw do
 
   namespace :v0, defaults: { format: 'json' } do
     resources :service_history, only: [:index]
+    resources :disability_rating, only: [:index]
   end
 
   namespace :docs do
     namespace :v0, defaults: { format: 'json' } do
       get 'service_history', to: 'api#history'
+      get 'disability_rating', to: 'api#rating'
     end
   end
 end

--- a/modules/veteran_verification/lib/tasks/veteran_verification_tasks.rake
+++ b/modules/veteran_verification/lib/tasks/veteran_verification_tasks.rake
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# desc "Explaining what the task does"
+# task :veteran_verification do
+#   # Task goes here
+# end

--- a/modules/veteran_verification/lib/veteran_verification.rb
+++ b/modules/veteran_verification/lib/veteran_verification.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'veteran_verification/engine'
+
+module VeteranVerification
+end

--- a/modules/veteran_verification/lib/veteran_verification/engine.rb
+++ b/modules/veteran_verification/lib/veteran_verification/engine.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module VeteranVerification
+  class Engine < ::Rails::Engine
+    isolate_namespace VeteranVerification
+  end
+end

--- a/modules/veteran_verification/lib/veteran_verification/version.rb
+++ b/modules/veteran_verification/lib/veteran_verification/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module VeteranVerification
+  VERSION = '0.0.1'
+end

--- a/modules/veteran_verification/spec/models/service_history_episode_spec.rb
+++ b/modules/veteran_verification/spec/models/service_history_episode_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe VeteranVerification::ServiceHistoryEpisode, skip_emis: true do
+  let(:user) { build(:user, :loa3) }
+
+  describe '#formatted_episodes' do
+    it 'should return service history and deployments' do
+      VCR.use_cassette('emis/get_deployment/valid') do
+        VCR.use_cassette('emis/get_military_service_episodes/valid') do
+          result = described_class.for_user(user)
+          expect(result.length).to eq(1)
+          expect(result[0][:branch_of_service]).to eq('Air Force Reserve')
+          expect(result[0][:deployments][0][:location]).to eq('ARE')
+        end
+      end
+    end
+
+    it 'should return service history and deploys when there are multiple episodes' do
+      VCR.use_cassette('emis/get_deployment/valid') do
+        VCR.use_cassette('emis/get_military_service_episodes/valid_multiple_episodes') do
+          result = described_class.for_user(user)
+          expect(result.length).to eq(2)
+          expect(result[0][:branch_of_service]).to eq('Air Force Reserve')
+          expect(result[0][:deployments][0][:location]).to eq('ARE')
+        end
+      end
+    end
+  end
+end

--- a/modules/veteran_verification/spec/rails_helper.rb
+++ b/modules/veteran_verification/spec/rails_helper.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'spec_helper'

--- a/modules/veteran_verification/spec/requests/api_docs_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/api_docs_request_spec.rb
@@ -2,10 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Appeals Status Documentation Endpoint', type: :request do
-  describe '#get /docs/v0/api' do
+RSpec.describe 'Veteran Verification Documentation Endpoints', type: :request do
+  describe '#get /docs/v0/service_history' do
     it 'should return Open API Spec v3 JSON' do
-      get '/services/appeals/docs/v0/api'
+      get '/services/veteran_verification/docs/v0/service_history'
       expect(response).to have_http_status(:ok)
       JSON.parse(response.body)
     end

--- a/modules/veteran_verification/spec/requests/api_docs_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/api_docs_request_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe 'Veteran Verification Documentation Endpoints', type: :request do
       JSON.parse(response.body)
     end
   end
+
+  describe '#get /docs/v0/disability_rating' do
+    it 'should return Open API Spec v3 JSON' do
+      get '/services/veteran_verification/docs/v0/disability_rating'
+      expect(response).to have_http_status(:ok)
+      JSON.parse(response.body)
+    end
+  end
 end

--- a/modules/veteran_verification/spec/requests/disability_rating_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/disability_rating_request_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Disability Rating API endpoint', type: :request, skip_emis: true do
+  include SchemaMatchers
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  context 'with valid emis responses' do
+    it 'should return the current users service history with one episode' do
+      VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
+        get '/services/veteran_verification/v0/disability_rating', nil, auth_header
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to be_a(String)
+        expect(response).to match_response_schema('disability_rating_response')
+      end
+    end
+  end
+
+  context 'with a 500 response' do
+    it 'should return a bad gateway response' do
+      VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_500') do
+        get '/v0/disability_compensation_form/rated_disabilities', nil, auth_header
+        expect(response).to have_http_status(:bad_gateway)
+        expect(response).to match_response_schema('evss_errors', strict: false)
+      end
+    end
+  end
+
+  context 'with a 403 unauthorized response' do
+    it 'should return a not authorized response' do
+      VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_403') do
+        get '/v0/disability_compensation_form/rated_disabilities', nil, auth_header
+        expect(response).to have_http_status(:forbidden)
+        expect(response).to match_response_schema('evss_errors', strict: false)
+      end
+    end
+  end
+
+  context 'with a generic 400 response' do
+    it 'should return a bad request response' do
+      VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_400') do
+        get '/v0/disability_compensation_form/rated_disabilities', nil, auth_header
+        expect(response).to have_http_status(:bad_request)
+        expect(response).to match_response_schema('evss_errors', strict: false)
+      end
+    end
+  end
+end

--- a/modules/veteran_verification/spec/requests/service_history_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/service_history_request_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Service History API endpoint', type: :request, skip_emis: true do
+  include SchemaMatchers
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  context 'with valid emis responses' do
+    it 'should return the current users service history with one episode' do
+      VCR.use_cassette('emis/get_deployment/valid') do
+        VCR.use_cassette('emis/get_military_service_episodes/valid') do
+          get '/services/veteran_verification/v0/service_history', nil, auth_header
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to be_a(String)
+          expect(response).to match_response_schema('service_and_deployment_history_response')
+        end
+      end
+    end
+
+    it 'should return the current users service history with multiple episodes' do
+      VCR.use_cassette('emis/get_deployment/valid') do
+        VCR.use_cassette('emis/get_military_service_episodes/valid_multiple_episodes') do
+          get '/services/veteran_verification/v0/service_history', nil, auth_header
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to be_a(String)
+          expect(JSON.parse(response.body)['data'].length).to eq(2)
+          expect(response).to match_response_schema('service_and_deployment_history_response')
+        end
+      end
+    end
+  end
+
+  context 'when emis response is invalid' do
+    before do
+      allow(EMISRedis::MilitaryInformation).to receive_message_chain(:for_user, :service_history) { nil }
+    end
+
+    it 'should match the errors schema', :aggregate_failures do
+      get '/services/veteran_verification/v0/service_history', nil, auth_header
+
+      expect(response).to have_http_status(:bad_gateway)
+      expect(response).to match_response_schema('errors')
+    end
+  end
+end

--- a/modules/veteran_verification/spec/spec_helper.rb
+++ b/modules/veteran_verification/spec/spec_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Configure Rails Envinronment
+ENV['RAILS_ENV'] = 'test'
+require File.expand_path('../dummy/config/environment.rb', __FILE__)
+
+require 'rspec/rails'
+
+ENGINE_RAILS_ROOT = File.join(File.dirname(__FILE__), '../')
+
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir[File.join(ENGINE_RAILS_ROOT, '../../spec/support/**/*.rb')].each { |f| p require f }
+
+RSpec.configure do |config|
+  config.use_transactional_fixtures = true
+end

--- a/modules/veteran_verification/veteran_verification.gemspec
+++ b/modules/veteran_verification/veteran_verification.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+
+# Maintain your gem's version:
+require 'veteran_verification/version'
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |s|
+  s.name        = 'veteran_verification'
+  s.version     = VeteranVerification::VERSION
+  s.authors     = ['Edward Paget']
+  s.email       = ['ed@adhocteam.us']
+  s.homepage    = 'https://api.vets.gov/services/veteran_verification/docs/v0/api'
+  s.summary     = 'Veteran Verification APIs'
+  s.description = 'Collection of API resources intended for 3rd verification of veteran status and service history'
+  s.license     = 'MIT'
+
+  s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
+  s.test_files = Dir['spec/**/*']
+
+  s.add_dependency 'rails', '~> 4.2.7.1'
+
+  s.add_development_dependency 'rspec-rails'
+end

--- a/modules/veteran_verification/veteran_verification.gemspec
+++ b/modules/veteran_verification/veteran_verification.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://api.vets.gov/services/veteran_verification/docs/v0/api'
   s.summary     = 'Veteran Verification APIs'
   s.description = 'Collection of API resources intended for 3rd verification of veteran status and service history'
-  s.license     = 'MIT'
+  s.license     = 'CC0'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['spec/**/*']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,7 @@ unless ENV['NOCOVERAGE']
     add_group 'VBADocuments', 'modules/vba_documents/'
     add_group 'AppealsApi', 'modules/appeals_api/'
     add_group 'VaFacilities', 'modules/va_facilities/'
+    add_group 'VeteranVerification', 'modules/veteran_verification/'
     add_filter 'version.rb'
     SimpleCov.minimum_coverage_by_file 90
     SimpleCov.refuse_coverage_drop

--- a/spec/support/schemas/disability_rating_response.json
+++ b/spec/support/schemas/disability_rating_response.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "items": {
+        "properties": {
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "decision": {
+                "type": "string"
+              },
+              "rating_percentage": {
+                "type": "number"
+              },
+              "effective_date": {
+                "type": "string"
+              }
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    }
+  }
+}

--- a/spec/support/schemas/service_and_deployment_history_response.json
+++ b/spec/support/schemas/service_and_deployment_history_response.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "items": {
+        "properties": {
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "branch_of_service": {
+                "type": "string"
+              },
+              "start_date": {
+                "type": "string"
+              },
+              "end_date": {
+                "type": "string"
+              },
+              "discharge_status": {
+                "type": "string"
+              },
+              "deployments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "start_date": {
+                      "type": "string"
+                    },
+                    "end_date": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    }
+  }
+}


### PR DESCRIPTION
## Background
Add a service endpoint for disability rating information to be shared for third parties. Like the service history endpoint this is dependent on having Okta or some other oauth provider added. For further information about why the response fields were chosen see [here](https://github.com/department-of-veterans-affairs/vets-contrib/blob/master/lighthouse/veteran-verification/disability-rating.md).

## Definition of Done

#### Unique to this PR

- [x] Add a `/services/veteran_verification/v0/disability_rating` endpoint

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
