### PR TITLE
Favors not passing the “noFilter” param in iHub production call

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -62,6 +62,7 @@ ihub:
   appointments:
     timeout: 30
     mock: false
+  in_production: false
 
 
 # Settings for EVSS

--- a/lib/ihub/appointments/service.rb
+++ b/lib/ihub/appointments/service.rb
@@ -11,7 +11,8 @@ module IHub
 
       # Fetches a collection of veteran appointment data from iHub.
       #
-      # Per iHub docs, requires a service parameter of noFilter=true.
+      # Per iHub docs, requires a service parameter of noFilter=true,
+      # in non-production environments.
       #
       # @return [IHub::Appointments::Response] Sample response:
       #   {
@@ -47,8 +48,7 @@ module IHub
         raise 'User has no ICN' if @user.icn.blank?
 
         with_monitoring do
-          service_url = "#{@user.icn}?noFilter=true"
-          response    = perform(:get, service_url, nil)
+          response = perform(:get, appointments_url, nil)
 
           IHub::Appointments::Response.from(response)
         end
@@ -61,6 +61,14 @@ module IHub
         )
 
         raise error
+      end
+
+      def appointments_url
+        if Settings.ihub.in_production
+          @user.icn
+        else
+          "#{@user.icn}?noFilter=true"
+        end
       end
     end
   end


### PR DESCRIPTION
## Background

In https://github.com/department-of-veterans-affairs/vets-api/pull/2148 a parameter of `noFilter` was added, as it is required for testing in staging.  

After discussing this with the iHub team, they confirmed that this is not be used in production.

The new variable of `Settings.ihub.in_production` is being set in staging and prod in a sibling DevOps PR: https://github.com/department-of-veterans-affairs/devops/pull/3080


## Definition of Done

#### Unique to this PR

- [x] Remove the `noFilter` parameters from the service call for non-production envs

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
