### PR TITLE
Update reserves for submit

### DIFF
--- a/config/form_profile_mappings/21-526EZ.yml
+++ b/config/form_profile_mappings/21-526EZ.yml
@@ -1,6 +1,5 @@
 veteran: [veteran_contact_information, veteran]
 disabilities: [rated_disabilities_information, rated_disabilities]
 servicePeriods: [military_information, service_periods]
-servedInCombatZone: [military_information, post_nov111998_combat]
 reservesNationalGuardService:
   obligationTermOfServiceDateRange: [military_information, latest_guard_reserve_service_period]

--- a/lib/evss/disability_compensation_form/data_translation.rb
+++ b/lib/evss/disability_compensation_form/data_translation.rb
@@ -86,8 +86,9 @@ module EVSS
           'obligationTermOfServiceFromDate' => reserves_service_info['obligationTermOfServiceDateRange']['from'],
           'obligationTermOfServiceToDate' => reserves_service_info['obligationTermOfServiceDateRange']['to'],
           'unitName' => reserves_service_info['unitName'],
-          'unitPhone' => split_phone_number(reserves_service_info['unitPhone']),
-          'inactiveDutyTrainingPay' => reserves_service_info['inactiveDutyTrainingPay']
+          'inactiveDutyTrainingPay' => {
+            'waiveVABenefitsToRetainTrainingPay' => reserves_service_info['waiveVABenefitsToRetainTrainingPay']
+          }
         }.compact
       end
 

--- a/spec/lib/evss/disability_compensation_form/data_translation_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_spec.rb
@@ -215,6 +215,42 @@ describe EVSS::DisabilityCompensationForm::DataTranslation do
     end
   end
 
+  describe '#translate_national_guard_service' do
+    context 'when the veteran has a reserve/guard service' do
+      before do
+        subject.instance_variable_set(
+          :@form_content,
+          'form526' => {
+            'serviceInformation' => {
+              'reservesNationalGuardService' => {
+                'obligationTermOfServiceDateRange' => {
+                  'from' => '2018-03-29T18:50:03.015Z',
+                  'to' => '2018-03-29T18:50:03.015Z'
+                },
+                'waiveVABenefitsToRetainTrainingPay' => false
+              }
+            }
+          }
+        )
+      end
+      it 'should translate the fields correctly' do
+        result_hash = {
+          'obligationTermOfServiceFromDate' => '2018-03-29T18:50:03.015Z',
+          'obligationTermOfServiceToDate' => '2018-03-29T18:50:03.015Z',
+          'inactiveDutyTrainingPay' => {
+            'waiveVABenefitsToRetainTrainingPay' => false
+          }
+        }
+        result = subject.send(
+          :translate_national_guard_service, subject.instance_variable_get(
+            :@form_content
+          ).dig('form526', 'serviceInformation', 'reservesNationalGuardService')
+        )
+        expect(result).to eq result_hash
+      end
+    end
+  end
+
   describe '#translate_homelessness' do
     context 'when the veteran is not homeless' do
       before do

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -349,7 +349,6 @@ RSpec.describe FormProfile, type: :model do
           ]
         }
       ],
-      'servedInCombatZone' => true,
       'servicePeriods' => [
         {
           'serviceBranch' => 'Air Force Reserve',

--- a/spec/support/disability_compensation_form/evss_submission.json
+++ b/spec/support/disability_compensation_form/evss_submission.json
@@ -67,9 +67,8 @@
         "obligationTermOfServiceFromDate": "2018-03-29T18:50:03.015Z",
         "obligationTermOfServiceToDate": "2018-03-29T18:50:03.015Z",
         "unitName": "string",
-        "unitPhone": {
-          "areaCode": "202",
-          "phoneNumber": "4561111"
+        "inactiveDutyTrainingPay": {
+          "waiveVABenefitsToRetainTrainingPay": false
         }
       },
       "servedInCombatZone": true,

--- a/spec/support/disability_compensation_form/front_end_submission.json
+++ b/spec/support/disability_compensation_form/front_end_submission.json
@@ -55,7 +55,7 @@
           "to": "2018-03-29T18:50:03.015Z"
         },
         "unitName": "string",
-        "unitPhone": "2024561111"
+        "waiveVABenefitsToRetainTrainingPay": false
       },
       "servedInCombatZone": true,
       "alternateNames": [


### PR DESCRIPTION
## Background
Ever changing requirements for submission for form 526. This change includes changes to the `serviceInformation`/`reservesNationalGuardService` block of the form.

## Definition of Done

#### Unique to this PR

- [x] Remove `servedInCombatZone` from prefill
- [x] Properly embed `waiveVABenefitsToRetainTrainingPay` in form before submission

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
