### PR TITLE
526 decision code/text prefill

### DIFF
--- a/app/models/form_profiles/va526ez.rb
+++ b/app/models/form_profiles/va526ez.rb
@@ -18,6 +18,8 @@ module VA526ez
     attribute :rated_disability_id, String
     attribute :rating_decision_id, String
     attribute :diagnostic_code, Integer
+    attribute :decision_code, String
+    attribute :decision_text, String
     attribute :rating_percentage, Integer
   end
 

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -324,6 +324,8 @@ RSpec.describe FormProfile, type: :model do
       'disabilities' => [
         {
           'diagnosticCode' => 5238,
+          'decisionCode' => 'SVCCONNCTED',
+          'decisionText' => 'Service Connected',
           'name' => 'Diabetes mellitus0',
           'ratedDisabilityId' => '0',
           'ratingDecisionId' => '63655',
@@ -337,6 +339,8 @@ RSpec.describe FormProfile, type: :model do
         },
         {
           'diagnosticCode' => 5238,
+          'decisionCode' => 'SVCCONNCTED',
+          'decisionText' => 'Service Connected',
           'name' => 'Diabetes mellitus1',
           'ratedDisabilityId' => '1',
           'ratingDecisionId' => '63655',


### PR DESCRIPTION
## Background
We are attempting to verify that all unrated disabilities are tagged non-service-connected. This status is held within `decisionCode` and needs to be returned in the prefill. With it also comes `decisionText` in case that holds more information.

## Definition of Done

#### Unique to this PR

- [x] add decision code/text to form526 prefilling

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
