### PR TITLE
526 opt in email

### DIFF
--- a/app/controllers/v0/form526_opt_ins_controller.rb
+++ b/app/controllers/v0/form526_opt_ins_controller.rb
@@ -2,9 +2,13 @@
 
 module V0
   class Form526OptInsController < ApplicationController
+    before_action { authorize :evss, :access? }
+
     def create
-      Form526OptIn.new(user_uuid: current_user.uuid, email: params[:email]).save!
-      render json: { 'email': current_user.email, 'status': 'OK' },
+      opt_in = Form526OptIn.where(user_uuid: current_user.uuid).first_or_initialize
+      opt_in.email = params[:email]
+      opt_in.save!
+      render json: opt_in,
              serializer: Form526OptInSerializer
     end
   end

--- a/app/controllers/v0/form526_opt_ins_controller.rb
+++ b/app/controllers/v0/form526_opt_ins_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module V0
+  class Form526OptInsController < ApplicationController
+    def create
+      Form526OptIn.new(user_uuid: current_user.uuid, email: params[:email]).save!
+      render json: { 'email': current_user.email, 'status': 'OK' },
+             serializer: Form526OptInSerializer
+    end
+  end
+end

--- a/app/models/form526_opt_in.rb
+++ b/app/models/form526_opt_in.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'attr_encrypted'
+
+class Form526OptIn < ActiveRecord::Base
+  attr_encrypted(:email, key: Settings.db_encryption_key)
+
+  validates(:email, :user_uuid, presence: true)
+end

--- a/app/serializers/form526_opt_in_serializer.rb
+++ b/app/serializers/form526_opt_in_serializer.rb
@@ -2,7 +2,6 @@
 
 class Form526OptInSerializer < ActiveModel::Serializer
   attribute :email
-  attribute :status
 
   def id
     nil

--- a/app/serializers/form526_opt_in_serializer.rb
+++ b/app/serializers/form526_opt_in_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Form526OptInSerializer < ActiveModel::Serializer
+  attribute :email
+  attribute :status
+
+  def id
+    nil
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
     resource :claim_documents, only: [:create]
     resource :claim_attachments, only: [:create], controller: :claim_documents
 
+    resource :form526_opt_in, only: :create
+
     resources :letters, only: [:index] do
       collection do
         get 'beneficiary', to: 'letters#beneficiary'

--- a/db/migrate/20180727211805_create_form526_opt_in.rb
+++ b/db/migrate/20180727211805_create_form526_opt_in.rb
@@ -1,0 +1,10 @@
+class CreateForm526OptIn < ActiveRecord::Migration
+  def change
+    create_table :form526_opt_ins do |t|
+      t.string :user_uuid, null: false
+      t.string :encrypted_email, null: false
+      t.string :encrypted_email_iv, null: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20180727213418_add_index_to_form526_opt_in.rb
+++ b/db/migrate/20180727213418_add_index_to_form526_opt_in.rb
@@ -1,0 +1,7 @@
+class AddIndexToForm526OptIn < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index(:form526_opt_ins, :user_uuid, unique: true, algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180709214011) do
+ActiveRecord::Schema.define(version: 20180727213418) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -132,6 +133,16 @@ ActiveRecord::Schema.define(version: 20180709214011) do
   end
 
   add_index "evss_claims", ["user_uuid"], name: "index_evss_claims_on_user_uuid", using: :btree
+
+  create_table "form526_opt_ins", force: :cascade do |t|
+    t.string   "user_uuid",          null: false
+    t.string   "encrypted_email",    null: false
+    t.string   "encrypted_email_iv", null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+  end
+
+  add_index "form526_opt_ins", ["user_uuid"], name: "index_form526_opt_ins_on_user_uuid", unique: true, using: :btree
 
   create_table "form_attachments", force: :cascade do |t|
     t.datetime "created_at",             null: false

--- a/spec/request/form526_opt_in_spec.rb
+++ b/spec/request/form526_opt_in_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Form526 Opt In Endpoint', type: :request do
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user, :loa3) }
+  let(:email) { { 'email' => 'test@adhocteam.us' } }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  it 'returns a 200' do
+    post '/v0/form526_opt_in', email, auth_header
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'returns the email' do
+    post '/v0/form526_opt_in', email, auth_header
+    expect(response).to be_success
+    expect(response.body).to be_a(String)
+    json = JSON.parse(response.body)
+    expect(json['data']['attributes']['email']).to eq(email['email'])
+  end
+
+  it 'creates a table entry' do
+    post '/v0/form526_opt_in', email, auth_header
+    expect(Form526OptIn.find_by(user_uuid: user.uuid).present?).to eq(true)
+  end
+
+  it 'updates table entry if called again' do
+    post '/v0/form526_opt_in', email, auth_header
+    post '/v0/form526_opt_in', { 'email' => 'test2@adhocteam.us' }, auth_header
+
+    expect(Form526OptIn.find_by(user_uuid: user.uuid).email).to eq('test2@adhocteam.us')
+  end
+end


### PR DESCRIPTION
## Background
We need to create a (temporary) database table to gather emails for veterans that will want to use form 526 for increase. This includes an endpoint that will create (or update) the veterans information and store it.

## Definition of Done

#### Unique to this PR

- [x] Create an endpoint to create/update the email data
- [x] Create a database migration
- [x] Create a serializer/route

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
