### PR TITLE
11756 ihub appointments endpoint

### DIFF
--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -117,6 +117,7 @@ module V0
     SWAGGERED_CLASSES = [
       Swagger::Requests::Address,
       Swagger::Requests::Appeals,
+      Swagger::Requests::Appointments,
       Swagger::Requests::BackendStatuses,
       Swagger::Requests::BB::HealthRecords,
       Swagger::Requests::BurialClaims,

--- a/app/controllers/v0/appointments_controller.rb
+++ b/app/controllers/v0/appointments_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module V0
+  class AppointmentsController < ApplicationController
+    def index
+      response = service.appointments
+
+      render json: response, serializer: AppointmentSerializer
+    end
+
+    private
+
+    def service
+      IHub::Appointments::Service.new @current_user
+    end
+  end
+end

--- a/app/serializers/appointment_serializer.rb
+++ b/app/serializers/appointment_serializer.rb
@@ -3,10 +3,6 @@
 class AppointmentSerializer < ActiveModel::Serializer
   attributes :appointments
 
-  # Returns an array of the veteran's appointments data.
-  #
-  # @return [Array]
-  #
   delegate :appointments, to: :object
 
   def id

--- a/app/serializers/appointment_serializer.rb
+++ b/app/serializers/appointment_serializer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AppointmentSerializer < ActiveModel::Serializer
+  attributes :appointments
+
+  # Returns an array of the veteran's appointments data.
+  #
+  # @return [Array]
+  #
+  delegate :appointments, to: :object
+
+  def id
+    nil
+  end
+end

--- a/app/swagger/requests/appointments.rb
+++ b/app/swagger/requests/appointments.rb
@@ -25,32 +25,38 @@ module Swagger
               property :data, type: :object do
                 key :required, [:attributes]
                 property :attributes, type: :object do
-                  property :appointment_status_code, type: :string
-                  property :appointment_status_name, type: :string
-                  property :assigning_facility, type: :string
-                  property :clinic_code, type: :string, example: '409'
-                  property :clinic_name, type: :string, example: 'ZZCHY WID BACK'
-                  property :date_time_date,
-                           type: :string,
-                           example: '1996-01-12T08:12:00',
-                           description: 'This time is in the same timezone of the associated facility_name'
-                  property :facility_name, type: :string, example: 'CHEYENNE VAMC'
-                  property :facility_code, type: :string, example: '442'
-                  property :local_id,
-                           type: :string,
-                           example: '2960112.0812',
-                           description: 'The LocalID element is an internal ID from the VistA/Source system'
-                  property :other_information, type: :string
-                  property :status_code, type: :string, example: '2'
-                  property :status_name,
-                           type: :string,
-                           example: 'CHECKED OUT',
-                           enum: IHub::Models::Appointment::STATUS_NAMES
-                  property :type_code, type: :string, example: '9'
-                  property :type_name,
-                           type: :string,
-                           example: 'REGULAR',
-                           enum: IHub::Models::Appointment::TYPE_NAMES
+                  key :required, [:appointments]
+                  property :appointments do
+                    key :type, :array
+                    items do
+                      property :appointment_status_code, type: :string
+                      property :appointment_status_name, type: :string
+                      property :assigning_facility, type: :string
+                      property :clinic_code, type: :string, example: '409'
+                      property :clinic_name, type: :string, example: 'ZZCHY WID BACK'
+                      property :date_time_date,
+                               type: :string,
+                               example: '1996-01-12T08:12:00',
+                               description: 'Start time. Time is in the same timezone of the associated facility_name'
+                      property :facility_name, type: :string, example: 'CHEYENNE VAMC'
+                      property :facility_code, type: :string, example: '442'
+                      property :local_id,
+                               type: :string,
+                               example: '2960112.0812',
+                               description: 'The LocalID element is an internal ID from the VistA/Source system'
+                      property :other_information, type: :string
+                      property :status_code, type: :string, example: '2'
+                      property :status_name,
+                               type: :string,
+                               example: 'CHECKED OUT',
+                               enum: IHub::Models::Appointment::STATUS_NAMES
+                      property :type_code, type: :string, example: '9'
+                      property :type_name,
+                               type: :string,
+                               example: 'REGULAR',
+                               enum: IHub::Models::Appointment::TYPE_NAMES
+                    end
+                  end
                 end
               end
             end

--- a/app/swagger/requests/appointments.rb
+++ b/app/swagger/requests/appointments.rb
@@ -44,7 +44,7 @@ module Swagger
                       property :start_time,
                                type: :string,
                                example: '1996-01-12T08:12:00',
-                               description: 'Start time. Time is in the same timezone of the associated facility_name'
+                               description: 'Time is in the same timezone that the associated facility_name is in.'
                       property :status_code, type: :string, example: '2'
                       property :status_name,
                                type: :string,

--- a/app/swagger/requests/appointments.rb
+++ b/app/swagger/requests/appointments.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Requests
+    class Appointments
+      include Swagger::Blocks
+
+      swagger_path '/v0/appointments' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'List of user appointments for the previous three months, through the upcoming six months'
+          key :operationId, 'getAppointments'
+          key :tags, %w[
+            appointments
+          ]
+
+          parameter :authorization
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :required, [:data]
+
+              property :data, type: :object do
+                key :required, [:attributes]
+                property :attributes, type: :object do
+                  property :appointment_status_code, type: :string
+                  property :appointment_status_name, type: :string
+                  property :assigning_facility, type: :string
+                  property :clinic_code, type: :string, example: '409'
+                  property :clinic_name, type: :string, example: 'ZZCHY WID BACK'
+                  property :date_time_date, type: :string, example: '1996-01-12T08:12:00', description: 'This time is in the same timezone of the associated facility_name'
+                  property :facility_name, type: :string, example: 'CHEYENNE VAMC'
+                  property :facility_code, type: :string, example: '442'
+                  property :local_id, type: :string, example: '2960112.0812', description: 'The LocalID element is an internal ID from the VistA/Source system'
+                  property :other_information, type: :string
+                  property :status_code, type: :string, example: '2'
+                  property :status_name, type: :string, example: 'CHECKED OUT', enum: IHub::Models::Appointment::STATUS_NAMES
+                  property :type_code, type: :string, example: '9'
+                  property :type_name, type: :string, example: 'REGULAR', enum: IHub::Models::Appointment::TYPE_NAMES
+                end
+              end
+            end
+          end
+
+          response 400 do
+            key :description, 'Error Occurred'
+            schema do
+              key :required, [:errors]
+
+              property :errors do
+                key :type, :array
+                items do
+                  key :required, %i[title detail code status source]
+                  property :title, type: :string, example: 'Error Occurred'
+                  property :detail,
+                           type: :string,
+                           example: 'General error received from iHub.  Check sentry logs for details.'
+                  property :code, type: :string, example: 'IHUB_101'
+                  property :status, type: :string, example: '400'
+                  property :source, type: :string, example: 'IHub::Appointments::Service'
+                end
+              end
+            end
+          end
+
+          response 502 do
+            key :description, 'User missing ICN'
+            schema do
+              key :required, [:errors]
+
+              property :errors do
+                key :type, :array
+                items do
+                  key :required, %i[title detail code status source]
+                  property :title, type: :string, example: 'User missing ICN'
+                  property :detail,
+                           type: :string,
+                           example: 'The user does not have an ICN.'
+                  property :code, type: :string, example: 'IHUB_102'
+                  property :status, type: :string, example: '502'
+                  property :source, type: :string, example: 'IHub::Appointments::Service'
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/swagger/requests/appointments.rb
+++ b/app/swagger/requests/appointments.rb
@@ -30,15 +30,27 @@ module Swagger
                   property :assigning_facility, type: :string
                   property :clinic_code, type: :string, example: '409'
                   property :clinic_name, type: :string, example: 'ZZCHY WID BACK'
-                  property :date_time_date, type: :string, example: '1996-01-12T08:12:00', description: 'This time is in the same timezone of the associated facility_name'
+                  property :date_time_date,
+                           type: :string,
+                           example: '1996-01-12T08:12:00',
+                           description: 'This time is in the same timezone of the associated facility_name'
                   property :facility_name, type: :string, example: 'CHEYENNE VAMC'
                   property :facility_code, type: :string, example: '442'
-                  property :local_id, type: :string, example: '2960112.0812', description: 'The LocalID element is an internal ID from the VistA/Source system'
+                  property :local_id,
+                           type: :string,
+                           example: '2960112.0812',
+                           description: 'The LocalID element is an internal ID from the VistA/Source system'
                   property :other_information, type: :string
                   property :status_code, type: :string, example: '2'
-                  property :status_name, type: :string, example: 'CHECKED OUT', enum: IHub::Models::Appointment::STATUS_NAMES
+                  property :status_name,
+                           type: :string,
+                           example: 'CHECKED OUT',
+                           enum: IHub::Models::Appointment::STATUS_NAMES
                   property :type_code, type: :string, example: '9'
-                  property :type_name, type: :string, example: 'REGULAR', enum: IHub::Models::Appointment::TYPE_NAMES
+                  property :type_name,
+                           type: :string,
+                           example: 'REGULAR',
+                           enum: IHub::Models::Appointment::TYPE_NAMES
                 end
               end
             end

--- a/app/swagger/requests/appointments.rb
+++ b/app/swagger/requests/appointments.rb
@@ -34,10 +34,6 @@ module Swagger
                       property :assigning_facility, type: :string
                       property :clinic_code, type: :string, example: '409'
                       property :clinic_name, type: :string, example: 'ZZCHY WID BACK'
-                      property :date_time_date,
-                               type: :string,
-                               example: '1996-01-12T08:12:00',
-                               description: 'Start time. Time is in the same timezone of the associated facility_name'
                       property :facility_name, type: :string, example: 'CHEYENNE VAMC'
                       property :facility_code, type: :string, example: '442'
                       property :local_id,
@@ -45,6 +41,10 @@ module Swagger
                                example: '2960112.0812',
                                description: 'The LocalID element is an internal ID from the VistA/Source system'
                       property :other_information, type: :string
+                      property :start_time,
+                               type: :string,
+                               example: '1996-01-12T08:12:00',
+                               description: 'Start time. Time is in the same timezone of the associated facility_name'
                       property :status_code, type: :string, example: '2'
                       property :status_name,
                                type: :string,

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -314,6 +314,18 @@ en:
         code: 'EMIS_HIST502'
         detail: EMIS service responded with something other than the expected array of service history hashes.
         status: 502
+      IHUB_101:
+        <<: *external_defaults
+        title: Error Occurred
+        code: 'IHUB_101'
+        detail: 'General error received from iHub.  Check sentry logs for details.'
+        status: 400
+      IHUB_102:
+        <<: *external_defaults
+        title: User missing ICN
+        code: 'IHUB_102'
+        detail: 'The user does not have an ICN.'
+        status: 502
       MVI_BD502:
         <<: *external_defaults
         title: Unexpected response body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       constraints: ->(request) { V0::SessionsController::REDIRECT_URLS.include?(request.path_parameters[:type]) }
 
   namespace :v0, defaults: { format: 'json' } do
+    resources :appointments, only: :index
     resources :in_progress_forms, only: %i[index show update destroy]
     resource :claim_documents, only: [:create]
     resource :claim_attachments, only: [:create], controller: :claim_documents

--- a/lib/ihub/appointments/response.rb
+++ b/lib/ihub/appointments/response.rb
@@ -9,7 +9,7 @@ module IHub
       include Common::Client::ServiceStatus
 
       attribute :status, Integer
-      attribute :response_data, Hash
+      attribute :appointments, Array
 
       def initialize(attributes = nil)
         super(attributes) if attributes
@@ -17,7 +17,7 @@ module IHub
       end
 
       def self.from(response)
-        new(status: response.status, response_data: response.body)
+        new(status: response.status, appointments: response.body&.fetch('data', []))
       end
 
       def ok?

--- a/lib/ihub/appointments/response.rb
+++ b/lib/ihub/appointments/response.rb
@@ -17,7 +17,12 @@ module IHub
       end
 
       def self.from(response)
-        new(status: response.status, appointments: response.body&.fetch('data', []))
+        all_appointments = response.body&.fetch('data', [])
+
+        new(
+          status: response.status,
+          appointments: IHub::Models::Appointment.convert(all_appointments)
+        )
       end
 
       def ok?

--- a/lib/ihub/appointments/response.rb
+++ b/lib/ihub/appointments/response.rb
@@ -21,7 +21,7 @@ module IHub
 
         new(
           status: response.status,
-          appointments: IHub::Models::Appointment.convert(all_appointments)
+          appointments: IHub::Models::Appointment.build_all(all_appointments)
         )
       end
 

--- a/lib/ihub/appointments/service.rb
+++ b/lib/ihub/appointments/service.rb
@@ -40,10 +40,12 @@ module IHub
       #   }
       #
       def appointments
-        raise 'User has no ICN' if @user.icn.blank?
+        icn_present!
 
         with_monitoring do
           response = perform(:get, appointments_url, nil)
+
+          report_error!(response)
 
           IHub::Appointments::Response.from(response)
         end
@@ -58,12 +60,60 @@ module IHub
         raise error
       end
 
+      private
+
+      def icn_present!
+        if @user.icn.blank?
+          error = Common::Client::Errors::ClientError.new('User has no ICN', 500, 'User has no ICN')
+
+          raise_backend_exception!('IHUB_102', self.class, error)
+        end
+      end
+
       def appointments_url
         if Settings.ihub.in_production
           @user.icn
         else
           "#{@user.icn}?noFilter=true"
         end
+      end
+
+      # When an iHub error occurs, iHub sets a 'error_occurred' key to true, returns
+      # a status of 200, and includes the error's details in the response.body hash.
+      #
+      # @param response [Faraday::Env] The raw response from the iHub Appointments endpoint.
+      #   Sample response.body when an error has occurred:
+      #     {
+      #       "error_occurred" => true,
+      #       "error_message"  => "An unexpected error occurred processing request!",
+      #       "status"         => "Error",
+      #       "debug_info"     => "Invalid CRM Webpart URL parameters. Invalid client name.",
+      #       "data"           => []
+      #     }
+      #
+      def report_error!(response)
+        if response.body&.dig('error_occurred')
+          log_error(response)
+          raise_backend_exception!('IHUB_101', self.class, response)
+        end
+      end
+
+      def log_error(response)
+        log_message_to_sentry(
+          'iHub Appointments Service Error',
+          :error,
+          response_body: response.body.merge('status_code' => response.status),
+          ihub: 'appointments_error_occurred'
+        )
+      end
+
+      def raise_backend_exception!(key, source, error = nil)
+        raise Common::Exceptions::BackendServiceException.new(
+          key,
+          { source: source.to_s },
+          error&.status,
+          error&.body
+        )
       end
     end
   end

--- a/lib/ihub/appointments/service.rb
+++ b/lib/ihub/appointments/service.rb
@@ -21,7 +21,7 @@ module IHub
       #       {
       #         "clinic_code"             => "409",
       #         "clinic_name"             => "ZZCHY WID BACK",
-      #         "date_time_date"          => "1996-01-12T08:12:00",
+      #         "start_time"              => "1996-01-12T08:12:00",
       #         "type_name"               => "REGULAR",
       #         "status_name"             => "CHECKED OUT",
       #         "status_code"             => "2",

--- a/lib/ihub/appointments/service.rb
+++ b/lib/ihub/appointments/service.rb
@@ -16,30 +16,25 @@ module IHub
       #
       # @return [IHub::Appointments::Response] Sample response:
       #   {
-      #     :status        => 200,
-      #     :response_data => {
-      #       "error_occurred" => false,
-      #       "error_message"  => nil,
-      #       "status"         => nil,
-      #       "debug_info"     => nil,
-      #       "data"           => [
-      #         {
-      #           "clinic_code"             => "409",
-      #           "clinic_name"             => "ZZCHY WID BACK",
-      #           "date_time_date"          => "1996-01-12T08:12:00",
-      #           "type_name"               => "REGULAR",
-      #           "status_name"             => "CHECKED OUT",
-      #           "status_code"             => "2",
-      #           "other_information"       => "",
-      #           "type_code"               => "9",
-      #           "date_time"               => "199601120812",
-      #           "appointment_status_code" => nil,
-      #           "local_id"                => "2960112.0812",
-      #           "appointment_status_name" => nil,
-      #           "assigning_facility"      => nil,
-      #           "facility_name"           => "CHEYENNE VAMC",
-      #           "facility_code"           => "442"
-      #         },
+      #     :status       => 200,
+      #     :appointments => [
+      #       {
+      #         "clinic_code"             => "409",
+      #         "clinic_name"             => "ZZCHY WID BACK",
+      #         "date_time_date"          => "1996-01-12T08:12:00",
+      #         "type_name"               => "REGULAR",
+      #         "status_name"             => "CHECKED OUT",
+      #         "status_code"             => "2",
+      #         "other_information"       => "",
+      #         "type_code"               => "9",
+      #         "date_time"               => "199601120812",
+      #         "appointment_status_code" => nil,
+      #         "local_id"                => "2960112.0812",
+      #         "appointment_status_name" => nil,
+      #         "assigning_facility"      => nil,
+      #         "facility_name"           => "CHEYENNE VAMC",
+      #         "facility_code"           => "442"
+      #       },
       #       ...
       #     ]
       #   }

--- a/lib/ihub/appointments/service.rb
+++ b/lib/ihub/appointments/service.rb
@@ -27,7 +27,6 @@ module IHub
       #         "status_code"             => "2",
       #         "other_information"       => "",
       #         "type_code"               => "9",
-      #         "date_time"               => "199601120812",
       #         "appointment_status_code" => nil,
       #         "local_id"                => "2960112.0812",
       #         "appointment_status_name" => nil,

--- a/lib/ihub/models/appointment.rb
+++ b/lib/ihub/models/appointment.rb
@@ -73,7 +73,7 @@ module IHub
         )
       end
 
-      def self.convert(appointments)
+      def self.build_all(appointments)
         appointments.map { |appointment| build(appointment) }
       end
     end

--- a/lib/ihub/models/appointment.rb
+++ b/lib/ihub/models/appointment.rb
@@ -39,12 +39,14 @@ module IHub
       TYPE_NAMES   = [COMPENSATION, CLASS_II, ORGAN, EMPLOYEE, PRIMA, RESEARCH, COLLATERAL,
                       SHARING, REGULAR, COMPUTER, SERVICE].freeze
 
+      # start_time is remapped from iHubs 'date_time_date' attribute
+      #
+      attribute :start_time, String
       attribute :appointment_status_code, String
       attribute :appointment_status_name, String
       attribute :assigning_facility, String
       attribute :clinic_code, String
       attribute :clinic_name, String
-      attribute :date_time_date, String
       attribute :facility_code, String
       attribute :facility_name, String
       attribute :local_id, String
@@ -54,6 +56,15 @@ module IHub
       attribute :type_code, String
       attribute :type_name, String
 
+      # Converts an appointment hash from iHub into an instance of the
+      # Appointment model class.
+      #
+      # Important to note that iHub's 'date_time_date' attribute is being
+      # remapped to start_time.
+      #
+      # @param appointment [Hash] A hash of data for one appointment
+      # @return [IHub::Models:Appointment] An instance of this class
+      #
       def self.build(appointment)
         IHub::Models::Appointment.new(
           appointment_status_code: appointment['appointment_status_code'],
@@ -61,11 +72,11 @@ module IHub
           assigning_facility: appointment['assigning_facility'],
           clinic_code: appointment['clinic_code'],
           clinic_name: appointment['clinic_name'],
-          date_time_date: appointment['date_time_date'],
           facility_code: appointment['facility_code'],
           facility_name: appointment['facility_name'],
           local_id: appointment['local_id'],
           other_information: appointment['other_information'],
+          start_time: appointment['date_time_date'],
           status_code: appointment['status_code'],
           status_name: appointment['status_name'],
           type_code: appointment['type_code'],

--- a/lib/ihub/models/appointment.rb
+++ b/lib/ihub/models/appointment.rb
@@ -3,37 +3,73 @@
 module IHub
   module Models
     class Appointment < Base
-      attribute :date_time_date, String
+      # Potential status_name's
+      #
+      CHECKED_IN        = 'CHECKED IN'
+      CHECKED_OUT       = 'CHECKED OUT'
+      NO_ACTION         = 'NO ACTION TAKEN'
+      NO_SHOW           = 'NO-SHOW'
+      NO_SHOW_RE_BOOK   = 'NO-SHOW & AUTO RE-BOOK'
+      INPATIENT         = 'INPATIENT APPOINTMENT'
+      FUTURE            = 'FUTURE'
+      NON_COUNT         = 'NON-COUNT'
+      DELETED           = 'DELETED'
+      ACTION_REQUIRED   = 'ACTION REQUIRED'
+      CLINIC_CANCELLED  = 'CANCELLED BY CLINIC'
+      PATIENT_CANCELLED = 'CANCELLED BY PATIENT'
+      CLINIC_CANCELLED_RE_BOOK  = 'CANCELLED BY CLINIC & AUTO RE-BOOK'
+      PATIENT_CANCELLED_RE_BOOK = 'CANCELLED BY PATIENT & AUTO-REBOOK'
+      STATUS_NAMES = [CHECKED_IN, CHECKED_OUT, NO_ACTION, NO_SHOW, NO_SHOW_RE_BOOK, INPATIENT,
+                      FUTURE, NON_COUNT, DELETED, ACTION_REQUIRED, CLINIC_CANCELLED, PATIENT_CANCELLED,
+                      CLINIC_CANCELLED_RE_BOOK, PATIENT_CANCELLED_RE_BOOK].freeze
+
+      # Potential type_name's
+      #
+      COMPENSATION = 'COMPENSATION & PENSION'
+      CLASS_II     = 'CLASS II DENTAL'
+      ORGAN        = 'ORGAN DONORS'
+      EMPLOYEE     = 'EMPLOYEE'
+      PRIMA        = 'PRIMA FACIA'
+      RESEARCH     = 'RESEARCH'
+      COLLATERAL   = 'COLLATERAL OF VET.'
+      SHARING      = 'SHARING AGREEMENT'
+      REGULAR      = 'REGULAR'
+      COMPUTER     = 'COMPUTER GENERATED'
+      SERVICE      = 'SERVICE CONNECTED'
+      TYPE_NAMES   = [COMPENSATION, CLASS_II, ORGAN, EMPLOYEE, PRIMA, RESEARCH, COLLATERAL,
+                      SHARING, REGULAR, COMPUTER, SERVICE].freeze
+
+      attribute :appointment_status_code, String
+      attribute :appointment_status_name, String
       attribute :assigning_facility, String
       attribute :clinic_code, String
       attribute :clinic_name, String
+      attribute :date_time_date, String
       attribute :facility_code, String
       attribute :facility_name, String
+      attribute :local_id, String
       attribute :other_information, String
       attribute :status_code, String
       attribute :status_name, String
       attribute :type_code, String
       attribute :type_name, String
-      attribute :appointment_status_code, String
-      attribute :appointment_status_name, String
-      attribute :local_id, String
 
       def self.build(appointment)
         IHub::Models::Appointment.new(
-          date_time_date: appointment['date_time_date'],
+          appointment_status_code: appointment['appointment_status_code'],
+          appointment_status_name: appointment['appointment_status_name'],
           assigning_facility: appointment['assigning_facility'],
           clinic_code: appointment['clinic_code'],
           clinic_name: appointment['clinic_name'],
+          date_time_date: appointment['date_time_date'],
           facility_code: appointment['facility_code'],
           facility_name: appointment['facility_name'],
+          local_id: appointment['local_id'],
           other_information: appointment['other_information'],
           status_code: appointment['status_code'],
           status_name: appointment['status_name'],
           type_code: appointment['type_code'],
-          type_name: appointment['type_name'],
-          appointment_status_code: appointment['appointment_status_code'],
-          appointment_status_name: appointment['appointment_status_name'],
-          local_id: appointment['local_id']
+          type_name: appointment['type_name']
         )
       end
 

--- a/lib/ihub/models/appointment.rb
+++ b/lib/ihub/models/appointment.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module IHub
+  module Models
+    class Appointment < Base
+      attribute :date_time, String
+      attribute :date_time_date, String
+      attribute :assigning_facility, String
+      attribute :clinic_code, String
+      attribute :clinic_name, String
+      attribute :facility_code, String
+      attribute :facility_name, String
+      attribute :other_information, String
+      attribute :status_code, String
+      attribute :status_name, String
+      attribute :type_code, String
+      attribute :type_name, String
+      attribute :appointment_status_code, String
+      attribute :appointment_status_name, String
+      attribute :local_id, String
+
+      def self.build(appointment)
+        IHub::Models::Appointment.new(
+          date_time: appointment['date_time'],
+          date_time_date: appointment['date_time_date'],
+          assigning_facility: appointment['assigning_facility'],
+          clinic_code: appointment['clinic_code'],
+          clinic_name: appointment['clinic_name'],
+          facility_code: appointment['facility_code'],
+          facility_name: appointment['facility_name'],
+          other_information: appointment['other_information'],
+          status_code: appointment['status_code'],
+          status_name: appointment['status_name'],
+          type_code: appointment['type_code'],
+          type_name: appointment['type_name'],
+          appointment_status_code: appointment['appointment_status_code'],
+          appointment_status_name: appointment['appointment_status_name'],
+          local_id: appointment['local_id']
+        )
+      end
+
+      def self.convert(appointments)
+        appointments.map { |appointment| build(appointment) }
+      end
+    end
+  end
+end

--- a/lib/ihub/models/appointment.rb
+++ b/lib/ihub/models/appointment.rb
@@ -3,7 +3,6 @@
 module IHub
   module Models
     class Appointment < Base
-      attribute :date_time, String
       attribute :date_time_date, String
       attribute :assigning_facility, String
       attribute :clinic_code, String
@@ -21,7 +20,6 @@ module IHub
 
       def self.build(appointment)
         IHub::Models::Appointment.new(
-          date_time: appointment['date_time'],
           date_time_date: appointment['date_time_date'],
           assigning_facility: appointment['assigning_facility'],
           clinic_code: appointment['clinic_code'],

--- a/lib/ihub/models/base.rb
+++ b/lib/ihub/models/base.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'common/models/base'
+
+module IHub
+  module Models
+    class Base
+      include ActiveModel::Validations
+      include ActiveModel::Serialization
+      include Virtus.model(nullify_blank: true)
+    end
+  end
+end

--- a/spec/lib/ihub/appointments/service_spec.rb
+++ b/spec/lib/ihub/appointments/service_spec.rb
@@ -37,8 +37,31 @@ describe IHub::Appointments::Service do
         allow_any_instance_of(User).to receive(:icn).and_return(nil)
       end
 
-      it 'raises an error' do
-        expect { subject.appointments }.to raise_error(StandardError, 'User has no ICN')
+      it 'raises an exception', :aggregate_failures do
+        expect { subject.appointments }.to raise_error do |e|
+          expect(e).to be_a(Common::Exceptions::BackendServiceException)
+          expect(e.status_code).to eq(502)
+          expect(e.original_body).to eq 'User has no ICN'
+          expect(e.errors.first.code).to eq('IHUB_102')
+        end
+      end
+    end
+
+    context 'when iHub returns error_occurred: true' do
+      before do
+        allow_any_instance_of(User).to receive(:icn).and_return('1234')
+      end
+
+      it 'raises an exception', :aggregate_failures do
+        VCR.use_cassette('ihub/appointments/error_occurred', VCR::MATCH_EVERYTHING) do
+          expect { subject.appointments }.to raise_error do |e|
+            expect(e).to be_a(Common::Exceptions::BackendServiceException)
+            expect(e.status_code).to eq(400)
+            expect(e.original_body['error_message']).to be_present
+            expect(e.original_body['debug_info']).to be_present
+            expect(e.errors.first.code).to eq('IHUB_101')
+          end
+        end
       end
     end
   end

--- a/spec/lib/ihub/appointments/service_spec.rb
+++ b/spec/lib/ihub/appointments/service_spec.rb
@@ -25,7 +25,7 @@ describe IHub::Appointments::Service do
         VCR.use_cassette('ihub/appointments/success', VCR::MATCH_EVERYTHING) do
           response    = subject.appointments
           appointment = response.appointments&.first
-          facility    = appointment&.dig('facility_name')
+          facility    = appointment.facility_name
 
           expect(facility).to be_present
         end

--- a/spec/lib/ihub/appointments/service_spec.rb
+++ b/spec/lib/ihub/appointments/service_spec.rb
@@ -24,7 +24,7 @@ describe IHub::Appointments::Service do
       it 'returns an array of appointment data' do
         VCR.use_cassette('ihub/appointments/success', VCR::MATCH_EVERYTHING) do
           response    = subject.appointments
-          appointment = response.response_data&.dig('data')&.first
+          appointment = response.appointments&.first
           facility    = appointment&.dig('facility_name')
 
           expect(facility).to be_present

--- a/spec/lib/ihub/appointments/service_spec.rb
+++ b/spec/lib/ihub/appointments/service_spec.rb
@@ -23,11 +23,12 @@ describe IHub::Appointments::Service do
 
       it 'returns an array of appointment data' do
         VCR.use_cassette('ihub/appointments/success', VCR::MATCH_EVERYTHING) do
-          response    = subject.appointments
-          appointment = response.appointments&.first
-          facility    = appointment.facility_name
+          response       = subject.appointments
+          appointment    = response.appointments&.first
+          facility       = appointment.facility_name
+          valid_facility = 'CHEYENNE VAMC'
 
-          expect(facility).to be_present
+          expect(facility).to eq valid_facility
         end
       end
     end

--- a/spec/request/appointments_request_spec.rb
+++ b/spec/request/appointments_request_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/error_details'
+
+RSpec.describe 'Appointments', type: :request do
+  include SchemaMatchers
+  include ErrorDetails
+
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) { { 'Authorization' => "Token token=#{token}" } }
+  let(:user) { build(:user, :loa3) }
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+    allow_any_instance_of(User).to receive(:icn).and_return('1234')
+  end
+
+  describe 'GET /v0/appointments' do
+    context 'with a 200 response' do
+      it 'should match the appointments schema' do
+        VCR.use_cassette('ihub/appointments/success') do
+          get '/v0/appointments', nil, auth_header
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('appointments_response')
+        end
+      end
+    end
+
+    context 'the user does not have an ICN' do
+      before do
+        allow_any_instance_of(User).to receive(:icn).and_return(nil)
+      end
+
+      it 'should match the errors schema', :aggregate_failures do
+        get '/v0/appointments', nil, auth_header
+
+        expect(response).to have_http_status(:bad_gateway)
+        expect(response).to match_response_schema('errors')
+      end
+    end
+
+    context 'when iHub experiences an error' do
+      it 'should match the errors schema', :aggregate_failures do
+        VCR.use_cassette('ihub/appointments/error_occurred') do
+          get '/v0/appointments', nil, auth_header
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_response_schema('errors')
+        end
+      end
+    end
+  end
+end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1178,7 +1178,7 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
 
       context 'when successful' do
         it 'supports getting appointments data' do
-          VCR.use_cassette('ihub/appointments/success') do
+          VCR.use_cassette('ihub/appointments/simple_success') do
             expect(subject).to validate(:get, '/v0/appointments', 200, auth_options)
           end
         end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1171,6 +1171,44 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
       end
     end
 
+    describe 'appointments' do
+      before do
+        allow_any_instance_of(User).to receive(:icn).and_return('1234')
+      end
+
+      context 'when successful' do
+        it 'supports getting appointments data' do
+          VCR.use_cassette('ihub/appointments/success') do
+            expect(subject).to validate(:get, '/v0/appointments', 200, auth_options)
+          end
+        end
+      end
+
+      context 'when not signed in' do
+        it 'returns a 401 with error details' do
+          expect(subject).to validate(:get, '/v0/appointments', 401)
+        end
+      end
+
+      context 'when iHub experiences an error' do
+        it 'returns a 400 with error details' do
+          VCR.use_cassette('ihub/appointments/error_occurred') do
+            expect(subject).to validate(:get, '/v0/appointments', 400, auth_options)
+          end
+        end
+      end
+
+      context 'the user does not have an ICN' do
+        before do
+          allow_any_instance_of(User).to receive(:icn).and_return(nil)
+        end
+
+        it 'returns a 502 with error details' do
+          expect(subject).to validate(:get, '/v0/appointments', 502, auth_options)
+        end
+      end
+    end
+
     describe 'profiles' do
       it 'supports getting email address data' do
         expect(subject).to validate(:get, '/v0/profile/email', 401)

--- a/spec/support/schemas/appointments_response.json
+++ b/spec/support/schemas/appointments_response.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "appointments": {
+              "description": "Array of appointments",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "date_time":               { "type": ["string", null] },
+                  "date_time_date":          { "type": ["string", null] },
+                  "assigning_facility":      { "type": ["string", null] },
+                  "clinic_code":             { "type": ["string", null] },
+                  "clinic_name":             { "type": ["string", null] },
+                  "facility_code":           { "type": ["string", null] },
+                  "facility_name":           { "type": ["string", null] },
+                  "other_information":       { "type": ["string", null] },
+                  "status_code":             { "type": ["string", null] },
+                  "status_name":             { "type": ["string", null] },
+                  "type_code":               { "type": ["string", null] },
+                  "type_name":               { "type": ["string", null] },
+                  "appointment_status_code": { "type": ["string", null] },
+                  "appointment_status_name": { "type": ["string", null] },
+                  "local_id":                { "type": ["string", null] }
+                }
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas/appointments_response.json
+++ b/spec/support/schemas/appointments_response.json
@@ -11,7 +11,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "date_time_date":          { "type": ["string", null] },
+                  "start_time":              { "type": ["string", null] },
                   "assigning_facility":      { "type": ["string", null] },
                   "clinic_code":             { "type": ["string", null] },
                   "clinic_name":             { "type": ["string", null] },

--- a/spec/support/schemas/appointments_response.json
+++ b/spec/support/schemas/appointments_response.json
@@ -11,7 +11,6 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "date_time":               { "type": ["string", null] },
                   "date_time_date":          { "type": ["string", null] },
                   "assigning_facility":      { "type": ["string", null] },
                   "clinic_code":             { "type": ["string", null] },

--- a/spec/support/vcr_cassettes/ihub/appointments/error_occurred.yml
+++ b/spec/support/vcr_cassettes/ihub/appointments/error_occurred.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://qacrmdac.np.crm.vrm.vba.va.gov/WebParts/DEV/api/Appointments/1.0/json/ftpCRM/1234?noFilter=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '77249'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE, HEAD
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept
+      Date:
+      - Fri, 20 Jul 2018 15:38:45 GMT
+    body:
+      encoding: UTF-8
+      string: '{"ErrorOccurred":true,"ErrorMessage":"An unexpected error occurred processing request!","Status":"Error","DebugInfo":"Invalid CRM Webpart URL parameters. Invalid client name.","Data":[]}'
+    http_version:
+  recorded_at: Fri, 20 Jul 2018 15:38:45 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/ihub/appointments/simple_success.yml
+++ b/spec/support/vcr_cassettes/ihub/appointments/simple_success.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://qacrmdac.np.crm.vrm.vba.va.gov/WebParts/DEV/api/Appointments/1.0/json/ftpCRM/1234?noFilter=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '77249'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE, HEAD
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept
+      Date:
+      - Fri, 20 Jul 2018 15:38:45 GMT
+    body:
+      encoding: UTF-8
+      string: '{"ErrorOccurred":false,"ErrorMessage":null,"Status":null,"DebugInfo":null,"Data":[{"DateTime":"199601120812","DateTimeDate":"1996-01-12T08:12:00","AssigningFacility":"","ClinicCode":"409","ClinicName":"ZZCHY
+        WID BACK","FacilityCode":"442","FacilityName":"CHEYENNE VAMC","OtherInformation":"","StatusCode":"2","StatusName":"CHECKED
+        OUT","TypeCode":"9","TypeName":"REGULAR","AppointmentStatusCode":"","AppointmentStatusName":"","LocalID":"2960112.0812"}]}'
+    http_version:
+  recorded_at: Fri, 20 Jul 2018 15:38:45 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Background

The **Integration Hub** is a collection of existing VA integrations which can be incorporated into products via "widget" or API. We just became aware of it. It offers dozens of APIs into services that we are very interested in surfacing to Veterans, such as appointments, HDR FPDS flags, payment history, enrollment system eligibility info, and dozens more.

Documentation (requires VA network access): https://qacrmdac.np.crm.vrm.vba.va.gov/WebParts/Documentation/Documentation

This PR implements an endpoint the exposes the relevant iHub Appointment data for our FE to consume.

## Definition of Done

#### Unique to this PR

- [x] new `GET` endpoint for a veteran's appointments
- [x] error handling
- [x] FE signoff on API schema

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
