### PR TITLE
switching to using JSON and native TTL

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -134,19 +134,38 @@ class ApplicationController < ActionController::API
       @session = Session.find(token)
       return false if @session.nil?
       @current_user = User.find(@session.uuid)
-      set_sso_cookie
+      extend_sso_cookie!
       SSOService.extend_session!(@session, @current_user)
     end
   end
 
-  def set_sso_cookie(ttl = 30.minutes)
+  # FIXME: methods starting here through encrypt, really ought to live in SSOService, but its complicated,
+  # Those methods should probably not be abstracted to class otherwise we'll be stuck doing controller.send(:cookies) etc.
+  # In a future refactor consider moving some of these methods into a module for some pseudo abstraction since classes and
+  # service objects don't play so nice with controller methods.
+  def set_sso_cookie!
     return unless Settings.set_sso_cookie && Settings.sso_cookie_key
-    contents = [expiryunix(ttl), @current_user.mhv_icn, @current_user.mhv_correlation_id]
-    cookies[:vamhv_session] = { value: encrypt(contents.join('|'), Settings.sso_cookie_key), httponly: true }
+    contents = ActiveSupport::JSON.encode(cookie_value)
+    cookies[:va_session] = {
+      value: encrypt(contents, Settings.sso_cookie_key),
+      expires: 30.minutes.from_now,
+      httponly: true
+    }
   end
 
-  def expiryunix(ttl)
-    (Time.zone.now + ttl).to_i
+  def extend_sso_cookie!
+    set_sso_cookie!
+  end
+
+  def destroy_sso_cookie!
+    cookies.delete(:va_session)
+  end
+
+  def cookie_value
+    {
+      icn: (@current_user.mhv_icn || @current_user.icn),
+      mhv_correlation_id: @current_user.mhv_correlation_id
+    }
   end
 
   def encrypt(message, key)

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -56,7 +56,7 @@ module V0
               SAML::SettingsService.idme_loa3_url(current_user)
             when 'slo'
               authenticate
-              set_sso_cookie(0)
+              destroy_sso_cookie!
               SAML::SettingsService.slo_url(session)
             end
       render json: { url: url }
@@ -114,7 +114,7 @@ module V0
         @current_user = @sso_service.new_user
         @session = @sso_service.new_session
         async_create_evss_account(current_user)
-        set_sso_cookie
+        set_sso_cookie!
         redirect_to saml_callback_success_url
 
         log_persisted_session_and_warnings

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe V0::SessionsController, type: :controller do
   let(:succesful_logout_response) do
     double('logout_response', validate: true, success?: true, in_response_to: logout_uuid, errors: [])
   end
+  let(:decrypter) { ActiveSupport::MessageEncryptor.new(Settings.sso_cookie_key) }
 
   before do
     allow(SAML::SettingsService).to receive(:saml_settings).and_return(rubysaml_settings)
@@ -133,6 +134,7 @@ RSpec.describe V0::SessionsController, type: :controller do
     before do
       allow(SAML::User).to receive(:new).and_return(saml_user)
       Session.create(uuid: uuid, token: token)
+      Settings.set_sso_cookie = true
       User.create(loa1_user.attributes)
       UserIdentity.create(loa1_user.identity.attributes)
     end
@@ -142,7 +144,18 @@ RSpec.describe V0::SessionsController, type: :controller do
         %w[mhv dslogon idme mfa verify slo].each do |type|
           it "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             request.env['HTTP_AUTHORIZATION'] = auth_header
+            request.cookies['va_session'] = 'bar'
             get(:new, type: type)
+            if type == 'slo'
+              expect(cookies[:va_session]).to be_nil
+            elsif %w[mhv dslogon idme].include?(type)
+              expect(cookies[:va_session]).not_to be_nil
+              expect(cookies[:va_session]).to eq('bar')
+            else
+              expect(cookies[:va_session]).not_to be_nil
+              expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
+                .to eq({ 'icn' => nil, 'mhv_correlation_id' => nil})
+            end
             expect(response).to have_http_status(:ok)
             expect(JSON.parse(response.body).keys).to eq %w[url]
           end
@@ -174,40 +187,6 @@ RSpec.describe V0::SessionsController, type: :controller do
       expect(Rails.logger).to receive(:error).exactly(1).times
       expect(post(:saml_logout_callback, SAMLResponse: '-'))
         .to redirect_to(Settings.saml.logout_relay + '?success=true')
-    end
-
-    context 'SSO cookie' do
-      let(:decrypter) { ActiveSupport::MessageEncryptor.new(Settings.sso_cookie_key) }
-      it 'does not produces a response cookie for SSO when disabled via Settings' do
-        request.env['HTTP_AUTHORIZATION'] = auth_header
-        get(:new, type: :slo)
-        expect(response).to have_http_status(:ok)
-        expect(response.cookies['vamhv_session']).to be_nil
-      end
-
-      it 'produces a response cookie for SSO on logout request' do
-        request.env['HTTP_AUTHORIZATION'] = auth_header
-        Settings.set_sso_cookie = true
-        get(:new, type: :slo)
-        Settings.set_sso_cookie = false
-        expect(response).to have_http_status(:ok)
-        expect(response.cookies['vamhv_session']).not_to be_nil
-        cookie = CGI.unescape(response.cookies['vamhv_session'])
-        expiryunix = decrypter.decrypt_and_verify(cookie).split('|').first
-        expect(Time.zone.at(expiryunix.to_i)).to be < Time.zone.now
-      end
-
-      it 'produces a response cookie for SSO on an authenticated request' do
-        request.env['HTTP_AUTHORIZATION'] = auth_header
-        Settings.set_sso_cookie = true
-        get(:new, type: :verify)
-        Settings.set_sso_cookie = false
-        expect(response).to have_http_status(:ok)
-        expect(response.cookies['vamhv_session']).not_to be_nil
-        cookie = CGI.unescape(response.cookies['vamhv_session'])
-        expiryunix = decrypter.decrypt_and_verify(cookie).split('|').first
-        expect(Time.zone.at(expiryunix.to_i)).to be > Time.zone.now
-      end
     end
 
     context 'logout has been requested' do
@@ -244,6 +223,8 @@ RSpec.describe V0::SessionsController, type: :controller do
 
     describe 'POST saml_callback' do
       before(:each) do
+        Settings.set_sso_cookie = true
+        allow(controller).to receive(:async_create_evss_account)
         allow(SAML::User).to receive(:new).and_return(saml_user)
       end
 
@@ -279,6 +260,9 @@ RSpec.describe V0::SessionsController, type: :controller do
         expect(new_user.loa).to eq(highest: LOA::THREE, current: LOA::THREE)
         expect(new_user.multifactor).to be_falsey
         expect(new_user.last_signed_in).not_to eq(existing_user.last_signed_in)
+        expect(cookies[:va_session]).not_to be_nil
+        expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
+          .to eq({ 'icn' => loa3_user.icn, 'mhv_correlation_id' => loa3_user.mhv_correlation_id})
       end
 
       it 'does not log to sentry when SSN matches' do
@@ -290,6 +274,9 @@ RSpec.describe V0::SessionsController, type: :controller do
         new_user = User.find(uuid)
         expect(new_user.ssn).to eq('796111863')
         expect(new_user.va_profile.ssn).to eq('796111863')
+        expect(cookies[:va_session]).not_to be_nil
+        expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
+          .to eq({ 'icn' => loa3_user.icn, 'mhv_correlation_id' => loa3_user.mhv_correlation_id})
       end
 
       context 'changing multifactor' do
@@ -309,6 +296,13 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(new_user.multifactor).to be_truthy
           expect(new_user.last_signed_in).to eq(existing_user.last_signed_in)
         end
+
+        it 'has a cookie, but values are nil because loa1 user' do
+          post :saml_callback
+          expect(cookies[:va_session]).not_to be_nil
+          expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
+            .to eq({ 'icn' => nil, 'mhv_correlation_id' => nil})
+        end
       end
 
       context 'when user has LOA current 1 and highest 3' do
@@ -321,6 +315,9 @@ RSpec.describe V0::SessionsController, type: :controller do
         it 'redirects to identity proof URL' do
           expect(SAML::SettingsService).to receive(:idme_loa3_url)
           post :saml_callback
+          expect(cookies[:va_session]).not_to be_nil
+          expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
+            .to eq({ 'icn' => nil, 'mhv_correlation_id' => nil})
         end
       end
 
@@ -338,6 +335,9 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(controller).to receive(:log_message_to_sentry).with('SSO Callback Success URL', :warn)
           post :saml_callback
           expect(response.location).to start_with(Settings.saml.relay + '?token=')
+          expect(cookies[:va_session]).not_to be_nil
+          expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
+            .to eq({ 'icn' => nil, 'mhv_correlation_id' => nil})
         end
       end
 
@@ -369,6 +369,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(Rails.logger).to receive(:warn).with(/#{SAML::AuthFailHandler::TOO_LATE_MSG}/)
           expect(post(:saml_callback)).to redirect_to(Settings.saml.relay + '?auth=fail&code=002')
           expect(response).to have_http_status(:found)
+          expect(cookies[:va_session]).to be_nil
         end
       end
 
@@ -379,6 +380,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(Rails.logger).to receive(:error).with(/#{SAML::AuthFailHandler::TOO_EARLY_MSG}/)
           expect(post(:saml_callback)).to redirect_to(Settings.saml.relay + '?auth=fail&code=003')
           expect(response).to have_http_status(:found)
+          expect(cookies[:va_session]).to be_nil
         end
 
         it 'increments the failed and total statsd counters' do
@@ -410,6 +412,7 @@ RSpec.describe V0::SessionsController, type: :controller do
             )
           expect(post(:saml_callback)).to redirect_to(Settings.saml.relay + '?auth=fail&code=007')
           expect(response).to have_http_status(:found)
+          expect(cookies[:va_session]).to be_nil
         end
 
         it 'increments the failed and total statsd counters' do
@@ -441,6 +444,7 @@ RSpec.describe V0::SessionsController, type: :controller do
             )
           expect(post(:saml_callback)).to redirect_to(Settings.saml.relay + '?auth=fail&code=001')
           expect(response).to have_http_status(:found)
+          expect(cookies[:va_session]).to be_nil
         end
 
         it 'increments the failed and total statsd counters' do
@@ -479,6 +483,7 @@ RSpec.describe V0::SessionsController, type: :controller do
             )
           expect(post(:saml_callback)).to redirect_to(Settings.saml.relay + '?auth=fail&code=')
           expect(response).to have_http_status(:found)
+          expect(cookies[:va_session]).to be_nil
         end
 
         it 'increments the failed and total statsd counters' do


### PR DESCRIPTION
## Background
For the cookie spike we needed to make some improvements based on the call this morning. These are those changes

## Definition of Done

#### Unique to this PR

- [ ] use JSON to encode the contents of the cookie
- [ ] use native TTL in lieu of expiration attribute
- [ ] rework specs / logic

#### Applies to all PRs

- [ ] Appropriate test coverage & logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
