### PR TITLE
526 update uploads fields

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/workers/evss/disability_compensation_form/submit_uploads.rb
@@ -24,12 +24,12 @@ module EVSS
       def self.perform(upload_data, claim_id, user)
         auth_headers = EVSS::AuthHeaders.new(user).to_h
         client = EVSS::DocumentsService.new(auth_headers)
-        file_body = SupportingEvidenceAttachment.find_by(guid: upload_data[:guid]).file_data
+        file_body = SupportingEvidenceAttachment.find_by(guid: upload_data[:confirmationCode]).file_data
         document_data = EVSSClaimDocument.new(
           evss_claim_id: claim_id,
-          file_name: upload_data[:fileName],
+          file_name: upload_data[:name],
           tracked_item_id: nil,
-          document_type: upload_data[:docType]
+          document_type: upload_data[:attachmentId]
         )
         client.upload(file_body, document_data)
       end

--- a/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
   let(:claim_id) { 123_456_789 }
   let(:uploads) do
     [
-      { guid: SecureRandom.uuid },
-      { guid: SecureRandom.uuid },
-      { guid: SecureRandom.uuid },
-      { guid: SecureRandom.uuid }
+      { confirmationCode: SecureRandom.uuid },
+      { confirmationCode: SecureRandom.uuid },
+      { confirmationCode: SecureRandom.uuid },
+      { confirmationCode: SecureRandom.uuid }
     ]
   end
 
@@ -45,9 +45,9 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
   describe 'perform' do
     let(:upload_data) do
       {
-        guid: 'foo',
-        file_name: 'bar',
-        doctype: 'foobar'
+        confirmationCode: 'foo',
+        name: 'bar',
+        attachmentId: 'foobar'
       }
     end
     let(:client) { double(:client) }


### PR DESCRIPTION
## Background
Due to schema changes, certain fields under `attachments` need to have their key names update so they match on form526 submissions.

## Definition of Done

#### Unique to this PR

- [x] Replace keys with new key names in `submit_disability_form`

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
