### PR TITLE
Revert "MHV Upgrade Launch (#2080)"

### DIFF
--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -28,77 +28,57 @@ class MhvAccount < ActiveRecord::Base
   scope :created_and_upgraded, -> { created.where.not(upgraded_at: nil) }
   scope :failed_create, -> { where(registered_at: nil, account_state: :register_failed) }
 
-  TERMS_AND_CONDITIONS_NAME = 'mhvac'
-  UPGRADABLE_ACCOUNT_LEVELS = [nil, 'Basic', 'Advanced'].freeze
-  INELIGIBLE_STATES = %i[
-    needs_identity_verification needs_ssn_resolution needs_va_patient
-    has_deactivated_mhv_ids has_multiple_active_mhv_ids
-    state_ineligible country_ineligible needs_terms_acceptance
-  ].freeze
-  PERSISTED_STATES = %i[registered upgraded register_failed upgrade_failed].freeze
-  ELIGIBLE_STATES = %i[existing eligible no_account].freeze
-  ALL_STATES = (%i[unknown] + INELIGIBLE_STATES + ELIGIBLE_STATES + PERSISTED_STATES).freeze
-
   after_initialize :setup
 
-  # rubocop:disable Metrics/BlockLength
   aasm(:account_state) do
     state :unknown, initial: true
-    state(*(INELIGIBLE_STATES + ELIGIBLE_STATES + PERSISTED_STATES))
+    state :needs_terms_acceptance, :existing, :ineligible, :registered, :upgraded, :register_failed, :upgrade_failed
 
-    # NOTE: This is eligibility for account creation or upgrade, not for access to services.
     event :check_eligibility do
-      transitions from: ALL_STATES, to: :needs_identity_verification, unless: :identity_proofed?
-      transitions from: ALL_STATES, to: :needs_ssn_resolution, if: :ssn_mismatch?
-      transitions from: ALL_STATES, to: :needs_va_patient, unless: :va_patient?
-      transitions from: ALL_STATES, to: :has_deactivated_mhv_ids, if: :deactivated_mhv_ids?
-      transitions from: ALL_STATES, to: :has_multiple_active_mhv_ids, if: :multiple_active_mhv_ids?
-      transitions from: ALL_STATES, to: :needs_terms_acceptance, if: :requires_terms_acceptance?
-      transitions from: ALL_STATES, to: :eligible
+      transitions from: ALL_STATES, to: :existing, if: :preexisting_account?
+      transitions from: ALL_STATES, to: :ineligible, unless: :eligible?
+      transitions from: ALL_STATES, to: :upgraded, if: :previously_upgraded?
+      transitions from: ALL_STATES, to: :registered, if: :previously_registered?
+      transitions from: ALL_STATES, to: :unknown
     end
 
-    event :check_account_state do
-      transitions from: %i[eligible], to: :no_account, unless: :exists?
-      # The states below this line and the next comment will be removed when reintroducing upgrade.665
-      transitions from: %i[eligible], to: :upgraded, if: :previously_upgraded?
-      transitions from: %i[eligible], to: :registered, if: :previously_registered?
-      # this could mean that vets.gov created / upgraded before we started tracking mhv_ids
-      transitions from: %i[eligible], to: :existing
+    event :check_terms_acceptance do
+      transitions from: ALL_STATES - %i[existing ineligible],
+                  to: :needs_terms_acceptance, unless: :terms_and_conditions_accepted?
     end
 
     event :register do
-      transitions from: %i[register_failed no_account], to: :registered
+      transitions from: %i[unknown register_failed], to: :registered
     end
 
-    # we will upgrade existing account only if it has not been previously upgraded (even if subsequently downgraded)
     event :upgrade do
-      transitions from: %i[upgrade_failed existing registered], to: :upgraded, unless: :already_premium?
-    end
-
-    event :existing_premium do
-      transitions from: %i[existing], to: :existing, if: :already_premium?
+      transitions from: %i[unknown registered upgrade_failed], to: :upgraded
     end
 
     event :fail_register do
-      transitions from: [:no_account], to: :register_failed
+      transitions from: [:unknown], to: :register_failed
     end
 
     event :fail_upgrade do
-      transitions from: %i[registered existing], to: :upgrade_failed
+      transitions from: %i[unknown registered], to: :upgrade_failed
     end
   end
-  # rubocop:enable Metrics/BlockLength
 
-  def creatable?
-    may_register?
+  def eligible?
+    user.authorize :mhv_account_creation, :access?
   end
 
-  def upgradable?
-    may_upgrade? && account_level.in?(UPGRADABLE_ACCOUNT_LEVELS)
+  def accessible?
+    return false if mhv_correlation_id.blank?
+    (user.loa3? || user.authn_context.include?('myhealthevet')) && (upgraded? || existing?)
   end
 
   def terms_and_conditions_accepted?
     terms_and_conditions_accepted.present?
+  end
+
+  def preexisting_account?
+    mhv_correlation_id.present? && !previously_registered?
   end
 
   def terms_and_conditions_accepted
@@ -109,73 +89,28 @@ class MhvAccount < ActiveRecord::Base
                                   .where(user_uuid: user_uuid).limit(1).first
   end
 
-  def exists?
-    mhv_correlation_id.present?
+  def previously_upgraded?
+    eligible? && upgraded_at?
   end
 
-  # if vets.gov upgraded the account it is premium, if not, we have to check eligible data classes
-  # NOTE: individual services should always check mhv_account_type using eligible data classes since
-  # it is possible for accounts to get downgraded.
-  def account_level
-    return 'Advanced' if registered?
-    return 'Advanced' if upgrade_failed? && registered_at.present?
-    return 'Premium' if upgraded?
-    user.mhv_account_type
+  def previously_registered?
+    eligible? && registered_at?
   end
+
+  private
 
   def user
     @user ||= User.find(user_uuid)
   end
 
-  def already_premium?
-    account_level == 'Premium' && !previously_upgraded?
-  end
-
-  private
-
-  def identity_proofed?
-    user.loa3?
-  end
-
-  def va_patient?
-    user.va_patient?
-  end
-
-  def ssn_mismatch?
-    user.ssn_mismatch?
-  end
-
-  def requires_terms_acceptance?
-    return false if account_level == 'Premium'
-    !terms_and_conditions_accepted?
-  end
-
-  def multiple_active_mhv_ids?
-    if previously_upgraded? || previously_registered?
-      false
-    else
-      user.va_profile.active_mhv_ids.size > 1
-    end
-  end
-
-  def deactivated_mhv_ids?
-    if previously_upgraded? || previously_registered?
-      false
-    else
-      (user.va_profile.mhv_ids - user.va_profile.active_mhv_ids).to_a.any?
-    end
-  end
-
-  def previously_upgraded?
-    exists? && eligible? && upgraded_at?
-  end
-
-  def previously_registered?
-    exists? && eligible? && registered_at?
+  # TODO: remove this in future migration
+  def mhv_correlation_id
+    user.mhv_correlation_id
   end
 
   def setup
-    check_eligibility
-    check_account_state if may_check_account_state?
+    raise StandardError, 'You must use find_or_initialize_by(user_uuid: #)' if user_uuid.nil?
+    check_eligibility unless accessible?
+    check_terms_acceptance if may_check_terms_acceptance?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,9 +166,17 @@ class User < Common::RedisStore
   def va_patient?
     facilities = va_profile&.vha_facility_ids
     facilities.to_a.any? do |f|
-      Settings.mhv.facility_range.any? { |range| f.to_i.between?(*range) } ||
-        Settings.mhv.facility_specific.include?(f)
+      Settings.mhv.facility_range.any? { |range| f.to_i.between?(*range) }
     end
+  end
+
+  # Must be LOA3 and a va patient
+  def mhv_account_eligible?
+    (MhvAccount::ALL_STATES - [:ineligible]).map(&:to_s).include?(mhv_account_state)
+  end
+
+  def mhv_account_state
+    mhv_account.account_state
   end
 
   def can_save_partial_forms?
@@ -191,7 +199,7 @@ class User < Common::RedisStore
   end
 
   def mhv_account
-    @mhv_account ||= MhvAccount.find_or_initialize_by(user_uuid: uuid, mhv_correlation_id: mhv_correlation_id)
+    @mhv_account ||= MhvAccount.find_or_initialize_by(user_uuid: uuid)
   end
 
   def in_progress_forms

--- a/app/policies/mhv_account_creation_policy.rb
+++ b/app/policies/mhv_account_creation_policy.rb
@@ -2,6 +2,14 @@
 
 MhvAccountCreationPolicy = Struct.new(:user, :mhv_account_creation) do
   def access?
-    user.mhv_account.creatable? || user.mhv_account.upgradable?
+    user.loa3? && user.va_patient?
+  end
+
+  def creatable?
+    access? && user.mhv_correlation_id.blank?
+  end
+
+  def upgradable?
+    access? && user.mhv_correlation_id.present? && user.mhv_account.registered_at? && !user.mhv_account.upgraded_at?
   end
 end

--- a/app/policies/mhv_prescriptions_policy.rb
+++ b/app/policies/mhv_prescriptions_policy.rb
@@ -6,6 +6,6 @@ MhvPrescriptionsPolicy = Struct.new(:user, :mhv_prescriptions) do
   # NOTE: This check for va_patient, might break functionality for mhv-sign-in users,
   # since we only query MVI for "Premium", and Rx is technically available to non-premium.
   def access?
-    RX_ACCOUNT_TYPES.include?(user.mhv_account_type) && (user.va_patient? || user.authn_context == 'myhealthevet')
+    RX_ACCOUNT_TYPES.include?(user.mhv_account_type) && user.va_patient?
   end
 end

--- a/app/serializers/mhv_account_serializer.rb
+++ b/app/serializers/mhv_account_serializer.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
 class MhvAccountSerializer < ActiveModel::Serializer
-  attribute :account_level
   attribute :account_state
-  attribute :terms_and_conditions_accepted
-
-  def terms_and_conditions_accepted
-    object.terms_and_conditions_accepted?
-  end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -6,7 +6,7 @@ require 'common/client/concerns/service_status'
 class UserSerializer < ActiveModel::Serializer
   include Common::Client::ServiceStatus
 
-  attributes :services, :profile, :va_profile, :veteran_status,
+  attributes :services, :profile, :va_profile, :veteran_status, :mhv_account_state, :health_terms_current,
              :in_progress_forms, :prefills_available, :vet360_contact_information
 
   def id
@@ -70,6 +70,10 @@ class UserSerializer < ActiveModel::Serializer
     { status: RESPONSE_STATUS[:not_found] }
   rescue StandardError
     { status: RESPONSE_STATUS[:server_error] }
+  end
+
+  def health_terms_current
+    object.mhv_account.terms_and_conditions_accepted?
   end
 
   def in_progress_forms

--- a/app/services/mhv_account_type_service.rb
+++ b/app/services/mhv_account_type_service.rb
@@ -25,9 +25,7 @@ class MhvAccountTypeService
     return nil unless mhv_account?
 
     if account_type_known?
-      user.identity.mhv_account_type
-    elsif eligible_data_classes.nil?
-      'Error'
+      @user.identity.mhv_account_type
     else
       ELIGIBLE_DATA_CLASS_COUNT_TO_ACCOUNT_LEVEL.fetch(eligible_data_classes.size)
     end
@@ -37,11 +35,11 @@ class MhvAccountTypeService
   end
 
   def mhv_account?
-    user.mhv_correlation_id.present?
+    @user.mhv_correlation_id.present?
   end
 
   def account_type_known?
-    user.identity.mhv_account_type.present?
+    @user.identity.mhv_account_type.present?
   end
 
   private
@@ -57,7 +55,7 @@ class MhvAccountTypeService
     end
   rescue StandardError
     log_account_type_heuristic_once(MHV_DOWN_MESSAGE)
-    nil
+    []
   end
 
   def cached_eligible_data_class

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,9 +212,7 @@ Rails.application.routes.draw do
     get 'terms_and_conditions/:name/versions/latest/user_data', to: 'terms_and_conditions#latest_user_data'
     post 'terms_and_conditions/:name/versions/latest/user_data', to: 'terms_and_conditions#accept_latest'
 
-    resource :mhv_account, only: %i[show create] do
-      post :upgrade
-    end
+    resource :mhv_account, only: %i[show create]
 
     [
       'profile',

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -142,9 +142,7 @@ locators:
 
 # Settings for MyHealthEVet
 mhv:
-  # include ranges first, then individual exceptions to the ranges last.
-  facility_range: [[358,718],[720,740],[742,758]]
-  facility_specific: [['741MM']] # 741 is excluded, but 741MM is included
+  facility_range: [[358,718],[720,758]]
   rx:
     host: https://mhv-api.example.com
     app_token: fake-app-token

--- a/lib/mvi/models/mvi_profile.rb
+++ b/lib/mvi/models/mvi_profile.rb
@@ -18,7 +18,6 @@ module MVI
       attribute :icn, String
       attribute :icn_with_aaid, String
       attribute :mhv_ids, Array[String]
-      attribute :active_mhv_ids, Array[String]
       attribute :vha_facility_ids, Array[String]
       attribute :edipi, String
       attribute :participant_id, String
@@ -28,7 +27,7 @@ module MVI
       attribute :historical_icns, Array[String]
 
       def mhv_correlation_id
-        @active_mhv_ids&.first
+        @mhv_ids&.first
       end
 
       def normalized_suffix

--- a/lib/mvi/responses/profile_parser.rb
+++ b/lib/mvi/responses/profile_parser.rb
@@ -102,7 +102,6 @@ module MVI
           home_phone: parse_phone(patient),
           icn: correlation_ids[:icn],
           mhv_ids: correlation_ids[:mhv_ids],
-          active_mhv_ids: correlation_ids[:active_mhv_ids],
           edipi: correlation_ids[:edipi],
           participant_id: correlation_ids[:vba_corp_id],
           vha_facility_ids: correlation_ids[:vha_facility_ids],

--- a/spec/factories/mhv_accounts.rb
+++ b/spec/factories/mhv_accounts.rb
@@ -4,19 +4,7 @@ FactoryBot.define do
   factory :mhv_account do
     user_uuid { SecureRandom.uuid }
     account_state 'unknown'
-    mhv_correlation_id nil
     registered_at nil
     upgraded_at nil
-  end
-
-  trait :upgraded do
-    account_state :upgraded
-    registered_at Time.current
-    upgraded_at Time.current
-  end
-
-  trait :registered do
-    account_state :registered
-    registered_at Time.current
   end
 end

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -37,7 +37,6 @@ FactoryBot.define do
     icn { Faker::Number.number(17) }
     icn_with_aaid { '1000123456V123456^NI^200M^USVHA' }
     mhv_ids { Array.new(2) { Faker::Number.number(11) } }
-    active_mhv_ids { mhv_ids }
     edipi { Faker::Number.number(10) }
     participant_id { Faker::Number.number(10) }
     birls_id { Faker::Number.number(10) }
@@ -55,7 +54,6 @@ FactoryBot.define do
       home_phone '1112223333'
       icn '1000123456V123456'
       mhv_ids ['123456']
-      active_mhv_ids ['123456']
       vha_facility_ids %w[516 553 200HD 200IP 200MHV]
       edipi '1234'
       participant_id '12345678'
@@ -71,7 +69,6 @@ FactoryBot.define do
         home_phone nil
         icn '1008714701V416111'
         mhv_ids nil
-        active_mhv_ids nil
         vha_facility_ids ['200MHS']
         participant_id '9100792239'
         edipi nil
@@ -88,7 +85,6 @@ FactoryBot.define do
         icn '12345678901234567'
         sec_id '0001234567'
         mhv_ids %w[12345678901 12345678902]
-        active_mhv_ids %w[12345678901]
         vha_facility_ids %w[200MH 200MH]
         edipi '1122334455'
         participant_id '12345678'

--- a/spec/lib/mvi/responses/profile_parser_spec.rb
+++ b/spec/lib/mvi/responses/profile_parser_spec.rb
@@ -81,7 +81,6 @@ describe MVI::Responses::ProfileParser do
             sec_id: nil,
             historical_icns: nil,
             mhv_ids: ['1100792239'],
-            active_mhv_ids: ['1100792239'],
             icn_with_aaid: icn_with_aaid
           )
         end

--- a/spec/models/mhv_account_spec.rb
+++ b/spec/models/mhv_account_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe MhvAccount, type: :model do
           birth_date: '1932-02-05',
           ssn: '796126859',
           mhv_ids: mhv_ids,
-          active_mhv_ids: active_mhv_ids,
           vha_facility_ids: vha_facility_ids,
           home_phone: nil,
           address: mvi_profile_address)
@@ -29,9 +28,8 @@ RSpec.describe MhvAccount, type: :model do
   end
 
   let(:user) do
-    create(:user,
-           loa: user_loa,
-           ssn: user_ssn,
+    create(:user, :loa3,
+           ssn: mvi_profile.ssn,
            first_name: mvi_profile.given_names.first,
            last_name: mvi_profile.family_name,
            gender: mvi_profile.gender,
@@ -39,10 +37,7 @@ RSpec.describe MhvAccount, type: :model do
            email: 'vets.gov.user+0@gmail.com')
   end
 
-  let(:user_loa) { { current: LOA::THREE, highest: LOA::THREE } }
-  let(:user_ssn) { mvi_profile.ssn }
   let(:mhv_ids) { [] }
-  let(:active_mhv_ids) { mhv_ids }
   let(:vha_facility_ids) { ['450'] }
 
   before(:each) do
@@ -55,176 +50,327 @@ RSpec.describe MhvAccount, type: :model do
     end
   end
 
+  it 'must have a user_uuid when initialized' do
+    expect { described_class.new }
+      .to raise_error(StandardError, 'You must use find_or_initialize_by(user_uuid: #)')
+  end
+
   describe 'event' do
-    subject { user.mhv_account }
-
     context 'check_eligibility' do
-      context 'user not loa3' do
-        let(:user_loa) { { current: LOA::ONE, highest: LOA::ONE } }
-
-        it 'needs_identity_verification' do
-          expect(subject.account_state).to eq('needs_identity_verification')
-          expect(subject.creatable?).to be_falsey
-        end
-      end
-
-      context 'user ssn mismatch' do
-        let(:user_ssn) { '123456789' }
-
-        it 'needs_ssn_resolution' do
-          expect(subject.account_state).to eq('needs_ssn_resolution')
-          expect(subject.creatable?).to be_falsey
-        end
-      end
-
-      context 'user not a va patient' do
-        let(:vha_facility_ids) { ['999'] }
-
-        it 'needs_va_patient' do
-          expect(subject.account_state).to eq('needs_va_patient')
-          expect(subject.creatable?).to be_falsey
-        end
-      end
-
-      context 'user has previously deactivated mhv ids' do
-        let(:mhv_ids) { %w[14221465 14221466] }
-        let(:active_mhv_ids) { %w[14221466] }
-
-        it 'has_deactivated_mhv_ids' do
-          expect(subject.account_state).to eq('has_deactivated_mhv_ids')
-          expect(subject.creatable?).to be_falsey
-        end
-      end
-
-      context 'user has multiple active mhv ids' do
-        let(:mhv_ids) { %w[14221465 14221466] }
-        let(:active_mhv_ids) { mhv_ids }
-
-        it 'has_multiple_active_mhv_ids' do
-          expect(subject.account_state).to eq('has_multiple_active_mhv_ids')
-          expect(subject.creatable?).to be_falsey
-        end
-      end
-
-      context 'user has not accepted terms and conditions' do
-        let(:mhv_ids) { %w[14221465] }
-
-        it 'needs_terms_acceptance' do
-          expect(subject.account_state).to eq('needs_terms_acceptance')
-          expect(subject.creatable?).to be_falsey
-        end
-      end
-    end
-
-    context 'check_account_state' do
       context 'with terms accepted' do
         let(:terms) { create(:terms_and_conditions, latest: true, name: described_class::TERMS_AND_CONDITIONS_NAME) }
         before(:each) { create(:terms_and_conditions_acceptance, terms_and_conditions: terms, user_uuid: user.uuid) }
 
-        context 'without an existing account' do
-          context 'nothing has been persisted and no mhv_id' do
-            it 'has no_account' do
-              expect(subject.account_state).to eq('no_account')
-              expect(subject.creatable?).to be_truthy
-              expect(subject.terms_and_conditions_accepted?).to be_truthy
-            end
+        let(:base_attributes) { { user_uuid: user.uuid, account_state: 'needs_terms_acceptance' } }
+
+        context 'not a va patient' do
+          let(:vha_facility_ids) { ['999'] }
+
+          it 'is ineligible if not a va patient' do
+            subject = described_class.new(base_attributes)
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('ineligible')
+            expect(subject.eligible?).to be_falsey
+            expect(subject.accessible?).to be_falsey
+            expect(subject.terms_and_conditions_accepted?).to be_truthy
           end
         end
 
-        context 'with existing account' do
-          let(:mhv_ids) { %w[14221465] }
+        context 'with mhv id' do
+          let(:mhv_ids) { ['14221465'] }
+          let(:base_attributes) { { user_uuid: user.uuid } }
 
-          context 'nothing has been persisted with current mhv id' do
-            before(:each) do
-              allow_any_instance_of(MhvAccountTypeService)
-                .to receive(:mhv_account_type).and_return(account_type)
-            end
-
-            context 'account level basic' do
-              let(:account_type) { 'Basic' }
-
-              it 'has existing' do
-                expect(subject.account_state).to eq('existing')
-                expect(subject.creatable?).to be_falsey
-                expect(subject.upgradable?).to be_truthy
-                expect(subject.terms_and_conditions_accepted?).to be_truthy
-              end
-            end
-
-            context 'account level advanced' do
-              let(:account_type) { 'Advanced' }
-
-              it 'has existing' do
-                expect(subject.account_state).to eq('existing')
-                expect(subject.creatable?).to be_falsey
-                expect(subject.upgradable?).to be_truthy
-                expect(subject.terms_and_conditions_accepted?).to be_truthy
-              end
-            end
-
-            context 'account level premium' do
-              let(:account_type) { 'Premium' }
-
-              it 'has existing' do
-                expect(subject.account_state).to eq('existing')
-                expect(subject.creatable?).to be_falsey
-                expect(subject.upgradable?).to be_falsey
-                expect(subject.terms_and_conditions_accepted?).to be_truthy
-              end
-            end
-
-            context 'account level unknown' do
-              let(:account_type) { 'Unknown' }
-
-              it 'has existing' do
-                expect(subject.account_state).to eq('existing')
-                expect(subject.creatable?).to be_falsey
-                expect(subject.upgradable?).to be_falsey
-                expect(subject.terms_and_conditions_accepted?).to be_truthy
-              end
-            end
-
-            context 'account level unknown' do
-              let(:account_type) { 'Error' }
-
-              it 'has existing' do
-                expect(subject.account_state).to eq('existing')
-                expect(subject.creatable?).to be_falsey
-                expect(subject.upgradable?).to be_falsey
-                expect(subject.terms_and_conditions_accepted?).to be_truthy
-              end
-            end
+          it 'a priori registered account stays registered' do
+            subject = described_class.new(
+              base_attributes.merge(registered_at: Time.current, account_state: :registered)
+            )
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('registered')
+            expect(subject.accessible?).to be_falsey
           end
 
-          context 'previously upgraded' do
-            before(:each) do
-              MhvAccount.skip_callback(:initialize, :after, :setup)
-              create(:mhv_account, :upgraded, user_uuid: user.uuid, mhv_correlation_id: user.mhv_correlation_id)
-              MhvAccount.set_callback(:initialize, :after, :setup)
-            end
-
-            it 'has upgraded' do
-              expect(subject.account_state).to eq('upgraded')
-              expect(subject.creatable?).to be_falsey
-              expect(subject.upgradable?).to be_falsey
-              expect(subject.terms_and_conditions_accepted?).to be_truthy
-            end
+          it 'a priori failed upgrade that has been registered changes to registered' do
+            subject = described_class.new(
+              base_attributes.merge(registered_at: Time.current, account_state: :upgrade_failed)
+            )
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('registered')
+            expect(subject.accessible?).to be_falsey
           end
 
-          context 'previously registered' do
-            before(:each) do
-              MhvAccount.skip_callback(:initialize, :after, :setup)
-              create(:mhv_account, :registered, user_uuid: user.uuid, mhv_correlation_id: user.mhv_correlation_id)
-              MhvAccount.set_callback(:initialize, :after, :setup)
-            end
-
-            it 'has registered' do
-              expect(subject.account_state).to eq('registered')
-              expect(subject.creatable?).to be_falsey
-              expect(subject.upgradable?).to be_truthy
-              expect(subject.terms_and_conditions_accepted?).to be_truthy
-            end
+          it 'a priori upgraded account stays upgraded' do
+            subject = described_class.new(
+              base_attributes.merge(upgraded_at: Time.current, account_state: :upgraded)
+            )
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('upgraded')
+            expect(subject.accessible?).to be_truthy
           end
+
+          it 'is able to transition back to upgraded' do
+            subject = described_class.new(
+              base_attributes.merge(registered_at: Time.current, upgraded_at: Time.current)
+            )
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('upgraded')
+            expect(subject.eligible?).to be_truthy
+            expect(subject.terms_and_conditions_accepted?).to be_truthy
+            expect(subject.accessible?).to be_truthy
+          end
+        end
+
+        context 'without mhv id' do
+          it 'a priori registered account changes to registered' do
+            subject = described_class.new(
+              base_attributes.merge(registered_at: Time.current, account_state: :registered)
+            )
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('registered')
+            expect(subject.accessible?).to be_falsey
+          end
+
+          it 'a priori upgraded account changes to upgraded' do
+            subject = described_class.new(
+              base_attributes.merge(upgraded_at: Time.current, account_state: :upgraded)
+            )
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('upgraded')
+            expect(subject.accessible?).to be_falsey
+          end
+
+          it 'is able to transition back to upgraded' do
+            subject = described_class.new(
+              base_attributes.merge(registered_at: Time.current, upgraded_at: Time.current)
+            )
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('upgraded')
+            expect(subject.eligible?).to be_truthy
+            expect(subject.terms_and_conditions_accepted?).to be_truthy
+            expect(subject.accessible?).to be_falsey
+          end
+        end
+
+        it 'is able to transition back to registered' do
+          subject = described_class.new(base_attributes.merge(registered_at: Time.current))
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).to eq('registered')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_truthy
+          expect(subject.accessible?).to be_falsey
+        end
+
+        it 'falls back to unknown' do
+          subject = described_class.new(base_attributes)
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).to eq('unknown')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_truthy
+          expect(subject.accessible?).to be_falsey
+        end
+
+        it 'a priori register_failed account changes to unknown' do
+          subject = described_class.new(base_attributes.merge(upgraded_at: nil, account_state: :register_failed))
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).to eq('unknown')
+          expect(subject.accessible?).to be_falsey
+        end
+
+        it 'a priori upgrade_failed account changes to unknown' do
+          subject = described_class.new(base_attributes.merge(upgraded_at: nil, account_state: :upgrade_failed))
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).to eq('unknown')
+          expect(subject.accessible?).to be_falsey
+        end
+      end
+
+      context 'with terms not accepted' do
+        context 'not a va patient' do
+          let(:vha_facility_ids) { ['999'] }
+
+          it 'is ineligible if not a va patient' do
+            subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('ineligible')
+            expect(subject.eligible?).to be_falsey
+            expect(subject.terms_and_conditions_accepted?).to be_falsey
+            expect(subject.accessible?).to be_falsey
+          end
+        end
+
+        context 'preexisting account' do
+          let(:mhv_ids) { ['14221465'] }
+          let(:base_attributes) { { user_uuid: user.uuid } }
+
+          it 'does not transition to needs_terms_acceptance' do
+            subject = described_class.new(base_attributes)
+            subject.send(:setup) # This gets called when object is first loaded
+            expect(subject.account_state).to eq('existing')
+            expect(subject.eligible?).to be_truthy
+            expect(subject.terms_and_conditions_accepted?).to be_falsey
+            expect(subject.accessible?).to be_truthy
+          end
+        end
+
+        it 'transitions to needs_terms_acceptance' do
+          subject = described_class.new(user_uuid: user.uuid, account_state: 'upgraded', upgraded_at: Time.current)
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).to eq('needs_terms_acceptance')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_falsey
+          expect(subject.accessible?).to be_falsey
+        end
+
+        it 'is able to transition back to registered' do
+          subject = described_class.new(user_uuid: user.uuid, account_state: 'registered', registered_at: Time.current)
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).to eq('needs_terms_acceptance')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_falsey
+          expect(subject.accessible?).to be_falsey
+        end
+
+        it 'it falls back to unknown' do
+          subject = described_class.new(user_uuid: user.uuid, account_state: 'unknown')
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).to eq('needs_terms_acceptance')
+          expect(subject.eligible?).to be_truthy
+          expect(subject.terms_and_conditions_accepted?).to be_falsey
+          expect(subject.accessible?).to be_falsey
+        end
+      end
+    end
+
+    context 'user with un-dashed uuid' do
+      let(:nodashuser) do
+        create(:user, :loa3,
+               uuid: 'abcdef12345678',
+               ssn: mvi_profile.ssn,
+               first_name: mvi_profile.given_names.first,
+               last_name: mvi_profile.family_name,
+               gender: mvi_profile.gender,
+               birth_date: mvi_profile.birth_date,
+               email: 'vets.gov.user+0@gmail.com')
+      end
+      let(:terms) { create(:terms_and_conditions, latest: true, name: described_class::TERMS_AND_CONDITIONS_NAME) }
+      before(:each) do
+        create(:terms_and_conditions_acceptance,
+               terms_and_conditions: terms,
+               user_uuid: nodashuser.uuid)
+      end
+      let(:base_attributes) { { user_uuid: nodashuser.uuid, account_state: 'needs_terms_acceptance' } }
+      let(:vha_facility_ids) { %w[200MH 488] }
+
+      it 'is eligible with at least one facility in range' do
+        subject = described_class.new(base_attributes)
+        subject.send(:setup) # This gets called when object is first loaded
+        expect(subject.eligible?).to be_truthy
+        expect(subject.accessible?).to be_falsey
+      end
+    end
+  end
+
+  describe 'va_patient eligibility' do
+    subject { described_class.new(user_uuid: user.uuid) }
+    context 'empty facility list' do
+      let(:vha_facility_ids) { [] }
+      it 'is ineligible if vha facility list is empty' do
+        subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
+        subject.send(:setup) # This gets called when object is first loaded
+        expect(subject.account_state).to eq('ineligible')
+        expect(subject.accessible?).to be_falsey
+      end
+    end
+
+    context 'nil facility list' do
+      let(:vha_facility_ids) { nil }
+      it 'is ineligible if vha facility list is nil' do
+        subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
+        subject.send(:setup) # This gets called when object is first loaded
+        expect(subject.account_state).to eq('ineligible')
+        expect(subject.accessible?).to be_falsey
+      end
+    end
+
+    context 'with standard range' do
+      it 'is eligible with facility in range' do
+        subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
+        subject.send(:setup) # This gets called when object is first loaded
+        expect(subject.account_state).not_to eq('ineligible')
+        expect(subject.accessible?).to be_falsey
+      end
+
+      context 'with multiple facilities' do
+        let(:vha_facility_ids) { %w[200MH 488] }
+        it 'is eligible with at least one facility in range' do
+          subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).not_to eq('ineligible')
+          expect(subject.accessible?).to be_falsey
+        end
+      end
+
+      context 'with alphanumeric facility' do
+        let(:vha_facility_ids) { ['566GE'] }
+        it 'is eligible with facility in range' do
+          subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).not_to eq('ineligible')
+          expect(subject.accessible?).to be_falsey
+        end
+      end
+
+      context 'with excluded facility in middle of range' do
+        let(:vha_facility_ids) { ['719'] }
+        it 'is ineligible' do
+          subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).to eq('ineligible')
+          expect(subject.accessible?).to be_falsey
+        end
+      end
+    end
+
+    context 'with user facility on edge of range' do
+      before do
+        Settings.mhv.facility_range = [[450, 758]]
+      end
+      it 'is eligible with facility at edge ef range' do
+        subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
+        subject.send(:setup) # This gets called when object is first loaded
+        expect(subject.account_state).not_to eq('ineligible')
+        expect(subject.accessible?).to be_falsey
+      end
+    end
+
+    context 'with even more abbreviated range' do
+      before do
+        Settings.mhv.facility_range = [[600, 758]]
+      end
+
+      it 'is ineligible with facility out of range' do
+        subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
+        subject.send(:setup) # This gets called when object is first loaded
+        expect(subject.account_state).to eq('ineligible')
+        expect(subject.accessible?).to be_falsey
+      end
+
+      context 'with multiple facilities' do
+        let(:vha_facility_ids) { %w[200MH 488] }
+        it 'is ineligible with all facilities out of range' do
+          subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).to eq('ineligible')
+          expect(subject.accessible?).to be_falsey
+        end
+      end
+
+      context 'with alphanumeric facility' do
+        let(:vha_facility_ids) { ['566GE'] }
+        it 'is ineligible with facility out of range' do
+          subject = described_class.new(user_uuid: user.uuid, account_state: 'needs_terms_acceptance')
+          subject.send(:setup) # This gets called when object is first loaded
+          expect(subject.account_state).to eq('ineligible')
+          expect(subject.accessible?).to be_falsey
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe User, type: :model do
 
   describe '.create()' do
     context 'with LOA 1' do
-      subject(:loa1_user) { described_class.new(build(:user, loa: loa_one)) }
+      subject(:loa1_user) { described_class.new(FactoryBot.build(:user, loa: loa_one)) }
 
       it 'should not allow a blank uuid' do
         loa1_user.uuid = ''
@@ -86,10 +86,10 @@ RSpec.describe User, type: :model do
     end
   end
 
-  subject { described_class.new(build(:user)) }
+  subject { described_class.new(FactoryBot.build(:user)) }
 
   context 'user without attributes' do
-    let(:test_user) { build(:user) }
+    let(:test_user) { FactoryBot.build(:user) }
 
     it 'expect ttl to an Integer' do
       expect(subject.ttl).to be_an(Integer)
@@ -154,8 +154,8 @@ RSpec.describe User, type: :model do
 
     describe 'getter methods' do
       context 'when saml user attributes available, icn is available, and user LOA3' do
-        let(:mvi_profile) { build(:mvi_profile) }
-        let(:user) { build(:user, :loa3, middle_name: 'J', mhv_icn: mvi_profile.icn) }
+        let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
+        let(:user) { FactoryBot.build(:user, :loa3, middle_name: 'J', mhv_icn: mvi_profile.icn) }
         before(:each) do
           stub_mvi(mvi_profile)
         end
@@ -194,8 +194,8 @@ RSpec.describe User, type: :model do
       end
 
       context 'when saml user attributes NOT available, icn is available, and user LOA3' do
-        let(:mvi_profile) { build(:mvi_profile) }
-        let(:user) { build(:user, :loa3, :mhv_sign_in, mhv_icn: mvi_profile.icn) }
+        let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
+        let(:user) { FactoryBot.build(:user, :loa3, :mhv_sign_in, mhv_icn: mvi_profile.icn) }
         before(:each) { stub_mvi(mvi_profile) }
 
         it 'fetches first_name from MVI' do
@@ -203,7 +203,7 @@ RSpec.describe User, type: :model do
         end
 
         context 'when given_names has no middle_name' do
-          let(:mvi_profile) { build(:mvi_profile, given_names: ['Joe']) }
+          let(:mvi_profile) { FactoryBot.build(:mvi_profile, given_names: ['Joe']) }
 
           it 'fetches middle name from MVI' do
             expect(user.middle_name).to be_nil
@@ -211,7 +211,7 @@ RSpec.describe User, type: :model do
         end
 
         context 'when given_names has middle_name' do
-          let(:mvi_profile) { build(:mvi_profile, given_names: %w[Joe Bob]) }
+          let(:mvi_profile) { FactoryBot.build(:mvi_profile, given_names: %w[Joe Bob]) }
 
           it 'fetches middle name from MVI' do
             expect(user.middle_name).to eq('Bob')
@@ -219,7 +219,7 @@ RSpec.describe User, type: :model do
         end
 
         context 'when given_names has multiple middle names' do
-          let(:mvi_profile) { build(:mvi_profile, given_names: %w[Michael Joe Bob Sinclair]) }
+          let(:mvi_profile) { FactoryBot.build(:mvi_profile, given_names: %w[Michael Joe Bob Sinclair]) }
 
           it 'fetches middle name from MVI' do
             expect(user.middle_name).to eq('Joe Bob Sinclair')
@@ -248,8 +248,8 @@ RSpec.describe User, type: :model do
       end
 
       context 'when saml user attributes NOT available, icn is available, and user NOT LOA3' do
-        let(:mvi_profile) { build(:mvi_profile) }
-        let(:user) { build(:user, :loa1, :mhv_sign_in, mhv_icn: mvi_profile.icn) }
+        let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
+        let(:user) { FactoryBot.build(:user, :loa1, :mhv_sign_in, mhv_icn: mvi_profile.icn) }
         before(:each) { stub_mvi(mvi_profile) }
 
         it 'fetches first_name from IDENTITY' do
@@ -282,8 +282,8 @@ RSpec.describe User, type: :model do
       end
 
       context 'when icn is not available from saml data' do
-        let(:mvi_profile) { build(:mvi_profile) }
-        let(:user) { build(:user, :loa3) }
+        let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
+        let(:user) { FactoryBot.build(:user, :loa3) }
         before(:each) { stub_mvi(mvi_profile) }
 
         it 'fetches first_name from IDENTITY' do
@@ -317,19 +317,18 @@ RSpec.describe User, type: :model do
 
       describe '#mhv_correlation_id' do
         context 'when mhv ids are nil' do
-          let(:user) { build(:user) }
+          let(:user) { FactoryBot.build(:user) }
           it 'has a mhv correlation id of nil' do
             expect(user.mhv_correlation_id).to be_nil
           end
         end
 
         context 'when there are mhv ids' do
-          let(:loa3_user) { build(:user, :loa3) }
-          let(:mvi_profile) { build(:mvi_profile) }
+          let(:loa3_user) { FactoryBot.build(:user, :loa3) }
+          let(:mvi_profile) { FactoryBot.build(:mvi_profile) }
           it 'has a mhv correlation id' do
             stub_mvi(mvi_profile)
             expect(loa3_user.mhv_correlation_id).to eq(mvi_profile.mhv_ids.first)
-            expect(loa3_user.mhv_correlation_id).to eq(mvi_profile.active_mhv_ids.first)
           end
         end
       end
@@ -343,14 +342,6 @@ RSpec.describe User, type: :model do
       stub_mvi(mvi_profile)
     end
 
-    around(:each) do |example|
-      with_settings(Settings.mhv, facility_range: [[450, 758]]) do
-        with_settings(Settings.mhv, facility_specific: ['759MM']) do
-          example.run
-        end
-      end
-    end
-
     context 'when there are no facilities' do
       let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: []) }
       it 'is false' do
@@ -358,75 +349,17 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'when there are nil facilities' do
-      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: nil) }
-      it 'is false' do
-        expect(user.va_patient?).to be_falsey
-      end
-    end
-
     context 'when there are no facilities in the defined range' do
-      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: [200, 759]) }
+      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: [719]) }
       it 'is false' do
         expect(user.va_patient?).to be_falsey
       end
     end
 
-    context 'when facility is at the bottom edge of range' do
-      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: [450]) }
+    context 'when there are facilities in the defined range' do
+      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: [400]) }
       it 'is true' do
         expect(user.va_patient?).to be_truthy
-      end
-    end
-
-    context 'when alphanumeric facility is at the bottom edge of range' do
-      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: %w[450MH]) }
-      it 'is true' do
-        expect(user.va_patient?).to be_truthy
-      end
-    end
-
-    context 'when facility is at the top edge of range' do
-      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: [758]) }
-      it 'is true' do
-        expect(user.va_patient?).to be_truthy
-      end
-    end
-
-    context 'when alphanumeric facility is at the top edge of range' do
-      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: %w[758MH]) }
-      it 'is true' do
-        expect(user.va_patient?).to be_truthy
-      end
-    end
-
-    context 'when there are multiple alphanumeric facilities all within defined range' do
-      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: %w[450MH 758MH]) }
-      it 'is true' do
-        expect(user.va_patient?).to be_truthy
-      end
-    end
-
-    context 'when there are multiple facilities all outside of defined range' do
-      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: %w[449MH 759MH]) }
-      it 'is false' do
-        expect(user.va_patient?).to be_falsey
-      end
-    end
-
-    context 'when it matches exactly to a facility_specific' do
-      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: %w[759MM]) }
-
-      it 'is true' do
-        expect(user.va_patient?).to be_truthy
-      end
-    end
-
-    context 'when it does not match exactly to a facility_specific and is outside of ranges' do
-      let(:mvi_profile) { build(:mvi_profile, vha_facility_ids: %w[759]) }
-
-      it 'is false' do
-        expect(user.va_patient?).to be_falsey
       end
     end
   end

--- a/spec/request/mhv_accounts_request_spec.rb
+++ b/spec/request/mhv_accounts_request_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Account creation and upgrade', type: :request do
 
   let(:user) do
     create(:user, :loa3,
-           ssn: user_ssn,
+           ssn: mvi_profile.ssn,
            first_name: mvi_profile.given_names.first,
            last_name: mvi_profile.family_name,
            gender: mvi_profile.gender,
@@ -37,216 +37,127 @@ RSpec.describe 'Account creation and upgrade', type: :request do
            email: 'vets.gov.user+0@gmail.com')
   end
 
-  let(:user_ssn) { mvi_profile.ssn }
-
   let(:mhv_ids) { [] }
   let(:vha_facility_ids) { ['450'] }
 
   let(:terms) { create(:terms_and_conditions, latest: true, name: MhvAccount::TERMS_AND_CONDITIONS_NAME) }
+  let(:tc_accepted) { create(:terms_and_conditions_acceptance, terms_and_conditions: terms, created_at: Time.current) }
 
   before(:each) do
     stub_mvi(mvi_profile)
     use_authenticated_current_user(current_user: user)
   end
 
-  shared_examples 'a failed POST #create' do |options|
-    it "responds with #{options[:http_status]}" do
-      post v0_mhv_account_path
-      expect(response).to have_http_status(options[:http_status])
-      expect(JSON.parse(response.body)['errors'].first['detail']).to eq(options[:message])
-    end
-  end
-
-  shared_examples 'a failed POST #upgrade' do |options|
-    it "responds with #{options[:http_status]}" do
-      post '/v0/mhv_account/upgrade'
-      expect(response).to have_http_status(options[:http_status])
-      expect(JSON.parse(response.body)['errors'].first['detail']).to eq(options[:message])
-    end
-  end
-
-  shared_examples 'a successful GET #show' do |options|
-    it 'responds with JSON indicating current account state / level' do
+  context 'without accepted terms and conditions' do
+    it 'responds to GET #show' do
       get v0_mhv_account_path
       expect(response).to be_success
-      base_response_body = JSON.parse(response.body)['data']['attributes']
-      expect(base_response_body['account_state']).to eq(options[:account_state])
-      expect(base_response_body['account_level']).to eq(options[:account_level])
+      expect(JSON.parse(response.body)['data']['attributes']['account_state']).to eq('needs_terms_acceptance')
+    end
+
+    it 'raises error for POST #create' do
+      post v0_mhv_account_path
+      expect(response).to have_http_status(:forbidden)
     end
   end
 
-  shared_context 'ssn mismatch' do |options|
-    let(:user_ssn) { '999999999' }
-
-    it_behaves_like 'a successful GET #show', account_state: 'needs_ssn_resolution',
-                                              account_level: options&.dig(:account_level)
-    it_behaves_like 'a failed POST #create', http_status: :forbidden,
-                                             message: V0::MhvAccountsController::CREATE_ERROR
-    it_behaves_like 'a failed POST #upgrade', http_status: :forbidden,
-                                              message: V0::MhvAccountsController::UPGRADE_ERROR
-  end
-
-  shared_context 'non va patient' do |options|
-    let(:vha_facility_ids) { [] }
-
-    it_behaves_like 'a successful GET #show', account_state: 'needs_va_patient',
-                                              account_level: options&.dig(:account_level)
-    it_behaves_like 'a failed POST #create', http_status: :forbidden,
-                                             message: V0::MhvAccountsController::CREATE_ERROR
-    it_behaves_like 'a failed POST #upgrade', http_status: :forbidden,
-                                              message: V0::MhvAccountsController::UPGRADE_ERROR
-  end
-
-  shared_context 'a successful POST #create' do
-    it 'creates' do
-      VCR.use_cassette('mhv_account_creation/creates_an_account') do
-        post v0_mhv_account_path
-        expect(response).to have_http_status(:created)
-        expect(JSON.parse(response.body)['data']['attributes']).to eq(
-          'account_level' => 'Advanced',
-          'account_state' => 'registered',
-          'terms_and_conditions_accepted' => true
-        )
-      end
-    end
-  end
-
-  shared_context 'a successful POST #upgrade' do
-    it 'upgrades' do
-      VCR.use_cassette('mhv_account_creation/upgrades_an_account') do
-        post '/v0/mhv_account/upgrade'
-        expect(response).to have_http_status(:accepted)
-        expect(JSON.parse(response.body)['data']['attributes']).to eq(
-          'account_level' => 'Premium',
-          'account_state' => 'upgraded',
-          'terms_and_conditions_accepted' => true
-        )
-      end
-    end
-  end
-
-  shared_context 'an unsuccessful POST #create' do
-    it 'fails to create' do
-      VCR.use_cassette('mhv_account_creation/account_creation_unknown_error') do
-        post v0_mhv_account_path
-        expect(response).to have_http_status(:bad_request)
-        expect(JSON.parse(response.body)['errors'].first['detail'])
-          .to eq('Something went wrong. Please try again later.')
-      end
-    end
-  end
-
-  shared_context 'an unsuccessful POST #upgrade' do
-    it 'fails to upgrade' do
-      VCR.use_cassette('mhv_account_creation/account_creation_unknown_error') do
-        post '/v0/mhv_account/upgrade'
-        expect(response).to have_http_status(:bad_request)
-        expect(JSON.parse(response.body)['errors'].first['detail'])
-          .to eq('Something went wrong. Please try again later.')
-      end
-    end
-  end
-
-  context 'without T&C acceptance' do
-    it_behaves_like 'a successful GET #show', account_state: 'needs_terms_acceptance', account_level: nil
-    it_behaves_like 'a failed POST #create', http_status: :forbidden,
-                                             message: V0::MhvAccountsController::CREATE_ERROR
-    it_behaves_like 'a failed POST #upgrade', http_status: :forbidden,
-                                              message: V0::MhvAccountsController::UPGRADE_ERROR
-    it_behaves_like 'ssn mismatch'
-    it_behaves_like 'non va patient'
-  end
-
-  context 'with T&C acceptance' do
+  context 'with accepted terms and conditions' do
     before { create(:terms_and_conditions_acceptance, terms_and_conditions: terms, user_uuid: user.uuid) }
 
-    it_behaves_like 'ssn mismatch'
-    it_behaves_like 'non va patient'
-
     context 'without an account' do
-      it_behaves_like 'a successful GET #show', account_state: 'no_account', account_level: nil
-      it_behaves_like 'a successful POST #create'
-      it_behaves_like 'a failed POST #upgrade', http_status: :forbidden,
-                                                message: V0::MhvAccountsController::UPGRADE_ERROR
-    end
+      it 'responds to GET #show' do
+        get v0_mhv_account_path
+        expect(response).to be_success
+        expect(JSON.parse(response.body)['data']['attributes']['account_state']).to eq('unknown')
+      end
 
-    context 'with account' do
-      let(:mhv_ids) { ['14221465'] }
-
-      context 'that is' do
-        %w[Basic Advanced].each do |type|
-          context type do
-            around(:each) do |example|
-              VCR.use_cassette("mhv_account_type_service/#{type.downcase}", allow_playback_repeats: true) do
-                example.run
-              end
-            end
-
-            it_behaves_like 'a successful GET #show', account_state: 'existing', account_level: type
-            it_behaves_like 'ssn mismatch', account_level: type
-            it_behaves_like 'non va patient', account_level: type
-            it_behaves_like 'a successful POST #upgrade'
-            it_behaves_like 'a failed POST #create', http_status: :forbidden,
-                                                     message: V0::MhvAccountsController::CREATE_ERROR
+      it 'responds to POST #create' do
+        VCR.use_cassette('mhv_account_creation/creates_an_account') do
+          VCR.use_cassette('mhv_account_creation/upgrades_an_account') do
+            post v0_mhv_account_path
           end
         end
+        expect(response).to have_http_status(:accepted)
+        expect(JSON.parse(response.body)['data']['attributes']['account_state']).to eq('upgraded')
+      end
 
-        %w[Premium Error Unknown].each do |type|
-          context type do
-            around(:each) do |example|
-              VCR.use_cassette("mhv_account_type_service/#{type.downcase}", allow_playback_repeats: true) do
-                example.run
-              end
-            end
+      it 'handles creation error in POST #create' do
+        VCR.use_cassette('mhv_account_creation/account_creation_unknown_error') do
+          post v0_mhv_account_path
+        end
+        expect(response).to have_http_status(:bad_request)
+      end
 
-            it_behaves_like 'a successful GET #show', account_state: 'existing', account_level: type
-            it_behaves_like 'ssn mismatch', account_level: type
-            it_behaves_like 'non va patient', account_level: type
-            it_behaves_like 'a failed POST #create', http_status: :forbidden,
-                                                     message: V0::MhvAccountsController::CREATE_ERROR
-            it_behaves_like 'a failed POST #upgrade', http_status: :forbidden,
-                                                      message: V0::MhvAccountsController::UPGRADE_ERROR
+      it 'handles upgrade error in POST #create' do
+        VCR.use_cassette('mhv_account_creation/creates_an_account') do
+          VCR.use_cassette('mhv_account_creation/account_upgrade_unknown_error') do
+            post v0_mhv_account_path
           end
+        end
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context 'with an account' do
+      let(:mhv_ids) { ['14221465'] }
+
+      context 'that is existing' do
+        it 'responds to GET #show' do
+          get v0_mhv_account_path
+          expect(response).to be_success
+          expect(JSON.parse(response.body)['data']['attributes']['account_state']).to eq('existing')
+        end
+
+        it 'raises error for POST #create' do
+          post v0_mhv_account_path
+          expect(response).to have_http_status(:forbidden)
         end
       end
 
       context 'that is registered' do
         before(:each) do
-          MhvAccount.create(user_uuid: user.uuid, mhv_correlation_id: mhv_ids.first,
-                            account_state: 'registered', registered_at: Time.current)
+          mhv_account = MhvAccount.find_or_initialize_by(user_uuid: user.uuid)
+          mhv_account.update(account_state: 'registered', registered_at: Time.current)
         end
 
-        around(:each) do |example|
-          VCR.use_cassette('mhv_account_type_service/advanced', allow_playback_repeats: true) do
-            example.run
+        it 'responds to GET #show' do
+          get v0_mhv_account_path
+          expect(response).to be_success
+          expect(JSON.parse(response.body)['data']['attributes']['account_state']).to eq('registered')
+        end
+
+        it 'responds to POST #create' do
+          VCR.use_cassette('mhv_account_creation/upgrades_an_account') do
+            post v0_mhv_account_path
           end
+          expect(response).to have_http_status(:accepted)
+          expect(JSON.parse(response.body)['data']['attributes']['account_state']).to eq('upgraded')
         end
 
-        it_behaves_like 'a successful GET #show', account_state: 'registered', account_level: 'Advanced'
-        it_behaves_like 'ssn mismatch', account_level: 'Advanced'
-        it_behaves_like 'non va patient', account_level: 'Advanced'
-        it_behaves_like 'a successful POST #upgrade'
-        it_behaves_like 'a failed POST #create', http_status: :forbidden,
-                                                 message: V0::MhvAccountsController::CREATE_ERROR
+        it 'handles upgrade error in POST #create' do
+          VCR.use_cassette('mhv_account_creation/account_upgrade_unknown_error') do
+            post v0_mhv_account_path
+          end
+          expect(response).to have_http_status(:bad_request)
+        end
       end
 
       context 'that is upgraded' do
         before(:each) do
-          MhvAccount.create(user_uuid: user.uuid, mhv_correlation_id: mhv_ids.first,
-                            account_state: 'upgraded', upgraded_at: Time.current)
+          mhv_account = MhvAccount.find_or_initialize_by(user_uuid: user.uuid)
+          mhv_account.update(account_state: 'upgraded', upgraded_at: Time.current)
         end
 
-        around(:each) do |example|
-          VCR.use_cassette('mhv_account_type_service/premium') do
-            example.run
-          end
+        it 'responds to GET #show' do
+          get v0_mhv_account_path
+          expect(response).to be_success
+          expect(JSON.parse(response.body)['data']['attributes']['account_state']).to eq('upgraded')
         end
 
-        it_behaves_like 'a successful GET #show', account_state: 'upgraded', account_level: 'Premium'
-        it_behaves_like 'ssn mismatch', account_level: 'Premium'
-        it_behaves_like 'non va patient', account_level: 'Premium'
-        it_behaves_like 'a failed POST #create', http_status: :forbidden,
-                                                 message: V0::MhvAccountsController::CREATE_ERROR
+        it 'raises error for POST #create' do
+          post v0_mhv_account_path
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
   end

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Fetching user data', type: :request do
     before do
       Session.create(uuid: mhv_user.uuid, token: token)
       allow_any_instance_of(MhvAccountTypeService).to receive(:mhv_account_type).and_return('Premium')
-      mhv_account = double('MhvAccount', creatable?: false, upgradable?: false, account_state: 'upgraded')
+      mhv_account = double('MhvAccount', account_state: 'upgraded')
       allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
       allow(mhv_account).to receive(:terms_and_conditions_accepted?).and_return(true)
       allow(mhv_account).to receive(:needs_terms_acceptance?).and_return(false)
@@ -39,7 +39,7 @@ RSpec.describe 'Fetching user data', type: :request do
           BackendServices::RX,
           BackendServices::MESSAGING,
           BackendServices::HEALTH_RECORDS,
-          # BackendServices::MHV_AC, this will be false if mhv account is premium
+          BackendServices::MHV_AC,
           BackendServices::FORM_PREFILL,
           BackendServices::SAVE_IN_PROGRESS,
           BackendServices::APPEALS_STATUS,

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -175,6 +175,31 @@ RSpec.describe UserSerializer, type: :serializer do
     end
   end
 
+  describe '#health_terms_current' do
+    context 'with an ineligible user' do
+      let(:user) { create(:user, :loa1) }
+
+      it 'should be false' do
+        expect(user.mhv_account.terms_and_conditions_accepted?).to be_falsey
+        expect(attributes['health_terms_current']).to be_falsey
+      end
+    end
+
+    context 'with an eligible user' do
+      let(:user) { create(:user, :mhv) }
+
+      it 'without terms accepted should be false' do
+        allow(user.mhv_account).to receive(:terms_and_conditions_accepted?).and_return(false)
+        expect(attributes['health_terms_current']).to be_falsey
+      end
+
+      it 'when terms are accepted should be true' do
+        allow(user.mhv_account).to receive(:terms_and_conditions_accepted?).and_return(true)
+        expect(attributes['health_terms_current']).to be_truthy
+      end
+    end
+  end
+
   describe '#vet360_contact_information' do
     context 'with an loa1 user' do
       let(:user) { create(:user, :loa1) }

--- a/spec/services/mhv_account_type_service_spec.rb
+++ b/spec/services/mhv_account_type_service_spec.rb
@@ -43,10 +43,9 @@ RSpec.describe MhvAccountTypeService do
     it '#mhv_account_type returns Premium' do
       VCR.use_cassette('mhv_account_type_service/premium') do
         eligible_data_classes = subject.eligible_data_classes
-        # expect(Raven).not_to receive(:capture_message)
+        expect(Raven).not_to receive(:capture_message)
         expect(eligible_data_classes.count).to eq(32)
         expect(subject.mhv_account_type).to eq('Premium')
-        described_class.new(user)
       end
     end
   end
@@ -112,7 +111,7 @@ RSpec.describe MhvAccountTypeService do
           expect(Raven).to receive(:extra_context).with(extra_context)
           expect(Raven).to receive(:tags_context).with(tags_context)
           expect(Raven).to receive(:capture_message).with(error_message, level: level)
-          expect(subject.mhv_account_type).to eq('Error')
+          expect(subject.mhv_account_type).to eq('Unknown')
         end
       end
     end

--- a/spec/services/mhv_accounts_service_spec.rb
+++ b/spec/services/mhv_accounts_service_spec.rb
@@ -40,113 +40,201 @@ RSpec.describe MhvAccountsService do
   let(:mhv_ids) { [] }
   let(:vha_facility_ids) { ['450'] }
 
+  let(:terms) { create(:terms_and_conditions, latest: true, name: MhvAccount::TERMS_AND_CONDITIONS_NAME) }
+  let(:tc_accepted) { double('terms_and_conditions_accepted', terms_and_conditions: terms, created_at: Time.current) }
+  let(:mhv_account) do
+    double(
+      'mhv_account',
+      may_register?: true,
+      may_upgrade?: true,
+      terms_and_conditions_accepted: tc_accepted
+    )
+  end
+
+  subject { described_class.new(user) }
   before(:each) do
     stub_mvi(mvi_profile)
-    terms = create(:terms_and_conditions, latest: true, name: MhvAccount::TERMS_AND_CONDITIONS_NAME, version: 'v3.4')
-    date_signed = Time.new(2017, 5, 9).utc
-    create(:terms_and_conditions_acceptance, terms_and_conditions: terms, user_uuid: user.uuid, created_at: date_signed)
+    allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
   end
 
   describe 'account creation and upgrade' do
-    let(:mhv_account) { MhvAccount.new(user_uuid: user.uuid, mhv_correlation_id: user.mhv_correlation_id) }
-    subject { described_class.new(mhv_account) }
-
     context 'account creation' do
+      before(:each) do
+        allow(mhv_account).to receive(:registered_at=)
+        allow(mhv_account).to receive(:register!)
+      end
+
       it 'handles failure to create' do
         allow_any_instance_of(MHVAC::Client).to receive(:post_register).and_raise(StandardError, 'random')
         expect(subject).to receive(:log_warning)
-
+        expect(mhv_account).to receive(:fail_register!)
         expect { subject.create }.to raise_error(StandardError, 'random')
           .and not_trigger_statsd_increment('mhv.account.creation.success')
           .and trigger_statsd_increment('mhv.account.creation.failure')
-        expect(mhv_account.account_state).to eq('register_failed')
-        expect(mhv_account.persisted?).to be_truthy
       end
 
       it 'successfully creates' do
         VCR.use_cassette('mhv_account_creation/creates_an_account') do
+          expect(mhv_account).to receive(:registered_at=).with(kind_of(Time))
+          expect(mhv_account).to receive(:register!)
           expect { subject.create }.to trigger_statsd_increment('mhv.account.creation.success')
             .and not_trigger_statsd_increment('mhv.account.creation.failure')
           expect(User.find(user.uuid).mhv_correlation_id).to eq('14221465')
-          expect(mhv_account.account_state).to eq('registered')
-          expect(mhv_account.registered_at).to be_a(Time)
-          expect(mhv_account.persisted?).to be_truthy
         end
       end
     end
 
     context 'account upgrade' do
-      let(:common_collection_namespace) do
-        Redis::Namespace.new('common_collection', redis: Redis.current)
-      end
       let(:mhv_ids) { ['14221465'] }
-      let(:edc_cache_key) { '14221465:geteligibledataclass' }
 
       before(:each) do
-        # ensure pristine state in cache
-        common_collection_namespace.del(edc_cache_key)
+        allow(mhv_account).to receive(:upgraded_at=)
+        allow(mhv_account).to receive(:upgrade!)
       end
 
-      context 'with an existing basic account' do
-        it 'handles unknown failure to upgrade' do
-          expect(common_collection_namespace.exists(edc_cache_key)).to be_falsey
-          VCR.use_cassette('mhv_account_type_service/basic', allow_playback_repeats: true) do
-            expect(mhv_account.account_level).to eq('Basic')
-            # ensure that the value is cached
-            expect(common_collection_namespace.exists(edc_cache_key)).to be_truthy
-            VCR.use_cassette('mhv_account_creation/account_upgrade_unknown_error') do
-              expect { subject.upgrade }.to raise_error(Common::Exceptions::BackendServiceException)
-                .and not_trigger_statsd_increment('mhv.account.existed')
-                .and not_trigger_statsd_increment('mhv.account.upgrade.success')
-                .and trigger_statsd_increment('mhv.account.upgrade.failure')
-              expect(mhv_account.account_state).to eq('upgrade_failed')
-              expect(mhv_account.persisted?).to be_truthy
-              # ensure that the cache was not busted since no action was taken
-              expect(common_collection_namespace.exists(edc_cache_key)).to be_truthy
-            end
-          end
-        end
-
-        it 'successfully upgrades' do
-          expect(common_collection_namespace.exists(edc_cache_key)).to be_falsey
-          VCR.use_cassette('mhv_account_type_service/advanced') do
-            expect(mhv_account.account_level).to eq('Advanced')
-            # ensure that the value is cached
-            expect(common_collection_namespace.exists(edc_cache_key)).to be_truthy
-            VCR.use_cassette('mhv_account_creation/upgrades_an_account') do
-              expect(mhv_account.account_level).to eq('Advanced')
-              expect { subject.upgrade }.to trigger_statsd_increment('mhv.account.upgrade.success')
-                .and not_trigger_statsd_increment('mhv.account.creation.failure')
-              expect(mhv_account.account_state).to eq('upgraded')
-
-              expect(mhv_account.upgraded_at).to be_a(Time)
-              expect(mhv_account.persisted?).to be_truthy
-              # ensure that upgrade busts the cache
-              expect(common_collection_namespace.exists(edc_cache_key)).to be_falsey
-              VCR.use_cassette('mhv_account_type_service/premium') do
-                expect(mhv_account.account_level).to eq('Premium')
-              end
-            end
-          end
+      it 'handles unknown failure to upgrade' do
+        VCR.use_cassette('mhv_account_creation/account_upgrade_unknown_error', record: :none) do
+          expect(subject).to receive(:log_warning)
+          expect(mhv_account).to receive(:fail_upgrade!)
+          expect { subject.upgrade }.to raise_error(Common::Exceptions::BackendServiceException)
+            .and not_trigger_statsd_increment('mhv.account.existed')
+            .and not_trigger_statsd_increment('mhv.account.upgrade.success')
+            .and trigger_statsd_increment('mhv.account.upgrade.failure')
         end
       end
 
-      context 'an account that cannot be upgraded' do
-        it 'handles an already upgraded account' do
-          expect(common_collection_namespace.exists(edc_cache_key)).to be_falsey
-          VCR.use_cassette('mhv_account_type_service/premium', allow_playback_repeats: true) do
-            expect(mhv_account.account_level).to eq('Premium')
-            # ensure that the value is cached
-            expect(common_collection_namespace.exists(edc_cache_key)).to be_truthy
-            expect { subject.upgrade }.to not_trigger_statsd_increment('mhv.account.upgrade.success')
-              .and not_trigger_statsd_increment('mhv.account.upgrade.failure')
-            expect(mhv_account.account_state).to eq('existing')
-            expect(mhv_account.persisted?).to be_truthy
-            # ensure that the cache was not busted since no action was taken
-            expect(common_collection_namespace.exists(edc_cache_key)).to be_truthy
-          end
+      it 'handles an already upgraded account' do
+        VCR.use_cassette('mhv_account_creation/should_not_upgrade_an_account_if_one_already_exists') do
+          expect(mhv_account).to receive(:upgrade!)
+          expect { subject.upgrade }.to trigger_statsd_increment('mhv.account.existed')
+            .and not_trigger_statsd_increment('mhv.account.upgrade.success')
+            .and not_trigger_statsd_increment('mhv.account.upgrade.failure')
         end
       end
+
+      it 'successfully upgrades' do
+        VCR.use_cassette('mhv_account_creation/upgrades_an_account') do
+          expect(mhv_account).to receive(:upgraded_at=).with(kind_of(Time))
+          expect(mhv_account).to receive(:upgrade!)
+          expect { subject.upgrade }.to trigger_statsd_increment('mhv.account.upgrade.success')
+            .and not_trigger_statsd_increment('mhv.account.creation.failure')
+        end
+      end
+    end
+  end
+
+  describe 'address population' do
+    let(:ac_client) { instance_double('MHVAC::Client') }
+
+    before(:each) do
+      allow(SM::Client).to receive(:new).and_return(ac_client)
+      allow(subject).to receive(:mhv_ac_client) { ac_client }
+      allow(mhv_account).to receive(:registered_at=)
+      allow(mhv_account).to receive(:register!)
+      allow(mhv_account).to receive(:upgraded_at=)
+      allow(mhv_account).to receive(:upgrade!)
+    end
+
+    it 'uses MVI address if present' do
+      expect(ac_client).to receive(:post_register).with(hash_including(
+                                                          address1: '20140624',
+                                                          city: 'Houston',
+                                                          state: 'TX',
+                                                          zip: '77040',
+                                                          country: 'USA'
+      )).and_return(api_completion_status: 'Successful', correlation_id: 123_456)
+      expect(ac_client).to receive(:post_upgrade).and_return(status: 'success')
+      subject.create
+      subject.upgrade
+    end
+
+    context 'with nil MVI address' do
+      let(:mvi_profile_address) { nil }
+      it 'defaults address if MVI address nil' do
+        expect(ac_client).to receive(:post_register).with(hash_including(
+                                                            address1: 'Unknown Address',
+                                                            city: 'Washington',
+                                                            state: 'DC',
+                                                            zip: '20571',
+                                                            country: 'USA'
+        )).and_return(api_completion_status: 'Successful', correlation_id: 123_456)
+        expect(ac_client).to receive(:post_upgrade).and_return(status: 'success')
+        subject.create
+        subject.upgrade
+      end
+    end
+
+    context 'with partially nil MVI address' do
+      let(:mvi_profile_address) do
+        build(:mvi_profile_address,
+              street: '20140624',
+              city: nil,
+              state: 'TX',
+              country: 'USA',
+              postal_code: nil)
+      end
+
+      it 'defaults address if MVI address nil' do
+        expect(ac_client).to receive(:post_register).with(hash_including(
+                                                            address1: 'Unknown Address',
+                                                            city: 'Washington',
+                                                            state: 'DC',
+                                                            zip: '20571',
+                                                            country: 'USA'
+        )).and_return(api_completion_status: 'Successful', correlation_id: 123_456)
+        expect(ac_client).to receive(:post_upgrade).and_return(status: 'success')
+        subject.create
+        subject.upgrade
+      end
+    end
+  end
+
+  describe 'user veteran status' do
+    let(:ac_client) { instance_double('MHVAC::Client') }
+
+    before(:each) do
+      allow(SM::Client).to receive(:new).and_return(ac_client)
+      allow(subject).to receive(:mhv_ac_client) { ac_client }
+      allow(mhv_account).to receive(:registered_at=)
+      allow(mhv_account).to receive(:register!)
+      allow(mhv_account).to receive(:upgraded_at=)
+      allow(mhv_account).to receive(:upgrade!)
+    end
+
+    it 'sets is_veteran true if user is veteran' do
+      allow(SM::Client).to receive(:new).and_return(ac_client)
+      allow_any_instance_of(User).to receive(:veteran?).and_return(true)
+      allow(subject).to receive(:mhv_ac_client) { ac_client }
+      expect(ac_client).to receive(:post_register).with(hash_including(
+                                                          is_veteran: true
+      )).and_return(api_completion_status: 'Successful', correlation_id: 123_456)
+      expect(ac_client).to receive(:post_upgrade).and_return(status: 'success')
+      subject.create
+      subject.upgrade
+    end
+
+    it 'sets is_veteran false if user is not veteran' do
+      allow(SM::Client).to receive(:new).and_return(ac_client)
+      allow_any_instance_of(User).to receive(:veteran?).and_return(false)
+      allow(subject).to receive(:mhv_ac_client) { ac_client }
+      expect(ac_client).to receive(:post_register).with(hash_including(
+                                                          is_veteran: false
+      )).and_return(api_completion_status: 'Successful', correlation_id: 123_456)
+      expect(ac_client).to receive(:post_upgrade).and_return(status: 'success')
+      subject.create
+      subject.upgrade
+    end
+
+    it 'sets is_veteran false if veteran status is unknown' do
+      allow(SM::Client).to receive(:new).and_return(ac_client)
+      allow_any_instance_of(User).to receive(:veteran?).and_raise(StandardError)
+      allow(subject).to receive(:mhv_ac_client) { ac_client }
+      expect(ac_client).to receive(:post_register).with(hash_including(
+                                                          is_veteran: false
+      )).and_return(api_completion_status: 'Successful', correlation_id: 123_456)
+      expect(ac_client).to receive(:post_upgrade).and_return(status: 'success')
+      subject.create
+      subject.upgrade
     end
   end
 end

--- a/spec/support/mvi/find_candidate_multiple_mhv_response.xml
+++ b/spec/support/mvi/find_candidate_multiple_mhv_response.xml
@@ -47,7 +47,7 @@
                 <id extension="12345678901234567^NI^200M^USVHA^P" root="2.16.840.1.113883.4.349"/>
                 <id extension="12345678^PI^200CORP^USVBA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="12345678901^PI^200MH^USVHA^A" root="2.16.840.1.113883.4.349"/>
-                <id extension="12345678902^PI^200MH^USVHA^D" root="2.16.840.1.113883.4.349"/>
+                <id extension="12345678902^PI^200MH^USVHA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="1122334455^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12"/>
                 <id extension="0001234567^PN^200PROV^USDVA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="123412345^PI^200BRLS^USVBA^A" root="2.16.840.1.113883.4.349"/>

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -11,8 +11,10 @@
         "type": { "type": "string"},
         "attributes": {
           "type": "object",
-          "required": ["services", "profile", "in_progress_forms"],
+          "required": ["services", "profile", "mhv_account_state", "in_progress_forms"],
           "properties": {
+            "mhv_account_state": { "type": [ "string", null]},
+            "health_terms_current": { "type": "boolean" },
             "in_progress_forms": {
               "type": "array",
               "items": {

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -11,8 +11,10 @@
         "type": { "type": "string"},
         "attributes": {
           "type": "object",
-          "required": ["services", "profile", "in_progress_forms"],
+          "required": ["services", "profile", "mhv_account_state", "in_progress_forms"],
           "properties": {
+            "mhv_account_state": { "type": ["string", null]},
+            "health_terms_current": { "type": "boolean" },
             "in_progress_forms": {
               "type": [ "array", null ],
               "items": {

--- a/spec/support/vcr_cassettes/complex_interaction/internal_interactions.yml
+++ b/spec/support/vcr_cassettes/complex_interaction/internal_interactions.yml
@@ -264,7 +264,7 @@ http_interactions:
       - '591'
     body:
       encoding: UTF-8
-      string: '{"data":{"id":"","type":"users","attributes":{"services":["facilities","hca","edu-benefits","user-profile","form-save-in-progress","form-prefill"],"profile":{"email":"vets.gov.user+0@gmail.com","first_name":"HECTOR","middle_name":null,"last_name":"ALLEN","birth_date":null,"gender":null,"zip":null,"last_signed_in":"2017-08-29T03:32:30.000Z","loa":{"current":1,"highest":3}},"va_profile":{"status":"NOT_AUTHORIZED"},"veteran_status":{"status":"SERVER_ERROR"},"in_progress_forms":[],"prefills_available":["1010ez","21P-527EZ","21P-530"]}}}'
+      string: '{"data":{"id":"","type":"users","attributes":{"services":["facilities","hca","edu-benefits","user-profile","form-save-in-progress","form-prefill"],"profile":{"email":"vets.gov.user+0@gmail.com","first_name":"HECTOR","middle_name":null,"last_name":"ALLEN","birth_date":null,"gender":null,"zip":null,"last_signed_in":"2017-08-29T03:32:30.000Z","loa":{"current":1,"highest":3}},"va_profile":{"status":"NOT_AUTHORIZED"},"veteran_status":{"status":"SERVER_ERROR"},"mhv_account_state":null,"health_terms_current":true,"in_progress_forms":[],"prefills_available":["1010ez","21P-527EZ","21P-530"]}}}'
     http_version:
   recorded_at: Tue, 29 Aug 2017 03:32:30 GMT
 - request:
@@ -479,7 +479,7 @@ http_interactions:
       - '741'
     body:
       encoding: UTF-8
-      string: '{"data":{"id":"","type":"users","attributes":{"services":["facilities","hca","edu-benefits","rx","messaging","health-records","user-profile","appeals-status","form-save-in-progress","form-prefill"],"profile":{"email":"vets.gov.user+0@gmail.com","first_name":"HECTOR","middle_name":"J","last_name":"ALLEN","birth_date":"1932-02-05","gender":"M","zip":null,"last_signed_in":"2017-08-29T03:32:42.000Z","loa":{"current":3,"highest":3}},"va_profile":{"status":"OK","birth_date":"19320205","family_name":"Allen","gender":"M","given_names":["Hector"]},"veteran_status":{"status":"SERVER_ERROR"},"in_progress_forms":[],"prefills_available":["1010ez","21P-527EZ","21P-530"]}}}'
+      string: '{"data":{"id":"","type":"users","attributes":{"services":["facilities","hca","edu-benefits","rx","messaging","health-records","user-profile","appeals-status","form-save-in-progress","form-prefill"],"profile":{"email":"vets.gov.user+0@gmail.com","first_name":"HECTOR","middle_name":"J","last_name":"ALLEN","birth_date":"1932-02-05","gender":"M","zip":null,"last_signed_in":"2017-08-29T03:32:42.000Z","loa":{"current":3,"highest":3}},"va_profile":{"status":"OK","birth_date":"19320205","family_name":"Allen","gender":"M","given_names":["Hector"]},"veteran_status":{"status":"SERVER_ERROR"},"mhv_account_state":"needs_terms_acceptance","health_terms_current":false,"in_progress_forms":[],"prefills_available":["1010ez","21P-527EZ","21P-530"]}}}'
     http_version:
   recorded_at: Tue, 29 Aug 2017 03:32:52 GMT
 - request:


### PR DESCRIPTION
This reverts commit c012dcfb5a32d9784dbd04c99748acee93ffa1d0.

## Background
Rolling back changes that were in Staging for testing but should not go into Production yet.

## Definition of Done

#### Unique to this PR

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
