### PR TITLE
Add name of document part of error message for improved debugging

### DIFF
--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -155,13 +155,13 @@ module VBADocuments
       metadata['receiveDt'] = timestamp.in_time_zone('US/Central').strftime('%Y-%m-%d %H:%M:%S')
       metadata['uuid'] = upload.guid
       check_size(parts[DOC_PART_NAME])
-      doc_info = get_hash_and_pages(parts[DOC_PART_NAME])
+      doc_info = get_hash_and_pages(parts[DOC_PART_NAME], DOC_PART_NAME)
       metadata['hashV'] = doc_info[:hash]
       metadata['numberPages'] = doc_info[:pages]
       attachment_names = parts.keys.select { |k| k.match(/attachment\d+/) }
       metadata['numberAttachments'] = attachment_names.size
       attachment_names.each_with_index do |att, i|
-        att_info = get_hash_and_pages(parts[att])
+        att_info = get_hash_and_pages(parts[att], att)
         check_size(parts[att])
         metadata["ahash#{i + 1}"] = att_info[:hash]
         metadata["numberPages#{i + 1}"] = att_info[:pages]
@@ -176,14 +176,14 @@ module VBADocuments
       end
     end
 
-    def get_hash_and_pages(file_path)
+    def get_hash_and_pages(file_path, part)
       {
         hash: Digest::SHA256.file(file_path).hexdigest,
         pages: PDF::Reader.new(file_path).pages.size
       }
     rescue PDF::Reader::MalformedPDFError
       raise VBADocuments::UploadError.new(code: 'DOC103',
-                                          detail: 'Invalid PDF content')
+                                          detail: "Invalid PDF content, part #{part}")
     end
   end
 end


### PR DESCRIPTION
## Background
Working with a customer to debug a submission, knowing the part that failed
would be useful for tracking down the error

## Definition of Done

#### Unique to this PR

- [x] Includes the updated error message

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
