### PR TITLE
bug fix: check for existence of opt[:address] before operating on it

### DIFF
--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -107,7 +107,7 @@ class FormProfile
     '22-0993'   => ::FormProfiles::VA0993
   }.freeze
 
-  APT_REGEX = /\S\s+((apt|apartment|unit|ste|suite).{2,})/i
+  APT_REGEX = /\S\s+((apt|apartment|unit|ste|suite).+)/i
 
   attr_accessor :form_id
 
@@ -265,7 +265,7 @@ class FormProfile
   def format_for_schema_compatibility(opt)
     if opt[:address][:street2].blank? && (apt = opt[:address][:street].match(APT_REGEX))
       opt[:address][:street2] = apt[1]
-      opt[:address][:street] = opt[:address][:street].gsub(apt[1], '').strip
+      opt[:address][:street] = opt[:address][:street].gsub(/\W?\s+#{apt[1]}/, '').strip
     end
 
     %i[home_phone us_phone mobile_phone].each do |phone|

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -263,7 +263,7 @@ class FormProfile
   end
 
   def format_for_schema_compatibility(opt)
-    if opt[:address][:street2].blank? && (apt = opt[:address][:street].match(APT_REGEX))
+    if opt[:address] && opt[:address][:street2].blank? && (apt = opt[:address][:street].match(APT_REGEX))
       opt[:address][:street2] = apt[1]
       opt[:address][:street] = opt[:address][:street].gsub(/\W?\s+#{apt[1]}/, '').strip
     end

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require 'faker'
-
-street = Faker::Address.street_address
-street2 = Faker::Address.secondary_address
+street = '49119 Jadon Mills'
+street2 = 'Apt. 832'
 
 FactoryBot.define do
   factory :street_check, class: Hash do
@@ -15,7 +13,7 @@ end
 
 FactoryBot.define do
   factory :mvi_profile_address, class: 'MVI::Models::MviProfileAddress' do
-    street { "#{street} #{street2}" }
+    street { "#{street}, #{street2}" }
     city { Faker::Address.city }
     state { Faker::Address.state_abbr }
     postal_code { Faker::Address.zip }

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -475,6 +475,13 @@ RSpec.describe FormProfile, type: :model do
       end
     end
 
+    context 'user without an address' do
+      it 'prefills properly' do
+        expect(user.va_profile).to receive(:address).and_return(nil)
+        described_class.for('22-1990e').prefill(user)
+      end
+    end
+
     context 'with emis data', skip_emis: true do
       before do
         military_information = user.military_information

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe FormProfile, type: :model do
 
   let(:address) do
     {
-      'street' => user.va_profile[:address][:street],
+      'street' => street_check[:street],
+      'street2' => street_check[:street2],
       'city' => user.va_profile[:address][:city],
       'state' => user.va_profile[:address][:state],
       'country' => user.va_profile[:address][:country],
@@ -97,7 +98,8 @@ RSpec.describe FormProfile, type: :model do
         'yes' => true
       },
       'veteranAddress' => {
-        'street' => user.va_profile[:address][:street],
+        'street' => street_check[:street],
+        'street2' => street_check[:street2],
         'city' => user.va_profile[:address][:city],
         'state' => user.va_profile[:address][:state],
         'country' => user.va_profile[:address][:country],
@@ -141,7 +143,8 @@ RSpec.describe FormProfile, type: :model do
         'yes' => true
       },
       'veteranAddress' => {
-        'street' => user.va_profile[:address][:street],
+        'street' => street_check[:street],
+        'street2' => street_check[:street2],
         'city' => user.va_profile[:address][:city],
         'state' => user.va_profile[:address][:state],
         'country' => user.va_profile[:address][:country],
@@ -163,7 +166,8 @@ RSpec.describe FormProfile, type: :model do
   let(:v22_1990_e_expected) do
     {
       'relativeAddress' => {
-        'street' => user.va_profile[:address][:street],
+        'street' => street_check[:street],
+        'street2' => street_check[:street2],
         'city' => user.va_profile[:address][:city],
         'state' => user.va_profile[:address][:state],
         'country' => user.va_profile[:address][:country],
@@ -181,7 +185,8 @@ RSpec.describe FormProfile, type: :model do
   let(:v22_1995_expected) do
     {
       'veteranAddress' => {
-        'street' => user.va_profile[:address][:street],
+        'street' => street_check[:street],
+        'street2' => street_check[:street2],
         'city' => user.va_profile[:address][:city],
         'state' => user.va_profile[:address][:state],
         'country' => user.va_profile[:address][:country],
@@ -250,7 +255,8 @@ RSpec.describe FormProfile, type: :model do
       'veteranDateOfBirth' => user.birth_date,
       'email' => user.pciu_email,
       'veteranAddress' => {
-        'street' => user.va_profile[:address][:street],
+        'street' => street_check[:street],
+        'street2' => street_check[:street2],
         'city' => user.va_profile[:address][:city],
         'state' => user.va_profile[:address][:state],
         'country' => user.va_profile[:address][:country],
@@ -528,7 +534,6 @@ RSpec.describe FormProfile, type: :model do
       context 'with a user that can prefill emis' do
         before do
           can_prefill_emis(true)
-          user.va_profile[:address].street = user.va_profile[:address].street.slice(0, 20)
         end
 
         %w[


### PR DESCRIPTION
## Background
bug fix

## Definition of Done

#### Unique to this PR

- [x] check for existence of opt[:address] before operating on it

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
