### PR TITLE
Force feedback scores to be numeric

### DIFF
--- a/app/models/base_facility.rb
+++ b/app/models/base_facility.rb
@@ -91,7 +91,7 @@ class BaseFacility < ActiveRecord::Base
       result = {}
       datum = FacilitySatisfaction.find(attrs['StationNumber'].upcase)
       if datum.present?
-        datum.metrics.each { |k, v| result[k.to_s] = v.present? ? v.round(2) : nil }
+        datum.metrics.each { |k, v| result[k.to_s] = v.present? ? v.round(2).to_f : nil }
         result['effective_date'] = to_date(datum.source_updated)
       end
       result

--- a/app/swagger/schemas/va_facilities.rb
+++ b/app/swagger/schemas/va_facilities.rb
@@ -158,10 +158,10 @@ module Swagger
         key :type, :object
         key :description, 'Patient satisfaction scores for health facilities'
 
-        property :primary_care_routine, type: :string, format: :float, example: 95.2
-        property :primary_care_urgent, type: :string, format: :float, example: 89.1
-        property :specialty_care_routine, type: :string, format: :float, example: 78
-        property :specialty_care_urgent, type: :string, format: :float, example: 75.3
+        property :primary_care_routine, type: :number, format: :float, example: 95.2
+        property :primary_care_urgent, type: :number, format: :float, example: 89.1
+        property :specialty_care_routine, type: :number, format: :float, example: 78
+        property :specialty_care_urgent, type: :number, format: :float, example: 75.3
         property :effective_date, type: :string, format: :date, example: '2017-07-01'
       end
 

--- a/spec/factories/vha_facilities.rb
+++ b/spec/factories/vha_facilities.rb
@@ -43,8 +43,8 @@ FactoryBot.define do
              'last_updated' => '2018-03-15')
     feedback('health' => {
                'effective_date' => '2017-08-15',
-               'primary_care_urgent' => '0.8',
-               'primary_care_routine' => '0.84'
+               'primary_care_urgent' => 0.8,
+               'primary_care_routine' => 0.84
              })
     access('health' => {
              'audiology' => {
@@ -125,10 +125,10 @@ FactoryBot.define do
              'last_updated' => '2018-03-15'
     feedback 'health' => {
       'effective_date' => '2017-08-15',
-      'primary_care_urgent' => '0.73',
-      'primary_care_routine' => '0.82',
-      'specialty_care_urgent' => '0.75',
-      'specialty_care_routine' => '0.82'
+      'primary_care_urgent' => 0.73,
+      'primary_care_routine' => 0.82,
+      'specialty_care_urgent' => 0.75,
+      'specialty_care_routine' => 0.82
     }
     access 'health' => {
       'audiology' => {


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12093

## Background
High-precision satisfaction scores were stored in redis as BigDecimals and getting serialized as strings. Low-precision scores were getting serialized as numerics. 

## Definition of Done
Satisfaction score fields in API responses have a consistent JSON type.

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
