### PR TITLE
form_profile street formatting bug fix

### DIFF
--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -263,7 +263,7 @@ class FormProfile
   end
 
   def format_for_schema_compatibility(opt)
-    if opt[:address] && opt[:address][:street2].blank? && (apt = opt[:address][:street].match(APT_REGEX))
+    if opt.dig(:address, :street) && opt[:address][:street2].blank? && (apt = opt[:address][:street].match(APT_REGEX))
       opt[:address][:street2] = apt[1]
       opt[:address][:street] = opt[:address][:street].gsub(/\W?\s+#{apt[1]}/, '').strip
     end


### PR DESCRIPTION
## Background
form_profile street formatting:  allow for possibility of address without a street

## Definition of Done

#### Unique to this PR

- [x] allow for possibility of address without a street

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
