### PR TITLE
Add vet360 initialization specific tag to sentry logging

### DIFF
--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -31,12 +31,9 @@ module Vet360
         raise_backend_exception('VET360_502', self.class)
       when Common::Client::Errors::ClientError
         log_error_messages(error)
-
         raise Common::Exceptions::Forbidden if error.status == 403
         raise_invalid_body(error, self.class) unless error.body.is_a?(Hash)
-
         message = parse_messages(error)&.first
-
         raise_backend_exception("VET360_#{message['code']}", self.class, error) if message.present?
         raise_backend_exception('VET360_502', self.class, error)
       else

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -62,7 +62,7 @@ module Vet360
     end
 
     def person_transaction?(error)
-      error&.backtrace&.join(',').include? 'get_person_transaction_status'
+      error&.backtrace&.join(',')&.include? 'get_person_transaction_status'
     end
 
     def final_failure?(error)

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -30,15 +30,43 @@ module Vet360
         log_message_to_sentry(error.message, :error, extra_context: { url: config.base_path })
         raise_backend_exception('VET360_502', self.class)
       when Common::Client::Errors::ClientError
-        log_message_to_sentry(error.message, :error, extra_context: { url: config.base_path, body: error.body })
+        log_error_messages(error)
+
         raise Common::Exceptions::Forbidden if error.status == 403
         raise_invalid_body(error, self.class) unless error.body.is_a?(Hash)
+
         message = parse_messages(error)&.first
+
         raise_backend_exception("VET360_#{message['code']}", self.class, error) if message.present?
         raise_backend_exception('VET360_502', self.class, error)
       else
         raise error
       end
+    end
+
+    def log_error_messages(error)
+      if person_transaction_failure?(error)
+        log_message_to_sentry(
+          error.message,
+          :error,
+          { url: config.base_path, body: error.body },
+          vet360: 'failed_vet360_id_initializations'
+        )
+      else
+        log_message_to_sentry(error.message, :error, extra_context: { url: config.base_path, body: error.body })
+      end
+    end
+
+    def person_transaction_failure?(error)
+      person_transaction?(error) && final_failure?(error)
+    end
+
+    def person_transaction?(error)
+      error&.backtrace&.join(',').include? 'get_person_transaction_status'
+    end
+
+    def final_failure?(error)
+      %w[COMPLETED_FAILURE REJECTED].include? error.body&.dig('status')
     end
 
     def parse_messages(error)

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -2,6 +2,8 @@
 
 require 'rails_helper'
 
+
+
 describe Vet360::ContactInformation::Service, skip_vet360: true do
   let(:user) { build(:user, :loa3) }
   subject { described_class.new(user) }
@@ -209,6 +211,17 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
           end
         end
       end
+
+      it 'does not include "failed_vet360_id_initializations" tag in sentry error' do
+        VCR.use_cassette('vet360/contact_information/email_transaction_status_error', VCR::MATCH_EVERYTHING) do
+        expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry).with(anything, anything, anything)
+          expect { subject.get_email_transaction_status(transaction_id) }.to raise_error do |e|
+            expect(e).to be_a(Common::Exceptions::BackendServiceException)
+            expect(e.status_code).to eq(400)
+            expect(e.errors.first.code).to eq('VET360_CORE103')
+          end
+        end
+      end
     end
   end
 
@@ -292,10 +305,26 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
     end
 
     context 'when not successful' do
+      RSpec::Matchers.define :vet360_tag do
+        match { |actual| actual[3] && actual[3].key?(:vet360) }
+      end
+
       let(:transaction_id) { 'd47b3d96-9ddd-42be-ac57-8e564aa38029' }
 
       it 'returns a status of 400', :aggregate_failures do
         VCR.use_cassette('vet360/contact_information/person_transaction_status_error', VCR::MATCH_EVERYTHING) do
+          expect { subject.get_person_transaction_status(transaction_id) }.to raise_error do |e|
+            expect(e).to be_a(Common::Exceptions::BackendServiceException)
+            expect(e.status_code).to eq(400)
+            expect(e.errors.first.code).to eq('VET360_PERS200')
+          end
+        end
+      end
+
+      it 'logs a vet360 tagged error message to sentry', :aggregate_failures do
+        VCR.use_cassette('vet360/contact_information/person_transaction_status_error', VCR::MATCH_EVERYTHING) do
+          expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry).with(vet360_tag)
+
           expect { subject.get_person_transaction_status(transaction_id) }.to raise_error do |e|
             expect(e).to be_a(Common::Exceptions::BackendServiceException)
             expect(e.status_code).to eq(400)

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -303,10 +303,6 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
     end
 
     context 'when not successful' do
-      RSpec::Matchers.define :vet360_tag do
-        match { |actual| actual[3]&.key?(:vet360) }
-      end
-
       let(:transaction_id) { 'd47b3d96-9ddd-42be-ac57-8e564aa38029' }
 
       it 'returns a status of 400', :aggregate_failures do
@@ -321,7 +317,8 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
 
       it 'logs a vet360 tagged error message to sentry', :aggregate_failures do
         VCR.use_cassette('vet360/contact_information/person_transaction_status_error', VCR::MATCH_EVERYTHING) do
-          expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry).with(vet360_tag)
+          expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry)
+            .with(any_args, hash_including(:vet360))
 
           expect { subject.get_person_transaction_status(transaction_id) }.to raise_error do |e|
             expect(e).to be_a(Common::Exceptions::BackendServiceException)

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -2,8 +2,6 @@
 
 require 'rails_helper'
 
-
-
 describe Vet360::ContactInformation::Service, skip_vet360: true do
   let(:user) { build(:user, :loa3) }
   subject { described_class.new(user) }
@@ -214,7 +212,7 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
 
       it 'does not include "failed_vet360_id_initializations" tag in sentry error' do
         VCR.use_cassette('vet360/contact_information/email_transaction_status_error', VCR::MATCH_EVERYTHING) do
-        expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry).with(anything, anything, anything)
+          expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry).with(anything, anything, anything)
           expect { subject.get_email_transaction_status(transaction_id) }.to raise_error do |e|
             expect(e).to be_a(Common::Exceptions::BackendServiceException)
             expect(e.status_code).to eq(400)
@@ -306,7 +304,7 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
 
     context 'when not successful' do
       RSpec::Matchers.define :vet360_tag do
-        match { |actual| actual[3] && actual[3].key?(:vet360) }
+        match { |actual| actual[3]&.key?(:vet360) }
       end
 
       let(:transaction_id) { 'd47b3d96-9ddd-42be-ac57-8e564aa38029' }

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -210,7 +210,7 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
         end
       end
 
-      it 'does not include "failed_vet360_id_initializations" tag in sentry error' do
+      it 'does not include "failed_vet360_id_initializations" tag in sentry error', :aggregate_failures do
         VCR.use_cassette('vet360/contact_information/email_transaction_status_error', VCR::MATCH_EVERYTHING) do
           expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry).with(anything, anything, anything)
           expect { subject.get_email_transaction_status(transaction_id) }.to raise_error do |e|


### PR DESCRIPTION
## Background

[This request](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11692#issuecomment-407748989) from @steve-gov states:

> we should have logging in place to let us know that this user attempted to procure a Vet360ID and failed for $error reason.

As part of this, investigate if this applies to both the `POST` initialize a Vet360 ID endpoint, as well as the transaction status checking endpoint.

## Definition of Done

#### Unique to this PR

- [x] logging in place for when initializing a `vet360_id` fails (failed states for transaction endpoint)

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
