### PR TITLE
Add pagination headers for GeoJSON output

### DIFF
--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -66,15 +66,23 @@ paths:
         Retrieve all facilities contained within the specified bounding box. Bounding box is 
         specified as four parameters long1, lat1, long2, lat2. Relative ordering of longitude and 
         latitude parameters is unimportant. 
+        
         Additionally one can filter the facilities within the bounding box by type and available
         services. Only facilities of type "health" and "benefits" may be filtered by available
         services.
+
+        Results of this operation are paginated. JSON responses include pagination information
+        in the standard JSON API "links" and "meta" elements. GeoJSON responses include pagination
+        information in the "Link" header.
       operationId: getFacilitiesByLocation
       security:
         - api_key: []
       parameters:
-        - in: query
-          name: bbox[]
+        - name: bbox[]
+          description: |
+            Bounding longitude/latitude/longitude/latitude within which facilities will be returned. 
+            Bounding box parameters should be specified in WGS84 coordinate reference system.
+          in: query
           required: true
           style: form
           exploded: true
@@ -84,8 +92,9 @@ paths:
             maxItems: 4
             items:
               type: float
-        - in: query
-          name: type
+        - name: type
+          description: Optional facility type search filter
+          in: query
           required: false
           schema:
             type: string
@@ -94,14 +103,29 @@ paths:
               - cemetery
               - benefits
               - vet_center
-        - in: query
-          name: services[]
+        - name: services[]
+          description: Optional facility service search filter
+          in: query
           style: form
           exploded: true
           schema:
             type: array
             items:
               type: string
+        - name: page
+          description: Page of results to return per paginated response.
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: per_page
+          description: Number of results to return per paginated response.
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
       responses:
         '200':
           description: Success
@@ -128,6 +152,12 @@ paths:
                     type: array
                     items: 
                       $ref: "#/components/schemas/FacilityFeature"
+          headers:
+            Link:
+              description: GitHub-style pagination information. Only present for GeoJSON-format responses.
+              schema:
+                type: string
+                example: '<https://dev-api.vets.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=2&per_page=20>; rel="self", <https://dev-api.vets.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="first", <https://dev-api.vets.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="prev", <https://dev-api.vets.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=3&per_page=20>; rel="next", <https://dev-api.vets.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=5&per_page=20>; rel="last"'
         '401':
           description: Missing API token
           content:

--- a/modules/va_facilities/app/controllers/concerns/va_facilities/pagination_headers.rb
+++ b/modules/va_facilities/app/controllers/concerns/va_facilities/pagination_headers.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Implements GitHub-style Link header for pagination.
+# URL derivation heavily cribbed from ActiveModelSerializers::Adapter::JsonApi
+module VaFacilities
+  module PaginationHeaders
+    extend ActiveSupport::Concern
+
+    LINK_FIRST_PAGE = 1
+
+    def link_header(collection)
+      @collection = collection
+      links.map { |k, v| v.blank? ? nil : "<#{v}>; rel=\"#{k}\"" }.compact.join(', ')
+    end
+
+    def links
+      {
+        self:  location_url,
+        first: first_page_url,
+        prev:  prev_page_url,
+        next:  next_page_url,
+        last:  last_page_url
+      }
+    end
+
+    private
+
+    def location_url
+      url_for_page(@collection.current_page)
+    end
+
+    def first_page_url
+      url_for_page(1)
+    end
+
+    def last_page_url
+      if @collection.total_pages.zero?
+        url_for_page(LINK_FIRST_PAGE)
+      else
+        url_for_page(@collection.total_pages)
+      end
+    end
+
+    def prev_page_url
+      return nil if @collection.current_page == LINK_FIRST_PAGE
+      url_for_page(@collection.current_page - LINK_FIRST_PAGE)
+    end
+
+    def next_page_url
+      return nil if @collection.total_pages.zero? || @collection.current_page >= @collection.total_pages
+      url_for_page(@collection.next_page)
+    end
+
+    def url_for_page(number)
+      params = query_parameters.dup
+      params[:page] = number
+      params[:per_page] = per_page
+      "#{url}?#{params.to_query}"
+    end
+
+    def url
+      @link_url ||= request.original_url[/\A[^?]+/]
+    end
+
+    def query_parameters
+      @link_query_parameters ||= request.query_parameters
+    end
+
+    def per_page
+      @link_per_page ||= @collection.try(:per_page) || @collection.try(:limit_value) || @collection.size
+    end
+  end
+end

--- a/modules/va_facilities/app/controllers/va_facilities/v0/facilities_controller.rb
+++ b/modules/va_facilities/app/controllers/va_facilities/v0/facilities_controller.rb
@@ -3,6 +3,7 @@
 require 'will_paginate/array'
 
 require_dependency 'va_facilities/application_controller'
+require_dependency 'va_facilities/pagination_headers'
 require_dependency 'va_facilities/geo_serializer'
 require_dependency 'va_facilities/csv_serializer'
 
@@ -10,6 +11,7 @@ module VaFacilities
   module V0
     class FacilitiesController < ApplicationController
       include ActionController::MimeResponds
+      include VaFacilities::PaginationHeaders
       skip_before_action(:authenticate)
       before_action :set_default_format
       before_action :validate_params, only: [:index]
@@ -29,7 +31,7 @@ module VaFacilities
       end
 
       def index
-        resource = BaseFacility.query(params).paginate(page: params[:page], per_page: BaseFacility.per_page)
+        resource = BaseFacility.query(params).paginate(page: params[:page], per_page: params[:per_page])
         respond_to do |format|
           format.json do
             render json: resource,
@@ -37,6 +39,7 @@ module VaFacilities
                    meta: metadata(resource)
           end
           format.geojson do
+            response.headers['Link'] = link_header(resource)
             render geojson: VaFacilities::GeoSerializer.to_geojson(resource)
           end
         end

--- a/modules/va_facilities/spec/requests/facilities_request_spec.rb
+++ b/modules/va_facilities/spec/requests/facilities_request_spec.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'cgi'
+require 'uri'
 
 RSpec.describe 'Facilities API endpoint', type: :request do
   include SchemaMatchers
 
-  let(:base_query_path) { '/services/va_facilities/v0/facilities?' }
-  let(:pdx_bbox) { 'bbox[]=-122.440689&bbox[]=45.451913&bbox[]=-122.786758&bbox[]=45.64' }
+  let(:base_query_path) { '/services/va_facilities/v0/facilities' }
+  let(:pdx_bbox) { '?bbox[]=-122.440689&bbox[]=45.451913&bbox[]=-122.786758&bbox[]=45.64' }
+  let(:empty_bbox) { '?bbox[]=-122&bbox[]=45&bbox[]=-122&bbox[]=45' }
 
   let(:setup_pdx) do
     %w[vc_0617V nca_907 vha_648 vha_648A4 vha_648GI vba_348 vba_348a vba_348d vba_348e vba_348h].map { |id| create id }
@@ -15,10 +18,24 @@ RSpec.describe 'Facilities API endpoint', type: :request do
   let(:accept_geojson) { { 'HTTP_ACCEPT' => 'application/vnd.geo+json' } }
   let(:accept_csv) { { 'HTTP_ACCEPT' => 'text/csv' } }
 
+  def parse_link_header(header)
+    links = header.split(',').map(&:strip)
+    links = links.map { |x| x.split(';').map(&:strip).reverse }
+    links.each_with_object({}) do |(f, s), h|
+      k = f.sub('rel="', '').sub('"', '')
+      v = query_params(s.tr('<>', ''))
+      h[k] = v
+    end
+  end
+
+  def query_params(url)
+    CGI.parse(URI.parse(url).query)
+  end
+
   context 'when requesting JSON API format' do
     it 'responds to GET #show for VHA prefix' do
       create :vha_648A4
-      get '/services/va_facilities/v0/facilities/vha_648A4', nil, accept_json
+      get base_query_path + '/vha_648A4', nil, accept_json
       expect(response).to be_success
       expect(response.body).to be_a(String)
       json = JSON.parse(response.body)
@@ -33,12 +50,69 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       json = JSON.parse(response.body)
       expect(json['data'].length).to eq(10)
     end
+
+    it 'responds with pagination links' do
+      setup_pdx
+      get base_query_path + pdx_bbox, nil, accept_json
+      expect(response).to be_success
+      json = JSON.parse(response.body)
+      expect(json).to have_key('links')
+      links = json['links']
+      expect(links).to have_key('self')
+      expect(links).to have_key('first')
+      expect(links).to have_key('last')
+      expect(links).to have_key('prev')
+      expect(links).to have_key('next')
+    end
+
+    it 'responds with pagination metadata' do
+      setup_pdx
+      get base_query_path + pdx_bbox, nil, accept_json
+      expect(response).to be_success
+      json = JSON.parse(response.body)
+      expect(json).to have_key('meta')
+      expect(json['meta']).to have_key('pagination')
+      pagination = json['meta']['pagination']
+      expect(pagination).to have_key('current_page')
+      expect(pagination).to have_key('per_page')
+      expect(pagination).to have_key('total_pages')
+      expect(pagination).to have_key('total_entries')
+    end
+
+    it 'paginates according to parameters' do
+      setup_pdx
+      get base_query_path + pdx_bbox + '&page=2&per_page=3', nil, accept_json
+      expect(response).to be_success
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(3)
+      links = json['links']
+      expect(query_params(links['self'])['page']).to eq(['2'])
+      expect(query_params(links['self'])['per_page']).to eq(['3'])
+      pagination = json['meta']['pagination']
+      expect(pagination['current_page']).to eq(2)
+      expect(pagination['per_page']).to eq(3)
+      expect(pagination['total_pages']).to eq(4)
+      expect(pagination['total_entries']).to eq(10)
+    end
+
+    it 'paginates empty result set' do
+      setup_pdx
+      get base_query_path + empty_bbox, nil, accept_json
+      expect(response).to be_success
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(0)
+      links = json['links']
+      expect(query_params(links['last'])['page']).to eq(['1'])
+      pagination = json['meta']['pagination']
+      expect(pagination['total_pages']).to eq(1)
+      expect(pagination['total_entries']).to eq(0)
+    end
   end
 
   context 'when requesting GeoJSON format' do
     it 'responds to GET #show for VHA prefix' do
       create :vha_648A4
-      get '/services/va_facilities/v0/facilities/vha_648A4', nil, accept_geojson
+      get base_query_path + '/vha_648A4', nil, accept_geojson
       expect(response).to be_success
       expect(response.body).to be_a(String)
       json = JSON.parse(response.body)
@@ -57,12 +131,55 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       expect(json['features'].length).to eq(10)
       expect(response.headers['Content-Type']).to eq 'application/vnd.geo+json; charset=utf-8'
     end
+
+    it 'responds with pagination link header' do
+      setup_pdx
+      get base_query_path + pdx_bbox, nil, accept_geojson
+      expect(response).to be_success
+      expect(response.headers['Link']).to be_present
+      parsed = parse_link_header(response.headers['Link'])
+      expect(parsed).to have_key('self')
+      expect(parsed).to have_key('first')
+      expect(parsed).to have_key('last')
+      expect(parsed).not_to have_key('prev')
+      expect(parsed).not_to have_key('next')
+    end
+
+    it 'paginates according to parameters' do
+      setup_pdx
+      get base_query_path + pdx_bbox + '&page=2&per_page=3', nil, accept_geojson
+      expect(response).to be_success
+      json = JSON.parse(response.body)
+      expect(json['type']).to eq('FeatureCollection')
+      expect(json['features'].length).to eq(3)
+      expect(response.headers['Link']).to be_present
+      parsed = parse_link_header(response.headers['Link'])
+      expect(parsed['self']['page']).to eq(['2'])
+      expect(parsed['first']['page']).to eq(['1'])
+      expect(parsed['last']['page']).to eq(['4'])
+      expect(parsed['prev']['page']).to eq(['1'])
+      expect(parsed['next']['page']).to eq(['3'])
+    end
+
+    it 'paginates empty result set' do
+      setup_pdx
+      get base_query_path + empty_bbox, nil, accept_geojson
+      expect(response).to be_success
+      json = JSON.parse(response.body)
+      expect(json['type']).to eq('FeatureCollection')
+      expect(json['features'].length).to eq(0)
+      expect(response.headers['Link']).to be_present
+      parsed = parse_link_header(response.headers['Link'])
+      expect(parsed['self']['page']).to eq(['1'])
+      expect(parsed['first']['page']).to eq(['1'])
+      expect(parsed['last']['page']).to eq(['1'])
+    end
   end
 
   context 'when requesting all facilities' do
     it 'responds to GeoJSON format' do
       setup_pdx
-      get '/services/va_facilities/v0/facilities/all', nil, accept_geojson
+      get base_query_path + '/all', nil, accept_geojson
       expect(response).to be_success
       expect(response.headers['Content-Type']).to eq 'application/vnd.geo+json; charset=utf-8'
       expect(response.body).to be_a(String)
@@ -72,7 +189,7 @@ RSpec.describe 'Facilities API endpoint', type: :request do
 
     it 'responds to CSV format' do
       setup_pdx
-      get '/services/va_facilities/v0/facilities/all', nil, accept_csv
+      get base_query_path + '/all', nil, accept_csv
       expect(response).to be_success
       expect(response.headers['Content-Type']).to eq 'text/csv'
       expect(response.body).to be_a(String)
@@ -81,23 +198,23 @@ RSpec.describe 'Facilities API endpoint', type: :request do
 
   context 'with invalid request parameters' do
     it 'returns 400 for nonsense bbox' do
-      get base_query_path + 'bbox[]=everywhere'
+      get base_query_path + '?bbox[]=everywhere'
       expect(response).to have_http_status(:bad_request)
     end
     it 'returns 400 for non-array bbox' do
-      get base_query_path + 'bbox=-90,180,45,80'
+      get base_query_path + '?bbox=-90,180,45,80'
       expect(response).to have_http_status(:bad_request)
     end
     it 'returns 400 for too many elements' do
-      get base_query_path + 'bbox[]=-45&bbox[]=-45&bbox[]=45&bbox=45&bbox=100'
+      get base_query_path + '?bbox[]=-45&bbox[]=-45&bbox[]=45&bbox=45&bbox=100'
       expect(response).to have_http_status(:bad_request)
     end
     it 'returns 400 for not enough elements' do
-      get base_query_path + 'bbox[]=-45&bbox[]=-45&bbox[]=45'
+      get base_query_path + '?bbox[]=-45&bbox[]=-45&bbox[]=45'
       expect(response).to have_http_status(:bad_request)
     end
     it 'returns 400 for non-numeric elements' do
-      get base_query_path + 'bbox[]=-45&bbox[]=-45&bbox[]=45&bbox=abc'
+      get base_query_path + '?bbox[]=-45&bbox[]=-45&bbox[]=45&bbox=abc'
       expect(response).to have_http_status(:bad_request)
     end
     it 'returns 400 for invalid type parameter' do


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets-contrib/issues/259

## Background
When returning GeoJSON output from the facilities API, adds GitHub-style pagination information via the `Link` header, since the GeoJSON format does not provide for pagination information. 

## Definition of Done
Bounding box query results include enough information for API consumer to know whether additional results can be retrieved.


#### Applies to all PRs

- [X] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [X] Provide link to originating GitHub issue, or connected to it via ZenHub
- [X] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
