### PR TITLE
Add explicit extra_context key to log_message_to_sentry call

### DIFF
--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -46,7 +46,7 @@ module Vet360
         log_message_to_sentry(
           error.message,
           :error,
-          { url: config.base_path, body: error.body },
+          extra_context: { url: config.base_path, body: error.body },
           vet360: 'failed_vet360_id_initializations'
         )
       else

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -53,7 +53,8 @@ module Vet360
         log_message_to_sentry(
           error.message,
           :error,
-          url: config.base_path, body: error.body
+          { url: config.base_path, body: error.body },
+          vet360: 'general_client_error'
         )
       end
     end

--- a/lib/vet360/service.rb
+++ b/lib/vet360/service.rb
@@ -46,11 +46,15 @@ module Vet360
         log_message_to_sentry(
           error.message,
           :error,
-          extra_context: { url: config.base_path, body: error.body },
+          { url: config.base_path, body: error.body },
           vet360: 'failed_vet360_id_initializations'
         )
       else
-        log_message_to_sentry(error.message, :error, extra_context: { url: config.base_path, body: error.body })
+        log_message_to_sentry(
+          error.message,
+          :error,
+          url: config.base_path, body: error.body
+        )
       end
     end
 

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -212,7 +212,7 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
 
       it 'does not include "failed_vet360_id_initializations" tag in sentry error', :aggregate_failures do
         VCR.use_cassette('vet360/contact_information/email_transaction_status_error', VCR::MATCH_EVERYTHING) do
-          expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry).with(anything, anything, anything)
+          expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry).with(any_args, hash_including(vet360: 'general_client_error'))
           expect { subject.get_email_transaction_status(transaction_id) }.to raise_error do |e|
             expect(e).to be_a(Common::Exceptions::BackendServiceException)
             expect(e.status_code).to eq(400)
@@ -318,7 +318,7 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
       it 'logs a vet360 tagged error message to sentry', :aggregate_failures do
         VCR.use_cassette('vet360/contact_information/person_transaction_status_error', VCR::MATCH_EVERYTHING) do
           expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry)
-            .with(any_args, hash_including(:vet360))
+            .with(any_args, hash_including(vet360: 'failed_vet360_id_initializations'))
 
           expect { subject.get_person_transaction_status(transaction_id) }.to raise_error do |e|
             expect(e).to be_a(Common::Exceptions::BackendServiceException)

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -212,7 +212,9 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
 
       it 'does not include "failed_vet360_id_initializations" tag in sentry error', :aggregate_failures do
         VCR.use_cassette('vet360/contact_information/email_transaction_status_error', VCR::MATCH_EVERYTHING) do
-          expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry).with(any_args, hash_including(vet360: 'general_client_error'))
+          expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry)
+            .with(any_args, hash_including(vet360: 'general_client_error'))
+
           expect { subject.get_email_transaction_status(transaction_id) }.to raise_error do |e|
             expect(e).to be_a(Common::Exceptions::BackendServiceException)
             expect(e.status_code).to eq(400)


### PR DESCRIPTION
## Background

[This request](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11692#issuecomment-407748989) from @steve-gov states:

> we should have logging in place to let us know that this user attempted to procure a Vet360ID and failed for $error reason.

As part of this, investigate if this applies to both the `POST` initialize a Vet360 ID endpoint, as well as the transaction status checking endpoint.

**This PR is to amend #2194, adding the explicit `extra_context` key for readability and consistency.** 

## Definition of Done

#### Unique to this PR

- [x] logging in place for when initializing a `vet360_id` fails (failed states for transaction endpoint)

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
