### PR TITLE
refactor specs to eliminate rspec warnings

### DIFF
--- a/spec/jobs/evss/retrieve_claims_from_remote_job_spec.rb
+++ b/spec/jobs/evss/retrieve_claims_from_remote_job_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe EVSS::RetrieveClaimsFromRemoteJob, type: :job do
         expect_any_instance_of(EVSSClaimsSyncStatusTracker).to(
           receive(:set_collection_status).with('FAILED').and_call_original
         )
-        expect { subject.perform(user.uuid) }.to raise_error
+        expect { subject.perform(user.uuid) }.to raise_error(StandardError)
         expect(tracker.get_collection_status).to eq('FAILED')
       end
     end

--- a/spec/jobs/evss/update_claim_from_remote_job_spec.rb
+++ b/spec/jobs/evss/update_claim_from_remote_job_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe EVSS::UpdateClaimFromRemoteJob, type: :job do
         expect_any_instance_of(EVSSClaimsSyncStatusTracker).to(
           receive(:set_single_status).with('FAILED').and_call_original
         )
-        expect { subject.perform(user.uuid, claim.id) }.to raise_error
+        expect { subject.perform(user.uuid, claim.id) }.to raise_error(StandardError)
         expect(tracker.get_single_status).to eq('FAILED')
       end
     end


### PR DESCRIPTION
## Background
Small refactor to eliminate Rspec warnings that are thrown when the specs run.
> WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives...

## Definition of Done

#### Unique to this PR

- [x] Small refactor to eliminate Rspec warnings that are thrown when the specs run

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
