### PR TITLE
Fix autoloading for redis-cached EMIS responses

### DIFF
--- a/app/models/emis_redis/model.rb
+++ b/app/models/emis_redis/model.rb
@@ -2,6 +2,7 @@
 
 require 'common/models/redis_store'
 require 'common/models/concerns/cache_aside'
+require_dependency 'emis/responses'
 
 module EMISRedis
   class Model < Common::RedisStore

--- a/lib/emis/responses.rb
+++ b/lib/emis/responses.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 
-require 'emis/responses/error_response'
-require 'emis/responses/get_combat_pay_response'
-require 'emis/responses/get_deployment_response'
-require 'emis/responses/get_disabilities_response'
-require 'emis/responses/get_guard_reserve_service_periods_response'
-require 'emis/responses/get_military_occupation_response'
-require 'emis/responses/get_military_service_eligibility_info_response'
-require 'emis/responses/get_military_service_episodes_response'
-require 'emis/responses/get_military_occupation_response'
-require 'emis/responses/get_reserve_drill_days_response'
-require 'emis/responses/get_retirement_response'
-require 'emis/responses/get_retirement_pay_response'
-require 'emis/responses/get_separation_pay_response'
-require 'emis/responses/get_unit_information_response'
-require 'emis/responses/get_veteran_status_response'
+require_dependency 'emis/responses/error_response'
+require_dependency 'emis/responses/get_combat_pay_response'
+require_dependency 'emis/responses/get_deployment_response'
+require_dependency 'emis/responses/get_disabilities_response'
+require_dependency 'emis/responses/get_guard_reserve_service_periods_response'
+require_dependency 'emis/responses/get_military_occupation_response'
+require_dependency 'emis/responses/get_military_service_eligibility_info_response'
+require_dependency 'emis/responses/get_military_service_episodes_response'
+require_dependency 'emis/responses/get_military_occupation_response'
+require_dependency 'emis/responses/get_reserve_drill_days_response'
+require_dependency 'emis/responses/get_retirement_response'
+require_dependency 'emis/responses/get_retirement_pay_response'
+require_dependency 'emis/responses/get_separation_pay_response'
+require_dependency 'emis/responses/get_unit_information_response'
+require_dependency 'emis/responses/get_veteran_status_response'
+
+module EMIS
+  module Responses
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11205
## Background
Development environments were seeing issues deserializing cached EMIS responses. I think it
was basically a variant of this problem: https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-and-sti
in that the deserialization was happening in `Oj`'s C code which was not autoloading-aware, hence
was running into undefined classes when deserializing cached objects.

This resolves the issue in my development environment, but willing to try other approaches based on feedback. 

## Definition of Done

#### Applies to all PRs

- [X] Appropriate test coverage & logging
- [X] Swagger docs have been updated, if applicable
- [X] Provide link to originating GitHub issue, or connected to it via ZenHub
- [X] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
