### PR TITLE
Rename example to reflect correct tag

### DIFF
--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -210,7 +210,7 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
         end
       end
 
-      it 'does not include "failed_vet360_id_initializations" tag in sentry error', :aggregate_failures do
+      it 'includes "general_client_error" tag in sentry error', :aggregate_failures do
         VCR.use_cassette('vet360/contact_information/email_transaction_status_error', VCR::MATCH_EVERYTHING) do
           expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry)
             .with(any_args, hash_including(vet360: 'general_client_error'))


### PR DESCRIPTION
## Background

[This request](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11692#issuecomment-407748989) from @steve-gov states:

> we should have logging in place to let us know that this user attempted to procure a Vet360ID and failed for $error reason.

As part of this, investigate if this applies to both the `POST` initialize a Vet360 ID endpoint, as well as the transaction status checking endpoint.

**This PR is to amend #2194, to fix an incorrectly named example**

## Definition of Done

#### Unique to this PR

- [x] logging in place for when initializing a `vet360_id` fails (failed states for transaction endpoint)


#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
