### PR TITLE
Log MVI findProfile lookups to temp PII table

### DIFF
--- a/app/models/personal_information_log.rb
+++ b/app/models/personal_information_log.rb
@@ -3,7 +3,7 @@
 class PersonalInformationLog < ActiveRecord::Base
   validates(:data, :error_class, presence: true)
 
-  # TODO utility method for working with data persisted by logger middleware
+  # TODO: utility method for working with data persisted by logger middleware
   # consider removing once we have determined how we are going to analyze the data
   def decoded_data
     return data unless data.key?('request_body') && data.key?('response_body')

--- a/app/models/personal_information_log.rb
+++ b/app/models/personal_information_log.rb
@@ -3,6 +3,8 @@
 class PersonalInformationLog < ActiveRecord::Base
   validates(:data, :error_class, presence: true)
 
+  # TODO utility method for working with data persisted by logger middleware
+  # consider removing once we have determined how we are going to analyze the data
   def decoded_data
     return data unless data.key?('request_body') && data.key?('response_body')
     data.merge('request_body' => Base64.decode64(data['request_body']),

--- a/app/models/personal_information_log.rb
+++ b/app/models/personal_information_log.rb
@@ -2,4 +2,10 @@
 
 class PersonalInformationLog < ActiveRecord::Base
   validates(:data, :error_class, presence: true)
+
+  def decoded_data
+    return data unless data.key?('request_body') && data.key?('response_body')
+    data.merge('request_body' => Base64.decode64(data['request_body']),
+               'response_body' => Base64.decode64(data['response_body']))
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -170,6 +170,7 @@ mvi:
   processing_code: T
   client_cert_path: /fake/client/cert/path
   client_key_path: /fake/client/key/path
+  pii_logging: false
 
 # Settings for eMIS
 # The certs used here can be obtained from the DevOps team. A different set is required for

--- a/lib/common/client/middleware/logging.rb
+++ b/lib/common/client/middleware/logging.rb
@@ -13,7 +13,7 @@ module Common
           request_body = Base64.encode64(env.body) if env.body
 
           @app.call(env).on_complete do |response_env|
-            PersonalInformationLog.create!(
+            PersonalInformationLog.create(
               error_class: @type_key, # TODO: error_class is probably worth renaming
               data: {
                 method: env.method,

--- a/lib/common/client/middleware/logging.rb
+++ b/lib/common/client/middleware/logging.rb
@@ -12,10 +12,10 @@ module Common
         end
 
         def call(env)
-          request_body = Base64.encode64(env.body)
+          request_body = Base64.encode64(env.body) if env.body
 
           @app.call(env).on_complete do |response_env|
-            PersonalInformationLog.create({
+            PersonalInformationLog.create(
               error_class: @type_key, # TODO: error_class is probably worth renaming
               data: {
                 method: env.method,
@@ -23,7 +23,7 @@ module Common
                 request_body: request_body,
                 response_body: Base64.encode64(response_env.body)
               }.to_json
-            })
+            )
           end
         end
       end

--- a/lib/common/client/middleware/logging.rb
+++ b/lib/common/client/middleware/logging.rb
@@ -4,25 +4,23 @@ module Common
   module Client
     module Middleware
       class Logging < Faraday::Middleware
-        DEFAULT_TYPE_KEY = 'undefined'
-
         def initialize(app, type_key)
           super(app)
-          @type_key = type_key || DEFAULT_TYPE_KEY
+          @type_key = type_key
         end
 
         def call(env)
           request_body = Base64.encode64(env.body) if env.body
 
           @app.call(env).on_complete do |response_env|
-            PersonalInformationLog.create(
+            PersonalInformationLog.create!(
               error_class: @type_key, # TODO: error_class is probably worth renaming
               data: {
                 method: env.method,
                 url: env.url.to_s,
                 request_body: request_body,
                 response_body: Base64.encode64(response_env.body)
-              }.to_json
+              }
             )
           end
         end

--- a/lib/mvi/configuration.rb
+++ b/lib/mvi/configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'common/client/configuration/soap'
+require 'common/client/middleware/logging'
 
 module MVI
   class Configuration < Common::Client::Configuration::SOAP
@@ -49,6 +50,7 @@ module MVI
         conn.request :soap_headers
         conn.response :soap_parser
         conn.use :breakers
+        conn.use :logging, 'MVIRequest'
         conn.response :betamocks if Settings.mvi.mock
         conn.adapter Faraday.default_adapter
       end

--- a/lib/mvi/configuration.rb
+++ b/lib/mvi/configuration.rb
@@ -50,7 +50,7 @@ module MVI
         conn.request :soap_headers
         conn.response :soap_parser
         conn.use :breakers
-        conn.use :logging, 'MVIRequest'
+        conn.use :logging, 'MVIRequest' if Settings.mvi.pii_logging
         conn.response :betamocks if Settings.mvi.mock
         conn.adapter Faraday.default_adapter
       end

--- a/spec/lib/common/client/middleware/logging_spec.rb
+++ b/spec/lib/common/client/middleware/logging_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'common/client/middleware/logging'
+
+describe 'Logging Middleware' do
+  let(:type_key) { 'razzledaz' }
+  let(:response_data) { 'muchado' }
+
+  subject(:client) do
+    Faraday.new do |conn|
+      conn.response :logging, type_key
+
+      conn.adapter :test do |stub|
+        stub.get('success') { |200, { 'Content-Type' => 'text/plain' }, response_data] }
+      end
+    end
+  end
+
+  it 'creates a new personal information log record' do
+
+  end
+
+  it 'correctly records (no) request body on a GET request' do
+
+  end
+
+  it 'correctly records the request body on a non-GET request' do
+
+  end
+
+  it 'correctly records the response body' do
+
+  end
+
+  it 'correctly records the url' do
+
+  end
+
+  it 'correctly records the request method' do
+
+  end
+
+  it 'raises client response error' do
+    message = 'BackendServiceException: {:status=>404, :detail=>"Veteran not found", ' \
+              ':code=>"APPEALSSTATUS404", :source=>"A veteran with that SSN was not found in our systems."}'
+    expect { appeals_client.get('not-found') }
+      .to raise_error do |error|
+        expect(error).to be_a(Common::Exceptions::BackendServiceException)
+        expect(error.message).to eq(message)
+        expect(error.errors.first[:detail]).to eq('Appeals data for a veteran with that SSN was not found')
+        expect(error.errors.first[:code]).to eq('APPEALSSTATUS404')
+      end
+  end
+end

--- a/spec/lib/mvi/service_spec.rb
+++ b/spec/lib/mvi/service_spec.rb
@@ -335,6 +335,14 @@ describe MVI::Service do
         end
         expect(StatsD).to have_received(:increment).with('api.mvi.find_profile.total')
       end
+
+      it 'should log the request and response data' do
+        expect {
+          VCR.use_cassette('mvi/find_candidate/valid') do
+            subject.find_profile(user)
+          end
+        }.to change{PersonalInformationLog.count}.by(1)
+      end
     end
 
     context 'with an unsuccessful request' do

--- a/spec/lib/mvi/service_spec.rb
+++ b/spec/lib/mvi/service_spec.rb
@@ -339,7 +339,9 @@ describe MVI::Service do
       it 'should log the request and response data' do
         expect do
           VCR.use_cassette('mvi/find_candidate/valid') do
+            Settings.mvi.pii_logging = true
             subject.find_profile(user)
+            Settings.mvi.pii_logging = false
           end
         end.to change { PersonalInformationLog.count }.by(1)
       end

--- a/spec/lib/mvi/service_spec.rb
+++ b/spec/lib/mvi/service_spec.rb
@@ -337,11 +337,11 @@ describe MVI::Service do
       end
 
       it 'should log the request and response data' do
-        expect {
+        expect do
           VCR.use_cassette('mvi/find_candidate/valid') do
             subject.find_profile(user)
           end
-        }.to change{PersonalInformationLog.count}.by(1)
+        end.to change { PersonalInformationLog.count }.by(1)
       end
     end
 

--- a/spec/models/personal_information_log_spec.rb
+++ b/spec/models/personal_information_log_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersonalInformationLog do
+  let(:pi_log) do
+    PersonalInformationLog.create(error_class: 'my_type', data: { cool: 'stuff' })
+  end
+
+  describe '#decoded_data' do
+    it 'should simply return data when not a logged request/response' do
+      expect(pi_log.decoded_data).to eq(pi_log.data)
+    end
+
+    it 'should return decoded request/response values when present' do
+      pi_log.data.merge!('request_body' => Base64.encode64('special request'),
+                         'response_body' => Base64.encode64('nominal response'))
+      expect(pi_log.data['request_body']).not_to eq('special request')
+      expect(pi_log.decoded_data['request_body']).to eq('special request')
+
+      expect(pi_log.data['response_body']).not_to eq('nominal response')
+      expect(pi_log.decoded_data['response_body']).to eq('nominal response')
+    end
+  end
+end


### PR DESCRIPTION
## Background

MVI profile lookups respond with a high rate of not founds. We suspect that this issue is caused either by a lack of associated MVI record, or potentially a misconfiguration in the request itself. 

Some recent stats for failure rates are provided in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12126. 

In order to collect more information, this change logs MVI request and response data to a `PersonalInformationLog` record. It provides a faraday middleware that can be used to log requests to any service configured with the common client when necessary.

## Definition of Done

#### Unique to this PR

- [x] Records MVI find profile request and response data to a temporary location
- [x] Can be enabled/disabled with a feature flag or configuration option

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable

Not applicable

- [x] Provide link to originating GitHub issue, or connected to it via ZenHub

Debug capability, link provided

- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)

Records sensitive information to a trusted location designed for temporary storage.