### PR TITLE
12289-ihub-appointments-betamocks

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -362,3 +362,12 @@
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: ssn
+
+# IHUB
+- :name: 'IHub'
+  :base_uri: <%= "#{URI(Settings.ihub.url).host}:#{URI(Settings.ihub.url).port}" %>
+  :endpoints:
+  # Appointments
+  - :method: :get
+    :path: "/WebParts/DEV/api/Appointments/1.0/json/ftpCRM/*"
+    :file_path: "ihub/appointments/default"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -67,7 +67,7 @@ ihub:
   url: "https://qacrmdac.np.crm.vrm.vba.va.gov"
   appointments:
     timeout: 30
-    mock: false
+    mock: true
   in_production: false
 
 


### PR DESCRIPTION
## Background
<!-- What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary -->

We are trying out the iHub external service through their "Appointments" endpoint. We now have this integrated into Vets-API. Next step is to enable betamocks support so that the FE can build out the UI, with the standard iHub Appointments endpoint response in place to build against.

**Sibling PR in Mockdata repo**

https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/49

**Sibling Devops PR**

https://github.com/department-of-veterans-affairs/devops/pull/3142

## Definition of Done

Betamocks for appointments endpoint will respond with default data.

This cannot currently be flexible to create unique beta mock data responses, based on the signed in user.  This is due to a [regular expression matching rule in the betamocks gem](https://github.com/department-of-veterans-affairs/betamocks/blob/master/lib/betamocks/configuration.rb#L64-L66).

For now, a default for any logged in user will work just fine.

#### Unique to this PR

- [x] Configure betamocks for iHub appointments endpoint

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
