### PR TITLE
Remove extra sentry logging added during Profile debugging

### DIFF
--- a/app/controllers/concerns/vet360/writeable.rb
+++ b/app/controllers/concerns/vet360/writeable.rb
@@ -22,21 +22,6 @@ module Vet360
       render_new_transaction!(type, response)
     end
 
-    # Temporary method for debugging during UAT
-    #
-    def log_profile_data_to_sentry(response)
-      log_message_to_sentry(
-        'Profile controller bug',
-        :info,
-        {
-          controller: self.class.to_s,
-          response: response,
-          params: params
-        },
-        profile: 'pciu_profile'
-      )
-    end
-
     def invalidate_cache
       Vet360Redis::Cache.invalidate(@current_user)
     end

--- a/app/controllers/v0/addresses_controller.rb
+++ b/app/controllers/v0/addresses_controller.rb
@@ -2,14 +2,10 @@
 
 module V0
   class AddressesController < ApplicationController
-    include Vet360::Writeable
-
     before_action { authorize :evss, :access? }
 
     def show
       response = service.get_address
-
-      log_profile_data_to_sentry(response) if response&.address&.address_one.blank?
 
       render json: response,
              serializer: AddressSerializer
@@ -19,8 +15,6 @@ module V0
       address = EVSS::PCIUAddress::Address.build_address(params)
       raise Common::Exceptions::ValidationErrors, address unless address.valid?
       response = service.update_address(address)
-
-      log_profile_data_to_sentry(response) if response&.address&.address_one.blank?
 
       render json: response,
              serializer: AddressSerializer

--- a/app/controllers/v0/profile/alternate_phones_controller.rb
+++ b/app/controllers/v0/profile/alternate_phones_controller.rb
@@ -3,15 +3,12 @@
 module V0
   module Profile
     class AlternatePhonesController < ApplicationController
-      include Vet360::Writeable
       include EVSS::Authorizeable
 
       before_action :authorize_evss!
 
       def show
         response = service.get_alternate_phone
-
-        log_profile_data_to_sentry(response) if response&.number.blank?
 
         render json: response, serializer: PhoneNumberSerializer
       end
@@ -21,8 +18,6 @@ module V0
 
         if phone.valid?
           response = service.post_alternate_phone phone
-
-          log_profile_data_to_sentry(response) if response&.number.blank?
 
           render json: response, serializer: PhoneNumberSerializer
         else

--- a/app/controllers/v0/profile/emails_controller.rb
+++ b/app/controllers/v0/profile/emails_controller.rb
@@ -3,15 +3,12 @@
 module V0
   module Profile
     class EmailsController < ApplicationController
-      include Vet360::Writeable
       include EVSS::Authorizeable
 
       before_action :authorize_evss!
 
       def show
         response = service.get_email_address
-
-        log_profile_data_to_sentry(response) if response&.email.blank?
 
         render json: response, serializer: EmailSerializer
       end
@@ -21,8 +18,6 @@ module V0
 
         if email_address.valid?
           response = service.post_email_address email_address
-
-          log_profile_data_to_sentry(response) if response&.email.blank?
 
           render json: response, serializer: EmailSerializer
         else

--- a/app/controllers/v0/profile/full_names_controller.rb
+++ b/app/controllers/v0/profile/full_names_controller.rb
@@ -3,8 +3,6 @@
 module V0
   module Profile
     class FullNamesController < ApplicationController
-      include Vet360::Writeable
-
       # Fetches the full name details for the current user.
       # Namely their first/middle/last name, and suffix.
       #
@@ -23,8 +21,6 @@ module V0
       #   }
       #
       def show
-        log_profile_data_to_sentry('') if @current_user&.full_name_normalized.blank?
-
         render(
           json: @current_user.full_name_normalized,
           serializer: FullNameSerializer

--- a/app/controllers/v0/profile/primary_phones_controller.rb
+++ b/app/controllers/v0/profile/primary_phones_controller.rb
@@ -3,15 +3,12 @@
 module V0
   module Profile
     class PrimaryPhonesController < ApplicationController
-      include Vet360::Writeable
       include EVSS::Authorizeable
 
       before_action :authorize_evss!
 
       def show
         response = service.get_primary_phone
-
-        log_profile_data_to_sentry(response) if response&.number.blank?
 
         render json: response, serializer: PhoneNumberSerializer
       end
@@ -21,8 +18,6 @@ module V0
 
         if phone.valid?
           response = service.post_primary_phone phone
-
-          log_profile_data_to_sentry(response) if response&.number.blank?
 
           render json: response, serializer: PhoneNumberSerializer
         else

--- a/app/controllers/v0/profile/service_histories_controller.rb
+++ b/app/controllers/v0/profile/service_histories_controller.rb
@@ -3,8 +3,6 @@
 module V0
   module Profile
     class ServiceHistoriesController < ApplicationController
-      include Vet360::Writeable
-
       before_action :check_authorization
 
       # Fetches the service history for the current user.
@@ -55,8 +53,6 @@ module V0
 
       def handle_errors!(response)
         raise_error! unless response.is_a?(Array)
-
-        log_profile_data_to_sentry(response) if response.try(:first).try(:dig, :branch_of_service).blank?
       end
 
       def raise_error!

--- a/app/policies/evss_policy.rb
+++ b/app/policies/evss_policy.rb
@@ -1,30 +1,12 @@
 # frozen_string_literal: true
 
 EVSSPolicy = Struct.new(:user, :evss) do
-  include SentryLogging
-
   def access?
     if user.edipi.present? && user.ssn.present? && user.participant_id.present?
       StatsD.increment('api.evss.policy.success') if user.loa3?
-
       true
     else
-      if user.loa3?
-        StatsD.increment('api.evss.policy.failure')
-
-        log_message_to_sentry(
-          'EVSS Pundit failure log',
-          :info,
-          {
-            edipi_present: user.edipi.present?,
-            ssn_present: user.ssn.present?,
-            participant_id_present: user.participant_id.present?,
-            user_loa: user&.loa
-          },
-          profile: 'pciu_profile'
-        )
-      end
-
+      StatsD.increment('api.evss.policy.failure') if user.loa3?
       false
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,8 +22,6 @@ unless ENV['NOCOVERAGE']
 
   SimpleCov.start 'rails' do
     track_files '**/{app,lib}/**/*.rb'
-    # TODO: remove this filter after removing sentry logging
-    add_filter 'app/controllers/v0/profile'
     add_filter 'config/initializers/sidekiq.rb'
     add_filter 'config/initializers/statsd.rb'
     add_filter 'config/initializers/mvi_settings.rb'


### PR DESCRIPTION
## Background

During the UAT process for the Profile form, we added a lot of sentry logging to debug issues.  This needs to be removed, once the feature is in production, and working as desired.|

* Essentially reverse changes made in commit 77ffebb

## Definition of Done
#### Unique to this PR

- [x] Remove sentry logging, and associated support code, that was added for the Profile endpoints

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] ~Swagger docs have been updated, if applicable~
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
