### PR TITLE
Use pdfinfo tool to validate incoming pdf documents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ git \
 libpq-dev \
 clamav \
 imagemagick \
-pdftk
+pdftk \
+poppler-utils
 
 WORKDIR $APP_PATH
 ADD Gemfile $APP_PATH

--- a/app/models/evss_claim_document.rb
+++ b/app/models/evss_claim_document.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'common/models/base'
-require 'pdf_info'
 
 class EVSSClaimDocument < Common::Base
   include ActiveModel::Validations

--- a/app/models/evss_claim_document.rb
+++ b/app/models/evss_claim_document.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'common/models/base'
-require 'pdf/reader'
+require 'pdf_info'
 
 class EVSSClaimDocument < Common::Base
   include ActiveModel::Validations
@@ -83,10 +83,10 @@ class EVSSClaimDocument < Common::Base
 
   def unencrypted_pdf?
     return unless file_name =~ /\.pdf$/i
-    xref = PDF::Reader::XRef.new file_obj.tempfile
-    errors.add(:base, 'PDF must not be encrypted') if xref.trailer[:Encrypt].present?
+    metadata = PdfInfo::Metadata.read(file_obj.tempfile)
+    errors.add(:base, 'PDF must not be encrypted') if metadata.encrypted?
     file_obj.tempfile.rewind
-  rescue PDF::Reader::MalformedPDFError
+  rescue PdfInfo::MetadataReadError
     errors.add(:base, 'PDF is malformed')
   end
 

--- a/app/workers/central_mail/submit_saved_claim_job.rb
+++ b/app/workers/central_mail/submit_saved_claim_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pdf_info'
+
 module CentralMail
   class SubmitSavedClaimJob
     include Sidekiq::Worker
@@ -73,7 +75,7 @@ module CentralMail
     def get_hash_and_pages(file_path)
       {
         hash: Digest::SHA256.file(file_path).hexdigest,
-        pages: PDF::Reader.new(file_path).pages.size
+        pages: PdfInfo::Metadata.read(file_path).pages
       }
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,6 @@
 binaries:
   # you can specify a full path in settings.local.yml if necessary
+  pdfinfo: pdfinfo
   pdftk: pdftk
   clamdscan: /usr/bin/clamdscan
 

--- a/lib/pdf_info.rb
+++ b/lib/pdf_info.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module PdfInfo
+  class MetadataReadError < Exception
+    def initialize(status, stdout)
+      @status = status
+      @stdout = stdout
+    end
+  end
+
+  class Metadata
+    def self.read(file_or_path)
+      if file_or_path.is_a? String
+        self.new(file_or_path, Settings.binaries.pdfinfo)
+      else
+        self.new(file_or_path.path, Settings.binaries.pdfinfo)
+      end
+    end
+
+    def initialize(path, bin)
+      @result = %x(#{bin} #{path})
+      init_error unless $? == 0
+    end
+
+    def [](key)
+      @internal_hash ||= parse_result
+      @internal_hash[key]
+    end
+
+    def encrypted?
+      return self['Encrypted'] == 'yes'
+    end
+
+    def pages
+      return self['Pages'].to_i
+    end
+
+    private
+
+    def init_error
+      raise PdfInfo::MetadataReadError.new($?, @result)
+    end
+
+    def parse_result
+      @result.split(/$/).reduce({}) do |out, line|
+        key, value = line.split(/:\s+/)
+        out[key.strip] = value.try(:strip)
+        out
+      end
+    end
+  end
+end

--- a/lib/pdf_info.rb
+++ b/lib/pdf_info.rb
@@ -28,7 +28,7 @@ module PdfInfo
     end
 
     def encrypted?
-      return self['Encrypted'] == 'yes'
+      return self['Encrypted'] != 'no'
     end
 
     def pages

--- a/lib/pdf_info.rb
+++ b/lib/pdf_info.rb
@@ -3,8 +3,7 @@
 module PdfInfo
   class MetadataReadError < RuntimeError
     def initialize(status, stdout)
-      @status = status
-      @stdout = stdout
+      super "pdfinfo exited with status #{status} and message #{stdout}"
     end
   end
 

--- a/lib/shrine/plugins/validate_unlocked_pdf.rb
+++ b/lib/shrine/plugins/validate_unlocked_pdf.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pdf_info'
+
 class Shrine
   module Plugins
     module ValidateUnlockedPdf
@@ -7,13 +9,14 @@ class Shrine
         def validate_unlocked_pdf
           return unless get.mime_type == Mime[:pdf].to_s
           cached_path = get.download
-          xref = PDF::Reader::XRef.new cached_path
-          errors << I18n.t('uploads.pdf.locked') if xref.trailer[:Encrypt].present?
-        rescue PDF::Reader::MalformedPDFError
+          metadata = PdfInfo::Metadata.read(cached_path)
+          errors << I18n.t('uploads.pdf.locked') if metadata.encrypted?
+        rescue PdfInfo::MetadataReadError
           errors << I18n.t('uploads.pdf.invalid')
         end
       end
     end
+
 
     register_plugin(:validate_unlocked_pdf, ValidateUnlockedPdf)
   end

--- a/lib/shrine/plugins/validate_unlocked_pdf.rb
+++ b/lib/shrine/plugins/validate_unlocked_pdf.rb
@@ -17,7 +17,6 @@ class Shrine
       end
     end
 
-
     register_plugin(:validate_unlocked_pdf, ValidateUnlockedPdf)
   end
 end

--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -179,9 +179,9 @@ module VBADocuments
     def get_hash_and_pages(file_path, part)
       {
         hash: Digest::SHA256.file(file_path).hexdigest,
-        pages: PDF::Reader.new(file_path).pages.size
+        pages: PdfInfo::Metadata.read(file_path).pages
       }
-    rescue PDF::Reader::MalformedPDFError
+    rescue PdfInfo::MetadataReadError
       raise VBADocuments::UploadError.new(code: 'DOC103',
                                           detail: "Invalid PDF content, part #{part}")
     end

--- a/spec/jobs/central_mail/submit_saved_claim_job_spec.rb
+++ b/spec/jobs/central_mail/submit_saved_claim_job_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe CentralMail::SubmitSavedClaimJob, uploader_helpers: true do
         expect(Digest::SHA256).to receive(:file).with('path').and_return(
           OpenStruct.new(hexdigest: 'hexdigest')
         )
-        expect(PDF::Reader).to receive(:new).with('path').and_return(
-          OpenStruct.new(pages: [1, 2])
+        expect(PdfInfo::Metadata).to receive(:read).with('path').and_return(
+          OpenStruct.new(pages: 2)
         )
 
         expect(described_class.new.get_hash_and_pages('path')).to eq(

--- a/spec/lib/pdf_info/metadata_spec.rb
+++ b/spec/lib/pdf_info/metadata_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+require 'pdf_info'
+
+def set_last_exit_code(code)
+  `exit #{code}`
+end
+
+describe PdfInfo::Metadata do
+  let(:result) do
+    <<EOF
+Title:          
+Subject:        
+Author:         
+Creator:        
+Producer:       
+CreationDate:   
+Tagged:         no
+UserProperties: no
+Suspects:       no
+Form:           none
+JavaScript:     no
+Pages:          4
+Encrypted:      no
+Page size:      612 x 792 pts (letter)
+Page rot:       0
+File size:      1099807 bytes
+Optimized:      no
+PDF version:    1.3"
+EOF
+  end
+
+  before(:each) do
+    allow_any_instance_of(described_class).to receive(:`).and_return(result)
+    set_last_exit_code(0)
+  end
+
+  describe '::read' do
+    context "when passed a string" do
+      it 'should shell out with the string as the file path' do
+        expect_any_instance_of(described_class).to receive(:`).with('pdfinfo /tmp/file.pdf').and_return(result)
+        described_class.read('/tmp/file.pdf')
+      end
+    end
+
+    context 'when passed a file' do
+      it 'should shell out with the file object path' do
+        file = double(File)
+        allow(file).to receive(:path).and_return('/tmp/file.pdf')
+        expect_any_instance_of(described_class).to receive(:`).with('pdfinfo /tmp/file.pdf').and_return(result)
+        described_class.read(file)
+      end
+    end
+
+    context 'when the command errors' do
+      it 'should raise a PdfInfo::MetadataReadError' do
+        set_last_exit_code(1)
+        expect{ described_class.read('/tmp/file.pdf') }.to raise_error(PdfInfo::MetadataReadError)
+      end
+    end
+  end
+
+  describe '#[]' do
+    it 'should fetch a key from the parsed result' do
+      metadata = described_class.read('/tmp/file.pdf')
+      expect(metadata['Title']).to be_nil
+      expect(metadata['Pages']).to eq('4')
+      expect(metadata['Encrypted']).to eq('no')
+    end
+  end
+
+  describe '#pages' do
+    it 'should return pages as an int' do
+      metadata = described_class.read('/tmp/file.pdf')
+      expect(metadata.pages).to eq(4)
+    end
+  end
+
+  describe '#encrypted?' do
+    it 'should return encryption as a boolean' do
+      metadata = described_class.read('/tmp/file.pdf')
+      expect(metadata.encrypted?).to be false
+    end
+
+    context 'when the document is encrypted' do
+      let(:result) do
+        <<EOF
+Title:          
+Subject:        
+Author:         
+Creator:        
+Producer:       
+CreationDate:   
+Tagged:         no
+UserProperties: no
+Suspects:       no
+Form:           none
+JavaScript:     no
+Pages:          4
+Encrypted:      yes
+Page size:      612 x 792 pts (letter)
+Page rot:       0
+File size:      1099807 bytes
+Optimized:      no
+PDF version:    1.3"
+EOF
+      end
+
+      it 'should return encryption as a boolean' do
+        metadata = described_class.read('/tmp/file.pdf')
+        expect(metadata.encrypted?).to be true
+      end
+    end
+  end
+end

--- a/spec/lib/pdf_info/metadata_spec.rb
+++ b/spec/lib/pdf_info/metadata_spec.rb
@@ -70,7 +70,7 @@ STDOUT
     context 'when the command errors' do
       it 'should raise a PdfInfo::MetadataReadError' do
         expect(Open3).to receive(:popen2e).with(%w[pdfinfo argv0], '/tmp/file.pdf').and_yield('', result, bad_exit)
-        expect { described_class.read('/tmp/file.pdf') }.to raise_error(PdfInfo::MetadataReadError)
+        expect { described_class.read('/tmp/file.pdf') }.to raise_error(PdfInfo::MetadataReadError, /pdfinfo exited/)
       end
     end
   end

--- a/spec/lib/pdf_info/metadata_spec.rb
+++ b/spec/lib/pdf_info/metadata_spec.rb
@@ -4,43 +4,56 @@ require 'rails_helper'
 
 require 'pdf_info'
 
-def set_last_exit_code(code)
-  `exit #{code}`
-end
-
 describe PdfInfo::Metadata do
   let(:result) do
-    <<EOF
-Title:          
-Subject:        
-Author:         
-Creator:        
-Producer:       
-CreationDate:   
-Tagged:         no
-UserProperties: no
-Suspects:       no
-Form:           none
-JavaScript:     no
-Pages:          4
-Encrypted:      no
-Page size:      612 x 792 pts (letter)
-Page rot:       0
-File size:      1099807 bytes
-Optimized:      no
-PDF version:    1.3"
-EOF
+    <<~STDOUT
+      Title:
+      Subject:
+      Author:
+      Creator:
+      Producer:
+      CreationDate:
+      Tagged:         no
+      UserProperties: no
+      Suspects:       no
+      Form:           none
+      JavaScript:     no
+      Pages:          4
+      Encrypted:      no
+      Page size:      612 x 792 pts (letter)
+      Page rot:       0
+      File size:      1099807 bytes
+      Optimized:      no
+      PDF version:    1.3"
+STDOUT
+  end
+
+  let(:good_exit) do
+    wait_thr = double
+    value = double
+    allow(wait_thr).to receive(:value).and_return(value)
+    allow(value).to receive(:success?).and_return(true)
+    allow(value).to receive(:exitstatus).and_return(0)
+    wait_thr
+  end
+
+  let(:bad_exit) do
+    wait_thr = double
+    value = double
+    allow(wait_thr).to receive(:value).and_return(value)
+    allow(value).to receive(:success?).and_return(false)
+    allow(value).to receive(:exitstatus).and_return(1)
+    wait_thr
   end
 
   before(:each) do
-    allow_any_instance_of(described_class).to receive(:`).and_return(result)
-    set_last_exit_code(0)
+    allow(Open3).to receive(:popen2e).and_yield('', result, good_exit)
   end
 
   describe '::read' do
-    context "when passed a string" do
+    context 'when passed a string' do
       it 'should shell out with the string as the file path' do
-        expect_any_instance_of(described_class).to receive(:`).with('pdfinfo /tmp/file.pdf').and_return(result)
+        expect(Open3).to receive(:popen2e).with(%w[pdfinfo argv0], '/tmp/file.pdf').and_yield('', result, good_exit)
         described_class.read('/tmp/file.pdf')
       end
     end
@@ -49,15 +62,15 @@ EOF
       it 'should shell out with the file object path' do
         file = double(File)
         allow(file).to receive(:path).and_return('/tmp/file.pdf')
-        expect_any_instance_of(described_class).to receive(:`).with('pdfinfo /tmp/file.pdf').and_return(result)
+        expect(Open3).to receive(:popen2e).with(%w[pdfinfo argv0], '/tmp/file.pdf').and_yield('', result, good_exit)
         described_class.read(file)
       end
     end
 
     context 'when the command errors' do
       it 'should raise a PdfInfo::MetadataReadError' do
-        set_last_exit_code(1)
-        expect{ described_class.read('/tmp/file.pdf') }.to raise_error(PdfInfo::MetadataReadError)
+        expect(Open3).to receive(:popen2e).with(%w[pdfinfo argv0], '/tmp/file.pdf').and_yield('', result, bad_exit)
+        expect { described_class.read('/tmp/file.pdf') }.to raise_error(PdfInfo::MetadataReadError)
       end
     end
   end
@@ -86,26 +99,26 @@ EOF
 
     context 'when the document is encrypted' do
       let(:result) do
-        <<EOF
-Title:          
-Subject:        
-Author:         
-Creator:        
-Producer:       
-CreationDate:   
-Tagged:         no
-UserProperties: no
-Suspects:       no
-Form:           none
-JavaScript:     no
-Pages:          4
-Encrypted:      yes
-Page size:      612 x 792 pts (letter)
-Page rot:       0
-File size:      1099807 bytes
-Optimized:      no
-PDF version:    1.3"
-EOF
+        <<~STDOUT
+          Title:
+          Subject:
+          Author:
+          Creator:
+          Producer:
+          CreationDate:
+          Tagged:         no
+          UserProperties: no
+          Suspects:       no
+          Form:           none
+          JavaScript:     no
+          Pages:          4
+          Encrypted:      yes
+          Page size:      612 x 792 pts (letter)
+          Page rot:       0
+          File size:      1099807 bytes
+          Optimized:      no
+          PDF version:    1.3"
+STDOUT
       end
 
       it 'should return encryption as a boolean' do

--- a/spec/lib/vic/service_spec.rb
+++ b/spec/lib/vic/service_spec.rb
@@ -98,7 +98,7 @@ describe VIC::Service, type: :model do
         ProcessFileJob.drain
         final_pdf = service.combine_files(records)
 
-        expect(PDF::Reader.new(final_pdf).pages.size).to eq(1)
+        expect(PdfInfo::Metadata.read(final_pdf).pages).to eq(1)
 
         File.delete(final_pdf)
       end
@@ -113,7 +113,7 @@ describe VIC::Service, type: :model do
         ProcessFileJob.drain
         final_pdf = service.combine_files(records)
 
-        expect(PDF::Reader.new(final_pdf).pages.size).to eq(2)
+        expect(PdfInfo::Metadata.read(final_pdf).pages).to eq(2)
 
         File.delete(final_pdf)
       end

--- a/spec/request/documents_spec.rb
+++ b/spec/request/documents_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe 'Documents management', type: :request do
     it 'should reject locked PDFs' do
       params = { file: locked_file, tracked_item_id: tracked_item_id, document_type: document_type }
       post '/v0/evss_claims/189625/documents', params, 'Authorization' => "Token token=#{session.token}"
-      p response.body
       expect(response.status).to eq(422)
       expect(JSON.parse(response.body)['errors'].first['title']).to eq('PDF must not be encrypted')
     end

--- a/spec/request/documents_spec.rb
+++ b/spec/request/documents_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe 'Documents management', type: :request do
     it 'should reject locked PDFs' do
       params = { file: locked_file, tracked_item_id: tracked_item_id, document_type: document_type }
       post '/v0/evss_claims/189625/documents', params, 'Authorization' => "Token token=#{session.token}"
+      p response.body
       expect(response.status).to eq(422)
       expect(JSON.parse(response.body)['errors'].first['title']).to eq('PDF must not be encrypted')
     end


### PR DESCRIPTION
## Background

The Ruby PDF::Reader library has a known issue where it is unable to open pdfs
that are close to the spec, but may violate it in some minor way (see:
https://github.com/yob/pdf-reader/issues/213). This results in users sending
pdfs that they can open on their device that we reject as being invalid.

This replaces that library with the pdfinfo command line tool based on the
poppler pdf rendering library that is more flexible with regards to pdf spec
compliance and gives us the data we need: pages counts and encryption
information.

## Definition of Done

#### Unique to this PR

- [x] Substitute as many pdf::reader uses with pdfinfo as possible
- [x] Update deployment scripts to install pdfinfo tool

#### Applies to all PRs

- [x] Appropriate test coverage & logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
