### PR TITLE
Status endpoint

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -37,16 +37,6 @@ module V0
       end
     end
 
-    def user_submissions
-      submissions = AsyncTransaction::EVSS::VA526ezSubmitTransaction.find_transactions(@current_user)
-      submissions.map do |submission|
-        {
-          status: submission.status,
-          response: submission.response
-        }
-      end
-    end
-
     private
 
     def service

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -7,7 +7,7 @@ module V0
     def rated_disabilities
       response = service.get_rated_disabilities
       render json: response,
-        serializer: RatedDisabilitiesSerializer
+             serializer: RatedDisabilitiesSerializer
     end
 
     def submit
@@ -24,7 +24,7 @@ module V0
         EVSS::DisabilityCompensationForm::SubmitUploads.start(@current_user, response.claim_id, uploads)
       end
       render json: response,
-        serializer: SubmitDisabilityFormSerializer
+             serializer: SubmitDisabilityFormSerializer
     end
 
     def submission_status

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -27,6 +27,13 @@ module V0
              serializer: SubmitDisabilityFormSerializer
     end
 
+    def submission_status
+      # pseudocode:
+      # submission = DisabilityCompensationSubmission.submission_for_user(params[:form_id], @current_user)
+      # if submission
+      #   return submission status and response body
+    end
+
     private
 
     def service

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -7,7 +7,7 @@ module V0
     def rated_disabilities
       response = service.get_rated_disabilities
       render json: response,
-             serializer: RatedDisabilitiesSerializer
+        serializer: RatedDisabilitiesSerializer
     end
 
     def submit
@@ -24,14 +24,27 @@ module V0
         EVSS::DisabilityCompensationForm::SubmitUploads.start(@current_user, response.claim_id, uploads)
       end
       render json: response,
-             serializer: SubmitDisabilityFormSerializer
+        serializer: SubmitDisabilityFormSerializer
     end
 
     def submission_status
-      # pseudocode:
-      # submission = DisabilityCompensationSubmission.submission_for_user(params[:form_id], @current_user)
-      # if submission
-      #   return submission status and response body
+      submission = AsyncTransaction::EVSS::VA526ezSubmitTransaction.find_transaction(params[:job_id])
+      if submission
+        {
+          status: submission.status,
+          response: submission.response
+        }.to_json
+      end
+    end
+
+    def user_submissions
+      submissions = AsyncTransaction::EVSS::VA526ezSubmitTransaction.find_transactions(@current_user)
+      submissions.map do |submission|
+        {
+          status: submission.status,
+          response: submission.response
+        }
+      end
     end
 
     private

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -29,12 +29,8 @@ module V0
 
     def submission_status
       submission = AsyncTransaction::EVSS::VA526ezSubmitTransaction.find_transaction(params[:job_id])
-      if submission
-        {
-          status: submission.status,
-          response: submission.response
-        }.to_json
-      end
+      raise Common::Exceptions::RecordNotFound, params[:job_id] unless submission
+      render json: submission, serializer: AsyncTransaction::BaseSerializer
     end
 
     private

--- a/app/models/async_transaction/evss/va526ez_submit_transaction.rb
+++ b/app/models/async_transaction/evss/va526ez_submit_transaction.rb
@@ -29,7 +29,8 @@ module AsyncTransaction
           source: SOURCE,
           status: REQUESTED,
           transaction_status: JOB_STATUS[:submitted],
-          transaction_id: job_id
+          transaction_id: job_id,
+          metadata: {}
         )
       end
 
@@ -39,7 +40,9 @@ module AsyncTransaction
       # @return [AsyncTransaction::EVSS::VA526ezSubmitTransaction] the transaction
       #
       def self.find_transaction(job_id)
-        VA526ezSubmitTransaction.job_id(job_id)
+        result = VA526ezSubmitTransaction.job_id(job_id)
+        return nil if result == []
+        result
       end
 
       # Finds all of a users submit transactions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
     resource :disability_compensation_form, only: [] do
       get 'rated_disabilities'
       post 'submit'
+      get 'submission_status/:form_id', to: 'disability_compensation_forms#submission_status', as: 'submission_status'
     end
 
     resource :upload_supporting_evidence, only: :create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,8 @@ Rails.application.routes.draw do
     resource :disability_compensation_form, only: [] do
       get 'rated_disabilities'
       post 'submit'
-      get 'submission_status/:form_id', to: 'disability_compensation_forms#submission_status', as: 'submission_status'
+      get 'submission_status/:job_id', to: 'disability_compensation_forms#submission_status', as: 'submission_status'
+      get 'user_submissions'
     end
 
     resource :upload_supporting_evidence, only: :create

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -169,21 +169,12 @@ RSpec.describe 'Disability compensation form', type: :request do
   end
 
   describe 'Get /v0/disability_compensation_form/submission_status' do
-    let(:job_id) { 'foo' }
-    let(:transaction) { double(:transaction, status: 'received', response: 'foo') }
+    let(:transaction) { build(:va526ez_submit_transaction) }
+    let(:job_id) { transaction.transaction_id }
 
     it 'should return the async submit transaction status and response' do
-      allow(AsyncTransaction::EVSS::VA526ezSubmitTransaction).
-        to receive(:find_transaction).
-        and_return(transaction)
-      VCR.use_cassette('evss/disability_compensation_form/submission_status') do
-        get "/v0/disability_compensation_form/submission_status/#{job_id}", auth_header
-        expect(response).to have_http_status(:ok)
-      end
+      get "/v0/disability_compensation_form/submission_status/#{job_id}", auth_header
+      expect(response).to have_http_status(:ok)
     end
-  end
-
-  describe 'Get /v0/disability_compensation_form/user_submissions' do
-    it 'should return an array of submissions'
   end
 end

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -169,11 +169,12 @@ RSpec.describe 'Disability compensation form', type: :request do
   end
 
   describe 'Get /v0/disability_compensation_form/submission_status' do
-    let(:transaction) { build(:va526ez_submit_transaction) }
-    let(:job_id) { transaction.transaction_id }
+    let(:job_id) { SecureRandom.uuid }
+    before { create(:va526ez_submit_transaction, transaction_id: job_id) }
 
     it 'should return the async submit transaction status and response' do
-      get "/v0/disability_compensation_form/submission_status/#{job_id}", auth_header
+      get "/v0/disability_compensation_form/submission_status/#{job_id}", nil, auth_header
+      puts response.inspect
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe 'Disability compensation form', type: :request do
                  end_product_claim_code: '020SUPP',
                  end_product_claim_name: 'eBenefits 526EZ-Supplemental (020)',
                  inflight_document_id: 194_300
-               }.to_json)
+               })
       end
 
       it 'should return the async submit transaction status and response', :aggregate_failures do
@@ -226,6 +226,43 @@ RSpec.describe 'Disability compensation form', type: :request do
                 'end_product_claim_code' => '020SUPP',
                 'end_product_claim_name' => 'eBenefits 526EZ-Supplemental (020)',
                 'inflight_document_id' => 194_300
+              }
+            }
+          }
+        )
+      end
+    end
+
+    context 'with a retrying transaction status' do
+      before do
+        create(:va526ez_submit_transaction,
+               transaction_id: job_id,
+               transaction_status: 'retrying',
+               metadata: {
+                 messages: {
+                   key: 'form526.submit.establishClaim.serviceError',
+                   severity: 'FATAL',
+                   text: 'Error calling external service to establish the claim during Submit'
+                 }
+               })
+      end
+
+      it 'should return the async submit transaction status and latest error', :aggregate_failures do
+        get "/v0/disability_compensation_form/submission_status/#{job_id}", nil, auth_header
+        expect(JSON.parse(response.body)).to have_deep_attributes(
+          'data' => {
+            'id' => '',
+            'type' => 'async_transaction_evss_va526ez_submit_transactions',
+            'attributes' => {
+              'transaction_id' => job_id,
+              'transaction_status' => 'retrying',
+              'type' => 'AsyncTransaction::EVSS::VA526ezSubmitTransaction',
+              'metadata' => {
+                'messages' => {
+                  'key' => 'form526.submit.establishClaim.serviceError',
+                  'severity' => 'FATAL',
+                  'text' => 'Error calling external service to establish the claim during Submit'
+                }
               }
             }
           }

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -169,11 +169,18 @@ RSpec.describe 'Disability compensation form', type: :request do
   end
 
   describe 'Get /v0/disability_compensation_form/submission_status' do
-    it 'should return no response body if the submission status is "submitted"'
-    it 'should return a response with a claim id if the status is "received"'
-    it 'should return the last error if the status is "retrying"'
-    it 'should return the last error if the status is "non_retryable_error"'
-    it 'should return the last error if the status is "exhausted"'
+    let(:job_id) { 'foo' }
+    let(:transaction) { double(:transaction, status: 'received', response: 'foo') }
+
+    it 'should return the async submit transaction status and response' do
+      allow(AsyncTransaction::EVSS::VA526ezSubmitTransaction).
+        to receive(:find_transaction).
+        and_return(transaction)
+      VCR.use_cassette('evss/disability_compensation_form/submission_status') do
+        get "/v0/disability_compensation_form/submission_status/#{job_id}", auth_header
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe 'Get /v0/disability_compensation_form/user_submissions' do

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -169,15 +169,14 @@ RSpec.describe 'Disability compensation form', type: :request do
   end
 
   describe 'Get /v0/disability_compensation_form/submission_status' do
-    let(:form_id) { '21-526EZ' }
     it 'should return no response body if the submission status is "submitted"'
     it 'should return a response with a claim id if the status is "received"'
     it 'should return the last error if the status is "retrying"'
     it 'should return the last error if the status is "non_retryable_error"'
     it 'should return the last error if the status is "exhausted"'
+  end
 
-    context 'with an invalid form id' do
-      it 'should return a 500'
-    end
+  describe 'Get /v0/disability_compensation_form/user_submissions' do
+    it 'should return an array of submissions'
   end
 end

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -169,43 +169,71 @@ RSpec.describe 'Disability compensation form', type: :request do
   end
 
   describe 'Get /v0/disability_compensation_form/submission_status' do
-    context 'with a found record' do
-      let(:job_id) { SecureRandom.uuid }
+    let(:job_id) { SecureRandom.uuid }
+
+    context 'with a submitted transaction status' do
       before do
-        create(:va526ez_submit_transaction, transaction_id: job_id, metadata: {
-          claim_id: 600130094,
-          end_product_claim_code: "020SUPP",
-          end_product_claim_name: "eBenefits 526EZ-Supplemental (020)",
-          inflight_document_id: 194300
-        })
+        create(:va526ez_submit_transaction,
+               transaction_id: job_id,
+               transaction_status: 'submitted',
+               metadata: {})
       end
 
       it 'should return the async submit transaction status and response', :aggregate_failures do
         get "/v0/disability_compensation_form/submission_status/#{job_id}", nil, auth_header
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)).to have_deep_attributes({
-          "data" => {
-            "id" => "",
-            "type" => "async_transaction_evss_va526ez_submit_transactions",
-            "attributes" => {
-              "transaction_id" => job_id,
-              "transaction_status" => "submitted",
-              "type" => "AsyncTransaction::EVSS::VA526ezSubmitTransaction",
-              "metadata" => {
-                "claim_id" => 600130094,
-                "end_product_claim_code" => "020SUPP",
-                "end_product_claim_name" => "eBenefits 526EZ-Supplemental (020)",
-                "inflight_document_id" => 194300
+        expect(JSON.parse(response.body)).to have_deep_attributes(
+          'data' => {
+            'id' => '',
+            'type' => 'async_transaction_evss_va526ez_submit_transactions',
+            'attributes' => {
+              'transaction_id' => job_id,
+              'transaction_status' => 'submitted',
+              'type' => 'AsyncTransaction::EVSS::VA526ezSubmitTransaction',
+              'metadata' => {}
+            }
+          }
+        )
+      end
+    end
+
+    context 'with a received transaction status' do
+      before do
+        create(:va526ez_submit_transaction,
+               transaction_id: job_id,
+               transaction_status: 'received',
+               metadata: {
+                 claim_id: 600_130_094,
+                 end_product_claim_code: '020SUPP',
+                 end_product_claim_name: 'eBenefits 526EZ-Supplemental (020)',
+                 inflight_document_id: 194_300
+               }.to_json)
+      end
+
+      it 'should return the async submit transaction status and response', :aggregate_failures do
+        get "/v0/disability_compensation_form/submission_status/#{job_id}", nil, auth_header
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to have_deep_attributes(
+          'data' => {
+            'id' => '',
+            'type' => 'async_transaction_evss_va526ez_submit_transactions',
+            'attributes' => {
+              'transaction_id' => job_id,
+              'transaction_status' => 'received',
+              'type' => 'AsyncTransaction::EVSS::VA526ezSubmitTransaction',
+              'metadata' => {
+                'claim_id' => 600_130_094,
+                'end_product_claim_code' => '020SUPP',
+                'end_product_claim_name' => 'eBenefits 526EZ-Supplemental (020)',
+                'inflight_document_id' => 194_300
               }
             }
           }
-        })
+        )
       end
     end
 
     context 'when no record is found' do
-      let(:job_id) { SecureRandom.uuid }
-
       it 'should return the async submit transaction status and response', :aggregate_failures do
         get "/v0/disability_compensation_form/submission_status/#{job_id}", nil, auth_header
         expect(response).to have_http_status(:not_found)

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Disability compensation form', type: :request do
     end
   end
 
-  describe 'Get /v0/disability_compensation_form/submit' do
+  describe 'Post /v0/disability_compensation_form/submit' do
     before(:each) do
       VCR.insert_cassette('emis/get_military_service_episodes/valid')
       VCR.insert_cassette('evss/ppiu/payment_information')
@@ -165,6 +165,19 @@ RSpec.describe 'Disability compensation form', type: :request do
           end
         end
       end
+    end
+  end
+
+  describe 'Get /v0/disability_compensation_form/submission_status' do
+    let(:form_id) { '21-526EZ' }
+    it 'should return no response body if the submission status is "submitted"'
+    it 'should return a response with a claim id if the status is "received"'
+    it 'should return the last error if the status is "retrying"'
+    it 'should return the last error if the status is "non_retryable_error"'
+    it 'should return the last error if the status is "exhausted"'
+
+    context 'with an invalid form id' do
+      it 'should return a 500'
     end
   end
 end


### PR DESCRIPTION
## Description of change
As per [this ticket](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12024), we need an endpoint that takes a job_id and returns the status and response of that submission transaction.

## Testing done
- [x] automated rspec tests

## Testing planned
- [ ] manually test in staging

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] submission_status endpoint
- [x] tests for endpoint

#### Applies to all PRs

- [x] Appropriate logging
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)