### PR TITLE
[wip] Hca Invalid format for Last Service Discharge Date

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -73,8 +73,9 @@ class HealthCareApplication < ActiveRecord::Base
   private
 
   def discharge_type_correct
+    return if form.blank?
     discharge_date = parsed_form.try(:[], 'lastDischargeDate')
-    return true if discharge_date.blank?
+    return if discharge_date.blank?
 
     future_date = Date.parse(discharge_date) > Time.now.in_time_zone('Central Time (US & Canada)').to_date
     discharge_type_present = parsed_form['dischargeType'].present?
@@ -84,8 +85,6 @@ class HealthCareApplication < ActiveRecord::Base
     elsif !discharge_type_present
       errors[:form] << 'dischargeType must be selected if discharge date is not in the future'
     end
-
-    true
   end
 
   def send_failure_mail

--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -81,8 +81,8 @@ class HealthCareApplication < ActiveRecord::Base
 
     if future_date
       errors[:form] << 'dischargeType must be blank if the discharge date is in the future' if discharge_type_present
-    else
-      errors[:form] << 'dischargeType must be selected if discharge date is not in the future' unless discharge_type_present
+    elsif !discharge_type_present
+      errors[:form] << 'dischargeType must be selected if discharge date is not in the future'
     end
 
     true

--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -76,7 +76,7 @@ class HealthCareApplication < ActiveRecord::Base
     discharge_date = parsed_form.try(:[], 'lastDischargeDate')
     return true if discharge_date.blank?
 
-    future_date = Date.parse(discharge_date).in_time_zone('Central Time (US & Canada)').future?
+    future_date = Date.parse(discharge_date) > Time.now.in_time_zone('Central Time (US & Canada)').to_date
     discharge_type_present = parsed_form['dischargeType'].present?
 
     if future_date

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -38,13 +38,17 @@ RSpec.describe HealthCareApplication, type: :model do
       end
 
       context 'with a future discharge date' do
-        let(:discharge_date) { Date.today + 1.day }
+        let(:discharge_date) { Time.zone.today + 1.day }
 
         context 'with a discharge type' do
           let(:discharge_type) { 'general' }
 
           it 'should create a validation error' do
-            expect_attr_invalid(health_care_application, :form, 'dischargeType must be blank if the discharge date is in the future')
+            expect_attr_invalid(
+              health_care_application,
+              :form,
+              'dischargeType must be blank if the discharge date is in the future'
+            )
           end
         end
 
@@ -54,7 +58,7 @@ RSpec.describe HealthCareApplication, type: :model do
       end
 
       context 'with a non-future discharge date' do
-        let(:discharge_date) { Date.today }
+        let(:discharge_date) { Time.zone.today }
 
         context 'with a discharge type' do
           let(:discharge_type) { 'general' }
@@ -64,7 +68,11 @@ RSpec.describe HealthCareApplication, type: :model do
 
         context 'without a discharge type' do
           it 'should create a validation error' do
-            expect_attr_invalid(health_care_application, :form, 'dischargeType must be selected if discharge date is not in the future')
+            expect_attr_invalid(
+              health_care_application,
+              :form,
+              'dischargeType must be selected if discharge date is not in the future'
+            )
           end
         end
       end

--- a/spec/request/health_care_applications_request_spec.rb
+++ b/spec/request/health_care_applications_request_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
         let(:discharge_date) { Time.zone.today + 181.days }
         let(:params) do
           test_veteran['lastDischargeDate'] = discharge_date.strftime('%Y-%m-%d')
+          test_veteran.delete('dischargeType')
 
           {
             form: test_veteran.to_json


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12107
this change will validate:
for a future discharge date (based on 12am central time), discharge type must be blank
for a past discharge date, discharge type must be present

don't merge until this has first been added to the frontend

## Testing done
<!-- Please describe testing done to verify the changes. -->
automated tests

## Testing planned
<!-- Please describe testing planned. -->
test sending an application in staging with a past discharge date and a future discharge date

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] test sending an application in staging with a past discharge date and a future discharge date

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
