### PR TITLE
Fixed to pass user uuid, not user object

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -27,7 +27,7 @@ module V0
       ).translate
 
       jid = EVSS::DisabilityCompensationForm::SubmitForm526.perform_async(
-        @current_user, converted_form_content, uploads
+        @current_user.uuid, converted_form_content, uploads
       )
 
       render json: { data: { attributes: { job_id: jid } } },


### PR DESCRIPTION
## Description of change
Async job required user uuid, not user object (since jobs cannot be passed objects).

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Update async submit job argument to be user uuid, not user obj

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
