### PR TITLE
remove table from schema.rb that does not have a matching migration

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -256,17 +256,6 @@ ActiveRecord::Schema.define(version: 20180815155404) do
   add_index "personal_information_logs", ["created_at"], name: "index_personal_information_logs_on_created_at", using: :btree
   add_index "personal_information_logs", ["error_class"], name: "index_personal_information_logs_on_error_class", using: :btree
 
-  create_table "post911_not_found_errors", force: :cascade do |t|
-    t.uuid     "user_uuid",              null: false
-    t.string   "encrypted_user_json",    null: false
-    t.string   "encrypted_user_json_iv", null: false
-    t.datetime "request_timestamp",      null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-  end
-
-  add_index "post911_not_found_errors", ["user_uuid"], name: "index_post911_not_found_errors_on_user_uuid", unique: true, using: :btree
-
   create_table "preneed_submissions", force: :cascade do |t|
     t.string   "tracking_number",    null: false
     t.string   "application_uuid"


### PR DESCRIPTION
## Description of change
Had some migrations that were only run locally and later removed. However the schema file made it into a PR with a version of db/schema.rb which had those migrations applied. This PR reverts the schema file so that it matches the current migration files.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] removes `post911_not_found_errors` from db/schema.rb

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
