### PR TITLE
VA_Facilities: Omit dod_health pseudo-facilities

### DIFF
--- a/app/models/base_facility.rb
+++ b/app/models/base_facility.rb
@@ -161,7 +161,7 @@ class BaseFacility < ActiveRecord::Base
         service_condition(type, service)
       end
       facilities = facilities.where(service_conditions.join(' OR ')) if service_conditions&.any?
-      facilities = facilities.where.not(facility_type: 'dod_health')
+      facilities = facilities.where.not(facility_type: DOD_HEALTH)
       facilities
     end
 

--- a/modules/va_facilities/app/controllers/va_facilities/v0/facilities_controller.rb
+++ b/modules/va_facilities/app/controllers/va_facilities/v0/facilities_controller.rb
@@ -19,7 +19,7 @@ module VaFacilities
       TYPE_SERVICE_ERR = 'Filtering by services is not allowed unless a facility type is specified'
 
       def all
-        resource = BaseFacility.all.order(:unique_id)
+        resource = BaseFacility.where.not(facility_type: BaseFacility::DOD_HEALTH).order(:unique_id)
         respond_to do |format|
           format.geojson do
             render geojson: VaFacilities::GeoSerializer.to_geojson(resource)

--- a/modules/va_facilities/spec/requests/facilities_request_spec.rb
+++ b/modules/va_facilities/spec/requests/facilities_request_spec.rb
@@ -179,6 +179,7 @@ RSpec.describe 'Facilities API endpoint', type: :request do
   context 'when requesting all facilities' do
     it 'responds to GeoJSON format' do
       setup_pdx
+      create :dod_001
       get base_query_path + '/all', nil, accept_geojson
       expect(response).to be_success
       expect(response.headers['Content-Type']).to eq 'application/vnd.geo+json; charset=utf-8'
@@ -189,6 +190,7 @@ RSpec.describe 'Facilities API endpoint', type: :request do
 
     it 'responds to CSV format' do
       setup_pdx
+      create :dod_001
       get base_query_path + '/all', nil, accept_csv
       expect(response).to be_success
       expect(response.headers['Content-Type']).to eq 'text/csv'


### PR DESCRIPTION
Reported in https://github.com/department-of-veterans-affairs/vets-api-clients/issues/13

## Description of change
Omits dod_health facilities from the formerly `all` query used to generate the bulk facilities output. These facilities aren't really applicable to the VA facilities semantics, and are in the table for use by the autocomplete endpoint used elsewhere in vets.gov. 

Ultimately I'd like a cleaner solution for this, it's awkward to have that conditional all over the place, but this will un-break the bulk facilities API for the moment.

## Testing done
Seeded dod_health facilities in localhost, confirmed that with change in place, bulk facilities endpoint no longer throws a 500 error. Seeded a dod_health facility in the bulk facility spec. 

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)
Bulk facilities resource no longer throws 500 error.

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
