### PR TITLE
Add sentry logging when theres a hard fail on the job (or its exhausted)

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -50,7 +50,8 @@ module EVSS
         # Treat unexpected errors as hard failures
         # This includes BackeEndService Errors (including 403's)
         transaction_class.update_transaction(jid, :non_retryable_error, e.to_s)
-        log_exception_to_sentry(error, extra_content(:non_retryable_error))
+        extra_content = { status: :non_retryable_error, jid: jid }
+        log_exception_to_sentry(e, extra_content)
       end
 
       private
@@ -69,16 +70,13 @@ module EVSS
           raise error
         end
         transaction_class.update_transaction(jid, :non_retryable_error, error.messages)
-        log_exception_to_sentry(error, extra_content(:non_retryable_error))
+        extra_content = { status: :non_retryable_error, jid: jid }
+        log_exception_to_sentry(error, extra_content)
       end
 
       def handle_gateway_timeout_exception(error)
         transaction_class.update_transaction(jid, :retrying, error.message)
         raise error
-      end
-
-      def extra_content(status)
-        { status: status, jid: jid }
       end
     end
   end

--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -4,6 +4,7 @@ module EVSS
   module DisabilityCompensationForm
     class SubmitForm526
       include Sidekiq::Worker
+      include SentryLogging
 
       # Sidekiq has built in exponential back-off functionality for retrys
       # A max retry attempt of 10 will result in a run time of ~8 hours
@@ -12,8 +13,12 @@ module EVSS
       sidekiq_options retry: RETRY
 
       # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
-      sidekiq_retries_exhausted do |_msg, _ex|
+      sidekiq_retries_exhausted do |msg, _ex|
         transaction_class.update_transaction(jid, :exhausted)
+        log_message_to_sentry(
+          "Failed all retries on Form526 submit, last error: #{msg['error_message']}",
+          :error
+        )
       end
 
       # Performs an asynchronous job for submitting a form526 to an upstream
@@ -45,6 +50,7 @@ module EVSS
         # Treat unexpected errors as hard failures
         # This includes BackeEndService Errors (including 403's)
         transaction_class.update_transaction(jid, :non_retryable_error, e.to_s)
+        log_exception_to_sentry(error, extra_content(:non_retryable_error))
       end
 
       private
@@ -63,11 +69,16 @@ module EVSS
           raise error
         end
         transaction_class.update_transaction(jid, :non_retryable_error, error.messages)
+        log_exception_to_sentry(error, extra_content(:non_retryable_error))
       end
 
       def handle_gateway_timeout_exception(error)
         transaction_class.update_transaction(jid, :retrying, error.message)
         raise error
+      end
+
+      def extra_content(status)
+        { status: status, jid: jid }
       end
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -256,17 +256,6 @@ ActiveRecord::Schema.define(version: 20180815155404) do
   add_index "personal_information_logs", ["created_at"], name: "index_personal_information_logs_on_created_at", using: :btree
   add_index "personal_information_logs", ["error_class"], name: "index_personal_information_logs_on_error_class", using: :btree
 
-  create_table "post911_not_found_errors", force: :cascade do |t|
-    t.uuid     "user_uuid",              null: false
-    t.string   "encrypted_user_json",    null: false
-    t.string   "encrypted_user_json_iv", null: false
-    t.datetime "request_timestamp",      null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-  end
-
-  add_index "post911_not_found_errors", ["user_uuid"], name: "index_post911_not_found_errors_on_user_uuid", unique: true, using: :btree
-
   create_table "preneed_submissions", force: :cascade do |t|
     t.string   "tracking_number",    null: false
     t.string   "application_uuid"

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526, type: :job do
     context 'with a client error' do
       it 'sets the transaction to "non_retryable_error"' do
         VCR.use_cassette('evss/disability_compensation_form/submit_400') do
+          expect_any_instance_of(described_class).to receive(:log_exception_to_sentry)
           subject.perform_async(user.uuid, valid_form_content, nil)
           described_class.drain
           expect(last_transaction.transaction_status).to eq 'non_retryable_error'


### PR DESCRIPTION
## Description of change
Add sentry logging for the form526 submission job when there is a hard failure or the job has exhausted.

## Testing done
Rspec tests.

## Testing planned
Will be tested on staging.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] add sentry logging.

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
