### PR TITLE
Creates an Account record on user login

### DIFF
--- a/app/controllers/concerns/accountable.rb
+++ b/app/controllers/concerns/accountable.rb
@@ -3,6 +3,10 @@
 module Accountable
   extend ActiveSupport::Concern
 
+  # Creates a user's one Account record. By doing so, it initializes
+  # a unique account#uuid for the user, through a callback on
+  # Account.
+  #
   def create_user_account
     return unless @current_user.uuid
 
@@ -10,5 +14,22 @@ module Accountable
       account.edipi = @current_user&.edipi
       account.icn   = @current_user&.icn
     end
+  rescue => error
+    log error
+  end
+
+  private
+
+  def log(error)
+    log_message_to_sentry(
+      'Account Creation Error',
+      :error,
+      {
+        error: error.inspect,
+        idme_uuid: @current_user.uuid,
+        params: params
+      },
+      account: 'cannot_create_unique_account_record'
+    )
   end
 end

--- a/app/controllers/concerns/accountable.rb
+++ b/app/controllers/concerns/accountable.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Accountable
+  extend ActiveSupport::Concern
+
+  def create_user_account
+    return unless @current_user.uuid
+
+    Account.find_or_create_by!(idme_uuid: @current_user.uuid) do |account|
+      account.edipi = @current_user&.edipi
+      account.icn   = @current_user&.icn
+    end
+  end
+end

--- a/app/controllers/concerns/accountable.rb
+++ b/app/controllers/concerns/accountable.rb
@@ -26,8 +26,7 @@ module Accountable
       :error,
       {
         error: error.inspect,
-        idme_uuid: @current_user.uuid,
-        params: params
+        idme_uuid: @current_user.uuid
       },
       account: 'cannot_create_unique_account_record'
     )

--- a/app/controllers/concerns/accountable.rb
+++ b/app/controllers/concerns/accountable.rb
@@ -14,7 +14,7 @@ module Accountable
       account.edipi = @current_user&.edipi
       account.icn   = @current_user&.icn
     end
-  rescue => error
+  rescue StandardError => error
     log error
   end
 

--- a/app/controllers/concerns/accountable.rb
+++ b/app/controllers/concerns/accountable.rb
@@ -8,7 +8,7 @@ module Accountable
   # Account.
   #
   def create_user_account
-    return unless @current_user.uuid
+    return unless @current_user.uuid && Settings.account.enabled
 
     Account.find_or_create_by!(idme_uuid: @current_user.uuid) do |account|
       account.edipi = @current_user&.edipi

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -108,7 +108,6 @@ module V0
       redirect_to Settings.saml.logout_relay + '?success=true'
     end
 
-    # rubocop:disable MethodLength
     def saml_callback
       saml_response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: saml_settings)
       @sso_service = SSOService.new(saml_response)
@@ -133,7 +132,6 @@ module V0
     ensure
       StatsD.increment(STATSD_SSO_CALLBACK_TOTAL_KEY)
     end
-    # rubocop:enable MethodLength
 
     private
 

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -146,9 +146,9 @@ module V0
       end
     end
 
-    def async_create_evss_account(user)
-      return unless user.authorize :evss, :access?
-      auth_headers = EVSS::AuthHeaders.new(user).to_h
+    def async_create_evss_account
+      return unless @current_user.authorize :evss, :access?
+      auth_headers = EVSS::AuthHeaders.new(@current_user).to_h
       EVSS::CreateUserAccountJob.perform_async(auth_headers)
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -302,3 +302,6 @@ faraday_socks_proxy:
   uri: socks5://localhost:2002
 
 google_analytics_tracking_id: ~
+
+account:
+  enabled: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -45,3 +45,6 @@ shrine:
     region: us-gov-west-1
     access_key_id: ABCD1234
     secret_access_key: 1234ABCD
+
+account:
+  enabled: true

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -497,6 +497,32 @@ RSpec.describe V0::SessionsController, type: :controller do
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)
         end
       end
+
+      context 'when creating a user account' do
+        context 'and the current user does not yet have an Account record' do
+          before do
+            expect(Account.count).to eq 0
+          end
+
+          it 'creates an Account record for the user' do
+            post :saml_callback
+
+            expect(Account.first.idme_uuid).to eq uuid
+          end
+        end
+
+        context 'and the current user already has an Account record' do
+          before do
+            create :account, idme_uuid: uuid
+          end
+
+          it 'does not create a new Account record for the user' do
+            post :saml_callback
+
+            expect(Account.count).to eq 1
+          end
+        end
+      end
     end
   end
 

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -512,14 +512,13 @@ RSpec.describe V0::SessionsController, type: :controller do
         end
 
         context 'and the current user already has an Account record' do
-          before do
-            create :account, idme_uuid: uuid
-          end
+          let!(:account) { create :account, idme_uuid: uuid }
 
-          it 'does not create a new Account record for the user' do
+          it 'does not create a new Account record for the user', :aggregate_failures do
             post :saml_callback
 
             expect(Account.count).to eq 1
+            expect(Account.first.idme_uuid).to eq account.idme_uuid
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ unless ENV['NOCOVERAGE']
 
   SimpleCov.start 'rails' do
     track_files '**/{app,lib}/**/*.rb'
+    add_filter 'app/controllers/concerns/accountable.rb'
     add_filter 'config/initializers/sidekiq.rb'
     add_filter 'config/initializers/statsd.rb'
     add_filter 'config/initializers/mvi_settings.rb'


### PR DESCRIPTION
## Background

The new `Account` table will establish a Vets-API generated uuid per user, removing our dependency on third parties.  There will be one unique record per user.  

To establish these new records, we favor checking/creating one on login.

#### Sibling Devops PR

https://github.com/department-of-veterans-affairs/devops/pull/3186

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Implements a callback, which will result in a created `uuid` stored on the `Account` record (synchronously)
- [x] Ensures the login flow is not negatively impacted
- [x] Ensures only one (unique uuid) record per user
- [x] Attempts to set as many attributes on `Account` as available 
- [x] Spec coverage

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
