### PR TITLE
Country field not validating when information is prefilled

### DIFF
--- a/app/models/form_profiles/complaint_tool.rb
+++ b/app/models/form_profiles/complaint_tool.rb
@@ -12,9 +12,7 @@ class FormProfiles::ComplaintTool < FormProfile
   def convert_country!(form_data)
     country = form_data.try(:[], 'address').try(:[], 'country')
 
-    if country.present? && country.size == 3
-      form_data['address']['country'] = IsoCountryCodes.find(country).alpha2
-    end
+    form_data['address']['country'] = IsoCountryCodes.find(country).alpha2 if country.present? && country.size == 3
   end
 
   def prefill(*args)

--- a/app/models/form_profiles/complaint_tool.rb
+++ b/app/models/form_profiles/complaint_tool.rb
@@ -8,4 +8,19 @@ class FormProfiles::ComplaintTool < FormProfile
       returnUrl: '/applicant-relationship'
     }
   end
+
+  def convert_country!(form_data)
+    country = form_data.try(:[], 'address').try(:[], 'country')
+
+    if country.present? && country.size == 3
+      form_data['address']['country'] = IsoCountryCodes.find(country).alpha2
+    end
+  end
+
+  def prefill(*args)
+    return_val = super
+    convert_country!(return_val[:form_data])
+
+    return_val
+  end
 end

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe FormProfile, type: :model do
         'street2' => street_check[:street2],
         'city' => user.va_profile[:address][:city],
         'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
+        'country' => 'US',
         'postal_code' => user.va_profile[:address][:postal_code][0..4]
       },
       'serviceBranch' => 'Air Force',
@@ -611,7 +611,6 @@ RSpec.describe FormProfile, type: :model do
           can_prefill_emis(true)
         end
         it 'returns prefilled complaint tool' do
-          user.va_profile.address.country = 'US'
           expect_prefilled('complaint-tool')
         end
       end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12560
use 2 letter country codes for prefill

## Testing done
<!-- Please describe testing done to verify the changes. -->
automated tests

## Testing planned
<!-- Please describe testing planned. -->
test in staging with a verified user that has a prefilled address
#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
