### PR TITLE
Add instructions for installing poppler and add to os x setup script

### DIFF
--- a/bin/setup-osx
+++ b/bin/setup-osx
@@ -100,6 +100,13 @@ fi
 
 freshclam -v
 
+if command_exists pdfinfo ; then
+  echo "${GREEN} * pdfinfo already installed.${RESET}"
+else
+  echo "${RED} * Installing pdfinfo (poppler). ${RESET}"
+  brew install poppler
+fi
+
 if command_exists pdftk ; then
   echo "${GREEN} * pdftk already installed.${RESET}"
 else

--- a/docs/setup/native.md
+++ b/docs/setup/native.md
@@ -41,6 +41,8 @@ the `vets-api` directory, run `./bin/setup-osx && source ~/.bash_profile && cd
     launch it manually with `brew services start redis`.
 1. Install ImageMagick
    - `brew install imagemagick`
+1. Install Poppler
+   -  `brew install poppler`
 1. Install ClamAV
   - `brew install clamav`
   - Take note of the the post-install instructions `To finish installation & run


### PR DESCRIPTION
## Description of change
Adds pdfinfo installation to OS X native development instructions.

## Testing planned
Asking reviewers to try running on their os x systems.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Installs poppler as part of the osx setup script

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
