### PR TITLE
Turn perform into an instance method. Update test

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/workers/evss/disability_compensation_form/submit_uploads.rb
@@ -21,7 +21,7 @@ module EVSS
         end
       end
 
-      def self.perform(upload_data, claim_id, user)
+      def perform(upload_data, claim_id, user)
         auth_headers = EVSS::AuthHeaders.new(user).to_h
         client = EVSS::DocumentsService.new(auth_headers)
         file_body = SupportingEvidenceAttachment.find_by(guid: upload_data[:confirmationCode]).file_data

--- a/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
         .and_return(document_data)
 
       expect(client).to receive(:upload).with(attachment.file_data, document_data)
-      subject.perform(upload_data, claim_id, user)
+      subject.new.perform(upload_data, claim_id, user)
     end
   end
 end


### PR DESCRIPTION
## Description of change
The Sidekiq panel in staging is reporting an issue when trying to run `perform_async` for submitted uploads for the form 526. This may be due to the job being a class method instead of an instance method (which is whats described in the Sidekiq docs). This change will update this method to be an instance method.

## Testing done
spec tests.

## Testing planned
Testing this change in staging.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Update class method to an instance method

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
