### PR TITLE
Feature/rate limit 526 submissions

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -112,8 +112,19 @@ class UserSerializer < ActiveModel::Serializer
     service_list << BackendServices::ID_CARD if object.can_access_id_card?
     service_list << BackendServices::IDENTITY_PROOFED if object.identity_proofed?
     service_list << BackendServices::VET360 if object.can_access_vet360?
+    service_list << BackendServices::CLAIM_INCREASE_AVAILABLE if claims_for_increase_availlable?
     service_list += BetaRegistration.where(user_uuid: object.uuid).pluck(:feature) || []
     service_list
   end
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
+
+  private
+
+  def claims_for_increase_availlable?
+    object.authorize(:evss, :access?) && !claims_for_increase_limiter.at_limit?
+  end
+
+  def claims_for_increase_limiter
+    Common::EventRateLimiter.new(REDIS_CONFIG['evss_526_submit_form_rate_limit'])
+  end
 end

--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -80,19 +80,6 @@ module EVSS
         raise error
       end
 
-      def redis
-        Redis::Namespace.new(REDIS_CONFIG['evss_526_submit_form_rate_limit']['namespace'], redis: Redis.current)
-      end
-
-      def increment_limits
-        increment(:threshold, REDIS_CONFIG['evss_526_submit_form_rate_limit']['threshold_ttl'])
-        increment(:count, REDIS_CONFIG['evss_526_submit_form_rate_limit']['count_ttl'])
-      end
-
-      def increment(key, ttl)
-        redis.expire(key, ttl) if redis.incr(key) == 1
-      end
-
       def submission_rate_limiter
         Common::EventRateLimiter.new(REDIS_CONFIG['evss_526_submit_form_rate_limit'])
       end

--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -78,6 +78,19 @@ module EVSS
         transaction_class.update_transaction(jid, :retrying, error.message)
         raise error
       end
+
+      def redis
+        Redis::Namespace.new(REDIS_CONFIG['evss_526_submit_form_rate_limit']['namespace'], redis: Redis.current)
+      end
+
+      def increment_limits
+        increment(:threshold, REDIS_CONFIG['evss_526_submit_form_rate_limit']['threshold_ttl'])
+        increment(:count, REDIS_CONFIG['evss_526_submit_form_rate_limit']['count_ttl'])
+      end
+
+      def increment(key, ttl)
+        redis.expire(key, ttl) if redis.incr(key) == 1
+      end
     end
   end
 end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -53,6 +53,12 @@ development: &defaults
   evss_claims_store:
     namespace: evss
     each_ttl: 3600
+  evss_526_submit_form_rate_limit:
+    namespace: evss-526-submit-form-rate-limit
+    threshold_limit: 10
+    threshold_ttl: 86400
+    threshold_count: 30
+    count_ttl: 604800
 
 test:
   <<: *defaults

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -57,7 +57,7 @@ development: &defaults
     namespace: evss-526-submit-form-rate-limit
     threshold_limit: 10
     threshold_ttl: 86400
-    threshold_count: 30
+    count_limit: 30
     count_ttl: 604800
 
 test:

--- a/lib/backend_services.rb
+++ b/lib/backend_services.rb
@@ -31,6 +31,6 @@ class BackendServices
   SAVE_IN_PROGRESS = 'form-save-in-progress'
   FORM_PREFILL = 'form-prefill'
 
-  # 526 claim for increase has not reached daily or weekly limit
+  # 526 claim for increase beta has not reached daily or weekly limit
   CLAIM_INCREASE_AVAILABLE = 'claim-increase-available'
 end

--- a/lib/backend_services.rb
+++ b/lib/backend_services.rb
@@ -30,4 +30,7 @@ class BackendServices
   # Core Form Features
   SAVE_IN_PROGRESS = 'form-save-in-progress'
   FORM_PREFILL = 'form-prefill'
+
+  # 526 claim for increase has not reached daily or weekly limit
+  CLAIM_INCREASE_AVAILABLE = 'claim-increase-available'
 end

--- a/lib/common/event_rate_limiter.rb
+++ b/lib/common/event_rate_limiter.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 module Common
-  class RateLimiter
+  class EventRateLimiter
     def initialize(namespace)
       @namespace = namespace
+      raise ArgumentError, 'threshold_ttl must be lower than count_ttl' if @namespace['threshold_ttl'] > @namespace['count_ttl']
       @redis = Redis::Namespace.new(@namespace, redis: Redis.current)
     end
 

--- a/lib/common/event_rate_limiter.rb
+++ b/lib/common/event_rate_limiter.rb
@@ -2,22 +2,34 @@
 
 module Common
   class EventRateLimiter
-    def initialize(namespace)
-      @namespace = namespace
-      raise ArgumentError, 'threshold_ttl must be lower than count_ttl' if @namespace['threshold_ttl'] > @namespace['count_ttl']
-      @redis = Redis::Namespace.new(@namespace, redis: Redis.current)
+    def initialize(redis_namespace)
+      @redis_namespace = redis_namespace
+      raise ArgumentError, 'threshold_ttl must be lower than count_ttl' if threshold_ttl_exceeds_count_ttl?
+      @redis = Redis::Namespace.new(@redis_namespace['namespace'], redis: Redis.current)
     end
 
     def increment
-      increment_with_expire(:threshold, @namespace['threshold_ttl'])
-      increment_with_expire(:count, @namespace['count_ttl'])
+      increment_with_expire(:threshold, @redis_namespace['threshold_ttl'])
+      increment_with_expire(:count, @redis_namespace['count_ttl'])
     end
 
     def at_limit?
-      @namespace['threshold_limit'] >= @redis.get(:threshold) || @namespace['count_limit'] >= @redis.get(:count)
+      threshold_exceeded? || count_exceeded?
     end
 
     private
+
+    def threshold_ttl_exceeds_count_ttl?
+      @redis_namespace['threshold_ttl'] > @redis_namespace['count_ttl']
+    end
+
+    def threshold_exceeded?
+      @redis.get(:threshold).to_i >= @redis_namespace['threshold_limit']
+    end
+
+    def count_exceeded?
+      @redis.get(:count).to_i >= @redis_namespace['count_limit']
+    end
 
     def increment_with_expire(key, ttl)
       @redis.expire(key, ttl) if @redis.incr(key) == 1

--- a/lib/common/rate_limiter.rb
+++ b/lib/common/rate_limiter.rb
@@ -13,7 +13,7 @@ module Common
     end
 
     def at_limit?
-      @namespace['threshold_limit'] >= @redis.get(:threshold) || @namespace['count_limit'] > @redis.get(:count)
+      @namespace['threshold_limit'] >= @redis.get(:threshold) || @namespace['count_limit'] >= @redis.get(:count)
     end
 
     private

--- a/lib/common/rate_limiter.rb
+++ b/lib/common/rate_limiter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Common
+  class RateLimiter
+    def initialize(namespace)
+      @namespace = namespace
+      @redis = Redis::Namespace.new(@namespace, redis: Redis.current)
+    end
+
+    def increment
+      increment_with_expire(:threshold, @namespace['threshold_ttl'])
+      increment_with_expire(:count, @namespace['count_ttl'])
+    end
+
+    def at_limit?
+      @namespace['threshold_limit'] >= @redis.get(:threshold) || @namespace['count_limit'] > @redis.get(:count)
+    end
+
+    private
+
+    def increment_with_expire(key, ttl)
+      @redis.expire(key, ttl) if @redis.incr(key) == 1
+    end
+  end
+end

--- a/spec/lib/common/event_rate_limiter_spec.rb
+++ b/spec/lib/common/event_rate_limiter_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Common::EventRateLimiter do
+  context 'with the default evss 526 config' do
+    subject { Common::EventRateLimiter.new(REDIS_CONFIG['evss_526_submit_form_rate_limit']) }
+
+    describe '.at_limit?' do
+      context 'with no events' do
+        it 'should return false' do
+          expect(subject.at_limit?).to be_falsey
+        end
+      end
+
+      context 'when the threshold is not exceeded (< 10 in day)' do
+        before { 5.times { subject.increment } }
+        it 'should return false' do
+          expect(subject.at_limit?).to be_falsey
+        end
+      end
+
+      context 'when the threshold is exceeded (> 10 in day)' do
+        before { 11.times { subject.increment } }
+        it 'should return true' do
+          expect(subject.at_limit?).to be_truthy
+        end
+      end
+
+      context 'when the count is not exceeded during its TTL (< 30 in a week)' do
+        before do
+          5.times { subject.increment }
+          Timecop.travel(1.day)
+          7.times { subject.increment }
+          Timecop.travel(1.day)
+          3.times { subject.increment }
+        end
+        it 'should return false' do
+          expect(subject.at_limit?).to be_falsey
+        end
+      end
+
+      context 'when the count is exceeded during its TTL (> 30 in a week)' do
+        before do
+          5.times do
+            7.times { subject.increment }
+            Timecop.travel(1.day)
+          end
+        end
+        it 'should return true' do
+          expect(subject.at_limit?).to be_truthy
+        end
+      end
+    end
+
+    describe '.increment' do
+      it 'should increment both threshold and count', :aggregate_failures do
+        expect(subject.instance_variable_get(:@redis).get(:threshold).to_i).to eq(0)
+        expect(subject.instance_variable_get(:@redis).get(:count).to_i).to eq(0)
+        subject.increment
+        expect(subject.instance_variable_get(:@redis).get(:threshold).to_i).to eq(1)
+        expect(subject.instance_variable_get(:@redis).get(:count).to_i).to eq(1)
+      end
+    end
+
+    after(:each) { Timecop.return }
+  end
+end

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Fetching user data', type: :request do
   context 'when an LOA 3 user is logged in' do
     let(:mhv_user) { build(:user, :mhv) }
 
-    before do
+    before(:each) do
       Session.create(uuid: mhv_user.uuid, token: token)
       allow_any_instance_of(MhvAccountTypeService).to receive(:mhv_account_type).and_return('Premium')
       mhv_account = double('MhvAccount', creatable?: false, upgradable?: false, account_state: 'upgraded')
@@ -20,45 +20,82 @@ RSpec.describe 'Fetching user data', type: :request do
       allow(mhv_account).to receive(:needs_terms_acceptance?).and_return(false)
       User.create(mhv_user)
       create(:account, idme_uuid: mhv_user.uuid)
-      auth_header = { 'Authorization' => "Token token=#{token}" }
-      get v0_user_url, nil, auth_header
     end
 
-    it 'GET /v0/user - returns proper json' do
-      assert_response :success
-      expect(response).to match_response_schema('user_loa3')
+    context 'when the claim for increase submission limit has not been reached' do
+      before do
+        auth_header = { 'Authorization' => "Token token=#{token}" }
+        get v0_user_url, nil, auth_header
+      end
+
+      it 'GET /v0/user - returns proper json' do
+        assert_response :success
+        expect(response).to match_response_schema('user_loa3')
+      end
+
+      it 'gives me the list of available prefill forms' do
+        num_enabled = 3
+        num_enabled += FormProfile::EDU_FORMS.length if Settings.edu.prefill
+        num_enabled += FormProfile::HCA_FORMS.length if Settings.hca.prefill
+        num_enabled += FormProfile::PENSION_BURIAL_FORMS.length if Settings.pension_burial.prefill
+        num_enabled += FormProfile::VIC_FORMS.length if Settings.vic.prefill
+        num_enabled += FormProfile::EVSS_FORMS.length if Settings.evss.prefill
+
+        expect(JSON.parse(response.body)['data']['attributes']['prefills_available'].length).to be(num_enabled)
+      end
+
+      it 'gives me the list of available services that includes claim increase' do
+        expect(JSON.parse(response.body)['data']['attributes']['services'].sort).to eq(
+          [
+            BackendServices::FACILITIES,
+            BackendServices::HCA,
+            BackendServices::EDUCATION_BENEFITS,
+            BackendServices::EVSS_CLAIMS,
+            BackendServices::USER_PROFILE,
+            BackendServices::RX,
+            BackendServices::MESSAGING,
+            BackendServices::HEALTH_RECORDS,
+            # BackendServices::MHV_AC, this will be false if mhv account is premium
+            BackendServices::FORM_PREFILL,
+            BackendServices::SAVE_IN_PROGRESS,
+            BackendServices::APPEALS_STATUS,
+            BackendServices::IDENTITY_PROOFED,
+            BackendServices::VET360,
+            BackendServices::CLAIM_INCREASE_AVAILABLE
+          ].sort
+        )
+      end
     end
 
-    it 'gives me the list of available services' do
-      expect(JSON.parse(response.body)['data']['attributes']['services'].sort).to eq(
-        [
-          BackendServices::FACILITIES,
-          BackendServices::HCA,
-          BackendServices::EDUCATION_BENEFITS,
-          BackendServices::EVSS_CLAIMS,
-          BackendServices::USER_PROFILE,
-          BackendServices::RX,
-          BackendServices::MESSAGING,
-          BackendServices::HEALTH_RECORDS,
-          # BackendServices::MHV_AC, this will be false if mhv account is premium
-          BackendServices::FORM_PREFILL,
-          BackendServices::SAVE_IN_PROGRESS,
-          BackendServices::APPEALS_STATUS,
-          BackendServices::IDENTITY_PROOFED,
-          BackendServices::VET360
-        ].sort
-      )
-    end
+    context 'when the claim for increase submission limit has been reached' do
+      let(:submission_rate_limiter) { Common::EventRateLimiter.new(REDIS_CONFIG['evss_526_submit_form_rate_limit']) }
 
-    it 'gives me the list of available prefill forms' do
-      num_enabled = 3
-      num_enabled += FormProfile::EDU_FORMS.length if Settings.edu.prefill
-      num_enabled += FormProfile::HCA_FORMS.length if Settings.hca.prefill
-      num_enabled += FormProfile::PENSION_BURIAL_FORMS.length if Settings.pension_burial.prefill
-      num_enabled += FormProfile::VIC_FORMS.length if Settings.vic.prefill
-      num_enabled += FormProfile::EVSS_FORMS.length if Settings.evss.prefill
+      before do
+        11.times { submission_rate_limiter.increment }
+        auth_header = { 'Authorization' => "Token token=#{token}" }
+        get v0_user_url, nil, auth_header
+      end
 
-      expect(JSON.parse(response.body)['data']['attributes']['prefills_available'].length).to be(num_enabled)
+      it 'gives me the list of available services without claim increase' do
+        expect(JSON.parse(response.body)['data']['attributes']['services'].sort).to eq(
+          [
+            BackendServices::FACILITIES,
+            BackendServices::HCA,
+            BackendServices::EDUCATION_BENEFITS,
+            BackendServices::EVSS_CLAIMS,
+            BackendServices::USER_PROFILE,
+            BackendServices::RX,
+            BackendServices::MESSAGING,
+            BackendServices::HEALTH_RECORDS,
+            # BackendServices::MHV_AC, this will be false if mhv account is premium
+            BackendServices::FORM_PREFILL,
+            BackendServices::SAVE_IN_PROGRESS,
+            BackendServices::APPEALS_STATUS,
+            BackendServices::IDENTITY_PROOFED,
+            BackendServices::VET360
+          ].sort
+        )
+      end
     end
   end
 


### PR DESCRIPTION
## Description of change
Adds a common event rate limiter, and a specific configuration for limiting the number of successful claims for increase submissions to 30/week with a threshold of 10/day.

## Testing done
Specs and local testing of the event rate limiter threshold and count are correctly working. Local testing to check that the `claim-increase-available` service is being added.

## Testing planned
Staging testing to confirm the beta increase form is unavailable once 10 submissions/day have gone through.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] adds generic event rate limiter to lib/common
- [ ] adds redis namespace config for 10/d 30/w
- [ ] increments on successful submit
- [ ] checks limit when creating user profile services array

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
