### PR TITLE
526 remove specialissues prefill

### DIFF
--- a/app/models/form_profiles/va526ez.rb
+++ b/app/models/form_profiles/va526ez.rb
@@ -14,7 +14,6 @@ module VA526ez
     include Virtus.model
 
     attribute :name, String
-    attribute :special_issues, Array[FormSpecialIssue]
     attribute :rated_disability_id, String
     attribute :rating_decision_id, String
     attribute :diagnostic_code, Integer

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -339,13 +339,7 @@ RSpec.describe FormProfile, type: :model do
           'name' => 'Diabetes mellitus0',
           'ratedDisabilityId' => '0',
           'ratingDecisionId' => '63655',
-          'ratingPercentage' => 100,
-          'specialIssues' => [
-            {
-              'code' => 'TRM',
-              'name' => 'Personal Trauma PTSD'
-            }
-          ]
+          'ratingPercentage' => 100
         },
         {
           'diagnosticCode' => 5238,
@@ -354,13 +348,7 @@ RSpec.describe FormProfile, type: :model do
           'name' => 'Diabetes mellitus1',
           'ratedDisabilityId' => '1',
           'ratingDecisionId' => '63655',
-          'ratingPercentage' => 100,
-          'specialIssues' => [
-            {
-              'code' => 'TRM',
-              'name' => 'Personal Trauma PTSD'
-            }
-          ]
+          'ratingPercentage' => 100
         }
       ],
       'servicePeriods' => [


### PR DESCRIPTION
## Description of change
Special Issues has been removed entirely from the form workflow. Its not supported on EVSS's end and will actually raise an exception if included.

Json schema changes are in this PR: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/251

## Testing done
rspec tests.

## Testing planned
Staging run throughs.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Remove special issues from form 526 prefill

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
