### PR TITLE
Allow bulk fetch of facilities by id

### DIFF
--- a/app/models/base_facility.rb
+++ b/app/models/base_facility.rb
@@ -165,8 +165,10 @@ class BaseFacility < ActiveRecord::Base
     def build_result_set_from_ids(ids)
       ids_for_types = ids.split(',').each_with_object({}) do |type_id, obj|
         facility_type, unique_id = type_id.split('_')
-        obj[facility_type] ||= []
-        obj[facility_type].push unique_id
+        if facility_type && unique_id
+          obj[facility_type] ||= []
+          obj[facility_type].push unique_id
+        end
       end
       ids_for_types.map do |facility_type, unique_ids|
         klass = "Facilities::#{facility_type.upcase}Facility".constantize

--- a/app/models/base_facility.rb
+++ b/app/models/base_facility.rb
@@ -148,6 +148,7 @@ class BaseFacility < ActiveRecord::Base
     end
 
     def query(params)
+      # TODO: Sort hours similar to `find_factility_by_id` method on line 146
       return build_result_set_from_ids(params[:ids]).flatten if params[:ids]
       return BaseFacility.none unless params[:bbox]
       bbox_num = params[:bbox].map { |x| Float(x) }

--- a/app/models/base_facility.rb
+++ b/app/models/base_facility.rb
@@ -24,6 +24,13 @@ class BaseFacility < ActiveRecord::Base
   DOD_HEALTH = 'dod_health'
   TYPES = [HEALTH, CEMETERY, BENEFITS, VET_CENTER, DOD_HEALTH].freeze
 
+  PREFIX_MAP = {
+    'va_health_facility' => 'vha',
+    'va_benefits_facility' => 'vba',
+    'va_cemetery' => 'nca',
+    'vet_center' => 'vc'
+  }.freeze
+
   FACILITY_MAPPINGS = {
     'va_cemetery' => 'Facilities::NCAFacility',
     'va_benefits_facility' => 'Facilities::VBAFacility',
@@ -141,6 +148,7 @@ class BaseFacility < ActiveRecord::Base
     end
 
     def query(params)
+      return build_result_set_from_ids(params[:ids]).flatten if params[:ids]
       return BaseFacility.none unless params[:bbox]
       bbox_num = params[:bbox].map { |x| Float(x) }
       build_result_set(bbox_num, params[:type], params[:services]).sort_by(&(dist_from_center bbox_num))
@@ -151,6 +159,18 @@ class BaseFacility < ActiveRecord::Base
       longs = bbox_num.values_at(2, 0)
       conditions = { lat: (lats.min..lats.max), long: (longs.min..longs.max) }
       TYPES.map { |facility_type| get_facility_data(conditions, type, facility_type, services) }.flatten
+    end
+
+    def build_result_set_from_ids(ids)
+      ids_for_types = ids.split(',').each_with_object({}) do |type_id, obj|
+        facility_type, unique_id = type_id.split('_')
+        obj[facility_type] ||= []
+        obj[facility_type].push unique_id
+      end
+      ids_for_types.map do |facility_type, unique_ids|
+        klass = "Facilities::#{facility_type.upcase}Facility".constantize
+        klass.where(unique_id: unique_ids)
+      end
     end
 
     def get_facility_data(conditions, type, facility_type, services)
@@ -338,6 +358,10 @@ class BaseFacility < ActiveRecord::Base
               'VBA_Facilities' => VBA_MAP,
               'VHA_VetCenters' => VC_MAP,
               'VHA_Facilities' => VHA_MAP }.freeze
+
+  def facility_type_prefix
+    PREFIX_MAP[facility_type]
+  end
 
   private
 

--- a/app/serializers/va_facility_serializer.rb
+++ b/app/serializers/va_facility_serializer.rb
@@ -4,16 +4,9 @@ class VAFacilitySerializer < ActiveModel::Serializer
   type 'va_facilities'
 
   def id
-    "#{PREFIX_MAP[object.facility_type]}_#{object.unique_id}"
+    "#{object.facility_type_prefix}_#{object.unique_id}"
   end
 
   attributes :unique_id, :name, :facility_type, :classification, :website, :lat, :long,
              :address, :phone, :hours, :services, :feedback, :access
-
-  PREFIX_MAP = {
-    'va_health_facility' => 'vha',
-    'va_benefits_facility' => 'vba',
-    'va_cemetery' => 'nca',
-    'vet_center' => 'vc'
-  }.freeze
 end

--- a/app/serializers/va_suggested_facility_serializer.rb
+++ b/app/serializers/va_suggested_facility_serializer.rb
@@ -4,15 +4,8 @@ class VASuggestedFacilitySerializer < ActiveModel::Serializer
   type 'va_facilities'
 
   def id
-    "#{PREFIX_MAP[object.facility_type]}_#{object.unique_id}"
+    "#{object.facility_type_prefix}_#{object.unique_id}"
   end
 
   attributes :name, :address
-
-  PREFIX_MAP = {
-    'va_health_facility' => 'vha',
-    'va_benefits_facility' => 'vba',
-    'va_cemetery' => 'nca',
-    'vet_center' => 'vc'
-  }.freeze
 end

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -72,7 +72,7 @@ paths:
         services.
 
         Alternatively, one can retrieve multiple facilities by id using this endpoint by making a
-        request with a comma-separated list of ids like `?ids=id1,id1`. When requesting facilities
+        request with a comma-separated list of ids like `?ids=id1,id2`. When requesting facilities
         in bulk by `id`, the API will return as many ids as it can find matches for and omit any
         ids where there is no match. It will not return an HTTP error code if it is unable to match
         a requested `id`. Clients may supply ids up to the limit a their HTTP client enforces for

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -72,7 +72,11 @@ paths:
         services.
 
         Alternatively, one can retrieve multiple facilities by id using this endpoint by making a
-        request with a comma-separated list of ids like `?ids=id1,id1`.
+        request with a comma-separated list of ids like `?ids=id1,id1`. When requesting facilities
+        in bulk by `id`, the API will return as many ids as it can find matches for and omit any
+        ids where there is no match. It will not return an HTTP error code if it is unable to match
+        a requested `id`. Clients may supply ids up to the limit a their HTTP client enforces for
+        URI path lengths -- usually 2,048 characters.
 
         Results of this operation are paginated. JSON responses include pagination information
         in the standard JSON API "links" and "meta" elements. GeoJSON responses include pagination

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -71,6 +71,9 @@ paths:
         services. Only facilities of type "health" and "benefits" may be filtered by available
         services.
 
+        Alternatively, one can retrieve multiple facilities by id using this endpoint by making a
+        request with a comma-separated list of ids like `?ids=id1,id1`.
+
         Results of this operation are paginated. JSON responses include pagination information
         in the standard JSON API "links" and "meta" elements. GeoJSON responses include pagination
         information in the "Link" header.
@@ -78,12 +81,23 @@ paths:
       security:
         - api_key: []
       parameters:
+        - name: ids
+          description: |
+            List of command separated ids of facilities to retrieve in a single request
+          in: query
+          style: form
+          explode: false
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
         - name: bbox[]
           description: |
             Bounding longitude/latitude/longitude/latitude within which facilities will be returned. 
             Bounding box parameters should be specified in WGS84 coordinate reference system.
           in: query
-          required: true
+          required: false
           style: form
           exploded: true
           schema:

--- a/modules/va_facilities/lib/va_facilities/api_serialization.rb
+++ b/modules/va_facilities/lib/va_facilities/api_serialization.rb
@@ -3,16 +3,9 @@
 module VaFacilities
   module ApiSerialization
     def id(object)
-      "#{PREFIX_MAP[object.facility_type]}_#{object.unique_id}"
+      "#{object.facility_type_prefix}_#{object.unique_id}"
     end
     module_function :id
-
-    PREFIX_MAP = {
-      'va_health_facility' => 'vha',
-      'va_benefits_facility' => 'vba',
-      'va_cemetery' => 'nca',
-      'vet_center' => 'vc'
-    }.freeze
 
     def services(object)
       result = object.services.dup

--- a/modules/va_facilities/spec/requests/facilities_request_spec.rb
+++ b/modules/va_facilities/spec/requests/facilities_request_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       expect(json['data'].length).to eq(1)
     end
 
+    it 'responds to GET #index with a malformed id' do
+      ids_query_with_extra = ids_query + ',0618B'
+      get base_query_path + ids_query_with_extra, nil, accept_json
+      expect(response).to be_success
+      expect(response.body).to be_a(String)
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(10)
+    end
+
     it 'responds to GET #index with ids where one does not exist' do
       ids_query_with_extra = ids_query + ',vc_0618B'
       get base_query_path + ids_query_with_extra, nil, accept_json

--- a/modules/va_facilities/spec/requests/facilities_request_spec.rb
+++ b/modules/va_facilities/spec/requests/facilities_request_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe 'Facilities API endpoint', type: :request do
   let(:base_query_path) { '/services/va_facilities/v0/facilities' }
   let(:pdx_bbox) { '?bbox[]=-122.440689&bbox[]=45.451913&bbox[]=-122.786758&bbox[]=45.64' }
   let(:empty_bbox) { '?bbox[]=-122&bbox[]=45&bbox[]=-122&bbox[]=45' }
+  let(:ids_query) do
+    ids = setup_pdx.map { |facility| facility.facility_type_prefix + '_' + facility.unique_id }
+    "?ids=#{ids.join(',')}"
+  end
 
   let(:setup_pdx) do
     %w[vc_0617V nca_907 vha_648 vha_648A4 vha_648GI vba_348 vba_348a vba_348d vba_348e vba_348h].map { |id| create id }
@@ -45,6 +49,14 @@ RSpec.describe 'Facilities API endpoint', type: :request do
     it 'responds to GET #index with bbox' do
       setup_pdx
       get base_query_path + pdx_bbox, nil, accept_json
+      expect(response).to be_success
+      expect(response.body).to be_a(String)
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(10)
+    end
+
+    it 'responds to GET #index with ids' do
+      get base_query_path + ids_query, nil, accept_json
       expect(response).to be_success
       expect(response.body).to be_a(String)
       json = JSON.parse(response.body)

--- a/modules/va_facilities/spec/requests/facilities_request_spec.rb
+++ b/modules/va_facilities/spec/requests/facilities_request_spec.rb
@@ -63,6 +63,25 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       expect(json['data'].length).to eq(10)
     end
 
+    it 'responds to GET #index with one id' do
+      first_pdx = setup_pdx[1]
+      id_query = "?ids=#{first_pdx.facility_type_prefix}_#{first_pdx.unique_id}"
+      get base_query_path + id_query, nil, accept_json
+      expect(response).to be_success
+      expect(response.body).to be_a(String)
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(1)
+    end
+
+    it 'responds to GET #index with ids where one does not exist' do
+      ids_query_with_extra = ids_query + ',vc_0618B'
+      get base_query_path + ids_query_with_extra, nil, accept_json
+      expect(response).to be_success
+      expect(response.body).to be_a(String)
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(10)
+    end
+
     it 'responds with pagination links' do
       setup_pdx
       get base_query_path + pdx_bbox, nil, accept_json

--- a/spec/request/va_facilities_request_spec.rb
+++ b/spec/request/va_facilities_request_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe 'VA GIS Integration', type: :request do
   PDX_BBOX = 'bbox[]=-122.440689&bbox[]=45.451913&bbox[]=-122.786758&bbox[]=45.64'
   NY_BBOX = 'bbox[]=-73.401&bbox[]=40.685&bbox[]=-77.36&bbox[]=43.03'
 
+  let(:ids_query) do
+    ids = []
+    setup_pdx.each do |facility|
+      ids.push("#{facility.facility_type_prefix}_#{facility.unique_id}") if facility.facility_type != 'dod_health'
+    end
+    "ids=#{ids.join(',')}"
+  end
   let(:setup_pdx) do
     %w[
       vc_0617V nca_907 vha_648 vha_648A4 vha_648GI vba_348
@@ -71,6 +78,15 @@ RSpec.describe 'VA GIS Integration', type: :request do
   it 'responds to GET #index with bbox' do
     setup_pdx
     get BASE_QUERY_PATH + PDX_BBOX
+    expect(response).to be_success
+    expect(response.body).to be_a(String)
+    json = JSON.parse(response.body)
+    expect(json['data'].length).to eq(10)
+  end
+
+  it 'responds to GET #index with ids' do
+    setup_pdx
+    get BASE_QUERY_PATH + ids_query
     expect(response).to be_success
     expect(response.body).to be_a(String)
     json = JSON.parse(response.body)


### PR DESCRIPTION
Closes department-of-veterans-affairs/vets-api-clients#14

## Description of change
We had a user request being able to do a bulk fetch by id. This adds the ability to do a `GET facilities?ids=id1,id2` to do that. 

## Testing done
- Wrote RSpec tests
- Tested locally via curl

## Testing planned
- None

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Provides bulk fetch by id

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
