### PR TITLE
disability contentions model

### DIFF
--- a/app/models/disability_contention.rb
+++ b/app/models/disability_contention.rb
@@ -2,7 +2,7 @@
 
 class DisabilityContention < ActiveRecord::Base
   validates :code, presence: true, uniqueness: true
-  validates :medical_term, presence:
+  validates :medical_term, presence: true
 
   def self.suggested(name_part)
     DisabilityContention.where('medical_term ILIKE ? OR lay_term ILIKE ?', "%#{name_part}%", "%#{name_part}%")

--- a/app/models/disability_contention.rb
+++ b/app/models/disability_contention.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class DisabilityContention < ActiveRecord::Base
+  validates :code, presence: true, uniqueness: true
+  validates :medical_term, presence:
+
+  def self.suggested(name_part)
+    DisabilityContention.where('medical_term ILIKE ? OR lay_term ILIKE ?', "%#{name_part}%", "%#{name_part}%")
+  end
+end

--- a/db/migrate/20180829235636_create_disability_contentions.rb
+++ b/db/migrate/20180829235636_create_disability_contentions.rb
@@ -3,7 +3,6 @@ class CreateDisabilityContentions < ActiveRecord::Migration
     create_table :disability_contentions do |t|
       t.integer :code, null: false, unique: true
       t.string :medical_term, null: false
-      t.string :medical_term, null: false
       t.string :lay_term
 
       t.timestamps null: false

--- a/db/migrate/20180829235636_create_disability_contentions.rb
+++ b/db/migrate/20180829235636_create_disability_contentions.rb
@@ -1,0 +1,12 @@
+class CreateDisabilityContentions < ActiveRecord::Migration
+  def change
+    create_table :disability_contentions do |t|
+      t.integer :code, null: false, unique: true
+      t.string :medical_term, null: false
+      t.string :medical_term, null: false
+      t.string :lay_term
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20180830212109_add_disability_contentions_medical_index.rb
+++ b/db/migrate/20180830212109_add_disability_contentions_medical_index.rb
@@ -1,0 +1,16 @@
+class AddDisabilityContentionsMedicalIndex < ActiveRecord::Migration
+  disable_ddl_transaction!
+  safety_assured
+
+  def up
+    execute <<-SQL
+      CREATE INDEX CONCURRENTLY index_disability_contentions_on_medical_term ON disability_contentions USING gin(medical_term gin_trgm_ops);
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP INDEX index_disability_contentions_on_medical_term;
+    SQL
+  end
+end

--- a/db/migrate/20180830212116_add_disability_contentions_lay_index.rb
+++ b/db/migrate/20180830212116_add_disability_contentions_lay_index.rb
@@ -1,0 +1,16 @@
+class AddDisabilityContentionsLayIndex < ActiveRecord::Migration
+  disable_ddl_transaction!
+  safety_assured
+
+  def up
+    execute <<-SQL
+      CREATE INDEX CONCURRENTLY index_disability_contentions_on_lay_term ON disability_contentions USING gin(lay_term gin_trgm_ops);
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP INDEX index_disability_contentions_on_lay_term;
+    SQL
+  end
+end

--- a/db/migrate/20180831155019_add_code_index_to_disability_contentions.rb
+++ b/db/migrate/20180831155019_add_code_index_to_disability_contentions.rb
@@ -1,0 +1,7 @@
+class AddCodeIndexToDisabilityContentions < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index(:disability_contentions, :code, unique: true, algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180821190945) do
+ActiveRecord::Schema.define(version: 20180830212116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,6 +99,17 @@ ActiveRecord::Schema.define(version: 20180821190945) do
   end
 
   add_index "disability_compensation_submissions", ["user_uuid", "form_type"], name: "index_disability_compensation_submissions_on_uuid_and_form_type", unique: true, using: :btree
+
+  create_table "disability_contentions", force: :cascade do |t|
+    t.integer  "code",         null: false
+    t.string   "medical_term", null: false
+    t.string   "lay_term"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "disability_contentions", ["lay_term"], name: "index_disability_contentions_on_lay_term", using: :gin
+  add_index "disability_contentions", ["medical_term"], name: "index_disability_contentions_on_medical_term", using: :gin
 
   create_table "education_benefits_claims", force: :cascade do |t|
     t.datetime "submitted_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180830212116) do
+ActiveRecord::Schema.define(version: 20180831155019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 20180830212116) do
     t.datetime "updated_at",   null: false
   end
 
+  add_index "disability_contentions", ["code"], name: "index_disability_contentions_on_code", unique: true, using: :btree
   add_index "disability_contentions", ["lay_term"], name: "index_disability_contentions_on_lay_term", using: :gin
   add_index "disability_contentions", ["medical_term"], name: "index_disability_contentions_on_medical_term", using: :gin
 

--- a/spec/factories/disability_contentions.rb
+++ b/spec/factories/disability_contentions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :disability_contention_arrhythmia, class: DisabilityContention do
+    code 450
+    medical_term 'arrhythmia'
+    lay_term 'irregular heart beat'
+  end
+  factory :disability_contention_arteriosclerosis, class: DisabilityContention do
+    code 460
+    medical_term 'arteriosclerosis'
+    lay_term 'hardened arteries'
+  end
+  factory :disability_contention_arthritis, class: DisabilityContention do
+    code 490
+    medical_term 'arthritis'
+    lay_term 'joint stiffness and pain'
+  end
+end

--- a/spec/models/disability_contention_spec.rb
+++ b/spec/models/disability_contention_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DisabilityContention, type: :model do
+  describe '.suggested' do
+    before(:each) do
+      create(:disability_contention_arrhythmia)
+      create(:disability_contention_arteriosclerosis)
+      create(:disability_contention_arthritis)
+    end
+
+    it 'finds records that only match the medical term' do
+      expect(DisabilityContention.suggested('ar').count).to eq(3)
+    end
+
+    it 'refines records that only match the medical term' do
+      expect(DisabilityContention.suggested('arte').count).to eq(1)
+    end
+
+    it 'finds records that only match the lay term' do
+      expect(DisabilityContention.suggested('joint').count).to eq(1)
+    end
+
+    it 'find records that match both medical and lay terms' do
+      expect(DisabilityContention.suggested('art').count).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Adds the model and migration for disability contentions (categories of conditions) which will be used for auto-suggesting disabilities in the all claims form (ch 2.2)

## Testing done
Unit tests, local db seeding

## Testing planned
Dev API testing once all the contentions are loaded

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] adds `disability_contentions` table via migration
- [ ] adds `DisabilityContention` model

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
