### PR TITLE
Change update to update_attributes

### DIFF
--- a/app/models/async_transaction/evss/va526ez_submit_transaction.rb
+++ b/app/models/async_transaction/evss/va526ez_submit_transaction.rb
@@ -64,7 +64,7 @@ module AsyncTransaction
       def self.update_transaction(job_id, status, response_body = nil)
         raise ArgumentError, "#{status} is not a valid status" unless JOB_STATUS.keys.include?(status)
         transaction = VA526ezSubmitTransaction.find_transaction(job_id)
-        transaction.update(
+        transaction.update_attributes(
           status: (status == :retrying ? REQUESTED : COMPLETED),
           transaction_status: JOB_STATUS[status],
           metadata: response_body || transaction.metadata


### PR DESCRIPTION
## Description of change
There have been instances of ArgumentErrors creeping up on staging. This is possibly due to using the incorrect `update` method when updating multiple attributes. This has been changed to `update_attributes` method which allows for multiple updates at once.

## Testing done
rspec tests.

## Testing planned
Staging submission tests.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] change `update` to `update_attributes` for va526ez model

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
