### PR TITLE
526 update for xref table

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: d90c85a4d9540bbb45e0f5ad55d6483d7291aba6
+  revision: ba39bd58651ada365824bc22b0ef9e659702b104
   branch: master
   specs:
-    vets_json_schema (3.84.0)
+    vets_json_schema (3.86.0)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -27,7 +27,7 @@ module V0
       ).translate
 
       jid = EVSS::DisabilityCompensationForm::SubmitForm526.perform_async(
-        @current_user.uuid, converted_form_content, uploads
+        @current_user.uuid, claim.id, converted_form_content, uploads
       )
 
       render json: { data: { attributes: { job_id: jid } } },

--- a/app/models/async_transaction/evss/va526ez_submit_transaction.rb
+++ b/app/models/async_transaction/evss/va526ez_submit_transaction.rb
@@ -3,6 +3,18 @@
 module AsyncTransaction
   module EVSS
     class VA526ezSubmitTransaction < AsyncTransaction::Base
+      has_one(
+        :disability_compensation_submission,
+        class_name: 'DisabilityCompensationSubmission',
+        inverse_of: :disability_compensation_job,
+        dependent: :destroy
+      )
+      has_one(
+        :saved_claim,
+        through: :disability_compensation_submission,
+        source: :disability_compensation_claim
+      )
+
       JOB_STATUS = {
         submitted: 'submitted',
         received: 'received',

--- a/app/models/disability_compensation_submission.rb
+++ b/app/models/disability_compensation_submission.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 class DisabilityCompensationSubmission < ActiveRecord::Base
-  validates :user_uuid, presence: true, uniqueness: { scope: :form_type }
-  validates :form_type, presence: true, uniqueness: { scope: :user_uuid }
-  validates :claim_id, presence: true, uniqueness: true
+  belongs_to(
+    :disability_compensation_claim,
+    class_name: 'SavedClaim::DisabilityCompensation',
+    foreign_key: 'disability_compensation_id'
+  )
+  belongs_to(
+    :disability_compensation_job,
+    class_name: 'AsyncTransaction::EVSS::VA526ezSubmitTransaction',
+    foreign_key: 'va526ez_submit_transaction_id'
+  )
 end

--- a/app/models/saved_claim/disability_compensation.rb
+++ b/app/models/saved_claim/disability_compensation.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
 class SavedClaim::DisabilityCompensation < SavedClaim
+  has_one(
+    :disability_compensation_submission,
+    class_name: 'DisabilityCompensationSubmission',
+    inverse_of: :disability_compensation_claim,
+    dependent: :destroy
+  )
+  has_one(
+    :async_transaction,
+    through: :disability_compensation_submission,
+    source: :disability_compensation_job
+  )
+
   add_form_and_validation('21-526EZ')
 end

--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -28,10 +28,12 @@ module EVSS
       # @param form_content [Hash] The form content that is to be submitted
       # @param uploads [Hash] The users ancillary uploads that will be submitted separately
       #
-      def perform(user_uuid, form_content, uploads)
+      def perform(user_uuid, claim_id, form_content, uploads)
         user = User.find(user_uuid)
 
-        transaction_class.start(user, jid) if transaction_class.find_transaction(jid).blank?
+        if transaction_class.find_transaction(jid).blank?
+          saved_claim(claim_id).async_transaction = transaction_class.start(user, jid)
+        end
         response = service(user).submit_form(form_content)
         transaction_class.update_transaction(jid, :received, response.attributes)
         submission_rate_limiter.increment
@@ -50,15 +52,17 @@ module EVSS
       rescue StandardError => e
         # Treat unexpected errors as hard failures
         # This includes BackeEndService Errors (including 403's)
-        transaction_class.update_transaction(jid, :non_retryable_error, e.to_s)
-        extra_content = { status: :non_retryable_error, jid: jid }
-        log_exception_to_sentry(e, extra_content)
+        handle_standard_error(e)
       end
 
       private
 
       def service(user)
         EVSS::DisabilityCompensationForm::Service.new(user)
+      end
+
+      def saved_claim(claim_id)
+        SavedClaim::DisabilityCompensation.find(claim_id)
       end
 
       def transaction_class
@@ -78,6 +82,12 @@ module EVSS
       def handle_gateway_timeout_exception(error)
         transaction_class.update_transaction(jid, :retrying, error.message)
         raise error
+      end
+
+      def handle_standard_error(error)
+        transaction_class.update_transaction(jid, :non_retryable_error, error.to_s)
+        extra_content = { status: :non_retryable_error, jid: jid }
+        log_exception_to_sentry(error, extra_content)
       end
 
       def submission_rate_limiter

--- a/spec/factories/va526ez.rb
+++ b/spec/factories/va526ez.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :va526ez, class: SavedClaim::DisabilityCompensation do
+    form(
+      JSON.parse(
+        File.read('spec/support/disability_compensation_form/front_end_submission.json')
+      )['form526'].to_json
+    )
+  end
+end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Create associations in the models for disability claims and the va526 transactions via a cross reference table. This allows claims to be tied to the transactions which will make debugging significantly easier.

## Testing done
Local testing. Rspec tests.

## Testing planned
Staging job submissions.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Add table associations for `VA526ezSubmitTransaction`, `DisabilityCompensation`, and `DisabilityCompensationSubmission`
- [x] Update submit form 526 job to assign the async job to a saved claim

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
