### PR TITLE
GIFBT:  ensure `profile_data` is always present in SalesForce request

### DIFF
--- a/app/models/gi_bill_feedback.rb
+++ b/app/models/gi_bill_feedback.rb
@@ -48,17 +48,19 @@ class GIBillFeedback < Common::RedisStore
   end
 
   def get_user_details
-    return {} if user.blank?
-    va_profile = user.va_profile
+    profile_data = {}
 
-    {
-      'profile_data' => {
+    if user.present?
+      va_profile = user.va_profile
+      profile_data = {
         'active_ICN' => user.icn,
         'historical_ICN' => va_profile&.historical_icns,
         'sec_ID' => va_profile&.sec_id,
         'SSN' => user.ssn
       }
-    }
+    end
+
+    { 'profile_data' => profile_data }
   end
 
   def transform_form


### PR DESCRIPTION
## Description of change
It appears that SalesForce requires `profile_data` to be present even if it's value is blank.

## Testing done
manual testing in dev/staging

## Testing planned
manual testing in dev/staging/production

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] ensure presence of `profile_data`

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
