### PR TITLE
Bug fix for dev-preview.va.gov login

### DIFF
--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -3,6 +3,9 @@
 module SAML
   # This module is responsible for providing the URLs for the various SSO and SLO endpoints
   module URLService
+    # converts from symbols to strings
+    SUCCESS_RELAY_KEYS = Settings.saml.relays&.keys&.map { |k| k.to_s }
+
     # SSO URLS
     def mhv_url(success_relay: nil)
       build_sso_url(authn_context: 'myhealthevet', connect: 'myhealthevet', success_relay: success_relay)
@@ -62,7 +65,7 @@ module SAML
     end
 
     def saml_options(success_relay: nil)
-      options = if Settings.saml.relays&.keys&.include?(success_relay)
+      options = if SUCCESS_RELAY_KEYS.include?(success_relay) && Settings.saml.relays[success_relay].present?
                   { RelayState: Settings.saml.relays[success_relay] }
                 elsif Settings.review_instance_slug
                   { RelayState: Settings.review_instance_slug }

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -117,6 +117,34 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(response).to have_http_status(:ok)
           expect(JSON.parse(response.body)['url']).to end_with('&op=signup')
         end
+
+        describe 'GET ?success_relay=vagov' do
+          context 'with a non-nil relay setting' do
+            let(:fake_vagov_url) { 'http://fake-vagov' }
+            before do
+              with_settings(Settings.saml.relays, vagov: fake_vagov_url) do
+                get(:new, type: :idme, success_relay: 'vagov')
+              end
+            end
+
+            it 'returns a RelayState of vagov' do
+              expect(response).to have_http_status(:ok)
+              expect(JSON.parse(response.body)['url']).to include("&RelayState=#{CGI.escape(fake_vagov_url)}")
+            end
+          end
+          context 'with a nil relay setting' do
+            before do
+              with_settings(Settings.saml.relays, vagov: nil) do
+                get(:new, type: :idme, success_relay: 'vagov')
+              end
+            end
+
+            it 'does not contain a RelayState' do
+              expect(response).to have_http_status(:ok)
+              expect(JSON.parse(response.body)['url']).to_not include('RelayState')
+            end
+          end
+        end
       end
 
       context 'routes requiring auth' do


### PR DESCRIPTION
The incoming `param[:success_relay]` was a `string` but `Settings.saml.relays.keys` was an array of symbols, so `Settings.saml.relays&.keys&.include?(success_relay)` always returned false.

This PR: 
- constantizes Settings.saml.relays.keys to be an array of strings
- adds two specs