### PR TITLE
hack fix for dev-preview login

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -186,7 +186,7 @@ module V0
       Settings.saml.relays.vetsgov
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
     def saml_login_relay_url
       return default_relay_url if current_user.nil?
       # TODO: this validation should happen when we create the user, not here
@@ -205,7 +205,7 @@ module V0
         default_relay_url
       end
     end
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
 
     def valid_relay_state?
       params['RelayState'].present? && Settings.saml.relays&.to_h&.values&.include?(params['RelayState'])

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -197,6 +197,8 @@ module V0
 
       if current_user.loa[:current] < current_user.loa[:highest] && valid_relay_state?
         SAML::SettingsService.idme_loa3_url(current_user, success_relay_url: params['RelayState'])
+      elsif current_user.loa[:current] < current_user.loa[:highest]
+        SAML::SettingsService.idme_loa3_url(current_user, success_relay: params['RelayState'])
       elsif valid_relay_state?
         params['RelayState']
       else

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -186,6 +186,7 @@ module V0
       Settings.saml.relays.vetsgov
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def saml_login_relay_url
       return default_relay_url if current_user.nil?
       # TODO: this validation should happen when we create the user, not here
@@ -194,14 +195,15 @@ module V0
         return default_relay_url
       end
 
-      if current_user.loa[:current] < current_user.loa[:highest]
-        SAML::SettingsService.idme_loa3_url(current_user, success_relay: params['RelayState'])
+      if current_user.loa[:current] < current_user.loa[:highest] && valid_relay_state?
+        SAML::SettingsService.idme_loa3_url(current_user, success_relay_url: params['RelayState'])
       elsif valid_relay_state?
         params['RelayState']
       else
         default_relay_url
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     def valid_relay_state?
       params['RelayState'].present? && Settings.saml.relays&.to_h&.values&.include?(params['RelayState'])

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/LineLength
+
 module SAML
   # This module is responsible for providing the URLs for the various SSO and SLO endpoints
   module URLService
@@ -19,9 +21,9 @@ module SAML
       build_sso_url(success_relay: success_relay)
     end
 
-    def idme_loa3_url(current_user, success_relay: nil)
+    def idme_loa3_url(current_user, success_relay: nil, success_relay_url: nil)
       build_sso_url(
-        authn_context: LOA::MAPPING.invert[3], connect: current_user.authn_context, success_relay: success_relay
+        authn_context: LOA::MAPPING.invert[3], connect: current_user.authn_context, success_relay: success_relay, success_relay_url: success_relay_url
       )
     end
 
@@ -41,11 +43,15 @@ module SAML
     # Builds the urls to trigger various SSO policies: mhv, dslogon, idme, mfa, or verify flows.
     # nil authn_context and nil connect will always default to idme level 1
     # authn_context is the policy, connect represents the ID.me specific flow.
-    def build_sso_url(authn_context: LOA::MAPPING.invert[1], connect: nil, session: nil, success_relay: nil)
+    def build_sso_url(authn_context: LOA::MAPPING.invert[1], connect: nil, session: nil, success_relay: nil, success_relay_url: nil)
       url_settings = url_settings(authn_context: authn_context, name_identifier_value: session&.uuid)
       saml_auth_request = OneLogin::RubySaml::Authrequest.new
       connect_param = "&connect=#{connect}"
-      link = saml_auth_request.create(url_settings, saml_options(success_relay: success_relay))
+      link = if success_relay_url.present?
+               saml_auth_request.create(url_settings, RelayState: success_relay_url)
+             else
+               saml_auth_request.create(url_settings, saml_options(success_relay: success_relay))
+             end
       connect.present? ? link + connect_param : link
     end
 
@@ -76,3 +82,4 @@ module SAML
     end
   end
 end
+# rubocop:enable Metrics/LineLength


### PR DESCRIPTION
This is a temporary solution to a redirect to dev.vets.gov vs dev-preview.vets.gov after the LOA1-LOA3 up-level process.

We opted for this approach to make today's code freeze deadline. We'll be working to establish a simpler URL whitelist approach - which will be documented in another ticket after this PR is accepted and merged for additional testing.

Testing included on-server dev-preview.va.gov, and dev.vets.gov. 