### PR TITLE
Env var for secure storage & reference of access key/value

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -308,3 +308,6 @@ google_analytics_tracking_id: ~
 
 account:
   enabled: false
+
+search:
+  access_key: SEARCH_GOV_ACCESS_KEY


### PR DESCRIPTION
## Description of change
Search.gov provides a unique access key for accessing their Search API. This will need to be properly stored, and accessible across all environments.

## Sibling Devops PR

https://github.com/department-of-veterans-affairs/devops/pull/3262

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Creates env var for secure storage and reference of `access_key` and its value

#### Applies to all PRs

- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)

