### PR TITLE
add max ep code error mapping for 526

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -1486,7 +1486,7 @@ en:
         detail: 'EVSS GI Bill Status is not available outside of working hours'
         code: 114
         status: 503
-    526:
+    disability_compensation_form:
       not_eligible:
         <<: *defaults
         title: Proxy error
@@ -1513,9 +1513,15 @@ en:
         status: 500
       start_batch_job_error:
         <<: *defaults
-        title: Cannot launch the 526 post submit batch job
+        title: 'Cannot launch the 526 post submit batch job'
         code: 125
         status: 502
+      max_ep_code:
+        <<: *defaults
+        title: Unprocessable Entity
+        detail: 'The Maximum number of EP codes have been reached for this benefit type claim code'
+        code: 126
+        status: 422
     ppiu:
       unprocessable_entity:
         <<: *defaults

--- a/lib/evss/disability_compensation_form/service_exception.rb
+++ b/lib/evss/disability_compensation_form/service_exception.rb
@@ -8,11 +8,11 @@ module EVSS
       ERROR_MAP = {
         serviceError: 'evss.external_service_unavailable',
         ServiceException: 'evss.external_service_unavailable',
-        notEligible: 'evss.526.not_eligible',
-        InProcess: 'evss.526.form_in_process',
-        disabled: 'evss.526.disabled',
-        marshalError: 'evss.526.marshall_error',
-        startBatchJobError: 'evss.526.start_batch_job_error',
+        notEligible: 'evss.disability_compensation_form.not_eligible',
+        InProcess: 'evss.disability_compensation_form.form_in_process',
+        disabled: 'evss.disability_compensation_form.disabled',
+        marshalError: 'evss.disability_compensation_form.marshall_error',
+        startBatchJobError: 'evss.disability_compensation_form.start_batch_job_error',
         Size: 'common.exceptions.validation_errors',
         Pattern: 'common.exceptions.validation_errors',
         NotNull: 'common.exceptions.validation_errors',
@@ -26,7 +26,8 @@ module EVSS
         militaryPayments: 'common.exceptions.validation_errors',
         serviceInformation: 'common.exceptions.validation_errors',
         treatments: 'common.exceptions.validation_errors',
-        veteran: 'common.exceptions.validation_errors'
+        veteran: 'common.exceptions.validation_errors',
+        MaxEPCode: 'evss.disability_compensation_form.max_ep_code'
       }.freeze
 
       def errors

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
@@ -99,6 +99,16 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526, type: :job do
       end
     end
 
+    context 'with a max ep code server error' do
+      it 'sets the transaction to "retrying"' do
+        VCR.use_cassette('evss/disability_compensation_form/submit_500_with_max_ep_code') do
+          subject.perform_async(user.uuid, auth_headers, claim.id, valid_form_content, nil)
+          described_class.drain
+          expect(last_transaction.transaction_status).to eq 'non_retryable_error'
+        end
+      end
+    end
+
     context 'with an unexpected error' do
       before do
         allow_any_instance_of(Faraday::Connection).to receive(:post).and_raise(StandardError.new('foo'))

--- a/spec/support/vcr_cassettes/evss/disability_compensation_form/submit_500_with_max_ep_code.yml
+++ b/spec/support/vcr_cassettes/evss/disability_compensation_form/submit_500_with_max_ep_code.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-form526-services-web/rest/form526/v1/submit"
+    body:
+      encoding: UTF-8
+      string: '{"form526":{"veteran":{"emailAddress":"string","alternateEmailAddress":"string","mailingAddress":{"addressLine1":"string","addressLine2":"string","addressLine3":"string","city":"string","state":"IL","zipFirstFive":"11111","zipLastFour":"1111","country":"string","militaryStateCode":"AA","militaryPostOfficeTypeCode":"APO","type":"DOMESTIC"},"forwardingAddress":{"addressLine1":"string","addressLine2":"string","addressLine3":"string","city":"string","state":"IL","zipFirstFive":"11111","zipLastFour":"1111","country":"string","militaryStateCode":"AA","militaryPostOfficeTypeCode":"APO","type":"DOMESTIC","effectiveDate":"2018-03-29T18:50:03.014Z"},"primaryPhone":{"areaCode":"202","phoneNumber":"4561111"},"homelessness":{"hasPointOfContact":false},"serviceNumber":"string"},"attachments":[],"militaryPayments":{"payments":[],"receiveCompensationInLieuOfRetired":false,"receivingInactiveDutyTrainingPay":false,"waveBenifitsToRecInactDutyTraiPay":false},"directDeposit":{"accountType":"CHECKING","accountNumber":"1234","bankName":"string","routingNumber":"123456789"},"serviceInformation":{"servicePeriods":[{"serviceBranch":"string","activeDutyBeginDate":"2018-03-29T18:50:03.015Z","activeDutyEndDate":"2018-03-29T18:50:03.015Z"}],"reservesNationalGuardService":{"title10Activation":{"title10ActivationDate":"2018-03-29T18:50:03.015Z","anticipatedSeparationDate":"2018-03-29T18:50:03.015Z"},"obligationTermOfServiceFromDate":"2018-03-29T18:50:03.015Z","obligationTermOfServiceToDate":"2018-03-29T18:50:03.015Z","unitName":"string","unitPhone":{"areaCode":"202","phoneNumber":"4561111"}},"servedInCombatZone":true,"separationLocationName":"OTHER","separationLocationCode":"SOME
+        VALUE","alternateNames":[{"firstName":"string","middleName":"string","lastName":"string"}],"confinements":[{"confinementBeginDate":"2018-03-29T18:50:03.015Z","confinementEndDate":"2018-03-29T18:50:03.015Z","verifiedIndicator":false}]},"disabilities":[{"diagnosticText":"Diabetes
+        mellitus","disabilityActionType":"INCREASE","decisionCode":"SVCCONNCTED","specialIssues":[{"code":"TRM","name":"Personal
+        Trauma PTSD"}],"ratedDisabilityId":"0","ratingDecisionId":63655,"diagnosticCode":5235,"secondaryDisabilities":[{"decisionCode":"","ratedDisabilityId":"","diagnosticText":"string","disabilityActionType":"NONE"}]}],"treatments":[],"specialCircumstances":[{"name":"string","code":"string","needed":false}]}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - Beyonce
+      va-eauth-lastName:
+      - Knowles
+      va-eauth-issueinstant:
+      - '2017-12-07T00:55:09Z'
+      va-eauth-dodedipnid:
+      - '4789224336'
+      va-eauth-birlsfilenumber:
+      - '796068948'
+      va-eauth-pid:
+      - '7420876015'
+      va-eauth-pnid:
+      - '796068949'
+      va-eauth-birthdate:
+      - '1959-10-24T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796068949","edi":"4789224336","firstName":"Beyonce","lastName":"Knowles","birthDate":"1959-10-24T00:00:00+00:00","gender":"FEMALE"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 500
+      message: Server error
+    headers:
+      Date:
+      - Mon, 02 Apr 2018 22:46:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.02; path=/
+      - WSS-FORM526-SERVICES_JSESSIONID=RPeIimX_DLhskhO20bPzBmWWKGghuW-YlSjLgIX3nN28Adki1xRE!-1392655551;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [
+            {
+              "key":  "form526.submit.save.draftForm.MaxEPCode",
+              "severity":  "FATAL",
+              "text":  "This claim could not be established. The Maximum number of EP codes have been reached for this benefit type claim code"
+            }
+          ]
+        }
+    http_version:
+  recorded_at: Mon, 02 Apr 2018 22:46:34 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Description of change
Received this error on staging and it didn't have an error mapping described. In testing the '526' part of the yaml error keys wasn't being picked up so I changed it to 'disability_compensation_form'.

## Testing done
unit tests based on staging responses

## Testing planned
staging testing

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] adds max ep code mapping
- [ ] changes `evss.526...` error namespace to `evss.disability_compensation_form...`

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
