### PR TITLE
526 background submission metrics

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -54,6 +54,8 @@ module EVSS
         # Treat unexpected errors as hard failures
         # This includes BackeEndService Errors (including 403's)
         handle_standard_error(e)
+      ensure
+        StatsD.increment('worker.evss.submit_form526.try')
       end
 
       private
@@ -73,26 +75,46 @@ module EVSS
       def handle_service_exception(error)
         if error.status_code.between?(500, 600)
           transaction_class.update_transaction(jid, :retrying, error.messages)
+          increment_retryable(error)
           raise error
         end
         transaction_class.update_transaction(jid, :non_retryable_error, error.messages)
         extra_content = { status: :non_retryable_error, jid: jid }
         log_exception_to_sentry(error, extra_content)
+        increment_non_retryable(error)
       end
 
       def handle_gateway_timeout_exception(error)
         transaction_class.update_transaction(jid, :retrying, error.message)
-        raise error
+        increment_retryable(error)
+        raise EVSS::DisabilityCompensationForm::GatewayTimeout.new(error)
       end
 
       def handle_standard_error(error)
         transaction_class.update_transaction(jid, :non_retryable_error, error.to_s)
         extra_content = { status: :non_retryable_error, jid: jid }
         log_exception_to_sentry(error, extra_content)
+        increment_non_retryable(error)
       end
 
       def submission_rate_limiter
         Common::EventRateLimiter.new(REDIS_CONFIG['evss_526_submit_form_rate_limit'])
+      end
+
+      def increment_non_retryable(error)
+        tags = statsd_tags(error)
+        StatsD.increment('worker.evss.submit_form526.non_retryable_error', tags: tags)
+      end
+
+      def increment_retryable(error)
+        tags = statsd_tags(error)
+        StatsD.increment('worker.evss.submit_form526.retryable_error', tags: tags)
+      end
+
+      def statsd_tags(error)
+        tags = ["error:#{error.class}"]
+        tags << "status:#{error.status}" if error.try(:status)
+        tags
       end
     end
   end

--- a/lib/evss/disability_compensation_form/gateway_timeout.rb
+++ b/lib/evss/disability_compensation_form/gateway_timeout.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module EVSS
+  module DisabilityCompensationForm
+    class GatewayTimeout < Common::Exceptions::GatewayTimeout
+    end
+  end
+end

--- a/lib/evss/disability_compensation_form/service_exception.rb
+++ b/lib/evss/disability_compensation_form/service_exception.rb
@@ -45,3 +45,6 @@ module EVSS
     end
   end
 end
+
+# {"messages"=>[{"key"=>"form526.submit.save.draftForm.MaxEPCode", "severity"=>"FATAL", "text"=>"This claim could not be established. The Maximum number of
+# EP codes have been reached for this benefit type claim code"}]}

--- a/lib/evss/disability_compensation_form/service_exception.rb
+++ b/lib/evss/disability_compensation_form/service_exception.rb
@@ -45,6 +45,3 @@ module EVSS
     end
   end
 end
-
-# {"messages"=>[{"key"=>"form526.submit.save.draftForm.MaxEPCode", "severity"=>"FATAL", "text"=>"This claim could not be established. The Maximum number of
-# EP codes have been reached for this benefit type claim code"}]}

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526, type: :job do
 
       it 'sets the transaction to "retrying"' do
         subject.perform_async(user.uuid, claim.id, valid_form_content, nil)
-        expect { described_class.drain }.to raise_error(Common::Exceptions::GatewayTimeout)
+        expect { described_class.drain }.to raise_error(EVSS::DisabilityCompensationForm::GatewayTimeout)
         expect(last_transaction.transaction_status).to eq 'retrying'
       end
     end


### PR DESCRIPTION
## Description of change
Adds more granular metrics to background submissions, tracking total tries, as well as retryable and non-retryable errors. Also adds `EVSS::DisabilityCompensationForm::GatewayTimeout` so that both 
it and `EVSS::DisabilityCompensationForm::ServiceException` have the namespace and can be hooked up to automated alerts.

## Testing done
unit tests

## Testing planned
check metrics in staging prometheus

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] adds submit job metrics
- [ ] creates `EVSS::DisabilityCompensationForm::GatewayTimeout`

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
