### PR TITLE
Fixes: Sessions Controller Delete/Destroy Action #12540

### DIFF
--- a/app/swagger/requests/sessions.rb
+++ b/app/swagger/requests/sessions.rb
@@ -5,34 +5,51 @@ module Swagger
     class Sessions
       include Swagger::Blocks
 
-      swagger_path '/v0/sessions/authn_urls' do
+      swagger_path '/sessions/mhv/new' do
         operation :get do
-          key :description, 'Fetch various urls for initiating authentication'
+          key :description, 'Get url for initiating SSO with MyHealtheVet'
           key :tags, %w[authentication]
 
-          parameter do
-            key :name, 'success_relay'
-            key :in, :query
-            key :description, 'Desired relay redirect location after login success'
-            key :required, false
-            key :type, :string
-            key :enum, %w[vetsgov vagov preview_vagov]
-          end
-
           response 200 do
-            key :description, 'returns a list of urls for invoking SAML authentication flow'
+            key :description, 'returns the url for invoking SAML authentication flow via MyHealtheVet'
             schema do
-              key :'$ref', :AuthenticationURLs
+              key :'$ref', :AuthenticationURL
             end
           end
         end
       end
 
-      swagger_path '/v0/sessions/multifactor' do
+      swagger_path '/sessions/dslogon/new' do
         operation :get do
-          extend Swagger::Responses::AuthenticationError
+          key :description, 'Get url for initiating SSO with DS Logon'
+          key :tags, %w[authentication]
 
-          key :description, 'Fetch url for invoking multifactor policy'
+          response 200 do
+            key :description, 'returns the url for invoking SAML authentication flow via DS Logon'
+            schema do
+              key :'$ref', :AuthenticationURL
+            end
+          end
+        end
+      end
+
+      swagger_path '/sessions/idme/new' do
+        operation :get do
+          key :description, 'Get url for initiating SSO with Id.me'
+          key :tags, %w[authentication]
+
+          response 200 do
+            key :description, 'returns the url for invoking SAML authentication flow via Id.me'
+            schema do
+              key :'$ref', :AuthenticationURL
+            end
+          end
+        end
+      end
+
+      swagger_path '/sessions/mfa/new' do
+        operation :get do
+          key :description, 'Get url for initiating enabling multifactor authentication'
           key :tags, %w[authentication]
 
           parameter do
@@ -43,20 +60,25 @@ module Swagger
             key :type, :string
           end
 
-          response 200 do
-            key :description, 'returns a url for triggering the multifactor policy when previously declined'
+          response 401 do
+            key :description, 'Unauthorized User'
             schema do
-              key :'$ref', :MultifactorURL
+              key :'$ref', :Errors
+            end
+          end
+
+          response 200 do
+            key :description, 'returns the url to enable multifactor authentication'
+            schema do
+              key :'$ref', :AuthenticationURL
             end
           end
         end
       end
 
-      swagger_path '/v0/sessions/identity_proof' do
+      swagger_path '/sessions/verify/new' do
         operation :get do
-          extend Swagger::Responses::AuthenticationError
-
-          key :description, 'Fetch url for verifying identity (or triggering ID.me FICAM flow)'
+          key :description, 'Get url for initiating FICAM identity proofing'
           key :tags, %w[authentication]
 
           parameter do
@@ -65,23 +87,27 @@ module Swagger
             key :description, 'The authorization method and token value'
             key :required, true
             key :type, :string
+          end
+
+          response 401 do
+            key :description, 'Unauthorized User'
+            schema do
+              key :'$ref', :Errors
+            end
           end
 
           response 200 do
-            key :description, 'returns a url for triggering identity proof verification / FICAM flow.'
+            key :description, 'returns the url to initiate FICAM identity proofing flow'
             schema do
-              key :'$ref', :IdentityProofURL
+              key :'$ref', :AuthenticationURL
             end
           end
         end
       end
 
-      swagger_path '/v0/sessions' do
-        operation :delete do
-          extend Swagger::Responses::AuthenticationError
-
-          key :description, 'Fetch url for terminating a session'
-          key :operationId, 'endSession'
+      swagger_path '/sessions/slo/new' do
+        operation :get do
+          key :description, 'Get url for terminating session and initiating SLO flow'
           key :tags, %w[authentication]
 
           parameter do
@@ -92,31 +118,24 @@ module Swagger
             key :type, :string
           end
 
-          response 202 do
-            key :description, 'returns a url to invoke SAML logout process'
+          response 401 do
+            key :description, 'Unauthorized User'
             schema do
-              key :'$ref', :LogoutURL
+              key :'$ref', :Errors
+            end
+          end
+
+          response 200 do
+            key :description, 'returns the url to terminate the current session and initiates external SLO flow'
+            schema do
+              key :'$ref', :AuthenticationURL
             end
           end
         end
       end
 
-      swagger_schema :AuthenticationURLs, required: %i[mhv dslogon idme] do
-        property :mhv, type: :string
-        property :dslogon, type: :string
-        property :idme, type: :string
-      end
-
-      swagger_schema :MultifactorURL, required: [:multifactor_url] do
-        property :multifactor_url, type: :string
-      end
-
-      swagger_schema :IdentityProofURL, required: [:identity_proof_url] do
-        property :identity_proof_url, type: :string
-      end
-
-      swagger_schema :LogoutURL, required: [:logout_via_get] do
-        property :logout_via_get, type: :string
+      swagger_schema :AuthenticationURL, required: %i[url] do
+        property :url, type: :string
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,10 +37,8 @@ Rails.application.routes.draw do
 
     resource :upload_supporting_evidence, only: :create
 
-    resource :sessions, only: :destroy do
-      get :authn_urls, on: :collection
-      get :multifactor, on: :member
-      get :identity_proof, on: :member
+    resource :sessions, only: [] do
+      get  :logout, to: 'sessions#logout'
       post :saml_callback, to: 'sessions#saml_callback'
       post :saml_slo_callback, to: 'sessions#saml_slo_callback'
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,7 @@ binaries:
   pdftk: pdftk
   clamdscan: /usr/bin/clamdscan
 
-hostname: www.example.com
+hostname: localhost:3000
 
 # For CORS requests; separate multiple origins with a comma
 web_origin: http://localhost:3000,http://localhost:3001,null
@@ -16,9 +16,6 @@ database_url: postgres:///vets-api
 relative_url_root: /
 
 secret_key_base: 8af0fe1e378586520e4324694897eb269bd0fffa1c5be6cc3b4ffb9dbde095d0bef5c7fdab73cd05685d8fe1dd589287d78b38e4de7116fbe14461e414072677
-
-set_sso_cookie: false
-sso_cookie_key: '$\xBB\xDA\xFD\xB9c;\x05@|w\xEB\x81\xC7\x0EPZ\xEA\xF6\xC2\xD1\x1C\xDCrl;\xDD\x10v\x99\x16\x1D'
 
 review_instance_slug: ~
 

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -37,7 +37,7 @@ module SAML
     # when this url gets invoked, the session should be destroyed, before the callback returns
     def logout_url(session)
       token = Base64.urlsafe_encode64(session.token)
-      Rails.application.routes.url_helpers.logout_v0_sessions_url(method: 'delete', session: token)
+      Rails.application.routes.url_helpers.logout_v0_sessions_url(session: token)
     end
 
     # SLO URLS

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -33,6 +33,13 @@ module SAML
       build_sso_url(authn_context: authn_context, connect: policy, success_relay: success_relay)
     end
 
+    # This is the internal vets-api url that first gets invoked, it should redirect without authentication
+    # when this url gets invoked, the session should be destroyed, before the callback returns
+    def logout_url(session)
+     token = Base64.urlsafe_encode64(session.token)
+     Rails.application.routes.url_helpers.logout_v0_sessions_url(method: 'delete', session: token)
+    end
+
     # SLO URLS
     def slo_url(session)
       build_slo_url(session)

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -36,8 +36,8 @@ module SAML
     # This is the internal vets-api url that first gets invoked, it should redirect without authentication
     # when this url gets invoked, the session should be destroyed, before the callback returns
     def logout_url(session)
-     token = Base64.urlsafe_encode64(session.token)
-     Rails.application.routes.url_helpers.logout_v0_sessions_url(method: 'delete', session: token)
+      token = Base64.urlsafe_encode64(session.token)
+      Rails.application.routes.url_helpers.logout_v0_sessions_url(method: 'delete', session: token)
     end
 
     # SLO URLS

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe V0::SessionsController, type: :controller do
   let(:succesful_logout_response) do
     double('logout_response', validate: true, success?: true, in_response_to: logout_uuid, errors: [])
   end
-  let(:decrypter) { ActiveSupport::MessageEncryptor.new(Settings.sso_cookie_key) }
 
   before do
     allow(SAML::SettingsService).to receive(:saml_settings).and_return(rubysaml_settings)
@@ -162,7 +161,6 @@ RSpec.describe V0::SessionsController, type: :controller do
     before do
       allow(SAML::User).to receive(:new).and_return(saml_user)
       Session.create(uuid: uuid, token: token)
-      Settings.set_sso_cookie = true
       User.create(loa1_user.attributes)
       UserIdentity.create(loa1_user.identity.attributes)
     end
@@ -170,45 +168,15 @@ RSpec.describe V0::SessionsController, type: :controller do
     describe 'new' do
       context 'routes not requiring auth' do
         %w[mhv dslogon idme mfa verify slo].each do |type|
+
           it "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             request.env['HTTP_AUTHORIZATION'] = auth_header
-            request.cookies['va_session'] = 'bar'
             get(:new, type: type)
-            if type == 'slo'
-              expect(cookies[:va_session]).to be_nil
-            elsif %w[mhv dslogon idme].include?(type)
-              expect(cookies[:va_session]).not_to be_nil
-              expect(cookies[:va_session]).to eq('bar')
-            else
-              expect(cookies[:va_session]).not_to be_nil
-              expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
-                .to eq('icn' => nil, 'mhv_correlation_id' => nil)
-            end
             expect(response).to have_http_status(:ok)
             expect(JSON.parse(response.body).keys).to eq %w[url]
           end
         end
       end
-    end
-
-    it 'returns a url for leveling up or verifying current level' do
-      request.env['HTTP_AUTHORIZATION'] = auth_header
-      get :identity_proof
-      expect(response).to have_http_status(200)
-      expect(JSON.parse(response.body).keys).to eq %w[identity_proof_url]
-    end
-
-    it 'returns a url for adding multifactor authentication to your account' do
-      request.env['HTTP_AUTHORIZATION'] = auth_header
-      get :multifactor
-      expect(response).to have_http_status(200)
-      expect(JSON.parse(response.body).keys).to eq %w[multifactor_url]
-    end
-
-    it 'returns a logout url' do
-      request.env['HTTP_AUTHORIZATION'] = auth_header
-      delete :destroy
-      expect(response).to have_http_status(202)
     end
 
     it 'redirects as success even when logout fails, but it logs the failure' do
@@ -217,10 +185,50 @@ RSpec.describe V0::SessionsController, type: :controller do
         .to redirect_to(Settings.saml.logout_relay + '?success=true')
     end
 
-    context 'logout has been requested' do
+    describe 'GET sessions/logout' do
+      let(:logout_request) { OneLogin::RubySaml::Logoutrequest.new }
+
+      before do
+        mhv_account = double('mhv_account', ineligible?: false, needs_terms_acceptance?: false, upgraded?: true)
+        allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
+        allow(OneLogin::RubySaml::Logoutrequest).to receive(:new).and_return(logout_request)
+      end
+
+      context 'cannot find a session' do
+        it 'raises a Forbidden exception' do
+          get(:logout, session: Base64.urlsafe_encode64('invalid_token'))
+          expect(JSON.parse(response.body))
+            .to eq('errors' => [{
+                     'title' => 'Forbidden',
+                     'detail' => 'Invalid request',
+                     'code' => '403',
+                     'status' => '403'
+                   }])
+        end
+      end
+
+      context 'can find an active session' do
+        it 'destroys the user and session, persists logout_request object, redirects to SLO url' do
+          # these should have been destroyed yet
+          expect(Session.find(token)).to_not be_nil
+          expect(User.find(uuid)).to_not be_nil
+          # this should not exist yet
+          expect(SingleLogoutRequest.find(logout_request.uuid)).to be_nil
+          get(:logout, session: Base64.urlsafe_encode64(token))
+          expect(response.location).to match('https://api.idmelabs.com/saml/SingleLogoutService')
+          # these should be destroyed.
+          expect(Session.find(token)).to be_nil
+          expect(User.find(uuid)).to be_nil
+          # this should be created in redis
+          expect(SingleLogoutRequest.find(logout_request.uuid)).to_not be_nil
+        end
+      end
+    end
+
+    describe 'POST saml_logout_callback' do
       before { SingleLogoutRequest.create(uuid: logout_uuid, token: token) }
 
-      context 'logout_response is invalid' do
+      context 'saml_logout_response is invalid' do
         before do
           allow(OneLogin::RubySaml::Logoutresponse).to receive(:new).and_return(invalid_logout_response)
         end
@@ -231,27 +239,33 @@ RSpec.describe V0::SessionsController, type: :controller do
             .to redirect_to(Settings.saml.logout_relay + '?success=true')
         end
       end
-      context ' logout_response is success' do
+
+      context 'saml_logout_response is success' do
         before do
           mhv_account = double('mhv_account', ineligible?: false, needs_terms_acceptance?: false, upgraded?: true)
           allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
           allow(OneLogin::RubySaml::Logoutresponse).to receive(:new).and_return(succesful_logout_response)
         end
 
-        it 'redirects to success and destroy the session' do
+        it 'redirects to success and destroys only the logout request' do
+          # these should have been destroyed in the initial call to sessions/logout, not in the callback.
           expect(Session.find(token)).to_not be_nil
           expect(User.find(uuid)).to_not be_nil
+          # this will be destroyed
+          expect(SingleLogoutRequest.find(succesful_logout_response&.in_response_to)).to_not be_nil
           expect(post(:saml_logout_callback, SAMLResponse: '-'))
             .to redirect_to(redirect_to(Settings.saml.logout_relay + '?success=true'))
-          expect(Session.find(token)).to be_nil
-          expect(User.find(uuid)).to be_nil
+          # these should have been destroyed in the initial call to sessions/logout, not in the callback.
+          expect(Session.find(token)).to_not be_nil
+          expect(User.find(uuid)).to_not be_nil
+          # this should be destroyed
+          expect(SingleLogoutRequest.find(succesful_logout_response&.in_response_to)).to be_nil
         end
       end
     end
 
     describe 'POST saml_callback' do
       before(:each) do
-        Settings.set_sso_cookie = true
         allow(controller).to receive(:async_create_evss_account)
         allow(SAML::User).to receive(:new).and_return(saml_user)
       end
@@ -288,9 +302,6 @@ RSpec.describe V0::SessionsController, type: :controller do
         expect(new_user.loa).to eq(highest: LOA::THREE, current: LOA::THREE)
         expect(new_user.multifactor).to be_falsey
         expect(new_user.last_signed_in).not_to eq(existing_user.last_signed_in)
-        expect(cookies[:va_session]).not_to be_nil
-        expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
-          .to eq('icn' => loa3_user.icn, 'mhv_correlation_id' => loa3_user.mhv_correlation_id)
       end
 
       it 'does not log to sentry when SSN matches', :aggregate_failures do
@@ -302,9 +313,6 @@ RSpec.describe V0::SessionsController, type: :controller do
         new_user = User.find(uuid)
         expect(new_user.ssn).to eq('796111863')
         expect(new_user.va_profile.ssn).to eq('796111863')
-        expect(cookies[:va_session]).not_to be_nil
-        expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
-          .to eq('icn' => loa3_user.icn, 'mhv_correlation_id' => loa3_user.mhv_correlation_id)
       end
 
       context 'changing multifactor' do
@@ -324,13 +332,6 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(new_user.multifactor).to be_truthy
           expect(new_user.last_signed_in).to eq(existing_user.last_signed_in)
         end
-
-        it 'has a cookie, but values are nil because loa1 user', :aggregate_failures do
-          post :saml_callback
-          expect(cookies[:va_session]).not_to be_nil
-          expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
-            .to eq('icn' => nil, 'mhv_correlation_id' => nil)
-        end
       end
 
       context 'when user has LOA current 1 and highest 3' do
@@ -343,9 +344,6 @@ RSpec.describe V0::SessionsController, type: :controller do
         it 'redirects to identity proof URL', :aggregate_failures do
           expect(SAML::SettingsService).to receive(:idme_loa3_url)
           post :saml_callback
-          expect(cookies[:va_session]).not_to be_nil
-          expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
-            .to eq('icn' => nil, 'mhv_correlation_id' => nil)
         end
       end
 
@@ -360,9 +358,6 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(controller).to receive(:log_message_to_sentry).with('ID.me did not provide LOA.highest!', :error)
           post :saml_callback
           expect(response.location).to start_with(Settings.saml.relays.vetsgov + '?token=')
-          expect(cookies[:va_session]).not_to be_nil
-          expect(JSON.parse(decrypter.decrypt_and_verify(cookies[:va_session])))
-            .to eq('icn' => nil, 'mhv_correlation_id' => nil)
         end
       end
 
@@ -394,7 +389,6 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(Rails.logger).to receive(:warn).with(/#{SAML::AuthFailHandler::TOO_LATE_MSG}/)
           expect(post(:saml_callback)).to redirect_to(Settings.saml.relays.vetsgov + '?auth=fail&code=002')
           expect(response).to have_http_status(:found)
-          expect(cookies[:va_session]).to be_nil
         end
       end
 
@@ -405,7 +399,6 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(Rails.logger).to receive(:error).with(/#{SAML::AuthFailHandler::TOO_EARLY_MSG}/)
           expect(post(:saml_callback)).to redirect_to(Settings.saml.relays.vetsgov + '?auth=fail&code=003')
           expect(response).to have_http_status(:found)
-          expect(cookies[:va_session]).to be_nil
         end
 
         it 'increments the failed and total statsd counters' do
@@ -437,7 +430,6 @@ RSpec.describe V0::SessionsController, type: :controller do
             )
           expect(post(:saml_callback)).to redirect_to(Settings.saml.relays.vetsgov + '?auth=fail&code=007')
           expect(response).to have_http_status(:found)
-          expect(cookies[:va_session]).to be_nil
         end
 
         it 'increments the failed and total statsd counters' do
@@ -469,7 +461,6 @@ RSpec.describe V0::SessionsController, type: :controller do
             )
           expect(post(:saml_callback)).to redirect_to(Settings.saml.relays.vetsgov + '?auth=fail&code=001')
           expect(response).to have_http_status(:found)
-          expect(cookies[:va_session]).to be_nil
         end
 
         it 'increments the failed and total statsd counters' do
@@ -508,7 +499,6 @@ RSpec.describe V0::SessionsController, type: :controller do
             )
           expect(post(:saml_callback)).to redirect_to(Settings.saml.relays.vetsgov + '?auth=fail&code=')
           expect(response).to have_http_status(:found)
-          expect(cookies[:va_session]).to be_nil
         end
 
         it 'increments the failed and total statsd counters' do
@@ -551,29 +541,6 @@ RSpec.describe V0::SessionsController, type: :controller do
   end
 
   context 'when not logged in' do
-    it 'returns the urls for for all three possible authN requests' do
-      get :authn_urls
-      expect(response).to have_http_status(200)
-      expect(JSON.parse(response.body).keys).to eq %w[mhv dslogon idme]
-    end
-
-    it 'does not allow fetching the identity proof url' do
-      get :identity_proof
-      expect(response).to have_http_status(401)
-    end
-
-    it 'does not allow fetching the multifactor url' do
-      get :multifactor
-      expect(response).to have_http_status(401)
-    end
-
-    describe ' DELETE destroy' do
-      it 'returns unauthorized' do
-        delete :destroy
-        expect(response).to have_http_status(:unauthorized)
-      end
-    end
-
     describe 'POST saml_callback' do
       context 'loa1_user' do
         let(:saml_user_attributes) { loa1_user.attributes.merge(loa1_user.identity.attributes) }

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -168,7 +168,6 @@ RSpec.describe V0::SessionsController, type: :controller do
     describe 'new' do
       context 'routes not requiring auth' do
         %w[mhv dslogon idme mfa verify slo].each do |type|
-
           it "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             request.env['HTTP_AUTHORIZATION'] = auth_header
             get(:new, type: type)

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -42,27 +42,37 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
   context 'has valid paths' do
     let(:auth_options) { { '_headers' => { 'Authorization' => "Token token=#{token}" } } }
 
+    context 'for authentication' do
+      it 'supports session mhv url' do
+        expect(subject).to validate(:get, '/sessions/mhv/new', 200)
+      end
+
+      it 'supports session dslogon urs' do
+        expect(subject).to validate(:get, '/sessions/dslogon/new', 200)
+      end
+
+      it 'supports session idme url' do
+        expect(subject).to validate(:get, '/sessions/idme/new', 200)
+      end
+
+      it 'supports session mfa url' do
+        expect(subject).to validate(:get, '/sessions/mfa/new', 200, auth_options)
+        expect(subject).to validate(:get, '/sessions/mfa/new', 401)
+      end
+
+      it 'supports session verify url' do
+        expect(subject).to validate(:get, '/sessions/verify/new', 200, auth_options)
+        expect(subject).to validate(:get, '/sessions/verify/new', 401)
+      end
+
+      it 'supports session slo url' do
+        expect(subject).to validate(:get, '/sessions/slo/new', 200, auth_options)
+        expect(subject).to validate(:get, '/sessions/slo/new', 401)
+      end
+    end
+
     it 'supports getting backend service status' do
       expect(subject).to validate(:get, '/v0/backend_statuses/{service}', 200, auth_options.merge('service' => 'gibs'))
-    end
-
-    it 'supports fetching authentication urls' do
-      expect(subject).to validate(:get, '/v0/sessions/authn_urls', 200)
-    end
-
-    it 'supports invoking multifactor policy' do
-      expect(subject).to validate(:get, '/v0/sessions/multifactor', 200, auth_options)
-      expect(subject).to validate(:get, '/v0/sessions/multifactor', 401)
-    end
-
-    it 'supports fetching identity verification url' do
-      expect(subject).to validate(:get, '/v0/sessions/identity_proof', 200, auth_options)
-      expect(subject).to validate(:get, '/v0/sessions/identity_proof', 401)
-    end
-
-    it 'supports session deletion' do
-      expect(subject).to validate(:delete, '/v0/sessions', 202, auth_options)
-      expect(subject).to validate(:delete, '/v0/sessions', 401)
     end
 
     it 'supports listing in-progress forms' do


### PR DESCRIPTION
Fixes: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12540

## Description of change
This is part of a larger effort in #2271 

- [x] Removes deprecated routes in sessions controller
- [x] Removes all cookie logic, this will make replacing the devops rules with the new ones easier. See also: https://github.com/department-of-veterans-affairs/vets-api/pull/2271
- [x] Updates the Swagger documentation for only the endpoints that need documentation.
- [x] sessions/slo/new no longer points to ID.me, instead it points to an intermediary vets-api endpoint called logout.
1. FE will `GET sessions/slo/new` (this endpoint still requires auth, which is how we know the session) it returns a URL to `GET sessions/logout?session=base64urlencodedtoken`. This url gets loaded in the popup by the FE once the signout button is clicked. 
2. The call to `sessions/logout` will destroy the session on vets-api side first before it automatically redirects through to the ID.me SLO flow. This endpoint does not require auth, hence why the base64urlencoded token needs to be passed to it.
3. Logging out and terminating the session no longer depends on the callback to return to destroy the user's session on vets-api side. Everything on the FE should work exactly the same as before.

## Testing done
Specs are passing. Tested Locally. Need to verify on staging.

## Testing planned
We're going to need to do a full manual regression on staging and dev-preview.

## Acceptance Criteria (Definition of Done)
Testing on staging should satisfy everything.

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)