### PR TITLE
[ON HOLD] Set `emis.mock = true` so prefill works locally

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -177,7 +177,7 @@ mvi:
 # The certs used here can be obtained from the DevOps team. A different set is required for
 # each environment when connecting to the service.
 emis:
-  mock: false
+  mock: true
   host: https://vaausvrsapp81.aac.va.gov
   veteran_status_url: /VIERSService/eMIS/v1/VeteranStatusService
   payment_url: /VIERSService/eMIS/v1/PaymentService


### PR DESCRIPTION
**NOTE:** [This corresponding PR](https://github.com/department-of-veterans-affairs/devops/pull/3284) in the `devops` repo should be merged first!


## Description of change
Flipping the `emis.mock` flag to `true` so that prefill works when testing locally.

## Testing done
Specs passed locally

## Testing planned

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
