### PR TITLE
update 526 pif in use error title

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -1525,7 +1525,7 @@ en:
         status: 409
       pif_in_use:
         <<: *defaults
-        title: Conflict
+        title: PIF in use
         detail: 'Claim could not be established. Contact the BDN team and have them run the WIPP process to delete Cancelled/Cleared PIFs'
         code: 127
         status: 409


### PR DESCRIPTION
## Description of change
Updates the PIF in use error title so it's more descriptive in prometheus/grafana.

## Testing done
N/A

## Testing planned
staging metric check

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] updates PIF error title

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
