### PR TITLE
Transform school address from 3 lines to 2 lines for SF submission.

### DIFF
--- a/app/models/gi_bill_feedback.rb
+++ b/app/models/gi_bill_feedback.rb
@@ -31,22 +31,6 @@ class GIBillFeedback < Common::RedisStore
     @parsed_response ||= JSON.parse(response)
   end
 
-  def get_school_details(facility_code)
-    attributes = GI::Client.new.get_institution_details(id: facility_code)[:data][:attributes]
-
-    {
-      'name' => attributes[:name],
-      'address' => {
-        'street' => [attributes[:address_1], attributes[:address_2]].compact.join(' '),
-        'street2' => attributes[:address_3],
-        'city' => attributes[:city],
-        'postal_code' => attributes[:zip],
-        'state' => attributes[:state],
-        'country' => attributes[:country]
-      }
-    }
-  end
-
   def get_user_details
     profile_data = {}
 
@@ -75,9 +59,7 @@ class GIBillFeedback < Common::RedisStore
     transformed.merge!(get_user_details)
 
     transformed['education_details'].tap do |education_details|
-      next if education_details.blank?
-      facility_code = education_details.delete('facility_code')
-      education_details['school'] = get_school_details(facility_code) if facility_code.present?
+      transform_school_address(education_details['school']['address'])
       %w[programs assistance].each do |key|
         education_details[key] = transform_keys_into_array(parsed_form['educationDetails'][key])
       end
@@ -85,7 +67,6 @@ class GIBillFeedback < Common::RedisStore
 
     transformed['issue'] = transform_keys_into_array(transformed['issue'])
     transformed['email'] = transformed.delete('anonymous_email') || transformed.delete('applicant_email')
-
     transformed
   end
 
@@ -99,6 +80,12 @@ class GIBillFeedback < Common::RedisStore
   end
 
   private
+
+  def transform_school_address(address)
+    return if address['street3'].blank?
+    address['street'] = [address['street'], address['street2']].compact.join(', ')
+    address['street2'] = address.delete('street3')
+  end
 
   def anonymous?
     parsed_form['onBehalfOf'] == 'Anonymous'

--- a/spec/factories/gi_bill_feedback.rb
+++ b/spec/factories/gi_bill_feedback.rb
@@ -30,9 +30,17 @@ FactoryBot.define do
         onBehalfOf: 'Myself',
         educationDetails: {
           school: {
-            name: 'school'
+            name: 'UNIVERSITY OF LOUISVILLE',
+            address: {
+              country: 'United States',
+              street: 'Office of Military and Veteran',
+              street2: 'Student Records',
+              street3: 'street 3',
+              city: 'LOUISVILLE',
+              state: 'KY',
+              postalCode: '40292'
+            }
           },
-          facilityCode: '20606313',
           programs: {
             'MGIB-AD Ch 30': true
           },

--- a/spec/fixtures/gibft/transform_form.json
+++ b/spec/fixtures/gibft/transform_form.json
@@ -18,14 +18,14 @@
   "on_behalf_of": "Myself",
   "education_details": {
     "school": {
-      "name": "ZURICH NORTH AMERICA",
+      "name": "UNIVERSITY OF LOUISVILLE",
       "address": {
-        "street": "1400 AMERICAN LN",
-        "street2": null,
-        "city": "SCHAUMBURG",
-        "postal_code": "60196",
-        "state": "IL",
-        "country": "USA"
+        "country": "United States",
+        "street": "Office of Military and Veteran, Student Records",
+        "street2": "street 3",
+        "city": "LOUISVILLE",
+        "state": "KY",
+        "postal_code": "40292"
       }
     },
     "programs": [


### PR DESCRIPTION
## Description of change
GIBFT will not send school `facility_code`.  Transform school address from 3 lines to 2 lines for SF submission.

## Testing done
specs

## Testing planned
manual testing locally/dev/staging

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] remove school lookup via `facility_code`
- [x] condense school address to 2 lines if 3 lines are popluated

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
