### PR TITLE
13353 Builds class to deliver page load metrics to StatsD

### DIFF
--- a/lib/benchmark/performance.rb
+++ b/lib/benchmark/performance.rb
@@ -3,7 +3,7 @@
 module Benchmark
   class Performance
     FE = 'frontend'
-    PAGE_LOAD = 'page_load'
+    PAGE_PERFORMANCE = 'page_performance'
 
     # Calls StatsD.measure with the passed benchmarking data.
     #
@@ -17,14 +17,16 @@ module Benchmark
       StatsD.measure(key, duration, tags: tags)
     end
 
-    # Calls StatsD.measure with frontend page load data.
+    # Calls StatsD.measure with benchmark data for the passed page and metric.
     #
+    # @param metric [String] Creates a namespace/bucket for what is being
+    #   measured.  For example, 'initial_pageload', 'dom_loaded', etc.
     # @param duration [Float] Duration of benchmark measurement in milliseconds
     # @param page_id [String] A unique identifier for the FE page being benchmarked
     # @return [StatsD::Instrument::Metric] The metric that was sent to StatsD
     #
-    def self.page_load(duration, page_id)
-      stats_d_key = "#{FE}.#{PAGE_LOAD}"
+    def self.by_page_and_metric(metric, duration, page_id)
+      stats_d_key = "#{FE}.#{PAGE_PERFORMANCE}.#{metric}"
 
       track(stats_d_key, duration, tags: [page_id])
     end

--- a/lib/benchmark/performance.rb
+++ b/lib/benchmark/performance.rb
@@ -10,7 +10,9 @@ module Benchmark
     #
     # @param key [String] A StatsD key. See https://github.com/Shopify/statsd-instrument#statsd-keys
     # @param duration [Float] Duration of benchmark measurement in milliseconds
-    # @param tags [Array<String>] An array of string tag names
+    # @param tags [Array<String>] An array of string tag names. Tags must be in the key:value
+    #   format in the string.  For example:
+    #   ['page_id:initial_pageload', 'page_id:dom_loaded']
     # @return [StatsD::Instrument::Metric] The metric that was sent to StatsD
     # @see https://github.com/Shopify/statsd-instrument#statsdmeasure
     #
@@ -34,7 +36,7 @@ module Benchmark
       check_for_metric! metric
 
       stats_d_key = "#{FE}.#{PAGE_PERFORMANCE}.#{metric}"
-      track(stats_d_key, duration, tags: [page_id])
+      track(stats_d_key, duration, tags: ["page_id:#{page_id}"])
     end
 
     # Calls StatsD.measure for a given page, for a given set of metrics and durations.

--- a/lib/benchmark/performance.rb
+++ b/lib/benchmark/performance.rb
@@ -22,6 +22,8 @@ module Benchmark
 
     # Calls StatsD.measure with benchmark data for the passed page and metric.
     #
+    # Checks for presence of 'metric'. Delegates check for duration to StatsD.
+    #
     # @param metric [String] Creates a namespace/bucket for what is being
     #   measured.  For example, 'initial_pageload', 'dom_loaded', etc.
     # @param duration [Float] Duration of benchmark measurement in milliseconds
@@ -29,9 +31,22 @@ module Benchmark
     # @return [StatsD::Instrument::Metric] The metric that was sent to StatsD
     #
     def self.by_page_and_metric(metric, duration, page_id)
-      stats_d_key = "#{FE}.#{PAGE_PERFORMANCE}.#{metric}"
+      check_for_metric! metric
 
+      stats_d_key = "#{FE}.#{PAGE_PERFORMANCE}.#{metric}"
       track(stats_d_key, duration, tags: [page_id])
+    end
+    class << self
+      private
+
+      def check_for_metric!(metric)
+        if metric.blank?
+          raise Common::Exceptions::ParameterMissing.new(
+            'Missing parameter',
+            detail: 'A value for metric is required.'
+          )
+        end
+      end
     end
   end
 end

--- a/lib/benchmark/performance.rb
+++ b/lib/benchmark/performance.rb
@@ -15,6 +15,8 @@ module Benchmark
     #
     def self.track(key, duration, tags:)
       StatsD.measure(key, duration, tags: tags)
+    rescue ArgumentError => error
+      raise Common::Exceptions::ParameterMissing.new('Missing parameter', detail: error&.message)
     end
 
     # Calls StatsD.measure with benchmark data for the passed page and metric.

--- a/lib/benchmark/performance.rb
+++ b/lib/benchmark/performance.rb
@@ -17,6 +17,7 @@ module Benchmark
     # @see https://github.com/Shopify/statsd-instrument#statsdmeasure
     #
     def self.track(key, duration, tags:)
+      Whitelist.new(tags).authorize!
       StatsD.measure(key, duration, tags: tags)
     rescue ArgumentError => error
       raise Common::Exceptions::ParameterMissing.new('Missing parameter', detail: error&.message)

--- a/lib/benchmark/performance.rb
+++ b/lib/benchmark/performance.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Benchmark
+  class Performance
+    FE = 'frontend'
+    PAGE_LOAD = 'page_load'
+
+    # Calls StatsD.measure with the passed benchmarking data.
+    #
+    # @param key [String] A StatsD key. See https://github.com/Shopify/statsd-instrument#statsd-keys
+    # @param duration [Float] Duration of benchmark measurement in milliseconds
+    # @param tags [Array<String>] An array of string tag names
+    # @return [StatsD::Instrument::Metric] The metric that was sent to StatsD
+    # @see https://github.com/Shopify/statsd-instrument#statsdmeasure
+    #
+    def self.track(key, duration, tags:)
+      StatsD.measure(key, duration, tags: tags)
+    end
+
+    # Calls StatsD.measure with frontend page load data.
+    #
+    # @param duration [Float] Duration of benchmark measurement in milliseconds
+    # @param page_id [String] A unique identifier for the FE page being benchmarked
+    # @return [StatsD::Instrument::Metric] The metric that was sent to StatsD
+    #
+    def self.page_load(duration, page_id)
+      stats_d_key = "#{FE}.#{PAGE_LOAD}"
+
+      track(stats_d_key, duration, tags: [page_id])
+    end
+  end
+end

--- a/lib/benchmark/performance.rb
+++ b/lib/benchmark/performance.rb
@@ -8,6 +8,8 @@ module Benchmark
     # Calls StatsD.measure with the passed benchmarking data. StatsD.measure lets
     # you benchmark how long the execution of a specific task/method takes.
     #
+    # The StatsD gem will raise ArgumentErrors if the correct params are not supplied.
+    #
     # @param key [String] A StatsD key. See https://github.com/Shopify/statsd-instrument#statsd-keys
     # @param duration [Float] Duration of benchmark measurement in milliseconds
     # @param tags [Array<String>] An array of string tag names. Tags must be in the key:value

--- a/lib/benchmark/performance.rb
+++ b/lib/benchmark/performance.rb
@@ -36,6 +36,24 @@ module Benchmark
       stats_d_key = "#{FE}.#{PAGE_PERFORMANCE}.#{metric}"
       track(stats_d_key, duration, tags: [page_id])
     end
+
+    # Calls StatsD.measure for a given page, for a given set of metrics and durations.
+    #
+    # @param page_id [String] A unique identifier for the FE page being benchmarked
+    # @param metrics_data [Array<Hash>] An array of hash metric data.  Hash must
+    #   have two keys: 'metric' and 'duration'. For example:
+    #   [
+    #     { "metric": "initial_page_load", "duration": 1234.56 }
+    #     { "metric": "time_to_paint", "duration": 123.45 }
+    #   ]
+    # @return [Array<StatsD::Instrument::Metric>] An array of metrics that were sent to StatsD
+    #
+    def self.metrics_for_page(page_id, metrics_data)
+      metrics_data.map do |metrics|
+        by_page_and_metric(metrics['metric'], metrics['duration'], page_id)
+      end
+    end
+
     class << self
       private
 

--- a/lib/benchmark/performance.rb
+++ b/lib/benchmark/performance.rb
@@ -5,7 +5,8 @@ module Benchmark
     FE = 'frontend'
     PAGE_PERFORMANCE = 'page_performance'
 
-    # Calls StatsD.measure with the passed benchmarking data.
+    # Calls StatsD.measure with the passed benchmarking data. StatsD.measure lets
+    # you benchmark how long the execution of a specific task/method takes.
     #
     # @param key [String] A StatsD key. See https://github.com/Shopify/statsd-instrument#statsd-keys
     # @param duration [Float] Duration of benchmark measurement in milliseconds

--- a/lib/benchmark/whitelist.rb
+++ b/lib/benchmark/whitelist.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Benchmark
+  class Whitelist
+    # This array of paths must remain identical to its sibling whitelist maintained
+    # in the department-of-veterans-affairs/vets-website repository at:
+    #   https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/monitoring/frontend-metrics/whitelisted-paths.js
+    #
+    # Any changes made must be made to both.
+    #
+    WHITELIST = ['/', '/disability', '/facilities', '/disability/how-to-file-claim'].freeze
+
+    attr_reader :tags
+
+    # @param tags [Array<String>] An array of string tag names. Tags must be in the key:value
+    #   format in the string.  For example:
+    #   ['page_id:/disability', 'page_id:/facilities']
+    #
+    def initialize(tags)
+      @tags = tags
+    end
+
+    # Ensures that the supplied tags are in the defined WHITELIST array.  If any tag
+    # is not on the WHITELIST, it raises a Common::Exceptions::Forbidden error.
+    #
+    # @return [Array<String>] The array of tags that initialized the class
+    # @return [Common::Exceptions::Forbidden] Raises error if a tag is not whitelisted
+    #
+    def authorize!
+      tags.each do |tag|
+        whitelisted? page_in(tag)
+      end
+    end
+
+    private
+
+    def page_in(tag)
+      tag.split(':').last
+    end
+
+    def whitelisted?(page)
+      unless WHITELIST.include?(page)
+        raise Common::Exceptions::Forbidden.new(
+          detail: "Page at #{page} is not whitelisted for performance monitoring.",
+          source: 'Benchmark::Performance'
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/benchmark/performance_spec.rb
+++ b/spec/lib/benchmark/performance_spec.rb
@@ -59,5 +59,16 @@ describe Benchmark::Performance do
         value: 100
       )
     end
+
+    context 'when "metric" attribute is missing' do
+      it 'raises a Common::Exceptions::ParameterMissing error', :aggregate_failures do
+        expect { Benchmark::Performance.by_page_and_metric(nil, 100, page_id) }.to raise_error do |error|
+          expect(error).to be_a Common::Exceptions::ParameterMissing
+          expect(error.message).to eq 'Missing parameter'
+          expect(error.status_code).to eq 400
+        end
+      end
+    end
+  end
   end
 end

--- a/spec/lib/benchmark/performance_spec.rb
+++ b/spec/lib/benchmark/performance_spec.rb
@@ -48,7 +48,7 @@ describe Benchmark::Performance do
         Benchmark::Performance.by_page_and_metric(metric, 100, page_id)
       end.to trigger_statsd_measure(
         stats_d_key,
-        tags: [page_id],
+        tags: ["page_id:#{page_id}"],
         times: 1,
         value: 100
       )
@@ -84,7 +84,7 @@ describe Benchmark::Performance do
         Benchmark::Performance.metrics_for_page(page_id, metrics_data)
       end.to trigger_statsd_measure(
         stats_d_key,
-        tags: [page_id],
+        tags: ["page_id:#{page_id}"],
         times: 1,
         value: 1234.56
       )

--- a/spec/lib/benchmark/performance_spec.rb
+++ b/spec/lib/benchmark/performance_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 describe Benchmark::Performance do
-  let(:stats_d_key) { "#{Benchmark::Performance::FE}.#{Benchmark::Performance::PAGE_LOAD}" }
+  let(:metric) { 'initial_pageload' }
+  let(:stats_d_key) { "#{Benchmark::Performance::FE}.#{Benchmark::Performance::PAGE_PERFORMANCE}.#{metric}" }
   let(:page_id) { 'some_unique_page_identifier' }
 
   describe '.track' do
@@ -19,10 +20,10 @@ describe Benchmark::Performance do
     end
   end
 
-  describe '.page_load' do
-    it 'calls StatsD.measure with frontend page load data' do
+  describe '.by_page_and_metric' do
+    it 'calls StatsD.measure with benchmark data for the passed page and metric.' do
       expect do
-        Benchmark::Performance.page_load(100, page_id)
+        Benchmark::Performance.by_page_and_metric(metric, 100, page_id)
       end.to trigger_statsd_measure(
         stats_d_key,
         tags: [page_id],

--- a/spec/lib/benchmark/performance_spec.rb
+++ b/spec/lib/benchmark/performance_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Benchmark::Performance do
+  let(:stats_d_key) { "#{Benchmark::Performance::FE}.#{Benchmark::Performance::PAGE_LOAD}" }
+  let(:page_id) { 'some_unique_page_identifier' }
+
+  describe '.track' do
+    it 'calls StatsD.measure with the passed benchmarking data' do
+      expect do
+        Benchmark::Performance.track(stats_d_key, 100, tags: [page_id])
+      end.to trigger_statsd_measure(
+        stats_d_key,
+        tags: [page_id],
+        times: 1,
+        value: 100
+      )
+    end
+  end
+
+  describe '.page_load' do
+    it 'calls StatsD.measure with frontend page load data' do
+      expect do
+        Benchmark::Performance.page_load(100, page_id)
+      end.to trigger_statsd_measure(
+        stats_d_key,
+        tags: [page_id],
+        times: 1,
+        value: 100
+      )
+    end
+  end
+end

--- a/spec/lib/benchmark/performance_spec.rb
+++ b/spec/lib/benchmark/performance_spec.rb
@@ -18,6 +18,34 @@ describe Benchmark::Performance do
         value: 100
       )
     end
+
+    context 'with an ArgumentError' do
+      context 'due to a StatsD key not being provided' do
+        it 'raises a Common::Exceptions::ParameterMissing error', :aggregate_failures do
+          expect { Benchmark::Performance.track(nil, 100, tags: [page_id]) }.to raise_error do |error|
+            error_detail = error.errors.first.detail
+
+            expect(error).to be_a Common::Exceptions::ParameterMissing
+            expect(error_detail).to eq 'Metric :name is required.'
+            expect(error.message).to eq 'Missing parameter'
+            expect(error.status_code).to eq 400
+          end
+        end
+      end
+
+      context 'due to a duration not being provided' do
+        it 'raises a Common::Exceptions::ParameterMissing error', :aggregate_failures do
+          expect { Benchmark::Performance.track(stats_d_key, nil, tags: [page_id]) }.to raise_error do |error|
+            error_detail = error.errors.first.detail
+
+            expect(error).to be_a Common::Exceptions::ParameterMissing
+            expect(error_detail).to eq 'A value is required for metric type :ms.'
+            expect(error.message).to eq 'Missing parameter'
+            expect(error.status_code).to eq 400
+          end
+        end
+      end
+    end
   end
 
   describe '.by_page_and_metric' do

--- a/spec/lib/benchmark/whitelist_spec.rb
+++ b/spec/lib/benchmark/whitelist_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Benchmark::Whitelist do
+  describe '.authorize!' do
+    context 'with tags that are whitelisted' do
+      let(:whitelisted_paths) { Benchmark::Whitelist::WHITELIST }
+
+      it 'returns the array of passed tags' do
+        results = Benchmark::Whitelist.new(whitelisted_paths).authorize!
+
+        expect(results).to eq whitelisted_paths
+      end
+    end
+
+    context 'with a tag that is not whitelisted' do
+      let(:bad_tag) { ['some_random_tag'] }
+
+      it 'raises a Common::Exceptions::Forbidden error', :aggregate_failures do
+        expect { Benchmark::Whitelist.new(bad_tag).authorize! }.to raise_error do |error|
+          expect(error).to be_a Common::Exceptions::Forbidden
+          expect(error.message).to eq 'Forbidden'
+          expect(error.status_code).to eq 403
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
As part of the work being done for the [performance monitoring](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13291), we need a way for the FE to pass page load times to the BE, and have those times sent to prometheus for analysis.

## Testing done
<!-- Please describe testing done to verify the changes. -->
Created automated test coverage.

## Testing planned
<!-- Please describe testing planned. -->
Will exercise this logic through a new endpoint.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] A common class/method that can be called for triggering the StatsD call, that can be repurposed in the future
- [x] Whitelist pages being measured
- [ ] Handoff to the DevOps team to creating the dashboard(s) in prometheus/grafana 

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
