### PR TITLE
add rake task

### DIFF
--- a/rakelib/import_disability_contentions.rake
+++ b/rakelib/import_disability_contentions.rake
@@ -1,0 +1,8 @@
+desc 'imports conditions into disability_contentions table'
+task :import_conditions, [:csv_path] => [:environment] do |_, args|
+  raise 'No CSV path provided' unless args[:csv_path]
+  CSV.foreach(args[:csv_path], headers: true) do |row|
+    condition = DisabilityContention.find_or_create_by(code: row['code'])
+    condition.update_attributes!(medical_term: row['medical_term'], lay_term: row['lay_term'])
+  end
+end

--- a/rakelib/import_disability_contentions.rake
+++ b/rakelib/import_disability_contentions.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc 'imports conditions into disability_contentions table'
 task :import_conditions, [:csv_path] => [:environment] do |_, args|
   raise 'No CSV path provided' unless args[:csv_path]


### PR DESCRIPTION
## Description of change
Add a rake task that takes a CSV and creates or updates DisabilityContention records for each line of the CSV.

## Testing done
Tested the rake task locally

## Testing planned
Test the rake task in staging

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] rake task exists to import conditions

#### Applies to all PRs

- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)