### PR TITLE
Add Processing Success and Processing Error status handling

### DIFF
--- a/modules/vba_documents/spec/models/upload_submission_spec.rb
+++ b/modules/vba_documents/spec/models/upload_submission_spec.rb
@@ -30,9 +30,21 @@ describe VBADocuments::UploadSubmission, type: :model do
         "errorMessage": '',
         "lastUpdated": '2018-04-25 00:02:39' }]].to_json
   end
+  let(:processing_success_body) do
+    [[{ "uuid": 'ignored',
+        "status": 'Processing Success',
+        "errorMessage": '',
+        "lastUpdated": '2018-04-25 00:02:39' }]].to_json
+  end
   let(:error_body) do
     [[{ "uuid": 'ignored',
         "status": 'Error',
+        "errorMessage": 'Invalid splines',
+        "lastUpdated": '2018-04-25 00:02:39' }]].to_json
+  end
+  let(:processing_error_body) do
+    [[{ "uuid": 'ignored',
+        "status": 'Processing Error',
         "errorMessage": 'Invalid splines',
         "lastUpdated": '2018-04-25 00:02:39' }]].to_json
   end
@@ -81,6 +93,15 @@ describe VBADocuments::UploadSubmission, type: :model do
       expect(updated.status).to eq('processing')
     end
 
+    it 'updates processing success status from downstream' do
+      expect(client_stub).to receive(:status).and_return(faraday_response)
+      expect(faraday_response).to receive(:success?).and_return(true)
+      expect(faraday_response).to receive(:body).at_least(:once).and_return(processing_success_body)
+      upload_received.refresh_status!
+      updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
+      expect(updated.status).to eq('processing')
+    end
+
     it 'updates success status from downstream' do
       expect(client_stub).to receive(:status).and_return(faraday_response)
       expect(faraday_response).to receive(:success?).and_return(true)
@@ -93,7 +114,29 @@ describe VBADocuments::UploadSubmission, type: :model do
     it 'updates error status from downstream' do
       expect(client_stub).to receive(:status).and_return(faraday_response)
       expect(faraday_response).to receive(:success?).and_return(true)
+      expect(faraday_response).to receive(:body).at_least(:once).and_return(processing_error_body)
+      upload_received.refresh_status!
+      updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
+      expect(updated.status).to eq('error')
+      expect(updated.code).to eq('DOC202')
+      expect(updated.detail).to include('Invalid splines')
+    end
+
+    it 'updates processing error status from downstream' do
+      expect(client_stub).to receive(:status).and_return(faraday_response)
+      expect(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(error_body)
+      upload_received.refresh_status!
+      updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
+      expect(updated.status).to eq('error')
+      expect(updated.code).to eq('DOC202')
+      expect(updated.detail).to include('Invalid splines')
+    end
+
+    it 'updates error status from downstream' do
+      expect(client_stub).to receive(:status).and_return(faraday_response)
+      expect(faraday_response).to receive(:success?).and_return(true)
+      expect(faraday_response).to receive(:body).at_least(:once).and_return(processing_error_body)
       upload_received.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
       expect(updated.status).to eq('error')


### PR DESCRIPTION
## Description of change

Resolves department-of-veterans-affairs/vets-contrib#234

Aliases Processing Success to 'processing' to avoid breaking existing consumers

Aliases Processing Error directly to 'error' without adding additional error
codes since it is unclear what exactly is different about this status.

Also cleaned the `response_object.blank?` check. It's already happening in the
`::refresh_statuses!` class method and rubocop was complaining about
`#map_downstream_status` being too long, so I added it and the logging that
to the `#refresh_status!` method.

## Testing done
Added unit tests for new statuses

## Testing planned
Will need to test against Central Mail's staging environment to verify this works as intended

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Should test against Central Mail staging.

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
