### PR TITLE
Preneeds:  ensure <state> attribute is present in XML request

### DIFF
--- a/app/models/preneeds/address.rb
+++ b/app/models/preneeds/address.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'common/models/form'
-
 module Preneeds
   class Address < Preneeds::Base
     attribute :street, String
@@ -15,7 +13,7 @@ module Preneeds
     def as_eoas
       hash = {
         address1: street, address2: street2, city: city,
-        countryCode: country, postalZip: postal_code, state: state
+        countryCode: country, postalZip: postal_code, state: state || ''
       }
 
       hash.delete(:address2) if hash[:address2].blank?

--- a/app/models/preneeds/base.rb
+++ b/app/models/preneeds/base.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'common/models/form'
-
 module Preneeds
   class Base
     extend ActiveModel::Naming

--- a/app/models/preneeds/date_range.rb
+++ b/app/models/preneeds/date_range.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'common/models/form'
-
 module Preneeds
   class DateRange < Preneeds::Base
     attribute :from, String

--- a/spec/factories/preneeds/addresses.rb
+++ b/spec/factories/preneeds/addresses.rb
@@ -9,4 +9,12 @@ FactoryBot.define do
     country 'USA'
     postal_code '10000'
   end
+
+  factory :foreign_address, class: Preneeds::Address do
+    sequence(:street) { generate(:street) }
+    sequence(:street2) { generate(:street2) }
+    city 'somewhere'
+    country 'AZE'
+    postal_code '12323-98AF'
+  end
 end

--- a/spec/factories/preneeds/applicants.rb
+++ b/spec/factories/preneeds/applicants.rb
@@ -10,4 +10,8 @@ FactoryBot.define do
     name { attributes_for :full_name }
     mailing_address { attributes_for :address }
   end
+
+  factory :applicant_foreign_address, parent: :applicant do
+    mailing_address { attributes_for :foreign_address }
+  end
 end

--- a/spec/factories/preneeds/burial_forms.rb
+++ b/spec/factories/preneeds/burial_forms.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     veteran { attributes_for :veteran }
   end
 
-  factory :burial_form_foreign_address, parent: :burial_form  do
+  factory :burial_form_foreign_address, parent: :burial_form do
     applicant { attributes_for :applicant_foreign_address }
     claimant { attributes_for :claimant_foreign_address }
     veteran { attributes_for :veteran_foreign_address }

--- a/spec/factories/preneeds/burial_forms.rb
+++ b/spec/factories/preneeds/burial_forms.rb
@@ -16,4 +16,10 @@ FactoryBot.define do
     currently_buried_persons { [attributes_for(:currently_buried_person), attributes_for(:currently_buried_person)] }
     veteran { attributes_for :veteran }
   end
+
+  factory :burial_form_foreign_address, parent: :burial_form  do
+    applicant { attributes_for :applicant_foreign_address }
+    claimant { attributes_for :claimant_foreign_address }
+    veteran { attributes_for :veteran_foreign_address }
+  end
 end

--- a/spec/factories/preneeds/claimants.rb
+++ b/spec/factories/preneeds/claimants.rb
@@ -12,4 +12,8 @@ FactoryBot.define do
     name { attributes_for :full_name }
     address { attributes_for :address }
   end
+
+  factory :claimant_foreign_address, parent: :claimant do
+    address { attributes_for :foreign_address }
+  end
 end

--- a/spec/factories/preneeds/veterans.rb
+++ b/spec/factories/preneeds/veterans.rb
@@ -18,4 +18,8 @@ FactoryBot.define do
     address { attributes_for :address }
     service_records { [attributes_for(:service_record)] }
   end
+
+  factory :veteran_foreign_address, parent: :veteran do
+    address { attributes_for :foreign_address }
+  end
 end

--- a/spec/lib/preneeds/service_spec.rb
+++ b/spec/lib/preneeds/service_spec.rb
@@ -137,6 +137,20 @@ describe Preneeds::Service do
         expect(application).to be_a(Preneeds::ReceiveApplication)
       end
     end
+
+    context 'with foreign address' do
+      let(:burial_form_foreign_address) { build(:burial_form_foreign_address) }
+      it 'includes the <state> attribute in the request XML' do
+        client = Savon.client(wsdl: Settings.preneeds.wsdl)
+        soap = client.build_request(
+          :receive_pre_need_application,
+          message: {
+            pre_need_request: burial_form_foreign_address.as_eoas
+          }
+        )
+        expect(soap.body).to match(%r{<\/postalZip><state><\/state>})
+      end
+    end
   end
 
   describe 'build_multipart' do

--- a/spec/models/preneeds/address_spec.rb
+++ b/spec/models/preneeds/address_spec.rb
@@ -5,29 +5,38 @@ require 'rails_helper'
 RSpec.describe Preneeds::Address do
   subject { described_class.new(params) }
 
-  let(:params) { attributes_for :address }
+  context 'with US/CAN address' do
+    let(:params) { attributes_for :address }
 
-  it 'specifies the permitted_params' do
-    expect(described_class.permitted_params).to include(
-      :street, :street2, :city, :country, :postal_code, :state
-    )
-  end
-
-  describe 'when converting to eoas' do
-    it 'produces an ordered hash' do
-      expect(subject.as_eoas.keys).to eq(%i[address1 address2 city countryCode postalZip state])
+    it 'specifies the permitted_params' do
+      expect(described_class.permitted_params).to include(
+        :street, :street2, :city, :country, :postal_code, :state
+      )
     end
 
-    it 'removes address2 if blank' do
-      params[:street2] = ''
-      expect(subject.as_eoas.keys).not_to include(:address2)
+    describe 'when converting to eoas' do
+      it 'produces an ordered hash' do
+        expect(subject.as_eoas.keys).to eq(%i[address1 address2 city countryCode postalZip state])
+      end
+
+      it 'removes address2 if blank' do
+        params[:street2] = ''
+        expect(subject.as_eoas.keys).not_to include(:address2)
+      end
+    end
+
+    describe 'when converting to json' do
+      it 'converts its attributes from snakecase to camelcase' do
+        camelcased = params.deep_transform_keys { |key| key.to_s.camelize(:lower) }
+        expect(camelcased).to eq(subject.as_json)
+      end
     end
   end
 
-  describe 'when converting to json' do
-    it 'converts its attributes from snakecase to camelcase' do
-      camelcased = params.deep_transform_keys { |key| key.to_s.camelize(:lower) }
-      expect(camelcased).to eq(subject.as_json)
+  context 'with foreign address' do
+    let(:params) { attributes_for :foreign_address }
+    it 'treats nil state as empty string' do
+      expect(subject.as_eoas[:state]).to eq('')
     end
   end
 end


### PR DESCRIPTION
## Description of change
Preneeds:  ensure <state> attribute is present in XML request even wh

## Testing done
specs

## Testing planned
manual testing in dev/staging

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] When state is nil, have Preneeds::Address treat it as an empty string when calling `#as_eoas`

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
