### PR TITLE
fix 526 upload data keys

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/workers/evss/disability_compensation_form/submit_uploads.rb
@@ -24,12 +24,14 @@ module EVSS
 
       def perform(upload_data, claim_id, auth_headers)
         client = EVSS::DocumentsService.new(auth_headers)
-        file_body = SupportingEvidenceAttachment.find_by(guid: upload_data[:confirmationCode]).file_data
+        code = upload_data['confirmationCode']
+        file_body = SupportingEvidenceAttachment.find_by(guid: code)&.file_data
+        raise ArgumentError, "supporting evidence attachment with guid #{code} has no file data" if file_body.nil?
         document_data = EVSSClaimDocument.new(
           evss_claim_id: claim_id,
-          file_name: upload_data[:name],
+          file_name: upload_data['name'],
           tracked_item_id: nil,
-          document_type: upload_data[:attachmentId]
+          document_type: upload_data['attachmentId']
         )
         client.upload(file_body, document_data)
       end

--- a/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
     context 'when file_data is nil' do
       let(:attachment) { double(:attachment, file_data: nil) }
 
-      it 'calls the documents service api with file body and document data' do
+      it 'raises an ArgumentError' do
         expect do
           subject.new.perform(upload_data, claim_id, auth_headers)
         end.to raise_error(

--- a/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -48,28 +48,53 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
   describe 'perform' do
     let(:upload_data) do
       {
-        confirmationCode: 'foo',
-        name: 'bar',
-        attachmentId: 'foobar'
+        'name' => 'private_medical_record.pdf',
+        'confirmationCode' => 'd44d6f52-2e85-43d4-a5a3-1d9cb4e482a0',
+        'attachmentId' => 'L451'
       }
     end
     let(:client) { double(:client) }
-    let(:attachment) { double(:attachment, file_data: nil) }
     let(:document_data) { double(:document_data) }
 
-    it 'calls the documents service api with file body and document data' do
+    before(:each) do
       allow(EVSS::DocumentsService)
         .to receive(:new)
         .and_return(client)
       allow(SupportingEvidenceAttachment)
         .to receive(:find_by)
         .and_return(attachment)
-      allow(EVSSClaimDocument)
-        .to receive(:new)
-        .and_return(document_data)
+    end
 
-      expect(client).to receive(:upload).with(attachment.file_data, document_data)
-      subject.new.perform(upload_data, claim_id, auth_headers)
+    context 'when file_data exists' do
+      let(:attachment) { double(:attachment, file_data: '%PDF-1.3\n') }
+
+      it 'calls the documents service api with file body and document data' do
+        expect(EVSSClaimDocument)
+          .to receive(:new)
+          .with(
+            evss_claim_id: claim_id,
+            file_name: upload_data['name'],
+            tracked_item_id: nil,
+            document_type: upload_data['attachmentId']
+          )
+          .and_return(document_data)
+
+        expect(client).to receive(:upload).with(attachment.file_data, document_data)
+        subject.new.perform(upload_data, claim_id, auth_headers)
+      end
+    end
+
+    context 'when file_data is nil' do
+      let(:attachment) { double(:attachment, file_data: nil) }
+
+      it 'calls the documents service api with file body and document data' do
+        expect do
+          subject.new.perform(upload_data, claim_id, auth_headers)
+        end.to raise_error(
+          ArgumentError,
+          'supporting evidence attachment with guid d44d6f52-2e85-43d4-a5a3-1d9cb4e482a0 has no file data'
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
Noticed a 526 submit uploads job retrying because of a nil file body. Inspecting the job args revealed that the upload data has string rather than symbol based keys `{"name"=>"private_medical_record.pdf", "confirmationCode"=>"d44d6f52-2e85-43d4-a5a3-1d9cb4e482a0", "attachmentId"=>"L451"}`.

## Testing done
Unit tests

## Testing planned
Staging integration tests

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Updates upload data keys
- [ ] Raises an error on nil file data

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
