### PR TITLE
Use change matcher in account_spec

### DIFF
--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -19,16 +19,18 @@ RSpec.describe Account, type: :model do
 
       user = create(:user, :loa3)
 
-      Account.create_if_needed!(user)
-      expect(Account.count).to eq 1
+      expect do
+        Account.create_if_needed!(user)
+      end.to change { Account.count }.by(1)
     end
 
     it 'should not create a second Account' do
       user = create(:user, :accountable)
       expect(Account.count).to eq 1
 
-      Account.create_if_needed!(user)
-      expect(Account.count).to eq 1
+      expect do
+        Account.create_if_needed!(user)
+      end.not_to change { Account.count }
     end
   end
 


### PR DESCRIPTION
## Description of change
The existing specs in `spec/models/account_spec.rb` are checking for explicit `Account.count`, but should be using the change matcher to expect a change in count.


## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Replace expectations on lines [23 and 31](https://github.com/department-of-veterans-affairs/vets-api/blob/master/spec/models/account_spec.rb) to use [change matcher](https://relishapp.com/rspec/rspec-expectations/v/3-7/docs/built-in-matchers/change-matcher)

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] ~Provide link to originating GitHub issue, or connected to it via ZenHub~ ([Raised in discussion in slack](https://dsva.slack.com/archives/C0MQ281DJ/p1538424957000100))
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
