### PR TITLE
WIP - Implement cookie based authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,9 +22,9 @@ class ApplicationController < ActionController::API
   ].freeze
 
   before_action :authenticate
+  before_action :extend_session! # Don't skip this outside of sessions_controller. Required.
   before_action :set_app_info_headers
   before_action :set_tags_and_extra_context
-  before_action :extend_session! # don't skip this!
   skip_before_action :authenticate, only: %i[cors_preflight routing_error]
 
   def tag_rainbows

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -95,12 +95,8 @@ module V0
         StatsD.increment(STATSD_SSO_CALLBACK_KEY, tags: ['status:failure', "context:#{context_key}"])
         StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [@sso_service.failure_instrumentation_tag])
       end
-    rescue NoMethodError => e
-      Raven.extra_context(
-        base64_params_saml_response: Base64.encode64(params[:SAMLResponse].to_s),
-        message: e.message,
-        backtrace: e.backtrace
-      )
+    rescue NoMethodError
+      Raven.extra_context(base64_params_saml_response: Base64.encode64(params[:SAMLResponse].to_s))
       raise
     ensure
       StatsD.increment(STATSD_SSO_CALLBACK_TOTAL_KEY)

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -42,6 +42,7 @@ class Session < Common::RedisStore
   def cookie_data
     return nil if user.blank?
     {
+      'vagovToken' => token,
       'patientIcn' => user.icn,
       'mhvCorrelationId' => user.mhv_correlation_id,
       'expirationTime' => ttl_in_time.iso8601(0)

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -386,9 +386,9 @@ RSpec.describe V0::SessionsController, type: :controller do
         expect(JSON.parse(decrypter.decrypt(cookies['vagov_session_dev'])))
           .to eq(
             'vagovToken' => response.location.split('token=').last,
-             'patientIcn' => loa3_user.icn,
-             'mhvCorrelationId' => loa3_user.mhv_correlation_id,
-             'expirationTime' => expire_at.iso8601(0)
+            'patientIcn' => loa3_user.icn,
+            'mhvCorrelationId' => loa3_user.mhv_correlation_id,
+            'expirationTime' => expire_at.iso8601(0)
           )
       end
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe Session, type: :model do
 
       it '#cookie_data returns certain attribute for user object' do
         expect(subject.cookie_data)
-          .to eq('patientIcn' => '1000123456V123456',
+          .to eq('vagovToken' => subject.token,
+                 'patientIcn' => '1000123456V123456',
                  'mhvCorrelationId' => '12345678901',
                  'expirationTime' => expry_time.iso8601(0))
       end

--- a/spec/request/authentication_request_spec.rb
+++ b/spec/request/authentication_request_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Authentication', type: :request do
+  let(:user) { FactoryBot.create(:user, :loa3) }
+  let(:session) { Session.create(uuid: user.uuid, token: 'abracadabra') }
+  let(:authenticated_resource_path) { '/v0/prescriptions' }
+
+  describe 'cookie based authentication' do
+    let(:expiration_time) { 10 }
+    let(:expiration_time_json) { expiration_time.minutes.from_now }
+    let(:expiration_time_ttl) { expiration_time * 60 }
+    let(:session_token) { session.token }
+    let(:cookie_data) do
+      {
+        'vagovToken' => session_token,
+        'patientIcn' => user.icn,
+        'mhvCorrelationId' => user.mhv_correlation_id,
+        'expirationTime' => expiration_time_json.iso8601(0)
+      }
+    end
+
+    before(:each) do
+      # set the users session to expire 10 minutes from now
+      session.expire(expiration_time_ttl)
+      user.identity.expire(expiration_time_ttl)
+      user.expire(expiration_time_ttl)
+
+      cookies[Settings.sso.cookie_name] = encrypt(ActiveSupport::JSON.encode(cookie_data))
+      get authenticated_resource_path
+    end
+
+    context 'cookie based auth enabled' do
+      around(:each) do |example|
+        Settings.sso.cookie_enabled = true
+        example.run
+        Settings.sso.cookie_enabled = false
+      end
+
+      context 'with a valid cookie session' do
+        it 'gets to the resource controller' do
+          expect(response).to have_http_status(:forbidden)
+          expect(JSON.parse(response.body)['errors'].first['detail'])
+            .to eq('You do not have access to prescriptions')
+        end
+
+        it 'extends the session despite exception' do
+          expect(Session.find('abracadabra').ttl).to be > expiration_time_ttl
+        end
+      end
+
+      context 'with an expired cookie session' do
+        let(:expiration_time_json) { 1.minute.ago }
+
+        it 'does not get to the resource controller' do
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)['errors'].first['detail'])
+            .to eq('Not authorized')
+        end
+
+        it 'does not extend the session' do
+          expect(Session.find('abracadabra')).to be_nil
+        end
+      end
+
+      context 'with invalid session token' do
+        let(:session_token) { 'open-sessame' }
+
+        it 'does not get to the resource controller' do
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)['errors'].first['detail'])
+            .to eq('Not authorized')
+        end
+
+        it 'does not extend the session' do
+          expect(Session.find('abracadabra').ttl).to be <= expiration_time_ttl
+        end
+      end
+    end
+
+    context 'cookie based auth disabled' do
+      context 'with a valid cookie session' do
+        it 'does not get to the resource controller' do
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)['errors'].first['detail'])
+            .to eq('Not authorized')
+        end
+
+        it 'does not extend the session' do
+          expect(Session.find('abracadabra').ttl).to be <= expiration_time_ttl
+        end
+      end
+
+      context 'with an expired cookie session' do
+        let(:expiration_time_json) { 1.minute.ago }
+
+        it 'does not get to the resource controller' do
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)['errors'].first['detail'])
+            .to eq('Not authorized')
+        end
+
+        it 'does not extend the session' do
+          expect(Session.find('abracadabra')).to be_nil
+        end
+      end
+
+      context 'with invalid session token' do
+        let(:session_token) { 'open-sessame' }
+
+        it 'does not get to the resource controller' do
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)['errors'].first['detail'])
+            .to eq('Not authorized')
+        end
+
+        it 'does not extend the session' do
+          expect(Session.find('abracadabra').ttl).to be <= expiration_time_ttl
+        end
+      end
+    end
+  end
+
+  def encrypt(payload)
+    Aes256CbcEncryptor.new(Settings.sso.cookie_key, Settings.sso.cookie_iv).encrypt(payload)
+  end
+end


### PR DESCRIPTION
## Description of change
1. Adds vetsgovToken (session.token), to the SSO cookie attributes.
2. Introduces cookie based authentication on vets.gov, you can now sign in with cookie if it is set.
3. Extends session, even if no authentication headers are provided, assuming that cookie is properly set.

## Testing done
Very basic local testing.

## Testing planned
Need to add comprehensive specs testing both cookie and authorization header sign-in methods.
Need to do testing with various sign-in types on staging.vets.gov to ensure compatible with current production.
Need to do testing with various sign-in types on staging.va.gov to ensure that MHV will be satisfied with proposed changes.

## Acceptance Criteria (Definition of Done)
As long as comprehensive unit / integration testing passes this is good to merge, but should be rolled back if staging.vets.gov fails. Only merge this after a scheduled production deploy, and suspend production deploys until this has been verified.

#### Unique to this PR
There are no additional feature flag checks for this. If SSO cookie is enabled it will be used.

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
