### PR TITLE
12697 betamocks for search

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -371,3 +371,12 @@
   - :method: :get
     :path: "/WebParts/DEV/api/Appointments/1.0/json/ftpCRM/*"
     :file_path: "ihub/appointments/default"
+
+# Search
+- :name: 'Search'
+  :base_uri: <%= "#{URI(Settings.search.url).host}:#{URI(Settings.search.url).port}" %>
+  :endpoints:
+  # Search results
+  - :method: :get
+    :path: "/api/v2/search/i14y"
+    :file_path: "search/default"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -329,4 +329,5 @@ account:
 search:
   access_key: SEARCH_GOV_ACCESS_KEY
   affiliate: va
+  mock_search: true
   url: https://search.usa.gov/api/v2

--- a/lib/search/configuration.rb
+++ b/lib/search/configuration.rb
@@ -19,7 +19,7 @@ module Search
     end
 
     def mock_enabled?
-      false
+      Settings.search.mock_search || false
     end
 
     def base_path

--- a/lib/search/service.rb
+++ b/lib/search/service.rb
@@ -4,12 +4,12 @@ require 'common/client/base'
 require 'search/response'
 
 module Search
-  class Service < Common::Client::Base
     # This class builds a wrapper around Search.gov web results API. Creating a new instance of class
     # will and calling #results will return a ResultsResponse upon success or an exception upon failure.
     #
     # @see https://search.usa.gov/sites/7378/api_instructions
     #
+  class Service < Common::Client::Base
     include Common::Client::Monitoring
 
     STATSD_KEY_PREFIX = 'api.search'

--- a/lib/search/service.rb
+++ b/lib/search/service.rb
@@ -4,11 +4,11 @@ require 'common/client/base'
 require 'search/response'
 
 module Search
-    # This class builds a wrapper around Search.gov web results API. Creating a new instance of class
-    # will and calling #results will return a ResultsResponse upon success or an exception upon failure.
-    #
-    # @see https://search.usa.gov/sites/7378/api_instructions
-    #
+  # This class builds a wrapper around Search.gov web results API. Creating a new instance of class
+  # will and calling #results will return a ResultsResponse upon success or an exception upon failure.
+  #
+  # @see https://search.usa.gov/sites/7378/api_instructions
+  #
   class Service < Common::Client::Base
     include Common::Client::Monitoring
 


### PR DESCRIPTION
## Description of change
Per precedence for integrating a third party service, we will want to add betamocks support for the new Search.gov API implementation.

#### Sibling Vets-API-Mockdata PR
https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/52

#### Sibling DevOps PR

https://github.com/department-of-veterans-affairs/devops/pull/3381

## Testing done
<!-- Please describe testing done to verify the changes. -->

Tested locally by curling the endpoint in dev. 

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] In Vets-API repo, update the betamocks config with Search.gov details
- [x] In Vets-API repo, indicate that mocks are enabled (main, dev, and test config)

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
