### PR TITLE
 Snake_cases key before call to StatsD.measure

### DIFF
--- a/app/swagger/requests/performance_monitoring.rb
+++ b/app/swagger/requests/performance_monitoring.rb
@@ -24,7 +24,7 @@ module Swagger
             schema do
               property :data,
                        type: :string,
-                       example: '{\"page_id\":\"/\",\"metrics\":[{\"metric\":\"initial_page_load\",\"duration\":1234.56},{\"metric\":\"time_to_paint\",\"duration\":123.45}]}',
+                       example: '{\"page_id\":\"/\",\"metrics\":[{\"metric\":\"totalPageLoad\",\"duration\":1234.56},{\"metric\":\"firstContentfulPaint\",\"duration\":123.45}]}',
                        description: '
  A JSON string of metrics data.  The required structure is an object with two properties: page_id (string) and metrics (array).
 
@@ -37,11 +37,11 @@ module Swagger
     "page_id": "/disability",
     "metrics": [
       {
-        "metric": "initial_page_load",
+        "metric": "totalPageLoad",
         "duration": 1234.56
       },
       {
-        "metric": "time_to_paint",
+        "metric": "firstContentfulPaint",
         "duration": 123.45
       }
     ]
@@ -72,7 +72,7 @@ module Swagger
                       key :required, %i[metric duration]
                       property :metric,
                                type: :string,
-                               example: 'frontend.page_performance.initial_page_load',
+                               example: 'frontend.page_performance.total_page_load',
                                description: 'Creates a namespace/bucket for what is being measured.'
                       property :duration,
                                example: 100.1,

--- a/lib/benchmark/performance.rb
+++ b/lib/benchmark/performance.rb
@@ -10,6 +10,8 @@ module Benchmark
     #
     # The StatsD gem will raise ArgumentErrors if the correct params are not supplied.
     #
+    # Snake_cases the passed key for the call to StatsD.
+    #
     # @param key [String] A StatsD key. See https://github.com/Shopify/statsd-instrument#statsd-keys
     # @param duration [Float] Duration of benchmark measurement in milliseconds
     # @param tags [Array<String>] An array of string tag names. Tags must be in the key:value
@@ -20,7 +22,7 @@ module Benchmark
     #
     def self.track(key, duration, tags:)
       Whitelist.new(tags).authorize!
-      StatsD.measure(key, duration, tags: tags)
+      StatsD.measure(key&.underscore, duration, tags: tags)
     rescue ArgumentError => error
       raise Common::Exceptions::ParameterMissing.new('Missing parameter', detail: error&.message)
     end

--- a/spec/lib/benchmark/performance_spec.rb
+++ b/spec/lib/benchmark/performance_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 describe Benchmark::Performance do
-  let(:metric) { 'initial_page_load' }
+  let(:metric) { 'totalPageLoad' }
   let(:stats_d_key) { "#{Benchmark::Performance::FE}.#{Benchmark::Performance::PAGE_PERFORMANCE}.#{metric}" }
+  let(:snake_cased_key) { stats_d_key.underscore }
   let(:page_id) { Benchmark::Whitelist::WHITELIST.first }
 
   describe '.track' do
@@ -12,7 +13,7 @@ describe Benchmark::Performance do
       expect do
         Benchmark::Performance.track(stats_d_key, 100, tags: [page_id])
       end.to trigger_statsd_measure(
-        stats_d_key,
+        snake_cased_key,
         tags: [page_id],
         times: 1,
         value: 100
@@ -59,7 +60,7 @@ describe Benchmark::Performance do
       expect do
         Benchmark::Performance.by_page_and_metric(metric, 100, page_id)
       end.to trigger_statsd_measure(
-        stats_d_key,
+        snake_cased_key,
         tags: ["page_id:#{page_id}"],
         times: 1,
         value: 100
@@ -95,7 +96,7 @@ describe Benchmark::Performance do
       expect do
         Benchmark::Performance.metrics_for_page(page_id, metrics_data)
       end.to trigger_statsd_measure(
-        stats_d_key,
+        snake_cased_key,
         tags: ["page_id:#{page_id}"],
         times: 1,
         value: 1234.56

--- a/spec/request/performance_monitorings_request_spec.rb
+++ b/spec/request/performance_monitorings_request_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe 'PerformanceMonitorings', type: :request do
         data: {
           page_id: whitelisted_path,
           metrics: [
-            { metric: 'initial_page_load', duration: 1234.56 },
-            { metric: 'time_to_paint', duration: 123.45 }
+            { metric: 'totalPageLoad', duration: 1234.56 },
+            { metric: 'firstContentfulPaint', duration: 123.45 }
           ]
         }.to_json
       }
@@ -42,8 +42,8 @@ RSpec.describe 'PerformanceMonitorings', type: :request do
           data: {
             page_id: whitelisted_path,
             metrics: [
-              { metric: 'initial_page_load', duration: 1234.56 },
-              { metric: 'time_to_paint', duration: nil }
+              { metric: 'totalPageLoad', duration: 1234.56 },
+              { metric: 'firstContentfulPaint', duration: nil }
             ]
           }.to_json
         }
@@ -71,8 +71,8 @@ RSpec.describe 'PerformanceMonitorings', type: :request do
           data: {
             page_id: non_whitelisted_tag,
             metrics: [
-              { metric: 'initial_page_load', duration: 1234.56 },
-              { metric: 'time_to_paint', duration: 123.45 }
+              { metric: 'totalPageLoad', duration: 1234.56 },
+              { metric: 'firstContentfulPaint', duration: 123.45 }
             ]
           }.to_json
         }

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1263,8 +1263,8 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           data: {
             page_id: whitelisted_path,
             metrics: [
-              { metric: 'initial_page_load', duration: 1234.56 },
-              { metric: 'time_to_paint', duration: 123.45 }
+              { metric: 'totalPageLoad', duration: 1234.56 },
+              { metric: 'firstContentfulPaint', duration: 123.45 }
             ]
           }.to_json
         }


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

In FE PR https://github.com/department-of-veterans-affairs/vets-website/pull/8533 , the new performance monitoring endpoint is being called with camelCase values. 

StatsD prefers keys be snake_case.

## Testing done
<!-- Please describe testing done to verify the changes. -->

Automated testing.


## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Snake_cases any keys passed to the `performance.rb` class

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
