### PR TITLE
Update exhausted retries callback to properly pull the jid

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -15,7 +15,7 @@ module EVSS
 
       # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
       sidekiq_retries_exhausted do |msg, _ex|
-        transaction_class.update_transaction(jid, :exhausted)
+        transaction_class.update_transaction(msg['jid'], :exhausted)
         log_message_to_sentry(
           "Failed all retries on Form526 submit, last error: #{msg['error_message']}",
           :error

--- a/config/evss/all_claims_submission.json
+++ b/config/evss/all_claims_submission.json
@@ -1,5 +1,5 @@
 {
-    "form526AllClaims": {
+    "form526": {
         "attachments": [],
         "disabilities": [
             {

--- a/config/evss/all_claims_submission.json
+++ b/config/evss/all_claims_submission.json
@@ -1,5 +1,5 @@
 {
-    "form526": {
+    "form526AllClaims": {
         "attachments": [],
         "disabilities": [
             {


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
In the sidekiq exhausted callback block we were accessing the job id via `jid`. This var isnt available and, rather, needs to be accessed via the passed in args.

## Testing done
<!-- Please describe testing done to verify the changes. -->
Local testing via a testing job class.

## Testing planned
<!-- Please describe testing planned. -->
Staging job submissions.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Replace `jid` with `msg['jid']` in the job callback 

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
