### PR TITLE
Update whitelist for metrics with trailing slashes

### DIFF
--- a/app/swagger/requests/performance_monitoring.rb
+++ b/app/swagger/requests/performance_monitoring.rb
@@ -34,7 +34,7 @@ module Swagger
 
  For example
   {
-    "page_id": "/disability",
+    "page_id": "/disability/",
     "metrics": [
       {
         "metric": "totalPageLoad",
@@ -63,7 +63,7 @@ module Swagger
                   key :required, %i[page_id metrics]
                   property :page_id,
                            type: :string,
-                           example: '/disability',
+                           example: '/disability/',
                            description: 'A unique identifier for the frontend page being benchmarked'
                   property :metrics do
                     key :type, :array

--- a/lib/benchmark/whitelist.rb
+++ b/lib/benchmark/whitelist.rb
@@ -14,7 +14,7 @@ module Benchmark
 
     # @param tags [Array<String>] An array of string tag names. Tags must be in the key:value
     #   format in the string.  For example:
-    #   ['page_id:/disability', 'page_id:/facilities']
+    #   ['page_id:/disability/', 'page_id:/facilities/']
     #
     def initialize(tags)
       @tags = tags

--- a/lib/benchmark/whitelist.rb
+++ b/lib/benchmark/whitelist.rb
@@ -8,7 +8,7 @@ module Benchmark
     #
     # Any changes made must be made to both.
     #
-    WHITELIST = ['/', '/disability', '/facilities', '/disability/how-to-file-claim'].freeze
+    WHITELIST = ['/', '/disability/', '/facilities/', '/disability/how-to-file-claim/'].freeze
 
     attr_reader :tags
 


### PR DESCRIPTION
## Description of change
Update the whitelist to include trailing slashes for simplicity and accuracy. 

## Testing done
Manually tested FE metrics requests are accepted when they match the whitelist. 

# Testing planned
Will test in dev and staging va.gov that request data is being sent from each page. 

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
White list entries updated to include trailing slash. 

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
