### PR TITLE
update pii sanitizer and specs

### DIFF
--- a/lib/sentry/processor/pii_sanitizer.rb
+++ b/lib/sentry/processor/pii_sanitizer.rb
@@ -4,7 +4,23 @@ module Sentry
   module Processor
     class PIISanitizer < Raven::Processor
       SANITIZED_FIELDS = Set.new(
-        %w[city country gender phone postalCode zipCode fileNumber state street vaEauthPnid vaEauthBirthdate]
+        %w[
+          city
+          country
+          gender
+          phone
+          postalCode
+          zipCode
+          fileNumber
+          state
+          street
+          vaEauthPnid
+          vaEauthBirthdate
+          accountType
+          accountNumber
+          routingNumber
+          bankName
+        ]
       )
 
       JSON_STARTS_WITH = ['[', '{'].freeze

--- a/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
+++ b/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe Sentry::Processor::PIISanitizer do
           street: '1234 Street St.',
           state: 'NV'
         },
+        directDeposit: {
+          accountType: 'SAVINGS',
+          accountNumber: '6456456456456464',
+          routingNumber: '122239982',
+          bankName: 'PACIFIC PREMIER BANK'
+        },
         zipCode: '12345',
         fileNumber: '123456789',
         json: '{"phone": "5035551234", "postalCode": 97850}',
@@ -24,11 +30,7 @@ RSpec.describe Sentry::Processor::PIISanitizer do
         gender: 'M',
         phone: '5035551234',
         va_eauth_birthdate: '1945-02-13T00:00:00+00:00',
-        va_eauth_pnid: '796375555',
-        accountType: 'SAVINGS',
-        accountNumber: '6456456456456464',
-        routingNumber: '122239982',
-        bankName: 'PACIFIC PREMIER BANK'
+        va_eauth_pnid: '796375555'
       }
     end
 
@@ -44,28 +46,16 @@ RSpec.describe Sentry::Processor::PIISanitizer do
       result[:veteran_address].each_value { |v| expect(v).to eq('FILTERED') }
     end
 
+    it 'should filter direct deposit data' do
+      result[:directDeposit].each_value { |v| expect(v).to eq('FILTERED') }
+    end
+
     it 'should filter gender data' do
       expect(result[:gender]).to eq('FILTERED')
     end
 
     it 'should filter phone data' do
       expect(result[:phone]).to eq('FILTERED')
-    end
-
-    it 'should filter accountType' do
-      expect(result[:accountType]).to eq('FILTERED')
-    end
-
-    it 'should filter accountNumber' do
-      expect(result[:accountNumber]).to eq('FILTERED')
-    end
-
-    it 'should filter routingNumber' do
-      expect(result[:routingNumber]).to eq('FILTERED')
-    end
-
-    it 'should filter bankName' do
-      expect(result[:bankName]).to eq('FILTERED')
     end
 
     it 'should filter json blobs' do

--- a/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
+++ b/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
@@ -24,7 +24,11 @@ RSpec.describe Sentry::Processor::PIISanitizer do
         gender: 'M',
         phone: '5035551234',
         va_eauth_birthdate: '1945-02-13T00:00:00+00:00',
-        va_eauth_pnid: '796375555'
+        va_eauth_pnid: '796375555',
+        accountType: 'SAVINGS',
+        accountNumber: '6456456456456464',
+        routingNumber: '122239982',
+        bankName: 'PACIFIC PREMIER BANK'
       }
     end
 
@@ -46,6 +50,22 @@ RSpec.describe Sentry::Processor::PIISanitizer do
 
     it 'should filter phone data' do
       expect(result[:phone]).to eq('FILTERED')
+    end
+
+    it 'should filter accountType' do
+      expect(result[:accountType]).to eq('FILTERED')
+    end
+
+    it 'should filter accountNumber' do
+      expect(result[:accountNumber]).to eq('FILTERED')
+    end
+
+    it 'should filter routingNumber' do
+      expect(result[:routingNumber]).to eq('FILTERED')
+    end
+
+    it 'should filter bankName' do
+      expect(result[:bankName]).to eq('FILTERED')
     end
 
     it 'should filter json blobs' do


### PR DESCRIPTION
## Description of change
Add bank account data to the PII sanitizer to prevent bank account data from being logged in Sentry

## Testing done
local rspec tests

## Testing planned
Recreate error in staging and check that the Sentry error doesn't include bank account data

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Update PII sanitizer
- [x] Update specs

#### Applies to all PRs

- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
