### PR TITLE
Update API URLs to va.gov domains in documentation

### DIFF
--- a/modules/appeals_api/README.yml
+++ b/modules/appeals_api/README.yml
@@ -24,7 +24,7 @@ info:
     
     Allows a client to check benefit appeals status
 
-    1. Client Request: GET https://api.vets.gov/services/appeals/v0/appeals
+    1. Client Request: GET https://dev-api.va.gov/services/appeals/v0/appeals
         * Provide the Veteran's SSN as the X-VA-SSN header
         * Provide the VA username of the person requesting the appeals status as the X-VA-User header
     
@@ -32,7 +32,7 @@ info:
           
       ## Reference
 
-      Raw Open API Spec: http://dev-api.vets.gov/services/appeals/docs/v0/api
+      Raw Open API Spec: http://dev-api.va.gov/services/appeals/docs/v0/api
 
   termsOfService: ''
   contact:
@@ -41,8 +41,18 @@ tags:
   - name: appeals
     description: Caseflow appeals status API
 servers: 
-  - url: dev-api.vets.gov/services/appeals/{version}
-    description: Vets.gov API development environment
+  - url: dev-api.va.gov/services/appeals/{version}
+    description: VA.gov API development environment
+    variables:
+      version:
+        default: v0
+  - url: staging-api.va.gov/services/appeals/{version}
+    description: VA.gov API staging environment
+    variables:
+      version:
+        default: v0
+  - url: api.va.gov/services/appeals/{version}
+    description: VA.gov API production environment
     variables:
       version:
         default: v0

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -40,7 +40,7 @@ info:
 
     ## Reference
 
-    - [Raw VA Facilities Open API Spec](http://dev-api.vets.gov/services/va_facilities/docs/v0/api)
+    - [Raw VA Facilities Open API Spec](http://dev-api.va.gov/services/va_facilities/docs/v0/api)
     - [GeoJSON Format](https://tools.ietf.org/html/rfc7946)
     - [JSON API Format](http://jsonapi.org/format/)
 
@@ -50,9 +50,19 @@ info:
 tags:
   - name: facilities
     description: VA Facilities API
-servers: 
-  - url: https://dev-api.vets.gov/services/va_facilities/{version}
-    description: Vets.gov API development environment
+servers:
+  - url: dev-api.va.gov/services/appeals/{version}
+    description: VA.gov API development environment
+    variables:
+      version:
+        default: v0
+  - url: staging-api.va.gov/services/appeals/{version}
+    description: VA.gov API staging environment
+    variables:
+      version:
+        default: v0
+  - url: api.va.gov/services/appeals/{version}
+    description: VA.gov API production environment
     variables:
       version:
         default: v0
@@ -175,7 +185,7 @@ paths:
               description: GitHub-style pagination information. Only present for GeoJSON-format responses.
               schema:
                 type: string
-                example: '<https://dev-api.vets.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=2&per_page=20>; rel="self", <https://dev-api.vets.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="first", <https://dev-api.vets.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="prev", <https://dev-api.vets.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=3&per_page=20>; rel="next", <https://dev-api.vets.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=5&per_page=20>; rel="last"'
+                example: '<https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=2&per_page=20>; rel="self", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="first", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="prev", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=3&per_page=20>; rel="next", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=5&per_page=20>; rel="last"'
         '401':
           description: Missing API token
           content:

--- a/modules/vba_documents/README.yml
+++ b/modules/vba_documents/README.yml
@@ -24,7 +24,7 @@ info:
     
     Allows a client to upload a document package (form + attachments + metadata).
 
-    1. Client Request: POST https://api.vets.gov/services/vba_documents/v0/
+    1. Client Request: POST https://dev-api.va.gov/services/vba_documents/v0/
         * No request body or parameters required
     
     2. Service Response: A JSON API object with the following attributes:
@@ -48,21 +48,30 @@ info:
 
     ## Reference
 
-    Raw Open API Spec: http://dev-api.vets.gov/services/vba_documents/docs/v0/api
+    Raw Open API Spec: http://dev-api.va.gov/services/vba_documents/docs/v0/api
 
   termsOfService: ''
   contact:
-    name: Vets.gov
+    name: va.gov
 tags:
   - name: document_uploads
     description: VA Benefits document upload functionality
 servers: 
-  - url: dev-api.vets.gov/services/vba_benefits/{version}
-    description: Vets.gov API development environment
+  - url: dev-api.va.gov/services/appeals/{version}
+    description: VA.gov API development environment
     variables:
       version:
         default: v0
-
+  - url: staging-api.va.gov/services/appeals/{version}
+    description: VA.gov API staging environment
+    variables:
+      version:
+        default: v0
+  - url: api.va.gov/services/appeals/{version}
+    description: VA.gov API production environment
+    variables:
+      version:
+        default: v0
 paths:
   /uploads:
     post:
@@ -134,7 +143,11 @@ paths:
         "metadata", "content", "attachment1"..."attachmentN"
 
       servers:
-        - url: https://dev-api.vets.gov/services_user_content/vba_benefits/
+        - url: https://dev-api.va.gov/services_user_content/vba_benefits/
+          description: Override base path for all operations with the /files path
+        - url: https://staging-api.va.gov/services_user_content/vba_benefits/
+          description: Override base path for all operations with the /files path
+        - url: https://api.va.gov/services_user_content/vba_benefits/
           description: Override base path for all operations with the /files path
       parameters:
         - name: Content-MD5
@@ -407,7 +420,7 @@ components:
             location:
               type: string
               format: uri
-              example: https://dev-api.vets.gov/services_content/idpath
+              example: https://dev-api.va.gov/services_content/idpath
               description: Location to which to PUT document payload
     DocumentUploadStatusGuidList:
       required:

--- a/modules/veteran_verification/DISABILITY_RATING.yml
+++ b/modules/veteran_verification/DISABILITY_RATING.yml
@@ -21,14 +21,14 @@ info:
 
     Allows a third-party application to request a Veteran's disability rating with the authorization of the Veteran.
 
-    1. Client Request: GET https://api.vets.gov/services/veteran_verification/v0/diability_rating
+    1. Client Request: GET https://dev-api.va.gov/services/veteran_verification/v0/diability_rating
        *  Provide the Bearer token as a header: `Authorization: Bearer <token>`
 
     2. Service Response: A JSON API object with the Veteran's disability rating
 
     ## Reference
 
-    Raw Open API Spec: https://dev-api.vets.gov/services/appeals/docs/v0/api
+    Raw Open API Spec: https://dev-api.va.gov/services/appeals/docs/v0/api
 
   termsOfService: ''
   contact:
@@ -37,8 +37,18 @@ tags:
   - name: disability_rating
     description: Veteran Verification - Disability Rating
 servers:
-  - url: https://dev-api.vets.gov/services/veteran_verification/{version}
-    description: Vets.gov API development environment
+  - url: dev-api.va.gov/services/appeals/{version}
+    description: VA.gov API development environment
+    variables:
+      version:
+        default: v0
+  - url: staging-api.va.gov/services/appeals/{version}
+    description: VA.gov API staging environment
+    variables:
+      version:
+        default: v0
+  - url: api.va.gov/services/appeals/{version}
+    description: VA.gov API production environment
     variables:
       version:
         default: v0

--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -29,24 +29,34 @@ info:
     Allows a third-party application to request service history with the authorization
     of a Veteran.
 
-    1. Client Request: GET https://api.vets.gov/services/veteran_verification/v0/service_history
+    1. Client Request: GET https://dev-api.va.gov/services/veteran_verification/v0/service_history
        * Provide the Bearer token as a header: `Authorization: Bearer <token>`
 
     2. Service Response: A JSON API object with the Veteran's complete service history
 
     ## Reference
 
-    Raw Open API Spec: http://dev-api.vets.gov/services/appeals/docs/v0/api
+    Raw Open API Spec: http://dev-api.va.gov/services/appeals/docs/v0/api
 
   termsOfService: ''
   contact:
-    name: Vets.gov
+    name: va.gov
 tags:
   - name: service_history
     description: Veteran Verification - Service History
 servers:
-  - url: https://dev-api.vets.gov/services/veteran_verification/{version}
-    description: Vets.gov API development environment
+  - url: dev-api.va.gov/services/appeals/{version}
+    description: VA.gov API development environment
+    variables:
+      version:
+        default: v0
+  - url: staging-api.va.gov/services/appeals/{version}
+    description: VA.gov API staging environment
+    variables:
+      version:
+        default: v0
+  - url: api.va.gov/services/appeals/{version}
+    description: VA.gov API production environment
     variables:
       version:
         default: v0


### PR DESCRIPTION
## Description of change
Now that the api.va.gov URLs are working we'd prefer users to use them instead of vets.gov one. This updates our documentation to refer to those urls. 

Resolves department-of-veterans-affairs/vets-contrib#342

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
