### PR TITLE
only retry evss timeouts

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -40,7 +40,6 @@ module EVSS
         submit_4142(form4142, user_uuid, auth_headers, response.claim_id, saved_claim_id) if form4142
         success_handler(user_uuid, auth_headers, saved_claim_id, response, uploads)
       rescue EVSS::DisabilityCompensationForm::ServiceException => e
-        retryable_error_handler(e) if e.status_code.between?(500, 600)
         non_retryable_error_handler(e)
       rescue Common::Exceptions::GatewayTimeout => e
         gateway_timeout_handler(e)
@@ -77,12 +76,6 @@ module EVSS
         transaction_class.update_transaction(jid, :non_retryable_error, error.messages)
         log_exception_to_sentry(error, status: :non_retryable_error, jid: jid)
         metrics.increment_non_retryable(error)
-      end
-
-      def retryable_error_handler(error)
-        transaction_class.update_transaction(jid, :retrying, error.messages)
-        metrics.increment_retryable(error)
-        raise error
       end
 
       def gateway_timeout_handler(error)

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
@@ -108,11 +108,11 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526, type: :job do
     end
 
     context 'with a server error' do
-      it 'sets the transaction to "retrying"' do
+      it 'sets the transaction to "non_retryable_error"' do
         VCR.use_cassette('evss/disability_compensation_form/submit_500_with_err_msg') do
           subject.perform_async(user.uuid, auth_headers, claim.id, valid_form_content, nil, nil)
-          expect { described_class.drain }.to raise_error(EVSS::DisabilityCompensationForm::ServiceException)
-          expect(last_transaction.transaction_status).to eq 'retrying'
+          described_class.drain
+          expect(last_transaction.transaction_status).to eq 'non_retryable_error'
         end
       end
     end


### PR DESCRIPTION
## Description of change
We currently can't differentiate EVSS internal server errors vs evss sub-system timeouts. This change sets the job to retry only if EVSS itself is timing out.

## Testing done
Unit tests

## Testing planned
Local testing, Staging testing (once PPIU is back up)

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Sets all `EVSS::DisabilityCompensationForm::ServiceException`s to be non_retryable

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
