### PR TITLE
Update VA Facilities Docs and Error Handling

### DIFF
--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -78,6 +78,9 @@ paths:
         a requested `id`. Clients may supply ids up to the limit a their HTTP client enforces for
         URI path lengths -- usually 2,048 characters.
 
+        Either the ids parameter or the bbox parameter is *required* to query this API. Requests
+        without one or the other will return `400 Bad Request`.
+
         Results of this operation are paginated. JSON responses include pagination information
         in the standard JSON API "links" and "meta" elements. GeoJSON responses include pagination
         information in the "Link" header.

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -24,7 +24,7 @@ info:
     ### Response Formats
     
     Clients may request several response formats by setting the `Accept` header. 
-    - application/json - The default JSON response format complies with JSON API.
+    - application/json - The default JSON response format complies with JSON API. This media type is *not* available for bulk requests using the `/facilities/all` endpoint. It will return `406 Not Acceptable`. .
     - application/vnd.geo+json - GeoJSON-compliant format, representing each facility as a Feature with a Point geometry.
     - text/csv - Available for the bulk download operation only. Some structured fields are omitted from the CSV response.
           
@@ -269,6 +269,13 @@ paths:
       security:
         - api_key: []
       parameters:
+        in: header
+        name: Accept
+        schema:
+          enum:
+            - application/vnd.geo+json
+            - text/csv
+          required: true
       responses:
         '200':
           description: Success

--- a/modules/va_facilities/app/controllers/va_facilities/v0/facilities_controller.rb
+++ b/modules/va_facilities/app/controllers/va_facilities/v0/facilities_controller.rb
@@ -17,6 +17,7 @@ module VaFacilities
       before_action :validate_params, only: [:index]
 
       TYPE_SERVICE_ERR = 'Filtering by services is not allowed unless a facility type is specified'
+      BBOX_OR_ID_ERR = 'Must supply either a bbox or ids parameter to query facilities data.'
 
       def all
         resource = BaseFacility.where.not(facility_type: BaseFacility::DOD_HEALTH).order(:unique_id)
@@ -67,9 +68,16 @@ module VaFacilities
       private
 
       def validate_params
+        validate_bbox_or_ids
         validate_bbox
         validate_no_services_without_type
         validate_type_and_services_known unless params[:type].nil?
+      end
+
+      def validate_bbox_or_ids
+        unless params.key?(:bbox) || params.key?(:ids)
+          raise Common::Exceptions::ParameterMissing.new('bbox', detail: BBOX_OR_ID_ERR)
+        end
       end
 
       def validate_bbox

--- a/modules/va_facilities/spec/requests/facilities_request_spec.rb
+++ b/modules/va_facilities/spec/requests/facilities_request_spec.rb
@@ -239,6 +239,10 @@ RSpec.describe 'Facilities API endpoint', type: :request do
   end
 
   context 'with invalid request parameters' do
+    it 'returns 400 for missing bbox or ids' do
+      get base_query_path
+      expect(response).to have_http_status(:bad_request)
+    end
     it 'returns 400 for nonsense bbox' do
       get base_query_path + '?bbox[]=everywhere'
       expect(response).to have_http_status(:bad_request)


### PR DESCRIPTION
## Description of change
This updates the VA Facilities Docs to clarify handling of media types and required query parameters for the index routes. These resolve some user feedback we've gotten.

## Testing done
Added RSpec tests

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Should make it clear media types not explicitly accepted for `/facilities/all` return `406`
- [x] Should return `400 Bad Request` when neither `bbox` or `ids` are supplied on a `/facilities` query

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
