### PR TITLE
adding mhv_icn to the cookie for mhv sign-in users regardless of LOA

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -42,7 +42,7 @@ class Session < Common::RedisStore
   def cookie_data
     return nil if user.blank?
     {
-      'patientIcn' => user.icn,
+      'patientIcn' => user.mhv_icn || user.icn,
       'mhvCorrelationId' => user.mhv_correlation_id,
       'expirationTime' => ttl_in_time.iso8601(0)
     }

--- a/lib/mvi/configuration.rb
+++ b/lib/mvi/configuration.rb
@@ -48,6 +48,11 @@ module MVI
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options, ssl: ssl_options) do |conn|
         conn.request :soap_headers
+
+        # Uncomment this if you want curl command equivalent or response output to log
+        # conn.request(:curl, ::Logger.new(STDOUT), :warn) unless Rails.env.production?
+        # conn.response(:logger, ::Logger.new(STDOUT), bodies: true) unless Rails.env.production?
+
         conn.response :soap_parser
         conn.use :breakers
         conn.use :logging, 'MVIRequest' if Settings.mvi.pii_logging


### PR DESCRIPTION
## Description of change
MHV sign in users should pass the mhv icn into the cookie, regardless of whether or not we query MVI on our side or not. We might not be able to upgrade these users on vets.gov to "Premium" until they have successfully identity proofed, but we should still allow them the same level of access and set the cookie properly.

## Testing done
local testing only, need to test on staging.

## Testing planned
will test on staging.va.gov as soon as code is merged.

## Acceptance Criteria (Definition of Done)
Should be able to successfully pass back a cookie with ICN properly set for INTBADVANCE user.

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
