### PR TITLE
Add rake tasks for retrieveing job information

### DIFF
--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'pp'
+
+namespace :form526 do
+  desc 'Get all jobs within a date period. [<start date>,<end date>]'
+  task :jobs, %i[start_date end_date] => [:environment] do |_, args|
+    def print_row(created_at, updated_at, job_id, status)
+      printf "%-24s %-24s %-25s %s\n", created_at, updated_at, job_id, status
+    end
+
+    TRXS = AsyncTransaction::EVSS::VA526ezSubmitTransaction
+
+    start_date = args[:start_date] || 30.days.ago.utc.to_s
+    end_date = args[:end_date] || Time.zone.now.utc.to_s
+
+    print_row('created at:', 'updated at:', 'job id:', 'job status:')
+    TRXS.where('created_at BETWEEN ? AND ?', start_date, end_date)
+        .order(created_at: :desc)
+        .find_each do |job|
+      print_row(job.created_at, job.updated_at, job.transaction_id, job.transaction_status)
+    end
+  end
+
+  desc 'Get job details given a job id'
+  task :job, %i[job_id] => [:environment] do |_, args|
+    raise 'No job id provided' unless args[:job_id]
+
+    job = AsyncTransaction::EVSS::VA526ezSubmitTransaction.where(transaction_id: args[:job_id]).first
+
+    form = JSON.parse(job.saved_claim.form)
+    form['form526']['veteran'] = 'OMITTED'
+
+    puts '----------------------------------------'
+    puts 'Job Details:'
+    puts "user uuid: #{job.user_uuid}"
+    puts "source id: #{job.source_id}"
+    puts "source: #{job.source}"
+    puts "transaction status: #{job.transaction_status}"
+    puts "created at: #{job.created_at}"
+    puts "updated at: #{job.updated_at}"
+    puts '----------------------------------------'
+    puts 'Job Metadata:'
+    puts job.metadata
+    puts '----------------------------------------'
+    puts 'Form Data:'
+    puts JSON.pretty_generate(form)
+  end
+end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
To ease the workload on the devs/devops, we are adding in a couple rake tasks that allow the user to pull out jobs and their statuses and then look up job details via the job ids.

## Testing done
<!-- Please describe testing done to verify the changes. -->
Run locally with local data.

## Testing planned
<!-- Please describe testing planned. -->
Staging.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Rake tasks for retrieving jobs and job data

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
