### PR TITLE
use relative path to rubocop formatter

### DIFF
--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -8,7 +8,7 @@ task :lint do
   require 'rainbow'
 
   opts = if ENV['CI']
-           "-r $(bundle show rubocop-junit-formatter)/lib/rubocop/formatter/junit_formatter.rb \
+           "-r rubocop/formatter/junit_formatter.rb \
            --format RuboCop::Formatter::JUnitFormatter --out log/rubocop.xml \
            --format clang"
          else


### PR DESCRIPTION
## Description of change
Since the release of bundler to 1.6.6, we've been seeing a warning from Bundler on some platform locking issues. While we figure out how to address those, one of the issues that popped up was a failing lint task due to some shell hackiness. This switches to a relative include and seems to work without doing that at all.

## Testing done
Launch a shell in container like Jenkins would:

`make bash`

Then run the linter:

`CI=true bundle exec rake lint`

## Testing planned

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

ref: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14125