### PR TITLE
Updates Swagger docs for /search endpoint

### DIFF
--- a/app/swagger/requests/search.rb
+++ b/app/swagger/requests/search.rb
@@ -62,6 +62,7 @@ module Swagger
                       key :type, :array
                       key :description, 'Graphic best bets, which appear only when the query matches the text of the best bet’s title, description, or keywords.'
                       items do
+                        property :id, type: :integer
                         property :title, type: :string
                         property :title_url, type: :string
                         property :image_url, type: :string
@@ -70,7 +71,8 @@ module Swagger
                           key :type, :array
                           key :description, 'An array of links in the graphic best bet. Each link contains a title and a URL'
                           items do
-                            key :type, :string
+                            property :title, type: :string
+                            property :url, type: :string
                           end
                         end
                       end
@@ -85,14 +87,16 @@ module Swagger
                           key :type, :array
                           key :description, 'An array of topics related to the health topic. Each topic contains a title and a URL'
                           items do
-                            key :type, :string
+                            property :title, type: :string
+                            property :url, type: :string
                           end
                         end
                         property :related_sites do
                           key :type, :array
                           key :description, 'An array of sites related to the the health topic. Each site contains a title and a URL'
                           items do
-                            key :type, :string
+                            property :title, type: :string
+                            property :url, type: :string
                           end
                         end
                       end
@@ -103,11 +107,12 @@ module Swagger
                         property :position_title, type: :string
                         property :organization_name, type: :string
                         property :rate_interval_code, type: :string
-                        property :minimum, type: :string, description: 'Minimum salary of the job opening'
-                        property :maximum, type: :string, description: 'Maximum salary of the job opening'
+                        property :minimum, type: :integer, description: 'Minimum salary of the job opening'
+                        property :maximum, type: :integer, description: 'Maximum salary of the job opening'
                         property :start_date, type: :string
                         property :end_date, type: :string
                         property :url, type: :string
+                        property :org_codes, type: :string
                         property :locations do
                           key :type, :array
                           key :description, 'An array of locations of the job opening'
@@ -118,7 +123,8 @@ module Swagger
                         property :related_sites do
                           key :type, :array
                           items do
-                            key :type, :string
+                            property :title, type: :string
+                            property :url, type: :string
                           end
                         end
                       end
@@ -170,9 +176,9 @@ module Swagger
                             key :type, :string
                           end
                         end
-                        property :page_length, type: :string
-                        property :start_page, type: :string
-                        property :end_page, type: :string
+                        property :page_length, type: :integer
+                        property :start_page, type: :integer
+                        property :end_page, type: :integer
                         property :publication_date, type: :string
                         property :comments_close_date, type: :string
                       end


### PR DESCRIPTION
## Background

Search.gov's API docs prior some, but not all, details on their response to their search endpoint.  I contacted their support staff, and they sent me some updates on the response's structure.

## Definition of done

- [x] Updates the Vets-API swagger docs for the `/search` endpoint 