### PR TITLE
async metadata must be json or json compatible hash

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -92,7 +92,7 @@ module EVSS
       end
 
       def retryable_error_handler(error)
-        transaction_class.update_transaction(jid, :retrying, { error: error.message })
+        transaction_class.update_transaction(jid, :retrying, error: error.message)
         super(error)
         raise EVSS::DisabilityCompensationForm::GatewayTimeout, error.message
       end

--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -86,13 +86,13 @@ module EVSS
       end
 
       def non_retryable_error_handler(error)
-        message = error.try(:messages) || error.message
+        message = error.try(:messages) || { error: error.message }
         transaction_class.update_transaction(jid, :non_retryable_error, message)
         super(error)
       end
 
       def retryable_error_handler(error)
-        transaction_class.update_transaction(jid, :retrying, error.message)
+        transaction_class.update_transaction(jid, :retrying, { error: error.message })
         super(error)
         raise EVSS::DisabilityCompensationForm::GatewayTimeout, error.message
       end

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526, type: :job do
       it 'sets the transaction to "retrying"' do
         subject.perform_async(user.uuid, auth_headers, claim.id, submission)
         expect(AsyncTransaction::EVSS::VA526ezSubmitTransaction).to receive(:update_transaction).with(
-          anything, :retrying, { error: 'Gateway timeout' }
+          anything, :retrying, error: 'Gateway timeout'
         )
         expect_any_instance_of(EVSS::DisabilityCompensationForm::Metrics).to receive(:increment_retryable).once
         expect { described_class.drain }.to raise_error(EVSS::DisabilityCompensationForm::GatewayTimeout)
@@ -264,7 +264,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526, type: :job do
         expect_any_instance_of(described_class).to receive(:log_exception_to_sentry)
         subject.perform_async(user.uuid, auth_headers, claim.id, submission)
         expect(AsyncTransaction::EVSS::VA526ezSubmitTransaction).to receive(:update_transaction).with(
-          anything, :non_retryable_error, { error: 'foo' }
+          anything, :non_retryable_error, error: 'foo'
         )
         described_class.drain
       end

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526, type: :job do
       it 'sets the transaction to "retrying"' do
         subject.perform_async(user.uuid, auth_headers, claim.id, submission)
         expect(AsyncTransaction::EVSS::VA526ezSubmitTransaction).to receive(:update_transaction).with(
-          anything, :retrying, 'Gateway timeout'
+          anything, :retrying, { error: 'Gateway timeout' }
         )
         expect_any_instance_of(EVSS::DisabilityCompensationForm::Metrics).to receive(:increment_retryable).once
         expect { described_class.drain }.to raise_error(EVSS::DisabilityCompensationForm::GatewayTimeout)
@@ -264,7 +264,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526, type: :job do
         expect_any_instance_of(described_class).to receive(:log_exception_to_sentry)
         subject.perform_async(user.uuid, auth_headers, claim.id, submission)
         expect(AsyncTransaction::EVSS::VA526ezSubmitTransaction).to receive(:update_transaction).with(
-          anything, :non_retryable_error, 'foo'
+          anything, :non_retryable_error, { error: 'foo' }
         )
         described_class.drain
       end


### PR DESCRIPTION
## Description of change
On staging I ran into a bug where a timeout error saved in a async record and wasn't being parsed correctly when it was retrieved during polling by the FE. The error was a string but it needs to be a json string or json compatible hash (which the async transaction class will convert into json).

## Testing done
unit tests

## Testing planned
staging integration tests

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] wraps error messages in a hash so the async transaction class will convert them to json

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
