### PR TITLE
Fix sentry error for SSO cookie with guard for nil session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -144,7 +144,7 @@ class ApplicationController < ActionController::API
 
   # https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/SSO/CookieSpecs-20180906.docx
   def set_sso_cookie!
-    return unless Settings.sso.cookie_enabled
+    return unless Settings.sso.cookie_enabled && @session
     encryptor = SSOEncryptor
     contents = ActiveSupport::JSON.encode(@session.cookie_data)
     encrypted_value = encryptor.encrypt(contents)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -144,7 +144,7 @@ class ApplicationController < ActionController::API
 
   # https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/SSO/CookieSpecs-20180906.docx
   def set_sso_cookie!
-    return unless Settings.sso.cookie_enabled && @session
+    return unless Settings.sso.cookie_enabled
     encryptor = SSOEncryptor
     contents = ActiveSupport::JSON.encode(@session.cookie_data)
     encrypted_value = encryptor.encrypt(contents)

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -113,8 +113,7 @@ module V0
     def log_saml_response_for_nil_session(authentication_persisted)
       # capturing details for a logic error
       if authentication_persisted && !@sso_service.new_session
-        log_message_to_sentry('Auth persisted but no session', :error,
-                              base64_params_saml_response: Base64.encode64(params[:SAMLResponse].to_s))
+        log_message_to_sentry('Auth persisted but no session', :error)
       end
     end
 


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
adding a guard condition to fix sentry error
## Testing done
<!-- Please describe testing done to verify the changes. -->
Spec suite passes, but not able to find a test case to cause this explicitly
## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)
avoids error condition, specs pass
#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] add guard condition to set_sso_cookie method

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
