### PR TITLE
Temporary fix for cookies not getting destroyed

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -43,7 +43,13 @@ module V0
               SAML::SettingsService.idme_loa3_url(current_user, relay_state)
             when 'slo'
               authenticate
-              SAML::SettingsService.logout_url(session, relay_state)
+              # HACK HACK HACK - should figure out why relay_state logic is not working.
+              logout_url = SAML::SettingsService.logout_url(session, relay_state)
+              if request.cookies[Settings.sso.cookie_name].present?
+                logout_url.gsub('vets.gov', 'va.gov')
+              else
+                logout_url
+              end
             end
       render json: { url: url }
     end


### PR DESCRIPTION
## Description of change
1. Rails.routes.url_helpers is used in url_service.rb to generate a url for the sessions/logout endpoint that the front-end invokes. This route helper depends on the hostname specified in Settings.hostname.
2. Because the configuration files are not unique between vets.gov and va.gov for vets-api, the hostname points to api-vets.gov instead of api-va.gov.
3. Using RelayState we should be able to come up with a better, more robust, more consistent way of handling this problem, but that's going to take more time to investigate. For now, let's verify that this solves the problem and if it does we can revisit a better solution. We should definitely open an issue to track of this better solution though.

## Testing done
none

## Testing planned
1. will test on staging.vets.gov to make sure session is properly destroyed
2. will test on staging.va.gov to make sure session and cookie are properly destroyed.


## Acceptance Criteria (Definition of Done)

#### Unique to this PR
#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
