### PR TITLE
Load va facilities migrations from subdirectory properly

### DIFF
--- a/modules/va_facilities/lib/va_facilities/engine.rb
+++ b/modules/va_facilities/lib/va_facilities/engine.rb
@@ -3,5 +3,13 @@
 module VaFacilities
   class Engine < ::Rails::Engine
     isolate_namespace VaFacilities
+
+    initializer :append_migrations do |app|
+      unless app.root.to_s.match root.to_s
+        config.paths['db/migrate'].expanded.each do |expanded_path|
+          app.config.paths['db/migrate'] << expanded_path
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change
I moved migrations out of the global `db/migrations` in to the va facilities one and didn't get the initializer to load the migrations added. This fixes that by adding the initializer to va_facilities engine migrations will run properly. 

## Acceptance Criteria (Definition of Done)
#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
