### PR TITLE
Fix migration class name to work correctly with inflector

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181017123903) do
+ActiveRecord::Schema.define(version: 20181017120746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "postgis"
   enable_extension "uuid-ossp"
   enable_extension "pg_trgm"
   enable_extension "btree_gin"
+  enable_extension "postgis"
 
   create_table "accounts", force: :cascade do |t|
     t.uuid     "uuid",       null: false

--- a/modules/va_facilities/db/migrate/20181017120746_enable_post_gis_extension.rb
+++ b/modules/va_facilities/db/migrate/20181017120746_enable_post_gis_extension.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EnablePostGISExtension < ActiveRecord::Migration
+class EnablePostGisExtension < ActiveRecord::Migration
   def up
     enable_extension('postgis') unless extensions.include?('postgis')
   end


### PR DESCRIPTION
## Description of change
Not entirely sure why this seemed to work correctly on @ATeal's machine and mine originally, but GIS needs to be Gis so the migration file can be correctly loaded with Rails's inflector Rules. 

## Acceptance Criteria (Definition of Done)
#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
