### PR TITLE
Temporary change of affiliate for staging load testing for Search

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -336,6 +336,6 @@ account:
 # Settings for search
 search:
   access_key: SEARCH_GOV_ACCESS_KEY
-  affiliate: va
+  affiliate: vets.gov_test
   mock_search: true
   url: https://search.usa.gov/api/v2


### PR DESCRIPTION
## Description of change
Search.gov requested the following for staging load testing:

- Please perform the test at 9am, to avoid our normal peak traffic time
- Please test against a separate search site that I've spun up and connected to our own index already, rather than Bing: https://search.usa.gov/sites/7552
- Site handle is vets.gov_test


## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Sets `affiliate` to testing value
- [x] Request that DevOps update the `SEARCH_GOV_ACCESS_KEY` value in staging

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
