### PR TITLE
Allow for web_origin to be defined as a regex

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -47,9 +47,10 @@ module VetsAPI
     config.eager_load_paths << Rails.root.join('app')
 
     # CORS configuration; see also cors_preflight route
+    web_origin_regex = Regexp.new(Settings.web_origin_regex)
     config.middleware.insert_before 0, 'Rack::Cors', logger: (-> { Rails.logger }) do
       allow do
-        origins { |source, _env| Settings.web_origin.split(',').include?(source) }
+        origins { |source, _env| Settings.web_origin.split(',').include?(source) || !web_origin_regex.match(source).nil? }
         resource '*', headers: :any,
                       methods: :any,
                       credentials: true,


### PR DESCRIPTION
## Description of change
Subdomains of va.gov need to be allowed CORS access.  E.g. `www.cem.va.gov`, & `benefits.va.gov`.  @rianfowler can better explain why these subdomains need access.

## Testing done
I've manually tested this using our swagger doc.

**Pre-requisites**
- Have a `settings.local.yml` file with the following:
```
web_origin: http://localhost:3000,http://localhost:3001
web_origin_regex: \Ahttps?:\/\/([a-zA-Z\d-]+\.){0,}swagger\.io\/?\z
```
**Steps**
1. Run rails server locally 
2. Navigate to `http://petstore.swagger.io/` in a browser
3. Type in `http://localhost:3000/v0/apidocs` and click "Explore"
![image](https://user-images.githubusercontent.com/3077884/47466943-bc24fa00-d7c1-11e8-8aa7-fe8690b8c437.png)
RESULT: No browser CORS issue seen


## Testing planned
None

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
