### PR TITLE
Configure ssl in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ To start, fetch this code:
 
 1. Install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/). This will configure both `docker` and `docker-compose`.
 1. Setup localhost certificates / keys:
-   - Create a folder in your vets-api directory:  `mkdir config/certs`
    - Copy the [certificate][certificate] to `config/certs/vetsgov-localhost.crt`
    - Copy the [key][key] to `config/certs/vetsgov-localhost.key`
    - *NOTE:* using `touch` to create blank cert and key files no longer works. 
@@ -36,6 +35,8 @@ they would be when running rails directly.
 
 The [Makefile](https://github.com/department-of-veterans-affairs/vets-api/blob/master/Makefile) has shortcuts for many common development tasks. You can still run manual [docker-compose commands](https://docs.docker.com/compose/),
 but the following tasks have been aliased to speed developlment:
+
+If you'd like to develop with SSL, ensure you have config/certs/localhost.crt and start the server wiht `bundle exec puma` rather than `bundle exec rails server`
 
 ### Running tests
 - `make spec` - Run the entire test suite via the docker image (alias for `rspec spec`)

--- a/bin/setup-osx
+++ b/bin/setup-osx
@@ -127,8 +127,27 @@ else
   brew install https://gist.githubusercontent.com/lihanli/03ec8f17a6a1ff52e3a149be4cf7f2ae/raw/d18eff01396bbc25a928f756ff21edcc3521fc5e/pdftk.rb
 fi
 
-# Make vetsgov-localhost.crt and .key
+if command_exists mkcert ; then
+  echo "${GREEN} * mkcert already installed.${RESET}"
+else
+  echo "${RED} * Installing mkcert. ${RESET}"
+  brew install mkcert
+  mkcert -install
+  echo "Remember that mkcert is meant for development purposes, not production, so it should not be used on end users' machines, and that you should not export or share rootCA-key.pem."
+fi
 
+if [ ! -f config/certs/localhost.crt ]; then
+  echo "${RED} * Installing localhost.crt.${RESET}"
+  mkcert localhost.ssl localhost 127.0.0.1 ::1
+  # If/when https://github.com/FiloSottile/mkcert/pull/77 is merged/released we can specify the file path in mkcert.
+  # in the meantime, move the files. Puma doesn't like the + in the file name.
+  mv localhost.ssl+3-key.pem config/certs/localhost.key
+  mv localhost.ssl+3.pem config/certs/localhost.crt
+else
+  echo "${GREEN} * config/certs/localhost.crt  installed.${RESET}"
+fi
+
+# Make vetsgov-localhost.crt and .key
 CERT_INSTALL_REQUIRED=false
 if [ ! -d ~/.certs ]; then
   mkdir ~/.certs

--- a/config/puma/development.rb
+++ b/config/puma/development.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+ssl_bind '0.0.0.0',
+         '3000',
+         key: 'config/certs/localhost.key',
+         cert: 'config/certs/localhost.crt'

--- a/docs/setup/native.md
+++ b/docs/setup/native.md
@@ -59,6 +59,7 @@ the `vets-api` directory, run `./bin/setup-osx && source ~/.bash_profile && cd
 1. Install pdftk
   - `brew install
     https://gist.githubusercontent.com/lihanli/03ec8f17a6a1ff52e3a149be4cf7f2ae/raw/d18eff01396bbc25a928f756ff21edcc3521fc5e/pdftk.rb`
+1. Install nss `brew install nss`
 1. Install gem dependencies: `cd vets-api; bundle install`
 1. Install overcommit `overcommit --install --sign`
 1. Setup localhost certificates / keys:
@@ -69,6 +70,12 @@ the `vets-api` directory, run `./bin/setup-osx && source ~/.bash_profile && cd
      commands will provide basic functionality, such as for running unit tests:
    - `touch ./config/certs/vetsgov-localhost.crt`
    - `touch ./config/certs/vetsgov-localhost.key`
+1. Install mkcert (optional, used for SSL)
+  -  `brew install mkcert`
+  -  `mkcert -install`
+  - create a certificate for local testing `mkcert localhost.ssl localhost 127.0.0.1 ::1`
+  - move the certificates `mv localhost.ssl+3.pem config/certs/localhost.crt` `mv localhost.ssl+3-key.pem config/certs/localhost.key`
+  - Remember that mkcert is meant for development purposes, not production, so it should not be used on end users' machines, and that you should not export or share rootCA-key.pem.
 1. Create dev database: `bundle exec rake db:setup`
 1. Go to the file `config/settings/development.yml` in your local vets-api. Switch the commented out lines pertaining to the cache_dir: uncomment out line 14 (what you use for running the app via Rails), and comment out line 15 (what you use for running the app via Docker).
 1. Make sure you have the [vets-api-mockdata](https://github.com/department-of-veterans-affairs/vets-api-mockdata) repo locally installed


### PR DESCRIPTION

I'm likely closing this PR for now, but I'm making it so that it's easier to find it later.
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14417
## Description of change
To start the server with SSL (https) 'bundle exec puma' rather than `bundle exec rails server`.
That will pick up the extra configuration at config/puma/development.rb that `rails s` doesn't.

Note: if you want to stop using ssl in chrome for localhost go to
chrome://net-internals/#hsts and enter 'localhost' under Delete domain security policies

## Testing done
started server with ssl
