### PR TITLE
Hot fix to remove bug that is pending removal, regardless

### DIFF
--- a/lib/search/response.rb
+++ b/lib/search/response.rb
@@ -16,8 +16,7 @@ module Search
     end
 
     def self.from(response)
-      web = response.body.dig('web')
-      body = response.body.merge('pagination' => pagination_object(web))
+      body = response.body
       new(response.status, body: body)
     end
 

--- a/spec/lib/search/service_spec.rb
+++ b/spec/lib/search/service_spec.rb
@@ -34,14 +34,6 @@ describe Search::Service do
       end
     end
 
-    context 'with an offset' do
-      [0, 20, 40, 60].each do |current_offset|
-        context "with a current offset of #{current_offset}" do
-          it_behaves_like 'pagination data', current_offset
-        end
-      end
-    end
-
     context 'with an empty search query' do
       let(:query) { '' }
 

--- a/spec/request/search_request_spec.rb
+++ b/spec/request/search_request_spec.rb
@@ -61,7 +61,7 @@ describe 'search', type: :request do
       let(:query_term) { 'test' }
 
       context "the endpoint's response" do
-        it 'should return pagination offsets for previous and next page results', :aggregate_failures do
+        xit 'should return pagination offsets for previous and next page results', :aggregate_failures do
           VCR.use_cassette('search/offset_40') do
             get '/v0/search', query: query_term, offset: 40
 
@@ -73,7 +73,7 @@ describe 'search', type: :request do
         end
 
         context 'on the first page of the search results' do
-          it 'previous should be null', :aggregate_failures do
+          xit 'previous should be null', :aggregate_failures do
             VCR.use_cassette('search/offset_0') do
               get '/v0/search', query: query_term, offset: 0
 
@@ -87,7 +87,7 @@ describe 'search', type: :request do
         end
 
         context 'on the last page of the search results' do
-          it 'next should be null', :aggregate_failures do
+          xit 'next should be null', :aggregate_failures do
             VCR.use_cassette('search/offset_60') do
               get '/v0/search', query: query_term, offset: 60
 

--- a/spec/support/schemas/search.json
+++ b/spec/support/schemas/search.json
@@ -12,17 +12,6 @@
                 "query": {
                   "type": "string"
                 },
-                "pagination": {
-                  "description": "The offset in order to return the previous or next set of results",
-                  "properties": {
-                    "previous": {
-                      "type": ["integer", null]
-                    },
-                    "next": {
-                      "type": ["integer", null]
-                    }
-                  }
-                },
                 "web": {
                   "description": "Contains all of the search result related data for the query",
                   "properties": {


### PR DESCRIPTION

## Description of change
We are seeing this error in sentry when conducting pre-load testing test:

http://sentry.vetsgov-internal/vets-gov/platform-api-staging/issues/49045/

The offset logic that was added in https://github.com/department-of-veterans-affairs/vets-api/pull/2356 is no longer needed, and will be properly removed in an upcoming PR.

This is a hot-fix so we can conduct our scheduled load testing today.


## Testing done
<!-- Please describe testing done to verify the changes. -->

Local testing

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] removes `offset` and pagination related logic from https://github.com/department-of-veterans-affairs/vets-api/pull/2356

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
