### PR TITLE
Add Search::Configuration to breakers initializer

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -19,6 +19,7 @@ require 'mvi/configuration'
 require 'preneeds/configuration'
 require 'rx/configuration'
 require 'sm/configuration'
+require 'search/configuration'
 
 require 'evss/claims_service'
 require 'evss/common_service'
@@ -52,7 +53,9 @@ services = [
   MVI::Configuration.instance.breakers_service,
   Preneeds::Configuration.instance.breakers_service,
   SM::Configuration.instance.breakers_service,
-  Vet360::ContactInformation::Configuration.instance.breakers_service
+  Vet360::ContactInformation::Configuration.instance.breakers_service,
+  Search::Configuration.instance.breakers_service
+
 ]
 
 services << CentralMail::Configuration.instance.breakers_service if Settings.central_mail&.upload&.enabled


### PR DESCRIPTION
## Description of change
We need to add the Search::Configuration to the breakers initialize for prometheus 

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] Search::Configuration included in breakers initializer

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
