### PR TITLE
Validation of PDFs

### DIFF
--- a/modules/vba_documents/README.yml
+++ b/modules/vba_documents/README.yml
@@ -399,8 +399,9 @@ components:
             * `DOC102` - Invalid metadata - not parseable as JSON, incorrect fields, etc.
             * `DOC103` - Invalid content - not parseable as PDF. Detail field will indicate which document or attachment part was affected.
             * `DOC104` - Upload rejected by downstream system. Detail field will indicate nature of rejection.
-            * `DOC105` - Invalid or unknown id
+            * `DOC105` - Invalid or unknown id.
             * 'DOC106' - File size limit exceeded. Each document may be a maximum of 100MB.
+            * `DOC107` - Malformed PDF.
             * `DOC201` - Upload server error.
             * `DOC202` - Error during processing by downstream system. Processing failed and could not be retried. Detail field will provide additional details where available.
           type: string

--- a/modules/vba_documents/lib/vba_documents/upload_error.rb
+++ b/modules/vba_documents/lib/vba_documents/upload_error.rb
@@ -11,6 +11,8 @@ module VBADocuments
     DOC103 = 'Invalid content part'
     DOC104 = 'Upload rejected by downstream system'
     DOC105 = 'Invalid or unknown id'
+    DOC106 = 'File size exceeded'
+    DOC107 = 'Malformed PDF'
 
     # DOC2xx errors: server errors either local or downstream
     # not unambiguously related to submitted content

--- a/modules/vba_documents/spec/fixtures/invalid_doc.pdf
+++ b/modules/vba_documents/spec/fixtures/invalid_doc.pdf
@@ -1,0 +1,12 @@
+--1669792f993
+Content-Disposition: form-data; name="metadata"
+Content-Type: application/json
+
+{"veteranLastName":"Test","veteranFirstName":"Test","docType":"21-526EZ","source":"test","fileNumber":"111111111","zipCode":"11111"}
+--1669792f993
+Content-Disposition: form-data; name="content";filename="21-526EZ Form NEW MAR 2018.pdf"
+Content-Type: application/pdf
+
+%PDF-1.6
+%����
+1 0 obj

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       expect(updated.status).to eq('received')
     end
 
-    it 'validates the overall pdf is not malformed' do
+    it 'sets error if the file is malformed' do
       allow(Tempfile).to receive(:new).and_return(invalid_doc)
       described_class.new.perform(upload.guid)
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
In order to not allow PDFs to go further down the stream (into central mail) we should validate that it passes inspection from `pdfinfo` first.

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/438

## Testing done
- console verification of malformed pdfs
- rspec testing


## Acceptance Criteria (Definition of Done)
- [x] PDFs that shouldn't make it through fail the check

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
