### PR TITLE
Reverts search affiliate to va

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -338,6 +338,6 @@ account:
 # Settings for search
 search:
   access_key: SEARCH_GOV_ACCESS_KEY
-  affiliate: vets.gov_test
+  affiliate: va
   mock_search: true
   url: https://search.usa.gov/api/v2


### PR DESCRIPTION
## Description of change
Changes were made in #2381, and now that we're done with this initial load test we are cleared (by Search.gov on 10/26/18) to do further testing on the actual site property we will use going forward.

## Acceptance Criteria

#### Unique to this PR
- [x] Sets affiliate to production value (va, 7378)

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
