### PR TITLE
14575 update search endpoint for pagination

### DIFF
--- a/app/controllers/v0/search_controller.rb
+++ b/app/controllers/v0/search_controller.rb
@@ -9,7 +9,7 @@ module V0
     def index
       response = Search::Service.new(query, page).results
 
-      render json: response, serializer: SearchSerializer
+      render json: response, serializer: SearchSerializer, meta: { pagination: response.pagination }
     end
 
     private

--- a/app/controllers/v0/search_controller.rb
+++ b/app/controllers/v0/search_controller.rb
@@ -6,6 +6,11 @@ module V0
 
     skip_before_action :authenticate
 
+    # Returns a page of search results from the Search.gov API, based on the passed query and page.
+    #
+    # Pagination schema follows precedence from other controllers that return pagination.
+    # For example, the prescriptions_controller.
+    #
     def index
       response = Search::Service.new(query, page).results
 

--- a/app/controllers/v0/search_controller.rb
+++ b/app/controllers/v0/search_controller.rb
@@ -7,7 +7,7 @@ module V0
     skip_before_action :authenticate
 
     def index
-      response = Search::Service.new(query, offset).results
+      response = Search::Service.new(query, page).results
 
       render json: response, serializer: SearchSerializer
     end
@@ -15,7 +15,7 @@ module V0
     private
 
     def search_params
-      params.permit(:query, :offset)
+      params.permit(:query, :page)
     end
 
     # Returns a sanitized, permitted version of the passed query params.
@@ -27,19 +27,17 @@ module V0
       sanitize search_params['query']
     end
 
-    # The offset defines the number of results you want to skip from the first result.
-    # Search.gov's default is 0 and the maximum is 999.
+    # This is the page (number) of results the FE is requesting to have returned.
     #
-    # Returns a sanitized, permitted version of the passed offset params. If 'offset'
+    # Returns a sanitized, permitted version of the passed page params. If 'page'
     # is not supplied, it returns nil.
     #
     # @return [String]
     # @return [NilClass]
-    # @see https://search.usa.gov/sites/7378/api_instructions
     # @see https://api.rubyonrails.org/v4.2/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize
     #
-    def offset
-      sanitize search_params['offset']
+    def page
+      sanitize search_params['page']
     end
   end
 end

--- a/app/controllers/v0/search_controller.rb
+++ b/app/controllers/v0/search_controller.rb
@@ -9,7 +9,7 @@ module V0
     # Returns a page of search results from the Search.gov API, based on the passed query and page.
     #
     # Pagination schema follows precedence from other controllers that return pagination.
-    # For example, the prescriptions_controller.
+    # For example, the app/controllers/v0/prescriptions_controller.rb.
     #
     def index
       response = Search::Service.new(query, page).results

--- a/app/swagger/requests/search.rb
+++ b/app/swagger/requests/search.rb
@@ -23,9 +23,9 @@ module Swagger
           end
 
           parameter do
-            key :name, 'offset'
+            key :name, 'page'
             key :in, :query
-            key :description, 'The offset from first result, in order to return the expected page of results'
+            key :description, 'The page number for the page of results that is being requested'
             key :required, false
             key :type, :integer
           end

--- a/app/swagger/requests/search.rb
+++ b/app/swagger/requests/search.rb
@@ -33,23 +33,13 @@ module Swagger
           response 200 do
             key :description, 'Response is OK'
             schema do
-              key :required, [:data]
+              key :required, [:data, :meta]
               property :data, type: :object do
                 key :required, [:attributes]
                 property :attributes, type: :object do
                   key :required, [:body]
                   property :body, type: :object do
                     property :query, type: :string, description: 'The term used to generate these search results'
-                    property :pagination, type: :object do
-                      property :previous,
-                               type: %i[integer null],
-                               description: "The offset from first result, in order to return the previous page's results set. Null indicates the response is the first page of results.",
-                               example: 20
-                      property :next,
-                               type: %i[integer null],
-                               description: "The offset from first result, in order to return the next page's results set. Null indicates the response is the last page of results.",
-                               example: 60
-                    end
                     property :web, type: :object do
                       property :total, type: :integer, description: 'Total number of results available.'
                       property :next_offset, type: :integer, description: 'Offset for the subsequent results.'
@@ -210,6 +200,10 @@ module Swagger
                     end
                   end
                 end
+              end
+
+              property :meta do
+                property :pagination, '$ref': :Pagination
               end
             end
           end

--- a/spec/request/search_request_spec.rb
+++ b/spec/request/search_request_spec.rb
@@ -58,44 +58,30 @@ describe 'search', type: :request do
     end
 
     context 'with pagination' do
-      let(:query_term) { 'test' }
+      let(:query_term) { 'benefits' }
 
       context "the endpoint's response" do
-        xit 'should return pagination offsets for previous and next page results', :aggregate_failures do
-          VCR.use_cassette('search/offset_40') do
+        it 'should return pagination meta data', :aggregate_failures do
+          VCR.use_cassette('search/page_1') do
             get '/v0/search', query: query_term, page: 1
 
             pagination = pagination_for(response)
 
-            expect(pagination['next']).to be_present
-            expect(pagination['previous']).to be_present
+            expect(pagination['current_page']).to be_present
+            expect(pagination['per_page']).to be_present
+            expect(pagination['total_pages']).to be_present
+            expect(pagination['total_entries']).to be_present
           end
         end
 
-        context 'on the first page of the search results' do
-          xit 'previous should be null', :aggregate_failures do
-            VCR.use_cassette('search/offset_0') do
+        context 'when a specific page number is requested' do
+          it 'current_page should be equal to the requested page number' do
+            VCR.use_cassette('search/page_2') do
               get '/v0/search', query: query_term, page: 2
 
               pagination = pagination_for(response)
 
-              expect(pagination.keys).to include 'previous'
-              expect(pagination['previous']).to_not be_present
-              expect(pagination['next']).to be_present
-            end
-          end
-        end
-
-        context 'on the last page of the search results' do
-          xit 'next should be null', :aggregate_failures do
-            VCR.use_cassette('search/offset_60') do
-              get '/v0/search', query: query_term, offset: 60
-
-              pagination = pagination_for(response)
-
-              expect(pagination.keys).to include 'next'
-              expect(pagination['next']).to_not be_present
-              expect(pagination['previous']).to be_present
+              expect(pagination['current_page']).to eq 2
             end
           end
         end
@@ -125,5 +111,5 @@ end
 def pagination_for(response)
   body = JSON.parse response.body
 
-  body.dig('data', 'attributes', 'body', 'pagination')
+  body.dig('meta', 'pagination')
 end

--- a/spec/request/search_request_spec.rb
+++ b/spec/request/search_request_spec.rb
@@ -50,9 +50,9 @@ describe 'search', type: :request do
           dirty_params     = '<script>alert(document.cookie);</script>'
           sanitized_params = 'alert(document.cookie);'
 
-          expect(Search::Service).to receive(:new).with(sanitized_params, '20')
+          expect(Search::Service).to receive(:new).with(sanitized_params, '2')
 
-          get '/v0/search', query: dirty_params, offset: 20
+          get '/v0/search', query: dirty_params, page: 2
         end
       end
     end
@@ -63,7 +63,7 @@ describe 'search', type: :request do
       context "the endpoint's response" do
         xit 'should return pagination offsets for previous and next page results', :aggregate_failures do
           VCR.use_cassette('search/offset_40') do
-            get '/v0/search', query: query_term, offset: 40
+            get '/v0/search', query: query_term, page: 1
 
             pagination = pagination_for(response)
 
@@ -75,7 +75,7 @@ describe 'search', type: :request do
         context 'on the first page of the search results' do
           xit 'previous should be null', :aggregate_failures do
             VCR.use_cassette('search/offset_0') do
-              get '/v0/search', query: query_term, offset: 0
+              get '/v0/search', query: query_term, page: 2
 
               pagination = pagination_for(response)
 
@@ -102,16 +102,16 @@ describe 'search', type: :request do
       end
 
       context 'when the endpoint is being called' do
-        context 'with an offset' do
-          it 'should pass the offset request to the search service object' do
-            expect(Search::Service).to receive(:new).with(query_term, '20')
+        context 'with a page' do
+          it 'should pass the page request to the search service object' do
+            expect(Search::Service).to receive(:new).with(query_term, '2')
 
-            get '/v0/search', query: query_term, offset: 20
+            get '/v0/search', query: query_term, page: 2
           end
         end
 
-        context 'with no offset present' do
-          it 'should pass offset=nil to the search service object' do
+        context 'with no page present' do
+          it 'should pass page=nil to the search service object' do
             expect(Search::Service).to receive(:new).with(query_term, nil)
 
             get '/v0/search', query: query_term

--- a/spec/support/schemas/search.json
+++ b/spec/support/schemas/search.json
@@ -12,20 +12,6 @@
                 "query": {
                   "type": "string"
                 },
-                "pagination": {
-                  "description": "The page data in order to return the previous or next set of results",
-                  "properties": {
-                    "current_page": {
-                      "type": "integer"
-                    },
-                    "total_pages": {
-                      "type": "integer"
-                    },
-                    "results_per_page": {
-                      "type": "integer"
-                    }
-                  }
-                },
                 "web": {
                   "description": "Contains all of the search result related data for the query",
                   "properties": {
@@ -125,6 +111,23 @@
         }
       },
       "type": "object"
+    },
+    "meta": {
+      "type": "object",
+      "required": ["pagination"],
+      "properties": {
+        "pagination": {
+          "type": "object",
+          "description": "The details around the page numbers and per page results",
+          "required": ["current_page", "per_page", "total_pages", "total_entries"],
+          "properties": {
+            "current_page": { "type": "integer" },
+            "per_page": { "type": "integer" },
+            "total_pages": { "type": "integer" },
+            "total_entries": { "type": "integer" }
+          }
+        }
+      }
     }
   },
   "type": "object"


### PR DESCRIPTION
## Description of change
Stemming from [this conversation](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13440#issuecomment-432793942), for the second iteration of the search pagination, we will implement a Google-like UI for the pagination end user experience.


## Testing done
<!-- Please describe testing done to verify the changes. -->

Automated specs 
## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Remove any `offset` logic (and specs)
- [x] Update the response to include a new `pagination` object nested in a `meta` key
- [x] Add a `page` param for the FE to request a specific page
- [x] Update swagger docs
- [x] Specs
- [x] Collaborate with FE before merging

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

## Screenshots

#### New Meta key with Pagination object

![image](https://user-images.githubusercontent.com/7482329/47588987-22765d80-d925-11e8-928c-fe1090550e8f.png)


<hr/> 

![image](https://user-images.githubusercontent.com/7482329/47588966-0e326080-d925-11e8-9177-06c4b5e816fb.png)
