### PR TITLE
introduce new toggle that can be used to enable sso loggout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -189,6 +189,7 @@ class ApplicationController < ActionController::API
 
   def should_signout_sso?
     return false unless Settings.sso.cookie_enabled
+    return false unless Settings.sso.cookie_signout_enabled
     cookies[Settings.sso.cookie_name].blank? && request.host.match(Settings.sso.cookie_domain)
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -268,11 +268,27 @@ RSpec.describe ApplicationController, type: :controller do
           let(:header_host_value) { 'localhost' }
           let(:sso_cookie_value)  { nil }
 
+          around(:each) do |example|
+            Settings.sso.cookie_signout_enabled = true
+            example.run
+            Settings.sso.cookie_signout_enabled = nil
+          end
+
           it 'returns json error' do
             get :test_authentication
             expect(response).to have_http_status(:unauthorized)
             expect(JSON.parse(response.body)['errors'].first)
               .to eq('title' => 'Not authorized', 'detail' => 'Not authorized', 'code' => '401', 'status' => '401')
+          end
+        end
+
+        context 'with a virtual host that matches sso cookie domain, but sso cookie destroyed: disabled' do
+          let(:header_host_value) { 'localhost' }
+          let(:sso_cookie_value)  { nil }
+
+          it 'returns success' do
+            get :test_authentication
+            expect(response).to have_http_status(:success)
           end
         end
       end


### PR DESCRIPTION
## Description of change
Putting the automatic logout mechanism on va.gov to be disabled temporarily. This is probably what we should have done for production as well, but too late now.

## Testing done
loca testing

## Testing planned
verify that staging.va.gov and staging.vets.gov login works again

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
