### PR TITLE
Correct schema version in db/schema file

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181017120746) do
+ActiveRecord::Schema.define(version: 20181017123729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
## Description of change
The db/schema file got out of sync with the current set of migrations, probably due to picking the incorrect timestamp in a merge commit. 

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Correct schema version

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
