### PR TITLE
Search endpoint accounts for Search.gov constraints 

### DIFF
--- a/app/swagger/requests/search.rb
+++ b/app/swagger/requests/search.rb
@@ -214,6 +214,27 @@ module Swagger
               key :'$ref', :Errors
             end
           end
+
+          response 429 do
+            key :description, 'Exceeded rate limit'
+            schema do
+              key :required, [:errors]
+
+              property :errors do
+                key :type, :array
+                items do
+                  key :required, %i[title detail code status source]
+                  property :title, type: :string, example: 'Exceeded rate limit'
+                  property :detail,
+                           type: :string,
+                           example: 'Exceeded Search.gov rate limit'
+                  property :code, type: :string, example: 'SEARCH_429'
+                  property :status, type: :string, example: '429'
+                  property :source, type: :string, example: 'Search::Service'
+                end
+              end
+            end
+          end
         end
       end
     end

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -356,6 +356,12 @@ en:
         code: 'SEARCH_400'
         detail: 'Search.gov service responded with a Bad Request'
         status: 400
+      SEARCH_429:
+        <<: *external_defaults
+        title: Exceeded rate limit
+        code: 'SEARCH_429'
+        detail: 'Exceeded Search.gov rate limit'
+        status: 429
       VET360_502:
         <<: *external_defaults
         title: Bad Gateway

--- a/lib/search/pagination.rb
+++ b/lib/search/pagination.rb
@@ -14,6 +14,15 @@ module Search
     #
     ENTRIES_PER_PAGE = 10
 
+    # Due to Search.gov's offset max of 999, we cannot view pages
+    # where the offset param exceeds 999.  This influences our:
+    #   - total_viewable_pages
+    #   - total_viewable_entries
+    #
+    # @see https://search.usa.gov/sites/7378/api_instructions under `offset`
+    #
+    OFFSET_LIMIT = 999
+
     attr_reader :next_offset
     attr_reader :total_entries
     attr_reader :total_pages
@@ -47,9 +56,25 @@ module Search
       {
         'current_page' => [current_page, total_pages].min,
         'per_page' => ENTRIES_PER_PAGE,
-        'total_pages' => total_pages,
-        'total_entries' => total_entries
+        'total_pages' => total_viewable_pages,
+        'total_entries' => total_viewable_entries
       }
+    end
+
+    def total_viewable_pages
+      [total_pages, maximum_viewable_pages].min
+    end
+
+    def maximum_viewable_pages
+      (OFFSET_LIMIT / ENTRIES_PER_PAGE.to_f).floor
+    end
+
+    def total_viewable_entries
+      [total_entries, maximum_viewable_entries].min
+    end
+
+    def maximum_viewable_entries
+      (ENTRIES_PER_PAGE * total_viewable_pages) + (ENTRIES_PER_PAGE - 1)
     end
   end
 end

--- a/lib/search/service.rb
+++ b/lib/search/service.rb
@@ -87,7 +87,8 @@ module Search
       when Common::Client::Errors::ClientError
         message = parse_messages(error).first
         log_error_message(message)
-        raise_backend_exception('SEARCH_400', self.class, error) if error.status == 400
+        raise_backend_exception('SEARCH_429', self.class, error) if error.status == 429
+        raise_backend_exception('SEARCH_400', self.class, error) if error.status >= 400
       else
         raise error
       end

--- a/spec/lib/search/pagination_spec.rb
+++ b/spec/lib/search/pagination_spec.rb
@@ -86,7 +86,7 @@ describe Search::Pagination do
       {
         'web' =>
           {
-            'total' => 35123,
+            'total' => 35_123,
             'next_offset' => 20
           }
       }
@@ -103,7 +103,7 @@ describe Search::Pagination do
 
     context 'when the ENTRIES_PER_PAGE is set to its max of 50' do
       before do
-        stub_const("Search::Pagination::ENTRIES_PER_PAGE", 50)
+        stub_const('Search::Pagination::ENTRIES_PER_PAGE', 50)
       end
 
       it 'sets total_pages to the maximum viewable number of pages' do

--- a/spec/lib/search/pagination_spec.rb
+++ b/spec/lib/search/pagination_spec.rb
@@ -80,4 +80,39 @@ describe Search::Pagination do
       expect(subject.object).to include('current_page' => 9)
     end
   end
+
+  context 'when Search.govs total entries exceed the OFFSET_LIMIT to view them' do
+    let(:raw_body) do
+      {
+        'web' =>
+          {
+            'total' => 35123,
+            'next_offset' => 20
+          }
+      }
+    end
+    subject { described_class.new(raw_body) }
+
+    it 'sets total_pages to the maximum viewable number of pages' do
+      expect(subject.object['total_pages']).to eq 99
+    end
+
+    it 'sets total_entries to the maximum viewable number of entries' do
+      expect(subject.object['total_entries']).to eq 999
+    end
+
+    context 'when the ENTRIES_PER_PAGE is set to its max of 50' do
+      before do
+        stub_const("Search::Pagination::ENTRIES_PER_PAGE", 50)
+      end
+
+      it 'sets total_pages to the maximum viewable number of pages' do
+        expect(subject.object['total_pages']).to eq 19
+      end
+
+      it 'sets total_entries to the maximum viewable number of entries' do
+        expect(subject.object['total_entries']).to eq 999
+      end
+    end
+  end
 end

--- a/spec/lib/search/service_spec.rb
+++ b/spec/lib/search/service_spec.rb
@@ -77,5 +77,17 @@ describe Search::Service do
         end
       end
     end
+
+    context 'when exceeding the Search.gov rate limit' do
+      it 'raises an exception', :aggregate_failures do
+        VCR.use_cassette('search/exceeds_rate_limit', VCR::MATCH_EVERYTHING) do
+          expect { subject.results }.to raise_error do |e|
+            expect(e).to be_a(Common::Exceptions::BackendServiceException)
+            expect(e.status_code).to eq(429)
+            expect(e.errors.first.code).to eq('SEARCH_429')
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1713,6 +1713,14 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
           end
         end
       end
+
+      context 'when the Search.gov rate limit has been exceeded' do
+        it 'returns a 429 with error details' do
+          VCR.use_cassette('search/exceeds_rate_limit') do
+            expect(subject).to validate(:get, '/v0/search', 429, '_query_string' => 'query=benefits')
+          end
+        end
+      end
     end
   end
 

--- a/spec/support/vcr_cassettes/search/exceeds_rate_limit.yml
+++ b/spec/support/vcr_cassettes/search/exceeds_rate_limit.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://search.usa.gov/api/v2/search/i14y?access_key=TESTKEY&affiliate=va&limit=10&offset=0&query=benefits
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 429
+      message: Too Many Requests
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Sep 2018 02:16:30 GMT
+      Etag:
+      - W/"c740cd937737ec25c05c833fee222c7f"
+      Server:
+      - Apache
+      Status:
+      - 429 Too Many Requests
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      - max-age=31536000; includeSubdomains; preload
+      Via:
+      - 1.1 proxy3.us-east-1.prod.infr.search.usa.gov:8443
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - '09de91a6-945a-484d-ab8a-7fa0b4dfe678'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '8720'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":["rate limit exceeded"]}'
+    http_version:
+  recorded_at: Thu, 13 Sep 2018 02:16:30 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Description of change
1. Load testing failed due to our staging IP address being blacklisted.  Consequently, we were receiving `429` errors from Search.gov around too many requests.
2. Since Search.gov’s offset is maxed out at 999, we cannot view all of the potential search results.

For example, if the total search results are 35k, we would only be able to view the first 1000.

The total pages and total entries now accounts for this constraint.

## Testing done

Local testing

## Testing planned
Load testing against the Search.gov API

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Adds error handling for Search.gov rate limiting case
- [x] Adds swagger docs specifically for the `429` rate limiting case for the FE to consume
- [x] For pagination, sets the `total_pages` value to the total viewable pages, based on Search.gov constraints
- [x] For pagination, sets the `total_entries` value to the total viewable entries, based on Search.gov constraints
- [x] Spec coverage
- [x] Updated swagger docs
- [x] Yard docs

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

## Screenshot

#### Dedicated 429 error response

![image](https://user-images.githubusercontent.com/7482329/47748989-b57b0480-dc51-11e8-9b26-ea44a0f23553.png)
