### PR TITLE
Update loofah gem to address CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -712,7 +712,7 @@ GEM
     connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.3)
+    crass (1.0.4)
     date_validator (0.9.0)
       activemodel
       activesupport
@@ -806,7 +806,7 @@ GEM
     listen (3.0.6)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.10)


### PR DESCRIPTION
CVE-2018-16468 - Loofah XSS Vulnerability

https://github.com/flavorjones/loofah/issues/154



## Description of change
bumped the version of loofah 

## Testing done
read change log 
https://github.com/flavorjones/loofah/blob/master/CHANGELOG.md#223--2018-10-30
## Testing planned
specs... no expected functionality changes

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
