### PR TITLE
fix sso service

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -97,6 +97,8 @@ module V0
         StatsD.increment(STATSD_SSO_CALLBACK_KEY, tags: ['status:failure', "context:#{context_key}"])
         StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [@sso_service.failure_instrumentation_tag])
       end
+    rescue NoMethodError
+      Raven.extra_context(base64_params_saml_response: params[:SAMLResponse])
     ensure
       StatsD.increment(STATSD_SSO_CALLBACK_TOTAL_KEY)
     end

--- a/app/services/sso_service.rb
+++ b/app/services/sso_service.rb
@@ -45,9 +45,10 @@ class SSOService
         end
       end
 
-      new_session.save && new_user.save && new_user_identity.save
+      return new_session.save && new_user.save && new_user_identity.save
     else
       handle_error_reporting_and_instrumentation
+      return false
     end
   end
 

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -453,6 +453,17 @@ RSpec.describe V0::SessionsController, type: :controller do
         end
       end
 
+      context 'when NoMethodError is encountered elsewhere' do
+        it 'redirects to adds context and re-raises the exception', :aggregate_failures do
+          allow_any_instance_of(SSOService).to receive(:persist_authentication!).and_raise(NoMethodError)
+          expect(Raven).to receive(:extra_context).twice
+          expect(Raven).not_to receive(:user_context)
+          expect(Raven).not_to receive(:tags_context).once
+          expect(controller).not_to receive(:log_message_to_sentry)
+          post :saml_callback
+        end
+      end
+
       context 'when user clicked DENY' do
         before { allow(OneLogin::RubySaml::Response).to receive(:new).and_return(saml_response_click_deny) }
 


### PR DESCRIPTION
## Description of change
We are seeing errors in Sentry 

http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/29280/
and http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/47158/

Both of these appear to be correlated, as we look at user IP.  Either something in the saml response was corrupted or the display of the SAML response in Sentry was not displaying correctly.

Additionally, we want to explicitly return false from persist_authentication! when the session is not persisted. 

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->


#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
