### PR TITLE
14820 StatsD tracking for Search.gov 429 errors

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -91,3 +91,6 @@ StatsD.increment("#{CentralMail::Service::STATSD_KEY_PREFIX}.upload.fail", 0)
 
 # init SentryJob error monitoring
 StatsD.increment(SentryJob::STATSD_ERROR_KEY, 0)
+
+# init Search
+StatsD.increment("#{Search::Service::STATSD_KEY_PREFIX}.exceptions", 0, tags: ['exception:429'])

--- a/lib/search/service.rb
+++ b/lib/search/service.rb
@@ -87,7 +87,7 @@ module Search
       when Common::Client::Errors::ClientError
         message = parse_messages(error).first
         save_error_details(message)
-        raise_backend_exception('SEARCH_429', self.class, error) if error.status == 429
+        handle_429!(error)
         raise_backend_exception('SEARCH_400', self.class, error) if error.status >= 400
       else
         raise error
@@ -104,6 +104,13 @@ module Search
         url: config.base_path
       )
       Raven.tags_context(search: 'general_search_query_error')
+    end
+
+    def handle_429!(error)
+      if error.status == 429
+        StatsD.increment("#{Search::Service::STATSD_KEY_PREFIX}.exceptions", tags: ['exception:429'])
+        raise_backend_exception('SEARCH_429', self.class, error)
+      end
     end
 
     def raise_backend_exception(key, source, error = nil)

--- a/lib/search/service.rb
+++ b/lib/search/service.rb
@@ -107,10 +107,10 @@ module Search
     end
 
     def handle_429!(error)
-      if error.status == 429
-        StatsD.increment("#{Search::Service::STATSD_KEY_PREFIX}.exceptions", tags: ['exception:429'])
-        raise_backend_exception('SEARCH_429', self.class, error)
-      end
+      return unless error.status == 429
+
+      StatsD.increment("#{Search::Service::STATSD_KEY_PREFIX}.exceptions", tags: ['exception:429'])
+      raise_backend_exception('SEARCH_429', self.class, error)
     end
 
     def raise_backend_exception(key, source, error = nil)


### PR DESCRIPTION
## Description of change
During our load testing of the Search.gov integration, we encountered many [429 errors](http://sentry.vetsgov-internal/vets-gov/platform-api-staging/issues/49190/) coming from their apache server.  We need to handle this error more gracefully. 

A follow up ticket will deal with PagerDuty alerting and/or Sentry logging, stemming from 429 errors. 

## Testing done
<!-- Please describe testing done to verify the changes. -->
Local testing

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] No longer logs to sentry for every 429 error
- [x] Increments a StatsD counter for each 429 error
- [ ] Work with DevOps to get the new StatsD data into a graph in Grafana 

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
