### PR TITLE
Adding a `.` in front of localhost fixed an login error in firefox

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,7 +21,7 @@ sso:
   cookie_key: 095B564B0F29EF88A96F1A7584E17516B14F85C2B3AD431E63349AC5272BC86B
   cookie_iv: A3C0567C78BEC6DDE75E2FEB92DE11AA
   cookie_secure: false
-  cookie_domain: localhost
+  cookie_domain: .localhost
 
 binaries:
   # you can specify a full path in settings.local.yml if necessary


### PR DESCRIPTION
Also seems to work fine in chrome

## Description of change
Observed login with the sso cookie was failing in Firefox, but it worked fine in chrome. This was due to some problem with how firefox handles localhost cookies. Changing the cookie domain to `.localhost` makes it work properly. 

## Testing done
Verified login works locally with these settings in Firefox and Chrome. 

## Testing planned
Nothing further

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Fix local login in Firefox. 

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
