### PR TITLE
Fix flapping application controller spec

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -269,9 +269,10 @@ RSpec.describe ApplicationController, type: :controller do
           let(:sso_cookie_value)  { nil }
 
           around(:each) do |example|
+            original_value = Settings.sso.cookie_signout_enabled
             Settings.sso.cookie_signout_enabled = true
             example.run
-            Settings.sso.cookie_signout_enabled = nil
+            Settings.sso.cookie_signout_enabled = original_value
           end
 
           it 'returns json error' do
@@ -285,6 +286,13 @@ RSpec.describe ApplicationController, type: :controller do
         context 'with a virtual host that matches sso cookie domain, but sso cookie destroyed: disabled' do
           let(:header_host_value) { 'localhost' }
           let(:sso_cookie_value)  { nil }
+
+          around(:each) do |example|
+            original_value = Settings.sso.cookie_signout_enabled
+            Settings.sso.cookie_signout_enabled = false
+            example.run
+            Settings.sso.cookie_signout_enabled = original_value
+          end
 
           it 'returns success' do
             get :test_authentication


### PR DESCRIPTION
 Settings.sso.cookie_signout_enabled is true in settings.yml, but a teardown was setting it to nil