### PR TITLE
add trailing slash to logout url

### DIFF
--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -15,7 +15,7 @@ module SAML
     }.freeze
 
     LOGIN_REDIRECT_PARTIAL = '/auth/login/callback'
-    LOGOUT_REDIRECT_PARTIAL = '/logout'
+    LOGOUT_REDIRECT_PARTIAL = '/logout/'
 
     attr_reader :saml_settings, :session, :authn_context
 

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe V0::SessionsController, type: :controller do
     end
 
     it 'redirects as success even when logout fails, but it logs the failure' do
-      expect(post(:saml_logout_callback)).to redirect_to('http://127.0.0.1:3001/logout?success=true')
+      expect(post(:saml_logout_callback)).to redirect_to('http://127.0.0.1:3001/logout/?success=true')
     end
 
     describe 'GET sessions/logout' do
@@ -227,7 +227,7 @@ RSpec.describe V0::SessionsController, type: :controller do
         it 'redirects as success and logs the failure' do
           expect(Rails.logger).to receive(:error).with(/bad thing/).exactly(1).times
           expect(post(:saml_logout_callback, SAMLResponse: '-'))
-            .to redirect_to('http://127.0.0.1:3001/logout?success=true')
+            .to redirect_to('http://127.0.0.1:3001/logout/?success=true')
         end
       end
 
@@ -245,7 +245,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           # this will be destroyed
           expect(SingleLogoutRequest.find(succesful_logout_response&.in_response_to)).to_not be_nil
           expect(post(:saml_logout_callback, SAMLResponse: '-'))
-            .to redirect_to(redirect_to('http://127.0.0.1:3001/logout?success=true'))
+            .to redirect_to(redirect_to('http://127.0.0.1:3001/logout/?success=true'))
           # these should have been destroyed in the initial call to sessions/logout, not in the callback.
           expect(Session.find(token)).to_not be_nil
           expect(User.find(uuid)).to_not be_nil


### PR DESCRIPTION
Addresses issue where logout popup was getting a 302 redirect and the JS on the page wasn't executing to close the popup.