### PR TITLE
update loofah gem

### DIFF
--- a/modules/vba_documents/Gemfile.lock
+++ b/modules/vba_documents/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (1.8.6)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -161,4 +161,4 @@ DEPENDENCIES
   vba_documents!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
## Description of change
Updates the `loofah` gem from 2.2.2 to 2.2.3 that is used by our `vba_documents` module/gem.

Command run:
```
williamryan:~/Github/vets-api (update-loofah) $ bundle update --source loofah
```

## Testing done
Ran local specs, i.e.:
```
williamryan:~/Github/vets-api (update-loofah) $ be rake spec SPEC=modules/vba_documents/
```

## Testing planned
None.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ x ] Update gem with bundler

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
