### PR TITLE
686 Prefill: use DateTime instead of Date when converting from epoch milliseconds

### DIFF
--- a/app/models/form_profiles/va21686c.rb
+++ b/app/models/form_profiles/va21686c.rb
@@ -197,7 +197,7 @@ class FormProfiles::VA21686c < FormProfile
 
   def convert_date(date)
     return unless date
-    Date.strptime(date.to_s, '%Q').to_s
+    DateTime.strptime(date.to_s, '%Q').to_date.to_s
   end
 
   def prefill_dependents(children)


### PR DESCRIPTION
## Description of change
686 Prefill: use DateTime instead of Date when converting from epoch milliseconds

## Testing done
specs

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] use DateTime instead of Date when converting from epoch milliseconds.  `Date` does not properly take time zone into account

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
