### PR TITLE
[WIP] remove 526 beta tracking

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -112,19 +112,8 @@ class UserSerializer < ActiveModel::Serializer
     service_list << BackendServices::ID_CARD if object.can_access_id_card?
     service_list << BackendServices::IDENTITY_PROOFED if object.identity_proofed?
     service_list << BackendServices::VET360 if object.can_access_vet360?
-    service_list << BackendServices::CLAIM_INCREASE_AVAILABLE if claims_for_increase_available?
     service_list += BetaRegistration.where(user_uuid: object.uuid).pluck(:feature) || []
     service_list
   end
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
-
-  private
-
-  def claims_for_increase_available?
-    object.authorize(:evss, :access?) && !claims_for_increase_limiter.at_limit?
-  end
-
-  def claims_for_increase_limiter
-    Common::EventRateLimiter.new(REDIS_CONFIG['evss_526_submit_form_rate_limit'])
-  end
 end

--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -80,7 +80,6 @@ module EVSS
       end
 
       def response_handler(response)
-        submission_rate_limiter.increment
         TRANSACTION_CLASS.update_transaction(jid, :received, response.attributes)
         perform_ancillary_jobs(response.claim_id)
       end
@@ -110,10 +109,6 @@ module EVSS
 
       def saved_claim(saved_claim_id)
         SavedClaim::DisabilityCompensation.find(saved_claim_id)
-      end
-
-      def submission_rate_limiter
-        Common::EventRateLimiter.new(REDIS_CONFIG['evss_526_submit_form_rate_limit'])
       end
     end
   end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -56,12 +56,6 @@ development: &defaults
   evss_claims_store:
     namespace: evss
     each_ttl: 3600
-  evss_526_submit_form_rate_limit:
-    namespace: evss-526-submit-form-rate-limit
-    threshold_limit: 10
-    threshold_ttl: 86400
-    count_limit: 30
-    count_ttl: 604800
   user_account_details:
     namespace: user-account-details
     each_ttl: 1296000 # 15 days

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,7 +233,6 @@ Rails.application.routes.draw do
       'profile',
       'dashboard',
       'veteran_id_card',
-      'claim_increase',
       FormProfile::EMIS_PREFILL_KEY
     ].each do |feature|
       resource(

--- a/lib/backend_services.rb
+++ b/lib/backend_services.rb
@@ -30,7 +30,4 @@ class BackendServices
   # Core Form Features
   SAVE_IN_PROGRESS = 'form-save-in-progress'
   FORM_PREFILL = 'form-prefill'
-
-  # 526 claim for increase beta has not reached daily or weekly limit
-  CLAIM_INCREASE_AVAILABLE = 'claim-increase-available'
 end

--- a/spec/lib/common/event_rate_limiter_spec.rb
+++ b/spec/lib/common/event_rate_limiter_spec.rb
@@ -4,7 +4,16 @@ require 'rails_helper'
 
 describe Common::EventRateLimiter do
   context 'with the default evss 526 config' do
-    subject { Common::EventRateLimiter.new(REDIS_CONFIG['evss_526_submit_form_rate_limit']) }
+    let(:config) do
+      {
+        'namespace' => 'evss-526-submit-form-rate-limit',
+        'threshold_limit' => 10,
+        'threshold_ttl' => 86400,
+        'count_limit' => 30,
+        'count_ttl' => 604800
+      }
+    end
+    subject { Common::EventRateLimiter.new(config) }
 
     describe '.at_limit?' do
       context 'with no events' do

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -22,80 +22,46 @@ RSpec.describe 'Fetching user data', type: :request do
       create(:account, idme_uuid: mhv_user.uuid)
     end
 
-    context 'when the claim for increase submission limit has not been reached' do
-      before do
-        auth_header = { 'Authorization' => "Token token=#{token}" }
-        get v0_user_url, nil, auth_header
-      end
-
-      it 'GET /v0/user - returns proper json' do
-        assert_response :success
-        expect(response).to match_response_schema('user_loa3')
-      end
-
-      it 'gives me the list of available prefill forms' do
-        num_enabled = 2
-        num_enabled += FormProfile::EDU_FORMS.length if Settings.edu.prefill
-        num_enabled += FormProfile::HCA_FORMS.length if Settings.hca.prefill
-        num_enabled += FormProfile::PENSION_BURIAL_FORMS.length if Settings.pension_burial.prefill
-        num_enabled += FormProfile::VIC_FORMS.length if Settings.vic.prefill
-        num_enabled += FormProfile::EVSS_FORMS.length if Settings.evss.prefill
-
-        expect(JSON.parse(response.body)['data']['attributes']['prefills_available'].length).to be(num_enabled)
-      end
-
-      it 'gives me the list of available services that includes claim increase' do
-        expect(JSON.parse(response.body)['data']['attributes']['services'].sort).to eq(
-          [
-            BackendServices::FACILITIES,
-            BackendServices::HCA,
-            BackendServices::EDUCATION_BENEFITS,
-            BackendServices::EVSS_CLAIMS,
-            BackendServices::USER_PROFILE,
-            BackendServices::RX,
-            BackendServices::MESSAGING,
-            BackendServices::HEALTH_RECORDS,
-            # BackendServices::MHV_AC, this will be false if mhv account is premium
-            BackendServices::FORM_PREFILL,
-            BackendServices::SAVE_IN_PROGRESS,
-            BackendServices::APPEALS_STATUS,
-            BackendServices::IDENTITY_PROOFED,
-            BackendServices::VET360,
-            BackendServices::CLAIM_INCREASE_AVAILABLE
-          ].sort
-        )
-      end
+    before do
+      auth_header = { 'Authorization' => "Token token=#{token}" }
+      get v0_user_url, nil, auth_header
     end
 
-    context 'when the claim for increase submission limit has been reached' do
-      let(:submission_rate_limiter) { Common::EventRateLimiter.new(REDIS_CONFIG['evss_526_submit_form_rate_limit']) }
+    it 'GET /v0/user - returns proper json' do
+      assert_response :success
+      expect(response).to match_response_schema('user_loa3')
+    end
 
-      before do
-        11.times { submission_rate_limiter.increment }
-        auth_header = { 'Authorization' => "Token token=#{token}" }
-        get v0_user_url, nil, auth_header
-      end
+    it 'gives me the list of available prefill forms' do
+      num_enabled = 2
+      num_enabled += FormProfile::EDU_FORMS.length if Settings.edu.prefill
+      num_enabled += FormProfile::HCA_FORMS.length if Settings.hca.prefill
+      num_enabled += FormProfile::PENSION_BURIAL_FORMS.length if Settings.pension_burial.prefill
+      num_enabled += FormProfile::VIC_FORMS.length if Settings.vic.prefill
+      num_enabled += FormProfile::EVSS_FORMS.length if Settings.evss.prefill
 
-      it 'gives me the list of available services without claim increase' do
-        expect(JSON.parse(response.body)['data']['attributes']['services'].sort).to eq(
-          [
-            BackendServices::FACILITIES,
-            BackendServices::HCA,
-            BackendServices::EDUCATION_BENEFITS,
-            BackendServices::EVSS_CLAIMS,
-            BackendServices::USER_PROFILE,
-            BackendServices::RX,
-            BackendServices::MESSAGING,
-            BackendServices::HEALTH_RECORDS,
-            # BackendServices::MHV_AC, this will be false if mhv account is premium
-            BackendServices::FORM_PREFILL,
-            BackendServices::SAVE_IN_PROGRESS,
-            BackendServices::APPEALS_STATUS,
-            BackendServices::IDENTITY_PROOFED,
-            BackendServices::VET360
-          ].sort
-        )
-      end
+      expect(JSON.parse(response.body)['data']['attributes']['prefills_available'].length).to be(num_enabled)
+    end
+
+    it 'gives me the list of available services' do
+      expect(JSON.parse(response.body)['data']['attributes']['services'].sort).to eq(
+        [
+          BackendServices::FACILITIES,
+          BackendServices::HCA,
+          BackendServices::EDUCATION_BENEFITS,
+          BackendServices::EVSS_CLAIMS,
+          BackendServices::USER_PROFILE,
+          BackendServices::RX,
+          BackendServices::MESSAGING,
+          BackendServices::HEALTH_RECORDS,
+          # BackendServices::MHV_AC, this will be false if mhv account is premium
+          BackendServices::FORM_PREFILL,
+          BackendServices::SAVE_IN_PROGRESS,
+          BackendServices::APPEALS_STATUS,
+          BackendServices::IDENTITY_PROOFED,
+          BackendServices::VET360
+        ].sort
+      )
     end
   end
 


### PR DESCRIPTION
## Description of change
Removes 526 beta submission tracking and limiting. 

## Testing done
unit tests

## Testing planned
local testing, staging testing

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Removes 526 beta increment on successful submission
- [ ] Removes 526 from beta routes
- [ ] Keeps the rate limiter but updates its spec

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
