### PR TITLE
Updates rack-protection and sprockets for vba_documents

### DIFF
--- a/modules/vba_documents/Gemfile.lock
+++ b/modules/vba_documents/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     pg (0.19.0)
     rack (1.6.9)
-    rack-protection (1.5.4)
+    rack-protection (2.0.4)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -139,7 +139,7 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
## Description of change
Updates 2 gems in `vba_documents`:
- `sprockets`
- `rack-protection`

I used the following commands:
- `bundle update --conservative sprockets`
- `bundle update --conservative rack-protection`

## Testing done
Ran local rspecs.

## Testing planned
None.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ x ] Update Gems

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ x ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
