### PR TITLE
virtual_host: request.host to tags context

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -134,6 +134,7 @@ class ApplicationController < ActionController::API
   def tags_context
     {
       controller_name: controller_name,
+      virtual_host: request.host,
       sign_in_method: @current_user.present? ? @current_user.authn_context || 'idme' : 'not-signed-in'
     }
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe ApplicationController, type: :controller do
       # if current user is nil it means user is not signed in.
       expect(Raven).to receive(:tags_context).once.with(
         controller_name: 'anonymous',
+        virtual_host: 'www.example.com',
         sign_in_method: 'not-signed-in'
       )
       # since user is not signed in this shouldnt get called.
@@ -175,6 +176,7 @@ RSpec.describe ApplicationController, type: :controller do
         # if authn_context is nil on current_user it means idme
         expect(Raven).to receive(:tags_context).once.with(
           controller_name: 'anonymous',
+          virtual_host: 'www.example.com',
           sign_in_method: 'idme'
         )
         # since user IS signed in, this SHOULD get called


### PR DESCRIPTION
## Description of change
adds additional tags context in application controller to know which virtual host was reached, this makes searchability in sentry easier, distinguishing preview.va.gov from vets.gov, etc.

## Testing done
local specs

## Testing planned
verify in sentry its working as expected.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
