### PR TITLE
increase frequency on maintenance window polling

### DIFF
--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -90,7 +90,7 @@ FacilityLocationBulkUpdateVHA:
   description: "Download and store facility location data"
 
 MaintenanceWindowRefresh:
-  cron: "*/5 * * * * America/New_York"
+  cron: "*/3 * * * * America/New_York"
   class: PagerDuty::PollMaintenanceWindows
   description: "Poll PagerDuty API for maintenance window information"
 


### PR DESCRIPTION
Update frequency of the polling for new maintenance windows on the backend. This is coupled with some caching we are doing at the proxy layer to ease burden on the API.

ref: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14519