### PR TITLE
Sanitize invalid EDIPI from MVI

### DIFF
--- a/lib/mvi/responses/profile_parser.rb
+++ b/lib/mvi/responses/profile_parser.rb
@@ -103,7 +103,7 @@ module MVI
           icn: correlation_ids[:icn],
           mhv_ids: correlation_ids[:mhv_ids],
           active_mhv_ids: correlation_ids[:active_mhv_ids],
-          edipi: correlation_ids[:edipi],
+          edipi: sanitize_edipi(correlation_ids[:edipi]),
           participant_id: correlation_ids[:vba_corp_id],
           vha_facility_ids: correlation_ids[:vha_facility_ids],
           sec_id: correlation_ids[:sec_id],
@@ -133,6 +133,12 @@ module MVI
 
       def get_patient_name(patient)
         locate_element(patient, NAME_XPATH)
+      end
+
+      def sanitize_edipi(edipi)
+        return nil unless edipi
+        # Get rid of invalid values like 'UNK'
+        edipi.match(/\d{10}/).to_s
       end
 
       # name can be a hash or an array of hashes with extra unneeded details

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -68,7 +68,7 @@ FactoryBot.define do
       mhv_ids ['123456']
       active_mhv_ids ['123456']
       vha_facility_ids %w[516 553 200HD 200IP 200MHV]
-      edipi '1234'
+      edipi '1234567890'
       participant_id '12345678'
       birls_id '796122306'
       vet360_id '123456789'

--- a/spec/lib/mvi/responses/profile_parser_spec.rb
+++ b/spec/lib/mvi/responses/profile_parser_spec.rb
@@ -53,7 +53,7 @@ describe MVI::Responses::ProfileParser do
         end
       end
 
-      context 'with a missing address' do
+      context 'with a missing address and an invalid edipi' do
         let(:body) { Ox.parse(File.read('spec/support/mvi/find_candidate_response_nil_address.xml')) }
         let(:mvi_profile) do
           build(
@@ -62,7 +62,8 @@ describe MVI::Responses::ProfileParser do
             birls_id: nil,
             sec_id: nil,
             historical_icns: nil,
-            vet360_id: nil
+            vet360_id: nil,
+            edipi: ''
           )
         end
         it 'should set the address to nil' do

--- a/spec/support/mvi/find_candidate_response.xml
+++ b/spec/support/mvi/find_candidate_response.xml
@@ -50,7 +50,7 @@
                 <id extension="12345^PI^200HD^USVHA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="TKIP123456^PI^200IP^USVHA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="123456^PI^200MHV^USVHA^A" root="2.16.840.1.113883.4.349"/>
-                <id extension="1234^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12" />
+                <id extension="1234567890^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12" />
                 <id extension="12345678^PI^200CORP^USVBA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="123456789^PI^200VETS^USDVA^A" root="2.16.840.1.113883.4.349" />
                 <statusCode code="active"/>

--- a/spec/support/mvi/find_candidate_response_nil_address.xml
+++ b/spec/support/mvi/find_candidate_response_nil_address.xml
@@ -50,7 +50,7 @@
                 <id extension="12345^PI^200HD^USVHA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="TKIP123456^PI^200IP^USVHA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="123456^PI^200MHV^USVHA^A" root="2.16.840.1.113883.4.349"/>
-                <id extension="1234^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12" />
+                <id extension="UNK^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12" />
                 <id extension="12345678^PI^200CORP^USVBA^A" root="2.16.840.1.113883.4.349"/>
                 <statusCode code="active"/>
                 <patientPerson>


### PR DESCRIPTION
## Description of change
An EDIPI is always a 10 digit number. Sometimes, MVI returns `UNK`.  For the sake of our presence checks, we're removing responses that aren't 10 digits.
## Testing done
Specs

## Testing planned
test on staging with steps in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14865

## Acceptance Criteria (Definition of Done)
we will see a reduction in errors here:
http://sentry.vetsgov-internal/vets-gov/platform-api-staging/issues/49776/
http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/48873/

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
