### PR TITLE
remove `require` statements that are not necessary due to autoload/eagerload

### DIFF
--- a/lib/evss/disability_compensation_form/form_submit_response.rb
+++ b/lib/evss/disability_compensation_form/form_submit_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'evss/response'
-
 module EVSS
   module DisabilityCompensationForm
     class FormSubmitResponse < EVSS::Response

--- a/lib/evss/disability_compensation_form/rated_disabilities_response.rb
+++ b/lib/evss/disability_compensation_form/rated_disabilities_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'evss/response'
-require 'evss/disability_compensation_form/rated_disabilities'
-
 module EVSS
   module DisabilityCompensationForm
     class RatedDisabilitiesResponse < EVSS::Response

--- a/lib/evss/disability_compensation_form/rated_disability.rb
+++ b/lib/evss/disability_compensation_form/rated_disability.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
-require 'evss/disability_compensation_form/special_issue'
-
 module EVSS
   module DisabilityCompensationForm
     class RatedDisability

--- a/lib/evss/gi_bill_status/gi_bill_status_response.rb
+++ b/lib/evss/gi_bill_status/gi_bill_status_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'common/client/concerns/service_status'
-require 'evss/response'
-
 module EVSS
   module GiBillStatus
     class GiBillStatusResponse < EVSS::Response

--- a/lib/evss/intent_to_file/intent_to_file_response.rb
+++ b/lib/evss/intent_to_file/intent_to_file_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'evss/response'
-require 'evss/intent_to_file/intent_to_file'
-
 module EVSS
   module IntentToFile
     class IntentToFileResponse < EVSS::Response

--- a/lib/evss/intent_to_file/intent_to_files_response.rb
+++ b/lib/evss/intent_to_file/intent_to_files_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'evss/response'
-require 'evss/intent_to_file/intent_to_file'
-
 module EVSS
   module IntentToFile
     class IntentToFilesResponse < EVSS::Response

--- a/lib/evss/letters/letters_response.rb
+++ b/lib/evss/letters/letters_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'common/client/concerns/service_status'
-require 'evss/response'
-
 module EVSS
   module Letters
     class LettersResponse < EVSS::Response

--- a/lib/evss/pciu/email_address_response.rb
+++ b/lib/evss/pciu/email_address_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'evss/response'
-
 module EVSS
   module PCIU
     class EmailAddressResponse < EVSS::Response

--- a/lib/evss/pciu/phone_number_response.rb
+++ b/lib/evss/pciu/phone_number_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'evss/response'
-
 module EVSS
   module PCIU
     class PhoneNumberResponse < EVSS::Response

--- a/lib/evss/pciu_address/address_response.rb
+++ b/lib/evss/pciu_address/address_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'evss/response'
-
 module EVSS
   module PCIUAddress
     class AddressResponse < EVSS::Response

--- a/lib/evss/pciu_address/countries_response.rb
+++ b/lib/evss/pciu_address/countries_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'evss/response'
-
 module EVSS
   module PCIUAddress
     class CountriesResponse < EVSS::Response

--- a/lib/evss/pciu_address/states_response.rb
+++ b/lib/evss/pciu_address/states_response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'evss/response'
-
 module EVSS
   module PCIUAddress
     class StatesResponse < EVSS::Response

--- a/lib/evss/ppiu/payment_information_response.rb
+++ b/lib/evss/ppiu/payment_information_response.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'evss/response'
-require 'evss/ppiu/payment_information'
-
 module EVSS
   module PPIU
     class PaymentInformationResponse < EVSS::Response


### PR DESCRIPTION
## Description of change
This is a Tech Debt PR.
Remove `require` statements that are not necessary due to autoload/eagerload.
I'll open these PRs in increments.  This one focuses on removing files that `require 'evss/response'`

## Testing done
specs

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] remove `require` statements that are not necessary due to autoload/eagerload.

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
