### PR TITLE
WIP - MVI Redis TTL threadsafe

### DIFF
--- a/app/models/mvi.rb
+++ b/app/models/mvi.rb
@@ -121,23 +121,11 @@ class Mvi < Common::RedisStore
 
   def response_from_redis_or_service
     do_cached_with(key: @user.uuid) do
-      profile = mvi_service.find_profile(@user)
-      self.class.redis_namespace_ttl = set_ttl(profile)
-      profile
+      mvi_service.find_profile(@user)
     end
   end
 
   def mvi_service
     @service ||= MVI::Service.new
-  end
-
-  def set_ttl(profile)
-    if profile.status == MVI::Responses::FindProfileResponse::RESPONSE_STATUS[:ok]
-      # ensure default ttl is used for 'ok' responses
-      REDIS_CONFIG[REDIS_CONFIG_KEY.to_s]['each_ttl']
-    else
-      # assign separate ttl to redis cache for failure responses
-      REDIS_CONFIG[REDIS_CONFIG_KEY.to_s]['failure_ttl']
-    end
   end
 end

--- a/lib/common/models/concerns/active_record_cache_aside.rb
+++ b/lib/common/models/concerns/active_record_cache_aside.rb
@@ -49,10 +49,7 @@ module Common
 
         record = yield
         raise NoMethodError, 'The record class being cached must implement #cache?' unless record.respond_to?(:cache?)
-        if record.cache?
-          ttl = record.respond_to?(:record_ttl) ? record.record_ttl : @redis_namespace_ttl
-          cache_record(key, record, ttl)
-        end
+        cache_record(key, record) if record.cache?
         record
       end
       # rubocop:enable Security/MarshalLoad
@@ -65,11 +62,11 @@ module Common
       #   redis_namespace, to be used together as the Redis key
       # @param record [ActiveRecord::Base] The ActiveRecord::Base db record to be cached
       #
-      def self.cache_record(key, record, ttl)
+      def self.cache_record(key, record)
         serialized = Marshal.dump(record)
 
         @redis_namespace.set(key, serialized)
-        @redis_namespace.expire(key, ttl)
+        @redis_namespace.expire(key, @redis_namespace_ttl)
       end
     end
   end

--- a/lib/common/models/concerns/cache_aside.rb
+++ b/lib/common/models/concerns/cache_aside.rb
@@ -42,7 +42,11 @@ module Common
 
     def cache(key, response)
       set_attributes(key, response)
-      save
+      if response.respond_to?(:record_ttl)
+        save(response.record_ttl)
+      else
+        save
+      end
     end
 
     private

--- a/lib/common/models/redis_store.rb
+++ b/lib/common/models/redis_store.rb
@@ -76,10 +76,14 @@ module Common
       redis_namespace.del(redis_key)
     end
 
-    def save
+    def save(record_ttl = nil)
       return false unless valid?
       redis_namespace.set(attributes[redis_namespace_key], Oj.dump(attributes))
-      expire(redis_namespace_ttl) if defined? redis_namespace_ttl
+      if record_ttl
+        expire(record_ttl)
+      elsif defined? redis_namespace_ttl
+        expire(redis_namespace_ttl)
+      end
       @persisted = true
     end
 

--- a/lib/mvi/responses/find_profile_response.rb
+++ b/lib/mvi/responses/find_profile_response.rb
@@ -59,6 +59,16 @@ module MVI
         Settings.mvi.cache_all_profile_responses || ok?
       end
 
+      def record_ttl
+        if ok?
+          # ensure default ttl is used for 'ok' responses
+          REDIS_CONFIG[Mvi::REDIS_CONFIG_KEY.to_s]['each_ttl']
+        else
+          # assign separate ttl to redis cache for failure responses
+          REDIS_CONFIG[Mvi::REDIS_CONFIG_KEY.to_s]['failure_ttl']
+        end
+      end
+
       def ok?
         @status == RESPONSE_STATUS[:ok]
       end

--- a/spec/models/mvi_spec.rb
+++ b/spec/models/mvi_spec.rb
@@ -32,6 +32,7 @@ describe Mvi, skip_mvi: true do
         expect(mvi.redis_namespace).to receive(:set).once
         expect_any_instance_of(MVI::Service).to receive(:find_profile).once
         expect(mvi.status).to eq('OK')
+        expect(mvi.mvi_response.record_ttl).to eq(default_ttl)
       end
       it 'should return an :error response but not cache it' do
         allow_any_instance_of(MVI::Service).to receive(:find_profile).and_return(profile_response_error)
@@ -57,21 +58,21 @@ describe Mvi, skip_mvi: true do
           expect(mvi.redis_namespace).to receive(:set).once
           expect_any_instance_of(MVI::Service).to receive(:find_profile).once
           expect(mvi.status).to eq('OK')
-          expect(mvi.redis_namespace_ttl).to eq(default_ttl)
+          expect(mvi.mvi_response.record_ttl).to eq(default_ttl)
         end
         it 'should cache and return an :error response' do
           allow_any_instance_of(MVI::Service).to receive(:find_profile).and_return(profile_response_error)
           expect(mvi.redis_namespace).to receive(:set).once
           expect_any_instance_of(MVI::Service).to receive(:find_profile).once
           expect(mvi.status).to eq('SERVER_ERROR')
-          expect(mvi.redis_namespace_ttl).to eq(failure_ttl)
+          expect(mvi.mvi_response.record_ttl).to eq(failure_ttl)
         end
         it 'should cache and return a :not_found response' do
           allow_any_instance_of(MVI::Service).to receive(:find_profile).and_return(profile_response_not_found)
           expect(mvi.redis_namespace).to receive(:set).once
           expect_any_instance_of(MVI::Service).to receive(:find_profile).once
           expect(mvi.status).to eq('NOT_FOUND')
-          expect(mvi.redis_namespace_ttl).to eq(failure_ttl)
+          expect(mvi.mvi_response.record_ttl).to eq(failure_ttl)
         end
       end
     end


### PR DESCRIPTION
## Description of change
Prompted by @omgitsbillryan's comment here: https://github.com/department-of-veterans-affairs/vets-api/pull/2406/files#diff-e70f53a2d7e86d5f7014c439e9f6ee02R126 

We want to set the redis TTL on the record for MVI success/failure

## Testing done
specs

## Testing planned
more specs

PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
