### PR TITLE
OpenID MHV support

### DIFF
--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -12,9 +12,9 @@ class OpenidApplicationController < ApplicationController
   before_action :authenticate
   TOKEN_REGEX = /Bearer /
 
-
   DSLOGON_PREMIUM_LOAS = %w[2 3].freeze
   MHV_PREMIUM_LOAS = %w[Premium].freeze
+
   private
 
   def permit_scopes(scopes, actions: [])
@@ -106,13 +106,13 @@ class OpenidApplicationController < ApplicationController
 
   def derive_loa(profile)
     if profile['last_login_type'] == 'myhealthevet'
-      ml = MHV_PREMIUM_LOAS.include?(profile['mhv_account_type']) ? 3: 1
-      return { current: ml, highest: ml }
+      ml = MHV_PREMIUM_LOAS.include?(profile['mhv_account_type']) ? 3 : 1
+      { current: ml, highest: ml }
     elsif profile['last_login_type'] == 'dslogon'
       dl = DSLOGON_PREMIUM_LOAS.include?(profile['dslogon_assurance']) ? 3 : 1
-      return { current: dl, highest: dl }
+      { current: dl, highest: dl }
     else
-      return { current: profile['idme_loa'], highest: profile['idme_loa'] }
+      { current: profile['idme_loa'], highest: profile['idme_loa'] }
     end
   end
 

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -12,6 +12,9 @@ class OpenidApplicationController < ApplicationController
   before_action :authenticate
   TOKEN_REGEX = /Bearer /
 
+
+  DSLOGON_PREMIUM_LOAS = %w[2 3].freeze
+  MHV_PREMIUM_LOAS = %w[Premium].freeze
   private
 
   def permit_scopes(scopes, actions: [])
@@ -94,8 +97,23 @@ class OpenidApplicationController < ApplicationController
       gender: profile['gender']&.chars&.first&.upcase,
       birth_date: profile['dob'],
       ssn: profile['ssn'],
-      loa: { current: profile['loa'], highest: profile['loa'] }
+      mhv_correlation_id: profile['mhv_uuid'],
+      mhv_icn: profile['mhv_icn'],
+      dslogon_edipi: profile['dslogon_edipi'],
+      loa: derive_loa(profile)
     }
+  end
+
+  def derive_loa(profile)
+    if profile['last_login_type'] == 'myhealthevet'
+      ml = MHV_PREMIUM_LOAS.include?(profile['mhv_account_type']) ? 3: 1
+      return { current: ml, highest: ml }
+    elsif profile['last_login_type'] == 'dslogon'
+      dl = DSLOGON_PREMIUM_LOAS.include?(profile['dslogon_assurance']) ? 3 : 1
+      return { current: dl, highest: dl }
+    else
+      return { current: profile['idme_loa'], highest: profile['idme_loa'] }
+    end
   end
 
   def user_from_identity(user_identity, ttl)

--- a/spec/controllers/openid_application_controller_spec.rb
+++ b/spec/controllers/openid_application_controller_spec.rb
@@ -177,8 +177,15 @@ RSpec.describe OpenidApplicationController, type: :controller do
     end
 
     context 'with a MHV credential profile' do
+      let(:mvi_profile) do
+        build(:mvi_profile,
+              icn: '10000012345V123457',
+              family_name: 'zackariah')
+      end
+
       before(:each) do
         allow(JWT).to receive(:decode).and_return(token)
+        stub_mvi(mvi_profile)
       end
 
       let(:idme_response) { FactoryBot.build(:okta_mhv_response) }
@@ -195,19 +202,25 @@ RSpec.describe OpenidApplicationController, type: :controller do
           expect(response).to be_ok
           expect(Session.find('FakeToken')).to_not be_nil
           expect(JSON.parse(response.body)['user']).to eq('mhvzack_0@example.com')
-          expect(JSON.parse(response.body)['icn']).to eq('66218882840651988')
-          expect(JSON.parse(response.body)['last_name']).to eq('Heidenreich')
+          expect(JSON.parse(response.body)['icn']).to eq('10000012345V123457')
+          expect(JSON.parse(response.body)['last_name']).to eq('zackariah')
         end
       end
     end
 
     context 'with a DSLogon credential profile' do
-      before(:each) do
-        allow(JWT).to receive(:decode).and_return(token)
-      end
-
       let(:idme_response) { FactoryBot.build(:okta_dslogon_response) }
       let(:faraday_response) { instance_double('Faraday::Response') }
+      let(:mvi_profile) do
+        build(:mvi_profile,
+              icn: '10000012345V123456',
+              family_name: 'WEAVER')
+      end
+
+      before(:each) do
+        allow(JWT).to receive(:decode).and_return(token)
+        stub_mvi(mvi_profile)
+      end
 
       it 'should return 200 and add user to session' do
         with_okta_configured do
@@ -220,7 +233,7 @@ RSpec.describe OpenidApplicationController, type: :controller do
           expect(response).to be_ok
           expect(Session.find('FakeToken')).to_not be_nil
           expect(JSON.parse(response.body)['user']).to eq('dslogon10923109@example.com')
-          expect(JSON.parse(response.body)['icn']).to eq('67402072736994358')
+          expect(JSON.parse(response.body)['icn']).to eq('10000012345V123456')
           expect(JSON.parse(response.body)['last_name']).to eq('WEAVER')
         end
       end

--- a/spec/controllers/openid_application_controller_spec.rb
+++ b/spec/controllers/openid_application_controller_spec.rb
@@ -146,7 +146,9 @@ RSpec.describe OpenidApplicationController, type: :controller do
       def index
         render json: {
           'test' => 'It worked.',
-          'user' => @current_user.email
+          'user' => @current_user.email,
+          'icn' => @current_user.icn,
+          'last_name' => @current_user.last_name
         }
       end
     end
@@ -170,6 +172,56 @@ RSpec.describe OpenidApplicationController, type: :controller do
           expect(response).to be_ok
           expect(Session.find('FakeToken')).to_not be_nil
           expect(JSON.parse(response.body)['user']).to eq('vets.gov.user+20@gmail.com')
+        end
+      end
+    end
+
+    context 'with a MHV credential profile' do
+      before(:each) do
+        allow(JWT).to receive(:decode).and_return(token)
+      end
+
+      let(:idme_response) { FactoryBot.build(:okta_mhv_response) }
+      let(:faraday_response) { instance_double('Faraday::Response') }
+
+      it 'should return 200 and add user to session' do
+        with_okta_configured do
+          Okta::Service.any_instance.stub(:user).and_return(faraday_response)
+          allow(faraday_response).to receive(:success?).and_return(true)
+          allow(faraday_response).to receive(:body).and_return(idme_response)
+
+          request.headers['Authorization'] = 'Bearer FakeToken'
+          get :index
+          expect(response).to be_ok
+          expect(Session.find('FakeToken')).to_not be_nil
+          expect(JSON.parse(response.body)['user']).to eq('mhvzack_0@example.com')
+          expect(JSON.parse(response.body)['icn']).to eq('66218882840651988')
+          expect(JSON.parse(response.body)['last_name']).to eq('Heidenreich')
+        end
+      end
+    end
+
+    context 'with a DSLogon credential profile' do
+      before(:each) do
+        allow(JWT).to receive(:decode).and_return(token)
+      end
+
+      let(:idme_response) { FactoryBot.build(:okta_dslogon_response) }
+      let(:faraday_response) { instance_double('Faraday::Response') }
+
+      it 'should return 200 and add user to session' do
+        with_okta_configured do
+          Okta::Service.any_instance.stub(:user).and_return(faraday_response)
+          allow(faraday_response).to receive(:success?).and_return(true)
+          allow(faraday_response).to receive(:body).and_return(idme_response)
+
+          request.headers['Authorization'] = 'Bearer FakeToken'
+          get :index
+          expect(response).to be_ok
+          expect(Session.find('FakeToken')).to_not be_nil
+          expect(JSON.parse(response.body)['user']).to eq('dslogon10923109@example.com')
+          expect(JSON.parse(response.body)['icn']).to eq('67402072736994358')
+          expect(JSON.parse(response.body)['last_name']).to eq('WEAVER')
         end
       end
     end

--- a/spec/factories/okta_profiles.rb
+++ b/spec/factories/okta_profiles.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :okta_idme_response, class: Hash do
+    profile do
+      {
+        'lastName' => 'CARROLL',
+        'gender' => 'F',
+        'secondEmail' => null,
+        'login' => 'ae9ff5f4e4b741389904087d94cd19b2',
+        'ssn' => '123456789',
+        'last_login_type' => 'http://idmanagement.gov/ns/assurance/loa/3',
+        'firstName' => 'KELLY',
+        'idme_loa' => '3',
+        'mobilePhone' => nil,
+        'dob' => '1998-01-23',
+        'middleName' => 'D',
+        'email' => 'vets.gov.user+20@gmail.com',
+        'loa' => 3
+      }
+    end
+    initialize_with { { 'profile' => profile } }
+  end
+
+  factory :okta_mhv_response, class: Hash do
+    profile do
+      {
+        'lastName' => nil,
+        'gender' => nil,
+        'secondEmail' => nil,
+        'login' => '1cafa21544034e8caceeeeca5c108600',
+        'ssn' => nil,
+        'last_login_type' => 'myhealthevet',
+        'firstName' => nil,
+        'idme_loa' => '0',
+        'mobilePhone' => nil,
+        'dob' => nil,
+        'middleName' => nil,
+        'email' => 'mhvzack_0@example.com',
+        'loa' => 0,
+        'mhv_profile' => '{"accountType":"Premium","availableServices":{"21":"VA Medications"}}',
+        'mhv_icn' => '1013062086V794840',
+        'mhv_account_type' => 'Premium',
+        'mhv_uuid' => '15093546'
+      }
+    end
+    initialize_with { { 'profile' => profile } }
+  end
+
+  factory :okta_dslogon_response, class: Hash do
+    profile do
+      {
+        'lastName' => 'WEAVER',
+        'gender' => 'M',
+        'secondEmail' => nil,
+        'login' => '1655c16aa0784dbe973814c95bd69177',
+        'ssn' => '796123607',
+        'last_login_type' => 'dslogon',
+        'firstName' => 'JOHNNIE',
+        'idme_loa' => '0',
+        'mobilePhone' => nil,
+        'dob' => '1956-07-10',
+        'middleName' => 'Leonard',
+        'dslogon_edipi' => '1005169255',
+        'email' => 'dslogon10923109@example.com',
+        'loa' => 2,
+        'dslogon_assurance' => '2'
+      }
+    end
+    initialize_with { { 'profile' => profile } }
+  end
+end

--- a/spec/factories/okta_profiles.rb
+++ b/spec/factories/okta_profiles.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
       {
         'lastName' => 'CARROLL',
         'gender' => 'F',
-        'secondEmail' => null,
+        'secondEmail' => nil,
         'login' => 'ae9ff5f4e4b741389904087d94cd19b2',
         'ssn' => '123456789',
         'last_login_type' => 'http://idmanagement.gov/ns/assurance/loa/3',

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,11 +53,11 @@ end
 def with_okta_configured(&block)
   with_settings(
     Settings.oidc,
-    auth_server_metadata_url: 'https://example.com/oauth2/default/.well-known/oauth-authorization-server',
+    auth_server_metadata_url: 'https://example.com/oauth2/default/.well-known/openid-configuration',
     issuer: 'https://example.com/oauth2/default',
     audience: 'api://default',
     base_api_url: 'https://example.com/',
-    base_api_token: 'token'
+#    base_api_token: 'token'
   ) do
     VCR.use_cassette('okta/metadata') do
       yield block
@@ -82,6 +82,7 @@ VCR.configure do |c|
   c.filter_sensitive_data('<MVI_URL>') { Settings.mvi.url }
   c.filter_sensitive_data('<PRENEEDS_HOST>') { Settings.preneeds.host }
   c.filter_sensitive_data('<PD_TOKEN>') { Settings.maintenance.pagerduty_api_token }
+  c.filter_sensitive_data('<OKTA_TOKEN>') { Settings.oidc.base_api_token }
   c.before_record do |i|
     %i[response request].each do |env|
       next unless i.send(env).headers.keys.include?('Token')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,7 +57,7 @@ def with_okta_configured(&block)
     issuer: 'https://example.com/oauth2/default',
     audience: 'api://default',
     base_api_url: 'https://example.com/',
-#    base_api_token: 'token'
+    base_api_token: 'token'
   ) do
     VCR.use_cassette('okta/metadata') do
       yield block

--- a/spec/support/vcr_cassettes/okta/metadata.yml
+++ b/spec/support/vcr_cassettes/okta/metadata.yml
@@ -2,24 +2,28 @@
 http_interactions:
 - request:
     method: get
-    uri: https://example.com/oauth2/default/.well-known/oauth-authorization-server
+    uri: https://example.com/oauth2/default/.well-known/openid-configuration
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
       - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - SSWS <OKTA_TOKEN>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 02 Oct 2018 18:36:13 GMT
+      - Tue, 13 Nov 2018 01:59:08 GMT
       Server:
       - nginx
       Public-Key-Pins-Report-Only:
@@ -29,7 +33,7 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       X-Okta-Request-Id:
-      - W7O6nd8xnATxaQEeDXGTKAAAEyA
+      - W@ov7KhiirzWZ3wxk4ekxQAAFH4
       P3p:
       - CP="HONK"
       X-Rate-Limit-Limit:
@@ -37,28 +41,30 @@ http_interactions:
       X-Rate-Limit-Remaining:
       - '9999'
       X-Rate-Limit-Reset:
-      - '1538505433'
+      - '1542074408'
       Cache-Control:
       - no-cache, no-store
       Pragma:
       - no-cache
       Expires:
       - '0'
+      X-Content-Type-Options:
+      - nosniff
       Strict-Transport-Security:
       - max-age=315360000
       X-Robots-Tag:
       - none
       Set-Cookie:
-      - JSESSIONID=6C6B00CF648414DFF3EF6F6BD318EFA4; Path=/; HttpOnly
+      - JSESSIONID=B8E5790E66E44F49B5DB0068DF81EFD9; Path=/; Secure; HttpOnly
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"issuer":"https://example.com/oauth2/default","authorization_endpoint":"https://example.com/oauth2/default/v1/authorize","token_endpoint":"https://example.com/oauth2/default/v1/token","registration_endpoint":"https://example.com/oauth2/v1/clients","jwks_uri":"https://example.com/oauth2/default/v1/keys","response_types_supported":["code","token","code
-        token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","client_credentials"],"subject_types_supported":["public"],"scopes_supported":["openid","profile","email","address","phone","offline_access"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["ver","jti","iss","aud","iat","exp","cid","uid","scp","sub"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://example.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://example.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://example.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"]}'
+      string: '{"issuer":"https://example.com/oauth2/default","authorization_endpoint":"https://example.com/oauth2/default/v1/authorize","token_endpoint":"https://example.com/oauth2/default/v1/token","userinfo_endpoint":"https://example.com/oauth2/default/v1/userinfo","registration_endpoint":"https://example.com/oauth2/v1/clients","jwks_uri":"https://example.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["launch/patient","openid","profile","email","address","phone","offline_access"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://example.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://example.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://example.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"]}'
     http_version: 
-  recorded_at: Tue, 02 Oct 2018 18:36:13 GMT
+  recorded_at: Tue, 13 Nov 2018 01:59:08 GMT
 - request:
     method: get
     uri: https://example.com/oauth2/default/v1/keys
@@ -68,17 +74,21 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - SSWS <OKTA_TOKEN>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 02 Oct 2018 18:36:13 GMT
+      - Tue, 13 Nov 2018 01:59:08 GMT
       Server:
       - nginx
       Public-Key-Pins-Report-Only:
@@ -88,7 +98,7 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       X-Okta-Request-Id:
-      - W7O6nUy6TLksAKp@-D0dPQAACgc
+      - W@ov7Ep1DmzgoRmpjpcStQAAFjI
       P3p:
       - CP="HONK"
       X-Rate-Limit-Limit:
@@ -96,25 +106,27 @@ http_interactions:
       X-Rate-Limit-Remaining:
       - '9998'
       X-Rate-Limit-Reset:
-      - '1538505433'
+      - '1542074408'
       Cache-Control:
-      - max-age=1671961, must-revalidate
+      - max-age=5965338, must-revalidate
       Expires:
-      - Mon, 22 Oct 2018 03:02:14 GMT
+      - Mon, 21 Jan 2019 03:01:26 GMT
+      X-Content-Type-Options:
+      - nosniff
       Strict-Transport-Security:
       - max-age=315360000
       X-Robots-Tag:
       - none
       Set-Cookie:
-      - JSESSIONID=A7363160F0500417774AF37DD2CC31F3; Path=/; HttpOnly
+      - JSESSIONID=0C63F982615E816FF04BB85C7447FEBC; Path=/; Secure; HttpOnly
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"keys":[{"kty":"RSA","alg":"RS256","kid":"1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU","use":"sig","e":"AQAB","n":"0i4GWoXmMg8pn3jJbv7oabdQKxiV43CKIwY05LaSRdXxE0XcsFEXLe58tcEV_1afM3ey4KuHcSYk22En6nl2uGkFGZ_bU0ckrb8bqZ09Adr9Vwogat0QcOfHvqxaCJI6kOqtCX46iP11ViqW6oVHP--exfNPazQE5NyKO6l4VPZ68fpMX82Z_YBB_xdoYkTwM_LuCv2jDpFlumZt539sv7EbhxAL1tq8bjIVH-3tfJB8Hpar8AfzTrcoA8V61qi3JfipU9Bupuex379rf5LNnSh-dvbd98ZIhQKA2yp5nk9gEGKoEuTd-FlqLXs2q2Lr-BlbPDQVkNWClXJICznu_Q"}]}'
+      string: '{"keys":[{"kty":"RSA","alg":"RS256","kid":"1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU","use":"sig","e":"AQAB","n":"0i4GWoXmMg8pn3jJbv7oabdQKxiV43CKIwY05LaSRdXxE0XcsFEXLe58tcEV_1afM3ey4KuHcSYk22En6nl2uGkFGZ_bU0ckrb8bqZ09Adr9Vwogat0QcOfHvqxaCJI6kOqtCX46iP11ViqW6oVHP--exfNPazQE5NyKO6l4VPZ68fpMX82Z_YBB_xdoYkTwM_LuCv2jDpFlumZt539sv7EbhxAL1tq8bjIVH-3tfJB8Hpar8AfzTrcoA8V61qi3JfipU9Bupuex379rf5LNnSh-dvbd98ZIhQKA2yp5nk9gEGKoEuTd-FlqLXs2q2Lr-BlbPDQVkNWClXJICznu_Q"},{"kty":"RSA","alg":"RS256","kid":"8ngL7RPjudB40hF1ALOrxMAn_O7dwljoFohYxcZmLds","use":"sig","e":"AQAB","n":"mTOj331L7Bc3aHolSLR_Vh752zfG3q49NogKuw3eEIgfemQl91CRoOa6yq3aI25Mp15VeuQeVC2YtIM3Uh3Ctvh6ZCcr2UiVFvToIkrETNdJOXwRdo-1Az3Txl-ik_VN55SIYcQN2UcHSD6CM4_icntg4M6uRdylLVPjkmcfhjcHd_NNRgCZGX40N2azg-491vWIpoTVx9jpZjQv_XChTViLRU0F2d9hjg79qqP09r2Pz56dcyr3p0XKUIcYG9WTcUxNlPFdb-vmZ7T4zY49OcTqNIWlM79-XPMgZ7b1HrLnz0Z6iDcVfiDBI2WVCNS_ut00DPs6UIOE94xdav1M0w"}]}'
     http_version: 
-  recorded_at: Tue, 02 Oct 2018 18:36:14 GMT
+  recorded_at: Tue, 13 Nov 2018 01:59:09 GMT
 - request:
     method: get
     uri: https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7
@@ -129,7 +141,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - SSWS fake_token
+      - SSWS <OKTA_TOKEN>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -138,7 +150,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 02 Oct 2018 18:36:14 GMT
+      - Tue, 13 Nov 2018 01:59:10 GMT
       Server:
       - nginx
       Public-Key-Pins-Report-Only:
@@ -150,7 +162,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Okta-Request-Id:
-      - W7O6nvHQTz@yQ9ZxkScGNQAADUE
+      - W@ov7srI2BDv@Fqf0Z7D3gAACgU
       P3p:
       - CP="HONK"
       X-Rate-Limit-Limit:
@@ -158,23 +170,25 @@ http_interactions:
       X-Rate-Limit-Remaining:
       - '1999'
       X-Rate-Limit-Reset:
-      - '1538505434'
+      - '1542074410'
       Cache-Control:
       - no-cache, no-store
       Pragma:
       - no-cache
       Expires:
       - '0'
+      X-Content-Type-Options:
+      - nosniff
       Strict-Transport-Security:
       - max-age=315360000
       Set-Cookie:
-      - JSESSIONID=7B65D06D7C4F1ADE0621C53F8361A21B; Path=/; HttpOnly
+      - JSESSIONID=F1DCE568599152B5B46246BC2DC8FCB7; Path=/; Secure; HttpOnly
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00u1zlqhuo3yLa2Xs2p7","status":"ACTIVE","created":"2018-09-06T20:33:22.000Z","activated":"2018-09-06T20:33:22.000Z","statusChanged":"2018-09-06T20:33:22.000Z","lastLogin":"2018-10-02T17:48:18.000Z","lastUpdated":"2018-10-02T17:48:18.000Z","passwordChanged":null,"profile":{"firstName":"KELLY","lastName":"CARROLL","gender":"","mobilePhone":null,"dob":"1998-01-23","secondEmail":null,"middleName":"D","login":"ae9ff5f4e4b741389904087d94cd19b2","email":"vets.gov.user+20@gmail.com","ssn":"123456789","loa":3},"credentials":{"provider":{"type":"FEDERATION","name":"FEDERATION"}},"_links":{"suspend":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/lifecycle/suspend","method":"POST"},"resetPassword":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/lifecycle/reset_password","method":"POST"},"changeRecoveryQuestion":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/credentials/change_recovery_question","method":"POST"},"self":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7"},"deactivate":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/lifecycle/deactivate","method":"POST"}}}'
+      string: '{"id":"00u1zlqhuo3yLa2Xs2p7","status":"ACTIVE","created":"2018-09-06T20:33:22.000Z","activated":"2018-09-06T20:33:22.000Z","statusChanged":"2018-09-06T20:33:22.000Z","lastLogin":"2018-11-13T01:58:12.000Z","lastUpdated":"2018-11-13T01:58:11.000Z","passwordChanged":null,"profile":{"lastName":"CARROLL","gender":"F","secondEmail":null,"login":"ae9ff5f4e4b741389904087d94cd19b2","ssn":"123456789","last_login_type":"http://idmanagement.gov/ns/assurance/loa/3","firstName":"KELLY","idme_loa":"3","mobilePhone":null,"dob":"1998-01-23","middleName":"D","email":"vets.gov.user+20@gmail.com","loa":3},"credentials":{"provider":{"type":"FEDERATION","name":"FEDERATION"}},"_links":{"suspend":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/lifecycle/suspend","method":"POST"},"resetPassword":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/lifecycle/reset_password","method":"POST"},"changeRecoveryQuestion":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/credentials/change_recovery_question","method":"POST"},"self":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7"},"deactivate":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/lifecycle/deactivate","method":"POST"}}}'
     http_version: 
-  recorded_at: Tue, 02 Oct 2018 18:36:14 GMT
+  recorded_at: Tue, 13 Nov 2018 01:59:10 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Description of change
Updates OpenidApplicationController to handle tokens from MHV and DSLogon credentials correctly, by populating certain mhv and dslogon-specific profile attributes from Okta profile and using those to build up the user session.

Part of https://github.com/department-of-veterans-affairs/vets-contrib/issues/457
Also goes with https://github.com/department-of-veterans-affairs/vets-saml-proxy/pull/10 which ensures that MHV attributes are propagated to Okta from the SAML IdP.

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
Will verify this with a sample app once deployed to a review instance.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
