### PR TITLE
user veteran status returning server error

### DIFF
--- a/app/models/emis_redis/veteran_status.rb
+++ b/app/models/emis_redis/veteran_status.rb
@@ -57,7 +57,7 @@ module EMISRedis
     # @return [Hash] A hash of veteran status properties
     #
     def validated_response
-      raise VeteranStatus::NotAuthorized unless @user.loa3?
+      raise VeteranStatus::NotAuthorized if !@user.loa3? || !@user.authorize(:emis, :access?)
       response = emis_response('get_veteran_status')
 
       raise VeteranStatus::RecordNotFound if response.empty?

--- a/spec/models/emis_redis/veteran_status_spec.rb
+++ b/spec/models/emis_redis/veteran_status_spec.rb
@@ -24,6 +24,16 @@ describe EMISRedis::VeteranStatus, skip_emis: true do
       end
     end
 
+    context 'when the user doesnt have an edipi' do
+      it 'raises VeteranStatus::NotAuthorized' do
+        expect(user).to receive(:edipi).and_return(nil)
+
+        expect do
+          subject.veteran?
+        end.to raise_error(described_class::NotAuthorized)
+      end
+    end
+
     context 'when a record can not be found' do
       it 'raises VeteranStatus::RecordNotFound' do
         VCR.use_cassette('emis/get_veteran_status/missing_edipi') do

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -557,7 +557,7 @@ RSpec.describe FormProfile, type: :model do
 
   describe '#prefill_form' do
     def can_prefill_emis(yes)
-      expect(user).to receive(:authorize).with(:emis, :access?).and_return(yes)
+      expect(user).to receive(:authorize).at_least(:once).with(:emis, :access?).and_return(yes)
     end
 
     def strip_required(schema)


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15086
raise `VeteranStatus::NotAuthorized` when trying to query for veteran status when a user does not have an edipi so that the user serializer does not return the ambiguous "server error" message. https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/serializers/user_serializer.rb#L67

## Testing done
automated tests
<!-- Please describe testing done to verify the changes. -->

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
