### PR TITLE
[Facility Locator] Provider serializer fix

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -52,6 +52,6 @@ class ProviderSerializer < ActiveModel::Serializer
     object.ProviderSpecialties.map { |specialty| specialty['SpecialtyName'] }
   end
 
-  attributes :unique_id, :name, :address, :phone, :fax,
+  attributes :unique_id, :name, :address, :phone, :fax, :lat, :long,
              :pref_contact, :acc_new_patients, :gender, :specialty
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :provider, class: Facilities::Provider do
+    ProviderIdentifier '111111'
+    Name 'Allergy Partners of Manassas'
+    Latitude 38.8476575
+    Longitude(-72.26950512)
+    AddressStreet '700 Centreville Rd'
+    AddressCity 'Manassas'
+    AddressStateProvince 'VA'
+    AddressPostalCode '22033'
+    MainPhone '703-823-8551'
+    ProviderSpecialties []
+  end
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :provider, class: Facilities::Provider do
+  factory :provider, class: Provider do
     ProviderIdentifier '111111'
     Name 'Allergy Partners of Manassas'
     Latitude 38.8476575

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProviderSerializer, type: :serializer do
+  let(:provider) { build :provider }
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+
+  subject { serialize(provider, serializer_class: described_class) }
+
+  it 'should include id' do
+    expect(data['id']).to eq('ccp_' + provider.ProviderIdentifier)
+  end
+
+  it 'should include latitude' do
+    expect(attributes['lat']).to eq(provider.Latitude)
+  end
+
+  it 'should include Longitude' do
+    expect(attributes['long']).to eq(provider.Longitude)
+  end
+
+  it 'should include the address' do
+    expect(attributes['address']['street']).to eq(provider.AddressStreet)
+  end
+
+  it 'should include the name' do
+    expect(attributes['name']).to eq(provider.Name)
+  end
+end


### PR DESCRIPTION
## Description of change
Adds Latitude and Longitude to the serialized attributes in the provider_serializer for compatibility with the search endpoint.

## Testing done
Added serializer level specs. Tested changes locally with fake data. Site to site connection issues prevented me from testing this in the review instance environment

## Testing planned
This PR should allow the ablevets testing team to continue testing the provider locator features in staging

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
