### PR TITLE
Correct LOA mapping for ID.me logins in openid tokens

### DIFF
--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -112,7 +112,7 @@ class OpenidApplicationController < ApplicationController
       dl = DSLOGON_PREMIUM_LOAS.include?(profile['dslogon_assurance']) ? 3 : 1
       { current: dl, highest: dl }
     else
-      { current: profile['idme_loa'], highest: profile['idme_loa'] }
+      { current: profile['idme_loa']&.to_i, highest: profile['idme_loa']&.to_i }
     end
   end
 


### PR DESCRIPTION
## Description of change
Fixes a regression introduced in dcb5b08b0df1bb6146092a923a4166b901c2b33a for ID.me-based OpenID tokens, due to the mapped LOA attribute changing from a string to an int type.

## Testing done
Manual testing. Will merge some specs in a subsequent PR but want to unblock a partner team.

## Testing planned
Add specs for all credential types verifying expected profile mapping.

