### PR TITLE
change 686 returnUrl

### DIFF
--- a/app/models/form_profiles/va21686c.rb
+++ b/app/models/form_profiles/va21686c.rb
@@ -101,7 +101,7 @@ class FormProfiles::VA21686c < FormProfile
     {
       version: 0,
       prefill: true,
-      returnUrl: '/applicant-information'
+      returnUrl: '/veteran-information'
     }
   end
 


### PR DESCRIPTION
## Description of change
change the 686 returnUrl from '/applicant-information' to '/veteran-information'

## Testing done
specs

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] change the 686 returnUrl from '/applicant-information' to '/veteran-information'

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
