### PR TITLE
fix issues with breakers middleware in rainbows products

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -26,10 +26,6 @@ class HealthCareApplication < ActiveRecord::Base
   def submit_sync
     result = begin
       HCA::Service.new(user).submit_form(parsed_form)
-    rescue HCA::SOAPParser::ValidationError => e
-      raise Common::Exceptions::BackendServiceException.new(
-        nil, detail: e.message
-      )
     rescue Common::Client::Errors::ClientError => e
       log_exception_to_sentry(e)
 

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -355,6 +355,18 @@ en:
         code: 'EVSS502'
         detail: 'Received an an invalid response from the upstream server'
         status: 502
+      EVSS503:
+        <<: *external_defaults
+        title: Service Unavailable
+        code: 'EVSS503'
+        detail: 'The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay'
+        status: 503
+      EVSS504:
+        <<: *external_defaults
+        title: Gateway Timeout
+        code: 'EVSS504'
+        detail: 'The server, while acting as a gateway or proxy, did not receive a timely response from an upstream server it needed to access in order to complete the request'
+        status: 504
       EMIS_HIST502:
         <<: *external_defaults
         title: Unexpected response body

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -242,6 +242,11 @@ en:
         code: 'SM99'
         detail: 'Something went wrong. Please try again later.'
         status: 502
+      HCA422:
+        <<: *external_defaults
+        code: 'HCA422'
+        detail: 'Validation error'
+        status: 422
       BB99: # 'Unknown application error occurred'
         <<: *external_defaults
         code: 'BB99'

--- a/lib/evss/error_middleware.rb
+++ b/lib/evss/error_middleware.rb
@@ -9,7 +9,7 @@ module EVSS
         @details = details
       end
     end
-    class EVSSBackendServiceError < EVSSError; end
+    class EVSSBackendServiceError < Common::Exceptions::BackendServiceException; end
 
     def handle_xml_body(env)
       resp = Hash.from_xml(env.body)
@@ -20,7 +20,9 @@ module EVSS
     end
 
     def on_complete(env)
-      case env[:status]
+      status = env[:status]
+
+      case status
       when 200
         if env.response_headers['content-type'].downcase.include?('xml')
           handle_xml_body(env)
@@ -34,7 +36,7 @@ module EVSS
         end
       when 503, 504
         resp = env.body
-        raise EVSSBackendServiceError, resp
+        raise EVSSBackendServiceError.new("EVSS#{status}", { status: status }, status, resp)
       end
     end
   end

--- a/lib/hca/soap_parser.rb
+++ b/lib/hca/soap_parser.rb
@@ -27,7 +27,7 @@ module HCA
         Raven.tags_context(validation: 'hca')
         log_exception_to_sentry(e)
 
-        raise ValidationError.new
+        raise ValidationError
       end
 
       raise

--- a/lib/hca/soap_parser.rb
+++ b/lib/hca/soap_parser.rb
@@ -4,7 +4,7 @@ module HCA
   class SOAPParser < Common::Client::Middleware::Response::SOAPParser
     include SentryLogging
 
-    class ValidationError < StandardError
+    class ValidationError < Common::Exceptions::BackendServiceException
     end
 
     VALIDATION_FAIL_KEY = 'api.hca.validation_fail'
@@ -24,7 +24,7 @@ module HCA
         Raven.tags_context(validation: 'hca')
         log_exception_to_sentry(e)
 
-        raise ValidationError, 'HCA validation error'
+        raise ValidationError, 'HCA422'
       end
 
       raise

--- a/lib/hca/soap_parser.rb
+++ b/lib/hca/soap_parser.rb
@@ -5,6 +5,9 @@ module HCA
     include SentryLogging
 
     class ValidationError < Common::Exceptions::BackendServiceException
+      def initialize
+        super('HCA422', status: 422)
+      end
     end
 
     VALIDATION_FAIL_KEY = 'api.hca.validation_fail'
@@ -24,7 +27,7 @@ module HCA
         Raven.tags_context(validation: 'hca')
         log_exception_to_sentry(e)
 
-        raise ValidationError.new('HCA422', status: 422)
+        raise ValidationError.new
       end
 
       raise

--- a/lib/hca/soap_parser.rb
+++ b/lib/hca/soap_parser.rb
@@ -24,7 +24,7 @@ module HCA
         Raven.tags_context(validation: 'hca')
         log_exception_to_sentry(e)
 
-        raise ValidationError, 'HCA422'
+        raise ValidationError.new('HCA422', status: 422)
       end
 
       raise

--- a/spec/request/health_care_applications_request_spec.rb
+++ b/spec/request/health_care_applications_request_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
             expect(response.code).to eq('422')
             expect(JSON.parse(response.body)).to eq(
               'errors' => [
-                {"title"=>"Operation failed", "detail"=>"Validation error", "code"=>"HCA422", "status"=>"422"}
+                { 'title' => 'Operation failed', 'detail' => 'Validation error', 'code' => 'HCA422', 'status' => '422' }
               ]
             )
           end

--- a/spec/request/health_care_applications_request_spec.rb
+++ b/spec/request/health_care_applications_request_spec.rb
@@ -166,15 +166,15 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
         end
 
         context 'with a validation error' do
-          let(:error) { HCA::SOAPParser::ValidationError.new('error') }
+          let(:error) { HCA::SOAPParser::ValidationError.new }
 
           it 'should render error message' do
             subject
 
-            expect(response.code).to eq('400')
+            expect(response.code).to eq('422')
             expect(JSON.parse(response.body)).to eq(
               'errors' => [
-                { 'title' => 'Operation failed', 'detail' => 'error', 'code' => 'VA900', 'status' => '400' }
+                {"title"=>"Operation failed", "detail"=>"Validation error", "code"=>"HCA422", "status"=>"422"}
               ]
             )
           end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15060
make all errors inside faraday middlewares in rainbows products subclasses of `Common::Exceptions::BackendServiceException`

## Testing done
automated tests
<!-- Please describe testing done to verify the changes. -->

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
