### PR TITLE
WIP: Ensure that Breakers is configured to handle `SentryIgnoredGatewayTimeout` errors

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/workers/evss/disability_compensation_form/submit_uploads.rb
@@ -21,7 +21,7 @@ module EVSS
           client = EVSS::DocumentsService.new(auth_headers)
           client.upload(file_body, document_data)
         end
-      rescue Common::Exceptions::SentryIgnoredGatewayTimeout, EVSS::ErrorMiddleware::EVSSError => e
+      rescue Breakers::OutageException, Common::Exceptions::SentryIgnoredGatewayTimeout, EVSS::ErrorMiddleware::EVSSError => e
         retryable_error_handler(e)
         raise e
       rescue StandardError => e

--- a/lib/common/client/configuration/base.rb
+++ b/lib/common/client/configuration/base.rb
@@ -59,6 +59,8 @@ module Common
               (500..599).cover?(exception.response_values[:status])
             elsif exception.is_a?(Common::Client::Errors::HTTPError)
               (500..599).cover?(exception.status)
+            elsif exception.is_a?(Common::Exceptions::SentryIgnoredGatewayTimeout)
+              true
             else
               false
             end

--- a/lib/evss/base_service.rb
+++ b/lib/evss/base_service.rb
@@ -23,9 +23,18 @@ module EVSS
         request_env.url.host == host && request_env.url.path =~ /^#{path}/
       end
 
+      exception_handler = proc do |exception|
+        if exception.is_a?(Common::Exceptions::SentryIgnoredGatewayTimeout)
+          true
+        else
+          false
+        end
+      end
+
       Breakers::Service.new(
         name: name,
-        request_matcher: matcher
+        request_matcher: matcher,
+        exception_handler: exception_handler
       )
     end
 

--- a/spec/lib/common/client/middleware/request/rescue_timeout_spec.rb
+++ b/spec/lib/common/client/middleware/request/rescue_timeout_spec.rb
@@ -6,6 +6,7 @@ describe Common::Client::Middleware::Request::RescueTimeout do
   describe '#request' do
     subject do
       Faraday.new do |builder|
+        builder.use     :breakers
         builder.request :rescue_timeout, { backend_service: :evss }, 'api.hca.timeout'
         builder.adapter :test do |stub|
           stub.get('/') { |_env| raise Faraday::TimeoutError }
@@ -14,14 +15,23 @@ describe Common::Client::Middleware::Request::RescueTimeout do
     end
 
     context 'encounters Faraday::TimeoutError' do
-      it 'should rescue Faraday::TimeoutError and raise' do
+      before do
         Settings.sentry.dsn = 'asdf'
+      end
+      after do
+        Settings.sentry.dsn = nil
+      end
+      it 'should rescue Faraday::TimeoutError and raise' do
         expect_any_instance_of(Common::Client::Middleware::Request::RescueTimeout).to(
           receive(:log_exception_to_sentry).with(Exception, Hash, Hash, :warn)
         )
         expect(StatsD).to receive(:increment).with('api.hca.timeout')
         expect { subject.get }.to raise_error(Common::Exceptions::SentryIgnoredGatewayTimeout)
-        Settings.sentry.dsn = nil
+      end
+
+      it 'should not interfere with Breakers' do
+        expect { subject.get }.to raise_error(Common::Exceptions::SentryIgnoredGatewayTimeout)
+        expect { subject.get }.to raise_error(Breakers::OutageException)
       end
     end
   end


### PR DESCRIPTION
## Description of change
the `rescue_timeout` request middleware was created to:
* rescue timeouts to external services
* log these errors to Sentry as :warn
* raise `SentryIgnoredGatewayTimeout`, which has been configured so that Sentry will ignore it.

The whole point is to make Sentry easier for engineers to use.  We have no ability to fix these external services timeouts, so the idea was to log these errors as :warn so they are not clogging up our entries when we are filtering by :error.  Signal vs Noise.

The unintended side effect that @saneshark realized is that by rescuing these timeouts and raising `SentryIgnoredGatewayTimeout`, we are bypassing the Breakers middleware.  A timeout never makes it to the `breakers` layer, and thus it can never do its job.

This PR adds `SentryIgnoredGatewayTimeout` to `breakers`' `exception_handler` configuration.

TODO:  write shared specs for each service that uses `breakers` to ensure that there are no other middlewares present that can break `breakers`.

## Testing done
specs

## Testing planned
TBD

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] adds `SentryIgnoredGatewayTimeout` to `breakers`' `exception_handler` configuration.

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
