### PR TITLE
Update 526 migration rake task

### DIFF
--- a/app/models/saved_claim/disability_compensation.rb
+++ b/app/models/saved_claim/disability_compensation.rb
@@ -14,6 +14,10 @@ class SavedClaim::DisabilityCompensation < SavedClaim
 
   attr_writer :form_hash
 
+  # For backwards compatibility, FORM constant needs to be set
+  # subclasses will overwrite this constant when using `add_form_and_validation`
+  const_set('FORM', '21-526EZ')
+
   # Defined for all claims in parent class as `increased only` is being deprecated
   TRANSLATION_CLASS = EVSS::DisabilityCompensationForm::DataTranslationAllClaim
 

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -50,7 +50,7 @@ namespace :form526 do
   def create_submission_hash(claim_id, submission, user_uuid)
     {
       user_uuid: user_uuid,
-      saved_claim_id: submission.disability_compensation_claim.id,
+      saved_claim_id: submission.disability_compensation_id,
       submitted_claim_id: claim_id,
       auth_headers_json: { metadata: 'migrated data auth headers unavailable' }.to_json,
       form_json: { metadata: 'migrated data form unavailable' }.to_json,
@@ -72,16 +72,23 @@ namespace :form526 do
     }
   end
 
+  desc 'update all disability compensation claims to have the correct type'
+  task update_types: :environment do
+    SavedClaim::DisabilityCompensation.each do |claim|
+      claim.type = 'SavedClaim::DisabilityCompensation::Form526IncreaseOnly'
+      claim.save
+    end
+  end
+
   desc 'dry run for migrating existing 526 submissions to the new tables'
   task migrate_dry_run: :environment do
     migrated = 0
 
     DisabilityCompensationSubmission.find_each do |submission|
-      user_uuid = submission.async_transaction.user_uuid
+      job = AsyncTransaction::EVSS::VA526ezSubmitTransaction.find(submission.va526ez_submit_transaction_id)
+      user_uuid = job.user_uuid
       claim_id = nil
-      if submission.async_transaction.transaction_status == 'received'
-        claim_id = JSON.parse(submission.async_transaction.metadata)['claim_id']
-      end
+      claim_id = JSON.parse(job.metadata)['claim_id'] if job.transaction_status == 'received'
 
       submission_hash = create_submission_hash(claim_id, submission, user_uuid)
 
@@ -107,11 +114,10 @@ namespace :form526 do
     migrated = 0
 
     DisabilityCompensationSubmission.find_each do |submission|
-      user_uuid = submission.async_transaction.user_uuid
+      job = AsyncTransaction::EVSS::VA526ezSubmitTransaction.find(submission.va526ez_submit_transaction_id)
+      user_uuid = job.user_uuid
       claim_id = nil
-      if submission.async_transaction.transaction_status == 'received'
-        claim_id = JSON.parse(submission.async_transaction.metadata)['claim_id']
-      end
+      claim_id = JSON.parse(job.metadata)['claim_id'] if job.transaction_status == 'received'
 
       new_submission = Form526Submission.create(create_submission_hash(claim_id, submission, user_uuid))
 


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Updated the form 526 migration rake tasks to not use associations since they are broken. Added a new rake task to update the old saved_claim disability_compensation model `type`s to the new `SavedClaim::DisabilityCompensation::Form526IncreaseOnly` type. Added a default constant to the saved_claim disability_compensation base class so it doesn't break when accessing the old rows.

## Testing done
<!-- Please describe testing done to verify the changes. -->
local console

## Testing planned
<!-- Please describe testing planned. -->
staging migration tests.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] add a default `FORM` constant in the disability compensation base class
- [x] add a rake task to update `type` on disability compensation base class rows
- [x] updated form526 migration rake tasks to not use associations

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
