### PR TITLE
[facility locator] Tweaking parameters to ppms calls for more consistent results

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -49,9 +49,10 @@ class ProviderSerializer < ActiveModel::Serializer
   end
 
   def specialty
-    object.ProviderSpecialties.map do |specialty| 
+    object.ProviderSpecialties.map do |specialty|
       { name: specialty['SpecialtyName'],
-        desc: specialty['SpecialtyDescription'] } end
+        desc: specialty['SpecialtyDescription'] }
+    end
   end
 
   attributes :unique_id, :name, :address, :phone, :fax, :lat, :long,

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -49,7 +49,9 @@ class ProviderSerializer < ActiveModel::Serializer
   end
 
   def specialty
-    object.ProviderSpecialties.map { |specialty| specialty['SpecialtyName'] }
+    object.ProviderSpecialties.map do |specialty| 
+      { name: specialty['SpecialtyName'],
+        desc: specialty['SpecialtyDescription'] } end
   end
 
   attributes :unique_id, :name, :address, :phone, :fax, :lat, :long,

--- a/lib/facilities/ppms_client.rb
+++ b/lib/facilities/ppms_client.rb
@@ -42,6 +42,7 @@ module Facilities
 
     def build_params(params)
       bbox_num = params[:bbox].map { |x| Float(x) }
+      page = Integer(params[:page] || 1)
       lats = bbox_num.values_at(1, 3)
       longs = bbox_num.values_at(2, 0)
       # more estimation fun about 69 miles between latitude lines, <= 69 miles between long lines
@@ -50,7 +51,7 @@ module Facilities
       radius = Math.sqrt(xlen * xlen + ylen * ylen) * 1.1 # go a little bit beyond the corner;
       { address: "'#{params[:address]}'", radius: radius, driveTime: 10_000, specialtycode1: 'null',
         specialtycode2: 'null', specialtycode3: 'null', specialtycode4: 'null',
-        network: 0, gender: 0, primarycare: 0, acceptingnewpatients: 0, maxResults: 20 * params[:page] }
+        network: 0, gender: 0, primarycare: 0, acceptingnewpatients: 0, maxResults: 20 * page }
     end
   end
 end

--- a/lib/facilities/ppms_client.rb
+++ b/lib/facilities/ppms_client.rb
@@ -51,7 +51,7 @@ module Facilities
       radius = Math.sqrt(xlen * xlen + ylen * ylen) * 1.1 # go a little bit beyond the corner;
       { address: "'#{params[:address]}'", radius: radius, driveTime: 10_000, specialtycode1: 'null',
         specialtycode2: 'null', specialtycode3: 'null', specialtycode4: 'null',
-        network: 0, gender: 0, primarycare: 0, acceptingnewpatients: 0, maxResults: 20 * page }
+        network: 0, gender: 0, primarycare: 0, acceptingnewpatients: 0, maxResults: 20 * page + 1 }
     end
   end
 end

--- a/lib/facilities/ppms_client.rb
+++ b/lib/facilities/ppms_client.rb
@@ -48,9 +48,9 @@ module Facilities
       xlen = (lats.max - lats.min) * 69 / 2
       ylen = (longs.max - longs.min) * 69 / 2
       radius = Math.sqrt(xlen * xlen + ylen * ylen) * 1.1 # go a little bit beyond the corner;
-      { address: params[:address], radius: radius, driveTime: 10_000, specialtycode1: 'null',
+      { address: "'#{params[:address]}'", radius: radius, driveTime: 10_000, specialtycode1: 'null',
         specialtycode2: 'null', specialtycode3: 'null', specialtycode4: 'null',
-        network: 0, gender: 0, primarycare: 0, acceptingnewpatients: 0, maxResults: 200 }
+        network: 0, gender: 0, primarycare: 0, acceptingnewpatients: 0, maxResults: 20 * params[:page] }
     end
   end
 end


### PR DESCRIPTION
## Description of change
Quotes addresses to prevent ppms from interpreting certain addresses incorrectly. Tweaks the number of results to work around performance issues with the provider locator ppms endpoint identified in the staging environment. Results now limited to the amount necessary to display the current page (+1 so that a next page will show up in the front end if appropriate). Also fixes an inconsistency for the providers details page.

## Testing done
Tested using local front-end pointed to review instance API. conducted large radius searches to ensure that they were not timing out.

## Testing planned
Performance issues addressed can only truly be tested in staging

## Acceptance Criteria (Definition of Done)

#### Unique to this PR


#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
