### PR TITLE
WIP - 12414 redis caching of preference and choices

### DIFF
--- a/app/controllers/v0/preferences_controller.rb
+++ b/app/controllers/v0/preferences_controller.rb
@@ -11,7 +11,8 @@ module V0
     private
 
     def set_preference
-      @preference = Preference.find_by(code: preference_params['code'])
+      @preference = PreferencesRedis::Cache.for(preference_params['code'])&.choices
+
       raise Common::Exceptions::RecordNotFound, preference_params['code'] if @preference.blank?
     end
 

--- a/app/models/preferences_redis/cache.rb
+++ b/app/models/preferences_redis/cache.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'common/models/redis_store'
+require 'common/models/concerns/cache_aside'
+
+module PreferencesRedis
+  class Cache < Common::RedisStore
+    include Common::CacheAside
+
+    # Redis settings for ttl and namespacing reside in config/redis.yml
+    #
+    redis_config_key :preferences
+
+    attr_reader :code
+
+    def initialize(code)
+      @code = code
+    end
+
+    def self.for(code)
+      instance = new(code)
+
+      instance.response
+    end
+
+    def response
+      @response ||= response_from_redis_or_service
+    end
+
+    private
+
+    def response_from_redis_or_service
+      do_cached_with(key: code) do
+        PreferencesRedis::Response.for(code)
+      end
+    end
+  end
+end

--- a/app/models/preferences_redis/response.rb
+++ b/app/models/preferences_redis/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PreferencesRedis
   class Response
     attr_reader :code, :choices

--- a/app/models/preferences_redis/response.rb
+++ b/app/models/preferences_redis/response.rb
@@ -1,0 +1,20 @@
+module PreferencesRedis
+  class Response
+    attr_reader :code, :choices
+
+    def initialize(code)
+      @code = code
+      @choices = Preference.with_choices(code)
+    end
+
+    def self.for(code)
+      new(code)
+    end
+
+    def cache?
+      return if choices.blank?
+
+      choices.dig(:preference_choices).present?
+    end
+  end
+end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -68,6 +68,9 @@ development: &defaults
   evss_dependents_retrieve_response:
     namespace: evss-dependents-retrieve-response
     each_ttl: 86400
+  preferences:
+    namespace: preferences
+    each_ttl: 1296000 # 15 days
 
 test:
   <<: *defaults


### PR DESCRIPTION
## Description of change

The new preferences are going to be consistent, be called frequently, and change very infrequently.  As such, it is favorable to cache the preferences for performance reasons.

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Build out the Redis cache layer for preferences
  - Explore the Vets-API mini-framework for requirements that need to be added at the [service class level](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/vet360/response.rb#L17-L23), and at the [caching level](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/models/vet360_redis/contact_information.rb#L168)
- [ ] Refactor the preference(s) endpoint to use Redis caching

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
