### PR TITLE
Order of importance for cache keys

### DIFF
--- a/app/models/okta_redis/model.rb
+++ b/app/models/okta_redis/model.rb
@@ -26,7 +26,7 @@ module OktaRedis
     private
 
     def get_identifier
-      @user ? @user.uuid : @id
+      @id ? @id : @user.uuid
     end
 
     def cache_key


### PR DESCRIPTION
## Description of change
Setting the user on the `OktaRedis::App` caused it to have colliding cache keys, leading to weird results in operation. Changing the order of precedents fixes this.

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/626

## Testing done
- local testing with the user from here https://github.com/department-of-veterans-affairs/vets-contrib/issues/626


#### Applies to all PRs
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
