### PR TITLE
BAH Sprint 8: Updated the header, footer stamping text for the ancillary forms

### DIFF
--- a/app/workers/central_mail/submit_form4142_job.rb
+++ b/app/workers/central_mail/submit_form4142_job.rb
@@ -78,15 +78,15 @@ module CentralMail
 
     # Invokes Filler ancillary form method to generate PDF document
     # Then calls method CentralMail::DatestampPdf to stamp the document.
-    # Its called twice, once to stamp with text "VETS.GOV" at the bottom of each page
+    # Its called twice, once to stamp with text "VA.gov YYYY-MM-DD" at the bottom of each page
     # and second time to stamp with text "FDC Reviewed - Vets.gov Submission" at the top of each page
     def generate_stamp_pdf(form_content, evss_claim_id)
       pdf_path = PdfFill::Filler.fill_ancillary_form(form_content, evss_claim_id, FORM_ID)
-      stamped_path1 = CentralMail::DatestampPdf.new(pdf_path).run(text: 'VETS.GOV', x: 5, y: 5)
+      stamped_path1 = CentralMail::DatestampPdf.new(pdf_path).run(text: 'VA.gov', x: 5, y: 5)
       CentralMail::DatestampPdf.new(stamped_path1).run(
-        text: 'FDC Reviewed - Vets.gov Submission',
-        x: 429,
-        y: 770,
+        text: 'VA.gov Submission',
+        x: 510,
+        y: 775,
         text_only: true
       )
     end

--- a/app/workers/evss/disability_compensation_form/submit_form0781.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form0781.rb
@@ -82,15 +82,15 @@ module EVSS
 
       # Invokes Filler ancillary form method to generate PDF document
       # Then calls method CentralMail::DatestampPdf to stamp the document.
-      # Its called twice, once to stamp with text "VETS.GOV" at the bottom of each page
-      # and second time to stamp with text "FDC Reviewed - Vets.gov Submission" at the top of each page
+      # Its called twice, once to stamp with text "VA.gov YYYY-MM-DD" at the bottom of each page
+      # and second time to stamp with text "VA.gov Submission" at the top of each page
       def generate_stamp_pdf(form_content, evss_claim_id, form_id)
         pdf_path = PdfFill::Filler.fill_ancillary_form(form_content, evss_claim_id, form_id)
-        stamped_path1 = CentralMail::DatestampPdf.new(pdf_path).run(text: 'VETS.GOV', x: 5, y: 5)
+        stamped_path1 = CentralMail::DatestampPdf.new(pdf_path).run(text: 'VA.gov', x: 5, y: 5)
         CentralMail::DatestampPdf.new(stamped_path1).run(
-          text: 'FDC Reviewed - Vets.gov Submission',
-          x: 429,
-          y: 770,
+          text: 'VA.gov Submission',
+          x: 510,
+          y: 775,
           text_only: true
         )
       end


### PR DESCRIPTION
## Description of change

**READY FOR THE MERGE**

Updated the text that is generated at the header and footer of the PDFs for the ancillary forms (21-4142, 21-4142A, 21-0781, 21-0781A so that it is helpful to the end user that will be receiving these PDFs after submission on the va.gov platform

Sample PDFs generated newly are attached to the connected story

## Testing done
- Unit testing
- Local testing

## Testing planned
- Unit testing
- Cross-browser (by QA)
- Manual testing (by QA)

## Acceptance Criteria (Definition of Done)
- Unit tests passed
    - spec/jobs/central_mail/submit_form4142_spec.rb
    - spec/jobs/evss/disability_compensation_form/submit_form0781_spec.rb

#### Unique to this PR
NA

#### Applies to all PRs

- [X] Appropriate logging
- [X] Swagger docs have been updated, if applicable
- [X] Provide link to originating GitHub issue, or connected to it via ZenHub
- [X] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [X] Provide which alerts would indicate a problem with this functionality (if applicable)
