### PR TITLE
update cleanup job to take submission id

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_form526_cleanup.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526_cleanup.rb
@@ -2,17 +2,17 @@
 
 module EVSS
   module DisabilityCompensationForm
-    class SubmitForm526Cleanup
+    class SubmitForm526Cleanup < Job
       include Sidekiq::Worker
 
       FORM_ID = '21-526EZ'
 
-      def perform(user_uuid)
-        user = User.find(user_uuid)
-
-        # Delete SiP form on successfull submission
-        InProgressForm.form_for_user(FORM_ID, user)&.destroy
-        EVSS::IntentToFile::ResponseStrategy.delete("#{user.uuid}:compensation")
+      def perform(submission_id)
+        super(submission_id)
+        with_tracking('Form526 Cleanup', submission.saved_claim_id, submission.id) do
+          InProgressForm.find_by(form_id: FORM_ID, user_uuid: submission.user_uuid)&.destroy
+          EVSS::IntentToFile::ResponseStrategy.delete("#{submission.user_uuid}:compensation")
+        end
       end
     end
   end

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_cleanup_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_cleanup_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526Cleanup, type: :jo
   end
 
   let(:user) { FactoryBot.create(:user, :loa3) }
+  let(:submission) { create(:form526_submission, user_uuid: user.uuid) }
 
   subject { described_class }
 
@@ -20,13 +21,13 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526Cleanup, type: :jo
     context 'with a successful call' do
       it 'deletes the in progress form' do
         create(:in_progress_form, user_uuid: user.uuid, form_id: '21-526EZ')
-        subject.perform_async(user.uuid)
+        subject.perform_async(submission.id)
         expect { described_class.drain }.to change { InProgressForm.count }.by(-1)
       end
 
       it 'deletes the cached ITF' do
         strategy.cache("#{user.uuid}:compensation", {})
-        subject.perform_async(user.uuid)
+        subject.perform_async(submission.id)
         described_class.drain
         expect(strategy_class.find("#{user.uuid}:compensation")).to equal nil
       end


### PR DESCRIPTION
## Description of change
Updates the 526 cleanup job to take submission_id, which then looks up the submission which includes user_uuid.

## Testing done
local unit tests

## Testing planned
staging integration tests

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Updates the 526 cleanup job to take submission_id

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
