### PR TITLE
Change meta/distances format for facilities queries to avoid keys getting transformed

### DIFF
--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -196,21 +196,19 @@ paths:
                       - distances
                     properties:
                       distances:
-                        type: object
-                        description: "For lat/long queries, a dictionary mapping facility ids to the distance from the search location. Distance is expressed in miles and represents straight-line distance, not driving distance."
-                        additional_properties:
-                          type: number
-                        example:
-                          vha_537: 2.45
-                          vha_537_ga: 25.81
-                          vha_537_gd: 1.12
-                          vha_537_ha: 8.64
-                          vha_537_qa: 3.48
-                          vha_556: 32.02
-                          vha_556_ga: 11.81
-                          vha_578: 10.95
-                          vha_578_ge: 32.05
-                          vha_578_gg: 13.09
+                        type: array
+                        description: "For lat/long queries, a list of mappings between facility ids and the distance from the search location. Distance is expressed in miles and represents straight-line distance, not driving distance."
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              description: "Facility id. Matches the facility id in the data part of the response."
+                              example: vha_688
+                            distance:
+                              type: float
+                              description: "Distance from search location"
+                              example: 3.14
                       pagination:
                         type: object
                         required:

--- a/modules/va_facilities/app/controllers/va_facilities/v0/facilities_controller.rb
+++ b/modules/va_facilities/app/controllers/va_facilities/v0/facilities_controller.rb
@@ -122,10 +122,11 @@ module VaFacilities
                                per_page: resource.per_page,
                                total_pages: resource.total_pages,
                                total_entries: resource.total_entries },
-                 distances: {} }
+                 distances: [] }
         if params[:lat] && params[:long]
           resource.each do |facility|
-            meta[:distances][ApiSerialization.id(facility)] = facility.distance.round(2)
+            meta[:distances] << { id: ApiSerialization.id(facility),
+                                  distance: facility.distance&.round(2) }
           end
         end
         meta

--- a/modules/va_facilities/spec/requests/facilities_request_spec.rb
+++ b/modules/va_facilities/spec/requests/facilities_request_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       expect(response.body).to be_a(String)
       json = JSON.parse(response.body)
       expect(json['data'].length).to eq(10)
-      expect(json['meta']['distances']).to eq({})
+      expect(json['meta']['distances']).to eq([])
     end
 
     it 'responds to GET #index with lat/long' do
@@ -65,6 +65,17 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       json = JSON.parse(response.body)
       expect(json['data'].length).to eq(10)
       expect(json['meta']['distances'].length).to eq(10)
+    end
+
+    it 'responds such that record and distance metadata IDs match up' do
+      setup_pdx
+      get base_query_path + lat_long, nil, accept_json
+      expect(response).to be_success
+      expect(response.body).to be_a(String)
+      json = JSON.parse(response.body)
+      record_ids = json['data'].map { |x| x['id'] }
+      distance_ids = json['meta']['distances'].map { |x| x['id'] }
+      expect(record_ids).to match_array(distance_ids)
     end
 
     it 'responds to GET #index with ids' do


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets-contrib/issues/612

## Description of change
Changes the format of the distances metadata so that facility IDs are not object keys, because object keys get snake_cased by olive branch, and when they do it's much harder for a consumer to match up the distances with the facility IDs from the main part of the response.

Consumer will have to build a map out of the distances array but that's pretty straightforward.

## Testing done
Manual testing, plus added a spec that ensures that IDs match up.

## Acceptance Criteria (Definition of Done)
Entries in distance metadata should be easily correlate-able to overall response objects.

#### Unique to this PR

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
