### PR TITLE
Configure betamocks to support ICN- and EDIPI-based MVI Lookups

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -255,6 +255,18 @@
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: '(?:root="2.16.840.1.113883.4.1" )?extension="(\d{9})"(?: root="2.16.840.1.113883.4.1")?'
+  - :method: :post
+    :path: <%= URI(Settings.mvi.url).path %>
+    :file_path: "mvi/profile_icn"
+    :cache_multiple_responses:
+      :uid_location: body
+      :uid_locator: '(?:root="2.16.840.1.113883.4.349" )?extension="(\d{10}V\d{6})"(?: root="2.16.840.1.113883.4.349")?'
+  - :method: :post
+    :path: <%= URI(Settings.mvi.url).path %>
+    :file_path: "mvi/profile_edipi"
+    :cache_multiple_responses:
+      :uid_location: body
+      :uid_locator: '(?:root="2.16.840.1.113883.3.42.10001.100001.12" )?extension="(\d{10})"(?: root="2.16.840.1.113883.3.42.10001.100001.12")?'
 
 
 # EMIS


### PR DESCRIPTION
## Description of change
Fixes https://github.com/department-of-veterans-affairs/vets-contrib/issues/661

Adds endpoint configurations to betamocks to allow it to resolve MVI queries using ICNs or EDIPIs. This will let us support MHV/DSLogon sign-ins in dev. No code changes required to betamocks as it already supports finding one of many matches. 

One thing I wasn't sure of was whether the separate directories are better, or to put everything under mvi/profile. There shouldn't be any collisions of filenames since SSNs are 9 digits, EDIPIs are 10 digits, and ICNS are 10+6 digits. But I thought it might be easier for people looking for users with a given login type to have things separate. Willing to be convinced otherwise.

## Testing done
Manual testing in an instance in staging. Confirmed I could record new cassettes for both lookup types.

## Acceptance Criteria (Definition of Done)
Betamocks should be able to record and resolve queries 

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
