### PR TITLE
Update rails 4.2.7.1 -> 4.2.11 due to activejob CVE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'veteran_verification', path: 'modules/veteran_verification'
 # Anchored versions, do not change
 gem 'puma', '~> 3.12.0'
 gem 'puma-plugin-statsd', git: 'https://github.com/department-of-veterans-affairs/puma-plugin-statsd', branch: 'master'
-gem 'rails', '4.2.7.1'
+gem 'rails', '4.2.11'
 
 # Gems with special version/repo needs
 gem 'active_model_serializers', '0.10.4' # breaking changed in 0.10.5 relating to .to_json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -906,7 +906,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.11)
       sprockets-rails
-    rails-api (0.4.0)
+    rails-api (0.4.1)
       actionpack (>= 3.2.11)
       railties (>= 3.2.11)
     rails-deprecated_sanitizer (1.0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,33 +38,33 @@ PATH
   remote: modules/appeals_api
   specs:
     appeals_api (0.0.1)
-      rails (~> 4.2.7.1)
+      rails (~> 4.2.11)
 
 PATH
   remote: modules/openid_auth
   specs:
     openid_auth (0.0.1)
-      rails (~> 4.2.7.1)
+      rails (~> 4.2.11)
 
 PATH
   remote: modules/va_facilities
   specs:
     va_facilities (0.0.1)
-      rails (~> 4.2.7.1)
+      rails (~> 4.2.11)
 
 PATH
   remote: modules/vba_documents
   specs:
     vba_documents (0.0.1)
       aws-sdk-s3 (~> 1)
-      rails (~> 4.2.7.1)
+      rails (~> 4.2.11)
       sidekiq
 
 PATH
   remote: modules/veteran_verification
   specs:
     veteran_verification (0.0.1)
-      rails (~> 4.2.7.1)
+      rails (~> 4.2.11)
 
 GEM
   remote: https://rubygems.org/
@@ -73,46 +73,45 @@ GEM
     Ascii85 (1.0.2)
     aasm (4.12.0)
       concurrent-ruby (~> 1.0)
-    actionmailer (4.2.7.1)
-      actionpack (= 4.2.7.1)
-      actionview (= 4.2.7.1)
-      activejob (= 4.2.7.1)
+    actionmailer (4.2.11)
+      actionpack (= 4.2.11)
+      actionview (= 4.2.11)
+      activejob (= 4.2.11)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-    actionpack (4.2.7.1)
-      actionview (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
+    actionpack (4.2.11)
+      actionview (= 4.2.11)
+      activesupport (= 4.2.11)
       rack (~> 1.6)
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (4.2.7.1)
-      activesupport (= 4.2.7.1)
+    actionview (4.2.11)
+      activesupport (= 4.2.11)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
     active_model_serializers (0.10.4)
       actionpack (>= 4.1, < 6)
       activemodel (>= 4.1, < 6)
       case_transform (>= 0.2)
       jsonapi (= 0.1.1.beta6)
-    activejob (4.2.7.1)
-      activesupport (= 4.2.7.1)
+    activejob (4.2.11)
+      activesupport (= 4.2.11)
       globalid (>= 0.3.0)
-    activemodel (4.2.7.1)
-      activesupport (= 4.2.7.1)
+    activemodel (4.2.11)
+      activesupport (= 4.2.11)
       builder (~> 3.1)
-    activerecord (4.2.7.1)
-      activemodel (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
+    activerecord (4.2.11)
+      activemodel (= 4.2.11)
+      activesupport (= 4.2.11)
       arel (~> 6.0)
     activerecord-postgis-adapter (3.1.5)
       activerecord (~> 4.2)
       rgeo-activerecord (>= 4.0.4)
-    activesupport (4.2.7.1)
+    activesupport (4.2.11)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
@@ -720,7 +719,7 @@ GEM
     coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.3)
     config (1.4.0)
       activesupport (>= 3.0)
       deep_merge (~> 1.1.1)
@@ -765,8 +764,8 @@ GEM
     foreman (0.82.0)
       thor (~> 0.19.1)
     formatador (0.2.5)
-    globalid (0.3.7)
-      activesupport (>= 4.1.0)
+    globalid (0.4.1)
+      activesupport (>= 4.2.0)
     govdelivery-tms (2.8.4)
       activesupport
       faraday
@@ -825,7 +824,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.10)
-    mail (2.6.4)
+    mail (2.6.6)
       mime-types (>= 1.16, < 4)
     memoist (0.15.0)
     method_source (0.8.2)
@@ -896,24 +895,24 @@ GEM
       rack (>= 1.0)
     rack-vcr (0.1.5)
       vcr (>= 2.9)
-    rails (4.2.7.1)
-      actionmailer (= 4.2.7.1)
-      actionpack (= 4.2.7.1)
-      actionview (= 4.2.7.1)
-      activejob (= 4.2.7.1)
-      activemodel (= 4.2.7.1)
-      activerecord (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
+    rails (4.2.11)
+      actionmailer (= 4.2.11)
+      actionpack (= 4.2.11)
+      actionview (= 4.2.11)
+      activejob (= 4.2.11)
+      activemodel (= 4.2.11)
+      activerecord (= 4.2.11)
+      activesupport (= 4.2.11)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.2.7.1)
+      railties (= 4.2.11)
       sprockets-rails
     rails-api (0.4.0)
       actionpack (>= 3.2.11)
       railties (>= 3.2.11)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.8)
-      activesupport (>= 4.2.0.beta, < 5.0)
+    rails-dom-testing (1.0.9)
+      activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.4)
@@ -921,13 +920,13 @@ GEM
     rails_semantic_logger (4.2.1)
       rails (>= 3.2)
       semantic_logger (~> 4.1)
-    railties (4.2.7.1)
-      actionpack (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
+    railties (4.2.11)
+      actionpack (= 4.2.11)
+      activesupport (= 4.2.11)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
-    rake (12.3.0)
+    rake (12.3.1)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -1046,7 +1045,7 @@ GEM
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.0)
+    sprockets-rails (3.2.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -1158,7 +1157,7 @@ DEPENDENCIES
   rack-cors
   rack-test
   rack-vcr
-  rails (= 4.2.7.1)
+  rails (= 4.2.11)
   rails-api
   rails_semantic_logger (~> 4.2)
   rainbow
@@ -1206,4 +1205,4 @@ DEPENDENCIES
   zero_downtime_migrations
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/modules/appeals_api/appeals_api.gemspec
+++ b/modules/appeals_api/appeals_api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '~> 4.2.7.1'
+  s.add_dependency 'rails', '~> 4.2.11'
 
   s.add_development_dependency 'rspec-rails'
 end

--- a/modules/openid_auth/openid_auth.gemspec
+++ b/modules/openid_auth/openid_auth.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
 
-  s.add_dependency 'rails', '~> 4.2.7.1'
+  s.add_dependency 'rails', '~> 4.2.11'
 
   s.add_development_dependency 'rspec-rails'
 end

--- a/modules/va_facilities/va_facilities.gemspec
+++ b/modules/va_facilities/va_facilities.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '~> 4.2.7.1'
+  s.add_dependency 'rails', '~> 4.2.11'
 
   s.add_development_dependency 'rspec-rails'
 end

--- a/modules/vba_documents/vba_documents.gemspec
+++ b/modules/vba_documents/vba_documents.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'aws-sdk-s3', '~> 1'
-  s.add_dependency 'rails', '~> 4.2.7.1'
+  s.add_dependency 'rails', '~> 4.2.11'
   s.add_dependency 'sidekiq'
 
   s.add_development_dependency 'factory_bot_rails'

--- a/modules/veteran_verification/veteran_verification.gemspec
+++ b/modules/veteran_verification/veteran_verification.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '~> 4.2.7.1'
+  s.add_dependency 'rails', '~> 4.2.11'
 
   s.add_development_dependency 'rspec-rails'
 end


### PR DESCRIPTION
## Description of change
Updates Rails 4.2.7.1 to 4.2.11 due to a CVE vulnerability in activejob.

## Testing done
No additional testing beyond `make ci`

## Acceptance Criteria (Definition of Done)
