### PR TITLE
13666 update 526 report rake task

### DIFF
--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -23,7 +23,7 @@ namespace :form526 do
 
   desc 'Get one or more submission details given an array of ids'
   task submission: :environment do |_, args|
-    raise 'No submission ids provided' unless args
+    raise 'No submission ids provided' unless args.extras.count > 0
 
     args.extras.each do |id|
       submission = Form526Submission.find(id)

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -3,48 +3,63 @@
 require 'pp'
 
 namespace :form526 do
-  desc 'Get all jobs within a date period. [<start date>,<end date>]'
-  task :jobs, %i[start_date end_date] => [:environment] do |_, args|
-    def print_row(created_at, updated_at, job_id, status)
-      printf "%-24s %-24s %-25s %s\n", created_at, updated_at, job_id, status
+  desc 'Get all submissions within a date period. [<start date: yyyy-mm-dd>,<end date: yyyy-mm-dd>]'
+  task :submissions, %i[start_date end_date] => [:environment] do |_, args|
+    def print_row(created_at, updated_at, id, claim_id, complete)
+      printf "%-24s %-24s %-15s %-10s %s\n", created_at, updated_at, id, claim_id, complete
     end
-
-    TRXS = AsyncTransaction::EVSS::VA526ezSubmitTransaction
 
     start_date = args[:start_date] || 30.days.ago.utc.to_s
     end_date = args[:end_date] || Time.zone.now.utc.to_s
 
-    print_row('created at:', 'updated at:', 'job id:', 'job status:')
-    TRXS.where('created_at BETWEEN ? AND ?', start_date, end_date)
+    print_row('created at:', 'updated at:', 'submission id:', 'claim id:', 'workflow complete:')
+
+    Form526Submission.where('created_at BETWEEN ? AND ?', start_date, end_date)
         .order(created_at: :desc)
-        .find_each do |job|
-      print_row(job.created_at, job.updated_at, job.transaction_id, job.transaction_status)
+        .find_each do |s|
+      print_row(s.created_at, s.updated_at, s.id, s.submitted_claim_id, s.workflow_complete)
     end
   end
 
-  desc 'Get job details given a job id'
-  task :job, %i[job_id] => [:environment] do |_, args|
-    raise 'No job id provided' unless args[:job_id]
+  desc 'Get one or more submission details given an array of ids'
+  task submission: :environment do |_, args|
+    raise 'No submission ids provided' unless args
 
-    job = AsyncTransaction::EVSS::VA526ezSubmitTransaction.where(transaction_id: args[:job_id]).first
+    args.extras.each do |id|
+      submission = Form526Submission.find(id)
 
-    form = JSON.parse(job.saved_claim.form)
-    form['veteran'] = 'OMITTED'
+      saved_claim_form = JSON.parse(submission.saved_claim.form)
+      saved_claim_form['veteran'] = 'FILTERED'
 
-    puts '----------------------------------------'
-    puts 'Job Details:'
-    puts "user uuid: #{job.user_uuid}"
-    puts "source id: #{job.source_id}"
-    puts "source: #{job.source}"
-    puts "transaction status: #{job.transaction_status}"
-    puts "created at: #{job.created_at}"
-    puts "updated at: #{job.updated_at}"
-    puts '----------------------------------------'
-    puts 'Job Metadata:'
-    puts job.metadata
-    puts '----------------------------------------'
-    puts 'Form Data:'
-    puts JSON.pretty_generate(form)
+      auth_headers = JSON.parse(submission.auth_headers_json)
+
+      puts '------------------------------------------------------------'
+      puts "Submission (#{submission.id}):\n\n"
+      puts "user uuid: #{submission.user_uuid}"
+      puts "user edipi: #{auth_headers['va_eauth_dodedipnid']}"
+      puts "user participant id: #{auth_headers['va_eauth_pid']}"
+      puts "user ssn: #{auth_headers['va_eauth_pnid'].gsub(/(?=\d{5})\d/,"*") }"
+      puts "saved claim id: #{submission.saved_claim_id}"
+      puts "submitted claim id: #{submission.submitted_claim_id}"
+      puts "workflow complete: #{submission.workflow_complete}"
+      puts "created at: #{submission.created_at}"
+      puts "updated at: #{submission.updated_at}"
+      puts "\n"
+      puts '----------------------------------------'
+      puts "Jobs:\n\n"
+      submission.form526_job_statuses.each do |s|
+        puts "#{s.job_class}"
+        puts "  status: #{s.status}"
+        puts "  error: #{s.error_class}" if s.error_class
+        puts "    message: #{s.error_message}" if s.error_message
+        puts "  updadated at: #{s.updated_at}"
+        puts "\n"
+      end
+      puts '----------------------------------------'
+      puts "Form JSON:\n\n"
+      puts JSON.pretty_generate(saved_claim_form)
+      puts "\n\n"
+    end
   end
 
   def create_submission_hash(claim_id, submission, user_uuid)

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -15,15 +15,15 @@ namespace :form526 do
     print_row('created at:', 'updated at:', 'submission id:', 'claim id:', 'workflow complete:')
 
     Form526Submission.where('created_at BETWEEN ? AND ?', start_date, end_date)
-        .order(created_at: :desc)
-        .find_each do |s|
+                     .order(created_at: :desc)
+                     .find_each do |s|
       print_row(s.created_at, s.updated_at, s.id, s.submitted_claim_id, s.workflow_complete)
     end
   end
 
   desc 'Get one or more submission details given an array of ids'
   task submission: :environment do |_, args|
-    raise 'No submission ids provided' unless args.extras.count > 0
+    raise 'No submission ids provided' unless args.extras.count.positive?
 
     args.extras.each do |id|
       submission = Form526Submission.find(id)
@@ -38,7 +38,7 @@ namespace :form526 do
       puts "user uuid: #{submission.user_uuid}"
       puts "user edipi: #{auth_headers['va_eauth_dodedipnid']}"
       puts "user participant id: #{auth_headers['va_eauth_pid']}"
-      puts "user ssn: #{auth_headers['va_eauth_pnid'].gsub(/(?=\d{5})\d/,"*") }"
+      puts "user ssn: #{auth_headers['va_eauth_pnid'].gsub(/(?=\d{5})\d/, '*')}"
       puts "saved claim id: #{submission.saved_claim_id}"
       puts "submitted claim id: #{submission.submitted_claim_id}"
       puts "workflow complete: #{submission.workflow_complete}"
@@ -48,7 +48,7 @@ namespace :form526 do
       puts '----------------------------------------'
       puts "Jobs:\n\n"
       submission.form526_job_statuses.each do |s|
-        puts "#{s.job_class}"
+        puts s.job_class.to_s
         puts "  status: #{s.status}"
         puts "  error: #{s.error_class}" if s.error_class
         puts "    message: #{s.error_message}" if s.error_message


### PR DESCRIPTION
## Description of change
Updates 526 submission report rake tasks to use Form526Submission model and associations. Also updates detail task to take one or more submission ids and list background job statuses, and user correlation ids.

## Testing done
local report runs

## Testing planned
staging report runs

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
