### PR TITLE
15367 all claims prefill

### DIFF
--- a/app/models/form_profiles/va526ez.rb
+++ b/app/models/form_profiles/va526ez.rb
@@ -28,6 +28,15 @@ module VA526ez
     attribute :rated_disabilities, Array[FormRatedDisability]
   end
 
+  class FormPaymentAccountInformation
+    include Virtus.model
+
+    attribute :account_type, String
+    attribute :account_number, String
+    attribute :routing_number, String
+    attribute :bank_name, String
+  end
+
   class FormAddress
     include Virtus.model
 
@@ -58,10 +67,12 @@ end
 class FormProfiles::VA526ez < FormProfile
   attribute :rated_disabilities_information, VA526ez::FormRatedDisabilities
   attribute :veteran_contact_information, VA526ez::FormContactInformation
+  attribute :payment_information, VA526ez::FormPaymentAccountInformation
 
   def prefill(user)
     @rated_disabilities_information = initialize_rated_disabilities_information(user)
     @veteran_contact_information = initialize_veteran_contact_information(user)
+    @payment_information = initialize_payment_information(user)
     super(user)
   end
 
@@ -155,5 +166,30 @@ class FormProfiles::VA526ez < FormProfile
       address_line_2: address&.address_two,
       address_line_3: address&.address_three
     }.compact
+  end
+
+  def initialize_payment_information(user)
+    return {} unless user.authorize :evss, :access?
+
+    service = EVSS::PPIU::Service.new(user)
+    response = service.get_payment_information
+    raw_account = response.responses.first&.payment_account
+
+    if raw_account
+      VA526ez::FormPaymentAccountInformation.new(
+        account_type: raw_account&.account_type&.capitalize,
+        account_number: mask(raw_account&.account_number),
+        routing_number: mask(raw_account&.financial_institution_routing_number),
+        bank_name: raw_account&.financial_institution_name
+      )
+    else
+      {}
+    end
+  rescue StandardError
+    {}
+  end
+
+  def mask(number)
+    number.gsub(/.(?=.{4})/, '*')
   end
 end

--- a/config/form_profile_mappings/21-526EZ.yml
+++ b/config/form_profile_mappings/21-526EZ.yml
@@ -3,3 +3,7 @@ disabilities: [rated_disabilities_information, rated_disabilities]
 servicePeriods: [military_information, service_periods]
 reservesNationalGuardService:
   obligationTermOfServiceDateRange: [military_information, latest_guard_reserve_service_period]
+bankAccountType: [payment_information, account_type]
+bankAccountNumber: [payment_information, account_number]
+bankRoutingNumber: [payment_information, routing_number]
+bankName: [payment_information, bank_name]

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -498,7 +498,11 @@ RSpec.describe FormProfile, type: :model do
         },
         'primaryPhone' => '4445551212',
         'emailAddress' => 'test2@test1.net'
-      }
+      },
+      'bankAccountNumber' => '*********1234',
+      'bankAccountType' => 'Checking',
+      'bankName' => 'Comerica',
+      'bankRoutingNumber' => '*****2115'
     }
   end
 
@@ -704,13 +708,17 @@ RSpec.describe FormProfile, type: :model do
             expect(user).to receive(:authorize).with(:evss, :access?).and_return(true).at_least(:once)
           end
 
+          # Note: `increase only` and `all claims` use the same form prefilling
           it 'returns prefilled 21-526EZ' do
             VCR.use_cassette('evss/pciu_address/address_domestic') do
               VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
-                expect_prefilled('21-526EZ')
+                VCR.use_cassette('evss/ppiu/payment_information') do
+                  expect_prefilled('21-526EZ')
+                end
               end
             end
           end
+
           it 'returns prefilled 21-686C' do
             VCR.use_cassette('evss/dependents/retrieve_user_with_max_attributes') do
               expect_prefilled('21-686C')


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Form 526 all claims will allow user banking information to be prefilled (masked for security reasons) when creating a new form.

## Testing done
<!-- Please describe testing done to verify the changes. -->
specs.

## Testing planned
<!-- Please describe testing planned. -->
integration testing via staging platform.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] add PPIU banking information to form526 prefill

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
