### PR TITLE
Allow cors requests from any origin

### DIFF
--- a/app/swagger/readme.md
+++ b/app/swagger/readme.md
@@ -3,39 +3,23 @@
 
 # Run the Swagger UI Container
 ## Option 1: Run it Locally from Filesystem
-_Note: This option doesn't work in Chrome because Chrome doesn't allow a null CORS Origin. Use Safari or use Option 2 or 3 below._
-1. Add `null` to `web_origin` in your `settings.local.yml`:
-```
-# For CORS requests; separate multiple origins with a comma
-web_origin: http://localhost:3000,http://localhost:3001,null
-```
-2. Clone the repo at: https://github.com/swagger-api/swagger-ui
-3. Navigate to YOUR_SWAGGER_REPO/dist/
-4. Open `index.html` in your browser
-5. Paste `http://localhost:3000/v0/apidocs` into the search box and click "Explore"
+1. Clone the repo at: https://github.com/swagger-api/swagger-ui
+1. Navigate to YOUR_SWAGGER_REPO/dist/
+1. Open `index.html` in your browser
+1. Paste `http://localhost:3000/v0/apidocs` into the search box and click "Explore"
 
 ## Option 2: Run it Locally from a Webserver
-1. Add `localhost:8000` to `web_origin` in your `settings.local.yml`:
-```
-# For CORS requests; separate multiple origins with a comma
-web_origin: http://localhost:3000,http://localhost:3001,localhost:8000
-```
-2. Clone the repo at: https://github.com/swagger-api/swagger-ui
-3. Navigate to YOUR_SWAGGER_REPO/dist/
-4. Run your favorite local http server to serve the current directory:
+1. Clone the repo at: https://github.com/swagger-api/swagger-ui
+1. Navigate to YOUR_SWAGGER_REPO/dist/
+1. Run your favorite local http server to serve the current directory:
 ```
 python -m SimpleHTTPServer 8000 # python 2
 python -m http.server           # python 3
 devd .                          # ("brew install devd" to install)
 ```
-5. Open `http://localhost:8000` in your browser
-6. Paste `http://localhost:3000/v0/apidocs` into the search box and click "Explore"
+1. Open `http://localhost:8000` in your browser
+1. Paste `http://localhost:3000/v0/apidocs` into the search box and click "Explore"
 
 ## Option 3: Use PetStore
-1. Add `http://petstore.swagger.io/` to `web_origin` in your `settings.local.yml`
-```
-# For CORS requests; separate multiple origins with a comma
-web_origin: http://localhost:3000,http://localhost:3001,http://petstore.swagger.io
-```
-2. Navigate to http://petstore.swagger.io/
-3. Paste `http://localhost:3000/v0/apidocs` into the search box and click "Explore"
+1. Navigate to http://petstore.swagger.io/
+1. Paste `http://localhost:3000/v0/apidocs` into the search box and click "Explore"

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,7 +49,7 @@ module VetsAPI
     # CORS configuration; see also cors_preflight route
     config.middleware.insert_before 0, 'Rack::Cors', logger: (-> { Rails.logger }) do
       allow do
-        origins { |source, _env| Settings.web_origin.split(',').include?(source) }
+        origins '*'
         resource '*', headers: :any,
                       methods: :any,
                       credentials: true,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,9 +1,6 @@
 hostname: 127.0.0.1:3000 # possible fallback for unsafe request.host
 virtual_hosts: ["127.0.0.1", "localhost"] # Safe host names
 
-# For CORS requests; separate multiple origins with a comma
-web_origin: http://localhost:3000,http://localhost:3001,http://127.0.0.1:3000,http://127.0.0.1:3001,null
-
 # Settings for SAML authentication
 saml:
   cert_path: config/certs/vetsgov-localhost.crt


### PR DESCRIPTION
## Description of change
Allows CORS requests from any origin. Removes the `web_origins` setting and updates the swagger readme appropriately. Part of https://github.com/department-of-veterans-affairs/vets-contrib/issues/485

## Testing done
Made fetch requests from a browser console against several endpoints and confirmed that correct headers are present.

## Testing planned
Making cross origin requests through the api gateway in dev/staging environments (potentially with our sample apps).

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [X] Cross origin requests succeed

#### Applies to all PRs

- [X] Appropriate logging
- [X] Swagger docs have been updated, if applicable
- [X] Provide link to originating GitHub issue, or connected to it via ZenHub
- [X] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [X] Provide which alerts would indicate a problem with this functionality (if applicable)
