### PR TITLE
Creates the endpoint for POSTing user preferences

### DIFF
--- a/app/controllers/v0/user_preferences_controller.rb
+++ b/app/controllers/v0/user_preferences_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module V0
+  class UserPreferencesController < ApplicationController
+    include Accountable
+
+    def create
+      account  = current_user.account.presence || create_user_account
+      response = SetUserPreferences.new(account, requested_user_preferences).execute!
+
+      render json: response, serializer: UserPreferenceSerializer
+    end
+
+    private
+
+    def user_preference_params
+      params.permit(
+        _json: [
+          {
+            preference: [:code]
+          },
+          {
+            user_preferences: [:code]
+          }
+        ]
+      )
+    end
+
+    def requested_user_preferences
+      user_preference_params['_json']
+    end
+  end
+end

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -12,7 +12,7 @@ class Preference < ActiveRecord::Base
 
   alias choices preference_choices
 
-  scope :with_code, ->(codes) { where(code: codes) }
+  scope :with_codes, ->(codes) { where(code: codes) }
 
   def self.with_choices(code)
     preference = find_by code: code

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -12,6 +12,8 @@ class Preference < ActiveRecord::Base
 
   alias choices preference_choices
 
+  scope :with_code, ->(codes) { where(code: codes) }
+
   def self.with_choices(code)
     preference = find_by code: code
 

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -9,4 +9,12 @@ class UserPreference < ActiveRecord::Base
   belongs_to :preference_choice
 
   validates :account_id, :preference_id, :preference_choice_id, presence: true
+
+  scope :for_account, ->(account_id) { where(account_id: account_id) }
+
+  def self.for_preference_and_account(account_id, preference_codes)
+    joins(:preference)
+    .merge(Preference.with_code(preference_codes))
+    .for_account(account_id)
+  end
 end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -13,8 +13,9 @@ class UserPreference < ActiveRecord::Base
   scope :for_account, ->(account_id) { where(account_id: account_id) }
 
   def self.for_preference_and_account(account_id, preference_codes)
-    joins(:preference)
-    .merge(Preference.with_code(preference_codes))
-    .for_account(account_id)
+    UserPreference
+      .joins(:preference)
+      .merge(Preference.with_code(preference_codes))
+      .for_account(account_id)
   end
 end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -15,7 +15,7 @@ class UserPreference < ActiveRecord::Base
   def self.for_preference_and_account(account_id, preference_codes)
     UserPreference
       .joins(:preference)
-      .merge(Preference.with_code(preference_codes))
+      .merge(Preference.with_codes(preference_codes))
       .for_account(account_id)
   end
 end

--- a/app/serializers/user_preference_serializer.rb
+++ b/app/serializers/user_preference_serializer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class UserPreferenceSerializer < ActiveModel::Serializer
+  attributes :user_preferences
+
+  def id
+    nil
+  end
+
+  # Object is an array of `Preference` and `PreferenceChoice` pairings.
+  # For example:
+  #   [
+  #     {
+  #       preference: Preference,
+  #       user_preferences: [PreferenceChoice, PreferenceChoice]
+  #     },
+  #     ...
+  #   ]
+  #
+  def user_preferences
+    object.map do |pair|
+      {
+        code: pair[:preference].code,
+        title: pair[:preference].title,
+        user_preferences: pair[:user_preferences].map { |pref| { code: pref.code } }
+      }
+    end
+  end
+end

--- a/app/serializers/user_preference_serializer.rb
+++ b/app/serializers/user_preference_serializer.rb
@@ -22,7 +22,7 @@ class UserPreferenceSerializer < ActiveModel::Serializer
       {
         code: pair[:preference].code,
         title: pair[:preference].title,
-        user_preferences: pair[:user_preferences].map { |pref| { code: pref.code } }
+        user_preferences: pair[:user_preferences].map { |pref| { code: pref.code, description: pref.description } }
       }
     end
   end

--- a/app/services/set_user_preferences.rb
+++ b/app/services/set_user_preferences.rb
@@ -1,9 +1,39 @@
 # frozen_string_literal: true
 
+# This class handles both the creating and updating of a user's UserPreferences.
+# It takes care of updating because, for each request, we are deleting all
+# of the user's associated UserPreference records, and creating new ones.
+
+# Also note that it accepts and sets multiple preference/choices combinations in
+# each request.  This is so that the end user can make a number of preference decisions
+# in one page, and the FE can send over just one request, in order to create all of the
+# UserPreference records for all of the user’s decisions.
+#
+# This class is responsible for:
+#   - accepting an Account record and an array of preference/choice pairings
+#   - destroying any associated existing UserPreference records
+#   - creating new UserPreference records based on the request
+#   - returning the successfully created pairings that were requested
+#
 class SetUserPreferences
   attr_reader :account, :requested_user_preferences, :preference_codes, :user_preferences,
               :preference, :preference_choice, :preference_records, :preference_choice_records
 
+  # @param account [Account] An instance of Account
+  # @param requested_user_preferences [Array<Hash>] An array of hashes. Each has contains
+  #   a Preference#code, and the associates PreferenceChoice#codes the user selected.
+  #   For example:
+  #   [
+  #     {
+  #       preference: { code: 'benefits' },
+  #       user_preferences: [
+  #         { code: 'health-care' },
+  #         ...
+  #       ]
+  #     },
+  #     ...
+  #   ]
+  #
   def initialize(account, requested_user_preferences)
     @account = account
     @requested_user_preferences = requested_user_preferences
@@ -12,6 +42,21 @@ class SetUserPreferences
     @preference_choice_records = eager_load_preference_choices
   end
 
+  # @return [Array<Hash>] An array of hashes. Each hash contains the db Preference and
+  #   PreferenceChoice records that are associated with the user's newly created
+  #   UserPreference records.  For example:
+  #   [
+  #     {
+  #       preference: <Preference>,
+  #       user_preferences: [
+  #         <PreferenceChoice>,
+  #         <PreferenceChoice>,
+  #         ...
+  #       ]
+  #     },
+  #     ...
+  #   ]
+  #
   def execute!
     destroy_user_preferences!
 

--- a/app/services/set_user_preferences.rb
+++ b/app/services/set_user_preferences.rb
@@ -61,7 +61,7 @@ class SetUserPreferences
     destroy_user_preferences!
 
     requested_user_preferences.map do |preferences|
-      assign_preference_codes preferences
+      assign_preference_codes(preferences)
 
       results = {
         preference: preference,
@@ -69,9 +69,9 @@ class SetUserPreferences
       }
 
       user_preferences.each do |user_preference|
-        assign_user_preference_codes user_preference
+        assign_user_preference_codes(user_preference)
         create_user_preference!
-        add_choice_to results
+        add_choice_to(results)
       end
 
       results
@@ -109,14 +109,14 @@ class SetUserPreferences
   def assign_preference_codes(preferences)
     preference_code   = preferences.dig 'preference', 'code'
     @user_preferences = preferences.dig 'user_preferences'
-    @preference       = find_record preference_records, preference_code
+    @preference       = find_record(preference_records, preference_code)
 
     raise Common::Exceptions::RecordNotFound, preference_code if preference.blank?
   end
 
   def assign_user_preference_codes(user_preference)
     choice_code        = user_preference.dig 'code'
-    @preference_choice = find_record preference_choice_records, choice_code
+    @preference_choice = find_record(preference_choice_records, choice_code)
 
     raise Common::Exceptions::RecordNotFound, choice_code if preference_choice.blank?
   end

--- a/app/services/set_user_preferences.rb
+++ b/app/services/set_user_preferences.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class SetUserPreferences
+  attr_reader :account, :requested_user_preferences, :preference_codes,
+              :user_preferences, :preference, :preference_choice
+
+  def initialize(account, requested_user_preferences)
+    @account = account
+    @requested_user_preferences = requested_user_preferences
+    @preference_codes = derive_preference_codes
+  end
+
+  def execute!
+    destroy_user_preferences!
+
+    requested_user_preferences.map do |preferences|
+      assign_preference_codes preferences
+
+      results = {
+        preference: preference,
+        user_preferences: []
+      }
+
+      user_preferences.each do |user_preference|
+        assign_user_preference_codes user_preference
+        create_user_preference!
+        add_choice_to results
+      end
+
+      results
+    end
+  end
+
+  private
+
+  def derive_preference_codes
+    requested_user_preferences.map { |requested| requested.dig 'preference', 'code' }
+  end
+
+  def destroy_user_preferences!
+    user_prefs = UserPreference.for_preference_and_account(account.id, preference_codes)
+
+    user_prefs.destroy_all
+  end
+
+  def assign_preference_codes(preferences)
+    preference_code   = preferences.dig 'preference', 'code'
+    @user_preferences = preferences.dig 'user_preferences'
+    @preference       = Preference.find_by code: preference_code
+
+    raise Common::Exceptions::RecordNotFound, preference_code if preference.blank?
+  end
+
+  def results_template
+    {
+      preference: preference,
+      user_preferences: []
+    }
+  end
+
+  def assign_user_preference_codes(user_preference)
+    choice_code        = user_preference.dig 'code'
+    @preference_choice = PreferenceChoice.find_by code: choice_code
+
+    raise Common::Exceptions::RecordNotFound, choice_code if preference_choice.blank?
+  end
+
+  def create_user_preference!
+    UserPreference.create!(
+      account_id: account.id,
+      preference_id: preference.id,
+      preference_choice_id: preference_choice.id
+    )
+  end
+
+  def add_choice_to(results)
+    results[:user_preferences] << preference_choice
+  end
+end

--- a/app/services/set_user_preferences.rb
+++ b/app/services/set_user_preferences.rb
@@ -7,7 +7,7 @@
 # Also note that it accepts and sets multiple preference/choices combinations in
 # each request.  This is so that the end user can make a number of preference decisions
 # in one page, and the FE can send over just one request, in order to create all of the
-# UserPreference records for all of the user’s decisions.
+# UserPreference records for all of the users decisions.
 #
 # This class is responsible for:
 #   - accepting an Account record and an array of preference/choice pairings

--- a/app/services/set_user_preferences.rb
+++ b/app/services/set_user_preferences.rb
@@ -20,7 +20,7 @@ class SetUserPreferences
               :preference, :preference_choice, :preference_records, :preference_choice_records
 
   # @param account [Account] An instance of Account
-  # @param requested_user_preferences [Array<Hash>] An array of hashes. Each has contains
+  # @param requested_user_preferences [Array<Hash>] An array of hashes. Each hash contains
   #   a Preference#code, and the associates PreferenceChoice#codes the user selected.
   #   For example:
   #   [
@@ -112,13 +112,6 @@ class SetUserPreferences
     @preference       = find_record preference_records, preference_code
 
     raise Common::Exceptions::RecordNotFound, preference_code if preference.blank?
-  end
-
-  def results_template
-    {
-      preference: preference,
-      user_preferences: []
-    }
   end
 
   def assign_user_preference_codes(user_preference)

--- a/app/swagger/requests/preferences.rb
+++ b/app/swagger/requests/preferences.rb
@@ -59,6 +59,87 @@ module Swagger
         end
       end
 
+      # rubocop:disable Metrics/LineLength
+      swagger_path '/v0/user/preferences' do
+        operation :post do
+          extend Swagger::Responses::AuthenticationError
+
+          key :description, 'Both creates and updates a users UserPreferences'
+          key :operationId, 'postUserPreferences'
+          key :tags, %w[
+            preferences
+          ]
+
+          parameter :authorization
+
+          parameter do
+            key :name, :body
+            key :in, :body
+            key :description, 'Array of Preference and PreferenceChoice selections that the user made'
+            key :required, true
+
+            schema do
+              key :type, :array
+              items do
+                key :required, %i[preference user_preferences]
+                property :preference, type: :object do
+                  key :required, %i[code]
+                  property :code, type: :string, description: 'The Preference#code'
+                end
+                property :user_preferences do
+                  key :type, :array
+                  key :description, 'Array of the PreferenceChoice#codes that the user selected for the associated Preference'
+                  items do
+                    key :required, %i[code]
+                    property :code, type: :string, description: 'The PreferenceChoice#code'
+                  end
+                end
+              end
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :required, %i[data]
+              property :data, type: :object do
+                key :required, %i[id type attributes]
+                property :id, type: :string
+                property :type, type: :string
+                property :attributes, type: :object do
+                  key :required, %i[user_preferences]
+                  property :user_preferences do
+                    key :type, :array
+                    items do
+                      key :required, %i[code title user_preferences]
+                      property :code, type: :string
+                      property :title, type: :string
+                      property :user_preferences do
+                        key :type, :array
+                        key :description, 'Array of the PreferenceChoice#codes that the user selected for the associated Preference'
+                        items do
+                          key :required, %i[code description]
+                          property :code, type: :string, description: 'The PreferenceChoice#code'
+                          property :description, type: :string, description: 'The PreferenceChoice#description'
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+
+          response 404 do
+            key :description, 'Not found: Preference record not found'
+            schema do
+              key :'$ref', :Errors
+            end
+          end
+        end
+      end
+      # rubocop:enable Metrics/LineLength
+
       swagger_schema :Preferences do
         property :data, type: :object do
           property :id, type: :string

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,6 +233,7 @@ Rails.application.routes.draw do
     end
 
     resources :preferences, only: %i[show index], path: 'user/preferences/choices', param: :code
+    resources :user_preferences, only: :create, path: 'user/preferences'
 
     [
       'profile',

--- a/db/migrate/20181128182716_remove_user_preference_indexes.rb
+++ b/db/migrate/20181128182716_remove_user_preference_indexes.rb
@@ -1,0 +1,6 @@
+class RemoveUserPreferenceIndexes < ActiveRecord::Migration
+  def change
+    remove_index(:user_preferences, :account_id)
+    remove_index(:user_preferences, :preference_id)
+  end
+end

--- a/db/migrate/20181128183509_add_back_user_preference_indexes.rb
+++ b/db/migrate/20181128183509_add_back_user_preference_indexes.rb
@@ -1,0 +1,8 @@
+class AddBackUserPreferenceIndexes < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index(:user_preferences, :account_id, unique: false,  algorithm: :concurrently)
+    add_index(:user_preferences, :preference_id, unique: false,  algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181126171800) do
+ActiveRecord::Schema.define(version: 20181128183509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "postgis"
   enable_extension "uuid-ossp"
   enable_extension "pg_trgm"
   enable_extension "btree_gin"
-  enable_extension "postgis"
 
   create_table "accounts", force: :cascade do |t|
     t.uuid     "uuid",       null: false
@@ -399,9 +399,9 @@ ActiveRecord::Schema.define(version: 20181126171800) do
     t.datetime "updated_at",           null: false
   end
 
-  add_index "user_preferences", ["account_id"], name: "index_user_preferences_on_account_id", unique: true, using: :btree
+  add_index "user_preferences", ["account_id"], name: "index_user_preferences_on_account_id", using: :btree
   add_index "user_preferences", ["preference_choice_id"], name: "index_user_preferences_on_preference_choice_id", unique: true, using: :btree
-  add_index "user_preferences", ["preference_id"], name: "index_user_preferences_on_preference_id", unique: true, using: :btree
+  add_index "user_preferences", ["preference_id"], name: "index_user_preferences_on_preference_id", using: :btree
 
   create_table "vba_documents_upload_submissions", force: :cascade do |t|
     t.uuid     "guid",                              null: false

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1340,6 +1340,44 @@ RSpec.describe 'the API documentation', type: :apivore, order: :defined do
         expect(subject).to validate(:get, "#{route}/{code}", 401, 'code' => preference.code)
         expect(subject).to validate(:get, "#{route}/{code}", 404, auth_options.merge('code' => 'wrong'))
       end
+
+      it 'supports creating and/or updating UserPreferences for POST /v0/user/preferences' do
+        preference = create :preference
+        choice = create :preference_choice, preference: preference
+        request_body = [
+          {
+            preference: { code: preference.code },
+            user_preferences: [{ code: choice.code }]
+          }
+        ]
+
+        expect(subject).to validate(
+          :post,
+          '/v0/user/preferences',
+          200,
+          auth_options.merge('_data' => { '_json' => request_body.as_json })
+        )
+      end
+
+      it 'supports authorization validation for POST /v0/user/preferences' do
+        expect(subject).to validate(:post, '/v0/user/preferences', 401)
+      end
+
+      it 'supports 404 error reporting for POST /v0/user/preferences' do
+        bad_request_body = [
+          {
+            preference: { code: 'code-not-in-db' },
+            user_preferences: [{ code: 'code-not-in-db' }]
+          }
+        ]
+
+        expect(subject).to validate(
+          :post,
+          '/v0/user/preferences',
+          404,
+          auth_options.merge('_data' => { '_json' => bad_request_body.as_json })
+        )
+      end
     end
 
     describe 'profiles' do

--- a/spec/request/user_preferences_request_spec.rb
+++ b/spec/request/user_preferences_request_spec.rb
@@ -51,120 +51,11 @@ describe 'user_preferences', type: :request do
   end
 
   describe 'POST /v0/user/preferences' do
-    context 'when the User does *not* already have UserPreference records for the Preference' do
-      it 'returns the expected shape of attributes', :aggregate_failures do
-        post '/v0/user/preferences', request_body.to_json, auth_header
+    it 'returns the expected shape of attributes', :aggregate_failures do
+      post '/v0/user/preferences', request_body.to_json, auth_header
 
-        expect(response).to have_http_status(:ok)
-        expect(response).to match_response_schema('user_preferences')
-      end
-
-      it 'creates UserPreference records' do
-        expect {
-          post '/v0/user/preferences', request_body.to_json, auth_header
-        }.to change{ UserPreference.count }.from(0).to(4)
-      end
-
-      it 'creates UserPreference records for the passed user Account' do
-        post '/v0/user/preferences', request_body.to_json, auth_header
-
-        expect(UserPreference.pluck(:account_id).uniq).to eq [user.account.id]
-      end
-
-      it 'creates UserPreference records for the passed Preferences', :aggregate_failures do
-        post '/v0/user/preferences', request_body.to_json, auth_header
-
-        expect(UserPreference.where(preference_id: preference_1.id).count).to eq 2
-        expect(UserPreference.where(preference_id: preference_2.id).count).to eq 2
-      end
-
-      it 'returns the Preference and PreferenceChoices that were associated in the new UserPreferences', :aggregate_failures do
-        post '/v0/user/preferences', request_body.to_json, auth_header
-
-        returned_codes_1 = returned_user_preference_codes_in(response, preference_1)
-        returned_codes_2 = returned_user_preference_codes_in(response, preference_2)
-
-        expect(returned_codes_1).to match_array [choice_1.code, choice_2.code]
-        expect(returned_codes_2).to match_array [choice_3.code, choice_4.code]
-      end
-    end
-
-    context 'when the User already has UserPreference records for the Preference' do
-      let!(:user_preference_1) { create_user_preference(preference_1, choice_1) }
-      let!(:user_preference_2) { create_user_preference(preference_1, choice_2) }
-      let!(:user_preference_3) { create_user_preference(preference_2, choice_3) }
-      let!(:user_preference_4) { create_user_preference(preference_2, choice_4) }
-      let!(:existing_user_preference_ids) { UserPreference.pluck(:id) }
-      let(:choice_5) { create :preference_choice, preference: preference_1 }
-      let(:choice_6) { create :preference_choice, preference: preference_1 }
-      let(:choice_7) { create :preference_choice, preference: preference_2 }
-      let(:choice_8) { create :preference_choice, preference: preference_2 }
-      let(:request_body) do
-        [
-          {
-            preference: {
-              code: preference_1.code
-            },
-            user_preferences: [
-              { code: choice_5.code },
-              { code: choice_6.code }
-            ]
-          },
-          {
-            preference: {
-              code: preference_2.code
-            },
-            user_preferences: [
-              { code: choice_7.code },
-              { code: choice_8.code }
-            ]
-          }
-        ]
-      end
-
-      before { expect(UserPreference.count).to eq 4 }
-
-      it "deletes the user's existing records for the associated Preference and creates new ones", :aggregate_failures do
-        post '/v0/user/preferences', request_body.to_json, auth_header
-
-        existing_user_preference_ids.each do |user_preference_id|
-          expect(UserPreference.find_by(id: user_preference_id)).to be_nil
-        end
-      end
-
-      it 'creates new UserPreference records', :aggregate_failures do
-        post '/v0/user/preferences', request_body.to_json, auth_header
-
-        expect(UserPreference.count).to eq 4
-        expect(existing_user_preference_ids).to_not match_array UserPreference.pluck(:id)
-      end
-
-      it 'returns the Preference and PreferenceChoices that were associated in the new UserPreferences', :aggregate_failures do
-        post '/v0/user/preferences', request_body.to_json, auth_header
-
-        returned_codes_1 = returned_user_preference_codes_in(response, preference_1)
-        returned_codes_2 = returned_user_preference_codes_in(response, preference_2)
-
-        expect(returned_codes_1).to match_array [choice_5.code, choice_6.code]
-        expect(returned_codes_2).to match_array [choice_7.code, choice_8.code]
-      end
-
-      context 'when the user has other non-related UserPreferences in place' do
-        let(:some_preference) { create(:preference) }
-        let(:some_choice) { create(:preference_choice) }
-        let!(:other_user_preference) { create_user_preference(some_preference, some_choice) }
-
-        before do
-          expect(user.account.user_preferences.count).to eq 5
-          expect(user.account.user_preferences).to include other_user_preference
-        end
-
-        it 'does not delete UserPreference records that are not associated with the passed Preferences' do
-          post '/v0/user/preferences', request_body.to_json, auth_header
-
-          expect(user.account.user_preferences).to include other_user_preference
-        end
-      end
+      expect(response).to have_http_status(:ok)
+      expect(response).to match_response_schema('user_preferences')
     end
 
     context 'current user does not have an Account record' do
@@ -230,21 +121,4 @@ describe 'user_preferences', type: :request do
       end
     end
   end
-end
-
-def create_user_preference(preference, preference_choice)
-  create(
-    :user_preference,
-    account: user.account,
-    preference: preference,
-    preference_choice: preference_choice
-  )
-end
-
-def returned_user_preference_codes_in(response, preference)
-    body     = JSON.parse response.body
-    pairings = body.dig('data', 'attributes', 'user_preferences')
-    pairings = pairings.select { |pair| pair['code'] == preference.code }
-
-    pairings.first.dig('user_preferences').map { |pref| pref['code'] }
 end

--- a/spec/request/user_preferences_request_spec.rb
+++ b/spec/request/user_preferences_request_spec.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/error_details'
+
+describe 'user_preferences', type: :request do
+  include SchemaMatchers
+  include ErrorDetails
+
+  let(:user) { build(:user, :accountable) }
+  let(:token) { 'fa0f28d6-224a-4015-a3b0-81e77de269f2' }
+  let(:auth_header) do
+    {
+      'Authorization' => "Token token=#{token}",
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+  let(:preference_1) { create :preference }
+  let(:preference_2) { create :preference }
+  let(:choice_1) { create :preference_choice, preference: preference_1 }
+  let(:choice_2) { create :preference_choice, preference: preference_1 }
+  let(:choice_3) { create :preference_choice, preference: preference_2 }
+  let(:choice_4) { create :preference_choice, preference: preference_2 }
+  let(:request_body) do
+    [
+      {
+        preference: {
+          code: preference_1.code
+        },
+        user_preferences: [
+          { code: choice_1.code },
+          { code: choice_2.code }
+        ]
+      },
+      {
+        preference: {
+          code: preference_2.code
+        },
+        user_preferences: [
+          { code: choice_3.code },
+          { code: choice_4.code }
+        ]
+      }
+    ]
+  end
+
+  before do
+    Session.create(uuid: user.uuid, token: token)
+    User.create(user)
+  end
+
+  describe 'POST /v0/user/preferences' do
+    context 'when the User does *not* already have UserPreference records for the Preference' do
+      it 'returns the expected shape of attributes', :aggregate_failures do
+        post '/v0/user/preferences', request_body.to_json, auth_header
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to match_response_schema('user_preferences')
+      end
+
+      it 'creates UserPreference records' do
+        expect {
+          post '/v0/user/preferences', request_body.to_json, auth_header
+        }.to change{ UserPreference.count }.from(0).to(4)
+      end
+
+      it 'creates UserPreference records for the passed user Account' do
+        post '/v0/user/preferences', request_body.to_json, auth_header
+
+        expect(UserPreference.pluck(:account_id).uniq).to eq [user.account.id]
+      end
+
+      it 'creates UserPreference records for the passed Preferences', :aggregate_failures do
+        post '/v0/user/preferences', request_body.to_json, auth_header
+
+        expect(UserPreference.where(preference_id: preference_1.id).count).to eq 2
+        expect(UserPreference.where(preference_id: preference_2.id).count).to eq 2
+      end
+
+      it 'returns the Preference and PreferenceChoices that were associated in the new UserPreferences', :aggregate_failures do
+        post '/v0/user/preferences', request_body.to_json, auth_header
+
+        returned_codes_1 = returned_user_preference_codes_in(response, preference_1)
+        returned_codes_2 = returned_user_preference_codes_in(response, preference_2)
+
+        expect(returned_codes_1).to match_array [choice_1.code, choice_2.code]
+        expect(returned_codes_2).to match_array [choice_3.code, choice_4.code]
+      end
+    end
+
+    context 'when the User already has UserPreference records for the Preference' do
+      let!(:user_preference_1) { create_user_preference(preference_1, choice_1) }
+      let!(:user_preference_2) { create_user_preference(preference_1, choice_2) }
+      let!(:user_preference_3) { create_user_preference(preference_2, choice_3) }
+      let!(:user_preference_4) { create_user_preference(preference_2, choice_4) }
+      let!(:existing_user_preference_ids) { UserPreference.pluck(:id) }
+      let(:choice_5) { create :preference_choice, preference: preference_1 }
+      let(:choice_6) { create :preference_choice, preference: preference_1 }
+      let(:choice_7) { create :preference_choice, preference: preference_2 }
+      let(:choice_8) { create :preference_choice, preference: preference_2 }
+      let(:request_body) do
+        [
+          {
+            preference: {
+              code: preference_1.code
+            },
+            user_preferences: [
+              { code: choice_5.code },
+              { code: choice_6.code }
+            ]
+          },
+          {
+            preference: {
+              code: preference_2.code
+            },
+            user_preferences: [
+              { code: choice_7.code },
+              { code: choice_8.code }
+            ]
+          }
+        ]
+      end
+
+      before { expect(UserPreference.count).to eq 4 }
+
+      it "deletes the user's existing records for the associated Preference and creates new ones", :aggregate_failures do
+        post '/v0/user/preferences', request_body.to_json, auth_header
+
+        existing_user_preference_ids.each do |user_preference_id|
+          expect(UserPreference.find_by(id: user_preference_id)).to be_nil
+        end
+      end
+
+      it 'creates new UserPreference records', :aggregate_failures do
+        post '/v0/user/preferences', request_body.to_json, auth_header
+
+        expect(UserPreference.count).to eq 4
+        expect(existing_user_preference_ids).to_not match_array UserPreference.pluck(:id)
+      end
+
+      it 'returns the Preference and PreferenceChoices that were associated in the new UserPreferences', :aggregate_failures do
+        post '/v0/user/preferences', request_body.to_json, auth_header
+
+        returned_codes_1 = returned_user_preference_codes_in(response, preference_1)
+        returned_codes_2 = returned_user_preference_codes_in(response, preference_2)
+
+        expect(returned_codes_1).to match_array [choice_5.code, choice_6.code]
+        expect(returned_codes_2).to match_array [choice_7.code, choice_8.code]
+      end
+
+      context 'when the user has other non-related UserPreferences in place' do
+        let(:some_preference) { create(:preference) }
+        let(:some_choice) { create(:preference_choice) }
+        let!(:other_user_preference) { create_user_preference(some_preference, some_choice) }
+
+        before do
+          expect(user.account.user_preferences.count).to eq 5
+          expect(user.account.user_preferences).to include other_user_preference
+        end
+
+        it 'does not delete UserPreference records that are not associated with the passed Preferences' do
+          post '/v0/user/preferences', request_body.to_json, auth_header
+
+          expect(user.account.user_preferences).to include other_user_preference
+        end
+      end
+    end
+
+    context 'current user does not have an Account record' do
+      let(:user_wo_account) { build(:user, :loa3) }
+
+      before do
+        Session.create(uuid: user_wo_account.uuid, token: token)
+        User.create(user_wo_account)
+      end
+
+      it 'creates an Account record for the current user', :aggregate_failures do
+        expect(user_wo_account.account).to be_nil
+
+        post '/v0/user/preferences', request_body.to_json, auth_header
+
+        expect(user_wo_account.account).to be_present
+        expect(response).to have_http_status(:ok)
+        expect(response).to match_response_schema('user_preferences')
+      end
+    end
+
+    context 'when a passed Preference#code is not in the db' do
+      let(:non_existant_code) { 'code-that-does-not-exist' }
+      let(:bad_request_body) do
+        [
+          {
+            preference: { code: non_existant_code },
+            user_preferences: [{ code: choice_1.code }]
+          }
+        ].to_json
+      end
+
+      it 'returns a 404 not found', :aggregate_failures do
+        post '/v0/user/preferences', bad_request_body, auth_header
+
+        expect(response).to have_http_status(:not_found)
+        expect(error_details_for(response, key: 'title')).to eq 'Record not found'
+        expect(
+          error_details_for(response, key: 'detail')
+        ).to eq "The record identified by #{non_existant_code} could not be found"
+      end
+    end
+
+    context 'when a passed PreferenceChoice#code is not in the db' do
+      let(:non_existant_code) { 'code-that-does-not-exist' }
+      let(:bad_request_body) do
+        [
+          {
+            preference: { code: preference_1.code },
+            user_preferences: [{ code: non_existant_code }]
+          }
+        ].to_json
+      end
+
+      it 'returns a 404 not found', :aggregate_failures do
+        post '/v0/user/preferences', bad_request_body, auth_header
+
+        expect(response).to have_http_status(:not_found)
+        expect(error_details_for(response, key: 'title')).to eq 'Record not found'
+        expect(
+          error_details_for(response, key: 'detail')
+        ).to eq "The record identified by #{non_existant_code} could not be found"
+      end
+    end
+  end
+end
+
+def create_user_preference(preference, preference_choice)
+  create(
+    :user_preference,
+    account: user.account,
+    preference: preference,
+    preference_choice: preference_choice
+  )
+end
+
+def returned_user_preference_codes_in(response, preference)
+    body     = JSON.parse response.body
+    pairings = body.dig('data', 'attributes', 'user_preferences')
+    pairings = pairings.select { |pair| pair['code'] == preference.code }
+
+    pairings.first.dig('user_preferences').map { |pref| pref['code'] }
+end

--- a/spec/services/set_user_preferences_spec.rb
+++ b/spec/services/set_user_preferences_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable Metrics/LineLength
+RSpec.describe SetUserPreferences do
+  let(:user) { build(:user, :accountable) }
+  let(:account) { user.account }
+  let(:preference_1) { create :preference }
+  let(:preference_2) { create :preference }
+  let(:choice_1) { create :preference_choice, preference: preference_1 }
+  let(:choice_2) { create :preference_choice, preference: preference_1 }
+  let(:choice_3) { create :preference_choice, preference: preference_2 }
+  let(:choice_4) { create :preference_choice, preference: preference_2 }
+  let(:requested_user_preferences) do
+    [
+      {
+        preference: {
+          code: preference_1.code
+        },
+        user_preferences: [
+          { code: choice_1.code },
+          { code: choice_2.code }
+        ]
+      },
+      {
+        preference: {
+          code: preference_2.code
+        },
+        user_preferences: [
+          { code: choice_3.code },
+          { code: choice_4.code }
+        ]
+      }
+    ].as_json
+  end
+
+  describe 'execute!' do
+    context 'when the User does *not* already have UserPreference records for the Preference' do
+      let(:set_user_preferences) { SetUserPreferences.new(account, requested_user_preferences) }
+
+      it 'creates UserPreference records' do
+        expect do
+          set_user_preferences.execute!
+        end.to change { UserPreference.count }.from(0).to(4)
+      end
+
+      # rubocop:disable Rails/UniqBeforePluck
+      it 'creates UserPreference records for the passed user Account' do
+        set_user_preferences.execute!
+
+        expect(UserPreference.pluck(:account_id).uniq).to eq [user.account.id]
+      end
+      # rubocop:enable Rails/UniqBeforePluck
+
+      it 'creates UserPreference records for the passed Preferences', :aggregate_failures do
+        set_user_preferences.execute!
+
+        expect(UserPreference.where(preference_id: preference_1.id).count).to eq 2
+        expect(UserPreference.where(preference_id: preference_2.id).count).to eq 2
+      end
+
+      it 'returns the Preference and PreferenceChoices that were associated in the new UserPreferences', :aggregate_failures do
+        response = set_user_preferences.execute!
+
+        returned_codes1 = returned_user_preference_codes_in(response, preference_1)
+        returned_codes2 = returned_user_preference_codes_in(response, preference_2)
+
+        expect(returned_codes1).to match_array [choice_1.code, choice_2.code]
+        expect(returned_codes2).to match_array [choice_3.code, choice_4.code]
+      end
+    end
+
+    context 'when the User already has UserPreference records for the Preference' do
+      let!(:user_preference_1) { create_user_preference(preference_1, choice_1) }
+      let!(:user_preference_2) { create_user_preference(preference_1, choice_2) }
+      let!(:user_preference_3) { create_user_preference(preference_2, choice_3) }
+      let!(:user_preference_4) { create_user_preference(preference_2, choice_4) }
+      let!(:existing_user_preference_ids) { UserPreference.pluck(:id) }
+      let(:choice_5) { create :preference_choice, preference: preference_1 }
+      let(:choice_6) { create :preference_choice, preference: preference_1 }
+      let(:choice_7) { create :preference_choice, preference: preference_2 }
+      let(:choice_8) { create :preference_choice, preference: preference_2 }
+      let(:requested_user_preferences) do
+        [
+          {
+            preference: {
+              code: preference_1.code
+            },
+            user_preferences: [
+              { code: choice_5.code },
+              { code: choice_6.code }
+            ]
+          },
+          {
+            preference: {
+              code: preference_2.code
+            },
+            user_preferences: [
+              { code: choice_7.code },
+              { code: choice_8.code }
+            ]
+          }
+        ].as_json
+      end
+      let(:set_user_preferences) { SetUserPreferences.new(account, requested_user_preferences) }
+
+      before { expect(UserPreference.count).to eq 4 }
+
+      it "deletes the user's existing records for the associated Preference and creates new ones", :aggregate_failures do
+        set_user_preferences.execute!
+
+        existing_user_preference_ids.each do |user_preference_id|
+          expect(UserPreference.find_by(id: user_preference_id)).to be_nil
+        end
+      end
+
+      it 'creates new UserPreference records', :aggregate_failures do
+        set_user_preferences.execute!
+
+        expect(UserPreference.count).to eq 4
+        expect(existing_user_preference_ids).to_not match_array UserPreference.pluck(:id)
+      end
+
+      it 'returns the Preference and PreferenceChoices that were associated in the new UserPreferences', :aggregate_failures do
+        response = set_user_preferences.execute!
+
+        returned_codes1 = returned_user_preference_codes_in(response, preference_1)
+        returned_codes2 = returned_user_preference_codes_in(response, preference_2)
+
+        expect(returned_codes1).to match_array [choice_5.code, choice_6.code]
+        expect(returned_codes2).to match_array [choice_7.code, choice_8.code]
+      end
+
+      context 'when the user has other non-related UserPreferences in place' do
+        let(:some_preference) { create(:preference) }
+        let(:some_choice) { create(:preference_choice) }
+        let!(:other_user_preference) { create_user_preference(some_preference, some_choice) }
+
+        before do
+          expect(user.account.user_preferences.count).to eq 5
+          expect(user.account.user_preferences).to include other_user_preference
+        end
+
+        it 'does not delete UserPreference records that are not associated with the passed Preferences' do
+          set_user_preferences.execute!
+
+          expect(user.account.user_preferences).to include other_user_preference
+        end
+      end
+    end
+
+    context 'when a passed Preference#code is not in the db' do
+      let(:non_existant_code) { 'code-that-does-not-exist' }
+      let(:bad_request_body) do
+        [
+          {
+            preference: { code: non_existant_code },
+            user_preferences: [{ code: choice_1.code }]
+          }
+        ].as_json
+      end
+      let(:set_user_preferences) { SetUserPreferences.new(account, bad_request_body) }
+
+      it 'returns a 404 not found', :aggregate_failures do
+        expect { set_user_preferences.execute! }.to raise_error do |error|
+          expect(error).to be_a(Common::Exceptions::RecordNotFound)
+          expect(error.status_code).to eq(404)
+          expect(error.message).to eq('Record not found')
+          expect(
+            error.errors.first.detail
+          ).to eq "The record identified by #{non_existant_code} could not be found"
+        end
+      end
+    end
+
+    context 'when a passed PreferenceChoice#code is not in the db' do
+      let(:non_existant_code) { 'code-that-does-not-exist' }
+      let(:bad_request_body) do
+        [
+          {
+            preference: { code: preference_1.code },
+            user_preferences: [{ code: non_existant_code }]
+          }
+        ].as_json
+      end
+      let(:set_user_preferences) { SetUserPreferences.new(account, bad_request_body) }
+
+      it 'returns a 404 not found', :aggregate_failures do
+        expect { set_user_preferences.execute! }.to raise_error do |error|
+          expect(error).to be_a(Common::Exceptions::RecordNotFound)
+          expect(error.status_code).to eq(404)
+          expect(error.message).to eq('Record not found')
+          expect(
+            error.errors.first.detail
+          ).to eq "The record identified by #{non_existant_code} could not be found"
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/LineLength
+
+def returned_user_preference_codes_in(response, preference)
+  pairings = response.select { |pair| pair[:preference].code == preference.code }
+
+  pairings.first.dig(:user_preferences).map(&:code)
+end
+
+def create_user_preference(preference, preference_choice)
+  create(
+    :user_preference,
+    account: user.account,
+    preference: preference,
+    preference_choice: preference_choice
+  )
+end

--- a/spec/support/schemas/user_preferences.json
+++ b/spec/support/schemas/user_preferences.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "user_preferences": {
+              "description": "Array of Preference and PreferenceChoice pairings",
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "user_preferences": {
+                    "description": "Array of PreferenceChoice codes the user selected",
+                    "items": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas/user_preferences.json
+++ b/spec/support/schemas/user_preferences.json
@@ -22,6 +22,9 @@
                       "properties": {
                         "code": {
                           "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
                         }
                       },
                       "type": "object"


### PR DESCRIPTION
## Description of change
In order to create and/or update a new set of `UserPreference` for a given user, we need an endpoint with which the FE can communicate.

## Testing done
<!-- Please describe testing done to verify the changes. -->
Comprehensive spec coverage

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] `UserPreference` controller and `POST` action are established
- [x] Communicate to the FE team that this is done synchronously 
- [x] Creates an `Account` record for the user, if they do not already have one (log if there are issues)
- [x] Endpoint can be used for both creating and/or updating a user `UserPreference`s
- [x] Endpoint accepts sets multiple preference/choices combinations in each request
- [x] Destroy any associated existing `UserPreference` records before creating new ones
- [x] Swagger docs
- [x] Yard docs
- [ ] Ask DevOps to run the migration files in staging/production

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

## Screenshot

Swagger docs for new endpoint

![image](https://user-images.githubusercontent.com/7482329/49313203-ca8ec180-f4a3-11e8-98ad-a92c53e68337.png)
