### PR TITLE
namespace test classes since they exist globally

### DIFF
--- a/spec/lib/common/client/base_spec.rb
+++ b/spec/lib/common/client/base_spec.rb
@@ -3,21 +3,29 @@
 require 'rails_helper'
 
 describe Common::Client::Base do
-  class TestConfiguration2 < Common::Client::Configuration::REST
-    def connection
-      @conn ||= Faraday.new('http://example.com') do |faraday|
-        faraday.adapter :httpclient
+  module Specs
+    module Common
+      module Client
+        class TestConfiguration < ::Common::Client::Configuration::REST
+          def connection
+            @conn ||= Faraday.new('http://example.com') do |faraday|
+              faraday.adapter :httpclient
+            end
+          end
+        end
+
+        class TestService < ::Common::Client::Base
+          configuration TestConfiguration
+        end
       end
     end
   end
 
-  class TestService2 < Common::Client::Base
-    configuration TestConfiguration2
-  end
-
   describe '#request' do
     it 'should raise security error when http client is used without stripping cookies' do
-      expect { TestService2.new.send(:request, :get, '', nil) }.to raise_error(Common::Client::SecurityError)
+      expect { Specs::Common::Client::TestService.new.send(:request, :get, '', nil) }.to raise_error(
+        Common::Client::SecurityError
+      )
     end
   end
 
@@ -26,7 +34,7 @@ describe Common::Client::Base do
       it 'should permanently set any nil values to an empty string' do
         symbolized_hash = { foo: nil, bar: 'baz' }
 
-        TestService2.new.send('sanitize_headers!', :request, :get, '', symbolized_hash)
+        Specs::Common::Client::TestService.new.send('sanitize_headers!', :request, :get, '', symbolized_hash)
 
         expect(symbolized_hash).to eq('foo' => '', 'bar' => 'baz')
       end
@@ -36,7 +44,7 @@ describe Common::Client::Base do
       it 'should permanently set any nil values to an empty string' do
         string_hash = { 'foo' => nil, 'bar' => 'baz' }
 
-        TestService2.new.send('sanitize_headers!', :request, :get, '', string_hash)
+        Specs::Common::Client::TestService.new.send('sanitize_headers!', :request, :get, '', string_hash)
 
         expect(string_hash).to eq('foo' => '', 'bar' => 'baz')
       end
@@ -46,7 +54,7 @@ describe Common::Client::Base do
       it 'should return an empty hash' do
         empty_hash = {}
 
-        TestService2.new.send('sanitize_headers!', :request, :get, '', empty_hash)
+        Specs::Common::Client::TestService.new.send('sanitize_headers!', :request, :get, '', empty_hash)
 
         expect(empty_hash).to eq({})
       end


### PR DESCRIPTION
## Description of change
Housekeeping.  Namespacing a few classes that exist solely for test purposes because they exist globally (and not just within the scope of the specs)

## Testing done
specs

## Testing planned
none

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] namespace test classes

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
