### PR TITLE
Add `uptimeRemaining` to `BackendStatus` for gibs

### DIFF
--- a/app/controllers/v0/backend_statuses_controller.rb
+++ b/app/controllers/v0/backend_statuses_controller.rb
@@ -11,14 +11,15 @@ module V0
 
       # get status
       be_status = BackendStatus.new(name: @backend_service)
-
-      be_status.is_available = case @backend_service
-                               when BackendServices::GI_BILL_STATUS
-                                 EVSS::GiBillStatus::Service.within_scheduled_uptime?
-                               else
-                                 # default service is up!
-                                 true
-                               end
+      case @backend_service
+      when BackendServices::GI_BILL_STATUS
+        be_status.is_available = EVSS::GiBillStatus::Service.within_scheduled_uptime?
+        be_status.uptime_remaining = EVSS::GiBillStatus::Service.seconds_until_downtime
+      else
+        # default service is up!
+        be_status.is_available = true
+        be_status.uptime_remaining = 0
+      end
 
       render json: be_status,
              serializer: BackendStatusSerializer

--- a/app/models/backend_status.rb
+++ b/app/models/backend_status.rb
@@ -9,7 +9,9 @@ class BackendStatus
 
   attribute :name, String
   attribute :is_available, Boolean
+  attribute :uptime_remaining, Integer
 
   validates :name, presence: true
   validates :is_available, presence: true
+  validates :uptime_remaining, presence: true
 end

--- a/app/serializers/backend_status_serializer.rb
+++ b/app/serializers/backend_status_serializer.rb
@@ -3,6 +3,7 @@
 class BackendStatusSerializer < ActiveModel::Serializer
   attribute :name
   attribute :is_available
+  attribute :uptime_remaining
 
   def id
     nil

--- a/spec/request/backend_status_request_spec.rb
+++ b/spec/request/backend_status_request_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe 'Backend Status', type: :request do
         expect(json['data']['attributes']['is_available']).to eq(false)
         expect(json['data']['attributes']['name']).to eq('gibs')
       end
+
+      it 'returns 0 as number of seconds until next downtime' do
+        get v0_backend_status_url('gibs'), nil, auth_header
+        json = JSON.parse(response.body)
+        expect(json['data']['attributes']['uptime_remaining']).to eq(0)
+      end
     end
   end
 
@@ -45,11 +51,17 @@ RSpec.describe 'Backend Status', type: :request do
         get v0_backend_status_url('gibs'), nil, auth_header
         expect(response).to have_http_status(:ok)
       end
-      it 'indicates the service is unavailable' do
+      it 'indicates the service is available' do
         get v0_backend_status_url('gibs'), nil, auth_header
         json = JSON.parse(response.body)
         expect(json['data']['attributes']['is_available']).to eq(true)
         expect(json['data']['attributes']['name']).to eq('gibs')
+      end
+
+      it 'returns number of seconds until next downtime' do
+        get v0_backend_status_url('gibs'), nil, auth_header
+        json = JSON.parse(response.body)
+        expect(json['data']['attributes']['uptime_remaining']).to eq(57_600)
       end
     end
   end


### PR DESCRIPTION
## Description of change
Add `uptimeRemaining` to response from `BackendStatusesController#show` for GIBS

## Testing done
specs

## Testing planned
manual testing after frontend integration

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] calculate number of seconds until downtime in `EVSS::GiBillStatus::Service`
- [x] add `uptime_remaining` attribute to `BackendStatus`
- [x] add `uptime_remaining` attribute to `BackendStatusSerializer`
- [x] populate `BackendStatus#uptime_remaining` in `BackendStatusesController#show`

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
