### PR TITLE
Update Preferences swagger doc

### DIFF
--- a/app/controllers/v0/preferences_controller.rb
+++ b/app/controllers/v0/preferences_controller.rb
@@ -6,8 +6,7 @@ module V0
 
     def index
       results = Preference.all
-      render json: results,
-             each_serializer: PreferenceSerializer
+      render json: results.to_a, serializer: PreferenceSerializer
     end
 
     def show

--- a/app/controllers/v0/preferences_controller.rb
+++ b/app/controllers/v0/preferences_controller.rb
@@ -6,11 +6,11 @@ module V0
 
     def index
       results = Preference.all
-      render json: results.to_a, serializer: PreferenceSerializer
+      render json: results.to_a, serializer: PreferencesSerializer
     end
 
     def show
-      render json: @preference
+      render json: @preference, serializer: PreferenceSerializer
     end
 
     private

--- a/app/serializers/preference_serializer.rb
+++ b/app/serializers/preference_serializer.rb
@@ -1,19 +1,10 @@
 # frozen_string_literal: true
 
 class PreferenceSerializer < ActiveModel::Serializer
-  attribute :preferences
+  attribute :code
+  attribute :title
 
-  def id
-    nil
-  end
-
-  def preferences
-    object.map do |o|
-      {
-        code: o.code,
-        title: o.title,
-        preference_choices: o.choices.select(%i[code description]).as_json(except: :id)
-      }
-    end
+  attribute :preference_choices do
+    object.choices.select(%i[code description]).as_json(except: :id)
   end
 end

--- a/app/serializers/preference_serializer.rb
+++ b/app/serializers/preference_serializer.rb
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 
 class PreferenceSerializer < ActiveModel::Serializer
-  attribute :code
-  attribute :title
+  attribute :preferences
 
-  attribute :preference_choices do
-    object.choices.select(%i[code description]).as_json(except: :id)
+  def id
+    nil
+  end
+
+  def preferences
+    object.map do |o|
+      {
+        code: o.code,
+        title: o.title,
+        preference_choices: o.choices.select(%i[code description]).as_json(except: :id)
+      }
+    end
   end
 end

--- a/app/serializers/preferences_serializer.rb
+++ b/app/serializers/preferences_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class PreferencesSerializer < ActiveModel::Serializer
+  attribute :preferences
+
+  def id
+    nil
+  end
+
+  def preferences
+    object.map do |o|
+      {
+        code: o.code,
+        title: o.title,
+        preference_choices: o.choices.select(%i[code description]).as_json(except: :id)
+      }
+    end
+  end
+end

--- a/app/swagger/requests/preferences.rb
+++ b/app/swagger/requests/preferences.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/LineLength
 module Swagger
   module Requests
     class Preferences
@@ -17,9 +18,30 @@ module Swagger
           response 200 do
             key :description, 'Response is OK'
             schema do
-              property :data, type: :array do
-                items do
-                  key :'$ref', :Preferences
+              key :required, %i[data]
+              property :data, type: :object do
+                key :required, %i[id type attributes]
+                property :id, type: :string
+                property :type, type: :string
+                property :attributes, type: :object do
+                  key :required, %i[preferences]
+                  property :preferences do
+                    key :type, :array
+                    items do
+                      key :required, %i[code title preference_choices]
+                      property :code, type: :string
+                      property :title, type: :string
+                      property :preference_choices do
+                        key :type, :array
+                        key :description, 'Array of PreferenceChoice#codes that the user selected for the associated Preference'
+                        items do
+                          key :required, %i[code description]
+                          property :code, type: :string, description: 'The PreferenceChoice#code'
+                          property :description, type: :string, description: 'The PreferenceChoice#description'
+                        end
+                      end
+                    end
+                  end
                 end
               end
             end
@@ -61,7 +83,6 @@ module Swagger
         end
       end
 
-      # rubocop:disable Metrics/LineLength
       swagger_path '/v0/user/preferences' do
         operation :post do
           extend Swagger::Responses::AuthenticationError
@@ -183,16 +204,19 @@ module Swagger
           end
         end
       end
-      # rubocop:enable Metrics/LineLength
 
       swagger_schema :Preferences do
-        property :type, type: :string
-        property :attributes, type: :object do
-          property :code, type: :string
-          property :title, type: :string
-          property :preference_choices, type: :array do
-            items do
-              key :'$ref', :PreferenceChoices
+        property :data, type: :object do
+          key :required, %i[id type attributes]
+          property :id, type: :string
+          property :type, type: :string
+          property :attributes, type: :object do
+            property :code, type: :string
+            property :title, type: :string
+            property :preference_choices, type: :array do
+              items do
+                key :'$ref', :PreferenceChoices
+              end
             end
           end
         end
@@ -200,11 +224,10 @@ module Swagger
 
       swagger_schema :PreferenceChoices do
         key :type, :object
-        property :attributes, type: :object do
-          property :code, type: :string
-          property :description, type: :string
-        end
+        property :code, type: :string
+        property :description, type: :string
       end
     end
   end
 end
+# rubocop:enable Metrics/LineLength

--- a/app/swagger/requests/preferences.rb
+++ b/app/swagger/requests/preferences.rb
@@ -46,7 +46,9 @@ module Swagger
           response 200 do
             key :description, 'Response is OK'
             schema do
-              key :'$ref', :Preferences
+              property :data, type: :array do
+                key :'$ref', :Preferences
+              end
             end
           end
 
@@ -184,13 +186,12 @@ module Swagger
       # rubocop:enable Metrics/LineLength
 
       swagger_schema :Preferences do
-        property :data, type: :object do
-          property :id, type: :string
-          property :type, type: :string
-          property :attributes, type: :object do
-            property :code, type: :string
-            property :title, type: :string
-            property :preference_choices, type: :array do
+        property :type, type: :string
+        property :attributes, type: :object do
+          property :code, type: :string
+          property :title, type: :string
+          property :preference_choices, type: :array do
+            items do
               key :'$ref', :PreferenceChoices
             end
           end
@@ -198,7 +199,8 @@ module Swagger
       end
 
       swagger_schema :PreferenceChoices do
-        property :data, type: :object do
+        key :type, :object
+        property :attributes, type: :object do
           property :code, type: :string
           property :description, type: :string
         end

--- a/app/swagger/requests/preferences.rb
+++ b/app/swagger/requests/preferences.rb
@@ -18,7 +18,9 @@ module Swagger
             key :description, 'Response is OK'
             schema do
               property :data, type: :array do
-                key :'$ref', :Preferences
+                items do
+                  key :'$ref', :Preferences
+                end
               end
             end
           end
@@ -46,9 +48,7 @@ module Swagger
           response 200 do
             key :description, 'Response is OK'
             schema do
-              property :data, type: :array do
-                key :'$ref', :Preferences
-              end
+              key :'$ref', :Preferences
             end
           end
 

--- a/spec/controllers/v0/preferences_controller_spec.rb
+++ b/spec/controllers/v0/preferences_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe V0::PreferencesController, type: :controller do
       end
 
       it 'matches the response schema' do
-        expect(response).to match_response_schema('preferences')
+        expect(response).to match_response_schema('preference')
       end
 
       it 'returns a single Preference' do
@@ -81,14 +81,13 @@ RSpec.describe V0::PreferencesController, type: :controller do
 
       it 'returns all existing Preferences with their choices' do
         body = json_body_for(response)
-        first_preference_code = body[0]['attributes']['code']
-
-        expect(body.size).to eq 2
-        expect(first_preference_code).to eq first_preference.code
+        preferences = body.dig('attributes', 'preferences')
+        expect(body['attributes']['preferences'].size).to eq 2
+        expect(preferences[0]['code']).to eq first_preference.code
       end
 
       it 'returns all PreferenceChoices for given Preference' do
-        preference_choices = json_body_for(response)[0]['attributes']['preference_choices']
+        preference_choices = json_body_for(response)['attributes']['preferences'][0]['preference_choices']
         preference_choice_codes = preference_choices.map { |pc| pc['code'] }
 
         expect(preference_choice_codes).to match_array first_preference.choices.map(&:code)

--- a/spec/support/schemas/preference.json
+++ b/spec/support/schemas/preference.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+              "code": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "preference_choices": {
+                "description": "Array of PreferenceChoice codes the user selected",
+                "items": {
+                  "properties": {
+                  "code": {
+                      "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                      }
+                  },
+                  "type": "object"
+                  },
+                "type": "array"
+              }
+            },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/spec/support/schemas/preferences.json
+++ b/spec/support/schemas/preferences.json
@@ -4,23 +4,36 @@
     "data": {
       "properties": {
         "attributes": {
-          "properties": {
-            "code": {
-              "description": "Unique identifying slug for the given Preference",
-              "type": "string"
-            },
-            "title": {
-              "description": "A human-readable title for the Preference",
-              "type": "string"
-            },
-            "preference_choices": {
-              "description": "An array of PreferenceChoice objects",
-              "items": {
-                "type": "object"
-              },
-              "type": "array"
-            }
-          },
+           "preferences": {
+             "description": "Array of Preference and PreferenceChoice pairings",
+             "items": {
+               "properties": {
+                 "code": {
+                   "type": "string"
+                 },
+                 "title": {
+                   "type": "string"
+                 },
+                 "preferences": {
+                   "description": "Array of PreferenceChoice codes the user selected",
+                   "items": {
+                     "properties": {
+                       "code": {
+                         "type": "string"
+                       },
+                       "description": {
+                         "type": "string"
+                       }
+                     },
+                     "type": "object"
+                   },
+                   "type": "array"
+                 }
+               },
+               "type": "object"
+             },
+             "type": "array"
+           },
           "type": "object"
         },
         "id": {


### PR DESCRIPTION
## Description of change

In the current swagger docs, it looks like this sample contract is off.  We’d want it to reflect that it is returning an array or pref/choice pairings:

`/v0/user/preferences/choices`: https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/preferences/getPreferences

This one has an extra `data` nested key in it:

`/v0/user/preferences/choices/{code}`: https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/preferences/getPreference 

Here is the contract:  https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12399#issuecomment-442205111

## Testing done
Verified swagger docs match contract and endpoint returns correct shape

## Screenshots
#### Updated `/v0/user/preferences/choices`
![2018-12-04-172033_1232x1152_scrot](https://user-images.githubusercontent.com/11085141/49479554-0483fe80-f7e9-11e8-8ec9-e304b142c6c5.png)


#### Updated `/v0/user/preferences/choices/:code`
![2018-12-03-153726_897x887_scrot](https://user-images.githubusercontent.com/11085141/49403647-ee0b7380-f712-11e8-95ad-239df6d9bb28.png)
## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Swagger docs for `/v0/user/preferences/choices` endpoint are in keeping with the contract
- [x] Swagger docs for `/v0/user/preferences/choices/:code` endpoint are in keeping with the contract
- [ ] `Preferences#index` endpoint response is in keeping with the contract

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

