### PR TITLE
15393 enable account creation

### DIFF
--- a/app/controllers/concerns/accountable.rb
+++ b/app/controllers/concerns/accountable.rb
@@ -9,8 +9,6 @@ module Accountable
   # Account.
   #
   def create_user_account
-    return unless Settings.account.enabled
-
     Account.cache_or_create_by! @current_user
   rescue StandardError => error
     log error

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,7 @@ class User < Common::RedisStore
   delegate :email, to: :identity, allow_nil: true
   delegate :first_name, to: :identity, allow_nil: true
 
-  # This delegated method can also be called with #account_uuid
+  # This delegated method is called with #account_uuid
   delegate :uuid, to: :account, prefix: true, allow_nil: true
 
   # Retrieve a user's Account record.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < Common::RedisStore
   # @return [Account] an instance of the Account object
   #
   def account
-    Account.find_by(idme_uuid: uuid) if Settings.account.enabled
+    Account.find_by(idme_uuid: uuid)
   end
 
   def pciu_email

--- a/app/swagger/requests/user.rb
+++ b/app/swagger/requests/user.rb
@@ -44,7 +44,7 @@ module Swagger
                 property :in_progress_forms
                 property :account, type: :object do
                   property :account_uuid,
-                           type: %w[string null], # while Account feature is still flagged we need to allow null
+                           type: %w[string null],
                            example: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef',
                            description: 'A UUID correlating all user identifiers. Intended to become the user\'s UUID.'
                 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -327,9 +327,6 @@ faraday_socks_proxy:
 
 google_analytics_tracking_id: ~
 
-account:
-  enabled: false
-
 # Settings for search
 search:
   access_key: SEARCH_GOV_ACCESS_KEY


### PR DESCRIPTION
## Description of change
We are ready to enable `Account` record creation in production.

## Sibling DevOps PR

https://github.com/department-of-veterans-affairs/devops/pull/3714

## Testing done
<!-- Please describe testing done to verify the changes. -->

Logged into a staging instance and confirmed that `Account` record creation/checks are working as expected.

## Testing planned
<!-- Please describe testing planned. -->

Once shipped, logging into a production instance to confirm things are working as expected.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Confirm `Account` creation is working in staging
- [x] Enable `Account` creation in production


#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
