### PR TITLE
Add setup instructions for ubuntu.

### DIFF
--- a/bin/install-ubuntu-packages
+++ b/bin/install-ubuntu-packages
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -o xtrace
+set -o errexit
+
+# These are just general tools and prerequisites for building other packages.
+sudo apt install \
+  build-essential \
+  codequery \
+  curl \
+  exuberant-ctags \
+  g++ \
+  gawk \
+  gcc \
+  gconf-service \
+  gconf2 \
+  gconf-service-backend \
+  gconf2-common \
+  gdb \
+  git \
+  gitk \
+  libappindicator1 \
+  libgconf2-4 \
+  libindicator7 \
+  libreadline-dev \
+  libssl1.0-dev:amd64 \
+  libssl1.0.0:amd64 \
+  libssl1.1:amd64 \
+  liblzma-dev \
+  openssl \
+  openssl1.0 \
+  patch \
+  ruby-dev \
+  v4l-utils \
+  v4l2ucp \
+  v4l-conf \
+  vgrabbj \
+  vlc \
+  wget \
+  zlib1g-dev
+
+# Install the various pre-requisites for vets-api
+sudo apt install \
+  postgresql-10 \
+  postgresql-10-postgis-2.4 \
+  postgresql-10-postgis-2.4-scripts \
+  postgresql-client-10 \
+  postgresql-client-common \
+  postgresql-common \
+  postgresql-server-dev-10 \
+  postgresql-server-dev-all \
+  postgresql-10-postgis-2.4 \
+  postgresql-10-postgis-2.4-scripts \
+  imagemagick \
+  imagemagick-6-common \
+  imagemagick-6.q16 \
+  libmagickcore-6.q16-3:amd64 \
+  libmagickcore-6.q16-3-extra:amd64 \
+  libmagickwand-6.q16-3:amd64 \
+  redis \
+  redis-server \
+  redis-tools \
+  clamav \
+  clamav-base \
+  clamav-freshclam \
+  libclamav7:amd64 \
+  libpoppler-dev:amd64 \
+  libpoppler-glib8:amd64 \
+  libpoppler73:amd64 \
+  poppler-data \
+  poppler-utils
+
+
+echo "deb http://ppa.launchpad.net/malteworld/ppa/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/malteworld-ubuntu-ppa-bionic.list
+sudo apt update
+sudo apt install pdftk pdftk-java
+

--- a/docs/setup/native.md
+++ b/docs/setup/native.md
@@ -72,3 +72,31 @@ the `vets-api` directory, run `./bin/setup-osx && source ~/.bash_profile && cd
 1. Create dev database: `bundle exec rake db:setup`
 1. Go to the file `config/settings/development.yml` in your local vets-api. Switch the commented out lines pertaining to the cache_dir: uncomment out line 14 (what you use for running the app via Rails), and comment out line 15 (what you use for running the app via Docker).
 1. Make sure you have the [vets-api-mockdata](https://github.com/department-of-veterans-affairs/vets-api-mockdata) repo locally installed
+
+#### Alternative (Ubuntu 18.04 LTS)
+1. Install Postgres, PostGIS, Redis, ImageMagick, Poppler, ClamAV, etc
+   - From the `vets-api` directory, run `./bin/install-ubuntu-packages`
+1. Edit `/etc/ImageMagick-6/policy.xml` and remove the lines below the comment `<!-- disable ghostscript format types -->`
+   - This may not be necessary. The default policy was updated to [fix a variety of vulnerabilities](https://usn.ubuntu.com/3785-1/) as of October, 2018.
+1. Install Ruby 2.3.
+   - It is suggested that you use a Ruby version manager such as
+    [rbenv](https://github.com/rbenv/rbenv#installation) and
+    [install Ruby 2.3](https://github.com/rbenv/rbenv#installing-ruby-versions).
+   - *NOTE*: rbenv will also provide additional installation instructions in the
+    console output. Make sure to follow those too.
+1. Install Bundler to manage dependencies
+   - `gem install bundler`
+1. Install gem dependencies: `cd vets-api; bundle install`
+1. Install overcommit `overcommit --install --sign`
+1. Setup localhost certificates / keys:
+   - Create certs directory within config:  `mkdir ./config/certs`
+   - Copy [these certificates](https://github.com/department-of-veterans-affairs/vets.gov-team/tree/master/Products/Identity/Files_From_IDme/development-certificates) into the certs dir.
+       - *NOTE*: If you don't have access to these keys, running the following
+         commands will provide basic functionality, such as for running unit tests:
+       - `touch ./config/certs/vetsgov-localhost.crt`
+       - `touch ./config/certs/vetsgov-localhost.key`
+1. Create dev database: `bundle exec rake db:setup`
+1. Go to the file `config/settings/development.yml` in your local vets-api. Switch the commented out lines pertaining to the cache_dir: uncomment out line 14 (what you use for running the app via Rails), and comment out line 15 (what you use for running the app via Docker).
+1. Make sure you have the [vets-api-mockdata](https://github.com/department-of-veterans-affairs/vets-api-mockdata) repo locally installed
+
+


### PR DESCRIPTION
## Description of change
I ran into a few hiccups getting the app up and running on ubuntu. This adds a script to do the tedious package installation and documents the manual fixes required. Hopefully we can get this on par with `setup-osx` in the future but this is a good first step.
