### PR TITLE
Remove log message

### DIFF
--- a/app/controllers/concerns/accountable.rb
+++ b/app/controllers/concerns/accountable.rb
@@ -19,9 +19,8 @@ module Accountable
   private
 
   def log(error)
-    log_message_to_sentry(
-      'Account Creation Error',
-      :error,
+    log_exception_to_sentry(
+      error,
       {
         error: error.inspect,
         idme_uuid: @current_user.uuid

--- a/app/controllers/v0/preneeds/burial_forms_controller.rb
+++ b/app/controllers/v0/preneeds/burial_forms_controller.rb
@@ -49,7 +49,7 @@ module V0
         validation_errors = ::Preneeds::BurialForm.validate(schema, form)
 
         if validation_errors.present?
-          log_message_to_sentry(validation_errors.join(','), :error, {}, validation: 'preneeds')
+          Raven.tags_context(validation: 'preneeds')
           raise Common::Exceptions::SchemaValidationErrors, validation_errors
         end
       end

--- a/lib/evss/disability_compensation_form/service.rb
+++ b/lib/evss/disability_compensation_form/service.rb
@@ -32,9 +32,7 @@ module EVSS
 
       def handle_error(error)
         if error.is_a?(Common::Client::Errors::ClientError) && error.status != 403 && error.body.is_a?(Hash)
-          log_message_to_sentry(
-            error.message, :error, extra_context: { url: config.base_path, body: error.body }
-          )
+          save_error_details(error)
           raise EVSS::DisabilityCompensationForm::ServiceException, error.body
         else
           super(error)

--- a/lib/evss/intent_to_file/service.rb
+++ b/lib/evss/intent_to_file/service.rb
@@ -35,9 +35,7 @@ module EVSS
 
       def handle_error(error)
         if error.is_a?(Common::Client::Errors::ClientError) && error.status != 403 && error.body.is_a?(Hash)
-          log_message_to_sentry(
-            error.message, :error, extra_context: { url: config.base_path, body: error.body }
-          )
+          save_error_details(error)
           raise EVSS::IntentToFile::ServiceException, error.body
         else
           super(error)

--- a/lib/evss/letters/download_service.rb
+++ b/lib/evss/letters/download_service.rb
@@ -25,10 +25,9 @@ module EVSS
           when 404
             raise Common::Exceptions::RecordNotFound, type
           else
-            log_message_to_sentry(
-              'EVSS letter generation failed', :error, extra_context: {
-                url: config.base_path, body: response.body
-              }
+            Raven.extra_context(
+              url: config.base_path,
+              body: response.body
             )
             raise_backend_exception('EVSS502', 'Letters')
           end

--- a/lib/evss/letters/service.rb
+++ b/lib/evss/letters/service.rb
@@ -36,9 +36,7 @@ module EVSS
 
       def handle_error(error)
         if error.is_a?(Common::Client::Errors::ClientError) && error.status != 403 && error.body.is_a?(Hash)
-          log_message_to_sentry(
-            error.message, :error, extra_context: { url: config.base_path, body: error.body }
-          )
+          save_error_details(error)
           raise EVSS::Letters::ServiceException, error.body
         else
           super(error)

--- a/lib/evss/ppiu/service.rb
+++ b/lib/evss/ppiu/service.rb
@@ -19,9 +19,7 @@ module EVSS
 
       def handle_error(error)
         if error.is_a?(Common::Client::Errors::ClientError) && error.status != 403 && error.body.is_a?(Hash)
-          log_message_to_sentry(
-            error.message, :error, extra_context: { url: config.base_path, body: error.body }
-          )
+          save_error_details(error)
           raise EVSS::PPIU::ServiceException, error.body
         else
           super(error)

--- a/lib/evss/service.rb
+++ b/lib/evss/service.rb
@@ -36,13 +36,25 @@ module EVSS
       EVSS::AuthHeaders.new(user).to_h
     end
 
+    def save_error_details(error)
+      Raven.extra_context(
+        url: config.base_path,
+        message: error.message,
+        body: error.body
+      )
+    end
+
     def handle_error(error)
+      Raven.extra_context(
+        message: error.message,
+        url: config.base_path
+      )
+
       case error
       when Faraday::ParsingError
-        log_message_to_sentry(error.message, :error, extra_context: { url: config.base_path })
         raise_backend_exception('EVSS502', self.class)
       when Common::Client::Errors::ClientError
-        log_message_to_sentry(error.message, :error, extra_context: { url: config.base_path, body: error.body })
+        Raven.extra_context(body: error.body)
         raise Common::Exceptions::Forbidden if error.status == 403
         raise_backend_exception('EVSS400', self.class, error) if error.status == 400
         raise_backend_exception('EVSS502', self.class, error)

--- a/lib/ihub/appointments/service.rb
+++ b/lib/ihub/appointments/service.rb
@@ -51,7 +51,7 @@ module IHub
       rescue StandardError => error
         Raven.extra_context(
           message: error.message,
-          url: confib.base_path
+          url: config.base_path
         )
         Raven.tags_context(ihub: 'appointments')
 

--- a/lib/ihub/appointments/service.rb
+++ b/lib/ihub/appointments/service.rb
@@ -49,12 +49,11 @@ module IHub
           IHub::Appointments::Response.from(response)
         end
       rescue StandardError => error
-        log_message_to_sentry(
-          error.message,
-          :error,
-          extra_context: { url: config.base_path },
-          ihub: 'appointments'
+        Raven.extra_context(
+          message: error.message,
+          url: confib.base_path
         )
+        Raven.tags_context(ihub: 'appointments')
 
         raise error
       end
@@ -98,12 +97,10 @@ module IHub
       end
 
       def log_error(response)
-        log_message_to_sentry(
-          'iHub Appointments Service Error',
-          :error,
-          response_body: response.body.merge('status_code' => response.status),
-          ihub: 'appointments_error_occurred'
+        Raven.extra_context(
+          response_body: response.body.merge('status_code' => response.status)
         )
+        Raven.tags_context(ihub: 'appointments_error_occurred')
       end
 
       def raise_backend_exception!(key, source, error = nil)

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -212,8 +212,7 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
 
       it 'includes "general_client_error" tag in sentry error', :aggregate_failures do
         VCR.use_cassette('vet360/contact_information/email_transaction_status_error', VCR::MATCH_EVERYTHING) do
-          expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry)
-            .with(any_args, hash_including(vet360: 'general_client_error'))
+          expect(Raven).to receive(:tags_context).with(vet360: 'general_client_error')
 
           expect { subject.get_email_transaction_status(transaction_id) }.to raise_error do |e|
             expect(e).to be_a(Common::Exceptions::BackendServiceException)
@@ -319,8 +318,7 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
 
       it 'logs a vet360 tagged error message to sentry', :aggregate_failures do
         VCR.use_cassette('vet360/contact_information/person_transaction_status_error', VCR::MATCH_EVERYTHING) do
-          expect_any_instance_of(Vet360::Service).to receive(:log_message_to_sentry)
-            .with(any_args, hash_including(vet360: 'failed_vet360_id_initializations'))
+          expect(Raven).to receive(:tags_context).with(vet360: 'failed_vet360_id_initializations')
 
           expect { subject.get_person_transaction_status(transaction_id) }.to raise_error do |e|
             expect(e).to be_a(Common::Exceptions::BackendServiceException)

--- a/spec/lib/vet360/service_spec.rb
+++ b/spec/lib/vet360/service_spec.rb
@@ -37,7 +37,7 @@ describe Vet360::Service do
     context 'when given a Common::Client::Errors::ParsingError from a Vet360 service call' do
       let(:error) { Common::Client::Errors::ParsingError.new }
       it 'logs an error message to sentry', :aggregate_failures do
-        expect(subject).to receive(:log_message_to_sentry).with(any_args)
+        expect(Raven).to receive(:extra_context)
 
         expect { subject.send('handle_error', error) }.to raise_error do |e|
           expect(e).to be_a(Common::Exceptions::BackendServiceException)


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15385
when `log_message_to_sentry` is used along with raising an error, the error is logged twice and clogs up sentry. also `log_message_to_sentry` is hard to diagnose because it doesn't include a stack trace. all relevant information about an error should be added with `Raven.extra_context` and `Raven.tags_context` and it will be passed onto whatever error is raised at the end.

## Testing done
automated tests
<!-- Please describe testing done to verify the changes. -->

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
