### PR TITLE
Remove to_json conversion within the all claims translator

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -35,7 +35,7 @@ module EVSS
         output_form.update(translate_treatments)
         output_form.update(translate_disabilities)
 
-        @translated_form.to_json
+        @translated_form
       end
 
       private

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -27,7 +27,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
       VCR.use_cassette('evss/ppiu/payment_information') do
         VCR.use_cassette('evss/intent_to_file/active_compensation') do
           VCR.use_cassette('emis/get_military_service_episodes/valid', allow_playback_repeats: true) do
-            expect(JSON.parse(subject.translate)).to eq JSON.parse(evss_json)
+            expect(subject.translate).to eq JSON.parse(evss_json)
           end
         end
       end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Previously uncaught double `to_json` call was breaking the submission json down the pipe when being submitted to EVSS submission end point.

## Testing done
<!-- Please describe testing done to verify the changes. -->
spec

## Testing planned
<!-- Please describe testing planned. -->
staging e2e

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] remove extra `to_json` translation for all claims form data

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
