### PR TITLE
log EVSS::ErrorMiddleware::EVSSErrors as :warning

### DIFF
--- a/lib/sentry/processor/log_as_warning.rb
+++ b/lib/sentry/processor/log_as_warning.rb
@@ -4,6 +4,10 @@ module Sentry
   module Processor
     class LogAsWarning < Raven::Processor
       SENTRY_LOG_LEVEL_WARNING = 30
+      RELEVANT_EXCEPTIONS = [
+        Common::Exceptions::GatewayTimeout.to_s,
+        EVSS::ErrorMiddleware::EVSSError.to_s
+      ]
 
       def process(data)
         process_if_symbol_keys(data) if data[:exception]
@@ -14,13 +18,13 @@ module Sentry
       private
 
       def process_if_symbol_keys(data)
-        if data[:exception][:values].last[:type] == Common::Exceptions::GatewayTimeout.to_s
+        if RELEVANT_EXCEPTIONS.include?(data[:exception][:values].last[:type])
           data[:level] = SENTRY_LOG_LEVEL_WARNING
         end
       end
 
       def process_if_string_keys(data)
-        if data['exception']['values'].last['type'] == Common::Exceptions::GatewayTimeout.to_s
+        if RELEVANT_EXCEPTIONS.include?(data['exception']['values'].last['type'])
           data['level'] = SENTRY_LOG_LEVEL_WARNING
         end
       end

--- a/lib/sentry/processor/log_as_warning.rb
+++ b/lib/sentry/processor/log_as_warning.rb
@@ -7,7 +7,7 @@ module Sentry
       RELEVANT_EXCEPTIONS = [
         Common::Exceptions::GatewayTimeout.to_s,
         EVSS::ErrorMiddleware::EVSSError.to_s
-      ]
+      ].freeze
 
       def process(data)
         process_if_symbol_keys(data) if data[:exception]
@@ -18,9 +18,7 @@ module Sentry
       private
 
       def process_if_symbol_keys(data)
-        if RELEVANT_EXCEPTIONS.include?(data[:exception][:values].last[:type])
-          data[:level] = SENTRY_LOG_LEVEL_WARNING
-        end
+        data[:level] = SENTRY_LOG_LEVEL_WARNING if RELEVANT_EXCEPTIONS.include?(data[:exception][:values].last[:type])
       end
 
       def process_if_string_keys(data)

--- a/spec/lib/sentry/processor/log_as_warning_processor_spec.rb
+++ b/spec/lib/sentry/processor/log_as_warning_processor_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Sentry::Processor::LogAsWarning do
       platform: 'ruby',
       sdk: { 'name' => 'sentry-raven', 'version' => '2.3.0' },
       logger: '',
-      server_name: 'Johnnys-MacBook-Pro.local',
+      server_name: 'cool server',
       release: 'c57d00f70',
       environment: 'default',
       modules: {},
@@ -30,7 +30,7 @@ RSpec.describe Sentry::Processor::LogAsWarning do
       exception: {
         values: [
           {
-            type: 'Common::Exceptions::GatewayTimeout',
+            type: exception,
             value: 'Common::Exceptions::GatewayTimeout',
             module: 'Common::Exceptions',
             stacktrace: nil
@@ -42,9 +42,26 @@ RSpec.describe Sentry::Processor::LogAsWarning do
   end
 
   context 'for Common::Exceptions::GatewayTimeout errors' do
+    let(:exception) { Common::Exceptions::GatewayTimeout.to_s }
     it 'sets the :level to 30 (warning)' do
       expect(processor.process(data)[:level]).to eq(30)
       expect(processor.process(data.deep_stringify_keys)['level']).to eq(30)
+    end
+  end
+
+  context 'for EVSS::ErrorMiddleware::EVSSError errors' do
+    let(:exception) { EVSS::ErrorMiddleware::EVSSError.to_s }
+    it 'sets the :level to 30 (warning)' do
+      expect(processor.process(data)[:level]).to eq(30)
+      expect(processor.process(data.deep_stringify_keys)['level']).to eq(30)
+    end
+  end
+
+  context 'for all other errors' do
+    let(:exception) { NoMethodError.to_s }
+    it 'does not change the :level' do
+      expect(processor.process(data)[:level]).to eq(40)
+      expect(processor.process(data.deep_stringify_keys)['level']).to eq(40)
     end
   end
 end


### PR DESCRIPTION
## Description of change
Before the introduction of `Sentry::Processor::LogAsWarning`, `EVSS::ErrorMiddleware::EVSSError` exceptions were treated like `GatewayTimeout`s and logged as :warning. 
This restores that behavior by adding ` EVSS::ErrorMiddleware::EVSSError` to `Sentry::Processor::LogAsWarning`
To note:  `EVSS::ErrorMiddleware::EVSSError` is a subclass of `Common::Exceptions::BackendServiceException` and since they are no longer being `rescue`d in faraday middleware they can now trigger `breakers`

## Testing done
specs

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] use Sentry::Processor::LogAsWarning to log EVSS::ErrorMiddleware::EVSSError as :warning

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
