### PR TITLE
Update route to Facility Locator

### DIFF
--- a/lib/benchmark/whitelist.rb
+++ b/lib/benchmark/whitelist.rb
@@ -8,7 +8,7 @@ module Benchmark
     #
     # Any changes made must be made to both.
     #
-    WHITELIST = ['/', '/disability/', '/facilities/', '/disability/how-to-file-claim/'].freeze
+    WHITELIST = ['/', '/disability/', '/find-locations/', '/disability/how-to-file-claim/'].freeze
 
     attr_reader :tags
 


### PR DESCRIPTION
## Description of change
The location of the Facility Locator has moved to `/find-locations/` on VA.gov. This PR updates the FE Metrics routing whitelist to reflect this change per the comment [here](https://github.com/department-of-veterans-affairs/vets-website/blob/7e62d5e3debe24f65240a1604ecf3cec5597dec8/src/platform/monitoring/frontend-metrics/whitelisted-paths.js#L2).

Being done in coordination with this FE PR, https://github.com/department-of-veterans-affairs/vets-website/pull/9219.

## Testing done
None 🙁 

## Testing planned
Depending entirely on your code review 🙂 

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- Nothing unique

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
