### PR TITLE
Add seedbank and development seeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ gem 'zero_downtime_migrations'
 
 group :development do
   gem 'guard-rubocop'
+  gem 'seedbank'
   gem 'socksify'
   gem 'spring', platforms: :ruby # Spring speeds up development by keeping your application running in the background
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -999,6 +999,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    seedbank (0.5.0)
+      rake (>= 10.0)
     semantic_logger (4.2.2)
       concurrent-ruby (~> 1.0)
     sentry-raven (2.3.0)
@@ -1172,6 +1174,7 @@ DEPENDENCIES
   ruby-saml
   savon
   sdoc (~> 0.4.0)
+  seedbank
   sentry-raven
   shrine
   shrine-memory

--- a/db/seeds/development/preferences.seeds.rb
+++ b/db/seeds/development/preferences.seeds.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+Rake::Task['preferences:initial_seed'].invoke
+Rails.logger.info 'Preferences have been seeded'

--- a/spec/controllers/v0/preferences_controller_spec.rb
+++ b/spec/controllers/v0/preferences_controller_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe V0::PreferencesController, type: :controller do
   end
 
   describe '#index' do
-    let!(:first_preference) { create(:preference, :with_choices) }
-    let!(:second_preference) { create(:preference, :with_choices) }
+    let!(:notifications) { create(:preference, :notifications) }
+    let!(:benefits) { create(:preference, :benefits) }
 
     context 'when not logged in' do
       it 'returns unauthorized' do
@@ -80,17 +80,16 @@ RSpec.describe V0::PreferencesController, type: :controller do
       end
 
       it 'returns all existing Preferences with their choices' do
-        body = json_body_for(response)
-        preferences = body.dig('attributes', 'preferences')
-        expect(body['attributes']['preferences'].size).to eq 2
-        expect(preferences[0]['code']).to eq first_preference.code
+        preferences = json_body_for(response).dig('attributes', 'preferences')
+        expect(preferences.size).to eq Preference.count
       end
 
       it 'returns all PreferenceChoices for given Preference' do
-        preference_choices = json_body_for(response)['attributes']['preferences'][0]['preference_choices']
-        preference_choice_codes = preference_choices.map { |pc| pc['code'] }
+        body = json_body_for(response)['attributes']['preferences']
+        preference_set = body.select { |o| o.dig('code') == 'notifications' }.first
+        preference_choice_codes = preference_set['preference_choices'].map { |pc| pc['code'] }
 
-        expect(preference_choice_codes).to match_array first_preference.choices.map(&:code)
+        expect(preference_choice_codes).to match_array notifications.choices.map(&:code)
       end
     end
   end

--- a/spec/factories/preferences.rb
+++ b/spec/factories/preferences.rb
@@ -23,18 +23,18 @@ FactoryBot.define do
     end
 
     trait :benefits do
-      code { 'benefits' }
-      title { 'Benefits' }
-      benefits = %w[health-care
-                    disability
-                    appeals
-                    education-training
-                    careers-employment
-                    pension
-                    housing-assistance
-                    life-insurance
-                    burials-memorials
-                    family-caregiver-benefits]
+      code { 'test-benefit' }
+      title { 'Test Benefits' }
+      benefits = %w[test-health-care
+                    test-disability
+                    test-appeals
+                    test-education-training
+                    test-careers-employment
+                    test-pension
+                    test-housing-assistance
+                    test-life-insurance
+                    test-burials-memorials
+                    test-family-caregiver-benefits]
 
       after :create do |preference|
         benefits.each do |benefit|

--- a/spec/factories/preferences.rb
+++ b/spec/factories/preferences.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     end
 
     trait :benefits do
-      code { 'test-benefit' }
+      code { 'test-benefits' }
       title { 'Test Benefits' }
       benefits = %w[test-health-care
                     test-disability


### PR DESCRIPTION
## Description of change
We need to allow for the developers who utilize the Docker workflow to test against Preferences changes. 

## Testing done
Tested by setting `RAILS_ENV` to both `test` and `production` and ensured the seeds did not trigger. 

## Acceptance Criteria (Definition of Done)
#### Unique to this PR
- [x] Upon running `make up` the seeds files are triggered and Preferences data is populated. 

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
