### PR TITLE
Configure appeals healthcheck betamock

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -374,6 +374,9 @@
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: ssn
+  - :method: :get
+    :path: "/health-check"
+    :file_path: "appeals/health-check"
 
 # IHUB
 - :name: 'IHub'


### PR DESCRIPTION
## Description of change
Configure appeals healthcheck betamock so that it's usable in dev. Depends on https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/59

## Testing done
curl

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Appeals healthcheck requests succeed
#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
