### PR TITLE
Global way to determine which env you are in: dev/staging/prod

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,18 @@
 hostname: 127.0.0.1:3000 # possible fallback for unsafe request.host
 virtual_hosts: ["127.0.0.1", "localhost"] # Safe host names
 
+# Defines the relative environment, i.e. Settings.env.production? => false
+#
+# Background: All of our deployed envs (dev, staging, and production) have
+# their `Rails.env` set to 'production'.
+#
+# This setting allows you to target behavior specifically for any of those
+# three environments (i.e. if Settings.env.production? ...)
+env:
+  development?: true
+  staging?: false
+  production?: false
+
 # For CORS requests; separate multiple origins with a comma
 web_origin: http://localhost:3000,http://localhost:3001,http://127.0.0.1:3000,http://127.0.0.1:3001,null
 
@@ -90,7 +102,6 @@ ihub:
   appointments:
     timeout: 30
     mock: true
-  in_production: false
 
 
 # Settings for EVSS

--- a/lib/ihub/appointments/service.rb
+++ b/lib/ihub/appointments/service.rb
@@ -69,7 +69,7 @@ module IHub
       end
 
       def appointments_url
-        if Settings.ihub.in_production
+        if Settings.env.production?
           @user.icn
         else
           "#{@user.icn}?noFilter=true"


### PR DESCRIPTION
## Description of change
All of our deployed envs (dev, staging, and production) have their `Rails.env` set to 'production'.  We need a global way to determine which env(staging, dev, or prod) we're in, to target behavior specifically to any of those envs.  

This is required for the iHub integration.  Their API uses a slightly different endpoint, depending on us calling their staging environment, vs. their production environment.

Here is an excerpt from a discussion in [a devops PR](https://github.com/department-of-veterans-affairs/devops/pull/3142#discussion_r210639256):

> I'm surprised something like this doesn't already exist as some kind of over-arching variable for everyone to use. Something that would return an enum of `DEV|STAGING|PRODUCTION` or something or perhaps named helpers like Vets.env.dev? & Vets.env.staging?, & Vets.env.production?.

And another excerpt from [another devops PR](https://github.com/department-of-veterans-affairs/devops/pull/3080#issuecomment-408097790)

> but do we want to just set like a global deployment_env variable? It might get confusing with RAILS_ENV (which is always prod for the environments we run in AWS), but I don't know if it'd be worthwhile other places?

## Sibling DevOps PR

TBD

## Testing done
<!-- Please describe testing done to verify the changes. -->
Local testing 

## Testing planned
<!-- Please describe testing planned. -->
Will be testing in staging once deployed

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Add three settings to `settings.yml`
- [ ] Refactor the current `Settings.ihub.in_production` usage to use new settings
- [ ] Update these settings in our DevOps repo 

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
