### PR TITLE
add statsd prefix to 526 cleanup job

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_form526_cleanup.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526_cleanup.rb
@@ -6,6 +6,7 @@ module EVSS
       include Sidekiq::Worker
 
       FORM_ID = '21-526EZ'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_cleanup'
 
       def perform(submission_id)
         super(submission_id)


### PR DESCRIPTION
## Description of change
Cleanup job was reporting errors when tracking job status, database tracking is working but metrics are not because it's missing the statsd prefix.

## Testing done
local integration tests

## Testing planned
staging integration tests

## Acceptance Criteria (Definition of Done)
Cleanup job no longer throws errors on staging when tracking job status.

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
