### PR TITLE
revert: add regex to cleanup endpoints #2622

### DIFF
--- a/lib/breakers/statsd_plugin.rb
+++ b/lib/breakers/statsd_plugin.rb
@@ -11,11 +11,7 @@ module Breakers
           # * (possibly negative) digit identifiers
           # * uuid's with or without dashes
           # * institution id's of form 111A2222 or 11A22222
-          digit = /\-?\d+/
-          contact_id = /\d{10}V\d{6}%5ENI%5E200M%5EUSVHA/
-          uuids = /[a-fA-F0-9]{8}(\-?[a-fA-F0-9]{4}){3}\-?[a-fA-F0-9]{12}/
-          institution_ids = /[\dA-Z]{8}/
-          r = %r{(\/)(#{digit}|#{contact_id}|#{uuids}|#{institution_ids})(\/|$)}
+          r = %r{(\/)(\-?\d+|[a-fA-F0-9]{8}(\-?[a-fA-F0-9]{4}){3}\-?[a-fA-F0-9]{12}|[\dA-Z]{8})(\/|$)}
           endpoint = request.url.path.gsub(r, '\1xxx\4')
           tags.append("endpoint:#{endpoint}")
         end

--- a/spec/lib/breakers/statsd_plugin_spec.rb
+++ b/spec/lib/breakers/statsd_plugin_spec.rb
@@ -42,9 +42,6 @@ describe Breakers::StatsdPlugin do
         request.url = URI(test_host + '/foo/aaaaaaaa/11A22222')
         expect(subject.get_tags(request)).to include('endpoint:/foo/aaaaaaaa/xxx')
 
-        request.url = URI(test_host + '/v1/foo/0123456789V123456%5ENI%5E200M%5EUSVHA')
-        expect(subject.get_tags(request)).to include('endpoint:/v1/foo/xxx')
-
         request.url = URI(test_host + '/foo/-1')
         expect(subject.get_tags(request)).to include('endpoint:/foo/xxx')
       end


### PR DESCRIPTION
reverting.  Looks like breakers outages are all in one bucket now, causing down time.