### PR TITLE
Ability to disable breakers with Settings.breakers_disabled

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -77,3 +77,4 @@ client = Breakers::Client.new(
 # No need to prefix it when using the namespace
 Breakers.redis_prefix = ''
 Breakers.client = client
+Breakers.disabled = true if Settings.breakers_disabled


### PR DESCRIPTION
## Description of change

Breakers can be disabled with a `breakers_disabled: true` setting in `config/settings.local.yml`. By default, Breakers remains enabled.

## Background

In light of recent outages that may be due to breakers integration issues, this commit adds the ability to disable breakers with a configuration setting. Not sure we'll need to use this yet, but would like to have a PR ready just in case.

References:

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15765

## Testing done

`Breakers.disabled?` from local console is false when setting is not present. `Breakers.disabled?` is true when `breakers_disabled = true` in `config/settings.local.yml`

## Testing planned

Confirm breakers is enabled when deployed. 

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

None

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
