### PR TITLE
[Facility Locator] Enable community care providers for UAT

### DIFF
--- a/app/controllers/v0/facilities/va_controller.rb
+++ b/app/controllers/v0/facilities/va_controller.rb
@@ -12,9 +12,6 @@ class V0::Facilities::VaController < FacilitiesController
   # @param type - Optional facility type, values = all (default), health, benefits, cemetery
   # @param services - Optional specialty services filter
   def index
-    # this first return is temporary for the rollout of provider locator to staging
-    return facilities unless Settings.locators.providers_enabled
-
     return facilities if BaseFacility::TYPES.include?(params[:type]) || params[:address].nil?
     return provider_locator if params[:type] == 'cc_provider'
     combined


### PR DESCRIPTION
## Description of change
Removed the hard feature flag for community care on the search endpoint in the facility locator. The new functionality will still be hidden behind the requirement to pass in an address parameter which only the updated UI will do. This is to support doing UAT in a production environment while not affecting behavior for regular users.

Supporting issue: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15807

## Testing done
The logic of falling back to old behavior if address is missing was tested earlier in the development cycle. Current change will only have impact in production environment

## Testing planned
UAT for the provider locator will occur

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Ensured functionality will not be affected for non-UAT users

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
