### PR TITLE
15873 handle secondary disabilities

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -2,7 +2,7 @@
 
 module EVSS
   module DisabilityCompensationForm
-    class DataTranslationAllClaim
+    class DataTranslationAllClaim # rubocop:disable Metrics/ClassLength
       HOMELESS_SITUATION_TYPE = {
         'shelter' => 'LIVING_IN_A_HOMELESS_SHELTER',
         'notShelter' => 'NOT_CURRENTLY_IN_A_SHELTERED_ENVIRONMENT',
@@ -356,19 +356,31 @@ module EVSS
         { 'treatments' => treatments }
       end
 
-      def translate_disabilities
-        disabilities = input_form['ratedDisabilities'].deep_dup.presence || []
-        { 'disabilities' => translate_new_disabilities(disabilities) }
-      end
-
       # `specialIssues` is a key that can hold an array of special issue strings
       # for the time being, evss only accepts one special issue per disability but
       # it is possible for every disability to have multiple issue. We are only
       # picking the first issue out of the list until evss can accept an array instead
-      def translate_new_disabilities(disabilities)
-        return disabilities if input_form['newDisabilities'].blank?
+      def translate_disabilities
+        rated_disabilities = input_form['ratedDisabilities'].deep_dup.presence || []
+        # New primary disabilities need to be added first before handling secondary
+        # disabilities because a new secondary disability can be added to a new
+        # primary disability
+        primary_disabilities = translate_new_primary_disabilities(rated_disabilities)
+        disabilities = translate_new_secondary_disabilities(primary_disabilities)
 
-        input_form['newDisabilities'].each do |input_disability|
+        # Strip out disabilites with ActionType eq to `None` that do not have any
+        # secondary disabilities to avoid sending extraneous data
+        disabilities.delete_if do |disability|
+          disability['disabilityActionType'] == 'NONE' && disability['secondaryDisabilities'].blank?
+        end
+
+        { 'disabilities' => disabilities }
+      end
+
+      def translate_new_primary_disabilities(disabilities)
+        return disabilities if input_form['newPrimaryDisabilities'].blank?
+
+        input_form['newPrimaryDisabilities'].each do |input_disability|
           case input_disability['cause']
           when 'NEW'
             disabilities.append(map_new(input_disability))
@@ -376,9 +388,17 @@ module EVSS
             disabilities.append(map_worsened(input_disability))
           when 'VA'
             disabilities.append(map_va(input_disability))
-          when 'SECONDARY'
-            disabilities = map_secondary(input_disability, disabilities)
           end
+        end
+
+        disabilities
+      end
+
+      def translate_new_secondary_disabilities(disabilities)
+        return disabilities if input_form['newSecondaryDisabilities'].blank?
+
+        input_form['newSecondaryDisabilities'].each do |input_disability|
+          disabilities = map_secondary(input_disability, disabilities)
         end
 
         disabilities
@@ -426,7 +446,7 @@ module EVSS
         }.compact
 
         disabilities.each do |output_disability|
-          if output_disability['name'] == input_disability['causedByDisability']
+          if output_disability['name'].casecmp(input_disability['causedByDisability']).zero?
             output_disability['secondaryDisabilities'] = [] if output_disability['secondaryDisabilities'].blank?
             output_disability['secondaryDisabilities'].append(disability)
           end

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -722,7 +722,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
             'ratedDisabilities' => [
               {
                 'diagnosticCode' => 9999,
-                'disabilityActionType' => 'NEW',
+                'disabilityActionType' => 'INCREASE',
                 'name' => 'PTSD (post traumatic stress disorder)',
                 'ratedDisabilityId' => '1100583'
               }
@@ -735,9 +735,88 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
         expect(subject.send(:translate_disabilities)).to eq 'disabilities' => [
           {
             'diagnosticCode' => 9999,
-            'disabilityActionType' => 'NEW',
+            'disabilityActionType' => 'INCREASE',
             'name' => 'PTSD (post traumatic stress disorder)',
             'ratedDisabilityId' => '1100583'
+          }
+        ]
+      end
+    end
+
+    context 'when there is an extraneous `NONE` action type disability' do
+      let(:form_content) do
+        {
+          'form526' => {
+            'ratedDisabilities' => [
+              {
+                'diagnosticCode' => 9999,
+                'disabilityActionType' => 'INCREASE',
+                'name' => 'PTSD (post traumatic stress disorder)',
+                'ratedDisabilityId' => '1100583'
+              },
+              {
+                'diagnosticCode' => 9998,
+                'disabilityActionType' => 'NONE',
+                'name' => 'Arthritis',
+                'ratedDisabilityId' => '1100582'
+              }
+            ]
+          }
+        }
+      end
+
+      it 'should not translate the disability with NONE action type' do
+        expect(subject.send(:translate_disabilities)).to eq 'disabilities' => [
+          {
+            'diagnosticCode' => 9999,
+            'disabilityActionType' => 'INCREASE',
+            'name' => 'PTSD (post traumatic stress disorder)',
+            'ratedDisabilityId' => '1100583'
+          }
+        ]
+      end
+    end
+
+    context 'when there is an  `NONE` action type disability but it has a new secondary disability' do
+      let(:form_content) do
+        {
+          'form526' => {
+            'ratedDisabilities' => [
+              {
+                'diagnosticCode' => 9999,
+                'disabilityActionType' => 'NONE',
+                'name' => 'PTSD (post traumatic stress disorder)',
+                'ratedDisabilityId' => '1100583'
+              }
+            ],
+            'newSecondaryDisabilities' => [
+              {
+                'cause' => 'SECONDARY',
+                'condition' => 'secondary condition',
+                'specialIssues' => ['POW'],
+                'causedByDisabilityDescription' => 'secondary description',
+                'causedByDisability' => 'PTSD (post traumatic stress disorder)'
+              }
+            ]
+          }
+        }
+      end
+
+      it 'should translate the NONE action type disability and its secondary disability' do
+        expect(subject.send(:translate_disabilities)).to eq 'disabilities' => [
+          {
+            'diagnosticCode' => 9999,
+            'disabilityActionType' => 'NONE',
+            'name' => 'PTSD (post traumatic stress disorder)',
+            'ratedDisabilityId' => '1100583',
+            'secondaryDisabilities' => [
+              {
+                'name' => 'secondary condition',
+                'disabilityActionType' => 'SECONDARY',
+                'specialIssue' => 'POW',
+                'serviceRelevance' => "Caused by a service-connected disability\nsecondary description"
+              }
+            ]
           }
         ]
       end
@@ -749,7 +828,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
       let(:form_content) do
         {
           'form526' => {
-            'newDisabilities' => [
+            'newPrimaryDisabilities' => [
               {
                 'cause' => 'NEW',
                 'condition' => 'new condition',
@@ -762,7 +841,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
       end
 
       it 'should translate only the NEW disabilities' do
-        expect(subject.send(:translate_new_disabilities, [])).to eq [
+        expect(subject.send(:translate_new_primary_disabilities, [])).to eq [
           {
             'disabilityActionType' => 'NEW',
             'name' => 'new condition',
@@ -777,7 +856,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
       let(:form_content) do
         {
           'form526' => {
-            'newDisabilities' => [
+            'newPrimaryDisabilities' => [
               {
                 'cause' => 'WORSENED',
                 'condition' => 'worsened condition',
@@ -791,7 +870,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
       end
 
       it 'should translate only the WORSENED disabilities' do
-        expect(subject.send(:translate_new_disabilities, [])).to eq [
+        expect(subject.send(:translate_new_primary_disabilities, [])).to eq [
           {
             'disabilityActionType' => 'NEW',
             'name' => 'worsened condition',
@@ -807,7 +886,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
       let(:form_content) do
         {
           'form526' => {
-            'newDisabilities' => [
+            'newPrimaryDisabilities' => [
               {
                 'cause' => 'VA',
                 'condition' => 'va condition',
@@ -822,7 +901,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
       end
 
       it 'should translate only the VA disabilities' do
-        expect(subject.send(:translate_new_disabilities, [])).to eq [
+        expect(subject.send(:translate_new_primary_disabilities, [])).to eq [
           {
             'disabilityActionType' => 'NEW',
             'name' => 'va condition',
@@ -839,7 +918,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
       let(:form_content) do
         {
           'form526' => {
-            'newDisabilities' => [
+            'newSecondaryDisabilities' => [
               {
                 'cause' => 'SECONDARY',
                 'condition' => 'secondary condition',
@@ -859,7 +938,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
                 'condition' => 'secondary condition3',
                 'specialIssues' => ['POW'],
                 'causedByDisabilityDescription' => 'secondary description',
-                'causedByDisability' => 'PTSD disability2'
+                'causedByDisability' => 'ptsd disability2' # check that the match is case insensitive
               }
             ]
           }
@@ -884,7 +963,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
       end
 
       it 'should translate SECONDARY disability to a current disability' do
-        expect(subject.send(:translate_new_disabilities, disability)).to eq [
+        expect(subject.send(:translate_new_secondary_disabilities, disability)).to eq [
           {
             'diagnosticCode' => 9999,
             'disabilityActionType' => 'NEW',

--- a/spec/support/disability_compensation_form/all_claims_evss_submission.json
+++ b/spec/support/disability_compensation_form/all_claims_evss_submission.json
@@ -11,7 +11,7 @@
         "disabilities": [
             {
                 "diagnosticCode": 9999,
-                "disabilityActionType": "NEW",
+                "disabilityActionType": "NONE",
                 "name": "PTSD (post traumatic stress disorder)",
                 "ratedDisabilityId": "1100583",
                 "secondaryDisabilities": [
@@ -22,6 +22,12 @@
                         "serviceRelevance": "Caused by a service-connected disability\nLengthy description"
                     }
                 ]
+            },
+            {
+                "disabilityActionType": "NEW",
+                "name": "Arthritis",
+                "specialIssue": "POW",
+                "serviceRelevance": "Caused by an in-service event, injury, or exposure\nJoints in hands"
             }
         ],
         "serviceInformation": {

--- a/spec/support/disability_compensation_form/all_claims_fe_submission.json
+++ b/spec/support/disability_compensation_form/all_claims_fe_submission.json
@@ -52,12 +52,20 @@
     "ratedDisabilities": [
       {
         "diagnosticCode": 9999,
-        "disabilityActionType": "NEW",
+        "disabilityActionType": "NONE",
         "name": "PTSD (post traumatic stress disorder)",
         "ratedDisabilityId": "1100583"
       }
     ],
-    "newDisabilities": [
+    "newPrimaryDisabilities": [
+      {
+        "cause": "NEW",
+        "condition": "Arthritis",
+        "primaryDescription": "Joints in hands",
+        "specialIssues": ["POW"]
+      }
+    ],
+    "newSecondaryDisabilities": [
       {
         "cause": "SECONDARY",
         "causedByDisability": "PTSD (post traumatic stress disorder)",


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Secondary disabilities are going to be handled as a separate key in the request payload for the form526 v2 submissions. Also, it is possible that extraneous related disabilities can be submitted that will not affect the submission process at all. These should be filtered out to avoid sending unneeded data further along the pipe. Lastly, it is possible that when matching secondary disabilities to primary disabilities via the name/causeby fields the casing can be different. The check has now been made case insensitive.

## Testing done
<!-- Please describe testing done to verify the changes. -->
specs

## Testing planned
<!-- Please describe testing planned. -->
staging e2e testing

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Handle `newSecondaryDisabilities` as separate key from the payload
- [x] Remove extraneous primary disabilities (any that are set to `NONE` and do not have a new secondary disability linked to them
- [x] Update string matching for secondary disabilities to primary disabilities to be case insensitive

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
