### PR TITLE
[Facility Locator] removing community care providers from all facilities search

### DIFF
--- a/app/controllers/v0/facilities/va_controller.rb
+++ b/app/controllers/v0/facilities/va_controller.rb
@@ -12,9 +12,8 @@ class V0::Facilities::VaController < FacilitiesController
   # @param type - Optional facility type, values = all (default), health, benefits, cemetery
   # @param services - Optional specialty services filter
   def index
-    return facilities if BaseFacility::TYPES.include?(params[:type]) || params[:address].nil?
     return provider_locator if params[:type] == 'cc_provider'
-    combined
+    facilities
   end
 
   def facilities
@@ -22,22 +21,6 @@ class V0::Facilities::VaController < FacilitiesController
     render json: resource,
            each_serializer: VAFacilitySerializer,
            meta: metadata(resource)
-  end
-
-  def combined
-    resource = BaseFacility.query(params)
-    ppms = Facilities::PPMSClient.new
-    providers = ppms.provider_locator(params)
-    bbox_num = params[:bbox].map { |x| Float(x) }
-    page = Integer(params[:page] || 1)
-    total = resource.length + providers.length
-    sorted = Provider.merge(resource, providers, (bbox_num[0] + bbox_num[2]) / 2,
-                            (bbox_num[1] + bbox_num[3]) / 2, page * BaseFacility.per_page)
-    sorted = sorted[(page - 1) * BaseFacility.per_page, BaseFacility.per_page]
-    sorted.map! { |row| format_records(row, ppms) }
-    pages = { current_page: page, per_page: BaseFacility.per_page,
-              total_pages: total / BaseFacility.per_page, total_entries: total }
-    render json: { data: sorted, meta: { pagination: pages } }
   end
 
   def show

--- a/app/controllers/v0/facilities/va_controller.rb
+++ b/app/controllers/v0/facilities/va_controller.rb
@@ -59,18 +59,6 @@ class V0::Facilities::VaController < FacilitiesController
 
   private
 
-  def format_records(record, ppms)
-    if record.is_a?(BaseFacility)
-      ser = VAFacilitySerializer.new(record)
-      { id: ser.id, type: 'vha_facility', name: record[:name], attributes: ser.as_json }
-    else
-      prov_info = ppms.provider_info(record['ProviderIdentifier'])
-      record.add_details(prov_info)
-      prov_ser = ProviderSerializer.new(record)
-      { id: prov_ser.id, type: 'cc_provider', name: record[:Name], attributes: prov_ser.as_json }
-    end
-  end
-
   def validate_types_name_part
     raise Common::Exceptions::ParameterMissing, 'name_part' if params[:name_part].blank?
     raise Common::Exceptions::ParameterMissing, 'type' if params[:type].blank?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -48,28 +48,4 @@ class Provider < Common::Base
     self.Longitude = caresite['Longitude']
     self.Latitude = caresite['Latitude']
   end
-
-  def self.merge(facilities, providers, center_x, center_y, limit)
-    distance_facilities = facilities.map do |facility|
-      { distance: 69 * Math.sqrt((facility.long - center_x)**2 + (facility.lat - center_y)**2),
-        facility: facility }
-    end
-    result = []
-    facility_ind = 0
-    prov_ind = 0
-    limit = facilities.length + providers.length if limit > facilities.length + providers.length
-    while result.length < limit
-      prov_remain = prov_ind < providers.length
-      facility_empty = facility_ind >= distance_facilities.length
-      # if there are providers left and either we're out of facilities or better than the next facility, pick provider
-      if prov_remain && (facility_empty || distance_facilities[facility_ind][:distance] > providers[prov_ind].Miles)
-        result.push providers[prov_ind]
-        prov_ind += 1
-      else
-        result.push distance_facilities[facility_ind][:facility]
-        facility_ind += 1
-      end
-    end
-    result
-  end
 end

--- a/spec/request/va_facilities_request_spec.rb
+++ b/spec/request/va_facilities_request_spec.rb
@@ -138,18 +138,6 @@ RSpec.describe 'VA GIS Integration', type: :request do
     end
   end
 
-  it 'responds to GET #index with bbox and address' do
-    VCR.use_cassette('facilities/va/ppms', match_requests_on: [regex_matcher], allow_playback_repeats: true) do
-      setup_pdx
-      get BASE_QUERY_PATH + PDX_BBOX + '&address=97089'
-      expect(response).to be_success
-      expect(response.body).to be_a(String)
-      json = JSON.parse(response.body)
-      expect(json['data'].length).to eq(11)
-      expect(json['data'][9]['id']).to eq('ccp_1700950045') # make sure provider is merged into correct position
-    end
-  end
-
   it 'responds to GET #index with success even if no providers are found' do
     VCR.use_cassette('facilities/va/ppms_empty_search', match_requests_on: [:method], allow_playback_repeats: true) do
       get BASE_QUERY_PATH + PDX_BBOX + '&type=cc_provider&address=97089'


### PR DESCRIPTION
## Description of change
Removing community care providers from the all facility search and reverting back to the old functionality in that case. Community care providers can now only be searched by passing "type=cc_provider" into the search endpoint (by selecting community care from the dropdown in the UI). All code related to merging cc providers with va facilities has been removed to prevent dead code/failing coverage tests.


## Testing done
Tested changes locally to ensure all facilities searches do not attempt to fetch community care providers

## Testing planned
Changes will be tested in staging prior to soft launch of provider locator.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Ensured existing functionality is not affected by this change

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
