### PR TITLE
[facility locator] Enabling breakers for ppms web service

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -50,6 +50,7 @@ services = [
   VIC::Configuration.instance.breakers_service,
   Facilities::AccessWaitTimeConfiguration.instance.breakers_service,
   Facilities::AccessSatisfactionConfiguration.instance.breakers_service,
+  Facilities::PPMSConfiguration.instance.breakers_service,
   VIC::Configuration.instance.breakers_service,
   GI::Configuration.instance.breakers_service,
   HCA::Configuration.instance.breakers_service,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -171,6 +171,7 @@ locators:
   
 ppms:
   url: https://some.fakesite.com
+  timeout: 55
 
 # Settings for MyHealthEVet
 mhv:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -171,7 +171,8 @@ locators:
   
 ppms:
   url: https://some.fakesite.com
-  timeout: 55
+  open_timeout: nil
+  read_timeout: 55
 
 # Settings for MyHealthEVet
 mhv:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -171,7 +171,7 @@ locators:
   
 ppms:
   url: https://some.fakesite.com
-  open_timeout: nil
+  open_timeout: 15
   read_timeout: 55
 
 # Settings for MyHealthEVet

--- a/lib/facilities/ppms_client.rb
+++ b/lib/facilities/ppms_client.rb
@@ -35,7 +35,7 @@ module Facilities
     end
 
     def provider_caresites(site_name)
-      response = perform(:get, 'v1.0/CareSites()?', name: site_name)
+      response = perform(:get, 'v1.0/CareSites()?', name: "'#{site_name}'")
       response.body
     end
 

--- a/lib/facilities/ppms_configuration.rb
+++ b/lib/facilities/ppms_configuration.rb
@@ -6,8 +6,8 @@ require 'common/client/middleware/response/ppms_parser'
 
 module Facilities
   class PPMSConfiguration < Common::Client::Configuration::REST
-    self.open_timeout = 60
-    self.read_timeout = 60
+    self.open_timeout = Settings.ppms.timeout
+    self.read_timeout = Settings.ppms.timeout
     def base_path
       Settings.ppms.url
     end

--- a/lib/facilities/ppms_configuration.rb
+++ b/lib/facilities/ppms_configuration.rb
@@ -6,14 +6,14 @@ require 'common/client/middleware/response/ppms_parser'
 
 module Facilities
   class PPMSConfiguration < Common::Client::Configuration::REST
-    self.open_timeout = 1500
-    self.read_timeout = 1500
+    self.open_timeout = 60
+    self.read_timeout = 60
     def base_path
       Settings.ppms.url
     end
 
     def service_name
-      'FL'
+      'PPMS'
     end
     # ppms has strange behavior for certain url-encoded characters, no url-encoding works best
     class DoNotEncoder

--- a/lib/facilities/ppms_configuration.rb
+++ b/lib/facilities/ppms_configuration.rb
@@ -6,8 +6,8 @@ require 'common/client/middleware/response/ppms_parser'
 
 module Facilities
   class PPMSConfiguration < Common::Client::Configuration::REST
-    self.open_timeout = Settings.ppms.timeout
-    self.read_timeout = Settings.ppms.timeout
+    self.open_timeout = Settings.ppms.open_timeout
+    self.read_timeout = Settings.ppms.read_timeout
     def base_path
       Settings.ppms.url
     end


### PR DESCRIPTION
## Description of change
Properly initializes breakers for the ppms backend. Changes the timeouts for the ppms client to be 60 seconds for clarity (it's limited to that amount of time by the forward-proxy anyway). Adds single quotes around CareSite names to ensure consistent results

## Testing done
Tested breakers locally and in review instance by editing the host for ppms. Tested parameter tweak against dev ppms in a review instance

## Testing planned
Further testing in staging is planned prior to soft launch of provider locator

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] ensured breakers is operating successfully for ppms calls

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
