### PR TITLE
Ww ppms id filter

### DIFF
--- a/lib/breakers/statsd_plugin.rb
+++ b/lib/breakers/statsd_plugin.rb
@@ -15,7 +15,8 @@ module Breakers
           contact_id = /\d{10}V\d{6}%5ENI%5E200M%5EUSVHA/
           uuids = /[a-fA-F0-9]{8}(\-?[a-fA-F0-9]{4}){3}\-?[a-fA-F0-9]{12}/
           institution_ids = /[\dA-Z]{8}/
-          r = %r{(\/)(#{digit}|#{contact_id}|#{uuids}|#{institution_ids})(\/|$)}
+          provider_ids = /\(\d{10}\)/
+          r = %r{(\/)(#{digit}|#{contact_id}|#{uuids}|#{institution_ids}|#{provider_ids})(\/|$)}
           endpoint = request.url.path.gsub(r, '\1xxx\4')
           tags.append("endpoint:#{endpoint}")
         end

--- a/lib/breakers/statsd_plugin.rb
+++ b/lib/breakers/statsd_plugin.rb
@@ -15,7 +15,7 @@ module Breakers
           contact_id = /\d{10}V\d{6}%5ENI%5E200M%5EUSVHA/
           uuids = /[a-fA-F0-9]{8}(\-?[a-fA-F0-9]{4}){3}\-?[a-fA-F0-9]{12}/
           institution_ids = /[\dA-Z]{8}/
-          provider_ids = /\(\d{10}\)/
+          provider_ids = /Providers\(\d{10}\)/
           r = %r{(\/)(#{digit}|#{contact_id}|#{uuids}|#{institution_ids}|#{provider_ids})(\/|$)}
           endpoint = request.url.path.gsub(r, '\1xxx\4')
           tags.append("endpoint:#{endpoint}")

--- a/spec/lib/breakers/statsd_plugin_spec.rb
+++ b/spec/lib/breakers/statsd_plugin_spec.rb
@@ -47,6 +47,9 @@ describe Breakers::StatsdPlugin do
 
         request.url = URI(test_host + '/foo/-1')
         expect(subject.get_tags(request)).to include('endpoint:/foo/xxx')
+
+        request.url = URI(test_host + '/v0.0/foo/(1234567890)/bar')
+        expect(subject.get_tags(request)).to include('endpoint:/v0.0/foo/xxx/bar')
       end
     end
   end

--- a/spec/lib/breakers/statsd_plugin_spec.rb
+++ b/spec/lib/breakers/statsd_plugin_spec.rb
@@ -48,8 +48,8 @@ describe Breakers::StatsdPlugin do
         request.url = URI(test_host + '/foo/-1')
         expect(subject.get_tags(request)).to include('endpoint:/foo/xxx')
 
-        request.url = URI(test_host + '/v0.0/foo/(1234567890)/bar')
-        expect(subject.get_tags(request)).to include('endpoint:/v0.0/foo/xxx/bar')
+        request.url = URI(test_host + '/v0.0/Providers(1234567890)/bar')
+        expect(subject.get_tags(request)).to include('endpoint:/v0.0/xxx/bar')
       end
     end
   end


### PR DESCRIPTION
## Description of change
Updates the ID filtering on breakers metrics to prevent unchecked growth in metrics. This ID pattern is quite unusual, I'm not sure how to build this more generically without major surgery here.

## Testing done

## Testing planned

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
