### PR TITLE
Claims Documentation was still pointing at vets gov vs va gov

### DIFF
--- a/modules/claims_api/EVSS_CLAIMS.yml
+++ b/modules/claims_api/EVSS_CLAIMS.yml
@@ -4,60 +4,60 @@ info:
   title: Benefit Claims
   description: |
     Benefit Claims Status
-    
+
     ## Background
-    
+
     This API is being provided as a proof of concept of a general-purpose VA  API gateway. The use case is to allow authorized third-party developers to request the status of a Veteran's benefit claims.
 
     The Benefit Claim API passes data through to Electronic Veterans Self Service, EVSS. EVSS uses VAAFI to authenticate requests. Consumers of this API not using OAuth will need to pass the minimum VAAFI headers to this service to retrieve records.
-    
+
     ## Design
-    
+
     ### Authorization
-    
+
     API requests are authorized by means of a symmetric API token, provided in an HTTP header
     with name "apikey".
 
     ### List Statuses Request
-    
+
     Allows a client to check claims status from EVSS.
 
-    1. Client Request: GET https://api.vets.gov/services/claims/v0/claims
+    1. Client Request: GET https://api.va.gov/services/claims/v0/claims
         * Provide the Veteran's SSN as the X-VA-SSN header
         * Provide the VA username of the person requesting the claim status as the X-VA-User header
         * Provide the Veteran's First Name as X-VA-First-Name
         * Provide the Veteran's Last Name as X-VA-Last-Name
         * Provide the Veteran's Birth Date as X-VA-Birth-Date in the iso8601 format
         * Provide the Veteran's EDIPI as X-VA-EDIPI
-    
+
     2. Service Response: A JSON API object with the current status of claims
 
     ### Single status request
 
     Allows a client to retrieve claim status by EVSS id.
 
-    1. Client Request: GET https://api.vets.gov/services/claims/v0/claims/123123
+    1. Client Request: GET https://api.va.gov/services/claims/v0/claims/123123
         * Provide the Veteran's SSN as the X-VA-SSN header
         * Provide the VA username of the person requesting the claim status as the X-VA-User header
         * Provide the Veteran's First Name as X-VA-First-Name
         * Provide the Veteran's Last Name as X-VA-Last-Name
         * Provide the Veteran's Birth Date as X-VA-Birth-Date in the iso8601 format
         * Provide the Veteran's EDIPI as X-VA-EDIPI
-    
+
     2. Service Response: A JSON API object with the current status of the requested claim
-          
+
     ## Reference
 
-    Raw Open API Spec: http://dev-api.vets.gov/services/claims/docs/v0/api
+    Raw Open API Spec: http://dev-api.va.gov/services/claims/docs/v0/api
 
   termsOfService: ''
   contact:
     name: Vets.gov
 tags:
-  - name: claims 
+  - name: claims
     description: EVSS claims status API
-servers: 
-  - url: dev-api.vets.gov/services/claims/{version}
+servers:
+  - url: dev-api.va.gov/services/claims/{version}
     description: Vets.gov API development environment
     variables:
       version:
@@ -200,7 +200,7 @@ components:
     api_key:
       type: apiKey
       name: apikey
-      in: header 
+      in: header
   schemas:
     Claim:
       description: |
@@ -242,23 +242,23 @@ components:
               type: boolean
               description: Has the claim been resolved
               example: true
-            waiver_submitted: 
+            waiver_submitted:
               type: boolean
               description: Requested Decision or Waiver 5103 Submitted
               example: false
-            documents_needed: 
+            documents_needed:
               type: boolean
               example: false
               description: Does the claim require additional documents to be submitted
-            development_letter_sent: 
+            development_letter_sent:
               type: boolean
               description: Indicates if a Development Letter has been sent to the Claimant regarding a benefit claim
               example: false
-            decision_letter_sent: 
+            decision_letter_sent:
               type: boolean
               description: Indicates if a Decision Notification Letter has been sent to the Claimant regarding a benefit claim
               example: false
-            updated_at: 
+            updated_at:
               type: string
               format: date-time
               example: '2018-07-30T17:31:15.958Z'
@@ -269,14 +269,14 @@ components:
               example: 2
               description: |
                 Phase the claim is in. Numbers map to the following
-                
-                1. 'claim received' 
-                2. 'under review' 
-                3. 'gathering of evidence' 
-                4. 'review of evidence' 
-                5. 'preparation for decision' 
-                6. 'pending decision approval' 
-                7. 'preparation for notification' 
+
+                1. 'claim received'
+                2. 'under review'
+                3. 'gathering of evidence'
+                4. 'review of evidence'
+                5. 'preparation for decision'
+                6. 'pending decision approval'
+                7. 'preparation for notification'
                 8. 'complete'
             ever_phase_back:
               type: boolean


### PR DESCRIPTION
## Description of change
Documentation is pointing at the old url, this updates it to be in line with reality.

## Acceptance Criteria (Definition of Done)
- documentation contains no references to the old URLs
