### PR TITLE
Add protocols to swagger doc server blocks

### DIFF
--- a/modules/appeals_api/README.yml
+++ b/modules/appeals_api/README.yml
@@ -41,17 +41,17 @@ tags:
   - name: appeals
     description: Caseflow appeals status API
 servers: 
-  - url: dev-api.va.gov/services/appeals/{version}
+  - url: https://dev-api.va.gov/services/appeals/{version}
     description: VA.gov API development environment
     variables:
       version:
         default: v0
-  - url: staging-api.va.gov/services/appeals/{version}
+  - url: https://staging-api.va.gov/services/appeals/{version}
     description: VA.gov API staging environment
     variables:
       version:
         default: v0
-  - url: api.va.gov/services/appeals/{version}
+  - url: https://api.va.gov/services/appeals/{version}
     description: VA.gov API production environment
     variables:
       version:

--- a/modules/claims_api/EVSS_CLAIMS.yml
+++ b/modules/claims_api/EVSS_CLAIMS.yml
@@ -52,12 +52,12 @@ info:
 
   termsOfService: ''
   contact:
-    name: Vets.gov
+    name: VA.gov
 tags:
   - name: claims
     description: EVSS claims status API
 servers: 
-  - url: https://dev-api.vets.gov/services/claims/{version}
+  - url: https://dev-api.va.gov/services/claims/{version}
     description: Vets.gov API development environment
     variables:
       version:

--- a/modules/claims_api/EVSS_CLAIMS.yml
+++ b/modules/claims_api/EVSS_CLAIMS.yml
@@ -56,8 +56,8 @@ info:
 tags:
   - name: claims
     description: EVSS claims status API
-servers:
-  - url: dev-api.va.gov/services/claims/{version}
+servers: 
+  - url: https://dev-api.vets.gov/services/claims/{version}
     description: Vets.gov API development environment
     variables:
       version:

--- a/modules/openid_auth/README.yml
+++ b/modules/openid_auth/README.yml
@@ -37,17 +37,17 @@ tags:
   - name: validated_token
     description: Oauth Validation for internal 3rd Party Services
 servers:
-  - url: dev-api.va.gov/internal/auth/{version}
+  - url: https://dev-api.va.gov/internal/auth/{version}
     description: VA.gov API development environment
     variables:
       version:
         default: v0
-  - url: staging-api.va.gov/internal/auth/{version}
+  - url: https://staging-api.va.gov/internal/auth/{version}
     description: VA.gov API staging environment
     variables:
       version:
         default: v0
-  - url: api.va.gov/internal/auth/{version}
+  - url: https://api.va.gov/internal/auth/{version}
     description: VA.gov API production environment
     variables:
       version:

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -51,17 +51,17 @@ tags:
   - name: facilities
     description: VA Facilities API
 servers:
-  - url: dev-api.va.gov/services/va_facilities/{version}
+  - url: https://dev-api.va.gov/services/va_facilities/{version}
     description: VA.gov API development environment
     variables:
       version:
         default: v0
-  - url: staging-api.va.gov/services/va_facilities/{version}
+  - url: https://staging-api.va.gov/services/va_facilities/{version}
     description: VA.gov API staging environment
     variables:
       version:
         default: v0
-  - url: api.va.gov/services/va_facilities/{version}
+  - url: https://api.va.gov/services/va_facilities/{version}
     description: VA.gov API production environment
     variables:
       version:

--- a/modules/vba_documents/README.yml
+++ b/modules/vba_documents/README.yml
@@ -57,17 +57,17 @@ tags:
   - name: document_uploads
     description: VA Benefits document upload functionality
 servers: 
-  - url: dev-api.va.gov/services/vba_documents/{version}
+  - url: https://dev-api.va.gov/services/vba_documents/{version}
     description: VA.gov API development environment
     variables:
       version:
         default: v0
-  - url: staging-api.va.gov/services/vba_documents/{version}
+  - url: https://staging-api.va.gov/services/vba_documents/{version}
     description: VA.gov API staging environment
     variables:
       version:
         default: v0
-  - url: api.va.gov/services/vba_documents/{version}
+  - url: https://api.va.gov/services/vba_documents/{version}
     description: VA.gov API production environment
     variables:
       version:

--- a/modules/veteran_verification/DISABILITY_RATING.yml
+++ b/modules/veteran_verification/DISABILITY_RATING.yml
@@ -37,17 +37,17 @@ tags:
   - name: disability_rating
     description: Veteran Verification - Disability Rating
 servers:
-  - url: dev-api.va.gov/services/veteran_verification/{version}
+  - url: https://dev-api.va.gov/services/veteran_verification/{version}
     description: VA.gov API development environment
     variables:
       version:
         default: v0
-  - url: staging-api.va.gov/services/veteran_verification/{version}
+  - url: https://staging-api.va.gov/services/veteran_verification/{version}
     description: VA.gov API staging environment
     variables:
       version:
         default: v0
-  - url: api.va.gov/services/veteran_verification/{version}
+  - url: https://api.va.gov/services/veteran_verification/{version}
     description: VA.gov API production environment
     variables:
       version:

--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -45,17 +45,17 @@ tags:
   - name: service_history
     description: Veteran Verification - Service History
 servers:
-  - url: dev-api.va.gov/services/veteran_verification/{version}
+  - url: https://dev-api.va.gov/services/veteran_verification/{version}
     description: VA.gov API development environment
     variables:
       version:
         default: v0
-  - url: staging-api.va.gov/services/veteran_verification/{version}
+  - url: https://staging-api.va.gov/services/veteran_verification/{version}
     description: VA.gov API staging environment
     variables:
       version:
         default: v0
-  - url: api.va.gov/services/veteran_verification/{version}
+  - url: https://api.va.gov/services/veteran_verification/{version}
     description: VA.gov API production environment
     variables:
       version:

--- a/modules/veteran_verification/VETERAN_CONFIRMATION.yml
+++ b/modules/veteran_verification/VETERAN_CONFIRMATION.yml
@@ -45,17 +45,17 @@ tags:
   - name: veteran_confirmation_status
     description: Veteran Verification - Veteran Status
 servers:
-  - url: dev-api.va.gov/services/veteran_verification/{version}
+  - url: https://dev-api.va.gov/services/veteran_verification/{version}
     description: VA.gov API development environment
     variables:
       version:
         default: v0
-  - url: staging-api.va.gov/services/veteran_verification/{version}
+  - url: https://staging-api.va.gov/services/veteran_verification/{version}
     description: VA.gov API staging environment
     variables:
       version:
         default: v0
-  - url: api.va.gov/services/veteran_verification/{version}
+  - url: https://api.va.gov/services/veteran_verification/{version}
     description: VA.gov API production environment
     variables:
       version:


### PR DESCRIPTION
## Description of change
Add protocols in front all urls in documented server blocks. Fixes Swagger UI adding an extra URL in front of the server selection.

Resolves department-of-veterans-affairs/vets-contrib#756

## Testing done
Verified that this generates the correct blocks locally.

## Testing planned
Nope should work!

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

- [x] Added protocols to server blocks in documentation

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
