### PR TITLE
Turns on SQL output in local dev Rails console sessions

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,6 +48,12 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   ConfigHelper.setup_action_mailer(config)
 
+  # Turns on SQL output in local dev Rails console sessions
+  config.semantic_logger.add_appender(
+    io: STDOUT,
+    level: :debug,
+    formatter: config.rails_semantic_logger.format
+  )
   config.rails_semantic_logger.semantic   = false
   config.rails_semantic_logger.started    = true
   config.rails_semantic_logger.processing = true


### PR DESCRIPTION
## Description of change
In a traditional Rails app, in the rails console we get SQL output when executing commands.  This gives us insight into what SQL is being called, in order to make queries more performant, and mitigate against any regression.

In the Vets-API repo, this SQL output has been removed.

There is a `.to_sql` command, but that is not always an option, b/c often times the last object that the `.to_sql` method is being called on, is not available.

## Testing done
<!-- Please describe testing done to verify the changes. -->
Local testing

## Testing planned
<!-- Please describe testing planned. -->
Testing once merged

## Changes

#### Local dev Rails console output *before* change

```
irb(main):001:0> BaseFacility.last
=> nil
```

#### Local dev Rails console output *after* change

```
irb(main):002:0> BaseFacility.last
2019-01-07 14:03:41.874567 D [33892:70260346796600] ActiveRecord::Base --   BaseFacility Load (11.2ms)  SELECT  "base_facilities".* FROM "base_facilities"  ORDER BY "base_facilities"."unique_id" DESC LIMIT 1
=> nil
```

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Find and implement a solution that turns on SQL output in the local development rails console

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)


