### PR TITLE
BAH Sprint 12: Updated to the latest vets-json-schema version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,10 +19,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 2aeedce8d4f4064ae75cc19ef2c5d7541a8c5a64
+  revision: 3bd461ead9c52d12f1e496e8c7f68faa064320df
   branch: master
   specs:
-    vets_json_schema (3.122.0)
+    vets_json_schema (3.126.0)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 


### PR DESCRIPTION
## Description of change
Bumping json schema version for form526 schema updates

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Bump vets-json-schema version in gemfile

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)