### PR TITLE
Bugfix for Vet360 phone prefill on 526

### DIFF
--- a/app/models/form_profiles/va526ez.rb
+++ b/app/models/form_profiles/va526ez.rb
@@ -93,7 +93,7 @@ class FormProfiles::VA526ez < FormProfile
     {
       mailing_address: convert_vets360_address(vet360_contact_info.mailing_address),
       email_address: vet360_contact_info.email.try(:email_address),
-      primary_phone: [vet360_contact_info.home_phone.area_code, vet360_contact_info.home_phone.phone_number].join('')
+      primary_phone: [vet360_contact_info.home_phone.try(:area_code), vet360_contact_info.home_phone.try(:phone_number)].join('')
     }.compact
   end
 

--- a/app/models/form_profiles/va526ez.rb
+++ b/app/models/form_profiles/va526ez.rb
@@ -93,7 +93,10 @@ class FormProfiles::VA526ez < FormProfile
     {
       mailing_address: convert_vets360_address(vet360_contact_info.mailing_address),
       email_address: vet360_contact_info.email.try(:email_address),
-      primary_phone: [vet360_contact_info.home_phone.try(:area_code), vet360_contact_info.home_phone.try(:phone_number)].join('')
+      primary_phone: [
+        vet360_contact_info.home_phone.try(:area_code),
+        vet360_contact_info.home_phone.try(:phone_number)
+      ].join('')
     }.compact
   end
 

--- a/app/models/form_profiles/va526ez.rb
+++ b/app/models/form_profiles/va526ez.rb
@@ -92,10 +92,10 @@ class FormProfiles::VA526ez < FormProfile
     vet360_contact_info = Vet360Redis::ContactInformation.for_user(user)
     {
       mailing_address: convert_vets360_address(vet360_contact_info.mailing_address),
-      email_address: vet360_contact_info.email.try(:email_address),
+      email_address: vet360_contact_info.email&.email_address,
       primary_phone: [
-        vet360_contact_info.home_phone.try(:area_code),
-        vet360_contact_info.home_phone.try(:phone_number)
+        vet360_contact_info.home_phone&.area_code,
+        vet360_contact_info.home_phone&.phone_number
       ].join('')
     }.compact
   end


### PR DESCRIPTION
## Description of change
Catches for case when home phone from Vet360 does not exist

## Testing done
Local testing

## Testing planned
Testing in staging with User 229

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
Resolves Sentry error http://sentry.vetsgov-internal/vets-gov/platform-api-staging/issues/55160/?query=is:unresolved

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16158

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
