### PR TITLE
Bug fix for user/preferences giving 500s locally/in Docker

### DIFF
--- a/app/controllers/v0/user_preferences_controller.rb
+++ b/app/controllers/v0/user_preferences_controller.rb
@@ -61,7 +61,7 @@ module V0
     end
 
     def user_preferences
-      @user_preferences ||= UserPreference.all_preferences_with_choices(current_user.account.id)
+      @user_preferences ||= UserPreference.all_preferences_with_choices(@account.id)
     end
   end
 end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

Per this [bug ticket](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16180), there was this issue:

```
"exception":"undefined method `id' for nil:NilClass",
  "backtrace":[
     "/src/vets-api/app/controllers/v0/user_preferences_controller.rb:64:in `user_preferences'",
     "/src/vets-api/app/controllers/v0/user_preferences_controller.rb:26:in `index'",
```

This is happening because `id` was not being called off of the `@account` instance variable that is being set as part of the `before_action :set_account`, which mitigates against background jobs either failing or not running (which is what is happening here).

## Testing done
<!-- Please describe testing done to verify the changes. -->

Local testing.  

## Testing planned
<!-- Please describe testing planned. -->

Having @erikphansen retest locally

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Ensure `@account` is set prior to calling its `id`

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
