### PR TITLE
log  NoMethodError to sentry

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -89,7 +89,7 @@ module V0
         StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [@sso_service.failure_instrumentation_tag])
       end
     rescue NoMethodError
-      log_message_to_sentry("NoMethodError", base64_params_saml_response: params[:SAMLResponse])
+      log_message_to_sentry('NoMethodError', base64_params_saml_response: params[:SAMLResponse])
       redirect_to url_service.login_redirect_url(auth: 'fail', code: 7) unless performed?
     ensure
       StatsD.increment(STATSD_SSO_CALLBACK_TOTAL_KEY)

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -89,7 +89,7 @@ module V0
         StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [@sso_service.failure_instrumentation_tag])
       end
     rescue NoMethodError
-      Raven.extra_context(base64_params_saml_response: params[:SAMLResponse])
+      log_message_to_sentry("NoMethodError", base64_params_saml_response: params[:SAMLResponse])
       redirect_to url_service.login_redirect_url(auth: 'fail', code: 7) unless performed?
     ensure
       StatsD.increment(STATSD_SSO_CALLBACK_TOTAL_KEY)

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -443,10 +443,10 @@ RSpec.describe V0::SessionsController, type: :controller do
       context 'when NoMethodError is encountered elsewhere' do
         it 'redirects to adds context and re-raises the exception', :aggregate_failures do
           allow_any_instance_of(SSOService).to receive(:persist_authentication!).and_raise(NoMethodError)
-          expect(Raven).to receive(:extra_context).twice
+          expect(Raven).to receive(:extra_context).once
           expect(Raven).not_to receive(:user_context)
           expect(Raven).not_to receive(:tags_context).twice
-          expect(controller).not_to receive(:log_message_to_sentry)
+          expect(controller).to receive(:log_message_to_sentry)
           post :saml_callback
         end
       end


### PR DESCRIPTION
## Description of change
I tried to replace the raven logging in https://github.com/department-of-veterans-affairs/vets-api/pull/2413 but i neglected to re-raise so it was never logged. 
## Testing done
specs
