### PR TITLE
16224 convert treatment date

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -131,9 +131,7 @@ module EVSS
           'payment' => {
             'serviceBranch' => service_branch(input_form['separationPayBranch'])
           },
-          'receivedDate' => {
-            'year' => input_form['separationPayDate'].to_s
-          }
+          'receivedDate' => approximate_date(input_form['separationPayDate'])
         }
       end
 
@@ -344,8 +342,8 @@ module EVSS
 
         treatments = input_form['vaTreatmentFacilities'].map do |treatment|
           {
-            'startDate' => treatment['treatmentDateRange']['from'],
-            'endDate' => treatment['treatmentDateRange']['to'],
+            'startDate' => approximate_date(treatment['treatmentDateRange']['from']),
+            'endDate' => approximate_date(treatment['treatmentDateRange']['to']),
             'treatedDisabilityNames' => treatment['treatedDisabilityNames'],
             'center' => {
               'name' => treatment['treatmentCenterName']
@@ -354,6 +352,20 @@ module EVSS
         end
 
         { 'treatments' => treatments }
+      end
+
+      def approximate_date(date)
+        year, month, day = date.split('-')
+
+        # month/day are optional and can be XXed out
+        month = nil if month == 'XX'
+        day = nil if day == 'XX'
+
+        {
+          'year' => year,
+          'month' => month,
+          'day' => day
+        }.compact
       end
 
       # `specialIssues` is a key that can hold an array of special issue strings

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -29,8 +29,8 @@ namespace :form526 do
       print_row(s.created_at, s.updated_at, s.id, s.submitted_claim_id, s.workflow_complete)
     end
 
-    total_jobs = submissions.count
-    success_jobs = submissions.group(:workflow_complete).count[true]
+    total_jobs = submissions.count || 0
+    success_jobs = submissions.group(:workflow_complete).count[true] || 0
     fail_jobs = total_jobs - success_jobs
 
     puts '------------------------------------------------------------'

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -29,7 +29,7 @@ namespace :form526 do
       print_row(s.created_at, s.updated_at, s.id, s.submitted_claim_id, s.workflow_complete)
     end
 
-    total_jobs = submissions.count || 0
+    total_jobs = submissions.count
     success_jobs = submissions.group(:workflow_complete).count[true] || 0
     fail_jobs = total_jobs - success_jobs
 

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -132,7 +132,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
         {
           'form526' => {
             'separationPayBranch' => 'Air Force',
-            'separationPayDate' => '2018'
+            'separationPayDate' => '2018-XX-XX'
           }
         }
       end
@@ -681,7 +681,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
               {
                 'treatmentDateRange' => {
                   'from' => '2018-01-01',
-                  'to' => '2018-02-01'
+                  'to' => '2018-02-XX'
                 },
                 'treatmentCenterName' => 'Super Hospital',
                 'treatmentCenterAddress' => {
@@ -699,8 +699,15 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
       it 'should translate the data correctly' do
         expect(subject.send(:translate_treatments)).to eq 'treatments' => [
           {
-            'startDate' => '2018-01-01',
-            'endDate' => '2018-02-01',
+            'startDate' => {
+              'year' => '2018',
+              'month' => '01',
+              'day' => '01'
+            },
+            'endDate' => {
+              'year' => '2018',
+              'month' => '02'
+            },
             'treatedDisabilityNames' => %w[PTSD PTSD2 PTSD3],
             'center' => {
               'name' => 'Super Hospital',

--- a/spec/support/disability_compensation_form/all_claims_evss_submission.json
+++ b/spec/support/disability_compensation_form/all_claims_evss_submission.json
@@ -101,8 +101,16 @@
                     "name": "Private Facility 2",
                     "country": "USA"
                 },
-                "endDate": "2018-03-03",
-                "startDate": "2018-03-02",
+                "endDate": {
+                    "year": "2018",
+                    "month": "03",
+                    "day": "03"
+                },
+                "startDate": {
+                    "year": "2018",
+                    "month": "03",
+                    "day": "02"
+                },
                 "treatedDisabilityNames": [
                     "PTSD (post traumatic stress disorder)"
                 ]
@@ -112,8 +120,14 @@
                     "name": "Huntsville VA Facility",
                     "country": "USA"
                 },
-                "endDate": "2018-03-04",
-                "startDate": "2015-04-03",
+                "endDate": {
+                    "year": "2018",
+                    "month": "03"
+                },
+                "startDate": {
+                    "year": "2015",
+                    "month": "04"
+                },
                 "treatedDisabilityNames": [
                     "PTSD personal trauma"
                 ]

--- a/spec/support/disability_compensation_form/all_claims_fe_submission.json
+++ b/spec/support/disability_compensation_form/all_claims_fe_submission.json
@@ -81,7 +81,7 @@
     },
     "privacyAgreementAccepted": true,
     "separationPayBranch": "Air Force",
-    "separationPayDate": "2000",
+    "separationPayDate": "2000-XX-XX",
     "serviceInformation": {
       "reservesNationalGuardService": {
         "obligationTermOfServiceDateRange": {
@@ -133,8 +133,8 @@
           "country": "USA"
         },
         "treatmentDateRange": {
-          "from": "2015-04-03",
-          "to": "2018-03-04"
+          "from": "2015-04-XX",
+          "to": "2018-03-XX"
         },
         "treatedDisabilityNames": [
           "PTSD personal trauma"


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
EVSS has pushed a change through that updates the behavior of the treatment start/end dates. Instead of this being a date string it is now a date object that contains 'year', optional 'month', and optional 'day'. The back end translator had to be updated to account for this. Also, the `separationPayDate` field has been updated to take advantage of this as well.

Also, theres a small submissions rake task bug fix ninja'd on to this PR, my apologies.

## Testing done
<!-- Please describe testing done to verify the changes. -->
Spec tests.

## Testing planned
<!-- Please describe testing planned. -->
Staging e2e testing.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Allow treatment dates/separationPayDate to be an approximate date object
- [x] submissions rake tasks will not fail anymore if there are no jobs in the provided date period

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
