### PR TITLE
BAH 4142 fix to avoid IsoCountryCodes::UnknownCodeError during PDF generation

### DIFF
--- a/lib/pdf_fill/forms/form_helper.rb
+++ b/lib/pdf_fill/forms/form_helper.rb
@@ -28,7 +28,13 @@ module PdfFill
       def extract_country(address)
         return if address.blank?
         country = address['country']
-        IsoCountryCodes.find(country).alpha2
+        if country.present? && country.size == 3
+          IsoCountryCodes.find(country).alpha2
+        else
+          IsoCountryCodes.search_by_name(country)[0].alpha2
+        end
+      rescue IsoCountryCodes::UnknownCodeError
+        country
       end
 
       def split_postal_code(address)

--- a/spec/lib/pdf_fill/forms/form_helper_spec.rb
+++ b/spec/lib/pdf_fill/forms/form_helper_spec.rb
@@ -55,6 +55,24 @@ describe PdfFill::Forms::FormHelper do
     end
   end
 
+  describe '#extract_country_if_not_usa' do
+    it 'should return the correct code for country' do
+      address = {
+        'country' => 'Ghana'
+      }
+      expect(including_class.new.extract_country(address)).to eq('GH')
+    end
+  end
+
+  describe '#extract_country_if_not_valid_code' do
+    it 'should return the passed value as country' do
+      address = {
+        'country' => 'InvalidCountry'
+      }
+      expect(including_class.new.extract_country(address)).to eq('InvalidCountry')
+    end
+  end
+
   describe '#split_postal_code' do
     it 'should return nil with blank address' do
       expect(including_class.new.split_postal_code({})).to eq(nil)


### PR DESCRIPTION
## Description of change

Fix for 4142 PDF generation due to non-us country in Veteran profile for mailing address
- PDF helper method fix
- Unit test update

## Testing done
- Unit testing
- Local testing

## Testing planned
- Unit testing
- Cross-browser (by QA)
- Manual testing (by QA)

## Acceptance Criteria (Definition of Done)
- Unit tests passed
    - spec/lib/pdf_fill/forms/form_helper_spec.rb
    - spec/lib/pdf_fill/filler_spec.rb

#### Unique to this PR
 NA

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
