### PR TITLE
Nil safe deep accessing

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
@@ -34,7 +34,7 @@ module AppealsApi
       end
 
       def log_response(appeals_response)
-        first_appeal_id = appeals_response.body['data'][0]['id']
+        first_appeal_id = appeals_response.body.dig('data', 0, 'id')
         count = appeals_response.body['data'].length
         Rails.logger.info('Caseflow Response',
                           'va_user' => requesting_va_user,

--- a/spec/support/vcr_cassettes/appeals/appeals_empty.yml
+++ b/spec/support/vcr_cassettes/appeals/appeals_empty.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://dsva-appeals-certification-dev-1895622301.us-gov-west-1.elb.amazonaws.com/api/v2/appeals
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Ssn:
+      - '120495723'
+      Authorization:
+      - Token token=PUBLICDEMO123
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 19 Jan 2018 17:26:32 GMT
+      Etag:
+      - W/"ab470b0240e45ddd9bd220cdea147828"
+      Server:
+      - nginx/1.12.1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 89ccfeb0-097a-4b26-9bdf-6570dd6f1c87
+      X-Runtime:
+      - '0.012297'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '3241'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "data": []
+        }
+    http_version:
+  recorded_at: Wed, 08 Jan 2018 14:44:00 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Description of change
Fix a bug where we would try to access attributes on a nil object.

## Testing done
- ci / rspec

## Testing planned
- staging calls

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
