### PR TITLE
Collect MVI error details in MVI::Responses::FindProfileResponse objects

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -403,6 +403,24 @@ en:
         code: 'IHUB_102'
         detail: 'The user does not have an ICN.'
         status: 502
+      MVI_404:
+        <<: *external_defaults
+        title: Record not found
+        detail: "The record for the requested user could not be found"
+        code: 'MVI_404'
+        status: 404
+      MVI_503:
+        <<: *external_defaults
+        title: Service unavailable
+        detail: "MVI service is currently unavailable"
+        code: 'MVI_503'
+        status: 503
+      MVI_504:
+        <<: *external_defaults
+        title: Gateway timeout
+        detail: "Did not receive a timely response from an upstream server"
+        code: 'MVI_504'
+        status: 504
       MVI_BD502:
         <<: *external_defaults
         title: Unexpected response body

--- a/lib/mvi/responses/find_profile_response.rb
+++ b/lib/mvi/responses/find_profile_response.rb
@@ -18,23 +18,28 @@ module MVI
       # @return [MVI::Models::MviProfile] The parsed MVI profile
       attribute :profile, MVI::Models::MviProfile
 
+      # @return [Common::Exceptions::BackendServiceException] The rescued exception
+      attribute :error, Common::Exceptions::BackendServiceException
+
       # Builds a response with a server error status and a nil profile
       #
       # @return [MVI::Responses::FindProfileResponse] the response
-      def self.with_server_error
+      def self.with_server_error(exception = nil)
         FindProfileResponse.new(
           status: FindProfileResponse::RESPONSE_STATUS[:server_error],
-          profile: nil
+          profile: nil,
+          error: exception
         )
       end
 
       # Builds a response with a not found status and a nil profile
       #
       # @return [MVI::Responses::FindProfileResponse] the response
-      def self.with_not_found
+      def self.with_not_found(exception = nil)
         FindProfileResponse.new(
           status: FindProfileResponse::RESPONSE_STATUS[:not_found],
-          profile: nil
+          profile: nil,
+          error: exception
         )
       end
 

--- a/lib/mvi/service.rb
+++ b/lib/mvi/service.rb
@@ -31,6 +31,7 @@ module MVI
     configuration MVI::Configuration
 
     STATSD_KEY_PREFIX = 'api.mvi' unless const_defined?(:STATSD_KEY_PREFIX)
+    SERVER_ERROR = 'server_error'
 
     # Given a user queries MVI and returns their VA profile.
     #
@@ -47,24 +48,43 @@ module MVI
     rescue Breakers::OutageException => e
       Raven.extra_context(breakers_error_message: e.message)
       log_console_and_sentry('MVI find_profile connection failed.', :error)
-      MVI::Responses::FindProfileResponse.with_server_error
+      mvi_profile_exception_response_for('MVI_503', e)
     rescue Faraday::ConnectionFailed => e
       log_console_and_sentry("MVI find_profile connection failed: #{e.message}", :error)
-      MVI::Responses::FindProfileResponse.with_server_error
+      mvi_profile_exception_response_for('MVI_504', e)
     rescue Common::Client::Errors::ClientError, Common::Exceptions::GatewayTimeout => e
       log_console_and_sentry("MVI find_profile error: #{e.message}", :error)
-      MVI::Responses::FindProfileResponse.with_server_error
+      mvi_profile_exception_response_for('MVI_504', e)
     rescue MVI::Errors::Base => e
       mvi_error_handler(user, e)
       if e.is_a?(MVI::Errors::RecordNotFound)
-        MVI::Responses::FindProfileResponse.with_not_found
+        mvi_profile_exception_response_for('MVI_404', e, type: 'not_found')
       else
-        MVI::Responses::FindProfileResponse.with_server_error
+        mvi_profile_exception_response_for('MVI_503', e)
       end
     end
     # rubocop:enable Metrics/MethodLength
 
     private
+
+    def mvi_profile_exception_response_for(key, error, type: SERVER_ERROR)
+      exception = build_exception(key, error)
+
+      if type == SERVER_ERROR
+        MVI::Responses::FindProfileResponse.with_server_error(exception)
+      else
+        MVI::Responses::FindProfileResponse.with_not_found(exception)
+      end
+    end
+
+    def build_exception(key, error)
+      Common::Exceptions::BackendServiceException.new(
+        key,
+        { source: self.class },
+        error.try(:status),
+        error.try(:body)
+      )
+    end
 
     def mvi_error_handler(user, e)
       case e

--- a/spec/lib/mvi/responses/find_profile_response_spec.rb
+++ b/spec/lib/mvi/responses/find_profile_response_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'mvi/responses/find_profile_response'
+require 'support/mvi/stub_mvi'
 
 describe MVI::Responses::FindProfileResponse do
   let(:faraday_response) { instance_double('Faraday::Response') }
@@ -19,12 +20,28 @@ describe MVI::Responses::FindProfileResponse do
       expect(error_response.status).to eq('SERVER_ERROR')
       expect(error_response.profile).to be_nil
     end
+
+    it 'optionally sets #error to the passed exception', :aggregate_failures do
+      response  = MVI::Responses::FindProfileResponse.with_server_error(server_error_exception)
+      exception = response.error.errors.first
+
+      expect(response.error).to be_present
+      expect(exception.code).to eq server_error_exception.errors.first.code
+    end
   end
 
   describe '.with_not_found' do
     it 'builds a response with a nil profile and a status of NOT_FOUND' do
       expect(not_found_response.status).to eq('NOT_FOUND')
       expect(not_found_response.profile).to be_nil
+    end
+
+    it 'optionally sets #error to the passed exception', :aggregate_failures do
+      response  = MVI::Responses::FindProfileResponse.with_not_found(not_found_exception)
+      exception = response.error.errors.first
+
+      expect(response.error).to be_present
+      expect(exception.code).to eq not_found_exception.errors.first.code
     end
   end
 

--- a/spec/models/mvi_spec.rb
+++ b/spec/models/mvi_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'common/exceptions'
+require 'support/mvi/stub_mvi'
 
 describe Mvi, skip_mvi: true do
   let(:user) { build(:user, :loa3) }
@@ -13,8 +14,8 @@ describe Mvi, skip_mvi: true do
       profile: mvi_profile
     )
   end
-  let(:profile_response_error) { MVI::Responses::FindProfileResponse.with_server_error }
-  let(:profile_response_not_found) { MVI::Responses::FindProfileResponse.with_not_found }
+  let(:profile_response_error) { MVI::Responses::FindProfileResponse.with_server_error(server_error_exception) }
+  let(:profile_response_not_found) { MVI::Responses::FindProfileResponse.with_not_found(not_found_exception) }
 
   let(:default_ttl) { REDIS_CONFIG[Mvi::REDIS_CONFIG_KEY.to_s]['each_ttl'] }
   let(:failure_ttl) { REDIS_CONFIG[Mvi::REDIS_CONFIG_KEY.to_s]['failure_ttl'] }

--- a/spec/support/mvi/stub_mvi.rb
+++ b/spec/support/mvi/stub_mvi.rb
@@ -16,6 +16,24 @@ end
 
 def stub_mvi_not_found
   allow_any_instance_of(Mvi).to receive(:response_from_redis_or_service).and_return(
-    MVI::Responses::FindProfileResponse.with_not_found
+    MVI::Responses::FindProfileResponse.with_not_found(not_found_exception)
+  )
+end
+
+def not_found_exception
+  Common::Exceptions::BackendServiceException.new(
+    'MVI_404',
+    { source: 'MVI::Service' },
+    404,
+    'some error body'
+  )
+end
+
+def server_error_exception
+  Common::Exceptions::BackendServiceException.new(
+    'MVI_503',
+    { source: 'MVI::Service' },
+    503,
+    'some error body'
   )
 end


### PR DESCRIPTION
## Description of change

The [MVI::Service#find_profile](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/mvi/service.rb#L40-L64) call returns an instance of the `MVI::Responses::FindProfileResponse` class.  Should an error occur, we want to include the details of that error in this response class, so that we can bubble up those error details to the new `meta-outages` has in the `UserSerializer`.

## Testing done
<!-- Please describe testing done to verify the changes. -->
Updated spec coverage

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Add an `errors` attribute to the `MVI::Responses::FindProfileResponse` class
- [x] By default `errors` attr should be `nil`
- [x] Should any errors occur in the `#find_profile` method, capture those errors in new attribute
- [x] Spec coverage illustrating new attribute being used

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
