### PR TITLE
Fix facilities api bugs

### DIFF
--- a/app/models/base_facility.rb
+++ b/app/models/base_facility.rb
@@ -172,7 +172,9 @@ class BaseFacility < ActiveRecord::Base
       )
     end
 
-    def build_distance_result_set(lat, long, type, services, ids = nil, limit = nil)
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/ParameterLists
+    def build_distance_result_set(lat, long, type, services, ids, limit = nil)
       additional_data = <<-SQL
         base_facilities.*,
         ST_Distance(base_facilities.location,
@@ -195,6 +197,8 @@ class BaseFacility < ActiveRecord::Base
         facilities.order('distance')
       end.flatten
     end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/ParameterLists
 
     def build_result_set(bbox_num, type, services)
       lats = bbox_num.values_at(1, 3)

--- a/modules/va_facilities/lib/tasks/facilities_tasks.rake
+++ b/modules/va_facilities/lib/tasks/facilities_tasks.rake
@@ -7,6 +7,6 @@ namespace :va_facilities do
       UPDATE base_facilities
       SET location=ST_GeogFromText('SRID=4326;POINT(' || long || ' ' || lat ||')')
     SQL
-    ActiveRecord::Base.conection.execute sql
+    ActiveRecord::Base.connection.execute sql
   end
 end


### PR DESCRIPTION
## Description of change
Resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/855 by allowing users to pass both a list of IDs and a lat/long in the same request. Didn't update the docs because they don't actually forbid this combination (which is why a user attempted it).

Also fixes a typo in an existing rake task, which will be used for https://github.com/department-of-veterans-affairs/vets-contrib/issues/990. Currently the majority of NCA, VBA, and VC facilities are missing location data, but running this task should solve that.

## Testing done
Verified against review instance and by running rake task locally
## Testing planned
Will run task in dev/staging environments.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Requests to the facilities API with an ID and lat/long don't trigger 500 errors

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
