### PR TITLE
Form526 allow nil dates

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -135,10 +135,6 @@ module EVSS
         }
       end
 
-      def split_approximate_date(approximate_date)
-        Date.strptime(approximate_date, '%Y-%m-%d')
-      end
-
       def translate_service_info
         {
           'serviceInformation' => {
@@ -348,13 +344,15 @@ module EVSS
             'center' => {
               'name' => treatment['treatmentCenterName']
             }.merge(treatment['treatmentCenterAddress'])
-          }
+          }.compact
         end
 
         { 'treatments' => treatments }
       end
 
       def approximate_date(date)
+        return nil if date.blank?
+
         year, month, day = date.split('-')
 
         # month/day are optional and can be XXed out

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -719,6 +719,49 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
         ]
       end
     end
+
+    context 'when given a treatment center with no `to` date' do
+      let(:form_content) do
+        {
+          'form526' => {
+            'vaTreatmentFacilities' => [
+              {
+                'treatmentDateRange' => {
+                  'from' => '2018-01-01',
+                  'to' => ''
+                },
+                'treatmentCenterName' => 'Super Hospital',
+                'treatmentCenterAddress' => {
+                  'country' => 'USA',
+                  'city' => 'Portland',
+                  'state' => 'OR'
+                },
+                'treatedDisabilityNames' => %w[PTSD PTSD2 PTSD3]
+              }
+            ]
+          }
+        }
+      end
+
+      it 'should translate the data correctly' do
+        expect(subject.send(:translate_treatments)).to eq 'treatments' => [
+          {
+            'startDate' => {
+              'year' => '2018',
+              'month' => '01',
+              'day' => '01'
+            },
+            'treatedDisabilityNames' => %w[PTSD PTSD2 PTSD3],
+            'center' => {
+              'name' => 'Super Hospital',
+              'country' => 'USA',
+              'city' => 'Portland',
+              'state' => 'OR'
+            }
+          }
+        ]
+      end
+    end
   end
 
   describe '#translate_disabilities' do
@@ -1006,6 +1049,49 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
             ]
           }
         ]
+      end
+    end
+
+    describe '#approximate_date' do
+      context 'when there is a full date' do
+        let(:date) { '2099-12-01' }
+
+        it 'should return the year, month, and day' do
+          expect(subject.send(:approximate_date, date)).to include(
+            'year' => '2099',
+            'month' => '12',
+            'day' => '01'
+          )
+        end
+      end
+
+      context 'when there is a partial date (year and month)' do
+        let(:date) { '2099-12-XX' }
+
+        it 'should return the year and month' do
+          expect(subject.send(:approximate_date, date)).to include(
+            'year' => '2099',
+            'month' => '12'
+          )
+        end
+      end
+
+      context 'when there is a partial date (year only)' do
+        let(:date) { '2099-XX-XX' }
+
+        it 'should return the year' do
+          expect(subject.send(:approximate_date, date)).to include(
+            'year' => '2099'
+          )
+        end
+      end
+
+      context 'when there is no date' do
+        let(:date) { '' }
+
+        it 'should return the year' do
+          expect(subject.send(:approximate_date, date)).to eq nil
+        end
       end
     end
   end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Treatment end dates are optional. To avoid the possibility of a blank end date breaking the form translation, a short circuit return has been introduced when generating the approximate date.

## Testing done
<!-- Please describe testing done to verify the changes. -->
spec tests

## Testing planned
<!-- Please describe testing planned. -->
staging e2e

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Add `nil` return to approximate_date generator

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
