### PR TITLE
Add environment task to facilities migration

### DIFF
--- a/modules/va_facilities/lib/tasks/facilities_tasks.rake
+++ b/modules/va_facilities/lib/tasks/facilities_tasks.rake
@@ -2,7 +2,7 @@
 
 namespace :va_facilities do
   desc 'Creates postgis geospatial columns from existing lat/lng'
-  task :migrate_points_for_facilities do
+  task migrate_points_for_facilities: :environment do
     sql = <<-SQL
       UPDATE base_facilities
       SET location=ST_GeogFromText('SRID=4326;POINT(' || long || ' ' || lat ||')')


### PR DESCRIPTION
## Description of change
Adds environment task as a prereq so the task can access the database. Should be the final step before we can run the task for https://github.com/department-of-veterans-affairs/vets-contrib/issues/990

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] migrate_points_for_facilities rake task is runnable

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
