### PR TITLE
External service backed UserSerializer attributes return null & populate a meta-outages hash with error details

### DIFF
--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -188,6 +188,7 @@ module V0
       Swagger::Schemas::UploadSupportingEvidence,
       Swagger::Schemas::VAFacilities,
       Swagger::Schemas::CCProviders,
+      Swagger::Schemas::UserInternalServices,
       Swagger::Schemas::Vet360::Address,
       Swagger::Schemas::Vet360::Email,
       Swagger::Schemas::Vet360::Telephone,

--- a/app/controllers/v0/in_progress_forms_controller.rb
+++ b/app/controllers/v0/in_progress_forms_controller.rb
@@ -4,7 +4,6 @@ module V0
   class InProgressFormsController < ApplicationController
     include IgnoreNotFound
 
-    before_action :check_access_denied
     before_action(:tag_rainbows)
 
     def index
@@ -13,13 +12,12 @@ module V0
 
     def show
       form_id = params[:id]
-      form = InProgressForm.form_for_user(form_id, @current_user)
+      form    = InProgressForm.form_for_user(form_id, @current_user)
+
       if form
         render json: form.data_and_metadata
-      elsif @current_user.can_access_prefill_data?
-        render json: FormProfile.for(form_id).prefill(@current_user)
       else
-        head 404
+        render json: FormProfile.for(form_id).prefill(@current_user)
       end
     end
 
@@ -34,13 +32,6 @@ module V0
       raise Common::Exceptions::RecordNotFound, params[:id] if form.blank?
       form.destroy
       render json: form
-    end
-
-    private
-
-    def check_access_denied
-      return if @current_user.can_save_partial_forms?
-      raise Common::Exceptions::Unauthorized, detail: 'You do not have access to save in progress forms'
     end
   end
 end

--- a/app/controllers/v0/users_controller.rb
+++ b/app/controllers/v0/users_controller.rb
@@ -3,7 +3,14 @@
 module V0
   class UsersController < ApplicationController
     def show
-      render json: @current_user
+      pre_serialized_profile = Users::Profile.new(current_user).pre_serialize
+
+      render(
+        json: pre_serialized_profile,
+        status: pre_serialized_profile.status,
+        serializer: UserSerializer,
+        meta: { outages: pre_serialized_profile.outages }
+      )
     end
   end
 end

--- a/app/controllers/v0/users_controller.rb
+++ b/app/controllers/v0/users_controller.rb
@@ -9,7 +9,7 @@ module V0
         json: pre_serialized_profile,
         status: pre_serialized_profile.status,
         serializer: UserSerializer,
-        meta: { outages: pre_serialized_profile.outages }
+        meta: { errors: pre_serialized_profile.errors }
       )
     end
   end

--- a/app/models/emis_redis/veteran_status.rb
+++ b/app/models/emis_redis/veteran_status.rb
@@ -37,6 +37,8 @@ module EMISRedis
     class NotAuthorized < StandardError
       attr_reader :status
 
+      # @param status [Integer] An HTTP status code
+      #
       def initialize(status: nil)
         @status = status
       end
@@ -45,6 +47,8 @@ module EMISRedis
     class RecordNotFound < StandardError
       attr_reader :status
 
+      # @param status [Integer] An HTTP status code
+      #
       def initialize(status: nil)
         @status = status
       end

--- a/app/models/mvi.rb
+++ b/app/models/mvi.rb
@@ -88,6 +88,14 @@ class Mvi < Common::RedisStore
     mvi_response.status
   end
 
+  # The error experienced when reaching out to the MVI service.
+  #
+  # @return [Common::Exceptions::BackendServiceException]
+  def error
+    return Common::Exceptions::Unauthorized.new(source: self.class) unless user.loa3?
+    mvi_response.try(:error)
+  end
+
   # @return [MVI::Responses::FindProfileResponse] the response returned from MVI
   def mvi_response
     @mvi_response ||= response_from_redis_or_service

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,14 +190,6 @@ class User < Common::RedisStore
     end
   end
 
-  def can_save_partial_forms?
-    true
-  end
-
-  def can_access_prefill_data?
-    true
-  end
-
   def can_access_id_card?
     loa3? && edipi.present? &&
       ID_CARD_ALLOWED_STATUSES.include?(veteran_status.title38_status)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -144,6 +144,10 @@ class User < Common::RedisStore
     mvi.status
   end
 
+  def va_profile_error
+    mvi.error
+  end
+
   # LOA1 no longer just means ID.me LOA1.
   # It could also be DSLogon or MHV NON PREMIUM users who have not yet done ID.me FICAM LOA3.
   # See also lib/saml/user_attributes/dslogon.rb

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -13,110 +13,12 @@ class UserSerializer < ActiveModel::Serializer
     nil
   end
 
-  def account
-    {
-      account_uuid: object.account_uuid
-    }
-  end
-
-  def profile
-    {
-      email: object.email,
-      first_name: object.first_name,
-      middle_name: object.middle_name,
-      last_name: object.last_name,
-      birth_date: object.birth_date,
-      gender: object.gender,
-      zip: object.zip,
-      last_signed_in: object.last_signed_in,
-      loa: object.loa,
-      multifactor: object.multifactor,
-      verified: object.loa3?,
-      # FIXME: this wont be necessary after FE makes appropriate changes
-      authn_context: object.authn_context.scan(/(myhealthevet|dslogon)/).flatten[0]
-    }
-  end
-
-  def vet360_contact_information
-    person = object.vet360_contact_info
-    return {} if person.blank?
-
-    {
-      email: person.email,
-      residential_address: person.residential_address,
-      mailing_address: person.mailing_address,
-      mobile_phone: person.mobile_phone,
-      home_phone: person.home_phone,
-      work_phone: person.work_phone,
-      temporary_phone: person.temporary_phone,
-      fax_number: person.fax_number
-    }
-  rescue Common::Exceptions::BackendServiceException
-    {}
-  end
-
-  def va_profile
-    status = object.va_profile_status
-    return { status: status } unless status == RESPONSE_STATUS[:ok]
-    {
-      status: status,
-      birth_date: object.va_profile.birth_date,
-      family_name: object.va_profile.family_name,
-      gender: object.va_profile.gender,
-      given_names: object.va_profile.given_names
-    }
-  end
-
-  def veteran_status
-    {
-      status: RESPONSE_STATUS[:ok],
-      is_veteran: object.veteran?,
-      served_in_military: object.served_in_military?
-    }
-  rescue EMISRedis::VeteranStatus::NotAuthorized
-    { status: RESPONSE_STATUS[:not_authorized] }
-  rescue EMISRedis::VeteranStatus::RecordNotFound
-    { status: RESPONSE_STATUS[:not_found] }
-  rescue StandardError
-    { status: RESPONSE_STATUS[:server_error] }
-  end
-
-  def in_progress_forms
-    object.in_progress_forms.map do |form|
-      {
-        form: form.form_id,
-        metadata: form.metadata,
-        last_updated: form.updated_at.to_i
-      }
-    end
-  end
-
-  def prefills_available
-    return [] unless object.identity.present? && object.can_access_prefill_data?
-    FormProfile.prefill_enabled_forms
-  end
-
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
-  def services
-    service_list = [
-      BackendServices::FACILITIES,
-      BackendServices::HCA,
-      BackendServices::EDUCATION_BENEFITS
-    ]
-    service_list << BackendServices::RX if object.authorize :mhv_prescriptions, :access?
-    service_list << BackendServices::MESSAGING if object.authorize :mhv_messaging, :access?
-    service_list << BackendServices::HEALTH_RECORDS if object.authorize :mhv_health_records, :access?
-    service_list << BackendServices::MHV_AC if object.authorize :mhv_account_creation, :access?
-    service_list << BackendServices::EVSS_CLAIMS if object.authorize :evss, :access?
-    service_list << BackendServices::USER_PROFILE if object.can_access_user_profile?
-    service_list << BackendServices::APPEALS_STATUS if object.authorize :appeals, :access?
-    service_list << BackendServices::SAVE_IN_PROGRESS if object.can_save_partial_forms?
-    service_list << BackendServices::FORM_PREFILL if object.can_access_prefill_data?
-    service_list << BackendServices::ID_CARD if object.can_access_id_card?
-    service_list << BackendServices::IDENTITY_PROOFED if object.identity_proofed?
-    service_list << BackendServices::VET360 if object.can_access_vet360?
-    service_list += BetaRegistration.where(user_uuid: object.uuid).pluck(:feature) || []
-    service_list
-  end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
+  delegate :account, to: :object
+  delegate :profile, to: :object
+  delegate :vet360_contact_information, to: :object
+  delegate :va_profile, to: :object
+  delegate :veteran_status, to: :object
+  delegate :in_progress_forms, to: :object
+  delegate :prefills_available, to: :object
+  delegate :services, to: :object
 end

--- a/app/services/users/exception_handler.rb
+++ b/app/services/users/exception_handler.rb
@@ -51,20 +51,30 @@ module Users
       exception = error.errors.first
 
       error_template.merge(
-        description: "#{exception.code}, #{exception.status}, #{exception.title}, #{exception.detail}"
+        description: "#{exception.code}, #{exception.status}, #{exception.title}, #{exception.detail}",
+        status: exception.status.to_s
       )
     end
 
     def client_error
-      error_template.merge(description: "#{error.class}, #{error.status}, #{error.message}, #{error.body}")
+      error_template.merge(
+        description: "#{error.class}, #{error.status}, #{error.message}, #{error.body}",
+        status: error.status.to_s
+      )
     end
 
     def emis_error(type)
-      error_template.merge(description: "#{error.class}, #{RESPONSE_STATUS[type]}")
+      error_template.merge(
+        description: "#{error.class}, #{RESPONSE_STATUS[type]}",
+        status: RESPONSE_STATUS[type]
+      )
     end
 
     def standard_error
-      error_template.merge(description: "#{error.class}, #{error.message}, #{error}")
+      error_template.merge(
+        description: "#{error.class}, #{error.message}, #{error}",
+        status: standard_error_status(error)
+      )
     end
 
     def error_template
@@ -72,8 +82,16 @@ module Users
         external_service: service,
         start_time: Time.current.iso8601,
         end_time: nil,
-        description: nil
+        description: nil,
+        status: nil
       }
+    end
+
+    def standard_error_status(error)
+      error.try(:status).to_s.presence ||
+        error.try(:status_code).to_s.presence ||
+        error.try(:code).to_s.presence ||
+        '503'
     end
   end
 end

--- a/app/services/users/exception_handler.rb
+++ b/app/services/users/exception_handler.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Users
+  class ExceptionHandler
+    include Common::Client::ServiceStatus
+
+    attr_reader :error, :service
+
+    # @param error [ErrorClass] An external service error
+    # @param service [String] The name of the external service (i.e. 'Vet360', 'MVI', 'EMIS')
+    #
+    def initialize(error, service)
+      @error = validate!(error)
+      @service = service
+    end
+
+    # Serializes the initialized error into one of the predetermined error types.
+    # Uses error classes that can be triggered by MVI, EMIS, or Vet360.
+    #
+    # The serialized error format is modelled after the Maintenance Windows schema,
+    # per the FE's request.
+    #
+    # @return [Hash] A serialized version of the initialized error. Follows maintenance
+    # window schema.
+    # @see https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/site/getMaintenanceWindows
+    #
+    def serialize_error
+      case error
+      when Common::Exceptions::BaseError
+        base_error
+      when Common::Client::Errors::ClientError
+        client_error
+      when EMISRedis::VeteranStatus::NotAuthorized
+        emis_error(:not_authorized)
+      when EMISRedis::VeteranStatus::RecordNotFound
+        emis_error(:not_found)
+      else
+        standard_error
+      end
+    end
+
+    private
+
+    def validate!(error)
+      raise Common::Exceptions::ParameterMissing.new('error'), 'error' if error.blank?
+
+      error
+    end
+
+    def base_error
+      exception = error.errors.first
+
+      error_template.merge(description: "#{exception.code}, #{exception.status}, #{exception.title}, #{exception.detail}")
+    end
+
+    def client_error
+      error_template.merge(description: "#{error.class}, #{error.status}, #{error.message}, #{error.body}")
+    end
+
+    def emis_error(type)
+      error_template.merge(description: "#{error.class}, #{RESPONSE_STATUS[type]}")
+    end
+
+    def standard_error
+      error_template.merge(description: "#{error.class}, #{error.message}, #{error}")
+    end
+
+    def error_template
+      {
+        external_service: service,
+        start_time: Time.current.iso8601,
+        end_time: nil,
+        description: nil
+      }
+    end
+  end
+end

--- a/app/services/users/exception_handler.rb
+++ b/app/services/users/exception_handler.rb
@@ -52,14 +52,14 @@ module Users
 
       error_template.merge(
         description: "#{exception.code}, #{exception.status}, #{exception.title}, #{exception.detail}",
-        status: exception.status.to_s
+        status: exception.status.to_i
       )
     end
 
     def client_error
       error_template.merge(
         description: "#{error.class}, #{error.status}, #{error.message}, #{error.body}",
-        status: error.status.to_s
+        status: error.status.to_i
       )
     end
 
@@ -88,10 +88,10 @@ module Users
     end
 
     def standard_error_status(error)
-      error.try(:status).to_s.presence ||
-        error.try(:status_code).to_s.presence ||
-        error.try(:code).to_s.presence ||
-        '503'
+      error.try(:status).presence ||
+        error.try(:status_code).presence ||
+        error.try(:code).presence ||
+        503
     end
   end
 end

--- a/app/services/users/exception_handler.rb
+++ b/app/services/users/exception_handler.rb
@@ -66,7 +66,7 @@ module Users
     def emis_error(type)
       error_template.merge(
         description: "#{error.class}, #{RESPONSE_STATUS[type]}",
-        status: RESPONSE_STATUS[type]
+        status: error.status.to_i
       )
     end
 

--- a/app/services/users/exception_handler.rb
+++ b/app/services/users/exception_handler.rb
@@ -50,7 +50,9 @@ module Users
     def base_error
       exception = error.errors.first
 
-      error_template.merge(description: "#{exception.code}, #{exception.status}, #{exception.title}, #{exception.detail}")
+      error_template.merge(
+        description: "#{exception.code}, #{exception.status}, #{exception.title}, #{exception.detail}"
+      )
     end
 
     def client_error

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -133,7 +133,7 @@ module Users
     end
 
     def prefills_available
-      return [] unless user.identity.present? && user.can_access_prefill_data?
+      return [] if user.identity.blank?
 
       FormProfile.prefill_enabled_forms
     end

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -70,7 +70,8 @@ module Users
         loa: user.loa,
         multifactor: user.multifactor,
         verified: user.loa3?,
-        authn_context: user.authn_context
+        # FIXME: this wont be necessary after FE makes appropriate changes
+        authn_context: user.authn_context.scan(/(myhealthevet|dslogon)/).flatten[0]
       }
     end
 

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+module Users
+  class Profile
+    include Common::Client::ServiceStatus
+
+    HTTP_OK = 200
+    HTTP_SOME_OUTAGES = 296
+
+    attr_reader :user, :scaffold
+
+    def initialize(user)
+      @user = validate!(user)
+      @scaffold = Users::Scaffold.new([], HTTP_OK)
+    end
+
+    # Fetches and serializes all of the initialized user's profile data that
+    # is returned in the '/v0/user' endpoint.
+    #
+    # If there are no external service errors, the status property is set to 200,
+    # and the outages property is set to nil.
+    #
+    # If there *are* errors from any associated external services, the status
+    # property is set to 296, and serialized versions of the errors are
+    # added to the `outages` array.
+    #
+    # @return [Struct] A Struct composed of the fetched, serialized profile data.
+    #
+    def pre_serialize
+      fetch_and_serialize_profile
+      update_status_and_outages
+      scaffold
+    end
+
+    private
+
+    def validate!(user)
+      raise Common::Exceptions::ParameterMissing.new('user'), 'user' unless user&.class == User
+
+      user
+    end
+
+    def fetch_and_serialize_profile
+      scaffold.account = account
+      scaffold.profile = profile
+      scaffold.vet360_contact_information = vet360_contact_information
+      scaffold.va_profile = va_profile
+      scaffold.veteran_status = veteran_status
+      scaffold.in_progress_forms = in_progress_forms
+      scaffold.prefills_available = prefills_available
+      scaffold.services = services
+    end
+
+    def account
+      {
+        account_uuid: user.account_uuid
+      }
+    end
+
+    def profile
+      {
+        email: user.email,
+        first_name: user.first_name,
+        middle_name: user.middle_name,
+        last_name: user.last_name,
+        birth_date: user.birth_date,
+        gender: user.gender,
+        zip: user.zip,
+        last_signed_in: user.last_signed_in,
+        loa: user.loa,
+        multifactor: user.multifactor,
+        verified: user.loa3?,
+        authn_context: user.authn_context
+      }
+    end
+
+    def vet360_contact_information
+      person = user.vet360_contact_info
+      return {} if person.blank?
+
+      {
+        email: person.email,
+        residential_address: person.residential_address,
+        mailing_address: person.mailing_address,
+        mobile_phone: person.mobile_phone,
+        home_phone: person.home_phone,
+        work_phone: person.work_phone,
+        temporary_phone: person.temporary_phone,
+        fax_number: person.fax_number
+      }
+    rescue StandardError => e
+      scaffold.outages << Users::ExceptionHandler.new(e, 'Vet360').serialize_error
+      nil
+    end
+
+    def va_profile
+      status = user.va_profile_status
+
+      if status == RESPONSE_STATUS[:ok]
+        {
+          status: status,
+          birth_date: user.va_profile.birth_date,
+          family_name: user.va_profile.family_name,
+          gender: user.va_profile.gender,
+          given_names: user.va_profile.given_names
+        }
+      else
+        scaffold.outages << Users::ExceptionHandler.new(user.va_profile_error, 'MVI').serialize_error
+        nil
+      end
+    end
+
+    def veteran_status
+      {
+        status: RESPONSE_STATUS[:ok],
+        is_veteran: user.veteran?,
+        served_in_military: user.served_in_military?
+      }
+    rescue StandardError => e
+      scaffold.outages << Users::ExceptionHandler.new(e, 'EMIS').serialize_error
+      nil
+    end
+
+    def in_progress_forms
+      user.in_progress_forms.map do |form|
+        {
+          form: form.form_id,
+          metadata: form.metadata,
+          last_updated: form.updated_at.to_i
+        }
+      end
+    end
+
+    def prefills_available
+      return [] unless user.identity.present? && user.can_access_prefill_data?
+
+      FormProfile.prefill_enabled_forms
+    end
+
+    def services
+      Users::Services.new(user).authorizations
+    end
+
+    def update_status_and_outages
+      if scaffold.outages.present?
+        scaffold.status = HTTP_SOME_OUTAGES
+      else
+        scaffold.outages = nil
+      end
+    end
+  end
+end

--- a/app/services/users/scaffold.rb
+++ b/app/services/users/scaffold.rb
@@ -7,7 +7,9 @@ module Users
   # Note that with Struct's, parameter order matters.  Namely having `outages` first
   # and `status` second.
   #
+  # rubocop:disable Style/StructInheritance
   class Scaffold < Struct.new(:outages, :status, :services, :account, :profile, :va_profile, :veteran_status,
                               :in_progress_forms, :prefills_available, :vet360_contact_information)
   end
+  # rubocop:enable Style/StructInheritance
 end

--- a/app/services/users/scaffold.rb
+++ b/app/services/users/scaffold.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Users
+  # Struct class serving as the pre-serialized object that is passed to the UserSerializer
+  # during the '/v0/user' endpoint call.
+  #
+  # Note that with Struct's, parameter order matters.  Namely having `outages` first
+  # and `status` second.
+  #
+  class Scaffold < Struct.new(:outages, :status, :services, :account, :profile, :va_profile, :veteran_status,
+                              :in_progress_forms, :prefills_available, :vet360_contact_information)
+  end
+end

--- a/app/services/users/scaffold.rb
+++ b/app/services/users/scaffold.rb
@@ -4,11 +4,11 @@ module Users
   # Struct class serving as the pre-serialized object that is passed to the UserSerializer
   # during the '/v0/user' endpoint call.
   #
-  # Note that with Struct's, parameter order matters.  Namely having `outages` first
+  # Note that with Struct's, parameter order matters.  Namely having `errors` first
   # and `status` second.
   #
   # rubocop:disable Style/StructInheritance
-  class Scaffold < Struct.new(:outages, :status, :services, :account, :profile, :va_profile, :veteran_status,
+  class Scaffold < Struct.new(:errors, :status, :services, :account, :profile, :va_profile, :veteran_status,
                               :in_progress_forms, :prefills_available, :vet360_contact_information)
   end
   # rubocop:enable Style/StructInheritance

--- a/app/services/users/services.rb
+++ b/app/services/users/services.rb
@@ -16,7 +16,7 @@ module Users
     #
     # @return [Array<String>] Array of names of services they have access to
     #
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def authorizations
       @list << BackendServices::RX if user.authorize :mhv_prescriptions, :access?
       @list << BackendServices::MESSAGING if user.authorize :mhv_messaging, :access?
@@ -25,15 +25,13 @@ module Users
       @list << BackendServices::EVSS_CLAIMS if user.authorize :evss, :access?
       @list << BackendServices::USER_PROFILE if user.can_access_user_profile?
       @list << BackendServices::APPEALS_STATUS if user.authorize :appeals, :access?
-      @list << BackendServices::SAVE_IN_PROGRESS if user.can_save_partial_forms?
-      @list << BackendServices::FORM_PREFILL if user.can_access_prefill_data?
       @list << BackendServices::ID_CARD if user.can_access_id_card?
       @list << BackendServices::IDENTITY_PROOFED if user.identity_proofed?
       @list << BackendServices::VET360 if user.can_access_vet360?
       @list += BetaRegistration.where(user_uuid: user.uuid).pluck(:feature)
       @list
     end
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     private
 
@@ -41,7 +39,9 @@ module Users
       [
         BackendServices::FACILITIES,
         BackendServices::HCA,
-        BackendServices::EDUCATION_BENEFITS
+        BackendServices::EDUCATION_BENEFITS,
+        BackendServices::SAVE_IN_PROGRESS,
+        BackendServices::FORM_PREFILL
       ]
     end
   end

--- a/app/services/users/services.rb
+++ b/app/services/users/services.rb
@@ -18,21 +18,20 @@ module Users
     #
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
     def authorizations
-      @list.tap do |list|
-        list << BackendServices::RX if user.authorize :mhv_prescriptions, :access?
-        list << BackendServices::MESSAGING if user.authorize :mhv_messaging, :access?
-        list << BackendServices::HEALTH_RECORDS if user.authorize :mhv_health_records, :access?
-        list << BackendServices::MHV_AC if user.authorize :mhv_account_creation, :access?
-        list << BackendServices::EVSS_CLAIMS if user.authorize :evss, :access?
-        list << BackendServices::USER_PROFILE if user.can_access_user_profile?
-        list << BackendServices::APPEALS_STATUS if user.authorize :appeals, :access?
-        list << BackendServices::SAVE_IN_PROGRESS if user.can_save_partial_forms?
-        list << BackendServices::FORM_PREFILL if user.can_access_prefill_data?
-        list << BackendServices::ID_CARD if user.can_access_id_card?
-        list << BackendServices::IDENTITY_PROOFED if user.identity_proofed?
-        list << BackendServices::VET360 if user.can_access_vet360?
-        list +  BetaRegistration.where(user_uuid: user.uuid).pluck(:feature)
-      end
+      @list << BackendServices::RX if user.authorize :mhv_prescriptions, :access?
+      @list << BackendServices::MESSAGING if user.authorize :mhv_messaging, :access?
+      @list << BackendServices::HEALTH_RECORDS if user.authorize :mhv_health_records, :access?
+      @list << BackendServices::MHV_AC if user.authorize :mhv_account_creation, :access?
+      @list << BackendServices::EVSS_CLAIMS if user.authorize :evss, :access?
+      @list << BackendServices::USER_PROFILE if user.can_access_user_profile?
+      @list << BackendServices::APPEALS_STATUS if user.authorize :appeals, :access?
+      @list << BackendServices::SAVE_IN_PROGRESS if user.can_save_partial_forms?
+      @list << BackendServices::FORM_PREFILL if user.can_access_prefill_data?
+      @list << BackendServices::ID_CARD if user.can_access_id_card?
+      @list << BackendServices::IDENTITY_PROOFED if user.identity_proofed?
+      @list << BackendServices::VET360 if user.can_access_vet360?
+      @list += BetaRegistration.where(user_uuid: user.uuid).pluck(:feature)
+      @list
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
 

--- a/app/services/users/services.rb
+++ b/app/services/users/services.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'backend_services'
+
+module Users
+  class Services
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+      @list = auth_free_services
+    end
+
+    # Checks if the initialized user has authorization to access any of the
+    # below services.  Returns an array of services they have access to.
+    #
+    # @return [Array<String>] Array of names of services they have access to
+    #
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
+    def authorizations
+      @list.tap do |list|
+        list << BackendServices::RX if user.authorize :mhv_prescriptions, :access?
+        list << BackendServices::MESSAGING if user.authorize :mhv_messaging, :access?
+        list << BackendServices::HEALTH_RECORDS if user.authorize :mhv_health_records, :access?
+        list << BackendServices::MHV_AC if user.authorize :mhv_account_creation, :access?
+        list << BackendServices::EVSS_CLAIMS if user.authorize :evss, :access?
+        list << BackendServices::USER_PROFILE if user.can_access_user_profile?
+        list << BackendServices::APPEALS_STATUS if user.authorize :appeals, :access?
+        list << BackendServices::SAVE_IN_PROGRESS if user.can_save_partial_forms?
+        list << BackendServices::FORM_PREFILL if user.can_access_prefill_data?
+        list << BackendServices::ID_CARD if user.can_access_id_card?
+        list << BackendServices::IDENTITY_PROOFED if user.identity_proofed?
+        list << BackendServices::VET360 if user.can_access_vet360?
+        list +  BetaRegistration.where(user_uuid: user.uuid).pluck(:feature)
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
+
+    private
+
+    def auth_free_services
+      [
+        BackendServices::FACILITIES,
+        BackendServices::HCA,
+        BackendServices::EDUCATION_BENEFITS
+      ]
+    end
+  end
+end

--- a/app/swagger/requests/user.rb
+++ b/app/swagger/requests/user.rb
@@ -60,7 +60,7 @@ module Swagger
         end
       end
 
-      swagger_schema :UserData, required: [:data, :meta] do
+      swagger_schema :UserData, required: %i[data meta] do
         allOf do
           schema do
             key :'$ref', :Vet360ContactInformation

--- a/app/swagger/requests/user.rb
+++ b/app/swagger/requests/user.rb
@@ -23,47 +23,56 @@ module Swagger
               key :'$ref', :UserData
             end
           end
+
+          response 296 do
+            key :description, 'Get user data with some external service outages'
+            schema do
+              allOf do
+                schema do
+                  key :'$ref', :UserInternalServices
+                end
+                schema do
+                  property :data, type: :object do
+                    property :id, type: :string
+                    property :type, type: :string
+                    property :attributes, type: :object do
+                      property :va_profile, type: %i[object null]
+                      property :veteran_status, type: %i[object null]
+                      property :vet360_contact_information, type: %i[object null]
+                    end
+                  end
+                  property :meta, type: :object do
+                    key :required, [:outages]
+                    property :outages do
+                      key :type, :array
+                      items do
+                        property :external_service, type: :string
+                        property :start_time, type: :string
+                        property :end_time, type: %i[string null]
+                        property :description, type: :string
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
         end
       end
 
-      swagger_schema :UserData, required: [:data] do
+      swagger_schema :UserData, required: [:data, :meta] do
         allOf do
           schema do
             key :'$ref', :Vet360ContactInformation
+          end
+          schema do
+            key :'$ref', :UserInternalServices
           end
           schema do
             property :data, type: :object do
               property :id, type: :string
               property :type, type: :string
               property :attributes, type: :object do
-                property :services, type: :array do
-                  key :example, %w[gibs facilities hca edu-benefits evss-claims appeals-status user-profile id-card
-                                   identity-proofed vet360 rx messaging health-records mhv-accounts
-                                   form-save-in-progress form-prefill]
-                  items do
-                    key :type, :string
-                  end
-                end
-                property :in_progress_forms
-                property :account, type: :object do
-                  property :account_uuid,
-                           type: %w[string null],
-                           example: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef',
-                           description: 'A UUID correlating all user identifiers. Intended to become the user\'s UUID.'
-                end
-                property :profile, type: :object do
-                  property :email, type: :string
-                  property :first_name, type: :string
-                  property :last_name, type: :string
-                  property :birth_date, type: :string
-                  property :gender, type: :string
-                  property :zip, type: :string
-                  property :last_signed_in, type: :string
-                  property :loa, type: :object do
-                    property :current, type: :integer, format: :int32
-                    property :highest, type: :integer, format: :int32
-                  end
-                end
                 property :va_profile, type: :object do
                   property :status, type: :string
                   property :birthdate, type: :string
@@ -82,6 +91,10 @@ module Swagger
                   property :served_in_military, type: :boolean, example: true
                 end
               end
+            end
+            property :meta, type: :object do
+              key :required, [:outages]
+              property :outages, type: :null
             end
           end
         end

--- a/app/swagger/requests/user.rb
+++ b/app/swagger/requests/user.rb
@@ -25,7 +25,7 @@ module Swagger
           end
 
           response 296 do
-            key :description, 'Get user data with some external service outages'
+            key :description, 'Get user data with some external service errors'
             schema do
               allOf do
                 schema do
@@ -42,8 +42,8 @@ module Swagger
                     end
                   end
                   property :meta, type: :object do
-                    key :required, [:outages]
-                    property :outages do
+                    key :required, [:errors]
+                    property :errors do
                       key :type, :array
                       items do
                         property :external_service, type: :string
@@ -93,8 +93,8 @@ module Swagger
               end
             end
             property :meta, type: :object do
-              key :required, [:outages]
-              property :outages, type: :null
+              key :required, [:errors]
+              property :errors, type: :null
             end
           end
         end

--- a/app/swagger/requests/user.rb
+++ b/app/swagger/requests/user.rb
@@ -50,6 +50,7 @@ module Swagger
                         property :start_time, type: :string
                         property :end_time, type: %i[string null]
                         property :description, type: :string
+                        property :status, type: :string
                       end
                     end
                   end

--- a/app/swagger/requests/user.rb
+++ b/app/swagger/requests/user.rb
@@ -50,7 +50,7 @@ module Swagger
                         property :start_time, type: :string
                         property :end_time, type: %i[string null]
                         property :description, type: :string
-                        property :status, type: :string
+                        property :status, type: :integer
                       end
                     end
                   end

--- a/app/swagger/schemas/user_internal_services.rb
+++ b/app/swagger/schemas/user_internal_services.rb
@@ -62,4 +62,3 @@ module Swagger
     end
   end
 end
-

--- a/app/swagger/schemas/user_internal_services.rb
+++ b/app/swagger/schemas/user_internal_services.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Schemas
+    class UserInternalServices
+      include Swagger::Blocks
+
+      swagger_schema :UserInternalServices do
+        property :data, type: :object do
+          property :id, type: :string
+          property :type, type: :string
+          property :attributes, type: :object do
+            property :services, type: :array do
+              key :example, %w[gibs facilities hca edu-benefits evss-claims appeals-status user-profile id-card
+                               identity-proofed vet360 rx messaging health-records mhv-accounts
+                               form-save-in-progress form-prefill]
+              items do
+                key :type, :string
+              end
+            end
+            property :in_progress_forms do
+              key :type, :array
+              items do
+                property :form, type: :string
+                property :metadata, type: :object do
+                  property :version, type: :integer
+                  property :return_url, type: :string
+                  property :expires_at, type: :integer
+                  property :last_updated, type: :integer
+                end
+                property :last_updated, type: :integer
+              end
+            end
+            property :account, type: :object do
+              property :account_uuid,
+                       type: %w[string null],
+                       example: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef',
+                       description: 'A UUID correlating all user identifiers. Intended to become the user\'s UUID.'
+            end
+            property :profile, type: :object do
+              property :email, type: :string
+              property :first_name, type: :string
+              property :last_name, type: :string
+              property :birth_date, type: :string
+              property :gender, type: :string
+              property :zip, type: :string
+              property :last_signed_in, type: :string
+              property :loa, type: :object do
+                property :current, type: :integer, format: :int32
+                property :highest, type: :integer, format: :int32
+              end
+            end
+            property :prefills_available do
+              key :type, :array
+              items do
+                key :type, :string
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -409,6 +409,12 @@ en:
         detail: "The record for the requested user could not be found"
         code: 'MVI_404'
         status: 404
+      MVI_502:
+        <<: *external_defaults
+        title: Bad Gateway
+        detail: "MVI service returned an invalid response"
+        code: 'MVI_502'
+        status: 502
       MVI_503:
         <<: *external_defaults
         title: Service unavailable

--- a/lib/mvi/service.rb
+++ b/lib/mvi/service.rb
@@ -60,7 +60,7 @@ module MVI
       if e.is_a?(MVI::Errors::RecordNotFound)
         mvi_profile_exception_response_for('MVI_404', e, type: 'not_found')
       else
-        mvi_profile_exception_response_for('MVI_503', e)
+        mvi_profile_exception_response_for('MVI_502', e)
       end
     end
     # rubocop:enable Metrics/MethodLength

--- a/modules/openid_auth/spec/requests/mvi_user_request_spec.rb
+++ b/modules/openid_auth/spec/requests/mvi_user_request_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'Return ICN for a User from MVI', type: :request, skip_emis: true
     it 'should respond properly when MVI is down' do
       VCR.use_cassette('mvi/find_candidate/failure') do
         get '/internal/auth/v0/mvi-user', nil, auth_headers
-        expect(response).to have_http_status(:service_unavailable)
+        expect(response).to have_http_status(:bad_gateway)
       end
     end
   end

--- a/spec/factories/beta_registrations.rb
+++ b/spec/factories/beta_registrations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :beta_registration do
+    user_uuid { SecureRandom.uuid }
+    sequence(:feature, 10) { |n| "feature_#{n}" }
+  end
+end

--- a/spec/lib/mvi/service_spec.rb
+++ b/spec/lib/mvi/service_spec.rb
@@ -129,7 +129,7 @@ describe MVI::Service do
         VCR.use_cassette('mvi/find_candidate/invalid_icn') do
           response = subject.find_profile(user)
 
-          server_error_503_expectations_for(response)
+          server_error_502_expectations_for(response)
         end
       end
 
@@ -142,7 +142,7 @@ describe MVI::Service do
         VCR.use_cassette('mvi/find_candidate/icn_not_found') do
           response = subject.find_profile(user)
 
-          server_error_503_expectations_for(response)
+          server_error_502_expectations_for(response)
         end
       end
     end
@@ -257,7 +257,7 @@ describe MVI::Service do
         VCR.use_cassette('mvi/find_candidate/invalid') do
           response = subject.find_profile(user)
 
-          server_error_503_expectations_for(response)
+          server_error_502_expectations_for(response)
         end
       end
     end
@@ -272,7 +272,7 @@ describe MVI::Service do
         VCR.use_cassette('mvi/find_candidate/failure') do
           response = subject.find_profile(user)
 
-          server_error_503_expectations_for(response)
+          server_error_502_expectations_for(response)
         end
       end
     end
@@ -435,6 +435,18 @@ describe MVI::Service do
       end
     end
   end
+end
+
+def server_error_502_expectations_for(response)
+  exception = response.error.errors.first
+
+  expect(response.class).to eq MVI::Responses::FindProfileResponse
+  expect(response.status).to eq server_error
+  expect(response.profile).to be_nil
+  expect(exception.title).to eq 'Bad Gateway'
+  expect(exception.code).to eq 'MVI_502'
+  expect(exception.status).to eq '502'
+  expect(exception.source).to eq MVI::Service
 end
 
 def server_error_503_expectations_for(response)

--- a/spec/request/in_progress_forms_request_spec.rb
+++ b/spec/request/in_progress_forms_request_spec.rb
@@ -234,4 +234,16 @@ RSpec.describe V0::InProgressFormsController, type: :request do
       end
     end
   end
+
+  context 'without a user' do
+    describe '#show' do
+      let(:in_progress_form) { FactoryBot.create(:in_progress_form) }
+
+      it 'returns a 401' do
+        get v0_in_progress_form_url(in_progress_form.form_id), nil
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1074,11 +1074,11 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
       expect(subject).to validate(:get, '/v0/user', 401)
     end
 
-    context '/v0/user endpoint with some external service outages' do
+    context '/v0/user endpoint with some external service errors' do
       let(:user) { build(:user) }
       let(:headers) { { '_headers' => { 'Cookie' => sign_in(user, nil, true) } } }
 
-      it 'supports getting user with some external outages', skip_mvi: true do
+      it 'supports getting user with some external errors', skip_mvi: true do
         expect(subject).to validate(:get, '/v0/user', 296, headers)
       end
     end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1074,6 +1074,15 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
       expect(subject).to validate(:get, '/v0/user', 401)
     end
 
+    context '/v0/user endpoint with some external service outages' do
+      let(:user) { build(:user) }
+      let(:headers) { { '_headers' => { 'Cookie' => sign_in(user, nil, true) } } }
+
+      it 'supports getting user with some external outages', skip_mvi: true do
+        expect(subject).to validate(:get, '/v0/user', 296, headers)
+      end
+    end
+
     context '#feedback' do
       before(:all) do
         Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(Redis.current)

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Fetching user data', type: :request do
       )
     end
 
-    context 'with an outage from a 503 raised by Vet360::ContactInformation::Service#get_person', skip_vet360: true do
+    context 'with an error from a 503 raised by Vet360::ContactInformation::Service#get_person', skip_vet360: true do
       before do
         exception  = 'the server responded with status 503'
         error_body = { 'status' => 'some service unavailable status' }
@@ -79,11 +79,11 @@ RSpec.describe 'Fetching user data', type: :request do
         expect(body.dig('data', 'attributes', 'vet360_contact_information')).to be_nil
       end
 
-      it 'returns meta.outages information', :aggregate_failures do
-        outage = body.dig('meta', 'outages').first
+      it 'returns meta.errors information', :aggregate_failures do
+        error = body.dig('meta', 'errors').first
 
-        expect(outage['external_service']).to eq 'Vet360'
-        expect(outage['description']).to be_present
+        expect(error['external_service']).to eq 'Vet360'
+        expect(error['description']).to be_present
       end
     end
   end
@@ -98,13 +98,13 @@ RSpec.describe 'Fetching user data', type: :request do
       expect(response).to match_response_schema('user_loa1')
     end
 
-    it 'returns a status of 296 with outages', :aggregate_failures do
+    it 'returns a status of 296 with errors', :aggregate_failures do
       body   = JSON.parse(response.body)
-      outage = body.dig('meta', 'outages').first
+      error = body.dig('meta', 'errors').first
 
       expect(response.status).to eq 296
-      expect(outage['external_service']).to eq 'MVI'
-      expect(outage['description']).to be_present
+      expect(error['external_service']).to eq 'MVI'
+      expect(error['description']).to be_present
     end
 
     it 'gives me the list of available services' do
@@ -134,12 +134,12 @@ RSpec.describe 'Fetching user data', type: :request do
         .and not_trigger_statsd_increment('api.external_http_request.MVI.success')
 
       body   = JSON.parse(response.body)
-      outage = body.dig('meta', 'outages').first
+      error = body.dig('meta', 'errors').first
 
       expect(body['data']['attributes']['va_profile']).to be_nil
       expect(response.status).to eq 296
-      expect(outage['external_service']).to eq 'MVI'
-      expect(outage['description']).to be_present
+      expect(error['external_service']).to eq 'MVI'
+      expect(error['description']).to be_present
     end
 
     it 'MVI RecordNotFound should only make a request to MVI one time per request!', :aggregate_failures do
@@ -150,12 +150,12 @@ RSpec.describe 'Fetching user data', type: :request do
         .and not_trigger_statsd_increment('api.external_http_request.MVI.failed')
 
       body   = JSON.parse(response.body)
-      outage = body.dig('meta', 'outages').first
+      error = body.dig('meta', 'errors').first
 
       expect(body['data']['attributes']['va_profile']).to be_nil
       expect(response.status).to eq 296
-      expect(outage['external_service']).to eq 'MVI'
-      expect(outage['description']).to be_present
+      expect(error['external_service']).to eq 'MVI'
+      expect(error['description']).to be_present
     end
 
     it 'MVI DuplicateRecords should only make a request to MVI one time per request!', :aggregate_failures do
@@ -166,12 +166,12 @@ RSpec.describe 'Fetching user data', type: :request do
         .and not_trigger_statsd_increment('api.external_http_request.MVI.failed')
 
       body   = JSON.parse(response.body)
-      outage = body.dig('meta', 'outages').first
+      error = body.dig('meta', 'errors').first
 
       expect(body['data']['attributes']['va_profile']).to be_nil
       expect(response.status).to eq 296
-      expect(outage['external_service']).to eq 'MVI'
-      expect(outage['description']).to be_present
+      expect(error['external_service']).to eq 'MVI'
+      expect(error['description']).to be_present
     end
 
     it 'MVI success should only make a request to MVI one time per multiple requests!' do

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Fetching user data', type: :request do
 
         expect(error['external_service']).to eq 'Vet360'
         expect(error['description']).to be_present
-        expect(error['status']).to eq '502'
+        expect(error['status']).to eq 502
       end
     end
   end
@@ -106,7 +106,7 @@ RSpec.describe 'Fetching user data', type: :request do
       expect(response.status).to eq 296
       expect(error['external_service']).to eq 'MVI'
       expect(error['description']).to be_present
-      expect(error['status']).to eq '401'
+      expect(error['status']).to eq 401
     end
 
     it 'gives me the list of available services' do
@@ -142,7 +142,7 @@ RSpec.describe 'Fetching user data', type: :request do
       expect(response.status).to eq 296
       expect(error['external_service']).to eq 'MVI'
       expect(error['description']).to be_present
-      expect(error['status']).to eq '504'
+      expect(error['status']).to eq 504
     end
 
     it 'MVI RecordNotFound should only make a request to MVI one time per request!', :aggregate_failures do
@@ -159,7 +159,7 @@ RSpec.describe 'Fetching user data', type: :request do
       expect(response.status).to eq 296
       expect(error['external_service']).to eq 'MVI'
       expect(error['description']).to be_present
-      expect(error['status']).to eq '404'
+      expect(error['status']).to eq 404
     end
 
     it 'MVI DuplicateRecords should only make a request to MVI one time per request!', :aggregate_failures do
@@ -176,7 +176,7 @@ RSpec.describe 'Fetching user data', type: :request do
       expect(response.status).to eq 296
       expect(error['external_service']).to eq 'MVI'
       expect(error['description']).to be_present
-      expect(error['status']).to eq '404'
+      expect(error['status']).to eq 404
     end
 
     it 'MVI success should only make a request to MVI one time per multiple requests!' do

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -6,7 +6,7 @@ require 'backend_services'
 RSpec.describe 'Fetching user data', type: :request do
   include SchemaMatchers
 
-  context 'when an LOA 3 user is logged in' do
+  context 'GET /v0/user - when an LOA 3 user is logged in' do
     let(:mhv_user) { build(:user, :mhv) }
 
     before(:each) do
@@ -88,13 +88,13 @@ RSpec.describe 'Fetching user data', type: :request do
     end
   end
 
-  context 'when an LOA 1 user is logged in', :skip_mvi do
+  context 'GET /v0/user - when an LOA 1 user is logged in', :skip_mvi do
     before(:each) do
       sign_in_as(new_user(:loa1))
       get v0_user_url, nil
     end
 
-    it 'GET /v0/user - returns proper json' do
+    it 'returns proper json' do
       expect(response).to match_response_schema('user_loa1')
     end
 
@@ -121,12 +121,12 @@ RSpec.describe 'Fetching user data', type: :request do
     end
   end
 
-  context 'MVI Integration', :skip_mvi do
+  context 'GET /v0/user - MVI Integration', :skip_mvi do
     before(:each) do
       sign_in_as(new_user(:loa3))
     end
 
-    it 'GET /v0/user - for MVI error should only make a request to MVI one time per request!', :aggregate_failures do
+    it 'MVI error should only make a request to MVI one time per request!', :aggregate_failures do
       stub_mvi_failure
       expect { get v0_user_url, nil }
         .to trigger_statsd_increment('api.external_http_request.MVI.failed', times: 1, value: 1)
@@ -142,7 +142,7 @@ RSpec.describe 'Fetching user data', type: :request do
       expect(outage['description']).to be_present
     end
 
-    it 'GET /v0/user - for MVI RecordNotFound should only make a request to MVI one time per request!', :aggregate_failures do
+    it 'MVI RecordNotFound should only make a request to MVI one time per request!', :aggregate_failures do
       stub_mvi_record_not_found
       expect { get v0_user_url, nil }
         .to trigger_statsd_increment('api.external_http_request.MVI.success', times: 1, value: 1)
@@ -158,7 +158,7 @@ RSpec.describe 'Fetching user data', type: :request do
       expect(outage['description']).to be_present
     end
 
-    it 'GET /v0/user - for MVI DuplicateRecords should only make a request to MVI one time per request!', :aggregate_failures do
+    it 'MVI DuplicateRecords should only make a request to MVI one time per request!', :aggregate_failures do
       stub_mvi_duplicate_record
       expect { get v0_user_url, nil }
         .to trigger_statsd_increment('api.external_http_request.MVI.success', times: 1, value: 1)
@@ -174,7 +174,7 @@ RSpec.describe 'Fetching user data', type: :request do
       expect(outage['description']).to be_present
     end
 
-    it 'GET /v0/user - for MVI success should only make a request to MVI one time per multiple requests!' do
+    it 'MVI success should only make a request to MVI one time per multiple requests!' do
       stub_mvi_success
       expect_any_instance_of(Common::Client::Base).to receive(:perform).once.and_call_original
       expect { get v0_user_url, nil }
@@ -185,7 +185,7 @@ RSpec.describe 'Fetching user data', type: :request do
         .not_to trigger_statsd_increment('api.external_http_request.MVI.success', times: 1, value: 1)
     end
 
-    it 'GET /v0/user - for MVI raises a breakers exception after 50% failure rate', :aggregate_failures do
+    it 'MVI raises a breakers exception after 50% failure rate', :aggregate_failures do
       now = Time.current
       start_time = now - 120
       Timecop.freeze(start_time)

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe 'Fetching user data', type: :request do
 
         expect(error['external_service']).to eq 'Vet360'
         expect(error['description']).to be_present
+        expect(error['status']).to eq '502'
       end
     end
   end
@@ -99,12 +100,13 @@ RSpec.describe 'Fetching user data', type: :request do
     end
 
     it 'returns a status of 296 with errors', :aggregate_failures do
-      body   = JSON.parse(response.body)
+      body  = JSON.parse(response.body)
       error = body.dig('meta', 'errors').first
 
       expect(response.status).to eq 296
       expect(error['external_service']).to eq 'MVI'
       expect(error['description']).to be_present
+      expect(error['status']).to eq '401'
     end
 
     it 'gives me the list of available services' do
@@ -133,13 +135,14 @@ RSpec.describe 'Fetching user data', type: :request do
         .and not_trigger_statsd_increment('api.external_http_request.MVI.skipped')
         .and not_trigger_statsd_increment('api.external_http_request.MVI.success')
 
-      body   = JSON.parse(response.body)
+      body  = JSON.parse(response.body)
       error = body.dig('meta', 'errors').first
 
       expect(body['data']['attributes']['va_profile']).to be_nil
       expect(response.status).to eq 296
       expect(error['external_service']).to eq 'MVI'
       expect(error['description']).to be_present
+      expect(error['status']).to eq '504'
     end
 
     it 'MVI RecordNotFound should only make a request to MVI one time per request!', :aggregate_failures do
@@ -149,13 +152,14 @@ RSpec.describe 'Fetching user data', type: :request do
         .and not_trigger_statsd_increment('api.external_http_request.MVI.skipped')
         .and not_trigger_statsd_increment('api.external_http_request.MVI.failed')
 
-      body   = JSON.parse(response.body)
+      body  = JSON.parse(response.body)
       error = body.dig('meta', 'errors').first
 
       expect(body['data']['attributes']['va_profile']).to be_nil
       expect(response.status).to eq 296
       expect(error['external_service']).to eq 'MVI'
       expect(error['description']).to be_present
+      expect(error['status']).to eq '404'
     end
 
     it 'MVI DuplicateRecords should only make a request to MVI one time per request!', :aggregate_failures do
@@ -165,13 +169,14 @@ RSpec.describe 'Fetching user data', type: :request do
         .and not_trigger_statsd_increment('api.external_http_request.MVI.skipped')
         .and not_trigger_statsd_increment('api.external_http_request.MVI.failed')
 
-      body   = JSON.parse(response.body)
+      body  = JSON.parse(response.body)
       error = body.dig('meta', 'errors').first
 
       expect(body['data']['attributes']['va_profile']).to be_nil
       expect(response.status).to eq 296
       expect(error['external_service']).to eq 'MVI'
       expect(error['description']).to be_present
+      expect(error['status']).to eq '404'
     end
 
     it 'MVI success should only make a request to MVI one time per multiple requests!' do

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -4,283 +4,48 @@ require 'rails_helper'
 
 RSpec.describe UserSerializer, type: :serializer do
   let(:user) { create(:user, :loa3) }
+  let!(:in_progress_form) { create(:in_progress_form, user_uuid: user.uuid) }
+  let(:pre_serialized_profile) { Users::Profile.new(user).pre_serialize }
   let(:data) { JSON.parse(subject)['data'] }
   let(:attributes) { data['attributes'] }
-  let(:account) { attributes['account'] }
-  let(:profile) { attributes['profile'] }
-  let(:va_profile) { attributes['va_profile'] }
-  let(:veteran_status) { attributes['veteran_status'] }
 
-  subject { serialize(user, serializer_class: described_class) }
+  subject { serialize(pre_serialized_profile, serializer_class: described_class) }
 
-  it 'should not include ssn anywhere' do
-    expect(attributes['ssn']).to be_nil
-    expect(profile['ssn']).to be_nil
-    expect(va_profile['ssn']).to be_nil
-  end
-
-  describe '#in_progress_forms' do
-    let!(:in_progress_form) { create(:in_progress_form, user_uuid: user.uuid) }
-
-    it 'should include metadata' do
-      expect(attributes['in_progress_forms'][0]['metadata']).to eq(in_progress_form.metadata)
+  context 'when initialized with an object that cannot be called by each of the attributes' do
+    it 'raises an error' do
+      expect { serialize(user, serializer_class: described_class) }.to raise_error(NoMethodError)
     end
   end
 
-  describe '#account' do
-    let(:user) { create(:user, :accountable) }
-    it 'should include account uuid' do
-      expect(account['account_uuid']).to eq(user.account_uuid)
-    end
+  it 'returns serialized #services data' do
+    expect(attributes.dig('services')).to be_present
   end
 
-  describe '#profile' do
-    # --- positive tests ---
-    context 'idme user' do
-      it 'should include authn_context' do
-        expect(profile['authn_context']).to eq(nil)
-      end
-
-      context 'multifactor' do
-        let(:user) { create(:user, :loa1, authn_context: 'multifactor') }
-
-        it 'should include authn_context' do
-          expect(profile['authn_context']).to eq(nil)
-        end
-      end
-    end
-
-    context 'mhv user' do
-      let(:user) { create(:user, :mhv) }
-
-      it 'should include authn_context' do
-        expect(profile['authn_context']).to eq('myhealthevet')
-      end
-
-      context 'multifactor' do
-        let(:user) { create(:user, :loa1, authn_context: 'myhealthevet_multifactor') }
-
-        it 'should include authn_context' do
-          expect(profile['authn_context']).to eq('myhealthevet')
-        end
-      end
-
-      context 'verified' do
-        let(:user) { create(:user, :loa1, authn_context: 'myhealthevet_loa3') }
-
-        it 'should include authn_context' do
-          expect(profile['authn_context']).to eq('myhealthevet')
-        end
-      end
-    end
-
-    context 'dslogon user' do
-      let(:user) { create(:user, :dslogon) }
-
-      it 'should include authn_context' do
-        expect(profile['authn_context']).to eq('dslogon')
-      end
-
-      context 'multifactor' do
-        let(:user) { create(:user, :loa1, authn_context: 'dslogon_multifactor') }
-
-        it 'should include authn_context' do
-          expect(profile['authn_context']).to eq('dslogon')
-        end
-      end
-
-      context 'verified' do
-        let(:user) { create(:user, :loa1, authn_context: 'dslogon_loa3') }
-
-        it 'should include authn_context' do
-          expect(profile['authn_context']).to eq('dslogon')
-        end
-      end
-    end
-
-    it 'should include email' do
-      expect(profile['email']).to eq(user.email)
-    end
-    it 'should include first_name' do
-      expect(profile['first_name']).to eq(user.first_name)
-    end
-    it 'should include middle_name' do
-      expect(profile['middle_name']).to eq(user.middle_name)
-    end
-    it 'should include last_name' do
-      expect(profile['last_name']).to eq(user.last_name)
-    end
-    it 'should include birth_date' do
-      expect(profile['birth_date']).to eq(user.birth_date)
-    end
-    it 'should include gender' do
-      expect(profile['gender']).to eq(user.gender)
-    end
-    it 'should include zip' do
-      expect(profile['zip']).to eq(user.zip)
-    end
-    it 'should include last_signed_in' do
-      expect(Time.zone.parse(profile['last_signed_in']).httpdate).to eq(user.last_signed_in.httpdate)
-    end
-
-    # --- negative tests ---
-    it 'should not include uuid in the profile' do
-      expect(profile['uuid']).to be_nil
-    end
-    it 'should not include edipi in the profile' do
-      expect(profile['edipi']).to be_nil
-    end
-    it 'should not include participant_id in the profile' do
-      expect(profile['participant_id']).to be_nil
-    end
+  it 'returns serialized #account data' do
+    expect(attributes.dig('account')).to be_present
   end
 
-  describe '#va_profile' do
-    context 'when user.mvi is not nil' do
-      it 'should include birth_date' do
-        expect(va_profile['birth_date']).to eq(user.va_profile[:birth_date])
-      end
-      it 'should include family_name' do
-        expect(va_profile['family_name']).to eq(user.va_profile[:family_name])
-      end
-      it 'should include gender' do
-        expect(va_profile['gender']).to eq(user.va_profile[:gender])
-      end
-      it 'should include given_names' do
-        expect(va_profile['given_names']).to eq(user.va_profile[:given_names])
-      end
-      it 'should include status' do
-        expect(va_profile['status']).to eq('OK')
-      end
-    end
-
-    context 'when user.mvi is nil' do
-      let(:user) { create :user }
-      let(:data) { JSON.parse(subject)['data'] }
-      let(:attributes) { data['attributes'] }
-      let(:va_profile) { attributes['va_profile'] }
-
-      it 'returns va_profile as null' do
-        expect(va_profile).to eq(
-          'status' => 'NOT_AUTHORIZED'
-        )
-      end
-    end
-
-    context 'when user.mvi is not found' do
-      before { stub_mvi_not_found }
-
-      let(:data) { JSON.parse(subject)['data'] }
-      let(:attributes) { data['attributes'] }
-      let(:va_profile) { attributes['va_profile'] }
-
-      it 'returns va_profile as null' do
-        expect(va_profile).to eq(
-          'status' => 'NOT_FOUND'
-        )
-      end
-    end
+  it 'returns serialized #profile data' do
+    expect(attributes.dig('profile')).to be_present
   end
 
-  describe '#veteran_status' do
-    context 'when a veteran status is succesfully returned' do
-      it 'should include is_veteran' do
-        expect(veteran_status['is_veteran']).to eq(user.veteran?)
-      end
-
-      it 'should include status' do
-        expect(veteran_status['status']).to eq('OK')
-      end
-
-      it 'should include served_in_military' do
-        expect(veteran_status['served_in_military']).to eq(user.served_in_military?)
-      end
-    end
-
-    context 'when a veteran status is not found' do
-      before(:each) do
-        allow_any_instance_of(
-          EMISRedis::VeteranStatus
-        ).to receive(:veteran?).and_raise(EMISRedis::VeteranStatus::RecordNotFound)
-      end
-
-      it 'should include is_veteran' do
-        expect(veteran_status['is_veteran']).to be_nil
-      end
-
-      it 'should include status' do
-        expect(veteran_status['status']).to eq('NOT_FOUND')
-      end
-    end
-
-    context 'when a veteran status call returns an error' do
-      before(:each) do
-        allow_any_instance_of(
-          EMISRedis::VeteranStatus
-        ).to receive(:veteran?).and_raise(Common::Client::Errors::ClientError)
-      end
-
-      it 'should include is_veteran' do
-        expect(veteran_status['is_veteran']).to be_nil
-      end
-
-      it 'should include status' do
-        expect(veteran_status['status']).to eq('SERVER_ERROR')
-      end
-    end
-
-    context 'with a LOA1 user' do
-      let(:user) { create(:user, :loa1) }
-      let(:serialized_user) { serialize(user, serializer_class: described_class) }
-      let(:expected) { JSON.parse(serialized_user) }
-
-      it 'returns va_profile as null' do
-        allow_any_instance_of(
-          EMISRedis::VeteranStatus
-        ).to receive(:veteran?).and_raise(EMISRedis::VeteranStatus::NotAuthorized)
-        expect(expected['data']['attributes']['veteran_status']).to eq(
-          'status' => 'NOT_AUTHORIZED'
-        )
-      end
-    end
+  it 'returns serialized #va_profile data' do
+    expect(attributes.dig('va_profile')).to be_present
   end
 
-  describe '#vet360_contact_information' do
-    context 'with an loa1 user' do
-      let(:user) { create(:user, :loa1) }
+  it 'returns serialized #veteran_status data' do
+    expect(attributes.dig('veteran_status')).to be_present
+  end
 
-      it 'should return nil' do
-        expect(user.vet360_contact_info).to be_nil
-        expect(attributes['vet360_contact_information']).to eq({})
-      end
-    end
+  it 'returns serialized #in_progress_forms data' do
+    expect(attributes.dig('in_progress_forms')).to be_present
+  end
 
-    context 'with a valid user' do
-      let(:user) { create(:user, :loa3) }
-      let(:json) { attributes['vet360_contact_information'] }
+  it 'returns serialized #prefills_available data' do
+    expect(attributes.dig('prefills_available')).to be_present
+  end
 
-      it 'should be populated' do
-        expect(user.vet360_contact_info).not_to be_nil
-        expect(json).to include(
-          'email',
-          'residential_address',
-          'mailing_address',
-          'home_phone',
-          'mobile_phone',
-          'work_phone',
-          'fax_number',
-          'temporary_phone'
-        )
-
-        expect(json['email']).not_to be_nil
-        expect(json['residential_address']).not_to be_nil
-        expect(json['mailing_address']).not_to be_nil
-        expect(json['home_phone']).not_to be_nil
-        expect(json['mobile_phone']).not_to be_nil
-        expect(json['work_phone']).not_to be_nil
-        expect(json['fax_number']).not_to be_nil
-        expect(json['temporary_phone']).not_to be_nil
-      end
-    end
+  it 'returns serialized #vet360_contact_information data' do
+    expect(attributes.dig('vet360_contact_information')).to be_present
   end
 end

--- a/spec/services/users/exception_handler_spec.rb
+++ b/spec/services/users/exception_handler_spec.rb
@@ -5,15 +5,13 @@ require 'support/mvi/stub_mvi'
 
 RSpec.describe Users::ExceptionHandler do
   let(:user) { build(:user, :loa3) }
-  let(:message)  { 'the server responded with status 503' }
+  let(:message) { 'the server responded with status 503' }
   let(:error_body) { { 'status' => 'some service unavailable status' } }
   let(:service) { 'Vet360' }
 
   describe '.initialize' do
     context 'when initialized without a nil error' do
       it 'raises an exception' do
-        account = build :account
-
         expect { Users::ExceptionHandler.new(nil, service) }.to raise_error(Common::Exceptions::ParameterMissing)
       end
     end

--- a/spec/services/users/exception_handler_spec.rb
+++ b/spec/services/users/exception_handler_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/mvi/stub_mvi'
+
+RSpec.describe Users::ExceptionHandler do
+  let(:user) { build(:user, :loa3) }
+  let(:message)  { 'the server responded with status 503' }
+  let(:error_body) { { 'status' => 'some service unavailable status' } }
+  let(:service) { 'Vet360' }
+
+  describe '.initialize' do
+    context 'when initialized without a nil error' do
+      it 'raises an exception' do
+        account = build :account
+
+        expect { Users::ExceptionHandler.new(nil, service) }.to raise_error(Common::Exceptions::ParameterMissing)
+      end
+    end
+  end
+
+  describe '#serialize_error' do
+    context 'with a Common::Client::Errors::ClientError' do
+      let(:error) { Common::Client::Errors::ClientError.new(message, 503, error_body) }
+      let(:results) { Users::ExceptionHandler.new(error, service).serialize_error }
+
+      it 'returns a serialized version of the error' do
+        expect(results[:description]).to include message, error_body.to_s
+      end
+
+      it 'identifies the external service' do
+        expect(results[:external_service]).to eq service
+      end
+
+      it 'sets the start_time' do
+        expect(results[:start_time]).to be_present
+      end
+    end
+
+    context 'with a Common::Exceptions::GatewayTimeout' do
+      let(:error) { Common::Exceptions::GatewayTimeout.new }
+      let(:results) { Users::ExceptionHandler.new(error, service).serialize_error }
+
+      it 'returns a serialized version of the error' do
+        expect(results[:description]).to include 'Gateway timeout', '504'
+      end
+    end
+
+    context 'with a Common::Exceptions::BackendServiceException' do
+      let(:error) { server_error_exception }
+      let(:results) { Users::ExceptionHandler.new(error, service).serialize_error }
+
+      it 'returns a serialized version of the error' do
+        expect(results[:description]).to include 'MVI_503', '503', 'Service unavailable'
+      end
+    end
+
+    context 'with a EMISRedis::VeteranStatus::NotAuthorized' do
+      let(:error) { EMISRedis::VeteranStatus::NotAuthorized.new }
+      let(:results) { Users::ExceptionHandler.new(error, service).serialize_error }
+
+      it 'returns a serialized version of the error' do
+        expect(results[:description]).to include 'NOT_AUTHORIZED', 'EMISRedis::VeteranStatus::NotAuthorized'
+      end
+    end
+
+    context 'with a EMISRedis::VeteranStatus::RecordNotFound' do
+      let(:error) { EMISRedis::VeteranStatus::RecordNotFound.new }
+      let(:results) { Users::ExceptionHandler.new(error, service).serialize_error }
+
+      it 'returns a serialized version of the error' do
+        expect(results[:description]).to include 'NOT_FOUND', 'EMISRedis::VeteranStatus::RecordNotFound'
+      end
+    end
+
+    context 'with a StandardError' do
+      let(:error) { StandardError.new(message) }
+      let(:results) { Users::ExceptionHandler.new(error, service).serialize_error }
+
+      it 'returns a serialized version of the error' do
+        expect(results[:description]).to include message, 'StandardError'
+      end
+    end
+  end
+end

--- a/spec/services/users/exception_handler_spec.rb
+++ b/spec/services/users/exception_handler_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe Users::ExceptionHandler do
       it 'sets the start_time' do
         expect(results[:start_time]).to be_present
       end
+
+      it 'returns a status' do
+        expect(results[:status]).to eq '503'
+      end
     end
 
     context 'with a Common::Exceptions::GatewayTimeout' do
@@ -41,6 +45,10 @@ RSpec.describe Users::ExceptionHandler do
 
       it 'returns a serialized version of the error' do
         expect(results[:description]).to include 'Gateway timeout', '504'
+      end
+
+      it 'returns a status' do
+        expect(results[:status]).to eq '504'
       end
     end
 
@@ -51,6 +59,10 @@ RSpec.describe Users::ExceptionHandler do
       it 'returns a serialized version of the error' do
         expect(results[:description]).to include 'MVI_503', '503', 'Service unavailable'
       end
+
+      it 'returns a status' do
+        expect(results[:status]).to eq '503'
+      end
     end
 
     context 'with a EMISRedis::VeteranStatus::NotAuthorized' do
@@ -59,6 +71,10 @@ RSpec.describe Users::ExceptionHandler do
 
       it 'returns a serialized version of the error' do
         expect(results[:description]).to include 'NOT_AUTHORIZED', 'EMISRedis::VeteranStatus::NotAuthorized'
+      end
+
+      it 'returns a status' do
+        expect(results[:status]).to eq 'NOT_AUTHORIZED'
       end
     end
 
@@ -69,6 +85,10 @@ RSpec.describe Users::ExceptionHandler do
       it 'returns a serialized version of the error' do
         expect(results[:description]).to include 'NOT_FOUND', 'EMISRedis::VeteranStatus::RecordNotFound'
       end
+
+      it 'returns a status' do
+        expect(results[:status]).to eq 'NOT_FOUND'
+      end
     end
 
     context 'with a StandardError' do
@@ -77,6 +97,10 @@ RSpec.describe Users::ExceptionHandler do
 
       it 'returns a serialized version of the error' do
         expect(results[:description]).to include message, 'StandardError'
+      end
+
+      it 'returns a status' do
+        expect(results[:status]).to eq '503'
       end
     end
   end

--- a/spec/services/users/exception_handler_spec.rb
+++ b/spec/services/users/exception_handler_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Users::ExceptionHandler do
     end
 
     context 'with a EMISRedis::VeteranStatus::NotAuthorized' do
-      let(:error) { EMISRedis::VeteranStatus::NotAuthorized.new }
+      let(:error) { EMISRedis::VeteranStatus::NotAuthorized.new(status: 401) }
       let(:results) { Users::ExceptionHandler.new(error, service).serialize_error }
 
       it 'returns a serialized version of the error' do
@@ -74,12 +74,12 @@ RSpec.describe Users::ExceptionHandler do
       end
 
       it 'returns a status' do
-        expect(results[:status]).to eq 'NOT_AUTHORIZED'
+        expect(results[:status]).to eq 401
       end
     end
 
     context 'with a EMISRedis::VeteranStatus::RecordNotFound' do
-      let(:error) { EMISRedis::VeteranStatus::RecordNotFound.new }
+      let(:error) { EMISRedis::VeteranStatus::RecordNotFound.new(status: 404) }
       let(:results) { Users::ExceptionHandler.new(error, service).serialize_error }
 
       it 'returns a serialized version of the error' do
@@ -87,7 +87,7 @@ RSpec.describe Users::ExceptionHandler do
       end
 
       it 'returns a status' do
-        expect(results[:status]).to eq 'NOT_FOUND'
+        expect(results[:status]).to eq 404
       end
     end
 

--- a/spec/services/users/exception_handler_spec.rb
+++ b/spec/services/users/exception_handler_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Users::ExceptionHandler do
       end
 
       it 'returns a status' do
-        expect(results[:status]).to eq '503'
+        expect(results[:status]).to eq 503
       end
     end
 
@@ -48,7 +48,7 @@ RSpec.describe Users::ExceptionHandler do
       end
 
       it 'returns a status' do
-        expect(results[:status]).to eq '504'
+        expect(results[:status]).to eq 504
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Users::ExceptionHandler do
       end
 
       it 'returns a status' do
-        expect(results[:status]).to eq '503'
+        expect(results[:status]).to eq 503
       end
     end
 
@@ -100,7 +100,7 @@ RSpec.describe Users::ExceptionHandler do
       end
 
       it 'returns a status' do
-        expect(results[:status]).to eq '503'
+        expect(results[:status]).to eq 503
       end
     end
   end

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -61,6 +61,68 @@ RSpec.describe Users::Profile do
 
     context '#profile' do
       # --- positive tests ---
+      context 'idme user' do
+        it 'should include authn_context' do
+          expect(profile[:authn_context]).to eq(nil)
+        end
+
+        context 'multifactor' do
+          let(:user) { create(:user, :loa1, authn_context: 'multifactor') }
+
+          it 'should include authn_context' do
+            expect(profile[:authn_context]).to eq(nil)
+          end
+        end
+      end
+
+      context 'mhv user' do
+        let(:user) { create(:user, :mhv) }
+
+        it 'should include authn_context' do
+          expect(profile[:authn_context]).to eq('myhealthevet')
+        end
+
+        context 'multifactor' do
+          let(:user) { create(:user, :loa1, authn_context: 'myhealthevet_multifactor') }
+
+          it 'should include authn_context' do
+            expect(profile[:authn_context]).to eq('myhealthevet')
+          end
+        end
+
+        context 'verified' do
+          let(:user) { create(:user, :loa1, authn_context: 'myhealthevet_loa3') }
+
+          it 'should include authn_context' do
+            expect(profile[:authn_context]).to eq('myhealthevet')
+          end
+        end
+      end
+
+      context 'dslogon user' do
+        let(:user) { create(:user, :dslogon) }
+
+        it 'should include authn_context' do
+          expect(profile[:authn_context]).to eq('dslogon')
+        end
+
+        context 'multifactor' do
+          let(:user) { create(:user, :loa1, authn_context: 'dslogon_multifactor') }
+
+          it 'should include authn_context' do
+            expect(profile[:authn_context]).to eq('dslogon')
+          end
+        end
+
+        context 'verified' do
+          let(:user) { create(:user, :loa1, authn_context: 'dslogon_loa3') }
+
+          it 'should include authn_context' do
+            expect(profile[:authn_context]).to eq('dslogon')
+          end
+        end
+      end
+
       it 'should include email' do
         expect(profile[:email]).to eq(user.email)
       end

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -394,7 +394,7 @@ RSpec.describe Users::Profile do
 
       context 'when user cannot access prefill data' do
         before do
-          allow(user).to receive(:can_access_prefill_data?).and_return(false)
+          allow_any_instance_of(UserIdentity).to receive(:blank?).and_return(true)
         end
 
         it 'returns an empty array' do

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -209,6 +209,7 @@ RSpec.describe Users::Profile do
           expect(error[:external_service]).to eq 'MVI'
           expect(error[:start_time]).to be_present
           expect(error[:description]).to include 'Not authorized'
+          expect(error[:status]).to eq '401'
         end
 
         it 'sets the status to 296' do
@@ -229,6 +230,7 @@ RSpec.describe Users::Profile do
           expect(error[:external_service]).to eq 'MVI'
           expect(error[:start_time]).to be_present
           expect(error[:description]).to include 'Record not found'
+          expect(error[:status]).to eq '404'
         end
 
         it 'sets the status to 296' do
@@ -273,6 +275,7 @@ RSpec.describe Users::Profile do
           expect(error[:external_service]).to eq 'EMIS'
           expect(error[:start_time]).to be_present
           expect(error[:description]).to include 'NOT_FOUND'
+          expect(error[:status]).to eq 'NOT_FOUND'
         end
 
         it 'sets the status to 296' do
@@ -284,7 +287,7 @@ RSpec.describe Users::Profile do
         before(:each) do
           allow_any_instance_of(
             EMISRedis::VeteranStatus
-          ).to receive(:veteran?).and_raise(Common::Client::Errors::ClientError)
+          ).to receive(:veteran?).and_raise(Common::Client::Errors::ClientError.new(nil, 503))
         end
 
         it 'sets veteran_status to nil' do
@@ -297,6 +300,7 @@ RSpec.describe Users::Profile do
           expect(error[:external_service]).to eq 'EMIS'
           expect(error[:start_time]).to be_present
           expect(error[:description]).to be_present
+          expect(error[:status]).to eq '503'
         end
 
         it 'sets the status to 296' do
@@ -323,6 +327,7 @@ RSpec.describe Users::Profile do
           expect(emis_error[:external_service]).to eq 'EMIS'
           expect(emis_error[:start_time]).to be_present
           expect(emis_error[:description]).to include 'NOT_AUTHORIZED'
+          expect(emis_error[:status]).to eq 'NOT_AUTHORIZED'
         end
 
         it 'sets the status to 296' do
@@ -374,11 +379,12 @@ RSpec.describe Users::Profile do
 
         it 'populates the #errors array with the serialized error', :aggregate_failures do
           results = Users::Profile.new(user).pre_serialize
-          error  = results.errors.first
+          error   = results.errors.first
 
           expect(error[:external_service]).to eq 'Vet360'
           expect(error[:start_time]).to be_present
           expect(error[:description]).to be_present
+          expect(error[:status]).to eq '503'
         end
 
         it 'sets the status to 296' do

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -1,0 +1,351 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::Profile do
+  let(:user) { build(:user, :accountable) }
+  let!(:in_progress_form) { create(:in_progress_form, user_uuid: user.uuid) }
+
+  describe '.initialize' do
+    let(:users_profile) { Users::Profile.new(user) }
+
+    it 'sets #scaffold.status to 200' do
+      expect(users_profile.scaffold.status).to eq 200
+    end
+
+    it 'sets #scaffold.outages to an empty array' do
+      expect(users_profile.scaffold.outages).to eq []
+    end
+
+    context 'when initialized with a non-User object' do
+      it 'raises an exception' do
+        account = build :account
+
+        expect { Users::Profile.new(account) }.to raise_error(Common::Exceptions::ParameterMissing)
+      end
+    end
+  end
+
+  describe '#pre_serialize' do
+    let(:profile) { subject.profile }
+    let(:va_profile) { subject.va_profile }
+    let(:veteran_status) { subject.veteran_status }
+
+    subject { Users::Profile.new(user).pre_serialize }
+
+    it 'should not include ssn anywhere', :aggregate_failures do
+      expect(subject.try(:ssn)).to be_nil
+      expect(subject.profile['ssn']).to be_nil
+      expect(subject.va_profile['ssn']).to be_nil
+    end
+
+    it 'sets the status to 200' do
+      expect(subject.status).to eq 200
+    end
+
+    it 'sets the outages to nil' do
+      expect(subject.outages).to be_nil
+    end
+
+    context '#in_progress_forms' do
+      it 'should include metadata' do
+        expect(subject.in_progress_forms[0][:metadata]).to eq(in_progress_form.metadata)
+      end
+    end
+
+    context '#account' do
+      it 'should include account uuid' do
+        expect(subject.account[:account_uuid]).to eq(user.account_uuid)
+      end
+    end
+
+    context '#profile' do
+      # --- positive tests ---
+      it 'should include email' do
+        expect(profile[:email]).to eq(user.email)
+      end
+
+      it 'should include first_name' do
+        expect(profile[:first_name]).to eq(user.first_name)
+      end
+
+      it 'should include middle_name' do
+        expect(profile[:middle_name]).to eq(user.middle_name)
+      end
+
+      it 'should include last_name' do
+        expect(profile[:last_name]).to eq(user.last_name)
+      end
+
+      it 'should include birth_date' do
+        expect(profile[:birth_date]).to eq(user.birth_date)
+      end
+
+      it 'should include gender' do
+        expect(profile[:gender]).to eq(user.gender)
+      end
+
+      it 'should include zip' do
+        expect(profile[:zip]).to eq(user.zip)
+      end
+
+      it 'should include last_signed_in' do
+        expect(profile[:last_signed_in].httpdate).to eq(user.last_signed_in.httpdate)
+      end
+
+      # --- negative tests ---
+      it 'should not include uuid in the profile' do
+        expect(profile[:uuid]).to be_nil
+      end
+
+      it 'should not include edipi in the profile' do
+        expect(profile[:edipi]).to be_nil
+      end
+
+      it 'should not include participant_id in the profile' do
+        expect(profile[:participant_id]).to be_nil
+      end
+    end
+
+    context '#va_profile' do
+      context 'when user.mvi is not nil' do
+        it 'should include birth_date' do
+          expect(va_profile[:birth_date]).to eq(user.va_profile[:birth_date])
+        end
+
+        it 'should include family_name' do
+          expect(va_profile[:family_name]).to eq(user.va_profile[:family_name])
+        end
+
+        it 'should include gender' do
+          expect(va_profile[:gender]).to eq(user.va_profile[:gender])
+        end
+
+        it 'should include given_names' do
+          expect(va_profile[:given_names]).to eq(user.va_profile[:given_names])
+        end
+
+        it 'should include status' do
+          expect(va_profile[:status]).to eq('OK')
+        end
+
+        it 'sets the status to 200' do
+          expect(subject.status).to eq 200
+        end
+      end
+
+      context 'when user.mvi is nil' do
+        let(:user) { build :user }
+
+        it 'returns va_profile as null' do
+          expect(va_profile).to be_nil
+        end
+
+        it 'populates the #outages array with the serialized error', :aggregate_failures do
+          outage = subject.outages.first
+
+          expect(outage[:external_service]).to eq 'MVI'
+          expect(outage[:start_time]).to be_present
+          expect(outage[:description]).to include 'Not authorized'
+        end
+
+        it 'sets the status to 296' do
+          expect(subject.status).to eq 296
+        end
+      end
+
+      context 'when user.mvi is not found' do
+        before { stub_mvi_not_found }
+
+        it 'returns va_profile as null' do
+          expect(va_profile).to be_nil
+        end
+
+        it 'populates the #outages array with the serialized error', :aggregate_failures do
+          outage = subject.outages.first
+
+          expect(outage[:external_service]).to eq 'MVI'
+          expect(outage[:start_time]).to be_present
+          expect(outage[:description]).to include 'Record not found'
+        end
+
+        it 'sets the status to 296' do
+          expect(subject.status).to eq 296
+        end
+      end
+    end
+
+    context '#veteran_status' do
+      context 'when a veteran status is succesfully returned' do
+        it 'should include is_veteran' do
+          expect(veteran_status[:is_veteran]).to eq(user.veteran?)
+        end
+
+        it 'should include status' do
+          expect(veteran_status[:status]).to eq('OK')
+        end
+
+        it 'should include served_in_military' do
+          expect(veteran_status[:served_in_military]).to eq(user.served_in_military?)
+        end
+
+        it 'sets the status to 200' do
+          expect(subject.status).to eq 200
+        end
+      end
+
+      context 'when a veteran status is not found' do
+        before(:each) do
+          allow_any_instance_of(
+            EMISRedis::VeteranStatus
+          ).to receive(:veteran?).and_raise(EMISRedis::VeteranStatus::RecordNotFound)
+        end
+
+        it 'sets veteran_status to nil' do
+          expect(veteran_status).to be_nil
+        end
+
+        it 'populates the #outages array with the serialized error', :aggregate_failures do
+          outage = subject.outages.first
+
+          expect(outage[:external_service]).to eq 'EMIS'
+          expect(outage[:start_time]).to be_present
+          expect(outage[:description]).to include 'NOT_FOUND'
+        end
+
+        it 'sets the status to 296' do
+          expect(subject.status).to eq 296
+        end
+      end
+
+      context 'when a veteran status call returns an error' do
+        before(:each) do
+          allow_any_instance_of(
+            EMISRedis::VeteranStatus
+          ).to receive(:veteran?).and_raise(Common::Client::Errors::ClientError)
+        end
+
+        it 'sets veteran_status to nil' do
+          expect(veteran_status).to be_nil
+        end
+
+        it 'populates the #outages array with the serialized error', :aggregate_failures do
+          outage = subject.outages.first
+
+          expect(outage[:external_service]).to eq 'EMIS'
+          expect(outage[:start_time]).to be_present
+          expect(outage[:description]).to be_present
+        end
+
+        it 'sets the status to 296' do
+          expect(subject.status).to eq 296
+        end
+      end
+
+      context 'with a LOA1 user' do
+        let(:user) { build(:user, :loa1) }
+
+        before do
+          allow_any_instance_of(
+            EMISRedis::VeteranStatus
+          ).to receive(:veteran?).and_raise(EMISRedis::VeteranStatus::NotAuthorized)
+        end
+
+        it 'returns va_profile as null' do
+          expect(veteran_status).to be_nil
+        end
+
+        it 'populates the #outages array with the serialized error', :aggregate_failures do
+          emis_outage = subject.outages.last
+
+          expect(emis_outage[:external_service]).to eq 'EMIS'
+          expect(emis_outage[:start_time]).to be_present
+          expect(emis_outage[:description]).to include 'NOT_AUTHORIZED'
+        end
+
+        it 'sets the status to 296' do
+          expect(subject.status).to eq 296
+        end
+      end
+    end
+
+    context '#vet360_contact_information' do
+      context 'with an loa1 user' do
+        let(:user) { build(:user, :loa1) }
+
+        it 'should return an empty hash', :aggregate_failures do
+          expect(user.vet360_contact_info).to be_nil
+          expect(subject.vet360_contact_information).to eq({})
+        end
+      end
+
+      context 'with a valid user' do
+        let(:user) { build(:user, :loa3) }
+        let(:vet360_info) { subject.vet360_contact_information }
+
+        it 'should be populated', :aggregate_failures do
+          expect(user.vet360_contact_info).not_to be_nil
+          expect(vet360_info[:email]).to be_present
+          expect(vet360_info[:residential_address]).to be_present
+          expect(vet360_info[:mailing_address]).to be_present
+          expect(vet360_info[:home_phone]).to be_present
+          expect(vet360_info[:mobile_phone]).to be_present
+          expect(vet360_info[:work_phone]).to be_present
+          expect(vet360_info[:fax_number]).to be_present
+          expect(vet360_info[:temporary_phone]).to be_present
+        end
+
+        it 'sets the status to 200' do
+          expect(subject.status).to eq 200
+        end
+      end
+
+      context 'with a rescued error' do
+        let(:message)  { 'the server responded with status 503' }
+        let(:error_body) { { 'status' => 'some service unavailable status' } }
+
+        before do
+          allow_any_instance_of(User).to receive(:vet360_contact_info).and_raise(
+            Common::Client::Errors::ClientError.new(message, 503, error_body)
+          )
+        end
+
+        it 'populates the #outages array with the serialized error', :aggregate_failures do
+          results = Users::Profile.new(user).pre_serialize
+          outage  = results.outages.first
+
+          expect(outage[:external_service]).to eq 'Vet360'
+          expect(outage[:start_time]).to be_present
+          expect(outage[:description]).to be_present
+        end
+
+        it 'sets the status to 296' do
+          expect(subject.status).to eq 296
+        end
+      end
+    end
+
+    context '#prefills_available' do
+      it 'populates with an array of available prefills' do
+        expect(subject.prefills_available).to be_present
+      end
+
+      context 'when user cannot access prefill data' do
+        before do
+          allow(user).to receive(:can_access_prefill_data?).and_return(false)
+        end
+
+        it 'returns an empty array' do
+          expect(subject.prefills_available).to eq []
+        end
+      end
+    end
+
+    context '#services' do
+      it 'returns an array of authorized services', :aggregate_failures do
+        expect(subject.services.class).to eq Array
+        expect(subject.services).to include 'facilities', 'hca', 'edu-benefits'
+      end
+    end
+  end
+end

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe Users::Profile do
       end
 
       context 'with a rescued error' do
-        let(:message)  { 'the server responded with status 503' }
+        let(:message) { 'the server responded with status 503' }
         let(:error_body) { { 'status' => 'some service unavailable status' } }
 
         before do

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Users::Profile do
           expect(error[:external_service]).to eq 'MVI'
           expect(error[:start_time]).to be_present
           expect(error[:description]).to include 'Not authorized'
-          expect(error[:status]).to eq '401'
+          expect(error[:status]).to eq 401
         end
 
         it 'sets the status to 296' do
@@ -230,7 +230,7 @@ RSpec.describe Users::Profile do
           expect(error[:external_service]).to eq 'MVI'
           expect(error[:start_time]).to be_present
           expect(error[:description]).to include 'Record not found'
-          expect(error[:status]).to eq '404'
+          expect(error[:status]).to eq 404
         end
 
         it 'sets the status to 296' do
@@ -300,7 +300,7 @@ RSpec.describe Users::Profile do
           expect(error[:external_service]).to eq 'EMIS'
           expect(error[:start_time]).to be_present
           expect(error[:description]).to be_present
-          expect(error[:status]).to eq '503'
+          expect(error[:status]).to eq 503
         end
 
         it 'sets the status to 296' do
@@ -384,7 +384,7 @@ RSpec.describe Users::Profile do
           expect(error[:external_service]).to eq 'Vet360'
           expect(error[:start_time]).to be_present
           expect(error[:description]).to be_present
-          expect(error[:status]).to eq '503'
+          expect(error[:status]).to eq 503
         end
 
         it 'sets the status to 296' do

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe Users::Profile do
         before(:each) do
           allow_any_instance_of(
             EMISRedis::VeteranStatus
-          ).to receive(:veteran?).and_raise(EMISRedis::VeteranStatus::RecordNotFound)
+          ).to receive(:veteran?).and_raise(EMISRedis::VeteranStatus::RecordNotFound.new(status: 404))
         end
 
         it 'sets veteran_status to nil' do
@@ -275,7 +275,7 @@ RSpec.describe Users::Profile do
           expect(error[:external_service]).to eq 'EMIS'
           expect(error[:start_time]).to be_present
           expect(error[:description]).to include 'NOT_FOUND'
-          expect(error[:status]).to eq 'NOT_FOUND'
+          expect(error[:status]).to eq 404
         end
 
         it 'sets the status to 296' do
@@ -314,7 +314,7 @@ RSpec.describe Users::Profile do
         before do
           allow_any_instance_of(
             EMISRedis::VeteranStatus
-          ).to receive(:veteran?).and_raise(EMISRedis::VeteranStatus::NotAuthorized)
+          ).to receive(:veteran?).and_raise(EMISRedis::VeteranStatus::NotAuthorized.new(status: 401))
         end
 
         it 'returns va_profile as null' do
@@ -327,7 +327,7 @@ RSpec.describe Users::Profile do
           expect(emis_error[:external_service]).to eq 'EMIS'
           expect(emis_error[:start_time]).to be_present
           expect(emis_error[:description]).to include 'NOT_AUTHORIZED'
-          expect(emis_error[:status]).to eq 'NOT_AUTHORIZED'
+          expect(emis_error[:status]).to eq 401
         end
 
         it 'sets the status to 296' do

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Users::Profile do
       expect(users_profile.scaffold.status).to eq 200
     end
 
-    it 'sets #scaffold.outages to an empty array' do
-      expect(users_profile.scaffold.outages).to eq []
+    it 'sets #scaffold.errors to an empty array' do
+      expect(users_profile.scaffold.errors).to eq []
     end
 
     context 'when initialized with a non-User object' do
@@ -43,8 +43,8 @@ RSpec.describe Users::Profile do
       expect(subject.status).to eq 200
     end
 
-    it 'sets the outages to nil' do
-      expect(subject.outages).to be_nil
+    it 'sets the errors to nil' do
+      expect(subject.errors).to be_nil
     end
 
     context '#in_progress_forms' do
@@ -203,12 +203,12 @@ RSpec.describe Users::Profile do
           expect(va_profile).to be_nil
         end
 
-        it 'populates the #outages array with the serialized error', :aggregate_failures do
-          outage = subject.outages.first
+        it 'populates the #errors array with the serialized error', :aggregate_failures do
+          error = subject.errors.first
 
-          expect(outage[:external_service]).to eq 'MVI'
-          expect(outage[:start_time]).to be_present
-          expect(outage[:description]).to include 'Not authorized'
+          expect(error[:external_service]).to eq 'MVI'
+          expect(error[:start_time]).to be_present
+          expect(error[:description]).to include 'Not authorized'
         end
 
         it 'sets the status to 296' do
@@ -223,12 +223,12 @@ RSpec.describe Users::Profile do
           expect(va_profile).to be_nil
         end
 
-        it 'populates the #outages array with the serialized error', :aggregate_failures do
-          outage = subject.outages.first
+        it 'populates the #errors array with the serialized error', :aggregate_failures do
+          error = subject.errors.first
 
-          expect(outage[:external_service]).to eq 'MVI'
-          expect(outage[:start_time]).to be_present
-          expect(outage[:description]).to include 'Record not found'
+          expect(error[:external_service]).to eq 'MVI'
+          expect(error[:start_time]).to be_present
+          expect(error[:description]).to include 'Record not found'
         end
 
         it 'sets the status to 296' do
@@ -267,12 +267,12 @@ RSpec.describe Users::Profile do
           expect(veteran_status).to be_nil
         end
 
-        it 'populates the #outages array with the serialized error', :aggregate_failures do
-          outage = subject.outages.first
+        it 'populates the #errors array with the serialized error', :aggregate_failures do
+          error = subject.errors.first
 
-          expect(outage[:external_service]).to eq 'EMIS'
-          expect(outage[:start_time]).to be_present
-          expect(outage[:description]).to include 'NOT_FOUND'
+          expect(error[:external_service]).to eq 'EMIS'
+          expect(error[:start_time]).to be_present
+          expect(error[:description]).to include 'NOT_FOUND'
         end
 
         it 'sets the status to 296' do
@@ -291,12 +291,12 @@ RSpec.describe Users::Profile do
           expect(veteran_status).to be_nil
         end
 
-        it 'populates the #outages array with the serialized error', :aggregate_failures do
-          outage = subject.outages.first
+        it 'populates the #errors array with the serialized error', :aggregate_failures do
+          error = subject.errors.first
 
-          expect(outage[:external_service]).to eq 'EMIS'
-          expect(outage[:start_time]).to be_present
-          expect(outage[:description]).to be_present
+          expect(error[:external_service]).to eq 'EMIS'
+          expect(error[:start_time]).to be_present
+          expect(error[:description]).to be_present
         end
 
         it 'sets the status to 296' do
@@ -317,12 +317,12 @@ RSpec.describe Users::Profile do
           expect(veteran_status).to be_nil
         end
 
-        it 'populates the #outages array with the serialized error', :aggregate_failures do
-          emis_outage = subject.outages.last
+        it 'populates the #errors array with the serialized error', :aggregate_failures do
+          emis_error = subject.errors.last
 
-          expect(emis_outage[:external_service]).to eq 'EMIS'
-          expect(emis_outage[:start_time]).to be_present
-          expect(emis_outage[:description]).to include 'NOT_AUTHORIZED'
+          expect(emis_error[:external_service]).to eq 'EMIS'
+          expect(emis_error[:start_time]).to be_present
+          expect(emis_error[:description]).to include 'NOT_AUTHORIZED'
         end
 
         it 'sets the status to 296' do
@@ -372,13 +372,13 @@ RSpec.describe Users::Profile do
           )
         end
 
-        it 'populates the #outages array with the serialized error', :aggregate_failures do
+        it 'populates the #errors array with the serialized error', :aggregate_failures do
           results = Users::Profile.new(user).pre_serialize
-          outage  = results.outages.first
+          error  = results.errors.first
 
-          expect(outage[:external_service]).to eq 'Vet360'
-          expect(outage[:start_time]).to be_present
-          expect(outage[:description]).to be_present
+          expect(error[:external_service]).to eq 'Vet360'
+          expect(error[:start_time]).to be_present
+          expect(error[:description]).to be_present
         end
 
         it 'sets the status to 296' do

--- a/spec/services/users/scaffold_spec.rb
+++ b/spec/services/users/scaffold_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::Scaffold do
+  let(:http_ok) { 200 }
+
+  subject { Users::Scaffold.new([], http_ok) }
+
+  context 'an instance of Scaffold' do
+    it 'has #outages as the first parameter' do
+      expect(subject.outages).to eq []
+    end
+
+    it 'has #status as the second parameter' do
+      expect(subject.status).to eq http_ok
+    end
+  end
+end

--- a/spec/services/users/scaffold_spec.rb
+++ b/spec/services/users/scaffold_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Users::Scaffold do
   subject { Users::Scaffold.new([], http_ok) }
 
   context 'an instance of Scaffold' do
-    it 'has #outages as the first parameter' do
-      expect(subject.outages).to eq []
+    it 'has #errors as the first parameter' do
+      expect(subject.errors).to eq []
     end
 
     it 'has #status as the second parameter' do

--- a/spec/services/users/services_spec.rb
+++ b/spec/services/users/services_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Users::Services do
           'edu-benefits',
           'user-profile',
           'form-save-in-progress',
-          'form-prefill',
+          'form-prefill'
         )
       end
     end

--- a/spec/services/users/services_spec.rb
+++ b/spec/services/users/services_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::Services do
+  describe '#authorizations' do
+    let(:user) { build :user, :loa3 }
+
+    subject { Users::Services.new(user).authorizations }
+
+    it 'returns an array of services authorized to the initialized user', :aggregate_failures do
+      expect(subject.class).to eq Array
+      expect(subject).to contain_exactly(
+        'facilities',
+        'hca',
+        'edu-benefits',
+        'evss-claims',
+        'user-profile',
+        'appeals-status',
+        'form-save-in-progress',
+        'form-prefill',
+        'identity-proofed',
+        'vet360'
+      )
+    end
+
+    context 'with an loa1 user' do
+      let(:user) { build :user }
+
+      it 'returns only the services that are authorized to this loa1 user' do
+        expect(subject).to contain_exactly(
+          'facilities',
+          'hca',
+          'edu-benefits',
+          'user-profile',
+          'form-save-in-progress',
+          'form-prefill',
+        )
+      end
+    end
+  end
+end

--- a/spec/services/users/services_spec.rb
+++ b/spec/services/users/services_spec.rb
@@ -5,22 +5,33 @@ require 'rails_helper'
 RSpec.describe Users::Services do
   describe '#authorizations' do
     let(:user) { build :user, :loa3 }
+    let(:beta_feature_preferences) { 'preferences' }
+    let(:beta_feature_admin) { 'admin' }
+
+    before do
+      create :beta_registration, user_uuid: user.uuid, feature: beta_feature_preferences
+      create :beta_registration, user_uuid: user.uuid, feature: beta_feature_admin
+    end
 
     subject { Users::Services.new(user).authorizations }
 
     it 'returns an array of services authorized to the initialized user', :aggregate_failures do
       expect(subject.class).to eq Array
-      expect(subject).to contain_exactly(
-        'facilities',
-        'hca',
-        'edu-benefits',
-        'evss-claims',
-        'user-profile',
-        'appeals-status',
-        'form-save-in-progress',
-        'form-prefill',
-        'identity-proofed',
-        'vet360'
+      expect(subject).to match_array(
+        [
+          'facilities',
+          'hca',
+          'edu-benefits',
+          'evss-claims',
+          'user-profile',
+          'appeals-status',
+          'form-save-in-progress',
+          'form-prefill',
+          'identity-proofed',
+          'vet360',
+          beta_feature_preferences,
+          beta_feature_admin
+        ]
       )
     end
 
@@ -28,13 +39,17 @@ RSpec.describe Users::Services do
       let(:user) { build :user }
 
       it 'returns only the services that are authorized to this loa1 user' do
-        expect(subject).to contain_exactly(
-          'facilities',
-          'hca',
-          'edu-benefits',
-          'user-profile',
-          'form-save-in-progress',
-          'form-prefill'
+        expect(subject).to match_array(
+          [
+            'facilities',
+            'hca',
+            'edu-benefits',
+            'user-profile',
+            'form-save-in-progress',
+            'form-prefill',
+            beta_feature_preferences,
+            beta_feature_admin
+          ]
         )
       end
     end

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -113,7 +113,7 @@
               "start_time": { "type": "string" },
               "end_time": { "type": ["string", null] },
               "description":{ "type": "string" },
-              "status":{ "type": "string" }
+              "status":{ "type": "integer" }
             }
           }
         }

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -112,7 +112,8 @@
               "external_service": { "type": "string" },
               "start_time": { "type": "string" },
               "end_time": { "type": ["string", null] },
-              "description":{ "type": "string" }
+              "description":{ "type": "string" },
+              "status":{ "type": "string" }
             }
           }
         }

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -1,7 +1,7 @@
 {
   "$schema" : "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "required": ["data"],
+  "required": ["data", "meta"],
   "properties": {
     "data": {
       "type": "object",
@@ -70,26 +70,7 @@
               }
             },
             "va_profile": {
-              "type": ["object", "null"],
-              "required": [
-                "status"
-              ],
-              "oneOf": [
-                {
-                  "properties": {
-                    "status": { "type": [ "string" ]  }
-                  }
-                },
-                {
-                  "properties": {
-                    "birth_date": { "type": "string" },
-                    "family_name": { "type": "string" },
-                    "gender": { "type": "string" },
-                    "given_names": { "type": "array" },
-                    "status": { "type": "string"  }
-                  }
-                }
-              ]
+              "type": ["object", "null"]
             },
             "veteran_status": {
               "type": ["object", "null"],
@@ -113,6 +94,25 @@
             },
             "vet360_contact_information": {
               "type": ["object", "null"]
+            }
+          }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": ["outages"],
+      "properties": {
+        "outages": {
+          "description": "Array of the potential external service outage details",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "external_service": { "type": "string" },
+              "start_time": { "type": "string" },
+              "end_time": { "type": ["string", null] },
+              "description":{ "type": "string" }
             }
           }
         }

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -101,10 +101,10 @@
     },
     "meta": {
       "type": "object",
-      "required": ["outages"],
+      "required": ["errors"],
       "properties": {
-        "outages": {
-          "description": "Array of the potential external service outage details",
+        "errors": {
+          "description": "Array of the potential external service error details",
           "type": "array",
           "items": {
             "type": "object",

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -121,9 +121,9 @@
     },
     "meta": {
       "type": "object",
-      "required": ["outages"],
+      "required": ["errors"],
       "properties": {
-        "outages": { "type": ["array", null] }
+        "errors": { "type": ["array", null] }
       }
     }
   }

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -1,7 +1,7 @@
 {
   "$schema" : "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "required": ["data"],
+  "required": ["data", "meta"],
   "properties": {
     "data": {
       "type": "object",
@@ -117,6 +117,13 @@
             }
           }
         }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": ["outages"],
+      "properties": {
+        "outages": { "type": ["array", null] }
       }
     }
   }


### PR DESCRIPTION
## Description of change
Per [this RFC](https://github.com/department-of-veterans-affairs/vets.gov-team/pull/15834), if during the calling of the `/user` endpoint we experience any external service failures, we want to catch them and return a `296` response, indicating "success with some external service errors". 

In addition to that, return `null` in the data object for the failing service and include a `meta errors` object listing the service and the error(s) it received.  The error format should follow the [maintenance windows schema](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/site/getMaintenanceWindows), per [FE request](https://github.com/department-of-veterans-affairs/vets.gov-team/pull/15834#issuecomment-454089359).

The three external service backed attributes are: 
- `vet360_contact_information` (Vet360)
- `va_profile` (MVI)
- `veteran_status` (EMIS) 

@kreek and I discussed at length the best way to implement this.  The three main challenges were:

1. Capturing external service errors in a serializer, and building an `errors` array of those errors, "on the fly" 
2. Adding captured errors from the serializer to a `meta` property that is **not** nested beneath the **data** property, but rather a sibling of it
3. Conditionally setting the `status` coming from the controller, based on the actions of the serializer

Our solution is to "pre-serialize" the user's profile data outside of both the controller and serializer.  And then use this pre-serialized object to:

- capture any external service errors, and serialize them
- set the `errors` property to `null`, or an array of the serialized outages
- set the `status` to `200` or `296`
- pass it to the `UserSerializer` to apply the final, standard serialization formatting


## Testing done
<!-- Please describe testing done to verify the changes. -->
Additional spec coverage.

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Add logic to capture and return a `meta-errors` hash per the RFC
- [x] Refactor `vet360_contact_information` attribute to comply with RFC
- [x] Refactor `va_profile` attribute to comply with RFC
- [x] Refactor `veteran_status` attribute to comply with RFC
- [x] Ensure `/user` endpoint returns a `296` response in these failure cases
- [x] Spec coverage
- [x] Update swagger docs with new potential responses
- [x] FE devs confirmed that the FE has been refactored to meet these changes

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

## Updated Swagger Docs

- `200` response returns a `meta.errors` property set to `null`
- `296` response indicates success with some external service errors.  Includes outage details in `meta.errors` array.  Associated properties are set to `null` (i.e. `va_profile`)

![image](https://user-images.githubusercontent.com/7482329/51624120-6f071000-1ef7-11e9-98d2-6ea754a885c8.png)


