### PR TITLE
Fix url for gids in settings.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -143,7 +143,7 @@ evss:
 
 # Settings for GI Bill Data Service
 gids:
-  url: https://dev.vets.gov/gids
+  url: https://dev.va.gov/gids
 
 # Settings for Healthcare Application
 # This CA chain is nonsense but allows local development to work with pre-prod environment.


### PR DESCRIPTION
## Description of change
This updates the url for gids, so that it works locally by default. I'm not sure if there are other changes that have to happen along with this.

## Testing done
Ran GIBCT locally.

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
