### PR TITLE
Do tests pass on Jenkins with the default saml cert?

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,18 +9,13 @@ mvi:
 
 locators:
   providers_enabled: true
-  
+
 reports:
   aws:
     access_key_id: key
     bucket: bucket
     region: region
     secret_access_key: secret
-
-saml:
-  cert_path: spec/support/certificates/ruby-saml.crt
-  key_path: spec/support/certificates/ruby-saml.key
-
 
 edu:
   prefill: true


### PR DESCRIPTION
I don't intend to merge this, just want to know if `/src/vets-api/config/certs/vetsgov-localhost.crt` is available