### PR TITLE
16160 set upload delay

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -68,9 +68,8 @@ class Form526Submission < ActiveRecord::Base
   private
 
   def submit_uploads
-    form[FORM_526_UPLOADS].each do |upload_data|
-      EVSS::DisabilityCompensationForm::SubmitUploads.perform_async(id, upload_data)
-    end
+    # Put uploads on a one minute delay because of shared workload with EVSS
+    EVSS::DisabilityCompensationForm::SubmitUploads.perform_in(60.seconds, id, form[FORM_526_UPLOADS])
   end
 
   def submit_form_4142

--- a/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
   subject { described_class }
 
   describe 'perform' do
-    let(:upload_data) { submission.form[Form526Submission::FORM_526_UPLOADS].first }
+    let(:upload_data) { [submission.form[Form526Submission::FORM_526_UPLOADS].first] }
     let(:client) { double(:client) }
     let(:document_data) { double(:document_data) }
 
@@ -47,9 +47,9 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
           .to receive(:new)
           .with(
             evss_claim_id: submission.submitted_claim_id,
-            file_name: upload_data['name'],
+            file_name: upload_data.first['name'],
             tracked_item_id: nil,
-            document_type: upload_data['attachmentId']
+            document_type: upload_data.first['attachmentId']
           )
           .and_return(document_data)
 

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -105,10 +105,10 @@ RSpec.describe Form526Submission do
         File.read('spec/support/disability_compensation_form/submissions/with_uploads.json')
       end
 
-      it 'queues 3 upload jobs' do
+      it 'queues 1 upload jobs' do
         expect do
           subject.perform_ancillary_jobs(bid)
-        end.to change(EVSS::DisabilityCompensationForm::SubmitUploads.jobs, :size).by(3)
+        end.to change(EVSS::DisabilityCompensationForm::SubmitUploads.jobs, :size).by(1)
       end
     end
 


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
EVSS has requested that upload jobs for 526 should be submitted sequentially and not in parallel. On top of that, uploads should not start until 60 seconds AFTER the 526 submission has gone through.

## Testing done
<!-- Please describe testing done to verify the changes. -->
local

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)
staging e2e

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] submit_uploads has a 60 second delay
- [x] submit_uploads runs each upload sequentially, not in parallel

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
