### PR TITLE
Form526 fix overflow text

### DIFF
--- a/app/models/saved_claim/disability_compensation.rb
+++ b/app/models/saved_claim/disability_compensation.rb
@@ -40,12 +40,11 @@ class SavedClaim::DisabilityCompensation < SavedClaim
     form8940 = EVSS::DisabilityCompensationForm::Form8940.new(user, @form_hash.deep_dup).translate
 
     form526 = @form_hash.deep_dup
-    form526 = append_overflow_text(form526) if form4142
 
     form526_uploads = form526['form526'].delete('attachments')
 
     {
-      FORM_526 => translate_data(user, form526),
+      FORM_526 => translate_data(user, form526, form4142.present?),
       FORM_526_UPLOADS => form526_uploads,
       FORM_4142 => form4142,
       FORM_0781 => form0781,
@@ -57,11 +56,5 @@ class SavedClaim::DisabilityCompensation < SavedClaim
 
   def translate_data(user, form526)
     self.class::TRANSLATION_CLASS.new(user, form526).translate
-  end
-
-  def append_overflow_text(form526)
-    form526['form526']['overflowText'] = 'VA Form 21-4142/4142a has been completed by the applicant and sent to the ' \
-      'PMR contractor for processing in accordance with M21-1 III.iii.1.D.2.'
-    form526
   end
 end

--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -17,9 +17,10 @@ module EVSS
         'other' => 'OTHER'
       }.freeze
 
-      def initialize(user, form_content)
+      def initialize(user, form_content, has_form4142)
         @user = user
         @form_content = form_content
+        @has_form4142 = has_form4142
         @translated_form = { 'form526' => {} }
       end
 
@@ -27,6 +28,8 @@ module EVSS
         output_form['claimantCertification'] = true
         output_form['standardClaim'] = input_form['standardClaim']
         output_form['applicationExpirationDate'] = application_expiration_date
+
+        output_form.update(append_overflow_text) if @has_form4142
 
         output_form.update(translate_banking_info)
         output_form.update(translate_service_pay)
@@ -50,6 +53,13 @@ module EVSS
 
       def output_form
         @translated_form['form526']
+      end
+
+      def append_overflow_text
+        {
+          'overflowText' => 'VA Form 21-4142/4142a has been completed by the applicant and sent to the ' \
+                            'PMR contractor for processing in accordance with M21-1 III.iii.1.D.2.'
+        }
       end
 
       def translate_banking_info


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
When a 4142 form is present in a 526 submission, the `overflowText` field was not being appended correctly to the form. This has been fixed by moving it into the data translator.

## Testing done
<!-- Please describe testing done to verify the changes. -->
spec

## Testing planned
<!-- Please describe testing planned. -->
staging e2e

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Move `overflowText` appending into data translator

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
