### PR TITLE
hca spec fix

### DIFF
--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
           200,
           '_data' => {
             'hca_dd214_attachment' => {
-              file_data: fixture_file_upload(Rails.root.join('spec', 'fixtures', 'pdf_fill', 'extras.pdf'))
+              file_data: Rack::Test::UploadedFile.new((Rails.root.join('spec', 'fixtures', 'pdf_fill', 'extras.pdf')), 'application/pdf')
             }
           }
         )

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -240,7 +240,9 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
           200,
           '_data' => {
             'hca_dd214_attachment' => {
-              file_data: Rack::Test::UploadedFile.new((Rails.root.join('spec', 'fixtures', 'pdf_fill', 'extras.pdf')), 'application/pdf')
+              file_data: Rack::Test::UploadedFile.new(
+                Rails.root.join('spec', 'fixtures', 'pdf_fill', 'extras.pdf'), 'application/pdf'
+              )
             }
           }
         )


### PR DESCRIPTION
## Description of change
fix hca spec not getting the content type of a file in rspec
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

## Testing done
<!-- Please describe testing done to verify the changes. -->

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
