### PR TITLE
Redirect for session requests made from full screen login.

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -42,7 +42,11 @@ module V0
               reset_session
               logout_url
             end
-      render json: { url: url }
+      if params[:json]
+        render json: { url: url }
+      else
+        redirect_to url
+      end
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
 


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
This allows the full screen login flow to immediately redirect without fetching a URL in a JSON payload first. Accepts a `json` query param to continue to support fetching the URL so that the current default flow with the pop-up can still work.

## Testing done
<!-- Please describe testing done to verify the changes. -->
Local testing of login/logout with FE changes. Verified that the redirect works.

## Testing planned
<!-- Please describe testing planned. -->
Same testing on the deploy environments.

## Acceptance Criteria (Definition of Done)
[x] Session URLs should redirect instead of return a JSON payload.
[x] Continue to accommodate auth flows that depend on the JSON payload.

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
