### PR TITLE
[WIP] Appeals 404 leads to server error

### DIFF
--- a/lib/appeals/responses/appeals.rb
+++ b/lib/appeals/responses/appeals.rb
@@ -7,8 +7,12 @@ module Appeals
       attribute :status, Integer
 
       def initialize(body, status)
-        self.body = body if json_format_is_valid?(body)
         self.status = status
+        if self.status == 404
+          self.body = { 'data' => [] }
+        elsif json_format_is_valid?(body)
+          self.body = body
+        end
       end
 
       private


### PR DESCRIPTION
## Description of change
In development we're throwing server errors hitting the appeals API, rather than just an empty response. The default mock is a 404 which we were trying to validate against the json schema, thereby throwing an error. 

It doesn't appear to happen in higher envs, making me feeling like for a missing ssn caseflow handles this situation differently. So the solution could be to fix the mocks to be more close to what it's doing in production

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
