### PR TITLE
tested authn_context for clicked_deny

### DIFF
--- a/app/services/sso_service.rb
+++ b/app/services/sso_service.rb
@@ -65,10 +65,9 @@ class SSOService
 
   def authn_context
     if saml_response.decrypted_document
-      REXML::XPath.first(saml_response.decrypted_document, '//saml:AuthnContextClassRef')&.text || SAML::User::UNKNOWN_AUTHN_CONTEXT
-    else
-      SAML::User::UNKNOWN_AUTHN_CONTEXT
+      authncontext = REXML::XPath.first(saml_response.decrypted_document, '//saml:AuthnContextClassRef')&.text
     end
+    authncontext || SAML::User::UNKNOWN_AUTHN_CONTEXT
   end
 
   private

--- a/app/services/sso_service.rb
+++ b/app/services/sso_service.rb
@@ -64,7 +64,11 @@ class SSOService
   end
 
   def authn_context
-    REXML::XPath.first(saml_response.decrypted_document, '//saml:AuthnContextClassRef')&.text || 'unknown'
+    if saml_response.decrypted_document
+      REXML::XPath.first(saml_response.decrypted_document, '//saml:AuthnContextClassRef')&.text || SAML::User::UNKNOWN_AUTHN_CONTEXT
+    else
+      SAML::User::UNKNOWN_AUTHN_CONTEXT
+    end
   end
 
   private

--- a/app/services/sso_service.rb
+++ b/app/services/sso_service.rb
@@ -65,9 +65,11 @@ class SSOService
 
   def authn_context
     if saml_response.decrypted_document
-      authncontext = REXML::XPath.first(saml_response.decrypted_document, '//saml:AuthnContextClassRef')&.text
+      REXML::XPath.first(saml_response.decrypted_document, '//saml:AuthnContextClassRef')&.text ||
+        SAML::User::UNKNOWN_AUTHN_CONTEXT
+    else
+      SAML::User::UNKNOWN_AUTHN_CONTEXT
     end
-    authncontext || SAML::User::UNKNOWN_AUTHN_CONTEXT
   end
 
   private

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -24,7 +24,7 @@ StatsD.increment(V0::SessionsController::STATSD_SSO_CALLBACK_FAILED_KEY, 0, tags
 StatsD.increment(V0::SessionsController::STATSD_SSO_CALLBACK_FAILED_KEY, 0, tags: ['error:validations_failed'])
 
 %w[success failure].each do |s|
-  (SAML::User::AUTHN_CONTEXTS.keys + ['unknown']).each do |ctx|
+  (SAML::User::AUTHN_CONTEXTS.keys + [SAML::User::UNKNOWN_AUTHN_CONTEXT]).each do |ctx|
     StatsD.increment(
       V0::SessionsController::STATSD_SSO_CALLBACK_KEY,
       0,

--- a/lib/saml/user.rb
+++ b/lib/saml/user.rb
@@ -21,7 +21,7 @@ module SAML
       'myhealthevet' => { loa_current: nil, sign_in: { service_name: 'myhealthevet' } },
       'dslogon' => { loa_current: nil, sign_in: { service_name: 'dslogon' } }
     }.freeze
-
+    UNKNOWN_AUTHN_CONTEXT = 'unknown'
     attr_reader :saml_response, :saml_attributes, :user_attributes
 
     def initialize(saml_response)

--- a/spec/support/saml/response_builder.rb
+++ b/spec/support/saml/response_builder.rb
@@ -70,17 +70,19 @@ module SAML
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     def build_invalid_saml_response(options)
-      options = options.reverse_merge(is_valid?: false, is_a?: true, decrypted_document: document_partial)
+      options = options.reverse_merge(is_valid?: false, is_a?: true)
       instance_double(OneLogin::RubySaml::Response, options)
     end
 
     def invalid_saml_response
-      build_invalid_saml_response(in_response_to: uuid)
+      build_invalid_saml_response(in_response_to: uuid,
+                                  decrypted_document: document_partial)
     end
 
     def saml_response_click_deny
       build_invalid_saml_response(
         in_response_to: uuid,
+        decrypted_document: nil,
         errors: ['ruh roh'],
         status_message: 'Subject did not consent to attribute release'
       )


### PR DESCRIPTION
## Description of change
`saml_response.decrypted_document` is nil when a user clicks `deny`

http://sentry.vetsgov-internal/vets-gov/platform-api-staging/issues/56491/?query=is:unresolved
## Testing done
modified spec


#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
