### PR TITLE
Using ICN from token before checking from @current_user

### DIFF
--- a/modules/openid_auth/app/controllers/openid_auth/v0/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v0/validation_controller.rb
@@ -15,8 +15,13 @@ module OpenidAuth
 
       private
 
+      def payload_object
+        @payload_object ||= OpenStruct.new(token_payload.merge(va_identifiers: { icn: nil }))
+      end
+
       def validated_payload
-        @validated_payload ||= OpenStruct.new(token_payload.merge(va_identifiers: { icn: @current_user.icn }))
+        payload_object.va_identifiers[:icn] = payload_object.try(:icn) || @current_user.icn
+        payload_object
       end
     end
   end

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
       'exp' => Time.current.utc.to_i + 3600,
       'cid' => '0oa1c01m77heEXUZt2p7',
       'uid' => '00u1zlqhuo3yLa2Xs2p7',
+      'icn' => '73806470379396828',
       'scp' => %w[profile email openid veteran_status.read],
       'sub' => 'ae9ff5f4e4b741389904087d94cd19b2'
     }, {


### PR DESCRIPTION
## Description of change
Based off original ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/1016

Update the openid application controller to fetch the ICN from the Okta profile (if it is not already present in the received token), and use that when establishing a session for the supplied token.

Seems safest to always lookup in the Okta profile even if the access_token contains an ICN.

## Testing done
Updated Rspec test and tested end point locally

## Testing planned
Will test against dev-api.va.gov once merged and deployed

## Acceptance Criteria (Definition of Done)
- /internal/openid_auth/v0/validate looks up Okta user from access_token
- Returns the same response as it does currently

#### Unique to this PR
- [x] ICN coming first from token

#### Applies to all PRs

- [x] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
