### PR TITLE
Enables user serializer to return an HTTP status code for EMIS errors

### DIFF
--- a/app/models/emis_redis/veteran_status.rb
+++ b/app/models/emis_redis/veteran_status.rb
@@ -35,9 +35,19 @@ module EMISRedis
     end
 
     class NotAuthorized < StandardError
+      attr_reader :status
+
+      def initialize(status: nil)
+        @status = status
+      end
     end
 
     class RecordNotFound < StandardError
+      attr_reader :status
+
+      def initialize(status: nil)
+        @status = status
+      end
     end
 
     private
@@ -57,10 +67,10 @@ module EMISRedis
     # @return [Hash] A hash of veteran status properties
     #
     def validated_response
-      raise VeteranStatus::NotAuthorized if !@user.loa3? || !@user.authorize(:emis, :access?)
+      raise VeteranStatus::NotAuthorized.new(status: 401) if !@user.loa3? || !@user.authorize(:emis, :access?)
       response = emis_response('get_veteran_status')
 
-      raise VeteranStatus::RecordNotFound if response.empty?
+      raise VeteranStatus::RecordNotFound.new(status: 404) if response.empty?
       response.items.first
     end
   end

--- a/spec/models/emis_redis/veteran_status_spec.rb
+++ b/spec/models/emis_redis/veteran_status_spec.rb
@@ -25,21 +25,21 @@ describe EMISRedis::VeteranStatus, skip_emis: true do
     end
 
     context 'when the user doesnt have an edipi' do
-      it 'raises VeteranStatus::NotAuthorized' do
+      it 'raises VeteranStatus::NotAuthorized', :aggregate_failures do
         expect(user).to receive(:edipi).and_return(nil)
 
-        expect do
-          subject.veteran?
-        end.to raise_error(described_class::NotAuthorized)
+        expect { subject.veteran? }.to raise_error(described_class::NotAuthorized) do |e|
+          expect(e.status).to eq 401
+        end
       end
     end
 
-    context 'when a record can not be found' do
-      it 'raises VeteranStatus::RecordNotFound' do
+    context 'when a record cannot be found' do
+      it 'raises VeteranStatus::RecordNotFound', :aggregate_failures do
         VCR.use_cassette('emis/get_veteran_status/missing_edipi') do
-          expect do
-            subject.veteran?
-          end.to raise_error(described_class::RecordNotFound)
+          expect { subject.veteran? }.to raise_error(described_class::RecordNotFound) do |e|
+            expect(e.status).to eq 404
+          end
         end
       end
     end


### PR DESCRIPTION
## Description of change

This is part of the work to implement this RFC:

https://github.com/department-of-veterans-affairs/vets.gov-team/pull/15834

It enables the user serializer to return an HTTP status code for EMIS errors.  This is the sibling work to the changes in the MVI error response from this PR: https://github.com/department-of-veterans-affairs/vets-api/pull/2731

And will be leveraged in the new user endpoint’s `meta.errors` array being implemented in: https://github.com/department-of-veterans-affairs/vets-api/pull/2738

## Acceptance Criteria

- [x] Adds an optional `status` attribute on `EMISRedis::VeteranStatus::*` error instances
- [x] By default `status` attr should be `nil`
- [x] Spec coverage 

## Testing done
<!-- Please describe testing done to verify the changes. -->
Added new spec coverage

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Adds an optional `status` attribute on `EMISRedis::VeteranStatus::*` error instances
- [x] By default `status` attr should be `nil`
- [x] Spec coverage 

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
