### PR TITLE
Fix too early late 

### DIFF
--- a/app/services/sso_service.rb
+++ b/app/services/sso_service.rb
@@ -118,6 +118,7 @@ class SSOService
     fail_handler = SAML::AuthFailHandler.new(saml_response)
     @auth_error_code = AUTH_ERRORS[DEFAULT_ERROR_MESSAGE]
     if fail_handler.errors?
+      # fixme status_message is nil for too early/late
       @auth_error_code = AUTH_ERRORS[fail_handler.context[:saml_response][:status_message]]
       @failure_instrumentation_tag = "error:#{fail_handler.error}"
       log_message_to_sentry(fail_handler.message, fail_handler.level, fail_handler.context)

--- a/lib/saml/auth_fail_handler.rb
+++ b/lib/saml/auth_fail_handler.rb
@@ -31,6 +31,7 @@ module SAML
     private
 
     def initialize_errors!
+      @code = '007'
       KNOWN_ERRORS.each do |known_error|
         break if send("#{known_error}?")
       end
@@ -43,7 +44,7 @@ module SAML
         saml_response: {
           status_message: @saml_response.status_message,
           errors: @saml_response.errors,
-          code: @code || '007'
+          code: @code
         }
       }
       set_sentry_params('Other SAML Response Error(s)', :error, context)

--- a/lib/saml/auth_fail_handler.rb
+++ b/lib/saml/auth_fail_handler.rb
@@ -42,7 +42,8 @@ module SAML
       context = {
         saml_response: {
           status_message: @saml_response.status_message,
-          errors: @saml_response.errors
+          errors: @saml_response.errors,
+          code: @code || '007'
         }
       }
       set_sentry_params('Other SAML Response Error(s)', :error, context)
@@ -50,16 +51,19 @@ module SAML
 
     def clicked_deny?
       return false unless only_one_error? && @saml_response.status_message == CLICKED_DENY_MSG
+      @code = '001'
       set_sentry_params(CLICKED_DENY_MSG, :warn)
     end
 
     def auth_too_late?
       return false unless only_one_error? && @saml_response.errors[0].include?(TOO_LATE_MSG)
+      @code = '002'
       set_sentry_params(TOO_LATE_MSG, :warn, @saml_response.errors[0])
     end
 
     def auth_too_early?
       return false unless only_one_error? && @saml_response.errors[0].include?(TOO_EARLY_MSG)
+      @code = '003'
       set_sentry_params(TOO_EARLY_MSG, :error, @saml_response.errors[0])
     end
 

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -474,10 +474,10 @@ RSpec.describe V0::SessionsController, type: :controller do
                   'Subject did not consent to attribute release',
                   'Other random error'
                 ],
-                code: '001'
+                code: '007'
               }
             )
-          expect(post(:saml_callback)).to redirect_to('http://127.0.0.1:3001/auth/login/callback?auth=fail&code=001')
+          expect(post(:saml_callback)).to redirect_to('http://127.0.0.1:3001/auth/login/callback?auth=fail&code=007')
           expect(response).to have_http_status(:found)
           expect(cookies['vagov_session_dev']).to be_nil
         end

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -440,7 +440,8 @@ RSpec.describe V0::SessionsController, type: :controller do
                 errors: [
                   'The status code of the Response was not Success, was Requester => NoAuthnContext ' \
                   '-> AuthnRequest without an authentication context.'
-                ]
+                ],
+                code: '007'
               }
             )
           expect(post(:saml_callback)).to redirect_to('http://127.0.0.1:3001/auth/login/callback?auth=fail&code=007')
@@ -472,7 +473,8 @@ RSpec.describe V0::SessionsController, type: :controller do
                 errors: [
                   'Subject did not consent to attribute release',
                   'Other random error'
-                ]
+                ],
+                code: '001'
               }
             )
           expect(post(:saml_callback)).to redirect_to('http://127.0.0.1:3001/auth/login/callback?auth=fail&code=001')

--- a/spec/support/saml/response_builder.rb
+++ b/spec/support/saml/response_builder.rb
@@ -90,7 +90,8 @@ module SAML
 
     def saml_response_too_late
       build_invalid_saml_response(
-        status_message: 'Current time is on or after NotOnOrAfter condition', in_response_to: uuid,
+        status_message: nil,
+        in_response_to: uuid,
         decrypted_document: document_partial,
         errors: [
           'Current time is on or after NotOnOrAfter condition (2017-02-10 17:03:40 UTC >= 2017-02-10 17:03:30 UTC)'
@@ -100,7 +101,8 @@ module SAML
 
     def saml_response_too_early
       build_invalid_saml_response(
-        status_message: 'Current time is earlier than NotBefore condition', in_response_to: uuid,
+        status_message: nil,
+        in_response_to: uuid,
         decrypted_document: document_partial,
         errors: [
           'Current time is earlier than NotBefore condition (2017-02-10 17:03:30 UTC) < 2017-02-10 17:03:40 UTC)'


### PR DESCRIPTION
## Description of change
written with the understanding that a cleaner refactor will happen shortly, ensure that the proper auth too early codes are passed

## Testing done
specs
## Testing planned
change my computer's clock and test on stage.


#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
