### PR TITLE
restore facility satisfaction data

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -168,7 +168,7 @@ locators:
   nca: https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/NCA_Facilities/FeatureServer/0
   vba: https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/VBA_Facilities/FeatureServer/0
   vc: https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/VHA_VetCenters/FeatureServer/0
-  vha_access_satisfaction: https://www.accesstoshep.va.gov/
+  vha_access_satisfaction: https://www.accesstopwt.va.gov/
   vha_access_waittime: https://www.accesstopwt.va.gov/
   base_path: https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/
   providers_enabled: false

--- a/lib/facilities/bulk_json_client.rb
+++ b/lib/facilities/bulk_json_client.rb
@@ -18,7 +18,7 @@ module Facilities
 
     def download
       query = { 'location' => '*' }
-      perform(:get, 'Main/getRawData', query, nil).body
+      perform(:get, 'Shep/getRawData', query, nil).body
     end
   end
 end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Fixes https://github.com/department-of-veterans-affairs/vets-contrib/issues/1216

## Testing done
<!-- Please describe testing done to verify the changes. -->
local testing of the download job and rspec
## Testing planned
<!-- Please describe testing planned. -->
I'll verify the data in staging and production as it's deployed
## Acceptance Criteria (Definition of Done)
The rake job for downloading facility satisfaction data runs without error and the data is available through the api

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
