### PR TITLE
this should be context, not authn_context...

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -28,7 +28,7 @@ StatsD.increment(V0::SessionsController::STATSD_SSO_CALLBACK_FAILED_KEY, 0, tags
     StatsD.increment(
       V0::SessionsController::STATSD_SSO_CALLBACK_KEY,
       0,
-      tags: ["status:#{s}", "authn_context:#{ctx}"]
+      tags: ["status:#{s}", "context:#{ctx}"]
     )
   end
 end


### PR DESCRIPTION
## Description of change
I was hoping to change this tag to be 'authn_context' but then we realized in code review that there were other dependencies on the old 'context' naming convention. We changed the tag back to 'context', but forgot to change it back here in the initializer.

## Testing done
none

## Testing planned
just verify on prometheus and grafana it's working as expected.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
