### PR TITLE
16721 scrub disability names

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -401,6 +401,13 @@ module EVSS
         return disabilities if input_form['newPrimaryDisabilities'].blank?
 
         input_form['newPrimaryDisabilities'].each do |input_disability|
+          # Disabilities that do not exist in the mapped list (disabilities without
+          # a classification code) need to be scrubbed of characters not allowed by
+          # EVSS's validation.
+          if input_disability['classificationCode'].blank?
+            input_disability['condition'] = scrub_disability_condition(input_disability['condition'])
+          end
+
           case input_disability['cause']
           when 'NEW'
             disabilities.append(map_new(input_disability))
@@ -412,6 +419,12 @@ module EVSS
         end
 
         disabilities
+      end
+
+      def scrub_disability_condition(condition)
+        # Note: the right single quote is intentional - apostrophes are not allowed.
+        re = %r{([a-zA-Z0-9\-’.,\/() ]+)}
+        condition.scan(re).join.squish
       end
 
       def translate_new_secondary_disabilities(disabilities)

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -1114,7 +1114,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
       context 'when given a condition name' do
         let(:condition1) { 'this is only a test' }
         let(:condition2) { '  this    is only     a      test ' }
-        let(:condition3) { '[ this  is ] (only) a ’test’' }
+        let(:condition3) { '[ \'this\'  is ] (only) a ’test’' }
         let(:condition4) { 'this-is,only.a-test' }
         let(:condition5) { 'this ¢is onÈly a töest' }
 


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Disability condition name scrubbing needs to be moved to the backend. Any disability without a `classificationCode` will need to be scrubbed of any characters that do not pass EVSS's validation.

## Testing done
<!-- Please describe testing done to verify the changes. -->
spec

## Testing planned
<!-- Please describe testing planned. -->
staging e2e

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Add disability scrubbing via `scan` regex

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
