### PR TITLE
Increases Vet360 Redis cache TTL to one day

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -49,7 +49,7 @@ development: &defaults
     each_ttl: 604800
   vet360_contact_info_response:
     namespace: vet360-contact-info-response
-    each_ttl: 60 # TODO: Verify that this is the best TTL
+    each_ttl: 86400 # 1 day
   vet360_reference_data_response:
     namespace: vet360-reference-data-response
     each_ttl: 86400


### PR DESCRIPTION
## Description of change

Vet360 team is seeing additional reads and writes.  From their team:

> The Vet360 team is seeing an increase in traffic from va.gov over the past few weeks, specifically a higher volume of writes/reads overall, but mainly a big spike in reads. Could you or someone on your team provide some clarity as to where that spike is coming from?

Associated Slack conversation with @kreek :  

https://dsva.slack.com/archives/CEDMA18AZ/p1549300089173600

We are also seeing increased Vet360 breaker activity and latency on the `v0/user` endpoint.  Associated conversation with @wyattwalter & @kreek :

https://dsva.slack.com/archives/C30LCU8S3/p1549539870720100

Currently the `ttl` for the user contact information coming from Vet360 is set to `60`.

## Testing done
<!-- Please describe testing done to verify the changes. -->
Automated tests

## Testing planned
<!-- Please describe testing planned. -->
Plan on merging this after our daily deploy so I can do testing in staging, where Redis is active, and we are linked up to Vet360's staging server.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Increases the `vet360_contact_info_response` `ttl` from `60`s to `86400`s (one day), in keeping with MVI's `ttl`

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
