### PR TITLE
[WIP] PPMS token proof of concept.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -177,6 +177,11 @@ ppms:
   url: https://some.fakesite.com
   open_timeout: 15
   read_timeout: 55
+  authority: some.fakeauthority.com
+  client_id: 123
+  client_secret: abc
+  tenant: tenant
+  resource: https://some.fakesite.com/resource
 
 # Settings for MyHealthEVet
 mhv:

--- a/lib/facilities/ppms_client.rb
+++ b/lib/facilities/ppms_client.rb
@@ -53,7 +53,7 @@ module Facilities
                     'client_id': Settings.ppms.client_id, 'client_secret': Settings.ppms.client_secret,
                     'grant_type': 'client_credentials', 'resource': Settings.ppms.resource }
       token_response = azure_client.post "/#{Settings.ppms.tenant}/oauth2/token", auth_body
-      token_hash = JSON.parse(token_response)
+      token_hash = JSON.parse(token_response.body)
       token = token_hash['access_token']
       redis.set('ppms-token', token, 'EX': token_hash['expires_in'].to_i - 30)
       token

--- a/lib/facilities/ppms_client.rb
+++ b/lib/facilities/ppms_client.rb
@@ -45,8 +45,7 @@ module Facilities
     end
 
     def fetch_token
-      redis = Redis.new
-      token = redis.get('ppms-token')
+      token = Redis.current.get('ppms-token')
       return token if token
       azure_client = Faraday.new("https://#{Settings.ppms.authority}")
       auth_body = { 'encoding': 'utf8', 'api-version': '1.0',
@@ -55,7 +54,7 @@ module Facilities
       token_response = azure_client.post "/#{Settings.ppms.tenant}/oauth2/token", auth_body
       token_hash = JSON.parse(token_response.body)
       token = token_hash['access_token']
-      redis.set('ppms-token', token, 'EX': token_hash['expires_in'].to_i - 30)
+      Redis.current.set('ppms-token', token, 'EX': token_hash['expires_in'].to_i - 30)
       token
     end
 

--- a/lib/facilities/ppms_client.rb
+++ b/lib/facilities/ppms_client.rb
@@ -50,12 +50,12 @@ module Facilities
       return token if token
       azure_client = Faraday.new("https://#{Settings.ppms.authority}")
       auth_body = { 'encoding': 'utf8', 'api-version': '1.0',
-                 'client_id': Settings.ppms.client_id, 'client_secret': Settings.ppms.client_secret,
-                 'grant_type': 'client_credentials', 'resource': Settings.ppms.resource }
+                    'client_id': Settings.ppms.client_id, 'client_secret': Settings.ppms.client_secret,
+                    'grant_type': 'client_credentials', 'resource': Settings.ppms.resource }
       token_response = azure_client.post "/#{Settings.ppms.tenant}/oauth2/token", auth_body
       token_hash = JSON.parse(token_response)
-      token = token_response['access_token']
-      redis.set('ppms-token', token, 'EX': token_response['expires_in'].to_i - 30)
+      token = token_hash['access_token']
+      redis.set('ppms-token', token, 'EX': token_hash['expires_in'].to_i - 30)
       token
     end
 

--- a/spec/lib/facilities/ppms_client_spec.rb
+++ b/spec/lib/facilities/ppms_client_spec.rb
@@ -55,7 +55,7 @@ module Facilities
       end
 
       it 'should get the token then get data' do
-        VCR.use_casette('facilities/va/ppms', match_requests_on: [regex_matcher]) do
+        VCR.use_cassette('facilities/va/ppms', match_requests_on: [regex_matcher]) do
           r = PPMSClient.new.caresites_test
           expect(r.length).to be > 0
         end

--- a/spec/lib/facilities/ppms_client_spec.rb
+++ b/spec/lib/facilities/ppms_client_spec.rb
@@ -55,7 +55,7 @@ module Facilities
       end
 
       it 'should get the token then get data' do
-        VCR.use_casette('facilities/va/ppms', match_requests_on:[regex_matcher]) do
+        VCR.use_casette('facilities/va/ppms', match_requests_on: [regex_matcher]) do
           r = PPMSClient.new.caresites_test
           expect(r.length).to be > 0
         end

--- a/spec/lib/facilities/ppms_client_spec.rb
+++ b/spec/lib/facilities/ppms_client_spec.rb
@@ -54,6 +54,13 @@ module Facilities
         end
       end
 
+      it 'should get the token then get data' do
+        VCR.use_casette('facilities/va/ppms', match_requests_on:[regex_matcher]) do
+          r = PPMSClient.new.caresites_test
+          expect(r.length).to be > 0
+        end
+      end
+
       it 'should edit the parameters' do
         params = PPMSClient.new.build_params('bbox': [73, -60, 74, -61])
         Rails.logger.info(params)

--- a/spec/support/vcr_cassettes/facilities/va/ppms.yml
+++ b/spec/support/vcr_cassettes/facilities/va/ppms.yml
@@ -128,6 +128,69 @@ http_interactions:
   recorded_at: Fri, 27 Jul 2018 21:30:16 GMT
 - request:
     method: get
+    uri: !ruby/regexp /oauth/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 27 Jul 2018 21:30:16 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips PHP/5.6.25
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      - max-age=31536000; includeSubdomains
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      - OPTIONS
+      - POST
+      - PUT
+      Access-Control-Allow-Headers:
+      - Content-Length
+      - Content-Type
+      - x-contact
+      - x-cull
+      - x-forward-for
+      - x-id
+      - x-token
+      - x-token2
+      - x-username
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '50'
+      Etag:
+      - W/"32-5e15861"
+      Vary:
+      - Accept-Encoding
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"access_token": "a", "expires_in": "3600"}'
+    http_version: 
+  recorded_at: Fri, 27 Jul 2018 21:30:16 GMT
+- request:
+    method: get
     uri: !ruby/regexp /Services/
     body:
       encoding: US-ASCII


### PR DESCRIPTION
## Description of change
This is a proof of concept demonstrating an approach to acquiring the bearer tokens that will be necessary at an undetermined point in the future to authenticate to ppms. Currently this authentication is only enabled for the /CareSites endpoint in the dev and nonprod ppms. For this code to work properly, the environment specific authority, tenant, resource, client id, and client secret need to be added into settings.local.yml. I have this information/a set of credentials for dev (also works for nonprod), someone on the DS team should probably request this information for production when they decide to roll these changes out to production.

Due to incompatibilities with the gems we're using, I opted to do this without a library. Due to the simplicity of the use case, I did not bother creating a client class to wrap the connection to the azure active directory authority. I also didn't put the key for the cached redis token into any namespace. That can be adjusted if desired. Other potential improvements would be to refactor the method into a Faraday middleware to make it easier to hook into all the existing ppms calls or to improve error handling to potentially allow this code to be deployed prior to authentication becoming possible in a production environment. 

Overall I'm looking for input on the approach taken and when and how it should be integrated with the rest of the website given that it's currently unknown when the token will be available/required for production (not for a few months at least).

## Testing done
Tested using rails console in a review instance environment against dev ppms/azure active directory.

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Successfully obtains token and connects to authenticated ppms endpoint.
- [ ] Properly hooked into all ppms calls.

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
