### PR TITLE
Module Migration Loading Issues

### DIFF
--- a/modules/va_facilities/lib/va_facilities/engine.rb
+++ b/modules/va_facilities/lib/va_facilities/engine.rb
@@ -14,6 +14,7 @@ module VaFacilities
       unless app.root.to_s.match root.to_s
         config.paths['db/migrate'].expanded.each do |expanded_path|
           app.config.paths['db/migrate'] << expanded_path
+          ActiveRecord::Migrator.migrations_paths << expanded_path
         end
       end
     end

--- a/modules/vba_documents/lib/vba_documents/engine.rb
+++ b/modules/vba_documents/lib/vba_documents/engine.rb
@@ -13,6 +13,7 @@ module VBADocuments
       unless app.root.to_s.match root.to_s
         config.paths['db/migrate'].expanded.each do |expanded_path|
           app.config.paths['db/migrate'] << expanded_path
+          ActiveRecord::Migrator.migrations_paths << expanded_path
         end
       end
     end


### PR DESCRIPTION
## Description of change
Currently in master there is an issue with modules and how they load migrations.

Can be reproduced by doing this `bundle exec rake db:drop && bundle exec rake db:setup && bundle exec rake db:migrate`

This is because of the way setup figures out which migrations have been run.

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/1310

## Testing done
- locally the above command now works

## Acceptance Criteria (Definition of Done)
- [x] Task no longer fails

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
