### PR TITLE
log more info for auth_too_late errors

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -152,6 +152,7 @@ module V0
       end
     end
 
+    # this method is intended to be temporary as we gather more information on the auth_too_late SAML error
     def log_auth_too_late
       session_object = Session.find(session[:token])
       user = User.find(session_object&.uuid)

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -154,13 +154,14 @@ module V0
 
     def log_auth_too_late
       session_object = Session.find(session[:token])
-      last_signed_in = User.find(session_object&.uuid)&.last_signed_in
+      user = User.find(session_object&.uuid)
 
-      log_message_to_sentry('Signin errror for user who was already signed in',
+      log_message_to_sentry('auth_too_late ',
                             :warn,
                             code: @sso_service.auth_error_code,
                             errors: @sso_service.errors.messages,
-                            last_signed_in: last_signed_in)
+                            last_signed_in_if_logged_in: user&.last_signed_in,
+                            authn_context: user&.authn_context)
     end
 
     def build_logout_errors(logout_response, logout_request)

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe V0::SessionsController, type: :controller do
   include SAML::ResponseBuilder
 
   let(:uuid) { SecureRandom.uuid }
-  let(:token) { SecureRandom.uuid }
+  let(:token) { 'abracadabra-open-sesame' }
   let(:loa1_user) { build(:user, :loa1, uuid: uuid) }
   let(:loa3_user) { build(:user, :loa3, uuid: uuid) }
   let(:saml_user_attributes) { loa3_user.attributes.merge(loa3_user.identity.attributes) }

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe V0::SessionsController, type: :controller do
   include SAML::ResponseBuilder
 
   let(:uuid) { SecureRandom.uuid }
-  let(:token) { 'abracadabra-open-sesame' }
+  let(:token) { SecureRandom.uuid }
   let(:loa1_user) { build(:user, :loa1, uuid: uuid) }
   let(:loa3_user) { build(:user, :loa3, uuid: uuid) }
   let(:saml_user_attributes) { loa3_user.attributes.merge(loa3_user.identity.attributes) }
@@ -434,7 +434,7 @@ RSpec.describe V0::SessionsController, type: :controller do
         before { allow(OneLogin::RubySaml::Response).to receive(:new).and_return(saml_response_too_late) }
 
         it 'redirects to an auth failure page' do
-          expect(Rails.logger).to receive(:warn).with(/#{SAML::AuthFailHandler::TOO_LATE_MSG}/)
+          expect(Rails.logger).to receive(:warn).with(/#{SAML::AuthFailHandler::TOO_LATE_MSG}/).twice
           expect(post(:saml_callback)).to redirect_to('http://127.0.0.1:3001/auth/login/callback?auth=fail&code=002')
           expect(response).to have_http_status(:found)
           expect(cookies['vagov_session_dev']).to be_nil


### PR DESCRIPTION
## Description of change
as a precursor or substitue to https://github.com/department-of-veterans-affairs/vets-api/pull/2816, log additional information about auth_too_late errors

## Testing done
specs
#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
