### PR TITLE
remove unnecessary code in user model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,9 +36,7 @@ class User < Common::RedisStore
   attribute :last_signed_in, Common::UTCTime # vaafi attributes
   attribute :mhv_last_signed_in, Common::UTCTime # MHV audit logging
 
-  # identity attributes, some of these will be overridden by MVI.
   delegate :email, to: :identity, allow_nil: true
-  delegate :first_name, to: :identity, allow_nil: true
 
   # This delegated method is called with #account_uuid
   delegate :uuid, to: :account, prefix: true, allow_nil: true


### PR DESCRIPTION
## Description of change
It looks like [here](https://github.com/department-of-veterans-affairs/vets-api/pull/1598/files#diff-4676c008b11a5480d73d4a6de01e45b9R40) ` delegate :first_name, to: :identity, allow_nil: true` may 
have unintentionally been left behind. As far as I can tell, it would be overwritten by `def first_name`

## Testing done
specs, should be no behavior change.

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
