### PR TITLE
Art.526 auto cest model

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190201211124) do
+ActiveRecord::Schema.define(version: 20190211163050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,17 @@ ActiveRecord::Schema.define(version: 20190201211124) do
 
   add_index "central_mail_submissions", ["saved_claim_id"], name: "index_central_mail_submissions_on_saved_claim_id", using: :btree
   add_index "central_mail_submissions", ["state"], name: "index_central_mail_submissions_on_state", using: :btree
+
+  create_table "claims_api_auto_established_claims", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.string   "status"
+    t.string   "encrypted_form_data"
+    t.string   "encrypted_form_data_iv"
+    t.string   "encrypted_auth_headers"
+    t.string   "encrypted_auth_headers_iv"
+    t.integer  "evss_id"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
 
   create_table "disability_compensation_job_statuses", force: :cascade do |t|
     t.integer  "disability_compensation_submission_id", null: false

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_dependency 'claims_api/form_526'
-
 module ClaimsApi
   class AutoEstablishedClaim < ActiveRecord::Base
     attr_encrypted(:form_data, key: Settings.db_encryption_key)

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -13,9 +13,5 @@ module ClaimsApi
     ERRORED = 'errored'
 
     alias token id
-
-    def form
-      @form ||= ClaimsApi::Form526.new(JSON.parse(form_data).deep_symbolize_keys)
-    end
   end
 end

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_dependency 'claims_api/form_526'
+
+module ClaimsApi
+  class AutoEstablishedClaim < ActiveRecord::Base
+    attr_encrypted(:form_data, key: Settings.db_encryption_key)
+    attr_encrypted(:auth_headers, key: Settings.db_encryption_key)
+
+    PENDING = 'pending'
+    SUBMITTED = 'submitted'
+    ESTABLISHED = 'established'
+    ERRORED = 'errored'
+
+    alias token id
+
+    def form
+      @form ||= ClaimsApi::Form526.new(JSON.parse(form_data).deep_symbolize_keys)
+    end
+  end
+end

--- a/modules/claims_api/db/migrate/20190211163050_create_auto_established_claims.rb
+++ b/modules/claims_api/db/migrate/20190211163050_create_auto_established_claims.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateAutoEstablishedClaims < ActiveRecord::Migration
+  def change
+    enable_extension 'uuid-ossp'
+
+    create_table :claims_api_auto_established_claims, id: :uuid do |t|
+      t.string :status
+      t.string :encrypted_form_data
+      t.string :encrypted_form_data_iv
+      t.string :encrypted_auth_headers
+      t.string :encrypted_auth_headers_iv
+      t.integer :evss_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/modules/claims_api/lib/claims_api/engine.rb
+++ b/modules/claims_api/lib/claims_api/engine.rb
@@ -3,5 +3,22 @@
 module ClaimsApi
   class Engine < ::Rails::Engine
     isolate_namespace ClaimsApi
+
+    initializer :append_migrations do |app|
+      unless app.root.to_s.match root.to_s
+        config.paths['db/migrate'].expanded.each do |expanded_path|
+          app.config.paths['db/migrate'] << expanded_path
+          ActiveRecord::Migrator.migrations_paths << expanded_path
+        end
+      end
+    end
+    config.generators do |g|
+      g.test_framework :rspec, view_specs: false
+      g.fixture_replacement :factory_bot
+      g.factory_bot dir: 'spec/factories'
+    end
+    initializer 'claims_api.factories', after: 'factory_bot.set_factory_paths' do
+      FactoryBot.definition_file_paths << File.expand_path('../../../spec/factories', __FILE__) if defined?(FactoryBot)
+    end
   end
 end

--- a/modules/claims_api/spec/factories/auto_established_claims.rb
+++ b/modules/claims_api/spec/factories/auto_established_claims.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :auto_established_claim, class: 'ClaimsApi::AutoEstablishedClaim' do
+    status 'pending'
+    evss_id nil
+    auth_headers nil
+    form_data do
+      File.read("#{::Rails.root}/modules/claims_api/spec/fixtures/form_526.json")
+    end
+  end
+end

--- a/modules/claims_api/spec/fixtures/form_526.json
+++ b/modules/claims_api/spec/fixtures/form_526.json
@@ -1,0 +1,85 @@
+{
+  "data": {
+    "attributes": {
+      "applicationExpirationDate": "2015-08-28T19:53:45+00:00",
+      "militaryPayments": {
+        "receiveCompensationInLieuOfRetired": false,
+        "payments": []
+      },
+      "serviceInformation": {
+        "servedInCombatZone": true,
+        "servicePeriods": [
+          {
+            "activeDutyEndDate": "2018-03-29",
+            "serviceBranch": "National Oceanic & Atmospheric Administration",
+            "activeDutyBeginDate": "2018-03-29"
+          }
+        ]
+      },
+      "veteran": {
+        "emailAddress": "test@email.com",
+        "primaryPhone": {
+          "areaCode": "202",
+          "phoneNumber": "4561111"
+        },
+        "mailingAddress": {
+          "city": "Quaint Town",
+          "country": "USA",
+          "zipFirstFive": "85918",
+          "addressLine1": "1234 Classy Street",
+          "addressLine2": "Apartment 567",
+          "type": "DOMESTIC",
+          "zipLastFour": "1212",
+          "state": "OR"
+        },
+        "alternateEmailAddress": "test2@email.com",
+        "serviceNumber": "string",
+        "forwardingAddress": {
+          "country": "USA",
+          "zipFirstFive": "12345",
+          "addressLine1": "1234 de Buen Tono Calle",
+          "militaryPostOfficeTypeCode": "APO",
+          "addressLine2": "Apartamento 567",
+          "type": "MILITARY",
+          "militaryStateCode": "AA",
+          "effectiveDate": "2018-03-29",
+          "zipLastFour": "6789"
+        }
+      },
+      "disabilities": [
+        {
+          "secondaryDisabilities": [
+            {
+              "diagnosticCode": 5235,
+              "ratedDisabilityId": "",
+              "classificationCode": "",
+              "name": "Diabetes mellitus",
+              "disabilityActionType": "NONE",
+              "specialIssues": [
+                {
+                  "name": "Personal Trauma PTSD",
+                  "code": "TRM"
+                }
+              ]
+            }
+          ],
+          "ratedDisabilityId": "0",
+          "classificationCode": "string",
+          "name": "Diabetes mellitus",
+          "disabilityActionType": "INCREASE",
+          "diagnosticCode": 5235
+        }
+      ],
+      "specialCircumstances": [
+        {
+          "name": "string",
+          "needed": false,
+          "code": "string"
+        }
+      ],
+      "standardClaim": false,
+      "claimantCertification": true
+    }
+  }
+}
+

--- a/modules/claims_api/spec/models/auto_establish_claim_spec.rb
+++ b/modules/claims_api/spec/models/auto_establish_claim_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/attr_encrypted_matcher'
+
+RSpec.describe ClaimsApi::AutoEstablishedClaim, type: :model do
+  let(:auto_form) { build(:auto_established_claim, auth_headers: { some: 'data' }) }
+
+  describe 'encrypted attributes' do
+    it 'should do the thing' do
+      expect(subject).to encrypt_attr(:form_data)
+      expect(subject).to encrypt_attr(:auth_headers)
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
In order to support the Auto CEST effort going on in the claims API, we need a DB model to capture things like form data, auth headers, and status of the submission.

for: https://github.com/department-of-veterans-affairs/vets-contrib/issues/1262

Originally in: #2800 

## Testing done
- quick rspec tests

## Testing planned
- more when the code based changes come in

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
