### PR TITLE
17081 parse incident location

### DIFF
--- a/lib/evss/disability_compensation_form/form0781.rb
+++ b/lib/evss/disability_compensation_form/form0781.rb
@@ -22,7 +22,7 @@ module EVSS
 
         # The pdf creation functionality is looking for a single street address
         # instead of a hash
-        @final_output['incidents'].map do |incident|
+        @final_output['incidents'].each do |incident|
           incident['incidentLocation'] = join_location(incident['incidentLocation']) if incident['incidentLocation']
         end
 

--- a/lib/evss/disability_compensation_form/form0781.rb
+++ b/lib/evss/disability_compensation_form/form0781.rb
@@ -19,10 +19,26 @@ module EVSS
         @final_output['veteranPhone'] = @phone_email['primaryPhone']
         @final_output['veteranSecondaryPhone'] = '' # No secondary phone available in 526 PreFill
         @final_output['veteranServiceNumber'] = '' # No veteran service number available in 526 PreFill
+
+        # The pdf creation functionality is looking for a single street address
+        # instead of a hash
+        @final_output['incidents'].map do |incident|
+          incident['incidentLocation'] = join_location(incident['incidentLocation']) if incident['incidentLocation']
+        end
+
         @final_output
       end
 
       private
+
+      def join_location(location)
+        [
+          location['city'],
+          location['state'],
+          location['country'],
+          location['additionalDetails']
+        ].reject(&:blank?).join(', ')
+      end
 
       def full_name
         {

--- a/spec/support/disability_compensation_form/all_claims_with_0781_fe_submission.json
+++ b/spec/support/disability_compensation_form/all_claims_with_0781_fe_submission.json
@@ -144,7 +144,12 @@
             "from": "2001-01-01",
             "to": "2002-02-02"
           },
-          "incidentLocation": "abcdefghijklmn opqrstuvwxyz1234a bpqrstuvwxyz1234a",
+          "incidentLocation": {
+            "city": "Olympia",
+            "state": "WA",
+            "country": "USA",
+            "additionalDetails": "extra details"
+          },
           "unitAssigned": "abcdefghijklmn opqrstuvwxyz1234a bpqrstuvwxyz1234a",
           "incidentDescription": "Lorem ipsum dolor sit amet.",
           "sources": [
@@ -202,7 +207,11 @@
             "from": "2001-01-01",
             "to": "2002-02-02"
           },
-          "incidentLocation": "abcdefghijklmn opqrstuvwxyz1234a bpqrstuvwxyz1234a",
+          "incidentLocation": {
+            "city": "Portland",
+            "state": "OR",
+            "country": "USA"
+          },
           "unitAssigned": "abcdefghijklmn opqrstuvwxyz1234a bpqrstuvwxyz1234a",
           "incidentDescription": "Lorem ipsum dolor sit amet.",
           "sources": [

--- a/spec/support/disability_compensation_form/form_0781.json
+++ b/spec/support/disability_compensation_form/form_0781.json
@@ -7,7 +7,7 @@
         "from": "2001-01-01",
         "to": "2002-02-02"
       },
-      "incidentLocation": "abcdefghijklmn opqrstuvwxyz1234a bpqrstuvwxyz1234a",
+      "incidentLocation": "Olympia, WA, USA, extra details",
       "unitAssigned": "abcdefghijklmn opqrstuvwxyz1234a bpqrstuvwxyz1234a",
       "incidentDescription": "Lorem ipsum dolor sit amet.",
       "sources": [
@@ -65,7 +65,7 @@
         "from": "2001-01-01",
         "to": "2002-02-02"
       },
-      "incidentLocation": "abcdefghijklmn opqrstuvwxyz1234a bpqrstuvwxyz1234a",
+      "incidentLocation": "Portland, OR, USA",
       "unitAssigned": "abcdefghijklmn opqrstuvwxyz1234a bpqrstuvwxyz1234a",
       "incidentDescription": "Lorem ipsum dolor sit amet.",
       "sources": [


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
The FE is changing how they are submitting incident location addresses for form 781(a). Instead of submitting a single string address it will now be in a more common address object. The PDF creator, however, still expects a single string. The 781 translator will now build this string.

## Testing done
<!-- Please describe testing done to verify the changes. -->
spec tests

## Testing planned
<!-- Please describe testing planned. -->
staging e2e test

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Join address fields for each incident location in 781 translator

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
