### PR TITLE
Fix spelling error in service_history.yml

### DIFF
--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -22,7 +22,7 @@ info:
 
     API requests are authorized using a Bearer token issued through an OpenID
     Connect service to allow third-party applications. The token should be
-    submitted as an `Authorization` header in the form `Bearer <toekn>`.
+    submitted as an `Authorization` header in the form `Bearer <token>`.
 
     ### Service History Request
 


### PR DESCRIPTION
Copied from department-of-veterans-affairs/vets-api/pull/2837.

Fixes error in https://github.com/department-of-veterans-affairs/vets-contrib/issues/1391
"toekn" -> "token"

## Description of change
Fix misspelling in Veteran Verification/Service History endpoint API docs ("toekn" -> "token")

## Testing done
- [x] Checked yml preview

## Testing planned
None

## Acceptance Criteria (Definition of Done)
- [x] Spelling error fixed

#### Unique to this PR
None

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub (above)
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
