### PR TITLE
Add link to API docs to repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vets.gov API [![Build Status](https://dev.vets.gov/jenkins/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vetsgov-internal/job/department-of-veterans-affairs/job/vets-api/job/master/)
 
-This project provides common APIs for applications that live on vets.gov.
+This project provides common APIs for applications that live on vets.gov. Read our [API docs](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/).
 
 ## Base setup
 


### PR DESCRIPTION
## Description of change
Adds link to our docs right up front in the repo readme. 

## Testing done
Clicked on the link.

## Testing planned
None.

## Acceptance Criteria (Definition of Done)
 - [ ] We're confident in the docs enough to link them right in the readme.

#### Unique to this PR

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
