### PR TITLE
17176 sanitize participant id

### DIFF
--- a/lib/mvi/responses/profile_parser.rb
+++ b/lib/mvi/responses/profile_parser.rb
@@ -106,7 +106,7 @@ module MVI
           mhv_ids: correlation_ids[:mhv_ids],
           active_mhv_ids: correlation_ids[:active_mhv_ids],
           edipi: sanitize_edipi(correlation_ids[:edipi]),
-          participant_id: correlation_ids[:vba_corp_id],
+          participant_id: sanitize_participant_id(correlation_ids[:vba_corp_id]),
           vha_facility_ids: correlation_ids[:vha_facility_ids],
           sec_id: correlation_ids[:sec_id],
           birls_id: correlation_ids[:birls_id],
@@ -148,6 +148,16 @@ module MVI
         # Get rid of invalid values like 'UNK'
         sanitized_result = edipi.match(/\d{10}/)&.to_s
         Rails.logger.info "Edipi sanitized was: '#{edipi}' now: '#{sanitized_result}'." unless sanitized_result == edipi
+        sanitized_result
+      end
+
+      def sanitize_participant_id(participant_id)
+        return if participant_id.nil?
+        # Get rid of non-digit characters like 'UNK'/'ASKU'
+        sanitized_result = participant_id.match(/\d+/)&.to_s
+        if sanitized_result != participant_id
+          Rails.logger.info "Participant id sanitized was: '#{participant_id}' now: '#{sanitized_result}'."
+        end
         sanitized_result
       end
 

--- a/spec/lib/mvi/responses/profile_parser_spec.rb
+++ b/spec/lib/mvi/responses/profile_parser_spec.rb
@@ -53,7 +53,7 @@ describe MVI::Responses::ProfileParser do
         end
       end
 
-      context 'with a missing address and an invalid edipi' do
+      context 'with a missing address, invalid edipi, and invalid participant id' do
         let(:body) { Ox.parse(File.read('spec/support/mvi/find_candidate_response_nil_address.xml')) }
         let(:mvi_profile) do
           build(
@@ -64,6 +64,7 @@ describe MVI::Responses::ProfileParser do
             historical_icns: nil,
             vet360_id: nil,
             edipi: nil,
+            participant_id: nil,
             full_mvi_ids: [
               '1000123456V123456^NI^200M^USVHA^P',
               '12345^PI^516^USVHA^PCE',
@@ -72,7 +73,7 @@ describe MVI::Responses::ProfileParser do
               'TKIP123456^PI^200IP^USVHA^A',
               '123456^PI^200MHV^USVHA^A',
               'UNK^NI^200DOD^USDOD^A',
-              '12345678^PI^200CORP^USVBA^A'
+              'UNK^PI^200CORP^USVBA^A'
             ]
           )
         end

--- a/spec/support/mvi/find_candidate_response_nil_address.xml
+++ b/spec/support/mvi/find_candidate_response_nil_address.xml
@@ -3,7 +3,7 @@
               xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <env:Header/>
   <env:Body>
-    <idm:PRPA_IN201306UV02 xmlns="urn:hl7-org:v3" xmlns:idm="http://vaww.oed.oit.va.gov" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    <idm:PRPA_IN201306UV02 xmlns="urn:hl7-org:v3" xmlns:idm="http://scraped.gov" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                            ITSVersion="XML_1.0" xsi:schemaLocation="urn:hl7-org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/PRPA_IN201306UV02.xsd">
       <id extension="WSDOC1609131753362231779394902" root="2.16.840.1.113883.4.349"/>
       <creationTime value="20160913175336"/>
@@ -51,7 +51,7 @@
                 <id extension="TKIP123456^PI^200IP^USVHA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="123456^PI^200MHV^USVHA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="UNK^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12" />
-                <id extension="12345678^PI^200CORP^USVBA^A" root="2.16.840.1.113883.4.349"/>
+                <id extension="UNK^PI^200CORP^USVBA^A" root="2.16.840.1.113883.4.349"/>
                 <statusCode code="active"/>
                 <patientPerson>
                   <name use="L">


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
In attempt to cut down on `unknown` error response from the evss claims service we need to sanitize the participant id that is returned. Essentially, this means making sure that it only contains digits (mostly removing `UNK` or `ASKU`).

## Testing done
<!-- Please describe testing done to verify the changes. -->
Spec tests

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Sanitize participant id from mvi response

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
