### PR TITLE
Move workflow complete handler to ancillary job Batch

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -19,11 +19,6 @@ class Form526Submission < ActiveRecord::Base
 
   def start(klass)
     workflow_batch = Sidekiq::Batch.new
-    workflow_batch.on(
-      :success,
-      'Form526Submission#workflow_complete_handler',
-      'submission_id' => id
-    )
     jids = workflow_batch.jobs do
       klass.perform_async(id)
     end
@@ -48,6 +43,11 @@ class Form526Submission < ActiveRecord::Base
 
   def perform_ancillary_jobs(bid)
     workflow_batch = Sidekiq::Batch.new(bid)
+    workflow_batch.on(
+      :success,
+      'Form526Submission#workflow_complete_handler',
+      'submission_id' => id
+    )
     workflow_batch.jobs do
       submit_uploads if form[FORM_526_UPLOADS].present?
       submit_form_4142 if form[FORM_4142].present?


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Because of a race condition due to a callback placed in the parent batch job and the `submitUploads` job being delayed via its `perform_in(...)` action, workflows are being marked as not complete even though all jobs are finishing successfully. To avoid this, the workflow complete handler is being moved to the child batch job.

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Move workflow complete callback to child job batch

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
