### PR TITLE
Accept no duplicate claim submissions

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 20190313163050) do
     t.integer  "evss_id"
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
+    t.string   "md5"
   end
 
   create_table "claims_api_supporting_documents", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -15,6 +15,9 @@ module ClaimsApi
     ESTABLISHED = 'established'
     ERRORED = 'errored'
 
+    before_validation :set_md5
+    validates :md5, uniqueness: true
+
     alias token id
 
     def form
@@ -28,6 +31,10 @@ module ClaimsApi
 
     def self.evss_id_by_token(token)
       find_by(id: token)&.evss_id
+    end
+
+    def set_md5
+      self.md5 = Digest::MD5.hexdigest form_data.merge(auth_headers).to_json
     end
   end
 end

--- a/modules/claims_api/db/migrate/20190305003907_add_md5_to_claims_api_auto_established_claims.rb
+++ b/modules/claims_api/db/migrate/20190305003907_add_md5_to_claims_api_auto_established_claims.rb
@@ -1,0 +1,5 @@
+class AddMd5ToClaimsApiAutoEstablishedClaims < ActiveRecord::Migration
+  def change
+    add_column :claims_api_auto_established_claims, :md5, :string
+  end
+end

--- a/modules/claims_api/db/migrate/20190305003907_add_md5_to_claims_api_auto_established_claims.rb
+++ b/modules/claims_api/db/migrate/20190305003907_add_md5_to_claims_api_auto_established_claims.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddMd5ToClaimsApiAutoEstablishedClaims < ActiveRecord::Migration
   def change
     add_column :claims_api_auto_established_claims, :md5, :string

--- a/modules/claims_api/spec/factories/auto_established_claims.rb
+++ b/modules/claims_api/spec/factories/auto_established_claims.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :auto_established_claim, class: 'ClaimsApi::AutoEstablishedClaim' do
     status 'pending'
     evss_id nil
-    auth_headers nil
+    auth_headers { {} }
     form_data do
       json = JSON.parse(File.read("#{::Rails.root}/modules/claims_api/spec/fixtures/form_526_json_api.json"))
       json['data']['attributes']

--- a/modules/claims_api/spec/requests/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/disability_compensation_request_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe 'Disability Claims ', type: :request do
       expect(auth_header_stub).to receive(:add_headers)
       post '/services/claims/v0/forms/526', JSON.parse(data), headers
     end
+
+    context 'with the same request already ran' do
+      let!(:count) do
+        post '/services/claims/v0/forms/526', JSON.parse(data), headers
+        ClaimsApi::AutoEstablishedClaim.count
+      end
+
+      it 'should reject the duplicated request' do
+        post '/services/claims/v0/forms/526', JSON.parse(data), headers
+        expect(count).to eq(ClaimsApi::AutoEstablishedClaim.count)
+      end
+    end
   end
 
   describe '#upload_supporting_documents' do


### PR DESCRIPTION
## Description of change
To prevent accepting duplicate claim requests we need a queryable field to allow us to spot dupes

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/1432
## Testing done
- rspec

## Acceptance Criteria (Definition of Done)
- [x] Two back to back requests of the same data fail

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
