### PR TITLE
Fix nokogiri install during 'bundle install'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ apt-get update -qq && \
 apt-get install -y build-essential \
 git \
 libpq-dev \
+libgmp-dev \
 clamav \
 imagemagick \
 pdftk \


### PR DESCRIPTION
The dockerfile we use to run our CI [recently removed `libgmp-dev`](https://github.com/docker-library/ruby/commit/73adf677cdb4b79ff4c98fb19aca11802e0d0ec9#diff-835bba16ea7fb377410c228971c0f4af) which is a dependency of `nokogiri`. This caused [`bundle install` to fail](http://jenkins.vetsgov-internal/blue/organizations/jenkins/testing%2Fvets-api/detail/upgrade_nokogiri/1/pipeline):

```
Fetching nokogiri 1.10.1
Installing nokogiri 1.10.1 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
```

This PR manually adds that back into our Dockerfile.