### PR TITLE
VET TEC: Add new emails to distro for 0994 daily file #17286

### DIFF
--- a/app/mailers/spool_submissions_report_mailer.rb
+++ b/app/mailers/spool_submissions_report_mailer.rb
@@ -12,6 +12,11 @@ class SpoolSubmissionsReportMailer < ApplicationMailer
     Walter_Jenny@bah.com
     Hoffmaster_David@bah.com
     akulkarni@meetveracity.com
+    Brandon.Scott2@va.gov
+    224C.VBAVACO@va.gov
+    peter.chou1@va.gov
+    Joseph.Welton@va.gov
+    222A.VBAVACO@va.gov
   ].freeze
   STAGING_RECIPIENTS = %w[
     lihan@adhocteam.us
@@ -20,6 +25,11 @@ class SpoolSubmissionsReportMailer < ApplicationMailer
     Turner_Desiree@bah.com
     Delli-Gatti_Michael@bah.com
     Walter_Jenny@bah.com
+    Brandon.Scott2@va.gov
+    224C.VBAVACO@va.gov
+    peter.chou1@va.gov
+    Joseph.Welton@va.gov
+    222A.VBAVACO@va.gov
   ].freeze
 
   def build(report_file)

--- a/app/mailers/year_to_date_report_mailer.rb
+++ b/app/mailers/year_to_date_report_mailer.rb
@@ -23,6 +23,11 @@ class YearToDateReportMailer < ApplicationMailer
       Walter_Jenny@bah.com
       Hoffmaster_David@bah.com
       akulkarni@meetveracity.com
+      Brandon.Scott2@va.gov
+      224C.VBAVACO@va.gov
+      peter.chou1@va.gov
+      Joseph.Welton@va.gov
+      222A.VBAVACO@va.gov
     ]
   }.freeze
 
@@ -34,6 +39,11 @@ class YearToDateReportMailer < ApplicationMailer
       Turner_Desiree@bah.com
       Delli-Gatti_Michael@bah.com
       Walter_Jenny@bah.com
+      Brandon.Scott2@va.gov
+      224C.VBAVACO@va.gov
+      peter.chou1@va.gov
+      Joseph.Welton@va.gov
+      222A.VBAVACO@va.gov
     ]
   }.freeze
 

--- a/spec/mailers/spool_submissions_report_mailer_spec.rb
+++ b/spec/mailers/spool_submissions_report_mailer_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
             Turner_Desiree@bah.com
             Delli-Gatti_Michael@bah.com
             Walter_Jenny@bah.com
+            Brandon.Scott2@va.gov
+            224C.VBAVACO@va.gov
+            peter.chou1@va.gov
+            Joseph.Welton@va.gov
+            222A.VBAVACO@va.gov
           ]
         )
       end
@@ -57,6 +62,11 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
             Walter_Jenny@bah.com
             Hoffmaster_David@bah.com
             akulkarni@meetveracity.com
+            Brandon.Scott2@va.gov
+            224C.VBAVACO@va.gov
+            peter.chou1@va.gov
+            Joseph.Welton@va.gov
+            222A.VBAVACO@va.gov
           ]
         )
       end

--- a/spec/mailers/year_to_date_report_mailer_spec.rb
+++ b/spec/mailers/year_to_date_report_mailer_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe YearToDateReportMailer, type: %i[mailer aws_helpers] do
             Turner_Desiree@bah.com
             Delli-Gatti_Michael@bah.com
             Walter_Jenny@bah.com
+            Brandon.Scott2@va.gov
+            224C.VBAVACO@va.gov
+            peter.chou1@va.gov
+            Joseph.Welton@va.gov
+            222A.VBAVACO@va.gov
           ]
         )
       end
@@ -65,6 +70,11 @@ RSpec.describe YearToDateReportMailer, type: %i[mailer aws_helpers] do
             Walter_Jenny@bah.com
             Hoffmaster_David@bah.com
             akulkarni@meetveracity.com
+            Brandon.Scott2@va.gov
+            224C.VBAVACO@va.gov
+            peter.chou1@va.gov
+            Joseph.Welton@va.gov
+            222A.VBAVACO@va.gov
           ]
         )
       end


### PR DESCRIPTION
## Description of change

As a developer I need to make sure that all of the customer's requested emails are added to the distribution for the 0994 daily file.

## Testing done
- unit testing

## Testing planned
- Verify with @Jennywalter or @dneel-bah that customers have received spool and ytd reports

## Acceptance Criteria (Definition of Done)
- The following emails have been added to the distro for the 0994 daily report in staging and production:
        - Brandon.Scott2@va.gov
        - 224C.VBAVACO@va.gov
        - peter.chou1@va.gov
        - Joseph.Welton@va.gov
        - 222A.VBAVACO@va.gov

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
