### PR TITLE
Pass GA clientId along in querystring to ID.me

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,6 @@ PATH
 
 GEM
   remote: https://rubygems.org/
-  remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.0.2)
     aasm (4.12.0)
@@ -1024,14 +1023,9 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
-    sidekiq-ent (1.6.1)
-      sidekiq (>= 4.2.9)
-      sidekiq-pro (>= 3.5.0)
     sidekiq-instrument (0.3.0)
       sidekiq (>= 4.2, < 6)
       statsd-instrument (~> 2.0, >= 2.0.4)
-    sidekiq-pro (3.7.0)
-      sidekiq (>= 4.1.5)
     sidekiq-scheduler (2.0.19)
       hashie (~> 3.4)
       redis (~> 3)
@@ -1189,9 +1183,7 @@ DEPENDENCIES
   shrine
   shrine-memory
   sidekiq
-  sidekiq-ent!
   sidekiq-instrument
-  sidekiq-pro!
   sidekiq-scheduler (~> 2.0)
   sidekiq-unique-jobs
   simplecov
@@ -1218,4 +1210,4 @@ DEPENDENCIES
   zero_downtime_migrations
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ PATH
 
 GEM
   remote: https://rubygems.org/
+  remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.0.2)
     aasm (4.12.0)
@@ -1023,9 +1024,14 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
+    sidekiq-ent (1.6.1)
+      sidekiq (>= 4.2.9)
+      sidekiq-pro (>= 3.5.0)
     sidekiq-instrument (0.3.0)
       sidekiq (>= 4.2, < 6)
       statsd-instrument (~> 2.0, >= 2.0.4)
+    sidekiq-pro (3.7.0)
+      sidekiq (>= 4.1.5)
     sidekiq-scheduler (2.0.19)
       hashie (~> 3.4)
       redis (~> 3)
@@ -1183,7 +1189,9 @@ DEPENDENCIES
   shrine
   shrine-memory
   sidekiq
+  sidekiq-ent!
   sidekiq-instrument
+  sidekiq-pro!
   sidekiq-scheduler (~> 2.0)
   sidekiq-unique-jobs
   simplecov
@@ -1210,4 +1218,4 @@ DEPENDENCIES
   zero_downtime_migrations
 
 BUNDLED WITH
-   1.17.3
+   1.17.1

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -30,7 +30,7 @@ module V0
               url_service.dslogon_url
             when 'idme'
               reset_session
-              url_service.idme_loa1_url + (params[:signup] ? '&op=signup' : '')
+              url_service.idme_loa1_url(params)
             when 'mfa'
               authenticate
               url_service.mfa_url

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -49,7 +49,7 @@ module SAML
       build_sso_url('dslogon')
     end
 
-    def idme_loa1_url(params)
+    def idme_loa1_url(params = {})
       build_sso_url(LOA::IDME_LOA1) +
         (params[:signup] ? '&op=signup' : '') +
         (params[:clientId] ? '&clientId=' + params[:clientId] : '')

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -49,8 +49,10 @@ module SAML
       build_sso_url('dslogon')
     end
 
-    def idme_loa1_url
-      build_sso_url(LOA::IDME_LOA1)
+    def idme_loa1_url(params)
+      build_sso_url(LOA::IDME_LOA1) +
+        (params[:signup] ? '&op=signup' : '') +
+        (params[:clientId] ? '&clientId=' + params[:clientId] : '')
     end
 
     def idme_loa3_url


### PR DESCRIPTION
## Description of change
In order to enable cross-domain tracking on Google Analytics, we must also append the clientId when redirecting to ID.me.  Added the clientId in `url_service` and moved the appending of the `signup` param into the URL service as well.

I didn't see a unit test present for the `signup` param, so was not sure how to test for the `clientId` param.  If we feel a unit test for this is necessary I could use some help in that area.

## Testing done
Tested locally along with front end changes (`13866-cross-domain-ga` branch) that clientId is appended when present.

## Acceptance Criteria (Definition of Done)
- [ ] Backend provides `clientId` if provided in the redirect url that is sent to the front end

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
