### PR TITLE
don't return 404 when mvi has a connection error

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -95,8 +95,6 @@ class HealthCareApplication < ActiveRecord::Base
   def self.user_icn(user_attributes)
     HCA::RateLimitedSearch.create_rate_limited_searches(user_attributes) unless Settings.mvi_hca.skip_rate_limit
     MVI::AttrService.new.find_profile(user_attributes)&.profile&.icn
-  rescue MVI::Errors::Base
-    nil
   end
 
   def self.user_attributes(form)

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe HealthCareApplication, type: :model do
     context 'when the user is not found' do
       it 'should return nil' do
         expect_any_instance_of(MVI::Service).to receive(
-          :find_profile
+          :perform
         ).and_raise(MVI::Errors::RecordNotFound)
 
         expect(described_class.user_icn(described_class.user_attributes(form))).to eq(nil)


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
this changes fixes a bug where the hca e&e api would return 404 when mvi had a connection error

## Testing done
automated tests
<!-- Please describe testing done to verify the changes. -->

## Testing planned
test on dev
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
