### PR TITLE
17233 781 upload retry bug

### DIFF
--- a/lib/pdf_fill/forms/common_ptsd.rb
+++ b/lib/pdf_fill/forms/common_ptsd.rb
@@ -23,7 +23,7 @@ module PdfFill
       def expand_incident_date(incident)
         incident_date = incident['incidentDate']
         return if incident_date.blank?
-        split_date(incident_date)
+        split_approximate_date(incident_date)
       end
 
       def expand_incident_location(incident)
@@ -43,9 +43,8 @@ module PdfFill
       def expand_unit_assigned_dates(incident)
         incident_unit_assigned_dates = incident['unitAssignedDates']
         return if incident_unit_assigned_dates.blank?
-        from_dates = split_date(incident_unit_assigned_dates['from'])
-        to_dates = split_date(incident_unit_assigned_dates['to'])
-
+        from_dates = split_approximate_date(incident_unit_assigned_dates['from'])
+        to_dates = split_approximate_date(incident_unit_assigned_dates['to'])
         unit_assignment_dates = {
           'fromMonth' => from_dates['month'],
           'fromDay' => from_dates['day'],
@@ -58,6 +57,21 @@ module PdfFill
         incident_unit_assigned_dates.except!('to')
         incident_unit_assigned_dates.except!('from')
         incident_unit_assigned_dates.merge!(unit_assignment_dates)
+      end
+
+      def split_approximate_date(date)
+        year, month, day = date.split('-')
+
+        # year/month/day are optional and can be XXed out
+        year = nil if year == 'XXXX'
+        month = nil if month == 'XX'
+        day = nil if day == 'XX'
+
+        {
+          'year' => year,
+          'month' => month,
+          'day' => day
+        }
       end
 
       def expand_incident_unit_assignment(incident)

--- a/lib/pdf_fill/forms/va210781.rb
+++ b/lib/pdf_fill/forms/va210781.rb
@@ -351,7 +351,7 @@ module PdfFill
       def expand_injury_death_date(person_involved, index)
         injury_date = person_involved['injuryDeathDate']
         return if injury_date.blank?
-        s_date = split_date(injury_date)
+        s_date = split_approximate_date(injury_date)
         person_involved["injuryDeathDateMonth#{index}"] = s_date['month']
         person_involved["injuryDeathDateDay#{index}"] = s_date['day']
         person_involved["injuryDeathDateYear#{index}"] = s_date['year']
@@ -372,10 +372,7 @@ module PdfFill
       def flatten_person_identification(person_involved, index)
         return if person_involved.blank?
 
-        extract_middle_i(person_involved, 'name')
-        person_involved["first#{index}"] = person_involved['name']['first']
-        person_involved["middleInitial#{index}"] = person_involved['name']['middleInitial']
-        person_involved["last#{index}"] = person_involved['name']['last']
+        flatten_person_name(person_involved, index) if person_involved['name'].present?
 
         unless person_involved['description'].nil?
           person_involved["description#{index}"] = person_involved['description']
@@ -386,6 +383,13 @@ module PdfFill
 
         person_involved["rank#{index}"] = person_involved['rank']
         person_involved.except!('rank')
+      end
+
+      def flatten_person_name(person_involved, index)
+        extract_middle_i(person_involved, 'name')
+        person_involved["first#{index}"] = person_involved['name']['first']
+        person_involved["middleInitial#{index}"] = person_involved['name']['middleInitial']
+        person_involved["last#{index}"] = person_involved['name']['last']
       end
 
       def resolve_cause_injury_death(person_involved, index)

--- a/lib/pdf_fill/forms/va210781a.rb
+++ b/lib/pdf_fill/forms/va210781a.rb
@@ -277,6 +277,7 @@ module PdfFill
       end
 
       def combine_full_address(address)
+        return '' if address.blank?
         combine_hash(
           address,
           %w[

--- a/spec/lib/pdf_fill/forms/common_ptsd_spec.rb
+++ b/spec/lib/pdf_fill/forms/common_ptsd_spec.rb
@@ -122,4 +122,50 @@ describe PdfFill::Forms::CommonPtsd do
       )
     end
   end
+
+  describe '#split_approximate_date' do
+    context 'when there is a full date' do
+      let(:date) { '2099-12-01' }
+
+      it 'should return the year, month, and day' do
+        expect(including_class.new.split_approximate_date(date)).to include(
+          'year' => '2099',
+          'month' => '12',
+          'day' => '01'
+        )
+      end
+    end
+
+    context 'when there is a partial date (year and month)' do
+      let(:date) { '2099-12-XX' }
+
+      it 'should return the year and month' do
+        expect(including_class.new.split_approximate_date(date)).to include(
+          'year' => '2099',
+          'month' => '12'
+        )
+      end
+    end
+
+    context 'when there is a partial date (year only)' do
+      let(:date) { '2099-XX-XX' }
+
+      it 'should return the year' do
+        expect(including_class.new.split_approximate_date(date)).to include(
+          'year' => '2099'
+        )
+      end
+    end
+
+    context 'when there is no year' do
+      let(:date) { 'XXXX-01-31' }
+
+      it 'should return the year' do
+        expect(including_class.new.split_approximate_date(date)).to include(
+          'month' => '01',
+          'day' => '31'
+        )
+      end
+    end
+  end
 end

--- a/spec/support/disability_compensation_form/submissions/with_0781.json
+++ b/spec/support/disability_compensation_form/submissions/with_0781.json
@@ -192,15 +192,7 @@
             }
           },
           {
-            "name": "Trusty Tester Testerson",
-            "address": {
-              "street": "100 Main Street",
-              "street2": "1B",
-              "city": "Baltimore",
-              "state": "MD",
-              "country": "USA",
-              "postalCode": "21200-1111"
-            }
+            "name": "Trusty Tester Testerson"
           }
         ]
       },
@@ -209,18 +201,13 @@
         "incidentDate": "2000-01-01",
         "unitAssignedDates": {
           "from": "2001-01-01",
-          "to": "2002-02-02"
+          "to": "2002-XX-XX"
         },
         "personsInvolved": [
           {
-            "name": {
-              "first": "Festy",
-              "middle": "Fester",
-              "last": "Festerson"
-            },
             "rank": "Inc 0 Rank 0",
             "injuryDeath": "killedInAction",
-            "injuryDeathDate": "2000-01-01",
+            "injuryDeathDate": "2000-01-XX",
             "unitAssigned": "abcdefghijklm0 opqrstuvwxyz12340 bpqrstuvwxyz12340"
           },
           {
@@ -241,15 +228,7 @@
         "incidentDescription": "Lorem ipsum dolor sit amet.",
         "sources": [
           {
-            "name": "Testy Tester Testerson",
-            "address": {
-              "street": "123 Main Street",
-              "street2": "1B",
-              "city": "Baltimore",
-              "state": "MD",
-              "country": "USA",
-              "postalCode": "21200-1111"
-            }
+            "name": "Testy Tester Testerson"
           },
           {
             "name": "Dusty Tester Testerson",
@@ -263,7 +242,6 @@
             }
           },
           {
-            "name": "Trusty Tester Testerson",
             "address": {
               "street": "100 Main Street",
               "street2": "1B",


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
The 781 pdf flow was potentially failing due to a few missing key values in the form hash. Almost all key/value pairs are optional when it comes to the form flow and this needs to be represented in the pdf fill. The offending issues have been corrected.

## Testing done
<!-- Please describe testing done to verify the changes. -->
spec

## Testing planned
<!-- Please describe testing planned. -->
staging e2e

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Allow for approximate date fields
- [x] Allow for `name` to be optional in `personsInvolved` section
- [x] Allow for `address` to be optional in `sources`

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
