### PR TITLE
Status page: Caching layer for pre-serialized status response

### DIFF
--- a/app/models/external_services_redis/status.rb
+++ b/app/models/external_services_redis/status.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'common/models/redis_store'
 require 'common/models/concerns/cache_aside'
 
 module ExternalServicesRedis

--- a/app/models/external_services_redis/status.rb
+++ b/app/models/external_services_redis/status.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'common/models/redis_store'
+require 'common/models/concerns/cache_aside'
+
+module ExternalServicesRedis
+  # Facade for the PagerDuty::ExternalServices::Service class.
+  #
+  class Status < Common::RedisStore
+    include Common::CacheAside
+
+    KEY = 'pager_duty_services'
+
+    # Redis settings for ttl and namespacing reside in config/redis.yml
+    #
+    redis_config_key :external_service_statuses_response
+
+    # The time from the call to PagerDuty's API
+    #
+    # @return [Time] For example, 2019-03-14 20:19:43 UTC
+    #
+    delegate :reported_at, to: :fetch_or_cache
+
+    # Returns either the cached response from the
+    # PagerDuty::ExternalServices::Service.new.get_services call, or makes
+    # a fresh call to that endpoint, then caches and returns the response.
+    #
+    # @return [PagerDuty::ExternalServices::Response] An instance of the
+    #   PagerDuty::ExternalServices::Response class
+    # @example ExternalServicesRedis.new.fetch_or_cache.as_json
+    #   {
+    #     "status"      => 200,
+    #     "reported_at" => "2019-03-14T19:47:47.000Z",
+    #     "statuses"    => [
+    #       {
+    #         "service"                 => "Appeals",
+    #         "status"                  => "active",
+    #         "last_incident_timestamp" => "2019-03-01T02:55:55.000-05:00"
+    #       },
+    #       ...
+    #     ]
+    #   }
+    #
+    def fetch_or_cache
+      @response ||= response_from_redis_or_service
+    end
+
+    # The HTTP status code from call to PagerDuty's API
+    #
+    # @return [Integer] For example, 200
+    #
+    def response_status
+      fetch_or_cache.status
+    end
+
+    private
+
+    def response_from_redis_or_service
+      do_cached_with(key: KEY) do
+        PagerDuty::ExternalServices::Service.new.get_services
+      end
+    end
+  end
+end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -74,6 +74,9 @@ development: &defaults
   evss_dependents_retrieve_response:
     namespace: evss-dependents-retrieve-response
     each_ttl: 86400
+  external_service_statuses_response:
+    namespace: external-service-statuses-response
+    each_ttl: 60 # 1 minute
 
 test:
   <<: *defaults

--- a/spec/models/external_services_redis/status_spec.rb
+++ b/spec/models/external_services_redis/status_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ExternalServicesRedis::Status do
+  let(:external_services) { ExternalServicesRedis::Status.new }
+  let(:get_services_response) do
+    VCR.use_cassette('pagerduty/external_services/get_services', VCR::MATCH_EVERYTHING) do
+      PagerDuty::ExternalServices::Service.new.get_services
+    end
+  end
+
+  before do
+    allow_any_instance_of(
+      PagerDuty::ExternalServices::Service
+    ).to receive(:get_services).and_return(get_services_response)
+
+    allow_any_instance_of(ExternalServicesRedis::Status).to receive(:cache).and_return(true)
+  end
+
+  it 'sets its cache to expire (ttl) after 60 seconds' do
+    expect(ExternalServicesRedis::Status.redis_namespace_ttl).to eq 60
+  end
+
+  describe '#fetch_or_cache' do
+    let(:fetch_or_cache) { external_services.fetch_or_cache }
+
+    it 'is an instance of PagerDuty::ExternalServices::Response' do
+      expect(fetch_or_cache.class).to eq PagerDuty::ExternalServices::Response
+    end
+
+    it "includes the HTTP status code from call to PagerDuty's API" do
+      expect(fetch_or_cache.status).to eq 200
+    end
+
+    it "includes the time from the call to PagerDuty's API" do
+      expect(fetch_or_cache.reported_at).to be_present
+    end
+
+    it 'includes an array of PagerDuty::Models::Service objects', :aggregate_failures do
+      expect(fetch_or_cache.statuses.class).to eq Array
+
+      fetch_or_cache.statuses.each do |status|
+        expect(status.class).to eq PagerDuty::Models::Service
+      end
+    end
+
+    it 'includes the relevant status details about each external service', :aggregate_failures do
+      service_status = fetch_or_cache.statuses.first
+
+      expect(service_status.service).to be_present
+      expect(service_status.status).to be_present
+      expect(service_status.last_incident_timestamp).to be_present
+    end
+
+    context 'when the cache is empty' do
+      it 'should cache and return the response', :aggregate_failures do
+        expect(external_services).to receive(:cache).once
+        expect_any_instance_of(PagerDuty::ExternalServices::Service).to receive(:get_services).once
+        expect(external_services.fetch_or_cache.class).to eq PagerDuty::ExternalServices::Response
+      end
+    end
+  end
+
+  describe '#response_status' do
+    it "returns the HTTP status code from call to PagerDuty's API" do
+      expect(external_services.response_status).to eq 200
+    end
+  end
+
+  describe '#reported_at' do
+    it "returns the time from the call to PagerDuty's API", :aggregate_failures do
+      expect(external_services.reported_at).to be_present
+      expect(external_services.reported_at.class).to eq Time
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

**User Story:** As a BE I want the pre-serialized status response from PagerDuty to be cached for performance, and assuring we do not exceed our rate limit.

Per PagerDuty's [rate limit docs](https://v2.developer.pagerduty.com/docs/rate-limiting), and this conversation with PagerDuty's support staff, PagerDuty's rate limit is 2,000/min (enforced at the account level):

> Feb 28, 15:10 PST
> 
> Hi Harry,
> 
> This is Tom from the PagerDuty support team. Sorry for missing you on chat earlier!
> 
> Our REST API's rate limit is 2,000/min (enforced at the account level).
> 
> API requests that exceed the API rate limit will return different HTTP status codes depending on which API you are using. REST v2 API will return a 429 code, and our v1 Events API will return a 403 code.
> 
> Please let me know if you have any other questions.
> 
> Kind regards,
> 
> Tom Roach
> Technical Support Specialist
> pagerduty.com



## Testing done
<!-- Please describe testing done to verify the changes. -->

Automated spec coverage

## Testing planned
<!-- Please describe testing planned. -->

Testing in staging

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Creates a caching layer for the `PagerDuty::ExternalServices::Service#get_services` pre-serialized response
- [x] Ensures cache of external service statuses are current (no older than 60 seconds)
- [x] Spec coverage
- [x] Yard docs

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
