### PR TITLE
Status page: Background job checking status

### DIFF
--- a/app/workers/external_services_status_job.rb
+++ b/app/workers/external_services_status_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ExternalServicesStatusJob
+  include Sidekiq::Worker
+
+  def perform
+    ExternalServicesRedis::Status.new.fetch_or_cache
+  end
+end

--- a/app/workers/external_services_status_job.rb
+++ b/app/workers/external_services_status_job.rb
@@ -3,6 +3,8 @@
 class ExternalServicesStatusJob
   include Sidekiq::Worker
 
+  sidekiq_options(retry: false)
+
   def perform
     ExternalServicesRedis::Status.new.fetch_or_cache
   end

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -120,3 +120,7 @@ DeleteOldTransactionsJob:
 MHV::AccountStatisticsJob:
   cron: "0 */4 * * * America/New_York"
   description: "Log MHV Account Statistics"
+
+ExternalServicesStatusJob:
+  every: '1m'
+  description: "Checks the current status of all external services through PagerDuty's API"

--- a/spec/jobs/external_services_status_job_spec.rb
+++ b/spec/jobs/external_services_status_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExternalServicesStatusJob do
+  describe '#perform' do
+    let(:get_services_response) do
+      VCR.use_cassette('pagerduty/external_services/get_services', VCR::MATCH_EVERYTHING) do
+        PagerDuty::ExternalServices::Service.new.get_services
+      end
+    end
+
+    before do
+      allow_any_instance_of(
+        PagerDuty::ExternalServices::Service
+      ).to receive(:get_services).and_return(get_services_response)
+
+      allow_any_instance_of(ExternalServicesRedis::Status).to receive(:cache).and_return(true)
+    end
+
+    it 'calls ExternalServicesRedis::Status.new.fetch_or_cache' do
+      expect_any_instance_of(ExternalServicesRedis::Status).to receive(:fetch_or_cache)
+
+      described_class.new.perform
+    end
+
+    it 'calls PagerDuty::ExternalServices::Service.new.get_services' do
+      expect_any_instance_of(PagerDuty::ExternalServices::Service).to receive(:get_services)
+
+      described_class.new.perform
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
**User Story:** As a BE I want a background job that runs once a minute, using our PagerDuty service class, checking for the current status of our external services.

## Testing done
<!-- Please describe testing done to verify the changes. -->

Automated specs

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Background job that checks current statuses of all external services
- [x] Cron job to call background job once per minute
- [x] Spec coverage

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
