### PR TITLE
Improve PII Sanitizer, don't sanitize certain fields

### DIFF
--- a/lib/sentry/processor/pii_sanitizer.rb
+++ b/lib/sentry/processor/pii_sanitizer.rb
@@ -16,7 +16,6 @@ module Sentry
 
       PATTERN = Regexp.union(SANITIZED_FIELDS.map { |field| field.downcase.tr('_', '') }).freeze
 
-
       JSON_STARTS_WITH = ['[', '{'].freeze
 
       FILTER_MASK = 'FILTERED-CLIENTSIDE'
@@ -51,8 +50,7 @@ module Sentry
       end
 
       def filter(key, unsanitized_value)
-        normalized_key = key.to_s.tr('_', '')
-        if normalized_key.downcase.match(PATTERN) && !SANITIZER_EXCEPTIONS.include?(normalized_key)
+        if filter_pattern(normalized_key)
           if unsanitized_value.is_a?(Array)
             unsanitized_value.map { |element| filter(key, element) }
           else
@@ -63,6 +61,11 @@ module Sentry
         else
           unsanitized_value
         end
+      end
+
+      def filter_pattern(key)
+        normalized_key = key.to_s.tr('_', '')
+        normalized_key.downcase.match(PATTERN) && !SANITIZER_EXCEPTIONS.include?(normalized_key)
       end
 
       def parse_json_or_nil(string)

--- a/lib/sentry/processor/pii_sanitizer.rb
+++ b/lib/sentry/processor/pii_sanitizer.rb
@@ -7,10 +7,15 @@ module Sentry
         %w[
           accountType city country gender phone postalCode zipCode fileNumber state street vaEauthPnid
           accountNumber routingNumber bankName ssn birth_date social fname lname mname dslogon_idvalue
-          icn edipi
+        ].freeze
+
+      SANITIZER_EXCEPTIONS =
+        %w[
+          relaystate
         ].freeze
 
       PATTERN = Regexp.union(SANITIZED_FIELDS.map { |field| field.downcase.tr('_', '') }).freeze
+
 
       JSON_STARTS_WITH = ['[', '{'].freeze
 
@@ -46,7 +51,8 @@ module Sentry
       end
 
       def filter(key, unsanitized_value)
-        if key.to_s.tr('_', '').downcase.match(PATTERN)
+        normalized_key = key.to_s.tr('_', '')
+        if normalized_key.downcase.match(PATTERN) && !SANITIZER_EXCEPTIONS.include?(normalized_key)
           if unsanitized_value.is_a?(Array)
             unsanitized_value.map { |element| filter(key, element) }
           else

--- a/lib/sentry/processor/pii_sanitizer.rb
+++ b/lib/sentry/processor/pii_sanitizer.rb
@@ -50,7 +50,7 @@ module Sentry
       end
 
       def filter(key, unsanitized_value)
-        if filter_pattern(normalized_key)
+        if filter_pattern(key)
           if unsanitized_value.is_a?(Array)
             unsanitized_value.map { |element| filter(key, element) }
           else

--- a/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
+++ b/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Sentry::Processor::PIISanitizer do
       expect(result[:state]).to eq('FILTERED-CLIENTSIDE')
     end
 
-    it 'does not saitize relay_state' do
+    it 'does not sanitize relay_state' do
       expect(result[:relay_state]).to eq('{"some_json_key": "some_json_value"}')
     end
 

--- a/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
+++ b/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
@@ -10,6 +10,35 @@ RSpec.describe Sentry::Processor::PIISanitizer do
   let(:processor) { Sentry::Processor::PIISanitizer.new(client) }
   let(:result) { processor.process(data) }
 
+  # These are needed for communicating issues to downstream parties and should not be sanitized
+  context 'sanitization exceptions' do
+    let(:data) do
+      {
+        state: 'SOME STATE',
+        relay_state: '{"some_json_key": "some_json_value"}',
+        icn: 'SOME ICN VALUE',
+        edipi: 'SOME EDIPI VALUE',
+        mhv_correlation_id: 'SOME MHV CORRELATION ID'
+      }
+    end
+
+    it 'sanitizes state' do
+      expect(result[:state]).to eq('FILTERED-CLIENTSIDE')
+    end
+
+    it 'does not saitize relay_state' do
+      expect(result[:relay_state]).to eq('{"some_json_key": "some_json_value"}')
+    end
+
+    it 'does not sanitize other important fields needed for logging / communicating to downstream partners' do
+      expect(result.slice(:icn, :edipi, :mhv_correlation_id)).to eq(
+        icn: 'SOME ICN VALUE',
+        edipi: 'SOME EDIPI VALUE',
+        mhv_correlation_id: 'SOME MHV CORRELATION ID'
+      )
+    end
+  end
+
   context 'with symbol keys' do
     let(:data) do
       {


### PR DESCRIPTION
## Description of change
ICN and EDIPI while PII, are just primary keys, and they're needed for correlating our logs with downstream partners. These fields cannot really be used to cause problems since you can't use an ICN or EDIPI to open a credit card for example. They're tremendously useful for debugging purposes.

## Testing done
specs

## Testing planned
none

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
Introduced an exceptions list. Since state gets triggered by regular expression, we will also check that whatever the key is, it is not in the exceptions list. There is a spec that tests that "state" is correctly filtered whereas relaystate, relayState, relay_state are not.

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
