### PR TITLE
Remove edipi for auto cest - 2

### DIFF
--- a/modules/claims_api/app/models/claims_api/veteran.rb
+++ b/modules/claims_api/app/models/claims_api/veteran.rb
@@ -69,13 +69,12 @@ module ClaimsApi
         first_name: ensure_header(headers, 'X-VA-First-Name'),
         last_name: ensure_header(headers, 'X-VA-Last-Name'),
         va_profile: build_profile(headers),
-        edipi: ensure_header(headers, 'X-VA-EDIPI'),
         last_signed_in: Time.now.utc
       )
       # commenting this out until the new non-veteran oauth flow is ready to replace this
       # veteran.loa = { current: 3, highest: 3 }
       veteran.gender = ensure_header(headers, 'X-VA-Gender') if with_gender
-
+      veteran.edipi = headers['X-VA-EDIPI'] if headers['X-VA-EDIPI'].present?
       veteran
     end
 

--- a/modules/claims_api/spec/models/veteran_spec.rb
+++ b/modules/claims_api/spec/models/veteran_spec.rb
@@ -4,6 +4,15 @@ require 'rails_helper'
 
 RSpec.describe ClaimsApi::Veteran, type: :model do
   describe 'attributes needed for MVI lookup' do
+    let(:headers) do
+      {
+        'X-VA-SSN' => '123456789',
+        'X-VA-First-Name' => 'MARK',
+        'X-VA-Last-Name' => 'WEBB',
+        'X-VA-Birth-Date' => '1928-01-01'
+      }
+    end
+
     before do
       @veteran = ClaimsApi::Veteran.new
       @veteran.loa = { current: 3, highest: 3 }
@@ -20,6 +29,17 @@ RSpec.describe ClaimsApi::Veteran, type: :model do
 
     it 'should alias dslogon_edipi to edipi for MVI' do
       expect(@veteran.dslogon_edipi).to be(@veteran.edipi)
+    end
+
+    it 'should set edipi not passed in headers' do
+      headers['X-VA-EDIPI'] = '12345'
+      veteran = ClaimsApi::Veteran.from_headers(headers)
+      expect(veteran.edipi).to eq('12345')
+    end
+
+    it 'should not set edipi if not passed in headers' do
+      veteran = ClaimsApi::Veteran.from_headers(headers)
+      expect(veteran.edipi).to be(nil)
     end
   end
 end

--- a/modules/claims_api/spec/requests/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/claims_request_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'EVSS Claims management', type: :request do
     'X-VA-SSN' => '111223333',
     'X-VA-First-Name' => 'Test',
     'X-VA-Last-Name' => 'Consumer',
-    'X-VA-EDIPI' => '12345',
     'X-VA-Birth-Date' => '11-11-1111',
     'X-Consumer-Username' => 'TestConsumer'
   }.freeze


### PR DESCRIPTION
## Description of change
This change is to remove the EDIPI as a required header when being passed for the 526 form.

## Testing done
Tested on staging that without mocks on. Verified that without the edipi, MVI is still getting the birls_number and pid for a veteran to pass to evss


## Acceptance Criteria (Definition of Done)
- [x] A successful call without edipi can be made in a non mocked env and the proper headers are set for EVSS


#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] https://github.com/department-of-veterans-affairs/vets-contrib/issues/1557
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
