### PR TITLE
Updated Veteran Verification API docs to remove "this is a proof of concept" verbiage

### DIFF
--- a/modules/veteran_verification/DISABILITY_RATING.yml
+++ b/modules/veteran_verification/DISABILITY_RATING.yml
@@ -7,7 +7,7 @@ info:
 
     ## Background
 
-    The use-case of this API is to allow third-parties to access the service history of a Veteran after receiving authorization to do so using an Open ID Connect flow.
+    The use-case of this API is to allow third-parties to access the disability rating of a Veteran after receiving authorization to do so using an Open ID Connect flow.
 
     The Disability Rating API passes requests through to EVSS, the Electronic Veterans Self Service, and formats the response into consumable data.
 

--- a/modules/veteran_verification/DISABILITY_RATING.yml
+++ b/modules/veteran_verification/DISABILITY_RATING.yml
@@ -7,7 +7,7 @@ info:
 
     ## Background
 
-    This API is provided as a proof of concept for a general-purpose VA API that allows Veterans to provide authorization to a third-party to access information on their behalf. The use-case of this API is to allow third-parties to access the service history of a Veteran after receiving authorization to do so using an Open ID Connect flow.
+    The use-case of this API is to allow third-parties to access the service history of a Veteran after receiving authorization to do so using an Open ID Connect flow.
 
     The Disability Rating API passes requests through to EVSS, the Electronic Veterans Self Service, and formats the response into consumable data.
 

--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -7,9 +7,7 @@ info:
 
     ## Background
 
-    This API is provided as a proof of concept for a general-purpose VA
-    API that allows Veterans to provide authorization to a third-party to access
-    information on their behalf. The use-case of this API is to allow third-parties
+    The use-case of this API is to allow third-parties
     to access the service history of a Veteran after receiving authorization to
     do so using an Open ID Connect flow.
 

--- a/modules/veteran_verification/VETERAN_CONFIRMATION.yml
+++ b/modules/veteran_verification/VETERAN_CONFIRMATION.yml
@@ -7,9 +7,7 @@ info:
 
     ## Background
 
-    This API is provided as a proof of concept for a general-purpose VA
-    API that allows Veterans to provide authorization to a third-party to access
-    information on their behalf. The use-case of this API is to allow third-parties
+    The use-case of this API is to allow third-parties
     to request confirmation from the VA of an individual's Veteran status after
     receiving authorization to do so using an Open ID Connect flow.
 


### PR DESCRIPTION
## Description of change
This PR fixes [this bug](https://github.com/department-of-veterans-affairs/vets-contrib/issues/1563).

The description of all 3 of the Veteran Verification APIs started with "This API is provided as a proof of concept for a general-purpose VA API...", which is incorrect. They are no longer proof of concept APIs. In addition, the remainder of the first sentence contained some of the same info that was already in the second sentence. Therefore, I removed the first sentence entirely.

Also fixes a typo in the `Disability Rating` description: "…access the service history of a Veteran…“ changed to "…access the disability rating of a Veteran…“

## Testing done
- [x] Tested locally

## Testing planned
None

## Acceptance Criteria (Definition of Done)
- [x] Verbiage is updated for all 3 Veteran Verification APIs

#### Unique to this PR
None

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
