### PR TITLE
Resolves "NoMemoryError: Too deeply nested." error from OJ gem

### DIFF
--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -120,3 +120,7 @@ DeleteOldTransactionsJob:
 MHV::AccountStatisticsJob:
   cron: "0 */4 * * * America/New_York"
   description: "Log MHV Account Statistics"
+
+ExternalServicesStatusJob:
+  every: '1m'
+  description: "Checks the current status of all external services through PagerDuty's API"

--- a/lib/pagerduty/external_services/response.rb
+++ b/lib/pagerduty/external_services/response.rb
@@ -19,7 +19,7 @@ module PagerDuty
         new(
           raw_response&.status,
           reported_at: Time.current.iso8601,
-          statuses: PagerDuty::Models::Service.statuses_for(services)
+          statuses: PagerDuty::Models::Service.statuses_for(services).map(&:to_h)
         )
       end
     end

--- a/lib/pagerduty/external_services/service.rb
+++ b/lib/pagerduty/external_services/service.rb
@@ -15,7 +15,7 @@ module PagerDuty
       # representation of the raw response.
       #
       # @return [PagerDuty::ExternalServices::Response] A class that wraps a
-      #   pre-serialized array of PagerDuty::Models::Service objects
+      #   pre-serialized array of PagerDuty::Models::Service hashes
       # @see https://api-reference.pagerduty.com/#!/Services/get_services
       #
       def get_services

--- a/spec/lib/pagerduty/external_services/service_spec.rb
+++ b/spec/lib/pagerduty/external_services/service_spec.rb
@@ -20,9 +20,9 @@ describe PagerDuty::ExternalServices::Service do
       expect(response.reported_at).to be_present
     end
 
-    it 'returns an array of PagerDuty::Models::Service objects', :aggregate_failures do
+    it 'returns an array of PagerDuty::Models::Service hashes', :aggregate_failures do
       expect(response.statuses.class).to eq Array
-      expect(response.statuses.first.class).to eq PagerDuty::Models::Service
+      expect(response.statuses.first.class).to eq Hash
     end
 
     context 'when PagerDuty returns an unknown service status' do

--- a/spec/models/external_services_redis/status_spec.rb
+++ b/spec/models/external_services_redis/status_spec.rb
@@ -37,20 +37,20 @@ describe ExternalServicesRedis::Status do
       expect(fetch_or_cache.reported_at).to be_present
     end
 
-    it 'includes an array of PagerDuty::Models::Service objects', :aggregate_failures do
+    it 'includes an array of PagerDuty::Models::Service hashes', :aggregate_failures do
       expect(fetch_or_cache.statuses.class).to eq Array
 
       fetch_or_cache.statuses.each do |status|
-        expect(status.class).to eq PagerDuty::Models::Service
+        expect(status.class).to eq Hash
       end
     end
 
     it 'includes the relevant status details about each external service', :aggregate_failures do
       service_status = fetch_or_cache.statuses.first
 
-      expect(service_status.service).to be_present
-      expect(service_status.status).to be_present
-      expect(service_status.last_incident_timestamp).to be_present
+      expect(service_status[:service]).to be_present
+      expect(service_status[:status]).to be_present
+      expect(service_status[:last_incident_timestamp]).to be_present
     end
 
     context 'when the cache is empty' do


### PR DESCRIPTION
## Description of change
The OJ gem we use for JSON parsing throws "NoMemoryError: Too deeply nested." errors when trying to dump an array of Virtus model objects.  This was uncovered in [this hotfix PR](https://github.com/department-of-veterans-affairs/vets-api/pull/2911).

This is resolved by converting the Virtus model objects to hashes, before dumping them in the OJ gem.

There is no need for the statuses to be in the Virtus model format, as we end up serializing them in the next step.

## Testing done
<!-- Please describe testing done to verify the changes. -->

I was able to reproduce the bug locally, with Redis running.  I was also able to prove that the `.to_h` addition fixes the issue, allow the [`Oj.dump(attributes)`](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/common/models/redis_store.rb#L81) call to complete successfully, and the data successfully saved in Redis, with the appropriate key and format.

## Testing planned
<!-- Please describe testing planned. -->

Will test in staging.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Reduce the overall size of the contents to fit OJ gem constraints by converting Virtus model objects to hashes prior to the [`Oj.dump`](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/common/models/redis_store.rb#L81) call
- [x] Reinstate the `ExternalServicesStatusJob` cron job

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
