### PR TITLE
update debian version for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-slim-jessie
+FROM ruby:2.3-slim-stretch
 
 ARG sidekiq_license
 ENV BUNDLE_ENTERPRISE__CONTRIBSYS__COM=$sidekiq_license


### PR DESCRIPTION
## Description of change
Slim-jessie is no longer supported so Jenkins fails because it has been removed from mirrors.  One way to fix this is to use `slim-stretch`, though I'm open to other ways of handling this.

https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html

````
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages  404  Not Found



E: Some index files failed to download. They have been ignored, or old ones used instead.

Service 'vets-api' failed to build: The command '/bin/sh -c groupadd -r vets-api && useradd -r -g vets-api vets-api && apt-get update -qq && apt-get install -y build-essential git libpq-dev libgmp-dev clamav imagemagick pdftk poppler-utils && freshclam' returned a non-zero code: 100

make: *** [ci] Error 1

script returned exit code 2
````

## Testing done
Jenkins runs tests.


## Acceptance Criteria (Definition of Done)
Jenkins runs tests.


#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)

cc: @bastosmichael 