### PR TITLE
form526 default to v2 evss service

### DIFF
--- a/lib/evss/disability_compensation_form/configuration.rb
+++ b/lib/evss/disability_compensation_form/configuration.rb
@@ -11,7 +11,7 @@ module EVSS
       # @return [String] The base path for the EVSS 526 endpoints
       #
       def base_path
-        "#{Settings.evss.url}/#{Settings.evss.service_name}/rest/form526/v1"
+        "#{Settings.evss.url}/#{Settings.evss.alternate_service_name}/rest/form526/v2"
       end
 
       # @return [String] The name of the service, used by breakers to set a metric name for the service

--- a/spec/lib/evss/disability_compensation_form/service_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/service_spec.rb
@@ -47,7 +47,7 @@ describe EVSS::DisabilityCompensationForm::Service do
     end
     context 'with valid input' do
       it 'returns a form submit response object' do
-        VCR.use_cassette('evss/disability_compensation_form/submit_form') do
+        VCR.use_cassette('evss/disability_compensation_form/submit_form_v2') do
           response = subject.submit_form526(valid_form_content)
           expect(response).to be_ok
           expect(response).to be_an EVSS::DisabilityCompensationForm::FormSubmitResponse

--- a/spec/support/vcr_cassettes/evss/disability_compensation_form/rated_disabilities.yml
+++ b/spec/support/vcr_cassettes/evss/disability_compensation_form/rated_disabilities.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<EVSS_BASE_URL>/wss-form526-services-web/rest/form526/v1/ratedDisabilities"
+    uri: "<EVSS_BASE_URL>/wss-form526-services-web-v2/rest/form526/v2/ratedDisabilities"
     body:
       encoding: US-ASCII
       string: ''
@@ -95,6 +95,6 @@ http_interactions:
             } ]
           } ]
         }
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Mar 2018 21:00:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/disability_compensation_form/rated_disabilities_400.yml
+++ b/spec/support/vcr_cassettes/evss/disability_compensation_form/rated_disabilities_400.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<EVSS_BASE_URL>/wss-form526-services-web/rest/form526/v1/ratedDisabilities"
+    uri: "<EVSS_BASE_URL>/wss-form526-services-web-v2/rest/form526/v2/ratedDisabilities"
     body:
       encoding: US-ASCII
       string: ''
@@ -61,6 +61,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |-
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Mar 2018 21:00:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/disability_compensation_form/rated_disabilities_401.yml
+++ b/spec/support/vcr_cassettes/evss/disability_compensation_form/rated_disabilities_401.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<EVSS_BASE_URL>/wss-form526-services-web/rest/form526/v1/ratedDisabilities"
+    uri: "<EVSS_BASE_URL>/wss-form526-services-web-v2/rest/form526/v2/ratedDisabilities"
     body:
       encoding: US-ASCII
       string: ''
@@ -61,6 +61,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |-
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Mar 2018 21:00:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/disability_compensation_form/rated_disabilities_403.yml
+++ b/spec/support/vcr_cassettes/evss/disability_compensation_form/rated_disabilities_403.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<EVSS_BASE_URL>/wss-form526-services-web/rest/form526/v1/ratedDisabilities"
+    uri: "<EVSS_BASE_URL>/wss-form526-services-web-v2/rest/form526/v2/ratedDisabilities"
     body:
       encoding: US-ASCII
       string: ''
@@ -61,6 +61,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |-
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Mar 2018 21:00:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/disability_compensation_form/rated_disabilities_500.yml
+++ b/spec/support/vcr_cassettes/evss/disability_compensation_form/rated_disabilities_500.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<EVSS_BASE_URL>/wss-form526-services-web/rest/form526/v1/ratedDisabilities"
+    uri: "<EVSS_BASE_URL>/wss-form526-services-web-v2/rest/form526/v2/ratedDisabilities"
     body:
       encoding: US-ASCII
       string: ''
@@ -61,6 +61,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |-
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Mar 2018 21:00:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/evss/disability_compensation_form/submit_form_v2.yml
+++ b/spec/support/vcr_cassettes/evss/disability_compensation_form/submit_form_v2.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<EVSS_BASE_URL>/wss-form526-services-web/rest/form526/v2/submit"
+    uri: "<EVSS_BASE_URL>/wss-form526-services-web-v2/rest/form526/v2/submit"
     body:
       encoding: UTF-8
       string: ''


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
EVSS has stated that rated disabilities retrieved from v1 api need to be used and submitted to v1 submission endpoint and vice versa for v2. Currently, all rated disabilities are retrieved from v1. Since the release of v2 no new v1 forms are being created, ergo all GET rated_disabilities calls can be rerouted to the v2 api. 

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Change disability_compensation_form service config base_path to the v2 api

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
