### PR TITLE
deploy dev from rails upgrade branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,7 @@
+dev_branch = 'rails-5.0.7.1'
+staging_branch = 'master'
+main_branch = 'master'
+
 pipeline {
   environment {
     DOCKER_IMAGE = env.BUILD_TAG.replaceAll(/[%\/]/, '')
@@ -52,8 +56,8 @@ pipeline {
       }
     }
 
-    stage('Deploy dev and staging') {
-      when { branch 'master' }
+    stage('Build AMI') {
+      when { anyOf { branch dev_branch; branch staging_branch; branch main_branch } }
 
       steps {
         // hack to get the commit hash, some plugin is swallowing git variables and I can't figure out which one
@@ -66,7 +70,13 @@ pipeline {
           stringParam(name: 'ref', value: commit),
           booleanParam(name: 'release', value: false),
         ], wait: true
+      }
+    }
 
+    stage('Deploy dev') {
+      when { branch dev_branch }
+
+      steps {
         build job: 'deploys/vets-api-server-dev', parameters: [
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),
@@ -76,7 +86,13 @@ pipeline {
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),
         ], wait: false
+      }
+    }
 
+    stage('Deploy staging') {
+      when { branch staging_branch }
+
+      steps {
         build job: 'deploys/vets-api-server-staging', parameters: [
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),


### PR DESCRIPTION
## Description of change
Adds logic to Jenkinsfile to let us specify a staging and dev branch for environment deploys. Supports https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16825

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
