### PR TITLE
Bug in auto establish claim dedupe

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -10,17 +10,18 @@ module ClaimsApi
         skip_before_action(:authenticate)
 
         def submit_form_526
-          auto_claim = ClaimsApi::AutoEstablishedClaim.create!(
+          auto_claim = ClaimsApi::AutoEstablishedClaim.create(
             status: ClaimsApi::AutoEstablishedClaim::PENDING,
             auth_headers: auth_headers,
             form_data: form_attributes
           )
+          auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5) unless auto_claim.id
           auto_claim.form.to_internal
 
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
 
           render json: auto_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
-        rescue RuntimeError, ActiveRecord::RecordInvalid => e
+        rescue RuntimeError => e
           render json: { errors: e.message }, status: 422
         end
 

--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -10,7 +10,7 @@ module ClaimsApi
         skip_before_action(:authenticate)
 
         def submit_form_526
-          auto_claim = ClaimsApi::AutoEstablishedClaim.create(
+          auto_claim = ClaimsApi::AutoEstablishedClaim.create!(
             status: ClaimsApi::AutoEstablishedClaim::PENDING,
             auth_headers: auth_headers,
             form_data: form_attributes
@@ -20,7 +20,7 @@ module ClaimsApi
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
 
           render json: auto_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
-        rescue RuntimeError => e
+        rescue RuntimeError, ActiveRecord::RecordInvalid => e
           render json: { errors: e.message }, status: 422
         end
 

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -34,7 +34,8 @@ module ClaimsApi
     end
 
     def set_md5
-      self.md5 = Digest::MD5.hexdigest form_data.merge(auth_headers).to_json
+      headers = auth_headers.except('va_eauth_issueinstant')
+      self.md5 = Digest::MD5.hexdigest form_data.merge(headers).to_json
     end
   end
 end


### PR DESCRIPTION
## Description of change
Remove va_eauth_issueinstant as it's always new
Ensure we're raising validation errors

## Testing done
- local curls

## Acceptance Criteria (Definition of Done)
- [x] local curls now error out

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
