### PR TITLE
remove raise_on_unfiltered_parameters config

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -8,8 +8,6 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
-Rails.application.config.action_controller.raise_on_unfiltered_parameters = true
-
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
 ActiveSupport.to_time_preserves_timezone = false


### PR DESCRIPTION
## Description of change
It's causing rails console errors and will have not effect once we're >= rails 5.1

## Testing done
Unit tests/Ran console locally

## Testing planned
Run console on dev

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] rails console doesn't throw an error

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
