### PR TITLE
add extra context to sentry for saml response errors if any

### DIFF
--- a/lib/saml/response.rb
+++ b/lib/saml/response.rb
@@ -31,6 +31,7 @@ module SAML
       @normalized_errors = []
       # passing true collects all validation errors
       is_valid_result = is_valid?(true)
+      Raven.extra_context(saml_response_errors: errors) unless errors.empty?
       errors.each do |error_message|
         normalized_errors << map_message_to_error(error_message).merge(full_message: error_message)
       end


### PR DESCRIPTION
## Description of change
Adds the original array of errors from the RubySAML errors array after it has processed the SAML Response if the array is non empty.

## Testing done
sessions controller has specs around all of this

## Testing planned
none

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
