### PR TITLE
Prepend terminal illness text

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -23,6 +23,11 @@ module EVSS
         'other' => 'OTHER'
       }.freeze
 
+      TERMILL_OVERFLOW_TEXT =  "Corporate Flash Details\n" \
+                               "This applicant has indicated that they're terminally ill.\n"
+      FORM4142_OVERFLOW_TEXT = 'VA Form 21-4142/4142a has been completed by the applicant and sent to the ' \
+                               'PMR contractor for processing in accordance with M21-1 III.iii.1.D.2.'
+
       def initialize(user, form_content, has_form4142)
         @user = user
         @form_content = form_content
@@ -38,8 +43,8 @@ module EVSS
         output_form['claimantCertification'] = true
         output_form['standardClaim'] = input_form['standardClaim']
         output_form['applicationExpirationDate'] = application_expiration_date
-
-        output_form.update(append_overflow_text) if @has_form4142
+        output_form['overflowText'] = overflow_text
+        output_form.compact!
 
         output_form.update(translate_banking_info)
         output_form.update(translate_service_pay)
@@ -65,11 +70,14 @@ module EVSS
         @translated_form['form526']
       end
 
-      def append_overflow_text
-        {
-          'overflowText' => 'VA Form 21-4142/4142a has been completed by the applicant and sent to the ' \
-                            'PMR contractor for processing in accordance with M21-1 III.iii.1.D.2.'
-        }
+      def overflow_text
+        return nil unless @has_form4142 || input_form['isTerminallyIll'].present?
+
+        overflow = ''
+        overflow += TERMILL_OVERFLOW_TEXT if input_form['isTerminallyIll'].present?
+        overflow += FORM4142_OVERFLOW_TEXT if @has_form4142
+
+        overflow
       end
 
       def translate_banking_info

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -34,24 +34,61 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
     end
   end
 
-  describe '#append_overflow_text' do
-    subject { described_class.new(user, form_content, true) }
+  describe '#overflow_text' do
+    context 'when the form has a 4142 and the vet is terminally ill' do
+      subject { described_class.new(user, form_content, true) }
+      let(:form_content) do
+        {
+          'form526' => {
+            'isTerminallyIll' => true
+          }
+        }
+      end
 
-    before do
-      create(:in_progress_form, form_id: VA526ez::FORM_ID, user_uuid: user.uuid)
+      it 'should add the correct overflow text' do
+        expect(subject.send(:overflow_text)).to eq "Corporate Flash Details\n" \
+          "This applicant has indicated that they're terminally ill.\n" \
+          'VA Form 21-4142/4142a has been completed by the applicant and sent to the ' \
+          'PMR contractor for processing in accordance with M21-1 III.iii.1.D.2.'
+      end
     end
 
-    let(:form_content) do
-      JSON.parse(File.read('spec/support/disability_compensation_form/all_claims_fe_submission.json'))
+    context 'when the form only has a 4142' do
+      subject { described_class.new(user, form_content, true) }
+
+      it 'should add the correct overflow text' do
+        expect(subject.send(:overflow_text)).to eq 'VA Form 21-4142/4142a has been completed ' \
+          'by the applicant and sent to the ' \
+          'PMR contractor for processing in accordance with M21-1 III.iii.1.D.2.'
+      end
     end
 
-    it 'should append the overflowText key correctly' do
-      VCR.use_cassette('evss/ppiu/payment_information') do
-        VCR.use_cassette('evss/intent_to_file/active_compensation') do
-          VCR.use_cassette('emis/get_military_service_episodes/valid', allow_playback_repeats: true) do
-            expect(subject.translate['form526'].key?('overflowText')).to eq true
-          end
-        end
+    context 'when the vet is terminally ill only' do
+      let(:form_content) do
+        {
+          'form526' => {
+            'isTerminallyIll' => true
+          }
+        }
+      end
+
+      it 'should add the correct overflow text' do
+        expect(subject.send(:overflow_text)).to eq "Corporate Flash Details\n" \
+          "This applicant has indicated that they're terminally ill.\n"
+      end
+    end
+
+    context 'when the vet has no overflow text' do
+      let(:form_content) do
+        {
+          'form526' => {
+            'isTerminallyIll' => false
+          }
+        }
+      end
+
+      it 'should add the correct overflow text' do
+        expect(subject.send(:overflow_text)).to eq nil
       end
     end
   end

--- a/spec/support/disability_compensation_form/all_claims_fe_submission.json
+++ b/spec/support/disability_compensation_form/all_claims_fe_submission.json
@@ -115,6 +115,7 @@
       ]
     },
     "standardClaim": false,
+    "isTerminallyIll": false,
     "vaTreatmentFacilities": [
       {
         "treatmentCenterName": "Private Facility 2",


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
For Form 526, veterans may be terminally Ill. To reflect this sad news in the form, some data will be prepended to the `overflowText` section of the form based conditionally on the `isTerimallyIll` key received in the payload.

## Testing done
<!-- Please describe testing done to verify the changes. -->
spec tests

## Testing planned
<!-- Please describe testing planned. -->
website e2e tests on staging

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Allow terminally ill text to be prepended to the overflow text block

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
