### PR TITLE
add additional loggoing for logout requests and logout responses

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -143,21 +143,23 @@ module V0
 
     # temporarily logging for discovery
     def additional_logging_for_logout_request(logout_response, logout_request)
-      request_id = begin
-                     JSON.parse(params[:RelayState] || '{}')['originating_request_id']
-                   rescue
-                     'UNKNOWN'
-                   end
-
-      if logout_request.present?
-        Rails.logger.info(
-          "SLO callback response to '#{logout_response&.in_response_to}' for originating_request_id '#{request_id}'"
-        )
+      if logout_response.errors.empty?
+        if logout_request.present?
+          Rails.logger.info("SLO callback response to '#{logout_response&.in_response_to}' for originating_request_id "\
+            "'#{originating_request_id}'")
+        else
+          Rails.logger.info('SLO callback response could not resolve logout request for originating_request_id '\
+            "'#{originating_request_id}'")
+        end
       else
-        Rails.logger.info(
-          "SLO callback response could not resolve logout request for originating_request_id '#{request_id}'"
-        )
+        Rails.logger.info("SLO callback response invalid for originating_request_id '#{originating_request_id}'")
       end
+    end
+
+    def originating_request_id
+      JSON.parse(params[:RelayState] || '{}')['originating_request_id']
+    rescue
+      'UNKNOWN'
     end
 
     def url_service

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -144,7 +144,7 @@ module V0
     # temporarily logging for discovery
     def additional_logging_for_logout_request(logout_response, logout_request)
       request_id = begin
-                     JSON.parse(params[:RelayState] || '{}')[:originating_request_id]
+                     JSON.parse(params[:RelayState] || '{}')['originating_request_id']
                    rescue
                      'UNKNOWN'
                    end

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -32,6 +32,7 @@ module V0
       logout_request  = SingleLogoutRequest.find(logout_response&.in_response_to)
 
       errors = build_logout_errors(logout_response, logout_request)
+      additional_logging_for_logout_request(logout_response, logout_request)
 
       if errors.size.positive?
         extra_context = { in_response_to: logout_response&.in_response_to }
@@ -138,6 +139,25 @@ module V0
       errors << 'inResponseTo attribute is nil!' if logout_response&.in_response_to.nil?
       errors << 'Logout Request not found!' if logout_request.nil?
       errors
+    end
+
+    # temporarily logging for discovery
+    def additional_logging_for_logout_request(logout_response, logout_request)
+      request_id = begin
+                     JSON.parse(params[:RelayState] || '{}')[:originating_request_id]
+                   rescue
+                     'UNKNOWN'
+                   end
+
+      if logout_request.present?
+        Rails.logger.info(
+          "SLO callback response to '#{logout_response&.in_response_to}' for originating_request_id '#{request_id}'"
+        )
+      else
+        Rails.logger.info(
+          "SLO callback response could not resolve logout request for originating_request_id '#{request_id}'"
+        )
+      end
     end
 
     def url_service

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -115,7 +115,7 @@ module SAML
       logout_request = OneLogin::RubySaml::Logoutrequest.new
       # cache the request for session.token lookup when we receive the response
       SingleLogoutRequest.create(uuid: logout_request.uuid, token: session.token)
-      Rails.logger.info "New SP SLO for userid '#{session.uuid}'"
+      Rails.logger.info "New SP SLO having logout_request '#{logout_request.uuid}' for userid '#{session.uuid}'"
       logout_request.create(url_settings, RelayState: relay_state_params)
     end
 

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -216,6 +216,9 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(User.find(uuid)).to_not be_nil
           # this will be destroyed
           expect(SingleLogoutRequest.find(successful_logout_response&.in_response_to)).to_not be_nil
+
+          msg = "SLO callback response to '1234' for originating_request_id ''"
+          expect(Rails.logger).to receive(:info).with(/#{msg}/).exactly(1).times
           expect(post(:saml_logout_callback, params: { SAMLResponse: '-' }))
             .to redirect_to(logout_redirect_url)
           # these should have been destroyed in the initial call to sessions/logout, not in the callback.


### PR DESCRIPTION
## Description of change
Trying to better understand why logout requests cannot be found in certain circumstances. Should be able discover this in Rails logs after adding this additional logging.

## Testing done
specs only

## Testing planned
after merging and getting a few failures in sentry, will use AWS api to try to track down where things get messed up.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
