### PR TITLE
Cleanup spec warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,10 +33,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 59807d15c8d8cf7312bedb3076478aad2fa7762e
+  revision: b8962e19a1dd9ab8e797f363fa5510e5fa5a3fc4
   branch: master
   specs:
-    vets_json_schema (3.138.2)
+    vets_json_schema (3.138.3)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   # config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,8 +19,8 @@ Rails.application.configure do
   config.eager_load = ENV['CI'].present?
 
   # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files   = true
-  config.static_cache_control = 'public, max-age=3600'
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/spec/jobs/education_form/forms/va1990_spec.rb
+++ b/spec/jobs/education_form/forms/va1990_spec.rb
@@ -7,14 +7,10 @@ RSpec.describe EducationForm::Forms::VA1990, type: :model, form: :education_bene
 
   subject { described_class.new(application) }
 
-  SAMPLE_APPLICATIONS = %i[
-    simple_ch33 kitchen_sink kitchen_sink_edu_prog kitchen_sink_active_duty
-  ].freeze
-
   # For each sample application we have, format it and compare it against a 'known good'
   # copy of that submission. This technically covers all the helper logic found in the
   # `Form` specs, but are a good safety net for tracking how forms change over time.
-  SAMPLE_APPLICATIONS.each do |application_name|
+  %i[simple_ch33 kitchen_sink kitchen_sink_edu_prog kitchen_sink_active_duty].each do |application_name|
     test_spool_file('1990', application_name)
   end
 

--- a/spec/jobs/education_form/forms/va1995_spec.rb
+++ b/spec/jobs/education_form/forms/va1995_spec.rb
@@ -7,14 +7,10 @@ RSpec.describe EducationForm::Forms::VA1995 do
 
   subject { described_class.new(education_benefits_claim) }
 
-  SAMPLE_APPLICATIONS = %i[
-    minimal kitchen_sink
-  ].freeze
-
   # For each sample application we have, format it and compare it against a 'known good'
   # copy of that submission. This technically covers all the helper logic found in the
   # `Form` specs, but are a good safety net for tracking how forms change over time.
-  SAMPLE_APPLICATIONS.each do |application_name|
+  %i[minimal kitchen_sink].each do |application_name|
     test_spool_file('1995', application_name)
   end
 

--- a/spec/lib/search/service_spec.rb
+++ b/spec/lib/search/service_spec.rb
@@ -103,7 +103,7 @@ describe Search::Service do
         VCR.use_cassette('search/exceeds_rate_limit', VCR::MATCH_EVERYTHING) do
           expect_any_instance_of(described_class).to_not receive(:log_message_to_sentry)
 
-          expect { subject.results }.to raise_error
+          expect { subject.results }.to raise_error(Common::Exceptions::BackendServiceException)
         end
       end
     end


### PR DESCRIPTION
## Description of change
Various fixes to minimize various warnings that appear when running specs

## Testing done
specs

## Testing planned
N/A

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] config changes to satisfy Rails 5.1 deprecation warnings
- [x] spec: specify which exception for `raise_error` matcher
- [x] Remove unnecessary constants from spec suite (since they live in a shared namespace)
- [x] bump version of vets_json_schema

#### Applies to all PRs

- [ ] ~~Appropriate logging~~
- [ ] ~~Swagger docs have been updated, if applicable~~
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] ~~Provide which alerts would indicate a problem with this functionality (if applicable)~~
