### PR TITLE
Adds effective date to /v0/health_care_applications/enrollment_status response

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -3,6 +3,7 @@
 class HealthCareApplication < ApplicationRecord
   include TempFormValidation
   include SentryLogging
+  include HCA::EnrollmentEligibility::ParsedStatuses
 
   FORM_ID = '10-10EZ'
 
@@ -81,7 +82,7 @@ class HealthCareApplication < ApplicationRecord
     else
       {
         parsed_status:
-          ee_data[:enrollment_status].present? ? :login_required : :none_of_the_above
+          ee_data[:enrollment_status].present? ? LOGIN_REQUIRED : NONE
       }
     end
   end

--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -75,7 +75,8 @@ class HealthCareApplication < ApplicationRecord
       ee_data.slice(
         :application_date,
         :enrollment_date,
-        :preferred_facility
+        :preferred_facility,
+        :effective_date
       ).merge(parsed_status: parsed_status)
     else
       {

--- a/app/swagger/requests/health_care_applications.rb
+++ b/app/swagger/requests/health_care_applications.rb
@@ -38,7 +38,9 @@ module Swagger
 
       swagger_path '/v0/health_care_applications/enrollment_status' do
         operation :get do
-          key :description, 'Check the status of a health care application'
+          key :description, 'Check the status of a health care application.'\
+            ' Non-logged in users must pass query parameters with user attributes.'\
+            ' No parameters needed for logged in loa3 users.'
           key :operationId, 'enrollmentStatusHealthCareApplication'
           key :tags, %w[benefits_forms]
 
@@ -87,10 +89,14 @@ module Swagger
             key :description, 'enrollment_status response'
 
             schema do
-              property :application_date, type: %i[string null]
-              property :enrollment_date, type: %i[string null]
-              property :preferred_facility, type: %i[string null]
-              property :parsed_status, type: :string
+              property :application_date, type: %i[string null], example: '2018-12-27T00:00:00.000-06:00'
+              property :enrollment_date, type: %i[string null], example: '2018-12-27T17:15:39.000-06:00'
+              property :preferred_facility, type: %i[string null], example: '988 - DAYT20'
+              property :parsed_status,
+                       type: :string,
+                       example: HCA::EnrollmentEligibility::ParsedStatuses::ENROLLED,
+                       enum: HCA::EnrollmentEligibility::ParsedStatuses::ELIGIBLE_STATUSES
+              property :effective_date, type: :string, example: '2019-01-02T21:58:55.000-06:00'
             end
           end
         end

--- a/lib/hca/enrollment_eligibility/parsed_statuses.rb
+++ b/lib/hca/enrollment_eligibility/parsed_statuses.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module HCA
+  module EnrollmentEligibility
+    module ParsedStatuses
+      ACTIVEDUTY = 'activeduty'
+      CANCELED_DECLINED = 'canceled_declined'
+      CLOSED = 'closed'
+      DECEASED = 'deceased'
+      ENROLLED = 'enrolled'
+      INELIG_CHAMPVA = 'inelig_champva'
+      INELIG_CHARACTER_OF_DISCHARGE = 'inelig_character_of_discharge'
+      INELIG_CITIZENS = 'inelig_citizens'
+      INELIG_FILIPINOSCOUTS = 'inelig_filipinoscouts'
+      INELIG_FUGITIVEFELON = 'inelig_fugitivefelon'
+      INELIG_GUARD_RESERVE = 'inelig_guard_reserve'
+      INELIG_MEDICARE = 'inelig_medicare'
+      INELIG_NOT_ENOUGH_TIME = 'inelig_not_enough_time'
+      INELIG_NOT_VERIFIED = 'inelig_not_verified'
+      INELIG_OVER65 = 'inelig_over65'
+      INELIG_REFUSEDCOPAY = 'inelig_refusedcopay'
+      INELIG_TRAINING_ONLY = 'inelig_training_only'
+      LOGIN_REQUIRED = 'login_required'
+      NONE = 'none_of_the_above'
+      PENDING_MT = 'pending_mt'
+      PENDING_OTHER = 'pending_other'
+      PENDING_PURPLEHEART = 'pending_purpleheart'
+      PENDING_UNVERIFIED = 'pending_unverified'
+      REJECTED_INC_WRONGENTRY = 'rejected_inc_wrongentry'
+      REJECTED_RIGHTENTRY = 'rejected_rightentry'
+      REJECTED_SC_WRONGENTRY = 'rejected_sc_wrongentry'
+
+      ELIGIBLE_STATUSES = [
+        ACTIVEDUTY,
+        CANCELED_DECLINED,
+        CLOSED,
+        DECEASED,
+        ENROLLED,
+        INELIG_CHAMPVA,
+        INELIG_CHARACTER_OF_DISCHARGE,
+        INELIG_CITIZENS,
+        INELIG_FILIPINOSCOUTS,
+        INELIG_FUGITIVEFELON,
+        INELIG_GUARD_RESERVE,
+        INELIG_MEDICARE,
+        INELIG_NOT_ENOUGH_TIME,
+        INELIG_NOT_VERIFIED,
+        INELIG_OVER65,
+        INELIG_REFUSEDCOPAY,
+        INELIG_TRAINING_ONLY,
+        LOGIN_REQUIRED,
+        NONE,
+        PENDING_MT,
+        PENDING_OTHER,
+        PENDING_PURPLEHEART,
+        PENDING_UNVERIFIED,
+        REJECTED_INC_WRONGENTRY,
+        REJECTED_RIGHTENTRY,
+        REJECTED_SC_WRONGENTRY
+      ].freeze
+    end
+  end
+end

--- a/lib/hca/enrollment_eligibility/service.rb
+++ b/lib/hca/enrollment_eligibility/service.rb
@@ -30,6 +30,10 @@ module HCA
           ineligibility_reason: get_xpath(
             response,
             "#{XPATH_PREFIX}enrollmentDeterminationInfo/ineligibilityFactor/reason"
+          ),
+          effective_date: get_xpath(
+            response,
+            "#{XPATH_PREFIX}enrollmentDeterminationInfo/effectiveDate"
           )
         }
       end

--- a/lib/hca/enrollment_eligibility/status_matcher.rb
+++ b/lib/hca/enrollment_eligibility/status_matcher.rb
@@ -5,26 +5,27 @@ module HCA
   module EnrollmentEligibility
     module StatusMatcher
       module_function
+      include ParsedStatuses
 
       CATEGORIES = [
         {
           enrollment_status: 'verified',
-          category: :enrolled
+          category: ENROLLED
         },
         {
           enrollment_status: ['not eligible', 'not eligible; ineligible date'],
           text_matches: [
             {
-              category: :inelig_not_enough_time,
+              category: INELIG_NOT_ENOUGH_TIME,
               strings: ['24 months', 'less than', '24 mos', '24months', 'two years']
             },
             {
-              category: :inelig_training_only,
+              category: INELIG_TRAINING_ONLY,
               strings: ['training only', 'trng only'],
               acronyms: %w[ADT ACDUTRA ADUTRA]
             },
             {
-              category: :inelig_character_of_discharge,
+              category: INELIG_CHARACTER_OF_DISCHARGE,
               strings: [
                 'other than honorable', 'dishonorable',
                 'bad conduct', 'dis for va pur'
@@ -32,86 +33,84 @@ module HCA
               acronyms: %w[OTH DVA]
             },
             {
-              category: :inelig_not_verified,
+              category: INELIG_NOT_VERIFIED,
               strings: ['no proof', 'no record', 'non-vet', 'non vet', 'unable to verify', 'not a veteran', '214']
             },
             {
-              category: :inelig_guard_reserve,
+              category: INELIG_GUARD_RESERVE,
               strings: %w[guard reserve reservist]
             },
             {
-              category: :inelig_champva,
+              category: INELIG_CHAMPVA,
               strings: ['champva']
             },
             {
-              category: :inelig_fugitivefelon,
+              category: INELIG_FUGITIVEFELON,
               strings: ['felon']
             },
             {
-              category: :inelig_medicare,
+              category: INELIG_MEDICARE,
               strings: ['medicare']
             },
             {
-              category: :inelig_over65,
+              category: INELIG_OVER65,
               strings: ['over 65']
             },
             {
-              category: :inelig_citizens,
+              category: INELIG_CITIZENS,
               strings: ['citizen']
             },
             {
-              category: :inelig_filipinoscouts,
+              category: INELIG_FILIPINOSCOUTS,
               strings: ['filipino']
             },
             {
-              category: :rejected_sc_wrongentry,
+              category: REJECTED_SC_WRONGENTRY,
               strings: ['disability']
             },
             {
-              category: :rejected_inc_wrongentry,
+              category: REJECTED_INC_WRONGENTRY,
               strings: ['income']
             }
           ]
         },
         {
           enrollment_status: 'not applicable',
-          category: :activeduty
+          category: ACTIVEDUTY
         },
         {
           enrollment_status: 'deceased',
-          category: :deceased
+          category: DECEASED
         },
         {
           enrollment_status: 'closed application',
-          category: :closed
+          category: CLOSED
         },
         {
           enrollment_status: 'not eligible; refused to pay copay',
-          category: :inelig_refusedcopay
+          category: INELIG_REFUSEDCOPAY
         },
         {
           enrollment_status: 'pending; means test required',
-          category: :pending_mt
+          category: PENDING_MT
         },
         {
           enrollment_status: 'pending; eligibility status is unverified',
-          category: :pending_unverified
+          category: PENDING_UNVERIFIED
         },
         {
           enrollment_status: 'pending; other',
-          category: :pending_other
+          category: PENDING_OTHER
         },
         {
           enrollment_status: 'pending; purple heart unconfirmed',
-          category: :pending_purpleheart
+          category: PENDING_PURPLEHEART
         },
         {
           enrollment_status: 'cancelled/declined',
-          category: :canceled_declined
+          category: CANCELED_DECLINED
         }
       ].freeze
-
-      NONE = :none_of_the_above
 
       def process_text_match(text_matches, ineligibility_reason)
         text_matches.each do |text_match_data|
@@ -153,7 +152,7 @@ module HCA
           end
         end
 
-        return :rejected_rightentry if enrollment_status.include?('rejected')
+        return REJECTED_RIGHTENTRY if enrollment_status.include?('rejected')
 
         NONE
       end

--- a/lib/hca/enrollment_eligibility/status_matcher.rb
+++ b/lib/hca/enrollment_eligibility/status_matcher.rb
@@ -5,6 +5,7 @@ module HCA
   module EnrollmentEligibility
     module StatusMatcher
       module_function
+
       include ParsedStatuses
 
       CATEGORIES = [

--- a/spec/lib/hca/enrollment_eligibility/service_spec.rb
+++ b/spec/lib/hca/enrollment_eligibility/service_spec.rb
@@ -17,7 +17,8 @@ describe HCA::EnrollmentEligibility::Service do
             application_date: '2018-01-24T00:00:00.000-06:00',
             enrollment_date: nil,
             preferred_facility: '987 - CHEY6',
-            ineligibility_reason: 'for testing'
+            ineligibility_reason: 'for testing',
+            effective_date: '2019-01-25T09:04:04.000-06:00'
           )
         end
       end
@@ -35,7 +36,8 @@ describe HCA::EnrollmentEligibility::Service do
           application_date: '2018-12-27T00:00:00.000-06:00',
           enrollment_date: '2018-12-27T17:15:39.000-06:00',
           preferred_facility: '988 - DAYT20',
-          ineligibility_reason: nil
+          ineligibility_reason: nil,
+          effective_date: '2019-01-02T21:58:55.000-06:00'
         )
       end
     end

--- a/spec/lib/hca/enrollment_eligibility/status_matcher_spec.rb
+++ b/spec/lib/hca/enrollment_eligibility/status_matcher_spec.rb
@@ -4,26 +4,28 @@ require 'rails_helper'
 
 describe HCA::EnrollmentEligibility::StatusMatcher do
   describe '#parse' do
+    STATUS = 'HCA::EnrollmentEligibility::ParsedStatuses'.constantize
+
     subject do
       described_class.parse(enrollment_status, ineligibility_reason)
     end
     let(:ineligibility_reason) { nil }
 
     [
-      ['Verified', :enrolled],
-      ['Not Eligible; Refused to Pay Copay', :inelig_refusedcopay],
-      ['Rejected', :rejected_rightentry],
-      ['Rejected;Initial Application by VAMC', :rejected_rightentry],
-      ['Not Applicable', :activeduty],
-      ['Deceased', :deceased],
-      ['Closed Application', :closed],
-      ['Pending; Means Test Required', :pending_mt],
-      ['Pending; Eligibility Status is Unverified', :pending_unverified],
-      ['Pending; Other', :pending_other],
-      ['Pending; Purple Heart Unconfirmed', :pending_purpleheart],
-      ['Cancelled/Declined', :canceled_declined],
-      [nil, :none_of_the_above],
-      ['Unverified', :none_of_the_above]
+      ['Verified', STATUS::ENROLLED],
+      ['Not Eligible; Refused to Pay Copay', STATUS::INELIG_REFUSEDCOPAY],
+      ['Rejected', STATUS::REJECTED_RIGHTENTRY],
+      ['Rejected;Initial Application by VAMC', STATUS::REJECTED_RIGHTENTRY],
+      ['Not Applicable', STATUS::ACTIVEDUTY],
+      ['Deceased', STATUS::DECEASED],
+      ['Closed Application', STATUS::CLOSED],
+      ['Pending; Means Test Required', STATUS::PENDING_MT],
+      ['Pending; Eligibility Status is Unverified', STATUS::PENDING_UNVERIFIED],
+      ['Pending; Other', STATUS::PENDING_OTHER],
+      ['Pending; Purple Heart Unconfirmed', STATUS::PENDING_PURPLEHEART],
+      ['Cancelled/Declined', STATUS::CANCELED_DECLINED],
+      [nil, STATUS::NONE],
+      ['Unverified', STATUS::NONE]
     ].each do |test_data|
       context "when enrollment status is #{test_data[0]}" do
         let(:enrollment_status) { test_data[0] }
@@ -42,22 +44,22 @@ describe HCA::EnrollmentEligibility::StatusMatcher do
         let(:enrollment_status) { enrollment_status }
 
         [
-          ['24 Months', :inelig_not_enough_time],
-          ['training only', :inelig_training_only],
-          ['ACDUTRA', :inelig_training_only],
-          ['ACDUTRa', :none_of_the_above],
-          ['Other than honorable', :inelig_character_of_discharge],
-          ['OTH', :inelig_character_of_discharge],
-          ['non vet', :inelig_not_verified],
-          ['Guard', :inelig_guard_reserve],
-          ['champva', :inelig_champva],
-          ['felon', :inelig_fugitivefelon],
-          ['medicare', :inelig_medicare],
-          ['over 65', :inelig_over65],
-          ['citizen', :inelig_citizens],
-          ['filipino', :inelig_filipinoscouts],
-          ['disability', :rejected_sc_wrongentry],
-          ['income', :rejected_inc_wrongentry]
+          ['24 Months', STATUS::INELIG_NOT_ENOUGH_TIME],
+          ['training only', STATUS::INELIG_TRAINING_ONLY],
+          ['ACDUTRA', STATUS::INELIG_TRAINING_ONLY],
+          ['ACDUTRa', STATUS::NONE],
+          ['Other than honorable', STATUS::INELIG_CHARACTER_OF_DISCHARGE],
+          ['OTH', STATUS::INELIG_CHARACTER_OF_DISCHARGE],
+          ['non vet', STATUS::INELIG_NOT_VERIFIED],
+          ['Guard', STATUS::INELIG_GUARD_RESERVE],
+          ['champva', STATUS::INELIG_CHAMPVA],
+          ['felon', STATUS::INELIG_FUGITIVEFELON],
+          ['medicare', STATUS::INELIG_MEDICARE],
+          ['over 65', STATUS::INELIG_OVER65],
+          ['citizen', STATUS::INELIG_CITIZENS],
+          ['filipino', STATUS::INELIG_FILIPINOSCOUTS],
+          ['disability', STATUS::REJECTED_SC_WRONGENTRY],
+          ['income', STATUS::REJECTED_INC_WRONGENTRY]
         ].each do |test_data|
           context "when text includes #{test_data[0]}" do
             let(:ineligibility_reason) { "abc #{test_data[0]}." }

--- a/spec/lib/hca/enrollment_eligibility/status_matcher_spec.rb
+++ b/spec/lib/hca/enrollment_eligibility/status_matcher_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe HCA::EnrollmentEligibility::StatusMatcher do
   describe '#parse' do
-    STATUS = 'HCA::EnrollmentEligibility::ParsedStatuses'.constantize
+    STATUS = HCA::EnrollmentEligibility::ParsedStatuses
 
     subject do
       described_class.parse(enrollment_status, ineligibility_reason)

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe HealthCareApplication, type: :model do
   let(:health_care_application) { create(:health_care_application) }
+  let(:inelig_character_of_discharge) { HCA::EnrollmentEligibility::ParsedStatuses::INELIG_CHARACTER_OF_DISCHARGE }
+  let(:login_required) { HCA::EnrollmentEligibility::ParsedStatuses::LOGIN_REQUIRED }
 
   describe '.enrollment_status' do
     it 'should return parsed enrollment status' do
@@ -21,7 +23,7 @@ RSpec.describe HealthCareApplication, type: :model do
         application_date: '2018-01-24T00:00:00.000-06:00',
         enrollment_date: nil,
         preferred_facility: '987 - CHEY6',
-        parsed_status: :inelig_character_of_discharge
+        parsed_status: inelig_character_of_discharge,
         effective_date: '2018-01-24T00:00:00.000-09:00'
       )
     end
@@ -45,7 +47,7 @@ RSpec.describe HealthCareApplication, type: :model do
           application_date: '2018-01-24T00:00:00.000-06:00',
           enrollment_date: nil,
           preferred_facility: '987 - CHEY6',
-          parsed_status: :inelig_character_of_discharge
+          parsed_status: inelig_character_of_discharge,
           effective_date: '2018-01-24T00:00:00.000-09:00'
         )
       end
@@ -54,7 +56,7 @@ RSpec.describe HealthCareApplication, type: :model do
     context 'with a loa1 user' do
       it 'should return partial ee data' do
         expect(described_class.parsed_ee_data(ee_data, false)).to eq(
-          parsed_status: :login_required
+          parsed_status: login_required
         )
       end
     end

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -14,13 +14,15 @@ RSpec.describe HealthCareApplication, type: :model do
         application_date: '2018-01-24T00:00:00.000-06:00',
         enrollment_date: nil,
         preferred_facility: '987 - CHEY6',
-        ineligibility_reason: 'OTH'
+        ineligibility_reason: 'OTH',
+        effective_date: '2018-01-24T00:00:00.000-09:00'
       )
       expect(described_class.enrollment_status('123', true)).to eq(
         application_date: '2018-01-24T00:00:00.000-06:00',
         enrollment_date: nil,
         preferred_facility: '987 - CHEY6',
         parsed_status: :inelig_character_of_discharge
+        effective_date: '2018-01-24T00:00:00.000-09:00'
       )
     end
   end
@@ -32,7 +34,8 @@ RSpec.describe HealthCareApplication, type: :model do
         application_date: '2018-01-24T00:00:00.000-06:00',
         enrollment_date: nil,
         preferred_facility: '987 - CHEY6',
-        ineligibility_reason: 'OTH'
+        ineligibility_reason: 'OTH',
+        effective_date: '2018-01-24T00:00:00.000-09:00'
       }
     end
 
@@ -43,6 +46,7 @@ RSpec.describe HealthCareApplication, type: :model do
           enrollment_date: nil,
           preferred_facility: '987 - CHEY6',
           parsed_status: :inelig_character_of_discharge
+          effective_date: '2018-01-24T00:00:00.000-09:00'
         )
       end
     end

--- a/spec/request/health_care_applications_request_spec.rb
+++ b/spec/request/health_care_applications_request_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
         it 'should return the enrollment status data' do
           allow_any_instance_of(User).to receive(:icn).and_return('1013032368V065534')
 
-          VCR.use_cassette('hca/ee/lookup_user', { erb: true }) do
+          VCR.use_cassette('hca/ee/lookup_user', erb: true) do
             get(enrollment_status_v0_health_care_applications_path)
 
             expect(response.body).to eq(success_response.to_json)

--- a/spec/request/health_care_applications_request_spec.rb
+++ b/spec/request/health_care_applications_request_spec.rb
@@ -31,14 +31,16 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
   end
 
   describe 'GET enrollment_status' do
+    let(:inelig_character_of_discharge) { HCA::EnrollmentEligibility::ParsedStatuses::INELIG_CHARACTER_OF_DISCHARGE }
+    let(:login_required) { HCA::EnrollmentEligibility::ParsedStatuses::LOGIN_REQUIRED }
     let(:success_response) do
       { application_date: '2018-01-24T00:00:00.000-06:00',
         enrollment_date: nil,
         preferred_facility: '987 - CHEY6',
-        parsed_status: :inelig_character_of_discharge }
+        parsed_status: inelig_character_of_discharge }
     end
     let(:loa1_response) do
-      { parsed_status: :login_required }
+      { parsed_status: login_required }
     end
 
     context 'with user attributes' do

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
     end
 
     context 'HCA tests' do
+      let(:login_required) { HCA::EnrollmentEligibility::ParsedStatuses::LOGIN_REQUIRED }
       let(:test_veteran) do
         File.read(
           Rails.root.join('spec', 'fixtures', 'hca', 'veteran.json')
@@ -228,7 +229,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
         expect(HealthCareApplication).to receive(:user_icn).and_return('123')
         expect(HealthCareApplication).to receive(:enrollment_status).with(
           '123', nil
-        ).and_return(parsed_status: :login_required)
+        ).and_return(parsed_status: login_required)
 
         expect(subject).to validate(
           :get,


### PR DESCRIPTION
## Description of change
Per the discovery in [#17798](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17798) around dismissed health care alerts, we will need to know when a user's current enrollment status became active.  Said otherwise, when their status changed from the former status, to the current enrollment status.

This data is already present in the [E&E API response](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16106#issuecomment-461677834) in the `enrollmentDeterminationInfo/effectiveDate` field.

## Testing done
<!-- Please describe testing done to verify the changes. -->
Local and automated testing

## Testing planned
<!-- Please describe testing planned. -->
Staging testing

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Adds `effective_date` to the `GET /v0/health_care_applications/enrollment_status` response
- [x] Identifies/encapsulates potential `parsed_status` values
- [x] Updates swagger docs
- [x] Updates specs
- [x] Updates swagger docs with enum of potential `parsed_status` values

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

## Screenshots

#### New `effective_date` property in `/v0/health_care_applications/enrollment_status`

![image](https://user-images.githubusercontent.com/7482329/55993041-4d523500-5c6b-11e9-9daf-72b8d71c5feb.png)

#### Enum of potential `parsed_status` values

![image](https://user-images.githubusercontent.com/7482329/55993058-58a56080-5c6b-11e9-8375-2ea8ecbd72f5.png)
