### PR TITLE
Add mock route for ratedDisabilities v2

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -201,6 +201,12 @@
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: 'va_eauth_pnid'
+  - :method: :get
+    :path: "/wss-form526-services-web-v2/rest/form526/v2/ratedDisabilities"
+    :file_path: "evss/disability_form/rated_disabilities"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: 'va_eauth_pnid' 
   - :method: :post
     :path: "/wss-form526-services-web/rest/form526/v1/submit"
     :file_path: "evss/disability_form/submit"


### PR DESCRIPTION
## Description of change
department-of-veterans-affairs/vets-api/pull/2919 changed the rate disabilities to use the v2 API. This pull requests adds a mocked route for the new path, so that Betamocks can retrieve mockdata for it.

Resolves department-of-veterans-affairs/vets-contrib/issues/1796.

## Testing done
Added mocked route and no longer receive 500 error locally.

## Testing planned
Once merged will verify that a `GET` request to `/ratedDisabilities` endpoint no longer receives a 500 error.

## Acceptance Criteria (Definition of Done)
#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
