### PR TITLE
Log saml validation errors

### DIFF
--- a/app/services/sso_service.rb
+++ b/app/services/sso_service.rb
@@ -84,7 +84,7 @@ class SSOService
     end
     @auth_error_code = error_hash[:code]
     @failure_instrumentation_tag = "error:#{error_hash[:tag]}"
-    log_message_to_sentry(message, error_hash[:level], error_context)
+    log_message_to_sentry(message, error_hash[:level], error_messages: error_context)
   end
 
   def validation_error_context

--- a/app/services/sso_service.rb
+++ b/app/services/sso_service.rb
@@ -74,7 +74,7 @@ class SSOService
     message = 'Login Fail! '
     if saml_response.normalized_errors.present?
       error_hash = saml_response.normalized_errors.first
-      error_context = saml_response.normalized_errors
+      error_context = { error_context: saml_response.normalized_errors }
       message += error_hash[:short_message]
       message += ' Multiple SAML Errors' if saml_response.normalized_errors.count > 1
     else
@@ -84,7 +84,7 @@ class SSOService
     end
     @auth_error_code = error_hash[:code]
     @failure_instrumentation_tag = "error:#{error_hash[:tag]}"
-    log_message_to_sentry(message, error_hash[:level], error_messages: error_context)
+    log_message_to_sentry(message, error_hash[:level], error_context)
   end
 
   def validation_error_context

--- a/lib/saml/response.rb
+++ b/lib/saml/response.rb
@@ -31,7 +31,6 @@ module SAML
       @normalized_errors = []
       # passing true collects all validation errors
       is_valid_result = is_valid?(true)
-      Raven.extra_context(saml_response_errors: errors) unless errors.empty?
       errors.each do |error_message|
         normalized_errors << map_message_to_error(error_message).merge(full_message: error_message)
       end

--- a/lib/saml/response.rb
+++ b/lib/saml/response.rb
@@ -31,6 +31,7 @@ module SAML
       @normalized_errors = []
       # passing true collects all validation errors
       is_valid_result = is_valid?(true)
+      Raven.extra_context(saml_response_errors: errors) unless errors.empty?
       errors.each do |error_message|
         normalized_errors << map_message_to_error(error_message).merge(full_message: error_message)
       end

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -500,12 +500,14 @@ RSpec.describe V0::SessionsController, type: :controller do
             .with(
               'Login Fail! Other SAML Response Error(s)',
               :error,
-              [{ code: '007',
-                 tag: :unknown,
-                 short_message: 'Other SAML Response Error(s)',
-                 level: :error,
-                 full_message: 'The status code of the Response was not Success, was Requester => NoAuthnContext ->'\
-                               ' AuthnRequest without an authentication context.' }]
+              error_context: [
+                { code: '007',
+                  tag: :unknown,
+                  short_message: 'Other SAML Response Error(s)',
+                  level: :error,
+                  full_message: 'The status code of the Response was not Success, was Requester => NoAuthnContext ->'\
+                                ' AuthnRequest without an authentication context.' }
+              ]
             )
           expect(post(:saml_callback)).to redirect_to('http://127.0.0.1:3001/auth/login/callback?auth=fail&code=007')
           expect(response).to have_http_status(:found)
@@ -531,10 +533,18 @@ RSpec.describe V0::SessionsController, type: :controller do
             .with(
               'Login Fail! Subject did not consent to attribute release Multiple SAML Errors',
               :warn,
-              [{ code: '001', tag: :clicked_deny, short_message: 'Subject did not consent to attribute release',
-                 level: :warn, full_message: 'Subject did not consent to attribute release' },
-               { code: '007', tag: :unknown, short_message: 'Other SAML Response Error(s)', level: :error,
-                 full_message: 'Other random error' }]
+              error_context: [
+                { code: '001',
+                  tag: :clicked_deny,
+                  short_message: 'Subject did not consent to attribute release',
+                  level: :warn,
+                  full_message: 'Subject did not consent to attribute release' },
+                { code: '007',
+                  tag: :unknown,
+                  short_message: 'Other SAML Response Error(s)',
+                  level: :error,
+                  full_message: 'Other random error' }
+              ]
             )
           expect(post(:saml_callback)).to redirect_to('http://127.0.0.1:3001/auth/login/callback?auth=fail&code=001')
           expect(response).to have_http_status(:found)


### PR DESCRIPTION
## Description of change
bugfix - log_message_to_sentry takes a hash for extra_context

## Testing done
specs

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
