### PR TITLE
Rails 5.1 belongs to changes

### DIFF
--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :form526_submission do
     user_uuid SecureRandom.uuid
-    saved_claim_id { create(:va526ez) }
+    saved_claim { create(:va526ez) }
     submitted_claim_id nil
     auth_headers_json ''
     form_json do

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :form526_submission do
     user_uuid SecureRandom.uuid
-    saved_claim_id '123'
+    saved_claim_id { create(:va526ez) }
     submitted_claim_id nil
     auth_headers_json ''
     form_json do

--- a/spec/factories/preference_choices.rb
+++ b/spec/factories/preference_choices.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :preference_choice do
     sequence(:code) { |n| "choice_#{n}" }
     sequence(:description) { |n| "Description of Choice #{n}" }
+    preference
   end
 end

--- a/spec/models/saved_claims/pension_spec.rb
+++ b/spec/models/saved_claims/pension_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe SavedClaim::Pension, uploader_helpers: true do
   context 'saved claims w/ attachments' do
     stub_virus_scan
 
-    let!(:attachment1) { FactoryBot.create(:pension_burial, saved_claim_id: nil) }
-    let!(:attachment2) { FactoryBot.create(:pension_burial, saved_claim_id: nil) }
+    let!(:attachment1) { FactoryBot.create(:pension_burial) }
+    let!(:attachment2) { FactoryBot.create(:pension_burial) }
 
     let(:claim) do
       FactoryBot.create(

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -10,14 +10,16 @@ describe UserPreference, type: :model do
 
   describe '.all_preferences_with_choices' do
     let(:user) { build(:user, :loa1) }
+    let(:account) { create(:account) }
+    let(:account_id) { account.id }
 
     before(:each) do
-      allow_any_instance_of(User).to receive(:account).and_return(OpenStruct.new(id: 1))
+      allow_any_instance_of(User).to receive(:account).and_return(OpenStruct.new(id: account_id))
     end
 
     context 'when the User has no UserPreferences' do
       it 'returns an empty array' do
-        results = UserPreference.all_preferences_with_choices(1)
+        results = UserPreference.all_preferences_with_choices(account_id)
         expect(results).to eq []
       end
     end
@@ -25,11 +27,11 @@ describe UserPreference, type: :model do
     context 'when the User has a single Preference with UserPreferences' do
       it 'returns a single object in the array' do
         benefits = create(:preference, :benefits)
-        UserPreference.create(account_id: 1,
+        UserPreference.create(account: account,
                               preference_id: benefits.id,
                               preference_choice_id: benefits.choices.first.id)
 
-        results = UserPreference.all_preferences_with_choices(1)
+        results = UserPreference.all_preferences_with_choices(account_id)
 
         expect(results.size).to eq 1
         expect(results.first).to have_key(:preference)
@@ -41,17 +43,17 @@ describe UserPreference, type: :model do
       it 'returns an array of objects including preference/user preference pairs' do
         benefits = create(:preference, :benefits)
         notifications = create(:preference, :notifications)
-        UserPreference.create(account_id: 1,
+        UserPreference.create(account: account,
                               preference_id: benefits.id,
                               preference_choice_id: benefits.choices.first.id)
-        UserPreference.create(account_id: 1,
+        UserPreference.create(account: account,
                               preference_id: notifications.id,
                               preference_choice_id: notifications.choices.first.id)
-        UserPreference.create(account_id: 1,
+        UserPreference.create(account: account,
                               preference_id: notifications.id,
                               preference_choice_id: notifications.choices.last.id)
 
-        results = UserPreference.all_preferences_with_choices(1)
+        results = UserPreference.all_preferences_with_choices(account_id)
 
         expect(results.size).to eq 2
         results.each do |result|


### PR DESCRIPTION
## Description of change
in rails 5.1 belongs_to associations will be required by default, this PR makes the specs pass for that change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

## Testing done
automated tests
<!-- Please describe testing done to verify the changes. -->

## Testing planned
test in staging
<!-- Please describe testing planned. -->

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
