### PR TITLE
create separate development, test, and production rails databases

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -22,7 +22,7 @@ default: &default
   pool: 5
 
 development:
-  url: <%= Settings.database_url %>
+  url: <%= Settings.database_developement_url %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -55,7 +55,7 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  url: <%= Settings.database_url %>
+  url: <%= Settings.database_test_url %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,6 +34,8 @@ binaries:
 
 db_encryption_key: f01ff8ebd1a2b053ad697ae1f0d86adb48ebb708021e4c76c3807d37f6b4e389d5aa45ea171f2f5074222784c1ee2bb8272390d1b9517a7a6987c22733ef00b2
 
+database_developement_url: postgis:///vets-api-development
+database_test_url: postgis:///vets-api-test
 database_url: postgis:///vets-api
 
 relative_url_root: /


### PR DESCRIPTION
## Description of change
Don't know the history of it but we have a non-standard Rails setup where one database is used for the development, test, and production dbs (note this is different that our deployed environments). This sometimes causes problems when running specs locally if the db has records from local integration tests. PR updates the database.yml and main settings file so that there's a separate db config for each Rails env.

## Testing done
local specs

## Testing planned
run CI/CD specs

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] vets-api builds correctly with the new config

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
