### PR TITLE
limit mvi profiles address factory city length to 20 chars

### DIFF
--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -14,7 +14,7 @@ end
 FactoryBot.define do
   factory :mvi_profile_address, class: 'MVI::Models::MviProfileAddress' do
     street { "#{street}, #{street2}" }
-    city { Faker::Address.city }
+    city { Faker::Address.city[0...20] }
     state { Faker::Address.state_abbr }
     postal_code { Faker::Address.zip }
     country 'USA'


### PR DESCRIPTION
## Description of change
Some specs that use the `mvi_profile_address` factory will fail json schema validation if city is over 20 characters.

## Testing done
local specs/irb testing

## Testing planned
N/A

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] address city is limited to 20 chars

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
