### PR TITLE
Add a logging line for missing birls id in evss rated_disabilities call

### DIFF
--- a/lib/evss/disability_compensation_form/service.rb
+++ b/lib/evss/disability_compensation_form/service.rb
@@ -31,6 +31,9 @@ module EVSS
       #
       def get_rated_disabilities
         with_monitoring_and_error_handling do
+          if @headers['va_eauth_birlsfilenumber'].blank?
+            Rails.logger.info('Missing `birls_id`', edipi: @headers['va_eauth_dodedipnid'])
+          end
           raw_response = perform(:get, 'ratedDisabilities')
           RatedDisabilitiesResponse.new(raw_response.status, raw_response)
         end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
In an effort to debug instances where we are missing `birls_id` numbers in the header for `rated_disabilities`/`submit` calls to EVSS's 526 api we are adding in logging to inform on just that case. This is to sanity check and make sure this is actually origination from our call and not somewhere else.

## Testing done
<!-- Please describe testing done to verify the changes. -->
None.

## Testing planned
<!-- Please describe testing planned. -->
None.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Add logging to GET rated_disabilities service call for missing birls_id

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
