### PR TITLE
hca backend statuses missing inelig_other

### DIFF
--- a/lib/hca/enrollment_eligibility/parsed_statuses.rb
+++ b/lib/hca/enrollment_eligibility/parsed_statuses.rb
@@ -17,10 +17,10 @@ module HCA
       INELIG_MEDICARE = 'inelig_medicare'
       INELIG_NOT_ENOUGH_TIME = 'inelig_not_enough_time'
       INELIG_NOT_VERIFIED = 'inelig_not_verified'
+      INELIG_OTHER = 'inelig_other'
       INELIG_OVER65 = 'inelig_over65'
       INELIG_REFUSEDCOPAY = 'inelig_refusedcopay'
       INELIG_TRAINING_ONLY = 'inelig_training_only'
-      INELIG_OTHER = 'inelig_other'
       LOGIN_REQUIRED = 'login_required'
       NONE = 'none_of_the_above'
       PENDING_MT = 'pending_mt'
@@ -46,10 +46,10 @@ module HCA
         INELIG_MEDICARE,
         INELIG_NOT_ENOUGH_TIME,
         INELIG_NOT_VERIFIED,
+        INELIG_OTHER,
         INELIG_OVER65,
         INELIG_REFUSEDCOPAY,
         INELIG_TRAINING_ONLY,
-        INELIG_OTHER,
         LOGIN_REQUIRED,
         NONE,
         PENDING_MT,

--- a/lib/hca/enrollment_eligibility/parsed_statuses.rb
+++ b/lib/hca/enrollment_eligibility/parsed_statuses.rb
@@ -20,6 +20,7 @@ module HCA
       INELIG_OVER65 = 'inelig_over65'
       INELIG_REFUSEDCOPAY = 'inelig_refusedcopay'
       INELIG_TRAINING_ONLY = 'inelig_training_only'
+      INELIG_OTHER = 'inelig_other'
       LOGIN_REQUIRED = 'login_required'
       NONE = 'none_of_the_above'
       PENDING_MT = 'pending_mt'
@@ -48,6 +49,7 @@ module HCA
         INELIG_OVER65,
         INELIG_REFUSEDCOPAY,
         INELIG_TRAINING_ONLY,
+        INELIG_OTHER,
         LOGIN_REQUIRED,
         NONE,
         PENDING_MT,

--- a/lib/hca/enrollment_eligibility/status_matcher.rb
+++ b/lib/hca/enrollment_eligibility/status_matcher.rb
@@ -8,6 +8,17 @@ module HCA
 
       include ParsedStatuses
 
+      CATCHALL_CATEGORIES = [
+        {
+          enrollment_status: 'rejected',
+          category: REJECTED_RIGHTENTRY
+        },
+        {
+          enrollment_status: 'not eligible',
+          category: INELIG_OTHER
+        }
+      ]
+
       CATEGORIES = [
         {
           enrollment_status: 'verified',
@@ -138,6 +149,14 @@ module HCA
         enroll_status == statuses
       end
 
+      def parse_catchall_categories(enrollment_status)
+        CATCHALL_CATEGORIES.each do |category_data|
+          return category_data[:category] if enrollment_status.include?(category_data[:enrollment_status])
+        end
+
+        nil
+      end
+
       def parse(enrollment_status, ineligibility_reason = '')
         return NONE if enrollment_status.blank?
         enrollment_status = enrollment_status.downcase.strip
@@ -153,7 +172,7 @@ module HCA
           end
         end
 
-        return REJECTED_RIGHTENTRY if enrollment_status.include?('rejected')
+        parse_catchall_categories(enrollment_status).tap { |c| return c if c.present? }
 
         NONE
       end

--- a/lib/hca/enrollment_eligibility/status_matcher.rb
+++ b/lib/hca/enrollment_eligibility/status_matcher.rb
@@ -17,7 +17,7 @@ module HCA
           enrollment_status: 'not eligible',
           category: INELIG_OTHER
         }
-      ]
+      ].freeze
 
       CATEGORIES = [
         {

--- a/spec/lib/hca/enrollment_eligibility/status_matcher_spec.rb
+++ b/spec/lib/hca/enrollment_eligibility/status_matcher_spec.rb
@@ -47,7 +47,7 @@ describe HCA::EnrollmentEligibility::StatusMatcher do
           ['24 Months', STATUS::INELIG_NOT_ENOUGH_TIME],
           ['training only', STATUS::INELIG_TRAINING_ONLY],
           ['ACDUTRA', STATUS::INELIG_TRAINING_ONLY],
-          ['ACDUTRa', STATUS::NONE],
+          ['ACDUTRa', STATUS::INELIG_OTHER],
           ['Other than honorable', STATUS::INELIG_CHARACTER_OF_DISCHARGE],
           ['OTH', STATUS::INELIG_CHARACTER_OF_DISCHARGE],
           ['non vet', STATUS::INELIG_NOT_VERIFIED],


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18093
add inelig_other status to backend status matcher

## Testing done
automated tests
<!-- Please describe testing done to verify the changes. -->

## Testing planned
test on staging
<!-- Please describe testing planned. -->


#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
