### PR TITLE
17982 :: VET TEC: Update spool file text for previously updated web questions : Update spool file content.

### DIFF
--- a/app/workers/education_form/templates/0994.erb
+++ b/app/workers/education_form/templates/0994.erb
@@ -30,10 +30,11 @@ Night Time Telephone Number: <%= @applicant.nightTimePhone %>
 
 Have you ever applied for VA education benefits?: <%= yesno(@applicant.appliedForVaEducationBenefits) %>
 
-Are you currently on active duty?: <%= yesno(@applicant.activeDuty) %>
+Are you on full-time duty in the Armed Forces? (This doesn't 
+include active-duty training for Reserve and National Guard members.): <%= yesno(@applicant.activeDuty) %>
 
-Do you anticipate you will go on active duty during the
-VET TEC program?: <%= yesno_or_blank(@applicant.activeDutyDuringVetTec) %>
+Are you in the Selected Reserve or National Guard and do
+you expect to be called to duty for 30 days or more?: <%= yesno_or_blank(@applicant.activeDutyDuringVetTec) %>
 
 DIRECT DEPOSIT INFORMATION:
 
@@ -63,7 +64,5 @@ Check all that apply:
 About how much per year do/did you earn as a high-tech worker?: <%= salary_text %>
 
 What is your highest level of education?: <%= education_level_name %>
-
-Signature of applicant:
 
 <%= parse_with_template_path('footer') %>

--- a/spec/fixtures/education_benefits_claims/0994/kitchen_sink.spl
+++ b/spec/fixtures/education_benefits_claims/0994/kitchen_sink.spl
@@ -42,10 +42,11 @@ Night Time Telephone Number: 5551231234
 
 Have you ever applied for VA education benefits?: YES
 
-Are you currently on active duty?: YES
+Are you on full-time duty in the Armed Forces? (This doesn't
+include active-duty training for Reserve and National Guard members.): YES
 
-Do you anticipate you will go on active duty during the
-VET TEC program?: YES
+Are you in the Selected Reserve or National Guard and do
+you expect to be called to duty for 30 days or more?: YES
 
 DIRECT DEPOSIT INFORMATION:
 
@@ -99,8 +100,6 @@ Computer software
 About how much per year do/did you earn as a high-tech worker?: <$20,000
 
 What is your highest level of education?: Other Education Type
-
-Signature of applicant:
 
 Electronically Received by VA:  2017-01-17
 Confirmation #:  V-EBC-1

--- a/spec/fixtures/education_benefits_claims/0994/prefill.spl
+++ b/spec/fixtures/education_benefits_claims/0994/prefill.spl
@@ -41,10 +41,11 @@ Night Time Telephone Number:
 
 Have you ever applied for VA education benefits?: YES
 
-Are you currently on active duty?: YES
+Are you on full-time duty in the Armed Forces? (This doesn't
+include active-duty training for Reserve and National Guard members.): YES
 
-Do you anticipate you will go on active duty during the
-VET TEC program?:
+Are you in the Selected Reserve or National Guard and do
+you expect to be called to duty for 30 days or more?:
 
 DIRECT DEPOSIT INFORMATION:
 
@@ -74,8 +75,6 @@ Check all that apply:
 About how much per year do/did you earn as a high-tech worker?:
 
 What is your highest level of education?: High school diploma or GED
-
-Signature of applicant:
 
 Electronically Received by VA:  2017-01-17
 Confirmation #:  V-EBC-1

--- a/spec/fixtures/education_benefits_claims/0994/simple.spl
+++ b/spec/fixtures/education_benefits_claims/0994/simple.spl
@@ -41,10 +41,11 @@ Night Time Telephone Number:
 
 Have you ever applied for VA education benefits?: YES
 
-Are you currently on active duty?: YES
+Are you on full-time duty in the Armed Forces? (This doesn't
+include active-duty training for Reserve and National Guard members.): YES
 
-Do you anticipate you will go on active duty during the
-VET TEC program?:
+Are you in the Selected Reserve or National Guard and do
+you expect to be called to duty for 30 days or more?:
 
 DIRECT DEPOSIT INFORMATION:
 
@@ -74,8 +75,6 @@ N/A
 About how much per year do/did you earn as a high-tech worker?: N/A
 
 What is your highest level of education?: High school diploma or GED
-
-Signature of applicant:
 
 Electronically Received by VA:  2017-01-17
 Confirmation #:  V-EBC-1


### PR DESCRIPTION
## Description of change
Changes were made to the text of the spool file so content would be consistent with what is displayed on the web.

Originating issue: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17982

## Testing done
Manual and Unit testing completed successfully

## Testing planned
Execution of unit tests

## Acceptance Criteria (Definition of Done)
- [x] The spool file text is updated to match the web text in the attached supporting document.

#### Unique to this PR
- Update "Are you currently on active duty?" to "Are you on full-time duty in the Armed Forces? (This doesn't include active-duty training for Reserve and National Guard members.)"
- Update "Do you anticipate you will go on active duty during the VET TEC program?" to "Are you in the Selected Reserve or National Guard and do you expect to be called to duty for 30 days or more?"
- Removal of "Signature of applicant:"

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
