### PR TITLE
make sure clientId is only added to the end of the generated URL.

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -25,7 +25,7 @@ module V0
       end
       # clientId must be added at the end or the URL will be invalid for users using various "Do not track"
       # extensions with their browser.
-      redirect_to (params[:client_id].present? ? url + "&clientId=#{params[:client_id]}" : url)
+      redirect_to params[:client_id].present? ? url + "&clientId=#{params[:client_id]}" : url
     end
 
     def saml_logout_callback

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -23,7 +23,9 @@ module V0
         Rails.logger.info('SSO: LOGOUT', sso_logging_info)
         reset_session
       end
-      redirect_to url
+      # clientId must be added at the end or the URL will be invalid for users using various "Do not track"
+      # extensions with their browser.
+      redirect_to (params[:client_id].present? ? url + "&clientId=#{params[:client_id]}" : url)
     end
 
     def saml_logout_callback

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -126,9 +126,7 @@ module SAML
     def initialize_query_params(params)
       @query_params = {}
 
-      if params[:action] == 'new'
-        @query_params[:clientId] = params[:client_id] if params[:client_id]
-      elsif params[:action] == 'saml_callback'
+      if params[:action] == 'saml_callback'
         @type = JSON.parse(params[:RelayState])['type'] if params[:RelayState]
       end
     end


### PR DESCRIPTION
## Description of change
Ensures that cliendId is only added to the end of the URL, this will mean that AdBlocker and other extensions can drop this query string but not drop the rest of the query strings needed for validating the SAML request.

## Testing done
specs, and ensuring this doesn't break production.

## Testing planned
just verifying in production

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
