### PR TITLE
Okta Poa

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -51,7 +51,9 @@ module ClaimsApi
 
     def target_veteran(with_gender: false)
       if poa_request?
-        ClaimsApi::Veteran.from_headers(request.headers, with_gender: with_gender)
+        vet = ClaimsApi::Veteran.from_headers(request.headers, with_gender: with_gender)
+        vet.loa = @current_user.loa if @current_user
+        vet
       else
         ClaimsApi::Veteran.from_identity(identity: @current_user)
       end

--- a/modules/claims_api/app/controllers/claims_api/v0/claims_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/claims_controller.rb
@@ -36,10 +36,6 @@ module ClaimsApi
       def service
         ClaimsApi::UnsynchronizedEVSSClaimService.new(target_veteran)
       end
-
-      def target_veteran
-        ClaimsApi::Veteran.from_headers(request.headers)
-      end
     end
   end
 end

--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -45,15 +45,11 @@ module ClaimsApi
           params.slice(*document_keys).values
         end
 
-        def target_veteran
-          @target_veteran ||= ClaimsApi::Veteran.from_headers(request.headers, with_gender: true)
-        end
-
         def auth_headers
           evss_headers = EVSS::DisabilityCompensationAuthHeaders
-                         .new(target_veteran)
+                         .new(target_veteran(with_gender: true))
                          .add_headers(
-                           EVSS::AuthHeaders.new(target_veteran).to_h
+                           EVSS::AuthHeaders.new(target_veteran(with_gender: true)).to_h
                          )
           if request.headers['Mock-Override'] &&
              Settings.claims_api.disability_claims_mock_override


### PR DESCRIPTION
## Description of change
In order to make valid requests for poa / okta requests, we need to set the loa of the incoming current user
resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/1834

## Testing done
- [x] Local with sample app



#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
