### PR TITLE
refactor spec to eliminate `should` deprecation warning.

### DIFF
--- a/spec/workers/delete_old_transactions_job_spec.rb
+++ b/spec/workers/delete_old_transactions_job_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
 require 'sidekiq/testing'
-Sidekiq::Testing.fake!
 
-describe DeleteOldTransactionsJob do
+RSpec.describe DeleteOldTransactionsJob do
   context 'if an exception happens' do
     before do
       allow_any_instance_of(AsyncTransaction::Vet360::AddressTransaction)
@@ -17,7 +17,7 @@ describe DeleteOldTransactionsJob do
              status: AsyncTransaction::Base::COMPLETED)
 
       job = DeleteOldTransactionsJob.new
-      job.should_receive(:log_message_to_sentry).once
+      expect(job).to receive(:log_message_to_sentry).once
       job.perform
     end
   end


### PR DESCRIPTION
## Description of change
Refactor of one spec to eliminate deprecation warning:
```
Deprecation Warnings:

Using `should_receive` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/johnny/Projects/Oddball/vets-api/spec/workers/delete_old_transactions_job_spec.rb:21:in `block (3 levels) in <top (required)>'.
```

## Testing done
specs

## Testing planned
N/A

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] refactor `spec/workers/delete_old_transactions_job.spec` to not use the deprecated `should` matcher

#### Applies to all PRs

- [ ] ~~Appropriate logging~~
- [ ] ~~Swagger docs have been updated, if applicable~~
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] ~~Provide which alerts would indicate a problem with this functionality (if applicable)~~
