### PR TITLE
Endpoint to persist the dismissal of a user's health care notification status

### DIFF
--- a/app/controllers/concerns/notifications/validateable.rb
+++ b/app/controllers/concerns/notifications/validateable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Notifications
+  module Validateable
+    extend ActiveSupport::Concern
+
+    def validate_subject!(subject)
+      unless Notification.subjects.keys.include?(subject)
+        message = "#{subject} is not a valid subject"
+
+        raise Common::Exceptions::UnprocessableEntity.new(detail: message), message
+      end
+    end
+
+    def validate_status!(status)
+      unless Notification.statuses.keys.include?(status)
+        message = "#{status} is not a valid status"
+
+        raise Common::Exceptions::UnprocessableEntity.new(detail: message), message
+      end
+    end
+  end
+end

--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -159,6 +159,7 @@ module V0
       Swagger::Schemas::BB::HealthRecords,
       Swagger::Schemas::Countries,
       Swagger::Schemas::ConnectedApplications,
+      Swagger::Schemas::DismissedStatus,
       Swagger::Schemas::Form526::RatedDisabilities,
       Swagger::Schemas::Email,
       Swagger::Schemas::Errors,

--- a/app/controllers/v0/notifications/dismissed_statuses_controller.rb
+++ b/app/controllers/v0/notifications/dismissed_statuses_controller.rb
@@ -10,6 +10,16 @@ module V0
       before_action -> { validate_status!(status) }, only: :create
       before_action :set_account, :set_notification
 
+      def create
+        notification = @account.notifications.build(dismissed_statuses_params.merge(read_at: Time.current))
+
+        if notification.save
+          render json: notification, serializer: DismissedStatusSerializer
+        else
+          raise Common::Exceptions::ValidationErrors.new(notification), 'Validation errors present'
+        end
+      end
+
       def show
         if @notification
           render json: @notification, serializer: DismissedStatusSerializer

--- a/app/controllers/v0/notifications/dismissed_statuses_controller.rb
+++ b/app/controllers/v0/notifications/dismissed_statuses_controller.rb
@@ -39,11 +39,15 @@ module V0
       end
 
       def dismissed_statuses_params
-        params.permit(:subject, :dismissed_status, :status_effective_at)
+        params.permit(:subject, :status, :status_effective_at)
       end
 
       def subject
         dismissed_statuses_params[:subject]
+      end
+
+      def status
+        dismissed_statuses_params[:status]
       end
     end
   end

--- a/app/controllers/v0/notifications/dismissed_statuses_controller.rb
+++ b/app/controllers/v0/notifications/dismissed_statuses_controller.rb
@@ -4,7 +4,10 @@ module V0
   module Notifications
     class DismissedStatusesController < ApplicationController
       include Accountable
+      include ::Notifications::Validateable
 
+      before_action -> { validate_subject!(subject) }
+      before_action -> { validate_status!(status) }, only: :create
       before_action :set_account, :set_notification
 
       def show

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,6 +4,7 @@ class Notification < ApplicationRecord
   belongs_to :account
 
   validates :subject, :account_id, presence: true
+  validates :subject, uniqueness: { scope: :account_id }
 
   # Creates the ActiveRecord::Enum mappings between the attribute values and
   # their associated database integers.

--- a/app/serializers/dismissed_status_serializer.rb
+++ b/app/serializers/dismissed_status_serializer.rb
@@ -2,16 +2,12 @@
 
 class DismissedStatusSerializer < ActiveModel::Serializer
   attribute :subject
-  attribute :dismissed_status
+  attribute :status
   attribute :status_effective_at
-  attribute :dismissed_at
+  attribute :read_at
 
   def id
     nil
-  end
-
-  def dismissed_status
-    object.status
   end
 
   # Converts status_effective_at into desired datetime string format.
@@ -22,7 +18,7 @@ class DismissedStatusSerializer < ActiveModel::Serializer
     object.status_effective_at.as_json
   end
 
-  def dismissed_at
+  def read_at
     object.read_at.as_json
   end
 end

--- a/app/swagger/requests/notifications.rb
+++ b/app/swagger/requests/notifications.rb
@@ -67,7 +67,7 @@ module Swagger
           parameter :authorization
 
           parameter do
-            key :name, :subject
+            key :name, :body
             key :in, :body
             key :description, 'The properties to create a dismissed status notification'
             key :required, true

--- a/app/swagger/requests/notifications.rb
+++ b/app/swagger/requests/notifications.rb
@@ -8,6 +8,7 @@ module Swagger
       swagger_path '/v0/notifications/dismissed_statuses/{subject}' do
         operation :get do
           extend Swagger::Responses::AuthenticationError
+          extend Swagger::Responses::ValidationError
 
           key :description, "Gets the user's most recent dismissed status notification details"
           key :operationId, 'getDismissedStatus'
@@ -28,23 +29,7 @@ module Swagger
           response 200 do
             key :description, 'Response is OK'
             schema do
-              key :required, [:data]
-              property :data, type: :object do
-                key :required, [:attributes]
-                property :attributes, type: :object do
-                  key :required, %i[subject dismissed_status dismissed_at]
-                  property :subject,
-                           type: :string,
-                           example: 'form_10_10ez',
-                           enum: Notification.subjects.keys.sort
-                  property :dismissed_status,
-                           type: :string,
-                           example: 'pending_mt',
-                           enum: Notification.statuses.keys.sort
-                  property :status_effective_at, type: :string, example: '2019-02-25T01:22:00.000Z'
-                  property :dismissed_at, type: :string, example: '2019-02-26T21:20:50.151Z'
-                end
-              end
+              key :'$ref', :DismissedStatus
             end
           end
 
@@ -65,6 +50,51 @@ module Swagger
                   property :status, type: :string, example: '404'
                 end
               end
+            end
+          end
+        end
+      end
+
+      swagger_path '/v0/notifications/dismissed_statuses' do
+        operation :post do
+          extend Swagger::Responses::AuthenticationError
+          extend Swagger::Responses::ValidationError
+
+          key :description, 'Create a dismissed status notification record'
+          key :operationId, 'postDismissedStatus'
+          key :tags, %w[notifications]
+
+          parameter :authorization
+
+          parameter do
+            key :name, :subject
+            key :in, :body
+            key :description, 'The properties to create a dismissed status notification'
+            key :required, true
+
+            schema do
+              key :required, %i[
+                subject
+                status
+                status_effective_at
+              ]
+
+              property :subject,
+                       type: :string,
+                       example: 'form_10_10ez',
+                       enum: Notification.subjects.keys.sort
+              property :status,
+                       type: :string,
+                       example: 'pending_mt',
+                       enum: Notification.statuses.keys.sort
+              property :status_effective_at, type: :string, example: '2019-02-25T01:22:00.000Z'
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :DismissedStatus
             end
           end
         end

--- a/app/swagger/schemas/dismissed_status.rb
+++ b/app/swagger/schemas/dismissed_status.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Schemas
+    class DismissedStatus
+      include Swagger::Blocks
+
+      swagger_schema :DismissedStatus do
+        key :required, [:data]
+        property :data, type: :object do
+          key :required, [:attributes]
+          property :attributes, type: :object do
+            key :required, %i[subject status read_at]
+            property :subject,
+                     type: :string,
+                     example: 'form_10_10ez',
+                     enum: Notification.subjects.keys.sort
+            property :status,
+                     type: :string,
+                     example: 'pending_mt',
+                     enum: Notification.statuses.keys.sort
+            property :status_effective_at, type: :string, example: '2019-02-25T01:22:00.000Z'
+            property :read_at, type: :string, example: '2019-02-26T21:20:50.151Z'
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,7 +236,7 @@ Rails.application.routes.draw do
     end
 
     namespace :notifications do
-      resources :dismissed_statuses, only: :show, param: :subject
+      resources :dismissed_statuses, only: %i[show create], param: :subject
     end
 
     resources :preferences, only: %i[index show], path: 'user/preferences/choices', param: :code

--- a/db/migrate/20190424212410_add_unique_index_combination_on_notifications.rb
+++ b/db/migrate/20190424212410_add_unique_index_combination_on_notifications.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexCombinationOnNotifications < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index(:notifications, [:account_id, :subject], unique: true, algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190419012709) do
+ActiveRecord::Schema.define(version: 20190424212410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -306,6 +306,7 @@ ActiveRecord::Schema.define(version: 20190419012709) do
     t.datetime "read_at"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
+    t.index ["account_id", "subject"], name: "index_notifications_on_account_id_and_subject", unique: true, using: :btree
     t.index ["account_id"], name: "index_notifications_on_account_id", using: :btree
     t.index ["status"], name: "index_notifications_on_status", using: :btree
     t.index ["subject"], name: "index_notifications_on_subject", using: :btree

--- a/spec/request/notifications/dismissed_statuses_request_spec.rb
+++ b/spec/request/notifications/dismissed_statuses_request_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'dismissed statuses', type: :request do
         }.to_json
       end
 
-      it 'should return a 422 unprocessable entity', :aggregate_failures  do
+      it 'should return a 422 unprocessable entity', :aggregate_failures do
         post '/v0/notifications/dismissed_statuses', params: invalid_post_body, headers: headers
 
         expect(response.status).to eq 422
@@ -96,7 +96,7 @@ RSpec.describe 'dismissed statuses', type: :request do
         }.to_json
       end
 
-      it 'should return a 422 unprocessable entity', :aggregate_failures  do
+      it 'should return a 422 unprocessable entity', :aggregate_failures do
         post '/v0/notifications/dismissed_statuses', params: invalid_post_body, headers: headers
 
         expect(response.status).to eq 422

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -2045,7 +2045,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
             :post,
             '/v0/notifications/dismissed_statuses',
             401,
-            { '_data' => post_body }
+            '_data' => post_body
           )
         end
 

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -2010,6 +2010,54 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
           )
         end
       end
+
+      context 'when the passed subject is not defined in the Notification#subject enum' do
+        it 'supports invalid subject validation' do
+          expect(subject).to validate(
+            :get,
+            '/v0/notifications/dismissed_statuses/{subject}',
+            422,
+            headers.merge('subject' => 'random_subject')
+          )
+        end
+      end
+
+      describe 'POST /v0/notifications/dismissed_statuses' do
+        let(:post_body) do
+          {
+            subject: notification_subject,
+            status: 'pending_mt',
+            status_effective_at: '2019-04-23T00:00:00.000-06:00'
+          }
+        end
+
+        it 'supports posting dismissed status data' do
+          expect(subject).to validate(
+            :post,
+            '/v0/notifications/dismissed_statuses',
+            200,
+            headers.merge('_data' => post_body)
+          )
+        end
+
+        it 'supports authorization validation' do
+          expect(subject).to validate(
+            :post,
+            '/v0/notifications/dismissed_statuses',
+            401,
+            { '_data' => post_body }
+          )
+        end
+
+        it 'supports validating posted dismissed status data' do
+          expect(subject).to validate(
+            :post,
+            '/v0/notifications/dismissed_statuses',
+            422,
+            headers.merge('_data' => post_body.merge(status: 'random_status'))
+          )
+        end
+      end
     end
   end
 

--- a/spec/support/schemas/dismissed_status.json
+++ b/spec/support/schemas/dismissed_status.json
@@ -9,13 +9,13 @@
             "subject": {
               "type": "string"
             },
-            "dismissed_status": {
+            "status": {
               "type": "string"
             },
             "status_effective_at": {
               "type": "string"
             },
-            "dismissed_at": {
+            "read_at": {
               "type": "string"
             }
           },


### PR DESCRIPTION
## Description of change
Per the discovery in [#17798](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17798) around dismissed health care alerts, we need an endpoint where the FE can persist that a user has dismissed a given health care notification alert.

This will be based off of the user's current enrollment status details that the FE retrieves from our `GET /v0/health_care_applications/enrollment_status` endpoint. 

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Create a `POST /v0/notifications/dismissed_statuses` endpoint with a `post` body of:

```javascript
{
  subject: subject,
  status: parsed_status,
  status_effective_at: effective_date 
}
```

- [x] Confirm contract
- [x] Swagger docs
- [x] Request specs
- [ ] ❗️Explicit request to DevOps for migrations to be ran across all envs❗️

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

## Screenshot

#### Swagger docs

![image](https://user-images.githubusercontent.com/7482329/56744687-35cc7f00-6736-11e9-9a8e-3c2a2d46a56b.png)
