### PR TITLE
Endpoint to update the dismissal status of a user's health care notification 

### DIFF
--- a/app/controllers/concerns/notifications/validateable.rb
+++ b/app/controllers/concerns/notifications/validateable.rb
@@ -19,5 +19,11 @@ module Notifications
         raise Common::Exceptions::UnprocessableEntity.new(detail: message), message
       end
     end
+
+    def validate_record_present!(notification, subject)
+      if notification.nil?
+        raise Common::Exceptions::RecordNotFound.new(subject), "User does not have a #{subject} record"
+      end
+    end
   end
 end

--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -152,6 +152,7 @@ module V0
       Swagger::Requests::VAFacilities,
       Swagger::Requests::CCProviders,
       Swagger::Responses::AuthenticationError,
+      Swagger::Responses::RecordNotFoundError,
       Swagger::Responses::SavedForm,
       Swagger::Schemas::Address,
       Swagger::Schemas::Appeals,

--- a/app/swagger/requests/notifications.rb
+++ b/app/swagger/requests/notifications.rb
@@ -76,7 +76,7 @@ module Swagger
           parameter do
             key :name, :body
             key :in, :body
-            key :description, 'The properties to create a dismissed status notification'
+            key :description, 'The properties to update an existing dismissed status notification'
             key :required, true
 
             schema do

--- a/app/swagger/requests/notifications.rb
+++ b/app/swagger/requests/notifications.rb
@@ -53,6 +53,53 @@ module Swagger
             end
           end
         end
+
+        operation :patch do
+          extend Swagger::Responses::AuthenticationError
+          extend Swagger::Responses::ValidationError
+          extend Swagger::Responses::RecordNotFoundError
+
+          key :description, 'Update an existing dismissed status notification record'
+          key :operationId, 'patchDismissedStatus'
+          key :tags, %w[notifications]
+
+          parameter :authorization
+
+          parameter do
+            key :name, 'subject'
+            key :in, :path
+            key :description, 'The subject of the dismissed status notification (i.e. "form_10_10ez")'
+            key :required, true
+            key :type, :string
+          end
+
+          parameter do
+            key :name, :body
+            key :in, :body
+            key :description, 'The properties to create a dismissed status notification'
+            key :required, true
+
+            schema do
+              key :required, %i[
+                status
+                status_effective_at
+              ]
+
+              property :status,
+                       type: :string,
+                       example: 'pending_mt',
+                       enum: Notification.statuses.keys.sort
+              property :status_effective_at, type: :string, example: '2019-02-25T01:22:00.000Z'
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :DismissedStatus
+            end
+          end
+        end
       end
 
       swagger_path '/v0/notifications/dismissed_statuses' do

--- a/app/swagger/responses/record_not_found_error.rb
+++ b/app/swagger/responses/record_not_found_error.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Responses
+    module RecordNotFoundError
+      def self.extended(base)
+        base.response 404 do
+          key :description, 'Record not found'
+          schema do
+            key :'$ref', :Errors
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,7 +236,7 @@ Rails.application.routes.draw do
     end
 
     namespace :notifications do
-      resources :dismissed_statuses, only: %i[show create], param: :subject
+      resources :dismissed_statuses, only: %i[show create update], param: :subject
     end
 
     resources :preferences, only: %i[index show], path: 'user/preferences/choices', param: :code

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -3,11 +3,11 @@
 FactoryBot.define do
   factory :notification do
     account
-    subject { :dashboard_health_care_application_notification }
+    subject { Notification::DASHBOARD_HEALTH_CARE_APPLICATION_NOTIFICATION }
 
     trait :dismissed_status do
-      subject { 'form_10_10ez' }
-      status { 'pending_mt' }
+      subject { Notification::FORM_10_10EZ }
+      status { Notification::PENDING_MT }
       status_effective_at { '2019-02-25 01:22:00 UTC' }
       read_at { '2019-02-25 03:47:08 UTC' }
     end

--- a/spec/request/notifications/dismissed_statuses_request_spec.rb
+++ b/spec/request/notifications/dismissed_statuses_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'dismissed statuses', type: :request do
 
   let(:user) { build(:user, :accountable) }
   let(:headers) { { 'Content-Type' => 'application/json', 'Accept' => 'application/json' } }
-  let(:notification_subject) { 'form_10_10ez' }
+  let(:notification_subject) { Notification::FORM_10_10EZ }
 
   before do
     sign_in_as(user)
@@ -41,7 +41,7 @@ RSpec.describe 'dismissed statuses', type: :request do
     let(:post_body) do
       {
         subject: notification_subject,
-        status: 'pending_mt',
+        status: Notification::PENDING_MT,
         status_effective_at: '2019-04-23T00:00:00.000-06:00'
       }.to_json
     end
@@ -73,7 +73,7 @@ RSpec.describe 'dismissed statuses', type: :request do
       let(:invalid_post_body) do
         {
           subject: invalid_subject,
-          status: 'pending_mt',
+          status: Notification::PENDING_MT,
           status_effective_at: '2019-04-23T00:00:00.000-06:00'
         }.to_json
       end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -2058,6 +2058,59 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
           )
         end
       end
+
+      describe 'PATCH /v0/notifications/dismissed_statuses/{subject}' do
+        let(:patch_body) do
+          {
+            status: Notification::CLOSED,
+            status_effective_at: '2019-04-23T00:00:00.000-06:00'
+          }
+        end
+
+        context 'user has an existing Notification record with the passed subject' do
+          let!(:notification) do
+            create :notification, :dismissed_status, account_id: mhv_user.account.id, read_at: Time.current
+          end
+
+          it 'supports updating dismissed status data' do
+            expect(subject).to validate(
+              :patch,
+              '/v0/notifications/dismissed_statuses/{subject}',
+              200,
+              headers.merge('_data' => patch_body, 'subject' => notification_subject)
+            )
+          end
+
+          it 'supports authorization validation' do
+            expect(subject).to validate(
+              :patch,
+              '/v0/notifications/dismissed_statuses/{subject}',
+              401,
+              '_data' => patch_body, 'subject' => notification_subject
+            )
+          end
+
+          it 'supports validating updated dismissed status data' do
+            expect(subject).to validate(
+              :patch,
+              '/v0/notifications/dismissed_statuses/{subject}',
+              422,
+              headers.merge('_data' => patch_body.merge(status: 'random_status'), 'subject' => notification_subject)
+            )
+          end
+        end
+
+        context 'user does not have a Notification record with the passed subject' do
+          it 'supports validating the presence of an existing record to be updated' do
+            expect(subject).to validate(
+              :patch,
+              '/v0/notifications/dismissed_statuses/{subject}',
+              404,
+              headers.merge('_data' => patch_body, 'subject' => notification_subject)
+            )
+          end
+        end
+      end
     end
   end
 

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1972,7 +1972,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
     end
 
     describe 'notifications' do
-      let(:notification_subject) { 'form_10_10ez' }
+      let(:notification_subject) { Notification::FORM_10_10EZ }
 
       context 'when user has an associated Notification record' do
         let!(:notification) do
@@ -2026,7 +2026,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
         let(:post_body) do
           {
             subject: notification_subject,
-            status: 'pending_mt',
+            status: Notification::PENDING_MT,
             status_effective_at: '2019-04-23T00:00:00.000-06:00'
           }
         end


### PR DESCRIPTION
## Description of change
Per the discovery in [#17798](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17798) around dismissed health care alerts, we need endpoint where the FE can update that a user has dismissed a given health care notification alert.

This will be based off of the user's current enrollment status details that the FE retrieves from our `GET /v0/health_care_applications/enrollment_status` endpoint, and the current dismissed status from the `GET /v0/notifications/dismissed_statuses/:subject` endpoint


## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Create a `PUT/PATCH /v0/notifications/dismissed_statuses/:subject` endpoint with a body of:

```javascript
{
  status: parsed_status,
  status_effective_at: effective_date 
}
```

- [x] Confirm contract
- [x] Swagger docs
- [x] Request specs

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

## Screenshot

#### Swagger docs

![image](https://user-images.githubusercontent.com/7482329/56762687-a63ac680-675d-11e9-9d7f-d608f9c7c8b2.png)
