### PR TITLE
add vagov-dev to deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,6 +86,16 @@ pipeline {
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),
         ], wait: false
+
+        build job: 'deploys/vets-api-server-vagov-dev', parameters: [
+          booleanParam(name: 'notify_slack', value: true),
+          stringParam(name: 'ref', value: commit),
+        ], wait: false
+
+        build job: 'deploys/vets-api-worker-vagov-dev', parameters: [
+          booleanParam(name: 'notify_slack', value: true),
+          stringParam(name: 'ref', value: commit),
+        ], wait: false
       }
     }
 


### PR DESCRIPTION
Adds build triggers for vagov-dev environment. We will have triggers for both the legacy environment and VAEC so that they are in sync during the transition. 

ref: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16410