### PR TITLE
Fix facilities error when querying for ids and lat/long

### DIFF
--- a/app/models/base_facility.rb
+++ b/app/models/base_facility.rb
@@ -151,10 +151,10 @@ class BaseFacility < ApplicationRecord
     end
 
     def query(params)
-      if params[:ids]
-        return build_result_set_from_ids(params[:ids]).flatten
-      elsif location_query_requested?(params)
+      if location_query_requested?(params)
         return query_by_location(params)
+      elsif params[:ids]
+        return build_result_set_from_ids(params[:ids]).flatten
       end
 
       BaseFacility.none

--- a/modules/va_facilities/spec/requests/facilities_request_spec.rb
+++ b/modules/va_facilities/spec/requests/facilities_request_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       expect(json['meta']['distances'].length).to eq(10)
     end
 
+    it 'responds to GET #index with ids sorted by distance from lat/long' do
+      setup_pdx
+      get "#{base_query_path}#{ids_query}&lat=45.451913&long=-122.440689", params: nil, headers: accept_json
+      expect(response).to be_success
+      expect(response.body).to be_a(String)
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(10)
+      expect(json['meta']['distances'].length).to eq(10)
+    end
+
     it 'responds to GET #index with zip' do
       setup_pdx
       get base_query_path + zip, params: nil, headers: accept_json


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
This change addresses [#1915](https://github.com/department-of-veterans-affairs/vets-contrib/issues/1915), which fixes an issue introduced in vets-api PR [#2992](https://github.com/department-of-veterans-affairs/vets-api/pull/2992) that causes the facilities index endpoint to throw a 500 error when a user tries to query with both ids and lat/long. 

## Testing done
<!-- Please describe testing done to verify the changes. -->
Added a unit test for the combination of ids and and lat/long being queried.

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
