### PR TITLE
Endpoint to create a Notification record

### DIFF
--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -189,6 +189,7 @@ module V0
       Swagger::Schemas::LetterBeneficiary,
       Swagger::Schemas::Letters,
       Swagger::Schemas::MaintenanceWindows,
+      Swagger::Schemas::Notification,
       Swagger::Schemas::PhoneNumber,
       Swagger::Schemas::PPIU,
       Swagger::Schemas::SavedForm,

--- a/app/controllers/v0/notifications_controller.rb
+++ b/app/controllers/v0/notifications_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module V0
+  class NotificationsController < ApplicationController
+    include Accountable
+    include ::Notifications::Validateable
+
+    before_action -> { validate_subject!(subject) }
+    before_action :set_account
+
+    def create
+      notification = @account.notifications.build(subject: subject, read_at: read_at)
+
+      if notification.save
+        render json: notification, serializer: NotificationSerializer
+      else
+        raise Common::Exceptions::ValidationErrors.new(notification), 'Validation errors present'
+      end
+    end
+
+    private
+
+    def set_account
+      @account = create_user_account
+    end
+
+    def notification_params
+      params.permit(:subject, :read)
+    end
+
+    def subject
+      notification_params[:subject]
+    end
+
+    def read_at
+      notification_params[:read] == true ? Time.current : nil
+    end
+  end
+end

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class NotificationSerializer < ActiveModel::Serializer
+  attribute :subject
+  attribute :read_at
+
+  def id
+    nil
+  end
+
+  # Converts status_effective_at into desired datetime string format.
+  #
+  # @see https://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html#method-i-as_json
+  #
+  def read_at
+    object.read_at.as_json
+  end
+end

--- a/app/swagger/requests/notifications.rb
+++ b/app/swagger/requests/notifications.rb
@@ -5,6 +5,46 @@ module Swagger
     class Notifications
       include Swagger::Blocks
 
+      swagger_path '/v0/notifications' do
+        operation :post do
+          extend Swagger::Responses::AuthenticationError
+          extend Swagger::Responses::ValidationError
+
+          key :description, 'Create a notification record'
+          key :operationId, 'postNotification'
+          key :tags, %w[notifications]
+
+          parameter :authorization
+
+          parameter do
+            key :name, :body
+            key :in, :body
+            key :description, 'The properties to create a notification record'
+            key :required, true
+
+            schema do
+              key :required, %i[
+                subject
+                read
+              ]
+
+              property :subject,
+                       type: :string,
+                       example: 'form_10_10ez',
+                       enum: Notification.subjects.keys.sort
+              property :read, type: :boolean, example: false, enum: [true, false]
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :Notification
+            end
+          end
+        end
+      end
+
       swagger_path '/v0/notifications/dismissed_statuses/{subject}' do
         operation :get do
           extend Swagger::Responses::AuthenticationError

--- a/app/swagger/schemas/notification.rb
+++ b/app/swagger/schemas/notification.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Schemas
+    class Notification
+      include Swagger::Blocks
+
+      swagger_schema :Notification do
+        key :required, [:data]
+        property :data, type: :object do
+          key :required, [:attributes]
+          property :attributes, type: :object do
+            key :required, %i[subject read_at]
+            property :subject,
+                     type: :string,
+                     example: 'form_10_10ez',
+                     enum: ::Notification.subjects.keys.sort
+            property :read_at, type: %i[string null], example: '2019-02-26T21:20:50.151Z'
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -235,6 +235,8 @@ Rails.application.routes.draw do
       post :upgrade
     end
 
+    resources :notifications, only: :create, param: :subject
+
     namespace :notifications do
       resources :dismissed_statuses, only: %i[show create update], param: :subject
     end

--- a/spec/request/notifications_request_spec.rb
+++ b/spec/request/notifications_request_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'notifications', type: :request do
+  include SchemaMatchers
+
+  let(:user) { build(:user, :accountable) }
+  let(:headers) { { 'Content-Type' => 'application/json', 'Accept' => 'application/json' } }
+  let(:notification_subject) { Notification::DASHBOARD_HEALTH_CARE_APPLICATION_NOTIFICATION }
+
+  before do
+    sign_in_as(user)
+  end
+
+  describe 'POST /v0/notifications' do
+    let(:post_body) do
+      {
+        subject: notification_subject,
+        read: false
+      }.to_json
+    end
+
+    context 'when user does *not* have a Notification record for the passed subject' do
+      it 'should match the notification schema', :aggregate_failures do
+        post '/v0/notifications', params: post_body, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to match_response_schema('notification')
+      end
+
+      it 'sets the passed values', :aggregate_failures do
+        post '/v0/notifications', params: post_body, headers: headers
+
+        notification = user.account.notifications.first
+
+        expect(notification.subject).to eq notification_subject.to_s
+        expect(notification.read_at).to be_nil
+      end
+
+      context 'when read: true' do
+        let(:post_body) do
+          {
+            subject: notification_subject,
+            read: true
+          }.to_json
+        end
+
+        it 'should set read_at: Time.current', :aggregate_failures do
+          post '/v0/notifications', params: post_body, headers: headers
+
+          read_at = JSON.parse(response.body).dig('data', 'attributes', 'read_at')
+
+          expect(read_at).to be_present
+          expect(read_at.class).to eq String
+        end
+      end
+    end
+
+    context 'when user already has a Notification record for the passed subject' do
+      let!(:notification) do
+        create :notification, subject: notification_subject, account_id: user.account.id
+      end
+
+      it 'returns a 422 unprocessable entity', :aggregate_failures do
+        post '/v0/notifications', params: post_body, headers: headers
+
+        expect(response.status).to eq 422
+        expect(response.body).to include 'Subject has already been taken'
+      end
+    end
+
+    context 'when the passed subject is not defined in the Notification#subject enum' do
+      let(:invalid_subject) { 'random_subject' }
+      let(:invalid_post_body) do
+        {
+          subject: invalid_subject,
+          read: false
+        }.to_json
+      end
+
+      it 'should return a 422 unprocessable entity', :aggregate_failures do
+        post '/v0/notifications', params: invalid_post_body, headers: headers
+
+        expect(response.status).to eq 422
+        expect(response.body).to include "#{invalid_subject} is not a valid subject"
+      end
+    end
+  end
+end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1974,51 +1974,89 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
     describe 'notifications' do
       let(:notification_subject) { Notification::FORM_10_10EZ }
 
-      context 'when user has an associated Notification record' do
-        let!(:notification) do
-          create :notification, :dismissed_status, account_id: mhv_user.account.id, read_at: Time.current
+      describe 'POST /v0/notifications' do
+        let(:post_body) do
+          {
+            subject: notification_subject,
+            read: false
+          }
         end
 
-        it 'supports getting dismissed status data' do
+        it 'supports posting notification data' do
           expect(subject).to validate(
-            :get,
-            '/v0/notifications/dismissed_statuses/{subject}',
+            :post,
+            '/v0/notifications',
             200,
-            headers.merge('subject' => notification_subject)
+            headers.merge('_data' => post_body)
           )
         end
-      end
 
-      context 'when user does not have an associated Notification record' do
-        it 'supports record not found feedback' do
-          expect(subject).to validate(
-            :get,
-            '/v0/notifications/dismissed_statuses/{subject}',
-            404,
-            headers.merge('subject' => notification_subject)
-          )
-        end
-      end
-
-      context 'authorization' do
         it 'supports authorization validation' do
           expect(subject).to validate(
-            :get,
-            '/v0/notifications/dismissed_statuses/{subject}',
+            :post,
+            '/v0/notifications',
             401,
-            'subject' => notification_subject
+            '_data' => post_body
+          )
+        end
+
+        it 'supports validating posted notification data' do
+          expect(subject).to validate(
+            :post,
+            '/v0/notifications',
+            422,
+            headers.merge('_data' => post_body.merge(subject: 'random_subject'))
           )
         end
       end
 
-      context 'when the passed subject is not defined in the Notification#subject enum' do
-        it 'supports invalid subject validation' do
-          expect(subject).to validate(
-            :get,
-            '/v0/notifications/dismissed_statuses/{subject}',
-            422,
-            headers.merge('subject' => 'random_subject')
-          )
+      describe 'GET /v0/notifications/dismissed_statuses/{subject}' do
+        context 'when user has an associated Notification record' do
+          let!(:notification) do
+            create :notification, :dismissed_status, account_id: mhv_user.account.id, read_at: Time.current
+          end
+
+          it 'supports getting dismissed status data' do
+            expect(subject).to validate(
+              :get,
+              '/v0/notifications/dismissed_statuses/{subject}',
+              200,
+              headers.merge('subject' => notification_subject)
+            )
+          end
+        end
+
+        context 'when user does not have an associated Notification record' do
+          it 'supports record not found feedback' do
+            expect(subject).to validate(
+              :get,
+              '/v0/notifications/dismissed_statuses/{subject}',
+              404,
+              headers.merge('subject' => notification_subject)
+            )
+          end
+        end
+
+        context 'authorization' do
+          it 'supports authorization validation' do
+            expect(subject).to validate(
+              :get,
+              '/v0/notifications/dismissed_statuses/{subject}',
+              401,
+              'subject' => notification_subject
+            )
+          end
+        end
+
+        context 'when the passed subject is not defined in the Notification#subject enum' do
+          it 'supports invalid subject validation' do
+            expect(subject).to validate(
+              :get,
+              '/v0/notifications/dismissed_statuses/{subject}',
+              422,
+              headers.merge('subject' => 'random_subject')
+            )
+          end
         end
       end
 

--- a/spec/support/schemas/notification.json
+++ b/spec/support/schemas/notification.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "subject": {
+              "type": "string"
+            },
+            "read_at": {
+              "type": ["string", null]
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## Description of change
Per the discovery in [#17421](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17421), we will need to persist if a given In-Account notification has/hasn't been read by a veteran.  

This work involves endpoints to create, show, and update a given In-Account`Notification` record.

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

- [x] Creates a `POST /v0/notifications` endpoint with a body of:

```javascript
{
    subject: "dashboard_health_care_application_notification", 
    read: false 
}
```

- [x] Confirm contract
- [x] Swagger docs
- [x] Request specs
#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

## Screenshot

#### Swagger docs

![image](https://user-images.githubusercontent.com/7482329/56911366-fff70580-6a69-11e9-9f8c-aac03284c761.png)
