### PR TITLE
remove triggers of legacy dev deploys

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,16 +77,6 @@ pipeline {
       when { branch dev_branch }
 
       steps {
-        build job: 'deploys/vets-api-server-dev', parameters: [
-          booleanParam(name: 'notify_slack', value: true),
-          stringParam(name: 'ref', value: commit),
-        ], wait: false
-
-        build job: 'deploys/vets-api-worker-dev', parameters: [
-          booleanParam(name: 'notify_slack', value: true),
-          stringParam(name: 'ref', value: commit),
-        ], wait: false
-
         build job: 'deploys/vets-api-server-vagov-dev', parameters: [
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),


### PR DESCRIPTION
## Description of change
Removes triggering the deploy of the old dev environment. 

Part of https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16410