### PR TITLE
Endpoint to get a Notification record

### DIFF
--- a/app/controllers/v0/notifications_controller.rb
+++ b/app/controllers/v0/notifications_controller.rb
@@ -7,6 +7,7 @@ module V0
 
     before_action -> { validate_subject!(subject) }
     before_action :set_account
+    before_action :set_notification, only: :show
 
     def create
       notification = @account.notifications.build(subject: subject, read_at: read_at)
@@ -18,10 +19,22 @@ module V0
       end
     end
 
+    def show
+      if @notification
+        render json: @notification, serializer: NotificationSerializer
+      else
+        raise Common::Exceptions::RecordNotFound.new(subject), 'No matching record found for that user'
+      end
+    end
+
     private
 
     def set_account
       @account = create_user_account
+    end
+
+    def set_notification
+      @notification = Notification.find_by(account_id: @account.id, subject: subject)
     end
 
     def notification_params

--- a/app/swagger/requests/notifications.rb
+++ b/app/swagger/requests/notifications.rb
@@ -45,10 +45,42 @@ module Swagger
         end
       end
 
+      swagger_path '/v0/notifications/{subject}' do
+        operation :get do
+          extend Swagger::Responses::AuthenticationError
+          extend Swagger::Responses::ValidationError
+          extend Swagger::Responses::RecordNotFoundError
+
+          key :description, "Gets the user's associated notification details"
+          key :operationId, 'getNotification'
+          key :tags, %w[
+            notifications
+          ]
+
+          parameter :authorization
+
+          parameter do
+            key :name, 'subject'
+            key :in, :path
+            key :description, 'The subject of the notification (i.e. "form_10_10ez")'
+            key :required, true
+            key :type, :string
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :Notification
+            end
+          end
+        end
+      end
+
       swagger_path '/v0/notifications/dismissed_statuses/{subject}' do
         operation :get do
           extend Swagger::Responses::AuthenticationError
           extend Swagger::Responses::ValidationError
+          extend Swagger::Responses::RecordNotFoundError
 
           key :description, "Gets the user's most recent dismissed status notification details"
           key :operationId, 'getDismissedStatus'
@@ -70,26 +102,6 @@ module Swagger
             key :description, 'Response is OK'
             schema do
               key :'$ref', :DismissedStatus
-            end
-          end
-
-          response 404 do
-            key :description, 'Record not found'
-            schema do
-              key :required, [:errors]
-
-              property :errors do
-                key :type, :array
-                items do
-                  key :required, %i[title detail code status]
-                  property :title, type: :string, example: 'Record not found'
-                  property :detail,
-                           type: :string,
-                           example: 'The record identified by form_10_10ez could not be found'
-                  property :code, type: :string, example: '404'
-                  property :status, type: :string, example: '404'
-                end
-              end
             end
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -235,7 +235,7 @@ Rails.application.routes.draw do
       post :upgrade
     end
 
-    resources :notifications, only: :create, param: :subject
+    resources :notifications, only: %i[create show], param: :subject
 
     namespace :notifications do
       resources :dismissed_statuses, only: %i[show create update], param: :subject

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -2010,6 +2010,56 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
         end
       end
 
+      describe 'GET /v0/notifications/{subject}' do
+        context 'when user has an associated Notification record' do
+          let!(:notification) do
+            create :notification, account_id: mhv_user.account.id, subject: notification_subject
+          end
+
+          it 'supports getting dismissed status data' do
+            expect(subject).to validate(
+              :get,
+              '/v0/notifications/{subject}',
+              200,
+              headers.merge('subject' => notification_subject)
+            )
+          end
+        end
+
+        context 'when user does not have an associated Notification record' do
+          it 'supports record not found feedback' do
+            expect(subject).to validate(
+              :get,
+              '/v0/notifications/{subject}',
+              404,
+              headers.merge('subject' => notification_subject)
+            )
+          end
+        end
+
+        context 'authorization' do
+          it 'supports authorization validation' do
+            expect(subject).to validate(
+              :get,
+              '/v0/notifications/{subject}',
+              401,
+              'subject' => notification_subject
+            )
+          end
+        end
+
+        context 'when the passed subject is not defined in the Notification#subject enum' do
+          it 'supports invalid subject validation' do
+            expect(subject).to validate(
+              :get,
+              '/v0/notifications/{subject}',
+              422,
+              headers.merge('subject' => 'random_subject')
+            )
+          end
+        end
+      end
+
       describe 'GET /v0/notifications/dismissed_statuses/{subject}' do
         context 'when user has an associated Notification record' do
           let!(:notification) do


### PR DESCRIPTION
## Description of change

Per the discovery in [#17421](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17421), we will need to persist if a given In-Account notification has/hasn't been read by a veteran.  

This work involves endpoints to create, show, and update a given In-Account`Notification` record.

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Creates a `GET /v0/notifications/:subject` endpoint
- [x] Confirm contract
- [x] Swagger docs
- [x] Request specs

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

## Screenshot

#### Swagger docs

![image](https://user-images.githubusercontent.com/7482329/56978523-f1295500-6b34-11e9-85a6-186a80afda73.png)

