### PR TITLE
Endpoint to update a Notification record

### DIFF
--- a/app/controllers/v0/notifications/dismissed_statuses_controller.rb
+++ b/app/controllers/v0/notifications/dismissed_statuses_controller.rb
@@ -2,6 +2,11 @@
 
 module V0
   module Notifications
+    # This class is for any notification `status` and `status_effective_at` related updates and use cases,
+    # for a given subject.
+    #
+    # For any conventional read/unread notification use cases, use the notifications_controller.rb
+    #
     class DismissedStatusesController < ApplicationController
       include Accountable
       include ::Notifications::Validateable

--- a/app/controllers/v0/notifications_controller.rb
+++ b/app/controllers/v0/notifications_controller.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 module V0
+  # This class is for any conventional read/unread notification use cases, for a given subject.
+  #
+  # For any `status` and `status_effective_at` related updates and use cases, use the
+  # notifications/dismissed_statuses_controller.rb
+  #
   class NotificationsController < ApplicationController
     include Accountable
     include ::Notifications::Validateable

--- a/app/controllers/v0/notifications_controller.rb
+++ b/app/controllers/v0/notifications_controller.rb
@@ -7,7 +7,7 @@ module V0
 
     before_action -> { validate_subject!(subject) }
     before_action :set_account
-    before_action :set_notification, only: :show
+    before_action :set_notification, only: %i[show update]
 
     def create
       notification = @account.notifications.build(subject: subject, read_at: read_at)
@@ -24,6 +24,16 @@ module V0
         render json: @notification, serializer: NotificationSerializer
       else
         raise Common::Exceptions::RecordNotFound.new(subject), 'No matching record found for that user'
+      end
+    end
+
+    def update
+      validate_record_present!(@notification, subject)
+
+      if @notification.update(read_at: read_at)
+        render json: @notification, serializer: NotificationSerializer
+      else
+        raise Common::Exceptions::ValidationErrors.new(@notification), 'Validation errors present'
       end
     end
 

--- a/app/swagger/requests/notifications.rb
+++ b/app/swagger/requests/notifications.rb
@@ -74,6 +74,46 @@ module Swagger
             end
           end
         end
+
+        operation :patch do
+          extend Swagger::Responses::AuthenticationError
+          extend Swagger::Responses::ValidationError
+          extend Swagger::Responses::RecordNotFoundError
+
+          key :description, 'Update an existing Notification record'
+          key :operationId, 'patchNotification'
+          key :tags, %w[notifications]
+
+          parameter :authorization
+
+          parameter do
+            key :name, 'subject'
+            key :in, :path
+            key :description, 'The subject of the notification (i.e. "form_10_10ez")'
+            key :required, true
+            key :type, :string
+          end
+
+          parameter do
+            key :name, :body
+            key :in, :body
+            key :description, 'The properties to update an existing notification record'
+            key :required, true
+
+            schema do
+              key :required, %i[read]
+
+              property :read, type: :boolean, example: true, enum: [true, false]
+            end
+          end
+
+          response 200 do
+            key :description, 'Response is OK'
+            schema do
+              key :'$ref', :Notification
+            end
+          end
+        end
       end
 
       swagger_path '/v0/notifications/dismissed_statuses/{subject}' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -235,7 +235,7 @@ Rails.application.routes.draw do
       post :upgrade
     end
 
-    resources :notifications, only: %i[create show], param: :subject
+    resources :notifications, only: %i[create show update], param: :subject
 
     namespace :notifications do
       resources :dismissed_statuses, only: %i[show create update], param: :subject

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -2060,6 +2060,54 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
         end
       end
 
+      describe 'PATCH /v0/notifications/{subject}' do
+        let(:patch_body) { { read: true } }
+
+        context 'user has an existing Notification record with the passed subject' do
+          let!(:notification) do
+            create :notification, :dismissed_status, account_id: mhv_user.account.id, read_at: Time.current
+          end
+
+          it 'supports updating notification data' do
+            expect(subject).to validate(
+              :patch,
+              '/v0/notifications/{subject}',
+              200,
+              headers.merge('_data' => patch_body, 'subject' => notification_subject)
+            )
+          end
+
+          it 'supports authorization validation' do
+            expect(subject).to validate(
+              :patch,
+              '/v0/notifications/{subject}',
+              401,
+              '_data' => patch_body, 'subject' => notification_subject
+            )
+          end
+
+          it 'supports validating updated notification data' do
+            expect(subject).to validate(
+              :patch,
+              '/v0/notifications/{subject}',
+              422,
+              headers.merge('_data' => patch_body, 'subject' => 'random_subject')
+            )
+          end
+        end
+
+        context 'user does not have a Notification record with the passed subject' do
+          it 'supports validating the presence of an existing record to be updated' do
+            expect(subject).to validate(
+              :patch,
+              '/v0/notifications/{subject}',
+              404,
+              headers.merge('_data' => patch_body, 'subject' => notification_subject)
+            )
+          end
+        end
+      end
+
       describe 'GET /v0/notifications/dismissed_statuses/{subject}' do
         context 'when user has an associated Notification record' do
           let!(:notification) do


### PR DESCRIPTION
## Description of change
Per the discovery in [#17421](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17421), we will need to persist if a given In-Account notification has/hasn't been read by a veteran.  

This work involves endpoints to create, show, and update a given In-Account`Notification` record.

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Creates a `PUT/PATCH /v0/notifications/:subject` endpoint with a body of:

```javascript
{
    read: true 
}
```

- [x] Confirm contract
- [x] Swagger docs
- [x] Request specs

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)

## Screenshots

#### Swagger docs 

![image](https://user-images.githubusercontent.com/7482329/57036739-5dc65180-6c12-11e9-8903-7f7b7d44b0f9.png)
