### PR TITLE
Session expiration header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -159,4 +159,9 @@ class ApplicationController < ActionController::API
   def render_job_id(jid)
     render json: { job_id: jid }, status: 202
   end
+
+  def append_info_to_payload(payload)
+    super
+    payload[:session] = Session.obscure_token(session[:token]) if session && session[:token]
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -159,9 +159,4 @@ class ApplicationController < ActionController::API
   def render_job_id(jid)
     render json: { job_id: jid }, status: 202
   end
-
-  def append_info_to_payload(payload)
-    super
-    payload[:session] = Session.obscure_token(session[:token]) if session && session[:token]
-  end
 end

--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -9,7 +9,6 @@ module AuthenticationAndSSOConcerns
 
   included do
     before_action :authenticate
-    before_action :set_api_cookie!
     before_action :set_session_expiration_header
   end
 
@@ -76,7 +75,6 @@ module AuthenticationAndSSOConcerns
   end
 
   # Sets a cookie "api_session" with all of the key/value pairs from session object.
-  # Ensures that we maintain session of currently signed-in user before switch to session cookies
   def set_api_cookie!
     return unless @session_object
     @session_object.to_hash.each { |k, v| session[k] = v }

--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -10,6 +10,7 @@ module AuthenticationAndSSOConcerns
   included do
     before_action :authenticate
     before_action :set_api_cookie!
+    before_action :set_session_expiration_header
   end
 
   protected
@@ -95,6 +96,10 @@ module AuthenticationAndSSOConcerns
       httponly: true,
       domain: Settings.sso.cookie_domain
     }
+  end
+
+  def set_session_expiration_header
+    headers['X-Session-Expiration'] = @session_object.ttl_in_time.httpdate if @session_object.present?
   end
 
   # The contents of MHV SSO Cookie with specifications found here:

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,7 +54,8 @@ module VetsAPI
                       expose: [
                         'X-RateLimit-Limit',
                         'X-RateLimit-Remaining',
-                        'X-RateLimit-Reset'
+                        'X-RateLimit-Reset',
+                        'X-Session-Expiration'
                       ]
       end
     end


### PR DESCRIPTION
## Description of change
Added session expiration as a header in authenticated responses so the front end can display the session timeout modal and page at the appropriate time.

Front-end PR: department-of-veterans-affairs/vets-website#10033

## Testing done
Locally tested. The header is included in authenticated responses. Also modified the session TTL to a short enough duration to quickly test that the modal works.

## Testing planned
The session timeout feature will initially be available only in lower environments for QA.

## Acceptance Criteria (Definition of Done)
- [x] The session expiration should be exposed as a header in authenticated responses.

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
