### PR TITLE
Validate Against Empty Files

### DIFF
--- a/modules/vba_documents/README.yml
+++ b/modules/vba_documents/README.yml
@@ -406,6 +406,7 @@ components:
             * `DOC104` - Upload rejected by downstream system. Detail field will indicate nature of rejection.
             * `DOC105` - Invalid or unknown id
             * 'DOC106' - File size limit exceeded. Each document may be a maximum of 100MB.
+            * 'DOC107' - Empty payload.
             * `DOC201` - Upload server error.
             * `DOC202` - Error during processing by downstream system. Processing failed and could not be retried. Detail field will provide additional details where available.
           type: string

--- a/modules/vba_documents/lib/vba_documents/multipart_parser.rb
+++ b/modules/vba_documents/lib/vba_documents/multipart_parser.rb
@@ -29,8 +29,8 @@ module VBADocuments
 
     def self.validate_size(infile)
       unless infile.size.positive?
-        raise VBADocuments::UploadError.new(code: 'DOC106',
-                                            detail: VBADocuments::UploadError::DOC106)
+        raise VBADocuments::UploadError.new(code: 'DOC107',
+                                            detail: VBADocuments::UploadError::DOC107)
       end
     end
 

--- a/modules/vba_documents/lib/vba_documents/multipart_parser.rb
+++ b/modules/vba_documents/lib/vba_documents/multipart_parser.rb
@@ -8,6 +8,7 @@ module VBADocuments
     LINE_BREAK = "\r\n"
 
     def self.parse(infile)
+      validate_size(infile)
       File.open(infile, 'rb') do |input|
         lines = input.each_line(LINE_BREAK).lazy.each_with_index
 
@@ -23,6 +24,13 @@ module VBADocuments
           break unless moreparts
         end
         parts
+      end
+    end
+
+    def self.validate_size(infile)
+      unless infile.size.positive?
+        raise VBADocuments::UploadError.new(code: 'DOC106',
+                                            detail: VBADocuments::UploadError::DOC106)
       end
     end
 

--- a/modules/vba_documents/lib/vba_documents/upload_error.rb
+++ b/modules/vba_documents/lib/vba_documents/upload_error.rb
@@ -11,6 +11,7 @@ module VBADocuments
     DOC103 = 'Invalid content part'
     DOC104 = 'Upload rejected by downstream system'
     DOC105 = 'Invalid or unknown id'
+    DOC106 = 'Empty payload'
 
     # DOC2xx errors: server errors either local or downstream
     # not unambiguously related to submitted content

--- a/modules/vba_documents/lib/vba_documents/upload_error.rb
+++ b/modules/vba_documents/lib/vba_documents/upload_error.rb
@@ -11,7 +11,8 @@ module VBADocuments
     DOC103 = 'Invalid content part'
     DOC104 = 'Upload rejected by downstream system'
     DOC105 = 'Invalid or unknown id'
-    DOC106 = 'Empty payload'
+    DOC106 = 'Maximum document size exceeded. Limit is 100MB per document'
+    DOC107 = 'Empty payload'
 
     # DOC2xx errors: server errors either local or downstream
     # not unambiguously related to submitted content

--- a/modules/vba_documents/spec/lib/multipart_parser_spec.rb
+++ b/modules/vba_documents/spec/lib/multipart_parser_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe VBADocuments::MultipartParser do
       empty_doc = get_fixture('emptyfile.blob')
       expect { described_class.parse(empty_doc) }.to raise_error do |error|
         expect(error).to be_a(VBADocuments::UploadError)
-        expect(error.code).to eq('DOC106')
+        expect(error.code).to eq('DOC107')
         expect(error.detail).to eq('Empty payload')
       end
     end

--- a/modules/vba_documents/spec/lib/multipart_parser_spec.rb
+++ b/modules/vba_documents/spec/lib/multipart_parser_spec.rb
@@ -82,5 +82,14 @@ RSpec.describe VBADocuments::MultipartParser do
         expect(error.detail).to eq('Missing part name parameter in header')
       end
     end
+
+    it 'raises on an empty payload' do
+      empty_doc = get_fixture('emptyfile.blob')
+      expect { described_class.parse(empty_doc) }.to raise_error do |error|
+        expect(error).to be_a(VBADocuments::UploadError)
+        expect(error.code).to eq('DOC106')
+        expect(error.detail).to eq('Empty payload')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change
In testing if someone uploads an empty file, it casues our code to bomb. We should instead error and return something useful instead of sticking in `uploaded` status.

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/1960

## Testing done
- rspec


#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
