### PR TITLE
VBA Documents Documentation Update

### DIFF
--- a/modules/vba_documents/README.yml
+++ b/modules/vba_documents/README.yml
@@ -121,6 +121,7 @@ paths:
         --17de1ed8f01442b2a2d7a93506314b76
         Content-Disposition: form-data; name="metadata"
         Content-Type: application/json
+
         {"veteranFirstName": "Jane",
         "veteranLastName": "Doe",
         "fileNumber": "012345678",
@@ -130,10 +131,12 @@ paths:
         --17de1ed8f01442b2a2d7a93506314b76
         Content-Disposition: form-data; name="content"
         Content-Type: application/pdf
+
         <Binary PDF contents>
         --17de1ed8f01442b2a2d7a93506314b76
         Content-Disposition: form-data; name="attachment1"
         Content-Type: application/pdf
+
         <Binary PDF attachment contents>
         --17de1ed8f01442b2a2d7a93506314b76--
         ```


### PR DESCRIPTION
## Description of change
According to w3, empty lines are required, so we use them
https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html

This makes our documentation more correct