### PR TITLE
Uptick Rubocop target Rails version to 5.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRailsVersion: 5.0
+  TargetRailsVersion: 5.1
   TargetRubyVersion: 2.3
   Include:
     - '**/Gemfile'


### PR DESCRIPTION
## Description of change
We forgot to uptick the target Rails version in `.rubocop.yml`. This PR does that.

## Testing done
Rubocop runs locally with no violations.

## Testing planned
CI 

## Acceptance Criteria (Definition of Done)
#### Applies to all PRs

~- [ ] Appropriate logging~
~- [ ] Swagger docs have been updated, if applicable~
~- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub~
~- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)~
~- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)~
