### PR TITLE
Facilities Drive Times - Phase 1

### DIFF
--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -299,9 +299,7 @@ components:
                     enum:
                       - "Online Scheduling"
                 health:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/HealthService"
+                  $ref: "#/components/schemas/HealthServices"
                 benefits:
                   type: array
                   items:
@@ -315,17 +313,6 @@ components:
               properties:
                 health:
                   $ref: "#/components/schemas/PatientSatisfaction"
-                effective_date:
-                  type: string
-                  format: date
-                  example: "2018-01-01"
-            wait_times:
-              type: object
-              properties:
-                health:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/PatientWaitTime"
                 effective_date:
                   type: string
                   format: date
@@ -397,9 +384,7 @@ components:
                     enum:
                       - "Online Scheduling"
                 health:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/HealthService"
+                  $ref: "#/components/schemas/HealthServices"
                 benefits:
                   type: array
                   items:
@@ -413,17 +398,6 @@ components:
               properties:
                 health:
                   $ref: "#/components/schemas/PatientSatisfaction"
-                effective_date:
-                  type: string
-                  format: date
-                  example: "2018-01-01"
-            wait_times:
-              type: object
-              properties:
-                health:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/PatientWaitTime"
                 effective_date:
                   type: string
                   format: date
@@ -497,23 +471,45 @@ components:
         Sunday:
           type: string
           example: "Closed"
+    HealthServices:
+      description: Health care services at a given facility, not all will be included at every facility
+      type: array
+      items:
+        type: object
+        properties:
+          PrimaryCare:
+            $ref: "#/components/schemas/HealthService" 
+          MentalHealthCare:
+            $ref: "#/components/schemas/HealthService" 
+          UrgentCare:
+            $ref: "#/components/schemas/HealthService" 
+          EmergencyCare:
+            $ref: "#/components/schemas/HealthService" 
+          Audiology:
+            $ref: "#/components/schemas/HealthService" 
+          Cardiology:
+            $ref: "#/components/schemas/HealthService" 
+          Dermatology:
+            $ref: "#/components/schemas/HealthService" 
+          Gastroenterology:
+            $ref: "#/components/schemas/HealthService" 
+          Gynecology:
+            $ref: "#/components/schemas/HealthService" 
+          Ophthalmology:
+            $ref: "#/components/schemas/HealthService" 
+          Optometry:
+            $ref: "#/components/schemas/HealthService" 
+          Orthopedics:
+            $ref: "#/components/schemas/HealthService" 
+          Urology:
+            $ref: "#/components/schemas/HealthService" 
+          WomensHealth:
+            $ref: "#/components/schemas/HealthService" 
     HealthService:
-      type: string
-      enum:
-        - PrimaryCare
-        - MentalHealthCare
-        - UrgentCare
-        - EmergencyCare
-        - Audiology
-        - Cardiology
-        - Dermatology
-        - Gastroenterology
-        - Gynecology
-        - Ophthalmology
-        - Optometry
-        - Orthopedics
-        - Urology
-        - WomensHealth
+      type: object
+      properties:
+        wait_times:
+          $ref: "#/components/schemas/PatientWaitTime" 
     BenefitsService:
       type: string
       enum:
@@ -561,8 +557,6 @@ components:
       description: Expected wait times for new and established patients for a given health care service
       type: object
       properties:
-        service:
-          $ref: "#/components/schemas/HealthService"
         new:
           description: The average number of days a Veteran who hasn’t been to this location has to wait for a non-urgent appointment
           type: integer
@@ -571,6 +565,10 @@ components:
           description: The average number of days a patient who has already been to this location has to wait for a non-urgent appointment
           type: integer
           example: 5
+        effective_date:
+          type: string
+          format: date
+          example: "2018-01-01"
     APIError:
       description: API invocation or processing error
       type: object

--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -1,6 +1,6 @@
 openapi: '3.0.0'
 info:
-  version: 0.0.1
+  version: 1.0.0
   title: VA Facilities
   description: |
 
@@ -40,7 +40,7 @@ info:
 
     ## Reference
 
-    - [Raw VA Facilities Open API Spec](http://dev-api.va.gov/services/va_facilities/docs/v0/api)
+    - [Raw VA Facilities Open API Spec](http://dev-api.va.gov/services/va_facilities/docs/v1/api)
     - [GeoJSON Format](https://tools.ietf.org/html/rfc7946)
     - [JSON API Format](http://jsonapi.org/format/)
 
@@ -55,113 +55,63 @@ servers:
     description: VA.gov API development environment
     variables:
       version:
-        default: v0
+        default: v1
   - url: https://staging-api.va.gov/services/va_facilities/{version}
     description: VA.gov API staging environment
     variables:
       version:
-        default: v0
+        default: v1
   - url: https://api.va.gov/services/va_facilities/{version}
     description: VA.gov API production environment
     variables:
       version:
-        default: v0
+        default: v1
 paths:
-  /facilities:
+  /nearby:
     get:
       tags:
         - facilities
-      summary: Query facilities based on a geographic bounding box and optional attribute filters
+      summary: Query facilities based on drive time from a specified point
       description: |
-        Retrieve all facilities contained within the specified bounding box. Bounding box is
-        specified as four parameters long1, lat1, long2, lat2. Relative ordering of longitude and
-        latitude parameters is unimportant.
+        Retrieve all facilities contained within an isochrone based on a the passed `lat`, `lng`, and `drivetime` parameters.
 
         Additionally one can filter the facilities within the bounding box by type and available
         services. Only facilities of type "health" and "benefits" may be filtered by available
         services.
 
-        Alternatively, one can retrieve multiple facilities by id using this endpoint by making a
-        request with a comma-separated list of ids like `?ids=id1,id2`. When requesting facilities
-        in bulk by `id`, the API will return as many ids as it can find matches for and omit any
-        ids where there is no match. It will not return an HTTP error code if it is unable to match
-        a requested `id`. Clients may supply ids up to the limit a their HTTP client enforces for
-        URI path lengths -- usually 2,048 characters.
-
-        One of the `ids` parameter, the `bbox` parameter, or the `lat` and `long` parameters are
-        *required* to query this API. Requests without one or the other will return `400 Bad Request`.
-
         Results of this operation are paginated. JSON responses include pagination information
         in the standard JSON API "links" and "meta" elements. GeoJSON responses include pagination
         information in the "Link" header.
-      operationId: getFacilitiesByLocation
+      operationId: getNearbyFacilities
       security:
         - api_key: []
       parameters:
-        - name: ids
-          description: |
-            List of comma separated ids of facilities to retrieve in a single request.
-            Can be combined with lat and long parameters to retrieve the facilities sorted by distance from a location.
-          in: query
-          style: form
-          explode: false
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-        - name: zip
-          in: query
-          description: |
-            Zip code to search for VA Facilities. 
-            More detailed zip codes can be passed in, but only the first five digits are used to determine facilities to return.
-          required: false
-          schema:
-            type: string
-            format: '##### or #####-####'
-        - name: state
-          in: query
-          description: |
-            Two character state code to search for VA Facilities.
-          required: false
-          schema:
-            type: string
-            format: XX
         - name: lat
           in: query
           description: |
             Latitude of point to search for nearest VA Facilities.
             Latitude and Longitude parameters should be specified in WGS84 coordinate reference system.
-          required: false
+          required: true
           schema:
             type: number
             format: float
-        - name: long
+        - name: lng
           in: query
           description: |
             Longitude of point to search for nearest VA Facilities.
             Latitude and Longitude parameters should be specified in WGS84 coordinate reference system.
-          required: false
+          required: true
           style: form
-          explode: true
           schema:
             type: number
             format: float
-        - name: bbox[]
+        - name: drivetime
+          description:  Filter to only include facilities that are within the specified number of drive time minutes from the requested point.
           in: query
-          description: |
-            Bounding longitude/latitude/longitude/latitude within which facilities will be returned.
-            Bounding box parameters should be specified in WGS84 coordinate reference system.
           required: false
-          style: form
-          explode: true
           schema:
-            type: array
-            minItems: 4
-            maxItems: 4
-            items:
-              type: number
-              format: float
+            type: integer
+            default: 60
         - name: type
           description: Optional facility type search filter
           in: query
@@ -214,23 +164,7 @@ paths:
                     type: object
                     required:
                       - pagination
-                      - distances
                     properties:
-                      distances:
-                        type: array
-                        description: "For lat/long queries, a list of mappings between facility ids and the distance from the search location. Distance is expressed in miles and represents straight-line distance, not driving distance."
-                        items:
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                              description: "Facility id. Matches the facility id in the data part of the response."
-                              example: vha_688
-                            distance:
-                              type: number
-                              format: float
-                              description: "Distance from search location"
-                              example: 3.14
                       pagination:
                         type: object
                         required:
@@ -269,133 +203,7 @@ paths:
               description: GitHub-style pagination information. Only present for GeoJSON-format responses.
               schema:
                 type: string
-                example: '<https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=2&per_page=20>; rel="self", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="first", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="prev", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=3&per_page=20>; rel="next", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=5&per_page=20>; rel="last"'
-        '401':
-          description: Missing API token
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthorizationError"
-        '403':
-          description: Invalid API token
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthorizationError"
-        '406':
-          description: Requested format unacceptable
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
-  /facilities/{id}:
-    get:
-      tags:
-        - facilities
-      summary: Retrieve a specific facility by ID
-      operationId: getFacilityById
-      security:
-        - api_key: []
-      parameters:
-        - in: path
-          name: id
-          description: |
-            Facility ID, in the form `<prefix>_<id>`, where prefix is one of "vha", "vba", "nca", or "vc"
-            for health, benefits, cemetery, or Vet Center facilities respectively.
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                required:
-                  - data
-                properties:
-                  data:
-                    $ref: "#/components/schemas/Facility"
-            application/vnd.geo+json:
-              schema:
-                $ref: "#/components/schemas/FacilityFeature"
-        '400':
-          description: Bad request - invalid or missing query parameters
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
-        '401':
-          description: Missing API token
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthorizationError"
-        '403':
-          description: Invalid API token
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthorizationError"
-        '404':
-          description: Facility not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
-        '406':
-          description: Requested format unacceptable
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
-  /facilities/all:
-    get:
-      tags:
-        - facilities
-      summary: Bulk download of all available facilities
-      description: |
-        Retrieve all available facilities in a single operation, formatted as either a GeoJSON
-        FeatureCollection or as a CSV. Due to the complexity of the facility resource type, the CSV
-        response contains a subset of available facility data - specifically it omits the
-        available services, patient satisfaction, and patient wait time data.
-      operationId: getAllFacilities
-      security:
-        - api_key: []
-      parameters:
-        - in: header
-          name: Accept
-          schema:
-            enum:
-              - application/vnd.geo+json
-              - text/csv
-          required: true
-      responses:
-        '200':
-          description: Success
-          content:
-            application/vnd.geo+json:
-              schema:
-                required:
-                  - type
-                  - features
-                properties:
-                  type:
-                    type: string
-                    enum: ["FeatureCollection"]
-                  features:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/FacilityFeature"
-            text/csv:
-              schema:
-                type: string
-                example: |
-                  id,name,station_id,latitude,longitude,facility_type,classification,website,physical_address_1,physical_address_2,physical_address_3,physical_city,physical_state,physical_zip,mailing_address_1,mailing_address_2,mailing_address_3,mailing_city,mailing_state,mailing_zip,phone_main,phone_fax,phone_mental_health_clinic,phone_pharmacy,phone_after_hours,phone_patient_advocate,phone_enrollment_coordinator,hours_monday,hours_tuesay,hours_wednesday,hours_thursday,hours_friday,hours_saturday,hours_sunday
-                  vc_0101V,Boston Vet Center,0101V,42.3445959000001,-71.0361051099999,vet_center,,,7 Drydock Avenue,Suite 2070,,Boston,MA,02210,,,,,,,857-203-6461 x,,,,,,,800AM-700PM,800AM-800PM,800AM-700PM,800AM-800PM,800AM-600PM,-,-
-                  vba_362b,Houston Regional Benefit Office at Frank Tejeda Outpatient Clinic,362b,29.51690196,-98.59601936,va_benefits_facility,Outbased,NULL,5788 Eckhert Road,,,San Antonio,TX,78240,,,,,,,210-699-5040,210-699-5079,,,,,,,,,,,,
-                  vha_402GC,Rumford VA Clinic,402GC,44.55185578,-70.55746856,va_health_facility,Primary Care CBOC,http://www.maine.va.gov/locations/rumford.asp,431 Franklin Street,,,Rumford,ME,04276-2100,,,,,,,207-369-3200 x,207-369-3277 x,207-369-3200 x 3200,207-623-8411 x5770,866-757-7503 x,207-623-5760 x,207-626-4743 x,,,,,,,
-                  nca_800,Alton National Cemetery,800,38.8905166870001,-90.1630421139999,va_cemetery,National Cemetery,https://www.cem.va.gov/cems/nchp/alton.asp,600 Pearl St,,,Alton,IL,62002,2900 Sheridan Rd,,,St. Louis,MO,63125,314-845-8320,314-845-8355,,,,,,,,,,,,
+                example: '<https://dev-api.va.gov/services/va_facilities/v1/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=2&per_page=20>; rel="self", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="first", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="prev", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=3&per_page=20>; rel="next", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=5&per_page=20>; rel="last"'
         '401':
           description: Missing API token
           content:

--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -73,9 +73,9 @@ paths:
         - facilities
       summary: Query facilities based on drive time from a specified point
       description: |
-        Retrieve all facilities contained within an isochrone based on a the passed `lat`, `lng`, and `drivetime` parameters.
+        Retrieve all facilities contained within an isochrone based on a the passed `lat`, `lng`, and `drive_time` parameters.
 
-        Additionally one can filter the facilities within the bounding box by type and available
+        Additionally one can filter the facilities within the isochrone by type and available
         services. Only facilities of type "health" and "benefits" may be filtered by available
         services.
 
@@ -105,7 +105,7 @@ paths:
           schema:
             type: number
             format: float
-        - name: drivetime
+        - name: drive_time
           description:  Filter to only include facilities that are within the specified number of drive time minutes from the requested point.
           in: query
           required: false

--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -9,7 +9,7 @@ info:
     This API provides information about physical VA facilities. Information available includes
     geographic location, address, phone, hours of operation, and available services. 
 
-    VA operates several different types of facilities, the types represented in this API include:
+    VA operates several different types of facilities. The types represented in this API include:
     - Health facilities
     - Benefits facilities
     - Cemeteries
@@ -73,7 +73,7 @@ paths:
         - facilities
       summary: Query facilities based on drive time from a specified point
       description: |
-        Retrieve all facilities contained within an isochrone based on a the passed `lat`, `lng`, and `drive_time` parameters.
+        Retrieve all facilities contained within an isochrone (a polygon composed of the area reachable in a certain amount of time from a central point) based on a the passed `lat`, `lng`, and `drive_time` parameters.
 
         Additionally one can filter the facilities within the isochrone by type and available
         services. Only facilities of type "health" and "benefits" may be filtered by available

--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -249,7 +249,7 @@ components:
             - name
             - facility_type
             - lat
-            - long
+            - lng
           properties:
             name:
               type: string
@@ -269,7 +269,7 @@ components:
               type: number
               format: float
               example: 38.9311137
-            long:
+            lng:
               description: Facility longitude
               type: number
               format: float

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -414,6 +414,161 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/APIError"
+  /nearby:
+    get:
+      tags:
+        - facilities
+      summary: Query facilities based on drive time from a specified point
+      description: |
+        Retrieve all facilities contained within an isochrone based on a the passed `lat`, `lng`, and `drivetime` parameters.
+
+        Additionally one can filter the facilities within the bounding box by type and available
+        services. Only facilities of type "health" and "benefits" may be filtered by available
+        services.
+
+        Results of this operation are paginated. JSON responses include pagination information
+        in the standard JSON API "links" and "meta" elements. GeoJSON responses include pagination
+        information in the "Link" header.
+      operationId: getNearbyFacilities
+      security:
+        - api_key: []
+      parameters:
+        - name: lat
+          in: query
+          description: |
+            Latitude of point to search for nearest VA Facilities.
+            Latitude and Longitude parameters should be specified in WGS84 coordinate reference system.
+          required: true
+          schema:
+            type: number
+            format: float
+        - name: lng
+          in: query
+          description: |
+            Longitude of point to search for nearest VA Facilities.
+            Latitude and Longitude parameters should be specified in WGS84 coordinate reference system.
+          required: true
+          style: form
+          schema:
+            type: number
+            format: float
+        - name: drivetime
+          description: Drive time is the maximum number of minutes to from the requested point that are included in the response.
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 60
+        - name: type
+          description: Optional facility type search filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - health
+              - cemetery
+              - benefits
+              - vet_center
+        - name: services[]
+          description: Optional facility service search filter
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: page
+          description: Page of results to return per paginated response.
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: per_page
+          description: Number of results to return per paginated response.
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Facility"
+                  meta:
+                    description: "Metadata about the response"
+                    type: object
+                    required:
+                      - pagination
+                    properties:
+                      pagination:
+                        type: object
+                        required:
+                          - current_page
+                          - per_page
+                          - total_entries
+                          - total_pages
+                        properties:
+                          current_page:
+                            type: integer
+                            example: 1
+                          per_page:
+                            type: integer
+                            example: 10
+                          total_entries:
+                            type: integer
+                            example: 2162
+                          total_pages:
+                            type: integer
+                            example: 217
+            application/vnd.geo+json:
+              schema:
+                required:
+                  - type
+                  - features
+                properties:
+                  type:
+                    type: string
+                    enum: ["FeatureCollection"]
+                  features:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FacilityFeature"
+          headers:
+            Link:
+              description: GitHub-style pagination information. Only present for GeoJSON-format responses.
+              schema:
+                type: string
+                example: '<https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=2&per_page=20>; rel="self", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="first", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=1&per_page=20>; rel="prev", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=3&per_page=20>; rel="next", <https://dev-api.va.gov/services/va_facilities/v0/facilities?bbox%5B%5D=-120&bbox%5B%5D=40&bbox%5B%5D=-125&bbox%5B%5D=50&page=5&per_page=20>; rel="last"'
+        '401':
+          description: Missing API token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        '403':
+          description: Invalid API token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        '406':
+          description: Requested format unacceptable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
 components:
   securitySchemes:
     api_key:

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -118,7 +118,7 @@ paths:
           required: false
           schema:
             type: string
-            format: #####
+            format: '##### or #####-####'
         - name: state
           in: query
           description: |

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -453,7 +453,7 @@ paths:
             type: number
             format: float
         - name: drivetime
-          description: Drive time is the maximum number of minutes to from the requested point that are included in the response.
+          description:  Filter to only include facilities that are within the specified number of drive time minutes from the requested point.
           in: query
           required: false
           schema:

--- a/modules/va_facilities/app/controllers/va_facilities/docs/v1/api_controller.rb
+++ b/modules/va_facilities/app/controllers/va_facilities/docs/v1/api_controller.rb
@@ -7,7 +7,7 @@ module VaFacilities
         skip_before_action(:authenticate)
 
         def index
-          swagger = YAML.safe_load(File.read(VaFacilities::Engine.root.join('README.yml')))
+          swagger = YAML.safe_load(File.read(VaFacilities::Engine.root.join('README.v1.yml')))
           render json: swagger
         end
       end

--- a/modules/va_facilities/app/controllers/va_facilities/docs/v1/api_controller.rb
+++ b/modules/va_facilities/app/controllers/va_facilities/docs/v1/api_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module VaFacilities
+  module Docs
+    module V1
+      class ApiController < ApplicationController
+        skip_before_action(:authenticate)
+
+        def index
+          swagger = YAML.safe_load(File.read(VaFacilities::Engine.root.join('README.yml')))
+          render json: swagger
+        end
+      end
+    end
+  end
+end

--- a/modules/va_facilities/config/routes.rb
+++ b/modules/va_facilities/config/routes.rb
@@ -13,5 +13,9 @@ VaFacilities::Engine.routes.draw do
     namespace :v0 do
       resources :api, only: [:index]
     end
+
+    namespace :v1 do
+      resources :api, only: [:index]
+    end
   end
 end

--- a/modules/va_facilities/spec/requests/api_docs_request_spec.rb
+++ b/modules/va_facilities/spec/requests/api_docs_request_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe 'VA Facilities Documentation Endpoint', type: :request do
   end
 
   describe '#get /docs/v1/api' do
-  it 'should return Open API Spec v3 JSON' do
-    get '/services/va_facilities/docs/v1/api'
-    expect(response).to have_http_status(:ok)
-    JSON.parse(response.body)
+    it 'should return Open API Spec v3 JSON' do
+      get '/services/va_facilities/docs/v1/api'
+      expect(response).to have_http_status(:ok)
+      JSON.parse(response.body)
+    end
   end
-end
 end

--- a/modules/va_facilities/spec/requests/api_docs_request_spec.rb
+++ b/modules/va_facilities/spec/requests/api_docs_request_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe 'VA Facilities Documentation Endpoint', type: :request do
       JSON.parse(response.body)
     end
   end
+
+  describe '#get /docs/v1/api' do
+  it 'should return Open API Spec v3 JSON' do
+    get '/services/va_facilities/docs/v1/api'
+    expect(response).to have_http_status(:ok)
+    JSON.parse(response.body)
+  end
+end
 end


### PR DESCRIPTION
## Description of change
This PR is the beginning of the first phase of work to provide drive times for VA facilities as required by the Mission Act. It provides documentation of a new endpoint `/nearby` for feedback from stakeholders and consumers. This endpoint is the start of VA Facilities v1 and incorporates schema changes unrelated to the drive time work that are wanted for v1 more generally.

Resolves department-of-veterans-affairs/vets-contrib/issues/1972

Includes schema changes for v1 from department-of-veterans-affairs/vets-contrib/issues/1228 and department-of-veterans-affairs/vets-contrib/issues/1869.

More information on Phase 1 can be found in the epic:
 department-of-veterans-affairs/vets-contrib/issues/1971 