### PR TITLE
Revert "disabling facility location data jobs"

### DIFF
--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -70,6 +70,30 @@ FacilityAccessBulkUpdate:
   class: Facilities::AccessDataDownload
   description: "Download and cache facility access-to-care metric data"
 
+FacilityLocationBulkUpdateNCA:
+  cron: "35 4 * * * America/New_York"
+  class: Facilities::FacilityLocationDownloadJob
+  args: ['nca']
+  description: "Download and store facility location data"
+
+FacilityLocationBulkUpdateVBA:
+  cron: "40 4 * * * America/New_York"
+  class: Facilities::FacilityLocationDownloadJob
+  args: ['vba']
+  description: "Download and store facility location data"
+
+FacilityLocationBulkUpdateVC:
+  cron: "45 4 * * * America/New_York"
+  class: Facilities::FacilityLocationDownloadJob
+  args: ['vc']
+  description: "Download and store facility location data"
+
+FacilityLocationBulkUpdateVHA:
+  cron: "50 4 * * * America/New_York"
+  class: Facilities::FacilityLocationDownloadJob
+  args: ['vha']
+  description: "Download and store facility location data"
+
 MaintenanceWindowRefresh:
   cron: "*/3 * * * * America/New_York"
   class: PagerDuty::PollMaintenanceWindows


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#3040

This got turned around a lot quicker than I expected! It's been agreed that the arcGIS endpoints will stay active until an internal va replacement is available and we can move to it. We are safe to re-enable these jobs.