### PR TITLE
Update /nearby spec to accept address params not lat/lng

### DIFF
--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -71,9 +71,11 @@ paths:
     get:
       tags:
         - facilities
-      summary: Query facilities based on drive time from a specified point
+      summary: Query facilities based on drive time from a specified location
       description: |
-        Retrieve all facilities contained within an isochrone (a polygon composed of the area reachable in a certain amount of time from a central point) based on a the passed `lat`, `lng`, and `drive_time` parameters.
+        Retrieve all facilities contained within an isochrone (a polygon composed of the area 
+        reachable in a certain amount of time from a central location) based on a the passed 
+        `address_1`, `city`, `state`, `zip`, and `drive_time` parameters.
 
         Additionally one can filter the facilities within the isochrone by type and available
         services. Only facilities of type "health" and "benefits" may be filtered by available
@@ -86,27 +88,37 @@ paths:
       security:
         - api_key: []
       parameters:
-        - name: lat
+        - name: address_1
           in: query
           description: |
-            Latitude of point to search for nearest VA Facilities.
-            Latitude and Longitude parameters should be specified in WGS84 coordinate reference system.
+            Street address of the location from which drive time is to be calculated.
           required: true
           schema:
-            type: number
-            format: float
-        - name: lng
+            type: string
+        - name: city
           in: query
           description: |
-            Longitude of point to search for nearest VA Facilities.
-            Latitude and Longitude parameters should be specified in WGS84 coordinate reference system.
+            City of the location from which drive time is to be calculated.
           required: true
-          style: form
           schema:
-            type: number
-            format: float
+            type: string
+        - name: state
+          in: query
+          description: |
+            Two character state code of the location from which drive time is to be calculated.
+          required: true
+          schema:
+            type: string
+        - name: zip
+          in: query
+          description: |
+            Zip code of the location from which drive time is to be calculated.
+          required: true
+          schema:
+            type: string
+            format: '##### or #####-####'
         - name: drive_time
-          description:  Filter to only include facilities that are within the specified number of drive time minutes from the requested point.
+          description:  Filter to only include facilities that are within the specified number of drive time minutes from the requested location.
           in: query
           required: false
           schema:

--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -88,7 +88,7 @@ paths:
       security:
         - api_key: []
       parameters:
-        - name: address_1
+        - name: street_address
           in: query
           description: |
             Street address of the location from which drive time is to be calculated.

--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -74,7 +74,7 @@ paths:
       summary: Query facilities based on drive time from a specified location
       description: |
         Retrieve all facilities contained within an isochrone (a polygon composed of the area 
-        reachable in a certain amount of time from a central location) based on a the passed 
+        reachable in a certain amount of time from a central location) based on the passed 
         `address_1`, `city`, `state`, `zip`, and `drive_time` parameters.
 
         Additionally one can filter the facilities within the isochrone by type and available
@@ -91,28 +91,28 @@ paths:
         - name: street_address
           in: query
           description: |
-            Street address of the location from which drive time is to be calculated.
+            Street address of the location from which drive time will be calculated.
           required: true
           schema:
             type: string
         - name: city
           in: query
           description: |
-            City of the location from which drive time is to be calculated.
+            City of the location from which drive time will be calculated.
           required: true
           schema:
             type: string
         - name: state
           in: query
           description: |
-            Two character state code of the location from which drive time is to be calculated.
+            Two character state code of the location from which drive time will be calculated.
           required: true
           schema:
             type: string
         - name: zip
           in: query
           description: |
-            Zip code of the location from which drive time is to be calculated.
+            Zip code of the location from which drive time will be calculated.
           required: true
           schema:
             type: string


### PR DESCRIPTION
## Description of change
It has been requested that we allow consumers to provide an address instead of lat/lng for requesting nearby facilities. This PR is for updating the `/nearby` endpoint documentation to align with this change.

We will pass the address to Bing Isochrone as a single string, but are requiring the consumer to past the address to us as separate params. This will allow us to better validate the inputs before passing them to Bing and quickly provide useful error messages instead of sending them on to Bing and either getting errors or unintended results back.

Speaking of getting unintended results back. We don't strictly need city, state, AND zip to get results, but my suspicion is that having all three (instead of just zip or city and state) will give us a higher chance of receiving an isochrone for the appropriate error with less than perfectly accurate inputs.

We are removing the lat/lng parameters from the endpoint for the mvp. They will not be a lot of work to add but keeping them out simplifies things a bit, so we are going to put off this work until we get feedback including lat/lng would be valuable for a consumer.

Resolves department-of-veterans-affairs/vets-contrib/issues/2036