### PR TITLE
Favors checking for cached Account prior to db calls

### DIFF
--- a/app/controllers/v0/user_preferences_controller.rb
+++ b/app/controllers/v0/user_preferences_controller.rb
@@ -29,7 +29,7 @@ module V0
     private
 
     def set_account
-      @account = current_user.account.presence || create_user_account
+      @account = create_user_account
     end
 
     def destroy_user_preferences!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,12 +41,13 @@ class User < Common::RedisStore
   # This delegated method is called with #account_uuid
   delegate :uuid, to: :account, prefix: true, allow_nil: true
 
-  # Retrieve a user's Account record.
+  # Retrieve a user's Account record.  Checks the cache before executing
+  # any database calls.
   #
   # @return [Account] an instance of the Account object
   #
   def account
-    Account.find_by(idme_uuid: uuid)
+    Account.cache_or_create_by!(self)
   end
 
   def pciu_email

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -52,9 +52,7 @@ module Users
     end
 
     def account
-      account = Account.cache_or_create_by!(user)
-
-      { account_uuid: account.uuid }
+      { account_uuid: user.account_uuid }
     rescue StandardError => e
       scaffold.errors << Users::ExceptionHandler.new(e, 'Account').serialize_error
       nil

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -52,9 +52,12 @@ module Users
     end
 
     def account
-      {
-        account_uuid: user.account_uuid
-      }
+      account = Account.cache_or_create_by!(user)
+
+      { account_uuid: account.uuid }
+    rescue StandardError => e
+      scaffold.errors << Users::ExceptionHandler.new(e, 'Account').serialize_error
+      nil
     end
 
     def profile

--- a/app/swagger/requests/user.rb
+++ b/app/swagger/requests/user.rb
@@ -36,6 +36,7 @@ module Swagger
                     property :id, type: :string
                     property :type, type: :string
                     property :attributes, type: :object do
+                      property :account, type: %i[object null]
                       property :va_profile, type: %i[object null]
                       property :veteran_status, type: %i[object null]
                       property :vet360_contact_information, type: %i[object null]
@@ -74,6 +75,12 @@ module Swagger
               property :id, type: :string
               property :type, type: :string
               property :attributes, type: :object do
+                property :account, type: :object do
+                  property :account_uuid,
+                           type: %w[string null],
+                           example: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef',
+                           description: 'A UUID correlating all user identifiers. Intended to become the user\'s UUID.'
+                end
                 property :va_profile, type: :object do
                   property :status, type: :string
                   property :birthdate, type: :string

--- a/app/swagger/schemas/user_internal_services.rb
+++ b/app/swagger/schemas/user_internal_services.rb
@@ -31,12 +31,6 @@ module Swagger
                 property :last_updated, type: :integer
               end
             end
-            property :account, type: :object do
-              property :account_uuid,
-                       type: %w[string null],
-                       example: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef',
-                       description: 'A UUID correlating all user identifiers. Intended to become the user\'s UUID.'
-            end
             property :profile, type: :object do
               property :email, type: :string
               property :first_name, type: :string

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -452,4 +452,39 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#account' do
+    context 'when user has an existing Account record' do
+      let(:user) { create :user, :accountable }
+
+      it 'returns the users Account record' do
+        account = Account.find_by(idme_uuid: user.uuid)
+
+        expect(user.account).to eq account
+      end
+
+      it 'first attempts to fetch the Account record from the Redis cache' do
+        expect(Account).to receive(:do_cached_with)
+
+        user.account
+      end
+    end
+
+    context 'when user does not have an existing Account record' do
+      let(:user) { create :user, :loa3 }
+
+      before do
+        account = Account.find_by(idme_uuid: user.uuid)
+
+        expect(account).to be_nil
+      end
+
+      it 'creates and returns the users Account record', :aggregate_failures do
+        account = user.account
+
+        expect(account.class).to eq Account
+        expect(account.idme_uuid).to eq user.uuid
+      end
+    end
+  end
 end

--- a/spec/request/user_preferences_request_spec.rb
+++ b/spec/request/user_preferences_request_spec.rb
@@ -56,9 +56,13 @@ describe 'user_preferences', type: :request do
     context 'current user does not have an Account record' do
       let(:user) { build(:user, :loa3) }
 
-      it 'creates an Account record for the current user', :aggregate_failures do
-        expect(user.account).to be_nil
+      before do
+        account = Account.find_by(idme_uuid: user.uuid)
 
+        expect(account).to be_nil
+      end
+
+      it 'creates an Account record for the current user', :aggregate_failures do
         post '/v0/user/preferences', params: request_body.to_json, headers: headers
 
         expect(user.account).to be_present


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

`user.account_uuid` makes a `.find_by` db call.  We are caching a user’s account record, so using:

```ruby
Account.cache_or_create_by!(user)
```

will first check if the account record is in the cache before making any database calls.

Under the hood this calls the Rails `find_or_create_by!` method.  So on the off chance there is a Redis or Rails error, we follow the same `rescue` pattern as the rest of the class, in order to ensure that the login flow is not blocked.  Rather, the errors are reported in the `meta.errors` hash.

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Favors checking for cached `Account` prior to db calls

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
