### PR TITLE
using a new url for wait time data, some shift in services since our last capture

### DIFF
--- a/app/workers/facilities/access_data_download.rb
+++ b/app/workers/facilities/access_data_download.rb
@@ -25,7 +25,7 @@ module Facilities
     WT_KEY_MAP = {
       'PRIMARY CARE' => 'primary_care',
       'MENTAL HEALTH' => 'mental_health',
-      'WOMEN\'S HEALTH' => 'womens_health',
+      'COMP WOMEN\'S HLTH' => 'womens_health',
       'AUDIOLOGY' => 'audiology',
       'CARDIOLOGY' => 'cardiology',
       'DERMATOLOGY' => 'dermatology',
@@ -34,7 +34,8 @@ module Facilities
       'OPHTHALMOLOGY' => 'ophthalmology',
       'OPTOMETRY' => 'optometry',
       'ORTHOPEDICS' => 'orthopedics',
-      'UROLOGY CLINIC' => 'urology'
+      'UROLOGY CLINIC' => 'urology',
+      'SPECIALTY CARE' => 'specialty_care'
     }.freeze
 
     WT_REQUIRED_KEYS = %w[facilityID ApptTypeName newWaitTime estWaitTime sliceEndDate].freeze
@@ -116,7 +117,7 @@ module Facilities
     def update_wait_time_data(client)
       records = client.download
       uniq_specialties = records.map { |facility| facility['ApptTypeName'] }.uniq
-      unless uniq_specialties == WT_KEY_MAP.keys
+      unless uniq_specialties.sort == WT_KEY_MAP.keys.sort
         log_message_to_sentry(
           'Facility Locator Specialty Wait Time Inconsistency',
           :error,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -174,7 +174,7 @@ locators:
   vba: https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/VBA_Facilities/FeatureServer/0
   vc: https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/VHA_VetCenters/FeatureServer/0
   vha_access_satisfaction: https://www.accesstopwt.va.gov/
-  vha_access_waittime: https://www.accesstopwt.va.gov/
+  vha_access_waittime: https://www.accesstocare.va.gov/
   base_path: https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/
   providers_enabled: false
 

--- a/lib/facilities/bulk_json_client.rb
+++ b/lib/facilities/bulk_json_client.rb
@@ -8,8 +8,7 @@ module Facilities
     configuration Facilities::AccessWaitTimeConfiguration
 
     def download
-      query = { 'location' => '*' }
-      perform(:get, 'Main/getRawData', query, nil).body
+      perform(:get, 'atcapis/v1.1/patientwaittimes', {}, nil).body
     end
   end
 

--- a/spec/fixtures/facility_access/wait_time_data.json
+++ b/spec/fixtures/facility_access/wait_time_data.json
@@ -265,7 +265,7 @@
     "url": "http://www.birmingham.va.gov/",
     "latitude": 33.50455985,
     "longitude": -86.80090691,
-    "ApptTypeName": "WOMEN'S HEALTH",
+    "ApptTypeName": "COMP WOMEN'S HLTH",
     "estWaitTime": 10.0,
     "newWaitTime": 12.0,
     "sliceEndDate": "2017-03-31T00:00:00",


### PR DESCRIPTION
## Description of change
We have a new url to use for wait time data. The list of services has changed a bit since our last recording of the data so I updated that as well

<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

## Testing done
<!-- Please describe testing done to verify the changes. -->
local testing of the data format including visual spot checking in va.gov running locally. Rspec testing as well.

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Data is pulled and parsed from the new url

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
