### PR TITLE
VBA Docs Self Service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ gem 'redis'
 gem 'redis-namespace'
 gem 'restforce'
 gem 'ruby-saml'
+gem 'rubyzip', '>= 1.0.0'
 gem 'savon'
 gem 'sentry-raven', '2.7.4' # don't change gem version unless sentry server is also upgraded
 gem 'shrine'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -477,6 +477,7 @@ GEM
     ruby-rc4 (0.1.5)
     ruby-saml (1.7.0)
       nokogiri (>= 1.5.10)
+    rubyzip (1.2.2)
     rufus-scheduler (3.1.10)
     safe_shell (1.0.3)
     safe_yaml (1.0.4)
@@ -689,6 +690,7 @@ DEPENDENCIES
   rubocop (~> 0.52.1)
   rubocop-junit-formatter
   ruby-saml
+  rubyzip (>= 1.0.0)
   savon
   sdoc (~> 0.4.0)
   seedbank

--- a/config/initializers/rubyzip.rb
+++ b/config/initializers/rubyzip.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'zip'
+
+Zip.continue_on_exists_proc = true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,7 +9,7 @@ mvi:
 
 locators:
   providers_enabled: true
-  
+
 reports:
   aws:
     access_key_id: key
@@ -59,3 +59,6 @@ search:
   access_key: TESTKEY
   affiliate: va
   url: https://search.usa.gov/api/v2
+
+vba_documents:
+  enable_download_endpoint: true

--- a/modules/vba_documents/app/controllers/vba_documents/v0/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v0/uploads_controller.rb
@@ -11,6 +11,7 @@ module VBADocuments
   module V0
     class UploadsController < ApplicationController
       skip_before_action(:authenticate)
+      before_action :verify_settings, only: [:download]
 
       def create
         submission = VBADocuments::UploadSubmission.create(
@@ -45,8 +46,6 @@ module VBADocuments
       end
 
       def download
-        raise ActionController::RoutingError, 'Not Found' unless Settings.vba_documents.enable_download_endpoint
-
         submission = VBADocuments::UploadSubmission.find_by(guid: params[:upload_id])
         raw_file = download_raw_file(submission.guid)
         parsed = VBADocuments::MultipartParser.parse(raw_file.path)
@@ -89,6 +88,10 @@ module VBADocuments
         tempfile.write(parsed['metadata'])
         tempfile.close
         tempfile
+      end
+
+      def verify_settings
+        render plain: 'Not found', status: 404 unless Settings.vba_documents.enable_download_endpoint
       end
     end
   end

--- a/modules/vba_documents/app/controllers/vba_documents/v0/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v0/uploads_controller.rb
@@ -4,8 +4,7 @@ require 'zip'
 
 require_dependency 'vba_documents/application_controller'
 require_dependency 'vba_documents/upload_error'
-require_dependency 'vba_documents/object_store'
-require_dependency 'vba_documents/multipart_parser'
+require_dependency 'vba_documents/payload_manager'
 
 module VBADocuments
   module V0
@@ -47,19 +46,8 @@ module VBADocuments
 
       def download
         submission = VBADocuments::UploadSubmission.find_by(guid: params[:upload_id])
-        raw_file = download_raw_file(submission.guid)
-        parsed = VBADocuments::MultipartParser.parse(raw_file.path)
-        files = [
-          { name: 'content.pdf', path: parsed['content'].path },
-          { name: 'metadata.json', path: write_json(submission.guid, parsed).path }
-        ] + attachments(parsed)
-        zip_file_name = "/tmp/#{submission.guid}.zip"
 
-        Zip::File.open(zip_file_name, Zip::File::CREATE) do |zipfile|
-          files.each do |file|
-            zipfile.add(file[:name], file[:path])
-          end
-        end
+        zip_file_name = VBADocuments::PayloadManager.zip(submission)
 
         File.open(zip_file_name, 'r') do |f|
           send_data f.read, filename: "#{submission.guid}.zip", type: 'application/zip'
@@ -69,26 +57,6 @@ module VBADocuments
       end
 
       private
-
-      def download_raw_file(guid)
-        store = VBADocuments::ObjectStore.new
-        tempfile = Tempfile.new(guid)
-        version = store.first_version(guid)
-        store.download(version, tempfile.path)
-        tempfile
-      end
-
-      def attachments(parsed)
-        attachment_keys = parsed.keys.select { |key| key.include? 'attachment' }
-        parsed.slice(*attachment_keys).map { |k, v| { name: "#{k}.pdf", path: v.path } }
-      end
-
-      def write_json(guid, parsed)
-        tempfile = Tempfile.new("#{guid}_metadata.json")
-        tempfile.write(parsed['metadata'])
-        tempfile.close
-        tempfile
-      end
 
       def verify_settings
         render plain: 'Not found', status: 404 unless Settings.vba_documents.enable_download_endpoint

--- a/modules/vba_documents/app/controllers/vba_documents/v0/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v0/uploads_controller.rb
@@ -50,7 +50,10 @@ module VBADocuments
         submission = VBADocuments::UploadSubmission.find_by(guid: params[:upload_id])
         raw_file = download_raw_file(submission.guid)
         parsed = VBADocuments::MultipartParser.parse(raw_file.path)
-        files = [{ name: 'content', path: parsed['content'].path }] + attachments(parsed)
+        files = [
+          { name: 'content.pdf', path: parsed['content'].path },
+          { name: 'metadata.json', path: write_json(submission.guid, parsed).path }
+        ] + attachments(parsed)
         zip_file_name = "/tmp/#{submission.guid}.zip"
 
         Zip::File.open(zip_file_name, Zip::File::CREATE) do |zipfile|
@@ -78,7 +81,14 @@ module VBADocuments
 
       def attachments(parsed)
         attachment_keys = parsed.keys.select { |key| key.include? 'attachment' }
-        parsed.slice(*attachment_keys).map { |k, v| { name: k, path: v.path } }
+        parsed.slice(*attachment_keys).map { |k, v| { name: "#{k}.pdf", path: v.path } }
+      end
+
+      def write_json(guid, parsed)
+        tempfile = Tempfile.new("#{guid}_metadata.json")
+        tempfile.write(parsed['metadata'])
+        tempfile.close
+        tempfile
       end
     end
   end

--- a/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
@@ -48,7 +48,10 @@ module VBADocuments
         submission = VBADocuments::UploadSubmission.find_by(guid: params[:upload_id])
         raw_file = download_raw_file(submission.guid)
         parsed = VBADocuments::MultipartParser.parse(raw_file.path)
-        files = [{ name: 'content', path: parsed['content'].path }] + attachments(parsed)
+        files = [
+          { name: 'content.pdf', path: parsed['content'].path },
+          { name: 'metadata.json', path: write_json(submission.guid, parsed).path }
+        ] + attachments(parsed)
         zip_file_name = "/tmp/#{submission.guid}.zip"
 
         Zip::File.open(zip_file_name, Zip::File::CREATE) do |zipfile|
@@ -76,7 +79,14 @@ module VBADocuments
 
       def attachments(parsed)
         attachment_keys = parsed.keys.select { |key| key.include? 'attachment' }
-        parsed.slice(*attachment_keys).map { |k, v| { name: k, path: v.path } }
+        parsed.slice(*attachment_keys).map { |k, v| { name: "#{k}.pdf", path: v.path } }
+      end
+
+      def write_json(guid, parsed)
+        tempfile = Tempfile.new("#{guid}_metadata.json")
+        tempfile.write(parsed['metadata'])
+        tempfile.close
+        tempfile
       end
     end
   end

--- a/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require 'zip'
+
 require_dependency 'vba_documents/application_controller'
 require_dependency 'vba_documents/upload_error'
+require_dependency 'vba_documents/object_store'
+require_dependency 'vba_documents/multipart_parser'
 
 module VBADocuments
   module V1
@@ -36,6 +40,43 @@ module VBADocuments
                  serializer: VBADocuments::V1::UploadSerializer,
                  render_location: false
         end
+      end
+
+      def download
+        raise ActionController::RoutingError, 'Not Found' unless Settings.vba_documents.enable_download_endpoint
+
+        submission = VBADocuments::UploadSubmission.find_by(guid: params[:upload_id])
+        raw_file = download_raw_file(submission.guid)
+        parsed = VBADocuments::MultipartParser.parse(raw_file.path)
+        files = [{ name: 'content', path: parsed['content'].path }] + attachments(parsed)
+        zip_file_name = "/tmp/#{submission.guid}.zip"
+
+        Zip::File.open(zip_file_name, Zip::File::CREATE) do |zipfile|
+          files.each do |file|
+            zipfile.add(file[:name], file[:path])
+          end
+        end
+
+        File.open(zip_file_name, 'r') do |f|
+          send_data f.read, filename: "#{submission.guid}.zip", type: 'application/zip'
+        end
+
+        File.delete(zip_file_name)
+      end
+
+      private
+
+      def download_raw_file(guid)
+        store = VBADocuments::ObjectStore.new
+        tempfile = Tempfile.new(guid)
+        version = store.first_version(guid)
+        store.download(version, tempfile.path)
+        tempfile
+      end
+
+      def attachments(parsed)
+        attachment_keys = parsed.keys.select { |key| key.include? 'attachment' }
+        parsed.slice(*attachment_keys).map { |k, v| { name: k, path: v.path } }
       end
     end
   end

--- a/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
@@ -11,6 +11,7 @@ module VBADocuments
   module V1
     class UploadsController < ApplicationController
       skip_before_action(:authenticate)
+      before_action :verify_settings, only: [:download]
 
       def create
         submission = VBADocuments::UploadSubmission.create(
@@ -43,8 +44,6 @@ module VBADocuments
       end
 
       def download
-        raise ActionController::RoutingError, 'Not Found' unless Settings.vba_documents.enable_download_endpoint
-
         submission = VBADocuments::UploadSubmission.find_by(guid: params[:upload_id])
         raw_file = download_raw_file(submission.guid)
         parsed = VBADocuments::MultipartParser.parse(raw_file.path)
@@ -87,6 +86,10 @@ module VBADocuments
         tempfile.write(parsed['metadata'])
         tempfile.close
         tempfile
+      end
+
+      def verify_settings
+        render plain: 'Not found', status: 404 unless Settings.vba_documents.enable_download_endpoint
       end
     end
   end

--- a/modules/vba_documents/app/swagger/vba_documents/v0/controller_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v0/controller_swagger.rb
@@ -137,6 +137,47 @@ module VbaDocuments
         end
       end
 
+      swagger_path '/uploads/{id}/download' do
+        operation :get do
+          key :summary, 'Download zip of "what the server sees"'
+          key :operationId, 'getBenefitsDocumentUploadDownload'
+
+          key :tags, ['document_uploads']
+
+          security do
+            key :api_key, []
+          end
+
+          parameter do
+            key :name, 'id'
+            key :in, :path
+            key :description, 'ID as returned by a previous create upload request'
+            key :required, true
+            key :example, '6d8433c1-cd55-4c24-affd-f592287a7572'
+            key :type, :string
+          end
+
+          response 200 do
+            key :description, 'Zip file with the contents of your payload as parsed by our server'
+            schema do
+              key :type, :file
+            end
+          end
+
+          response 401 do
+            key :description, 'Unauthorized request'
+          end
+
+          response 403 do
+            key :description, 'Bad API Token'
+          end
+
+          response 404 do
+            key :description, 'Not Found'
+          end
+        end
+      end
+
       swagger_path '/uploads/report' do
         operation :post do
           key :tags, %i[document_uploads]

--- a/modules/vba_documents/app/swagger/vba_documents/v0/controller_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v0/controller_swagger.rb
@@ -140,6 +140,7 @@ module VbaDocuments
       swagger_path '/uploads/{id}/download' do
         operation :get do
           key :summary, 'Download zip of "what the server sees"'
+          key :description, 'An endpoint that will allow you to see exactly what the server sees. We split apart all submitted docs and metadata and zip the file to make it available to you to help with debugging purposes. Only available in dev and staging'
           key :operationId, 'getBenefitsDocumentUploadDownload'
 
           key :tags, ['document_uploads']

--- a/modules/vba_documents/app/swagger/vba_documents/v1/controller_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v1/controller_swagger.rb
@@ -165,6 +165,47 @@ module VbaDocuments
         end
       end
 
+      swagger_path '/uploads/{id}/download' do
+        operation :get do
+          key :summary, 'Download zip of "what the server sees"'
+          key :operationId, 'getBenefitsDocumentUploadDownload'
+
+          key :tags, ['document_uploads']
+
+          security do
+            key :api_key, []
+          end
+
+          parameter do
+            key :name, 'id'
+            key :in, :path
+            key :description, 'ID as returned by a previous create upload request'
+            key :required, true
+            key :example, '6d8433c1-cd55-4c24-affd-f592287a7572'
+            key :type, :string
+          end
+
+          response 200 do
+            key :description, 'Zip file with the contents of your payload as parsed by our server'
+            schema do
+              key :type, :file
+            end
+          end
+
+          response 401 do
+            key :description, 'Unauthorized request'
+          end
+
+          response 403 do
+            key :description, 'Bad API Token'
+          end
+
+          response 404 do
+            key :description, 'Not Found'
+          end
+        end
+      end
+
       swagger_path '/uploads/report' do
         operation :post do
           key :tags, %i[document_uploads]

--- a/modules/vba_documents/app/swagger/vba_documents/v1/controller_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v1/controller_swagger.rb
@@ -168,6 +168,7 @@ module VbaDocuments
       swagger_path '/uploads/{id}/download' do
         operation :get do
           key :summary, 'Download zip of "what the server sees"'
+          key :description, 'An endpoint that will allow you to see exactly what the server sees. We split apart all submitted docs and metadata and zip the file to make it available to you to help with debugging purposes. Only available in dev and staging'
           key :operationId, 'getBenefitsDocumentUploadDownload'
 
           key :tags, ['document_uploads']

--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -2,6 +2,7 @@
 
 require 'sidekiq'
 require_dependency 'vba_documents/multipart_parser'
+require_dependency 'vba_documents/payload_manager'
 require 'vba_documents/object_store'
 require 'vba_documents/upload_error'
 
@@ -24,7 +25,7 @@ module VBADocuments
 
     def perform(guid)
       upload = VBADocuments::UploadSubmission.find_by(guid: guid)
-      tempfile, timestamp = download_raw_file(guid)
+      tempfile, timestamp = VBADocuments::PayloadManager.download_raw_file(guid)
       begin
         parts = VBADocuments::MultipartParser.parse(tempfile.path)
         validate_parts(parts)
@@ -121,14 +122,6 @@ module VBADocuments
         raise VBADocuments::UploadError.new(code: 'DOC201',
                                             detail: "Downstream status: #{status} - #{body}")
       end
-    end
-
-    def download_raw_file(guid)
-      store = VBADocuments::ObjectStore.new
-      tempfile = Tempfile.new(guid)
-      version = store.first_version(guid)
-      store.download(version, tempfile.path)
-      [tempfile, version.last_modified]
     end
 
     def validate_parts(parts)

--- a/modules/vba_documents/config/routes.rb
+++ b/modules/vba_documents/config/routes.rb
@@ -6,6 +6,7 @@ VBADocuments::Engine.routes.draw do
 
   namespace :v0, defaults: { format: 'json' } do
     resources :uploads, only: %i[create show] do
+      get 'download', to: 'uploads#download'
       collection do
         resource :report, only: %i[create]
       end
@@ -20,6 +21,7 @@ VBADocuments::Engine.routes.draw do
 
   namespace :v1, defaults: { format: 'json' } do
     resources :uploads, only: %i[create show] do
+      get 'download', to: 'uploads#download'
       collection do
         resource :report, only: %i[create]
       end

--- a/modules/vba_documents/lib/vba_documents/payload_manager.rb
+++ b/modules/vba_documents/lib/vba_documents/payload_manager.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_dependency 'vba_documents/multipart_parser'
+require_dependency 'vba_documents/object_store'
+
+module VBADocuments
+  class PayloadManager
+    def self.zip(submission)
+      raw_file, = download_raw_file(submission.guid)
+      parsed = VBADocuments::MultipartParser.parse(raw_file.path)
+      files = [
+        { name: 'content.pdf', path: parsed['content'].path },
+        { name: 'metadata.json', path: write_json(submission.guid, parsed).path }
+      ] + attachments(parsed)
+      zip_file_name = "/tmp/#{submission.guid}.zip"
+
+      Zip::File.open(zip_file_name, Zip::File::CREATE) do |zipfile|
+        files.each do |file|
+          zipfile.add(file[:name], file[:path])
+        end
+      end
+
+      zip_file_name
+    end
+
+    def self.download_raw_file(guid)
+      store = VBADocuments::ObjectStore.new
+      tempfile = Tempfile.new(guid)
+      version = store.first_version(guid)
+      store.download(version, tempfile.path)
+      [tempfile, version.last_modified]
+    end
+
+    def self.attachments(parsed)
+      attachment_keys = parsed.keys.select { |key| key.include? 'attachment' }
+      parsed.slice(*attachment_keys).map { |k, v| { name: "#{k}.pdf", path: v.path } }
+    end
+
+    def self.write_json(guid, parsed)
+      tempfile = Tempfile.new("#{guid}_metadata.json")
+      tempfile.write(parsed['metadata'])
+      tempfile.close
+      tempfile
+    end
+  end
+end

--- a/modules/vba_documents/spec/request/v0/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v0/uploads_request_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
       end
     end
 
+    # rubocop:disable Style/DateTime
     it 'should return a 200 with content-type of zip' do
       objstore = instance_double(VBADocuments::ObjectStore)
       version = instance_double(Aws::S3::ObjectVersion)
@@ -127,5 +128,6 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
       expect(response.status).to eq(200)
       expect(response.headers['Content-Type']).to eq('application/zip')
     end
+    # rubocop:enable Style/DateTime
   end
 end

--- a/modules/vba_documents/spec/request/v0/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v0/uploads_request_spec.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../../support/vba_document_fixtures'
+
+require_dependency 'vba_documents/object_store'
+require_dependency 'vba_documents/multipart_parser'
 
 RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
+  include VBADocuments::Fixtures
+
   describe '#create /v0/uploads' do
     it 'should return a UUID and location' do
       with_settings(Settings.vba_documents.location,
@@ -93,12 +99,33 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
 
   describe '#download /v0/uploads/{id}' do
     let(:upload) { FactoryBot.create(:upload_submission) }
+    let(:valid_doc) { get_fixture('valid_doc.pdf') }
+    let(:valid_metadata) { get_fixture('valid_metadata.json').read }
+
+    let(:valid_parts) do
+      { 'metadata' => valid_metadata,
+        'content' => valid_doc }
+    end
 
     it "should raise if settings aren't set" do
       with_settings(Settings.vba_documents, enable_download_endpoint: false) do
         get "/services/vba_documents/v0/uploads/#{upload.guid}/download"
         expect(response.status).to eq(404)
       end
+    end
+
+    it 'should return a 200 with content-type of zip' do
+      objstore = instance_double(VBADocuments::ObjectStore)
+      version = instance_double(Aws::S3::ObjectVersion)
+      allow(VBADocuments::ObjectStore).to receive(:new).and_return(objstore)
+      allow(objstore).to receive(:first_version).and_return(version)
+      allow(objstore).to receive(:download)
+      allow(version).to receive(:last_modified).and_return(DateTime.now.utc)
+      allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
+
+      get "/services/vba_documents/v0/uploads/#{upload.guid}/download"
+      expect(response.status).to eq(200)
+      expect(response.headers['Content-Type']).to eq('application/zip')
     end
   end
 end

--- a/modules/vba_documents/spec/request/v0/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v0/uploads_request_spec.rb
@@ -90,4 +90,15 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
       end
     end
   end
+
+  describe '#download /v0/uploads/{id}' do
+    let(:upload) { FactoryBot.create(:upload_submission) }
+
+    it "should raise if settings aren't set" do
+      with_settings(Settings.vba_documents, enable_download_endpoint: false) do
+        get "/services/vba_documents/v0/uploads/#{upload.guid}/download"
+        expect(response.status).to eq(404)
+      end
+    end
+  end
 end

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -92,4 +92,15 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
       end
     end
   end
+
+  describe '#download /v1/uploads/{id}' do
+    let(:upload) { FactoryBot.create(:upload_submission) }
+
+    it "should raise if settings aren't set" do
+      with_settings(Settings.vba_documents, enable_download_endpoint: false) do
+        get "/services/vba_documents/v1/uploads/#{upload.guid}/download"
+        expect(response.status).to eq(404)
+      end
+    end
+  end
 end

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -115,13 +115,15 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
         expect(response.status).to eq(404)
       end
     end
+
+    # rubocop:enable Style/DateTime
     it 'should return a 200 with content-type of zip' do
       objstore = instance_double(VBADocuments::ObjectStore)
       version = instance_double(Aws::S3::ObjectVersion)
       allow(VBADocuments::ObjectStore).to receive(:new).and_return(objstore)
       allow(objstore).to receive(:first_version).and_return(version)
       allow(objstore).to receive(:download)
-      allow(version).to receive(:last_modified).and_return(Date.now.utc)
+      allow(version).to receive(:last_modified).and_return(DateTime.now.utc)
       allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
 
       get "/services/vba_documents/v1/uploads/#{upload.guid}/download"

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../../support/vba_document_fixtures'
+
+require_dependency 'vba_documents/object_store'
+require_dependency 'vba_documents/multipart_parser'
 
 RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
+  include VBADocuments::Fixtures
+
   describe '#create /v1/uploads' do
     it 'should return a UUID and location' do
       with_settings(Settings.vba_documents.location,
@@ -95,12 +101,33 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
 
   describe '#download /v1/uploads/{id}' do
     let(:upload) { FactoryBot.create(:upload_submission) }
+    let(:valid_doc) { get_fixture('valid_doc.pdf') }
+    let(:valid_metadata) { get_fixture('valid_metadata.json').read }
+
+    let(:valid_parts) do
+      { 'metadata' => valid_metadata,
+        'content' => valid_doc }
+    end
 
     it "should raise if settings aren't set" do
       with_settings(Settings.vba_documents, enable_download_endpoint: false) do
         get "/services/vba_documents/v1/uploads/#{upload.guid}/download"
         expect(response.status).to eq(404)
       end
+    end
+
+    it 'should return a 200 with content-type of zip' do
+      objstore = instance_double(VBADocuments::ObjectStore)
+      version = instance_double(Aws::S3::ObjectVersion)
+      allow(VBADocuments::ObjectStore).to receive(:new).and_return(objstore)
+      allow(objstore).to receive(:first_version).and_return(version)
+      allow(objstore).to receive(:download)
+      allow(version).to receive(:last_modified).and_return(DateTime.now.utc)
+      allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
+
+      get "/services/vba_documents/v1/uploads/#{upload.guid}/download"
+      expect(response.status).to eq(200)
+      expect(response.headers['Content-Type']).to eq('application/zip')
     end
   end
 end

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
       end
     end
 
-    # rubocop:enable Style/DateTime
+    # rubocop:disable Style/DateTime
     it 'should return a 200 with content-type of zip' do
       objstore = instance_double(VBADocuments::ObjectStore)
       version = instance_double(Aws::S3::ObjectVersion)

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -115,19 +115,19 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
         expect(response.status).to eq(404)
       end
     end
-
     it 'should return a 200 with content-type of zip' do
       objstore = instance_double(VBADocuments::ObjectStore)
       version = instance_double(Aws::S3::ObjectVersion)
       allow(VBADocuments::ObjectStore).to receive(:new).and_return(objstore)
       allow(objstore).to receive(:first_version).and_return(version)
       allow(objstore).to receive(:download)
-      allow(version).to receive(:last_modified).and_return(DateTime.now.utc)
+      allow(version).to receive(:last_modified).and_return(Date.now.utc)
       allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
 
       get "/services/vba_documents/v1/uploads/#{upload.guid}/download"
       expect(response.status).to eq(200)
       expect(response.headers['Content-Type']).to eq('application/zip')
     end
+    # rubocop:enable Style/DateTime
   end
 end


### PR DESCRIPTION
## Description of change
In order to help users onboard better. We've implemented an endpoint that will allow the user to "see what the server sees". It's gated by a setting that we'll only enable in dev and staging.

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/2059

## Testing done
- rspec
- local requests

#### Unique to this PR
- adds ruby zip gem

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
