### PR TITLE
Fix each_with_index error that could be potentially a nil value

### DIFF
--- a/lib/pdf_fill/forms/va210781a.rb
+++ b/lib/pdf_fill/forms/va210781a.rb
@@ -236,7 +236,7 @@ module PdfFill
       end
 
       def combine_source_name_address(incident)
-        return if incident.blank?
+        return if incident.blank? || incident['sources'].blank?
 
         incident['sources'].each_with_index do |source, index|
           combined_source_address = combine_full_address(source['address'])

--- a/spec/lib/pdf_fill/forms/va210781a_spec.rb
+++ b/spec/lib/pdf_fill/forms/va210781a_spec.rb
@@ -82,6 +82,12 @@ describe PdfFill::Forms::Va210781a do
         'combinedAddress1' => '456 Main Street, 1B, Baltimore, MD, 21200-1111, USA'
       )
     end
+
+    it 'should handle sources being empty correctly' do
+      incident = {}
+
+      expect(new_form_class.send(:combine_source_name_address, incident)).to be_nil
+    end
   end
 
   describe '#expand_other_information' do


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Since all keys are "optional" within a form 781/781a submission, all points of iterating over data need to be accounted for to prevent iteration errors. In this case, the pdf fill was attempting to iterate over a list using `each_with_index` and encountering a `undefined method `each_with_index' for nil:NilClass`. The offending iterator has been found and a guard clause has been added.

## Testing done
<!-- Please describe testing done to verify the changes. -->
local testing

## Testing planned
<!-- Please describe testing planned. -->
Test via staging website

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Add guard clause for key iteration

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
