### PR TITLE
1995 STEM routing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,10 +33,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: b8962e19a1dd9ab8e797f363fa5510e5fa5a3fc4
+  revision: 690941f6034314c85c3a50a7e83ba83bf3334b47
   branch: master
   specs:
-    vets_json_schema (3.138.3)
+    vets_json_schema (3.138.7)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 

--- a/app/workers/education_form/education_facility.rb
+++ b/app/workers/education_form/education_facility.rb
@@ -70,11 +70,13 @@ module EducationForm
       address = routing_address(record, form_type: model.form_type)
 
       # special case Philippines
-      if address&.country == 'PHL' || model.form_type == '0993'
-        return :western
-      elsif model.form_type == '0994'
-        return :eastern
-      end
+      return :western if address&.country == 'PHL' || model.form_type == '0993'
+
+      # special case 0994
+      return :eastern if model.form_type == '0994'
+
+      # special case 1995 STEM
+      return :eastern if model.form_type == '1995' && record.applyingForStem
 
       check_area(address)
     end

--- a/app/workers/education_form/education_facility.rb
+++ b/app/workers/education_form/education_facility.rb
@@ -76,7 +76,7 @@ module EducationForm
       return :eastern if model.form_type == '0994'
 
       # special case 1995 STEM
-      return :eastern if model.form_type == '1995' && record.applyingForStem
+      return :eastern if model.form_type == '1995' && record.isEdithNourseRogersScholarship
 
       check_area(address)
     end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -103,19 +103,19 @@ RSpec.describe EducationForm::EducationFacility do
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
     end
-    context '22-0993' do
-      it 'should route to Western RPO' do
-        education_benefits_claim.form_type = '0993'
-        expect(described_class.region_for(education_benefits_claim)).to eq(:western)
-      end
-    end
-    context 'address country Phillipines' do
-      it 'should route to Western RPO' do
-        new_form = education_benefits_claim.parsed_form
-        new_form.address = OpenStruct.new(relativeAddress: OpenSturct.new(country: 'PHL'))
-        education_benefits_claim.form_type = '0993'
-        expect(described_class.region_for(education_benefits_claim)).to eq(:western)
-      end
-    end
+    # context '22-0993' do
+    #   it 'should route to Western RPO' do
+    #     education_benefits_claim.form_type = '0993'
+    #     expect(described_class.region_for(education_benefits_claim)).to eq(:western)
+    #   end
+    # end
+    # context 'address country Phillipines' do
+    #   it 'should route to Western RPO' do
+    #     new_form = education_benefits_claim.parsed_form
+    #     new_form.address = OpenStruct.new(relativeAddress: OpenSturct.new(country: 'PHL'))
+    #     education_benefits_claim.form_type = '0993'
+    #     expect(described_class.region_for(education_benefits_claim)).to eq(:western)
+    #   end
+    # end
   end
 end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -88,28 +88,25 @@ RSpec.describe EducationForm::EducationFacility do
   end
 
   describe '#region_for' do
-    # context '22-1995' do
-    #   it 'should route to Eastern RPO' do
-    #     new_form = education_benefits_claim.parsed_form
-    #     new_form['isActiveDuty'] = true
-    #     education_benefits_claim.saved_claim.form = new_form.to_json
-    #     education_benefits_claim.form_type = '1995'
-    #     expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
-    #   end
-    # end
-    # context '22-0994' do
-    #   it 'should route to Eastern RPO' do
-    #     form = OpenStruct.new(form_type: '0994')
-    #     expect(described_class.region_for(form)).to eq(:eastern)
-    #   end
-    # end
+    context '22-1995' do
+      it 'should route to Eastern RPO' do
+        new_form = education_benefits_claim.parsed_form
+        new_form['isActiveDuty'] = true
+        education_benefits_claim.saved_claim.form = new_form.to_json
+        education_benefits_claim.saved_claim.form_id = '22-1995'
+        expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
+      end
+    end
+    context '22-0994' do
+      it 'should route to Eastern RPO' do
+        education_benefits_claim.saved_claim.form_id = '22-0994'
+        expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
+      end
+    end
     context '22-0993' do
       it 'should route to Western RPO' do
-        new_form = education_benefits_claim.parsed_form
-        new_form['form_id'] = '22-0993'
-        education_benefits_claim.saved_claim.form = new_form.to_json
-        # form = OpenStruct.new(form_type: '0993')
-        expect(described_class.region_for(form)).to eq(:western)
+        education_benefits_claim.saved_claim.form_id = '22-0993'
+        expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end
     end
     # context 'address country Phillipines' do

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -94,12 +94,14 @@ RSpec.describe EducationForm::EducationFacility do
         new_form['isActiveDuty'] = true
         education_benefits_claim.saved_claim.form = new_form.to_json
         education_benefits_claim.form_type = '1995'
+        expect(education_benefits_claim.form_type).to eq('1995')
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
     end
     context '22-0994' do
       it 'should route to Eastern RPO' do
         education_benefits_claim.form_type = '0994'
+        expect(education_benefits_claim.form_type).to eq('0994')
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
     end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -103,12 +103,12 @@ RSpec.describe EducationForm::EducationFacility do
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
     end
-    # context '22-0993' do
-    #   it 'should route to Western RPO' do
-    #     education_benefits_claim.form_type = '0993'
-    #     expect(described_class.region_for(education_benefits_claim)).to eq(:western)
-    #   end
-    # end
+    context '22-0993' do
+      it 'should route to Western RPO' do
+        education_benefits_claim.form_type = '0993'
+        expect(described_class.region_for(education_benefits_claim)).to eq(:western)
+      end
+    end
     # context 'address country Phillipines' do
     #   it 'should route to Western RPO' do
     #     new_form = education_benefits_claim.parsed_form

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -104,18 +104,13 @@ RSpec.describe EducationForm::EducationFacility do
     #   end
     # end
     context '22-0993' do
-      let(:form_type) do
-        '0993'
-      end
       it 'should route to Western RPO' do
         # new_form = education_benefits_claim
         # new_form.form_type = '0993'
 
         # verifier_stub = double(education_benefits_claim)
 
-        form = {
-          form_type => '0993'
-        }
+        form = OpenStruct.new(form_type: '0993')
 
         expect(form.form_type).to eq('0993')
         expect(described_class.region_for(form)).to eq(:western)

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe EducationForm::EducationFacility do
   describe '#regional_office_for' do
     {
       eastern: ['VA', "Eastern Region\nVA Regional Office\nP.O. Box 4616\nBuffalo, NY 14240-4616"],
-      # rubocop:disable Metrics/LineLength
       central: ['CO', "Central Region\nVA Regional Office\n9770 Page Avenue\nSuite 101 Education\nSt. Louis, MO 63132-1502"],
       # rubocop:enable Metrics/LineLength
       western: ['AK', "Western Region\nVA Regional Office\nP.O. Box 8888\nMuskogee, OK 74402-8888"]
@@ -111,9 +110,10 @@ RSpec.describe EducationForm::EducationFacility do
     end
     context 'address country Phillipines' do
       it 'should route to Western RPO' do
-        new_form = education_benefits_claim.parsed_form
-        new_form['newSchool']['address']['country'] = 'PHL'
-        education_benefits_claim.saved_claim.form = new_form.to_json
+        form.newSchool = school(OpenStruct.new(country: 'PHL'))
+        # new_form = education_benefits_claim.parsed_form
+        # new_form['newSchool']['address']['country'] = 'PHL'
+        education_benefits_claim.saved_claim.form = form.to_json
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end
     end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -86,4 +86,36 @@ RSpec.describe EducationForm::EducationFacility do
       end
     end
   end
+
+  describe '#region_for' do
+    context '22-1995' do
+      it 'should route to Eastern RPO' do
+        new_form = education_benefits_claim.parsed_form
+        new_form['isActiveDuty'] = true
+        education_benefits_claim.saved_claim.form = new_form.to_json
+        education_benefits_claim.form_type = '1995'
+        expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
+      end
+    end
+    context '22-0994' do
+      it 'should route to Eastern RPO' do
+        education_benefits_claim.form_type = '0994'
+        expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
+      end
+    end
+    context '22-0993' do
+      it 'should route to Western RPO' do
+        education_benefits_claim.form_type = '0993'
+        expect(described_class.region_for(education_benefits_claim)).to eq(:western)
+      end
+    end
+    context 'address country Phillipines' do
+      it 'should route to Western RPO' do
+        new_form = education_benefits_claim.parsed_form
+        new_form.address = OpenStruct.new(relativeAddress: OpenSturct.new(country: 'PHL'))
+        education_benefits_claim.form_type = '0993'
+        expect(described_class.region_for(education_benefits_claim)).to eq(:western)
+      end
+    end
+  end
 end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -89,10 +89,23 @@ RSpec.describe EducationForm::EducationFacility do
 
   describe '#region_for' do
     context '22-1995' do
+      it 'should route to Central RPO' do
+        form = education_benefits_claim.parsed_form
+        form['newSchool'] = {
+          'address' => {
+            'state': 'IL'
+          }
+        }
+        education_benefits_claim.saved_claim.form = form.to_json
+        education_benefits_claim.saved_claim.form_id = '22-1995'
+        expect(described_class.region_for(education_benefits_claim)).to eq(:central)
+      end
+    end
+    context '22-1995 STEM' do
       it 'should route to Eastern RPO' do
-        new_form = education_benefits_claim.parsed_form
-        new_form['isEdithNourseRogersScholarship'] = true
-        education_benefits_claim.saved_claim.form = new_form.to_json
+        form = education_benefits_claim.parsed_form
+        form['isEdithNourseRogersScholarship'] = true
+        education_benefits_claim.saved_claim.form = form.to_json
         education_benefits_claim.saved_claim.form_id = '22-1995'
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -104,16 +104,17 @@ RSpec.describe EducationForm::EducationFacility do
     #   end
     # end
     context '22-0993' do
+      let(:form_type) do
+        '0993'
+      end
       it 'should route to Western RPO' do
-        new_form = education_benefits_claim
-        new_form.form_type = '0993'
+        # new_form = education_benefits_claim
+        # new_form.form_type = '0993'
 
-        let(:form_type) do
-          '0993'
-        end
+        # verifier_stub = instance_double('EVSS::PowerOfAttorneyVerifier')
 
-        expect(new_form.form_type).to eq('0993')
-        expect(described_class.region_for(new_form)).to eq(:western)
+        expect(education_benefits_claim.form_type).to eq('0993')
+        expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end
     end
     # context 'address country Phillipines' do

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -111,11 +111,12 @@ RSpec.describe EducationForm::EducationFacility do
     end
     context 'address country Phillipines' do
       it 'should route to Western RPO' do
-        # form = education_benefits_claim.parsed_form
-        # form['newSchool'] = null
-        # form['veteranAddress'] = OpenStruct.new(country: 'PHL')
-        form = OpenStruct.new
-        form.veteranAddress = OpenStruct.new(country: 'PHL')
+        form = education_benefits_claim.parsed_form
+        form['newSchool'] = {
+          'address' => {
+            'country': 'PHL'
+          }
+        }
         education_benefits_claim.saved_claim.form = form.to_json
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe EducationForm::EducationFacility do
           }
         }
         education_benefits_claim.saved_claim.form = form.to_json
+        education_benefits_claim.saved_claim.form_id = '22-1995'
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end
     end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -111,8 +111,11 @@ RSpec.describe EducationForm::EducationFacility do
     end
     context 'address country Phillipines' do
       it 'should route to Western RPO' do
+        # form = education_benefits_claim.parsed_form
+        # form['newSchool'] = null
+        # form['veteranAddress'] = OpenStruct.new(country: 'PHL')
         form = OpenStruct.new
-        form.newSchool = school(OpenStruct.new(country: 'PHL'))
+        form.veteranAddress = OpenStruct.new(country: 'PHL')
         education_benefits_claim.saved_claim.form = form.to_json
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe EducationForm::EducationFacility do
   describe '#regional_office_for' do
     {
       eastern: ['VA', "Eastern Region\nVA Regional Office\nP.O. Box 4616\nBuffalo, NY 14240-4616"],
-      # rubocop:disable Metrics/LineLength
       central: ['CO', "Central Region\nVA Regional Office\n9770 Page Avenue\nSuite 101 Education\nSt. Louis, MO 63132-1502"],
       # rubocop:enable Metrics/LineLength
       western: ['AK', "Western Region\nVA Regional Office\nP.O. Box 8888\nMuskogee, OK 74402-8888"]
@@ -99,20 +98,16 @@ RSpec.describe EducationForm::EducationFacility do
     # end
     # context '22-0994' do
     #   it 'should route to Eastern RPO' do
-    #     education_benefits_claim.form_type = '0994'
-    #     expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
+    #     form = OpenStruct.new(form_type: '0994')
+    #     expect(described_class.region_for(form)).to eq(:eastern)
     #   end
     # end
     context '22-0993' do
       it 'should route to Western RPO' do
-        # new_form = education_benefits_claim
-        # new_form.form_type = '0993'
+        form = double(education_benefits_claim)
+        form.stub(:form_type) { '0993' }
 
-        # verifier_stub = double(education_benefits_claim)
-
-        form = OpenStruct.new(form_type: '0993')
-
-        expect(form.form_type).to eq('0993')
+        # form = OpenStruct.new(form_type: '0993')
         expect(described_class.region_for(form)).to eq(:western)
       end
     end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe EducationForm::EducationFacility do
     context 'address country Phillipines' do
       it 'should route to Western RPO' do
         new_form = education_benefits_claim.parsed_form
-        new_form.address = OpenStruct.new(relativeAddress: OpenStruct.new(country: 'PHL'))
+        new_form['veteranAddress'] = OpenStruct.new(relativeAddress: OpenStruct.new(country: 'PHL'))
         education_benefits_claim.saved_claim.form = new_form.to_json
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -94,22 +94,21 @@ RSpec.describe EducationForm::EducationFacility do
         new_form['isActiveDuty'] = true
         education_benefits_claim.saved_claim.form = new_form.to_json
         education_benefits_claim.form_type = '1995'
-        expect(education_benefits_claim.form_type).to eq('1995')
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
     end
     context '22-0994' do
       it 'should route to Eastern RPO' do
         education_benefits_claim.form_type = '0994'
-        expect(education_benefits_claim.form_type).to eq('0994')
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
     end
     context '22-0993' do
       it 'should route to Western RPO' do
-        education_benefits_claim.form_type = '0993'
-        expect(education_benefits_claim.form_type).to eq('0993')
-        expect(described_class.region_for(education_benefits_claim)).to eq(:western)
+        new_form = education_benefits_claim
+        new_form.form_type = '0993'
+        expect(new_form.form_type).to eq('0993')
+        expect(described_class.region_for(new_form)).to eq(:western)
       end
     end
     # context 'address country Phillipines' do

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe EducationForm::EducationFacility do
   describe '#regional_office_for' do
     {
       eastern: ['VA', "Eastern Region\nVA Regional Office\nP.O. Box 4616\nBuffalo, NY 14240-4616"],
+      # rubocop:disable Metrics/LineLength
       central: ['CO', "Central Region\nVA Regional Office\n9770 Page Avenue\nSuite 101 Education\nSt. Louis, MO 63132-1502"],
       # rubocop:enable Metrics/LineLength
       western: ['AK', "Western Region\nVA Regional Office\nP.O. Box 8888\nMuskogee, OK 74402-8888"]

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe EducationForm::EducationFacility do
     context 'address country Phillipines' do
       it 'should route to Western RPO' do
         new_form = education_benefits_claim.parsed_form
-        new_form['veteranAddress'] = OpenStruct.new(country: 'PHL')
+        new_form['newSchool']['address']['country'] = 'PHL'
         education_benefits_claim.saved_claim.form = new_form.to_json
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe EducationForm::EducationFacility do
     context '22-0993' do
       it 'should route to Western RPO' do
         education_benefits_claim.form_type = '0993'
+        expect(education_benefits_claim.form_type).to eq('0993')
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end
     end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -111,10 +111,14 @@ RSpec.describe EducationForm::EducationFacility do
         # new_form = education_benefits_claim
         # new_form.form_type = '0993'
 
-        # verifier_stub = instance_double('EVSS::PowerOfAttorneyVerifier')
+        # verifier_stub = double(education_benefits_claim)
 
-        expect(education_benefits_claim.form_type).to eq('0993')
-        expect(described_class.region_for(education_benefits_claim)).to eq(:western)
+        form = {
+          form_type => '0993'
+        }
+
+        expect(form.form_type).to eq('0993')
+        expect(described_class.region_for(form)).to eq(:western)
       end
     end
     # context 'address country Phillipines' do

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe EducationForm::EducationFacility do
     context '22-1995' do
       it 'should route to Eastern RPO' do
         new_form = education_benefits_claim.parsed_form
-        new_form['isActiveDuty'] = true
+        new_form['isEdithNourseRogersScholarship'] = true
         education_benefits_claim.saved_claim.form = new_form.to_json
         education_benefits_claim.saved_claim.form_id = '22-1995'
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
@@ -109,13 +109,13 @@ RSpec.describe EducationForm::EducationFacility do
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end
     end
-    # context 'address country Phillipines' do
-    #   it 'should route to Western RPO' do
-    #     new_form = education_benefits_claim.parsed_form
-    #     new_form.address = OpenStruct.new(relativeAddress: OpenSturct.new(country: 'PHL'))
-    #     education_benefits_claim.form_type = '0993'
-    #     expect(described_class.region_for(education_benefits_claim)).to eq(:western)
-    #   end
-    # end
+    context 'address country Phillipines' do
+      it 'should route to Western RPO' do
+        new_form = education_benefits_claim.parsed_form
+        new_form.address = OpenStruct.new(relativeAddress: OpenStruct.new(country: 'PHL'))
+        education_benefits_claim.saved_claim.form = new_form.to_json
+        expect(described_class.region_for(education_benefits_claim)).to eq(:western)
+      end
+    end
   end
 end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe EducationForm::EducationFacility do
     context 'address country Phillipines' do
       it 'should route to Western RPO' do
         new_form = education_benefits_claim.parsed_form
-        new_form['veteranAddress'] = OpenStruct.new(relativeAddress: OpenStruct.new(country: 'PHL'))
+        new_form['veteranAddress'] = OpenStruct.new(country: 'PHL')
         education_benefits_claim.saved_claim.form = new_form.to_json
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe EducationForm::EducationFacility do
   describe '#regional_office_for' do
     {
       eastern: ['VA', "Eastern Region\nVA Regional Office\nP.O. Box 4616\nBuffalo, NY 14240-4616"],
+      # rubocop:disable Metrics/LineLength
       central: ['CO', "Central Region\nVA Regional Office\n9770 Page Avenue\nSuite 101 Education\nSt. Louis, MO 63132-1502"],
       # rubocop:enable Metrics/LineLength
       western: ['AK', "Western Region\nVA Regional Office\nP.O. Box 8888\nMuskogee, OK 74402-8888"]
@@ -112,8 +113,6 @@ RSpec.describe EducationForm::EducationFacility do
       it 'should route to Western RPO' do
         form = OpenStruct.new
         form.newSchool = school(OpenStruct.new(country: 'PHL'))
-        # new_form = education_benefits_claim.parsed_form
-        # new_form['newSchool']['address']['country'] = 'PHL'
         education_benefits_claim.saved_claim.form = form.to_json
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
       end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe EducationForm::EducationFacility do
     end
     context 'address country Phillipines' do
       it 'should route to Western RPO' do
+        form = OpenStruct.new
         form.newSchool = school(OpenStruct.new(country: 'PHL'))
         # new_form = education_benefits_claim.parsed_form
         # new_form['newSchool']['address']['country'] = 'PHL'

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -105,9 +105,9 @@ RSpec.describe EducationForm::EducationFacility do
     # end
     context '22-0993' do
       it 'should route to Western RPO' do
-        form = double(education_benefits_claim)
-        form.stub(:form_type) { '0993' }
-
+        new_form = education_benefits_claim.parsed_form
+        new_form['form_id'] = '22-0993'
+        education_benefits_claim.saved_claim.form = new_form.to_json
         # form = OpenStruct.new(form_type: '0993')
         expect(described_class.region_for(form)).to eq(:western)
       end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -88,25 +88,30 @@ RSpec.describe EducationForm::EducationFacility do
   end
 
   describe '#region_for' do
-    context '22-1995' do
-      it 'should route to Eastern RPO' do
-        new_form = education_benefits_claim.parsed_form
-        new_form['isActiveDuty'] = true
-        education_benefits_claim.saved_claim.form = new_form.to_json
-        education_benefits_claim.form_type = '1995'
-        expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
-      end
-    end
-    context '22-0994' do
-      it 'should route to Eastern RPO' do
-        education_benefits_claim.form_type = '0994'
-        expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
-      end
-    end
+    # context '22-1995' do
+    #   it 'should route to Eastern RPO' do
+    #     new_form = education_benefits_claim.parsed_form
+    #     new_form['isActiveDuty'] = true
+    #     education_benefits_claim.saved_claim.form = new_form.to_json
+    #     education_benefits_claim.form_type = '1995'
+    #     expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
+    #   end
+    # end
+    # context '22-0994' do
+    #   it 'should route to Eastern RPO' do
+    #     education_benefits_claim.form_type = '0994'
+    #     expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
+    #   end
+    # end
     context '22-0993' do
       it 'should route to Western RPO' do
         new_form = education_benefits_claim
         new_form.form_type = '0993'
+
+        let(:form_type) do
+          '0993'
+        end
+
         expect(new_form.form_type).to eq('0993')
         expect(described_class.region_for(new_form)).to eq(:western)
       end


### PR DESCRIPTION
## Description of change
New education form routing rule: route all 1995 that are STEM applications to the Buffalo RPO

## Testing done
Unit tests updated, and QA review

## Testing planned
N/A

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] If the answer to "Are you applying for the Edith Nourse Rogers STEM Scholarship (Chapter 33)? Learn more" is "Yes", the submission is routed to the Buffalo RPO on the spool file.
- [x] If the answer to "Are you applying for the Edith Nourse Rogers STEM Scholarship (Chapter 33)? Learn more" is "No" or blank, the submission is routed according to the current routing rules.

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
