### PR TITLE
Get request for displaying JSON Schema for each form

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -12,6 +12,7 @@ module ClaimsApi
     skip_before_action :authenticate, only: %i[schema]
     skip_before_action :verify_power_of_attorney, only: %i[schema]
     skip_before_action :verify_mvi, only: %i[schema]
+    skip_before_action :log_request, only: %i[schema]
 
     def schema
       render json: ClaimsApi::FormSchemas::SCHEMAS[self.class::FORM_NUMBER]

--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -7,8 +7,14 @@ module ClaimsApi
   class BaseFormController < ClaimsApi::ApplicationController
     before_action :validate_json_schema
 
+    # schema endpoint should be wide open
+    skip_before_action :validate_json_schema, only: %i[schema]
+    skip_before_action :authenticate, only: %i[schema]
+    skip_before_action :verify_power_of_attorney, only: %i[schema]
+    skip_before_action :verify_mvi, only: %i[schema]
+
     def schema
-      ClaimsApi::FormSchemas::SCHEMAS[self.class::FORM_NUMBER]
+      render json: ClaimsApi::FormSchemas::SCHEMAS[self.class::FORM_NUMBER]
     end
 
     private

--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -7,6 +7,10 @@ module ClaimsApi
   class BaseFormController < ClaimsApi::ApplicationController
     before_action :validate_json_schema
 
+    def schema
+      ClaimsApi::FormSchemas::SCHEMAS[self.class::FORM_NUMBER]
+    end
+
     private
 
     def validate_json_schema

--- a/modules/claims_api/config/routes.rb
+++ b/modules/claims_api/config/routes.rb
@@ -8,9 +8,11 @@ ClaimsApi::Engine.routes.draw do
     resources :claims, only: %i[index show]
     namespace :forms do
       ## 526 Forms
+      get '526', to: 'disability_compensation#schema'
       post '526', to: 'disability_compensation#submit_form_526'
       post '526/:id/attachments', to: 'disability_compensation#upload_supporting_documents'
       ## 0966 Forms
+      get '526', to: 'intent_to_file#schema'
       post '0966', to: 'intent_to_file#submit_form_0966'
       get '0966/active', to: 'intent_to_file#active'
     end
@@ -20,9 +22,11 @@ ClaimsApi::Engine.routes.draw do
     resources :claims, only: %i[index show]
     namespace :forms do
       ## 526 Forms
+      get '526', to: 'disability_compensation#schema'
       post '526', to: 'disability_compensation#submit_form_526'
       post '526/:id/attachments', to: 'disability_compensation#upload_supporting_documents'
       ## 0966 Forms
+      get '526', to: 'intent_to_file#schema'
       post '0966', to: 'intent_to_file#submit_form_0966'
       get '0966/active', to: 'intent_to_file#active'
     end


### PR DESCRIPTION
## Description of change
For Ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/2031 

We should be exposing our JSON Validation Schema publicly so that people can build forms against it so something like:

/services/claims/v1/forms/526/schema
/services/claims/v1/forms/0966/schema

but decided instead to go with

GET /services/claims/v1/forms/526
GET /services/claims/v1/forms/0966

This will ensure that people can quickly implement our form schema ahead of time and if hey do it right any changes that may come up on our will be easier for them to implement on their end.

## Testing done
Adding an Rspec test

## Testing planned
Will build this into the Rails client app to test out automated form generation.

## Acceptance Criteria (Definition of Done)
- Adding JSON Form schema

#### Unique to this PR
- [x] Put out JSON Schema

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
