### PR TITLE
fix the routing in the swagger for claims

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
@@ -4,7 +4,7 @@ module ClaimsApi
   class Form0966V0ControllerSwagger
     include Swagger::Blocks
 
-    swagger_path '/form/0966' do
+    swagger_path '/forms/0966' do
       operation :post do
         key :summary, 'Accepts 0966 Intent to File form submission'
         key :description, 'Accepts JSON payload. Full URL, including\nquery parameters.'
@@ -119,7 +119,7 @@ module ClaimsApi
       end
     end
 
-    swagger_path '/form/0966/active' do
+    swagger_path '/forms/0966/active' do
       operation :get do
         key :summary, 'Returns last active 0966 Intent to File form submission'
         key :description, 'Returns last active JSON payload. Full URL, including\nquery parameters.'

--- a/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
@@ -4,7 +4,7 @@ module ClaimsApi
   class Form0966V1ControllerSwagger
     include Swagger::Blocks
 
-    swagger_path '/form/0966' do
+    swagger_path '/forms/0966' do
       operation :post do
         key :summary, 'Accepts 0966 Intent to File form submission'
         key :description, 'Accepts JSON payload. Full URL, including\nquery parameters.'
@@ -119,7 +119,7 @@ module ClaimsApi
       end
     end
 
-    swagger_path '/form/0966/active' do
+    swagger_path '/forms/0966/active' do
       operation :get do
         key :summary, 'Returns last active 0966 Intent to File form submission'
         key :description, 'Returns last active JSON payload. Full URL, including\nquery parameters.'

--- a/modules/claims_api/app/swagger/claims_api/form_526_v0_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_526_v0_controller_swagger.rb
@@ -4,7 +4,7 @@ module ClaimsApi
   class Form526V0ControllerSwagger
     include Swagger::Blocks
 
-    swagger_path '/form/526' do
+    swagger_path '/forms/526' do
       operation :post do
         key :summary, 'Accepts 526 claim form submission'
         key :description, 'Accepts JSON payload. Full URL, including\nquery parameters.'
@@ -146,7 +146,7 @@ module ClaimsApi
       end
     end
 
-    swagger_path '/form/526/{id}/attachments' do
+    swagger_path '/forms/526/{id}/attachments' do
       operation :post do
         key :summary, 'Upload documents in support of a 526 claim'
         key :description, 'Accpets document binaries as part of a multipart payload. Accepts N number of attachments, via attachment1 .. attachmentN'

--- a/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
@@ -4,7 +4,7 @@ module ClaimsApi
   class Form526V1ControllerSwagger
     include Swagger::Blocks
 
-    swagger_path '/form/526' do
+    swagger_path '/forms/526' do
       operation :post do
         key :summary, 'Accepts 526 claim form submission'
         key :description, 'Accpets document binaries as part of a multipart payload. Accepts N number of attachments, via attachment1 .. attachmentN'
@@ -146,7 +146,7 @@ module ClaimsApi
       end
     end
 
-    swagger_path '/form/526/{id}/attachments' do
+    swagger_path '/forms/526/{id}/attachments' do
       operation :post do
         key :summary, 'Upload documents in support of a 526 claim'
         key :description, 'Accpets document binaries as part of a multipart payload.'


### PR DESCRIPTION
## Description of change
Right now our swagger docs have a bug in the routing, leading to 404s if you import it into something that makes client from swagger

## Testing Done
- local / swagger ui



#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
