### PR TITLE
Adding Form Schema documentation and json api compliance

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -15,7 +15,7 @@ module ClaimsApi
     skip_before_action :log_request, only: %i[schema]
 
     def schema
-      render json: ClaimsApi::FormSchemas::SCHEMAS[self.class::FORM_NUMBER]
+      render json: {data: [ClaimsApi::FormSchemas::SCHEMAS[self.class::FORM_NUMBER]]}
     end
 
     private

--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -15,7 +15,7 @@ module ClaimsApi
     skip_before_action :log_request, only: %i[schema]
 
     def schema
-      render json: {data: [ClaimsApi::FormSchemas::SCHEMAS[self.class::FORM_NUMBER]]}
+      render json: { data: [ClaimsApi::FormSchemas::SCHEMAS[self.class::FORM_NUMBER]] }
     end
 
     private

--- a/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
@@ -5,6 +5,46 @@ module ClaimsApi
     include Swagger::Blocks
 
     swagger_path '/forms/0966' do
+      operation :get do
+        key :summary, 'Get 0966 JSON Schema for form'
+        key :description, 'Returns a single JSON schema to auto generate a form'
+        key :operationId, 'get0966JsonSchema'
+        key :produces, [
+          'application/json'
+        ]
+        key :tags, [
+          'Disability'
+        ]
+
+        response 200 do
+          key :description, 'schema response'
+          schema do
+            key :type, :object
+            key :required, [:data]
+            property :data do
+              key :type, :array
+              items do
+                key :'$ref', :Form526Input
+              end
+            end
+          end
+        end
+        
+        response :default do
+          key :description, 'unexpected error'
+          schema do
+            key :type, :object
+            key :required, [:errors]
+            property :errors do
+              key :type, :array
+              items do
+                key :'$ref', :ErrorModel
+              end
+            end
+          end
+        end
+      end
+
       operation :post do
         key :summary, 'Accepts 0966 Intent to File form submission'
         key :description, 'Accepts JSON payload. Full URL, including\nquery parameters.'

--- a/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
@@ -39,7 +39,7 @@ module ClaimsApi
             end
           end
         end
-        
+
         response :default do
           key :description, 'unexpected error'
           schema do

--- a/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
@@ -24,7 +24,17 @@ module ClaimsApi
             property :data do
               key :type, :array
               items do
-                key :'$ref', :Form526Input
+                key :type, :object
+                property :type do
+                  key :type, :string
+                  key :example, 'compensation'
+                  key :description, 'Required by JSON API standard'
+                  key :enum, %w[
+                    compensation
+                    burial
+                    pension
+                  ]
+                end
               end
             end
           end

--- a/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency 'claims_api/form_schemas'
+
 module ClaimsApi
   class Form0966V0ControllerSwagger
     include Swagger::Blocks
@@ -25,16 +27,8 @@ module ClaimsApi
               key :type, :array
               items do
                 key :type, :object
-                property :type do
-                  key :type, :string
-                  key :example, 'compensation'
-                  key :description, 'Required by JSON API standard'
-                  key :enum, %w[
-                    compensation
-                    burial
-                    pension
-                  ]
-                end
+                key :description, 'Returning Variety of JSON and UI Schema Objects'
+                key :example, ClaimsApi::FormSchemas::SCHEMAS['0966']
               end
             end
           end

--- a/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v0_controller_swagger.rb
@@ -13,7 +13,7 @@ module ClaimsApi
           'application/json'
         ]
         key :tags, [
-          'Disability'
+          'Intent to File'
         ]
 
         response 200 do

--- a/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
@@ -5,6 +5,46 @@ module ClaimsApi
     include Swagger::Blocks
 
     swagger_path '/forms/0966' do
+      operation :get do
+        key :summary, 'Get 0966 JSON Schema for form'
+        key :description, 'Returns a single JSON schema to auto generate a form'
+        key :operationId, 'get0966JsonSchema'
+        key :produces, [
+          'application/json'
+        ]
+        key :tags, [
+          'Disability'
+        ]
+
+        response 200 do
+          key :description, 'schema response'
+          schema do
+            key :type, :object
+            key :required, [:data]
+            property :data do
+              key :type, :array
+              items do
+                key :'$ref', :Form526Input
+              end
+            end
+          end
+        end
+        
+        response :default do
+          key :description, 'unexpected error'
+          schema do
+            key :type, :object
+            key :required, [:errors]
+            property :errors do
+              key :type, :array
+              items do
+                key :'$ref', :ErrorModel
+              end
+            end
+          end
+        end
+      end
+
       operation :post do
         key :summary, 'Accepts 0966 Intent to File form submission'
         key :description, 'Accepts JSON payload. Full URL, including\nquery parameters.'

--- a/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
@@ -39,7 +39,7 @@ module ClaimsApi
             end
           end
         end
-        
+
         response :default do
           key :description, 'unexpected error'
           schema do

--- a/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
@@ -24,7 +24,17 @@ module ClaimsApi
             property :data do
               key :type, :array
               items do
-                key :'$ref', :Form526Input
+                key :type, :object
+                property :type do
+                  key :type, :string
+                  key :example, 'compensation'
+                  key :description, 'Required by JSON API standard'
+                  key :enum, %w[
+                    compensation
+                    burial
+                    pension
+                  ]
+                end
               end
             end
           end

--- a/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency 'claims_api/form_schemas'
+
 module ClaimsApi
   class Form0966V1ControllerSwagger
     include Swagger::Blocks
@@ -25,16 +27,8 @@ module ClaimsApi
               key :type, :array
               items do
                 key :type, :object
-                property :type do
-                  key :type, :string
-                  key :example, 'compensation'
-                  key :description, 'Required by JSON API standard'
-                  key :enum, %w[
-                    compensation
-                    burial
-                    pension
-                  ]
-                end
+                key :description, 'Returning Variety of JSON and UI Schema Objects'
+                key :example, ClaimsApi::FormSchemas::SCHEMAS['0966']
               end
             end
           end

--- a/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_0966_v1_controller_swagger.rb
@@ -13,7 +13,7 @@ module ClaimsApi
           'application/json'
         ]
         key :tags, [
-          'Disability'
+          'Intent to File'
         ]
 
         response 200 do

--- a/modules/claims_api/app/swagger/claims_api/form_526_v0_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_526_v0_controller_swagger.rb
@@ -5,6 +5,46 @@ module ClaimsApi
     include Swagger::Blocks
 
     swagger_path '/forms/526' do
+      operation :get do
+        key :summary, 'Get 526 JSON Schema for form'
+        key :description, 'Returns a single JSON schema to auto generate a form'
+        key :operationId, 'get526JsonSchema'
+        key :produces, [
+          'application/json'
+        ]
+        key :tags, [
+          'Disability'
+        ]
+
+        response 200 do
+          key :description, 'schema response'
+          schema do
+            key :type, :object
+            key :required, [:data]
+            property :data do
+              key :type, :array
+              items do
+                key :'$ref', :Form526Input
+              end
+            end
+          end
+        end
+        
+        response :default do
+          key :description, 'unexpected error'
+          schema do
+            key :type, :object
+            key :required, [:errors]
+            property :errors do
+              key :type, :array
+              items do
+                key :'$ref', :ErrorModel
+              end
+            end
+          end
+        end
+      end
+      
       operation :post do
         key :summary, 'Accepts 526 claim form submission'
         key :description, 'Accepts JSON payload. Full URL, including\nquery parameters.'

--- a/modules/claims_api/app/swagger/claims_api/form_526_v0_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_526_v0_controller_swagger.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency 'claims_api/form_schemas'
+
 module ClaimsApi
   class Form526V0ControllerSwagger
     include Swagger::Blocks
@@ -24,7 +26,9 @@ module ClaimsApi
             property :data do
               key :type, :array
               items do
-                key :'$ref', :Form526Input
+                key :type, :object
+                key :description, 'Returning Variety of JSON and UI Schema Objects'
+                key :example, ClaimsApi::FormSchemas::SCHEMAS['526']
               end
             end
           end

--- a/modules/claims_api/app/swagger/claims_api/form_526_v0_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_526_v0_controller_swagger.rb
@@ -29,7 +29,7 @@ module ClaimsApi
             end
           end
         end
-        
+
         response :default do
           key :description, 'unexpected error'
           schema do
@@ -44,7 +44,7 @@ module ClaimsApi
           end
         end
       end
-      
+
       operation :post do
         key :summary, 'Accepts 526 claim form submission'
         key :description, 'Accepts JSON payload. Full URL, including\nquery parameters.'

--- a/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
@@ -5,6 +5,46 @@ module ClaimsApi
     include Swagger::Blocks
 
     swagger_path '/forms/526' do
+      operation :get do
+        key :summary, 'Get 526 JSON Schema for form'
+        key :description, 'Returns a single JSON schema to auto generate a form'
+        key :operationId, 'get526JsonSchema'
+        key :produces, [
+          'application/json'
+        ]
+        key :tags, [
+          'Disability'
+        ]
+
+        response 200 do
+          key :description, 'schema response'
+          schema do
+            key :type, :object
+            key :required, [:data]
+            property :data do
+              key :type, :array
+              items do
+                key :'$ref', :Form526Input
+              end
+            end
+          end
+        end
+        
+        response :default do
+          key :description, 'unexpected error'
+          schema do
+            key :type, :object
+            key :required, [:errors]
+            property :errors do
+              key :type, :array
+              items do
+                key :'$ref', :ErrorModel
+              end
+            end
+          end
+        end
+      end
+      
       operation :post do
         key :summary, 'Accepts 526 claim form submission'
         key :description, 'Accpets document binaries as part of a multipart payload. Accepts N number of attachments, via attachment1 .. attachmentN'

--- a/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency 'claims_api/form_schemas'
+
 module ClaimsApi
   class Form526V1ControllerSwagger
     include Swagger::Blocks
@@ -24,7 +26,9 @@ module ClaimsApi
             property :data do
               key :type, :array
               items do
-                key :'$ref', :Form526Input
+                key :type, :object
+                key :description, 'Returning Variety of JSON and UI Schema Objects'
+                key :example, ClaimsApi::FormSchemas::SCHEMAS['526']
               end
             end
           end

--- a/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
@@ -29,7 +29,7 @@ module ClaimsApi
             end
           end
         end
-        
+
         response :default do
           key :description, 'unexpected error'
           schema do
@@ -44,7 +44,7 @@ module ClaimsApi
           end
         end
       end
-      
+
       operation :post do
         key :summary, 'Accepts 526 claim form submission'
         key :description, 'Accpets document binaries as part of a multipart payload. Accepts N number of attachments, via attachment1 .. attachmentN'


### PR DESCRIPTION
## Description of change
Wrapping up work for ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/2031

Adding documentation and minor JSON API compliance change.

## Testing done
Testing locally.

## Testing planned
Testing against client implementation.

## Acceptance Criteria (Definition of Done)
- Documentation is updated and json compliance achieved.

#### Unique to this PR
- [x] Forms GET request returns a json compliant array of json schema

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
