### PR TITLE
more expressive constant name and docstring

### DIFF
--- a/app/controllers/v0/facilities/ccp_controller.rb
+++ b/app/controllers/v0/facilities/ccp_controller.rb
@@ -3,7 +3,12 @@
 class V0::Facilities::CcpController < FacilitiesController
   before_action :validate_id, only: [:show]
 
-  URGENT_CARE_CODES = %w[261QU0200X 3336C0003X].freeze
+  ##
+  # 
+  # Urgent Care:261QU0200X
+  # Community/Retail Pharmacy:3336C0003X
+  
+  EXCLUDED_PROVIDER_TYPES = %w[261QU0200X 3336C0003X].freeze
 
   def show
     ppms = Facilities::PPMSClient.new
@@ -16,7 +21,7 @@ class V0::Facilities::CcpController < FacilitiesController
 
   def services
     ppms = Facilities::PPMSClient.new
-    result = ppms.specialties.reject { |item| URGENT_CARE_CODES.include? item['SpecialtyCode'] }
+    result = ppms.specialties.reject { |item| EXCLUDED_PROVIDER_TYPES.include? item['SpecialtyCode'] }
     render json: result
   end
 

--- a/app/controllers/v0/facilities/ccp_controller.rb
+++ b/app/controllers/v0/facilities/ccp_controller.rb
@@ -4,10 +4,10 @@ class V0::Facilities::CcpController < FacilitiesController
   before_action :validate_id, only: [:show]
 
   ##
-  # 
+  #
   # Urgent Care:261QU0200X
   # Community/Retail Pharmacy:3336C0003X
-  
+
   EXCLUDED_PROVIDER_TYPES = %w[261QU0200X 3336C0003X].freeze
 
   def show


### PR DESCRIPTION
## Description of change
Small tweaks to make things slightly more clear/expressive. Builds on https://github.com/department-of-veterans-affairs/vets-api/pull/3082.

Pretty clueless on how Ruby handles docstrings, so gave it my best shot :-)

## Testing done
None.

## Testing planned
Should be covered by existing unit tests.

## Acceptance Criteria (Definition of Done)

- [x] Developer better understands what arbitrary provider type codes mean.

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
