### PR TITLE
fixing link to certs, part deux

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To start, fetch this code:
    - *NOTE:* using `touch` to create blank cert and key files no longer works. 
    If you previously added certs in this manner replace them with the team repo certificate and key listed above.
    
-   [certificate]: https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Login/Identity/IDme/development-certificates/vetsgov-localhost.crt
+   [certificate]: https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Identity/Login/IDme/development-certificates/vetsgov-localhost.crt
    [key]: https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Identity/Login/IDme/development-certificates/vetsgov-localhost.key
 
 ## Running the app


### PR DESCRIPTION
## Description of change
Correcting link to local dev certificate.

## Testing done
Clicked through in browser.

## Testing planned
None.

## Acceptance Criteria (Definition of Done)
- [x] Can navigate to localdev certificate from repo root.

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
