### PR TITLE
Remove bulk logging

### DIFF
--- a/lib/central_mail/service.rb
+++ b/lib/central_mail/service.rb
@@ -49,17 +49,6 @@ module CentralMail
         body
       )
 
-      if Rails.env.production?
-        log_message_to_sentry(
-          'central mail api status',
-          :info,
-          response: {
-            status: response.status,
-            body: response.body
-          }
-        )
-      end
-
       response
     end
   end


### PR DESCRIPTION
## Description of change
Within the central mail service there is some logging to sentry that's getting called a boatload (25k - 30k depending on environment). I'm going to guess it's not needed.

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/1968

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
