### PR TITLE
Remove POA from appeals

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
@@ -9,10 +9,6 @@ module AppealsApi
 
       def index
         log_request
-        if header('X-Consumer-PoA').present?
-          verifier = EVSS::PowerOfAttorneyVerifier.new(target_veteran)
-          verifier.verify(header('X-Consumer-PoA'))
-        end
         appeals_response = Appeals::Service.new.get_appeals(
           target_veteran,
           'Consumer' => consumer,
@@ -85,18 +81,7 @@ module AppealsApi
       end
 
       def target_veteran
-        if header('X-Consumer-PoA').present?
-          ClaimsApi::Veteran.new(
-            ssn: ssn,
-            loa: { current: :loa3 },
-            first_name: first_name,
-            last_name: last_name,
-            edipi: edipi,
-            last_signed_in: Time.zone.now
-          )
-        else
-          OpenStruct.new(ssn: ssn)
-        end
+        OpenStruct.new(ssn: ssn)
       end
     end
   end

--- a/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
@@ -47,37 +47,17 @@ module AppealsApi
       end
 
       def ssn
-        ssn = request.headers['X-VA-SSN']
-        raise Common::Exceptions::ParameterMissing, 'X-VA-SSN' unless ssn
-        ssn
+        header('X-VA-SSN')
       end
 
       def requesting_va_user
-        va_user = request.headers['X-VA-User']
-        raise Common::Exceptions::ParameterMissing, 'X-VA-User' unless va_user
-        va_user
-      end
-
-      def first_name
-        va_first_name = header('X-VA-First-Name')
-        raise Common::Exceptions::ParameterMissing, 'X-VA-First-Name' unless va_first_name
-        va_first_name
-      end
-
-      def last_name
-        va_last_name = header('X-VA-Last-Name')
-        raise Common::Exceptions::ParameterMissing, 'X-VA-Last-Name' unless va_last_name
-        va_last_name
-      end
-
-      def edipi
-        va_edipi = header('X-VA-EDIPI')
-        raise Common::Exceptions::ParameterMissing, 'X-VA-EDIPI' unless va_edipi
-        va_edipi
+        header('X-VA-User')
       end
 
       def header(key)
-        request.headers[key]
+        value = request.headers[key]
+        raise Common::Exceptions::ParameterMissing, key unless value
+        value
       end
 
       def target_veteran

--- a/modules/appeals_api/spec/requests/appeals_request_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_request_spec.rb
@@ -35,16 +35,6 @@ RSpec.describe 'Claim Appeals API endpoint', type: :request do
       end
     end
 
-    it 'checks PoA when present?' do
-      VCR.use_cassette('appeals/appeals') do
-        get '/services/appeals/v0/appeals', params: nil, headers: { 'X-Consumer-PoA' => 'A1Q' }.merge(user_headers)
-
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to be_a(String)
-        expect(response).to match_response_schema('appeals')
-      end
-    end
-
     it 'should log details about the request' do
       VCR.use_cassette('appeals/appeals') do
         allow(Rails.logger).to receive(:info)


### PR DESCRIPTION
## Description of change
Back whenever appeals was DigDug's purview we added some appeals logic. That was based on the idea that poa would come from kong and has since gone in a different direction. In order to remove some noise, I gutted it out. It was never really documented so no documentation changes were necessary.

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/1907

## Testing done
- rspec

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
