### PR TITLE
add document report rate limit docs

### DIFF
--- a/modules/vba_documents/app/swagger/vba_documents/v0/controller_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v0/controller_swagger.rb
@@ -184,6 +184,7 @@ module VbaDocuments
           key :tags, %i[document_uploads]
 
           key :summary, 'Get a bulk status report for a list of previous uploads'
+          key :description, 'This endpoint is rate limited at 25 requests per minute and 80 requests per hour'
           key :operationId, 'getBenefitsDocumentUploadStatusReport'
 
           security do


### PR DESCRIPTION
## Description of change
Documenting the specific rate limit for documents report.


## Acceptance Criteria (Definition of Done)
- [x] The specific document report rate limit appears in the documentation

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
