### PR TITLE
Remove non-applicable language from Facilities v1 OAS

### DIFF
--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -24,9 +24,8 @@ info:
     ### Response Formats
 
     Clients may request several response formats by setting the `Accept` header.
-    - application/json - The default JSON response format complies with JSON API. This media type is *not* available for bulk requests using the `/facilities/all` endpoint. It will return `406 Not Acceptable`. .
+    - application/json - The default JSON response format complies with JSON API.
     - application/vnd.geo+json - GeoJSON-compliant format, representing each facility as a Feature with a Point geometry.
-    - text/csv - Available for the bulk download operation only. Some structured fields are omitted from the CSV response.
 
     ### Response Elements
 


### PR DESCRIPTION
## Description of change
v1 of Facilities will only initially contain `/nearby` as an available endpoint. The rest will be upgraded later on. However, [the currently published OAS](https://dev-api.va.gov/services/va_facilities/docs/v1/api) has some language for the other endpoints that needs to be removed.

Fixes https://github.com/department-of-veterans-affairs/vets-contrib/issues/2352

## Acceptance Criteria (Definition of Done)
Removed:
- [x] "This media type is not available for bulk requests using the /facilities/all endpoint. It will return 406 Not Acceptable. ."
- [x] "- text/csv - Available for the bulk download operation only. Some structured fields are omitted from the CSV response."