### PR TITLE
docker cache bundled gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,13 @@ poppler-utils && \
 freshclam
 
 WORKDIR $APP_PATH
-ADD Gemfile $APP_PATH
-ADD Gemfile.lock $APP_PATH
 ADD . /src/vets-api
 
-RUN bundle install
+COPY ./docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+ENV BUNDLE_PATH=/bundle \
+    BUNDLE_BIN=/bundle/bin \
+    GEM_HOME=/bundle
+ENV PATH="${BUNDLE_BIN}:${PATH}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       - .:/src/vets-api:cached
       - "../vets-api-mockdata:/cache"
+      - bundle:/bundle
     ports:
       - "3000:3000"
     environment:
@@ -42,3 +43,4 @@ services:
       - redis
 volumes:
   db-data:
+  bundle:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+bundle check || bundle install --binstubs="$BUNDLE_BIN"
+
+exec "$@"


### PR DESCRIPTION
## Description of change
Caches bundle install by moving it out of the docker build process and into an entry point script. Adding a new gem will no longer require reinstalling all our gems (which takes some time; looking at you nokogiri 👀) 

## Testing done
Added a new gem locally in both existing and fresh docker installs.

## Testing planned
Confirm CI builds still run

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] Docker does not need to rebuild all gems when the Gemfile changes

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
