### PR TITLE
Typo in the word receive

### DIFF
--- a/modules/vba_documents/app/swagger/description.md
+++ b/modules/vba_documents/app/swagger/description.md
@@ -44,7 +44,7 @@ Allows a client to upload a document package (form + attachments + metadata).
     integrity of the upload
 
 ### Status Simulation
-Given the downstream connections of this API, we allow (**IN DEVELOPER ENVIRONMENT ONLY**) passing in a header `Status-Override` on the `/uploads/{id}` endpoint that will allow you to change the status of your submission to simulate the various scenarios. The available statuses are `pending`, `uploaded`, `recieved`, `processing`, `success`, `error`.
+Given the downstream connections of this API, we allow (**IN DEVELOPER ENVIRONMENT ONLY**) passing in a header `Status-Override` on the `/uploads/{id}` endpoint that will allow you to change the status of your submission to simulate the various scenarios. The available statuses are `pending`, `uploaded`, `received`, `processing`, `success`, `error`.
 
 ## Reference
 


### PR DESCRIPTION
Misspelled a word in swagger docs

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/2441