### PR TITLE
Creating ITF expiration validation for 526

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -20,6 +20,10 @@ module ClaimsApi
 
     private
 
+    def itf_service
+      EVSS::IntentToFile::Service.new(target_veteran)
+    end
+
     def validate_json_schema
       ClaimsApi::FormSchemas.validate!(self.class::FORM_NUMBER, form_attributes)
     rescue ClaimsApi::JsonApiMissingAttribute => e

--- a/modules/claims_api/app/controllers/claims_api/v0/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/intent_to_file_controller.rb
@@ -13,13 +13,13 @@ module ClaimsApi
         skip_before_action :validate_json_schema, only: [:active]
 
         def submit_form_0966
-          response = service.create_intent_to_file(form_type)
+          response = itf_service.create_intent_to_file(form_type)
           render json: response['intent_to_file'],
                  serializer: ClaimsApi::IntentToFileSerializer
         end
 
         def active
-          response = service.get_active(active_param)
+          response = itf_service.get_active(active_param)
           render json: response['intent_to_file'],
                  serializer: ClaimsApi::IntentToFileSerializer
         end
@@ -42,10 +42,6 @@ module ClaimsApi
             }
             render json: error, status: 422
           end
-        end
-
-        def service
-          EVSS::IntentToFile::Service.new(target_veteran)
         end
 
         def form_type

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
@@ -12,13 +12,13 @@ module ClaimsApi
 
         FORM_NUMBER = '0966'
         def submit_form_0966
-          response = service.create_intent_to_file(form_type)
+          response = itf_service.create_intent_to_file(form_type)
           render json: response['intent_to_file'],
                  serializer: ClaimsApi::IntentToFileSerializer
         end
 
         def active
-          response = service.get_active(active_param)
+          response = itf_service.get_active(active_param)
           render json: response['intent_to_file'],
                  serializer: ClaimsApi::IntentToFileSerializer
         end
@@ -41,10 +41,6 @@ module ClaimsApi
             }
             render json: error, status: 422
           end
-        end
-
-        def service
-          EVSS::IntentToFile::Service.new(target_veteran)
         end
 
         def form_type


### PR DESCRIPTION
## Description of change
Solves the issue for ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/2363

## Testing done
- RSpec corrections made

## Testing planned
- Will test in dev-api.va.gov

## Acceptance Criteria (Definition of Done)
- We are using header timestamps to check whether a claim's Intent to File is still valid (one year).

#### Applies to all PRs

- [ ] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
