### PR TITLE
Add metrics for auth attempts

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -9,6 +9,7 @@ module V0
   class SessionsController < ApplicationController
     REDIRECT_URLS = %w[signup mhv dslogon idme mfa verify slo].freeze
 
+    STATSD_SSO_NEW_KEY = 'api.auth.new'
     STATSD_SSO_CALLBACK_KEY = 'api.auth.saml_callback'
     STATSD_SSO_CALLBACK_TOTAL_KEY = 'api.auth.login_callback.total'
     STATSD_SSO_CALLBACK_FAILED_KEY = 'api.auth.login_callback.failed'
@@ -20,6 +21,7 @@ module V0
     def new
       type = params[:type]
       raise Common::Exceptions::RoutingError, params[:path] unless REDIRECT_URLS.include?(type)
+      StatsD.increment(STATSD_SSO_NEW_KEY, tags: ["context:#{type}"])
       url = url_service.send("#{type}_url")
       if type == 'slo'
         Rails.logger.info('SSO: LOGOUT', sso_logging_info)

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -28,6 +28,14 @@ end
   end
 end
 
+V0::SessionsController::REDIRECT_URLS.each do |ctx|
+  StatsD.increment(
+    V0::SessionsController::STATSD_SSO_NEW_KEY,
+    0,
+    tags: ["context:#{ctx}"]
+  )
+end
+
 # init GiBillStatus stats to 0
 StatsD.increment(V0::Post911GIBillStatusesController::STATSD_GI_BILL_TOTAL_KEY, 0)
 StatsD.increment(V0::Post911GIBillStatusesController::STATSD_GI_BILL_FAIL_KEY, 0, tags: ['error:unknown'])

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe V0::SessionsController, type: :controller do
         %w[mhv dslogon idme].each do |type|
           context "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             it 'redirects' do
-              expect{ get(:new, params: { type: type, clientId: '123123' })}
+              expect { get(:new, params: { type: type, clientId: '123123' }) }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ["context:#{type}"], **once)
 
               expect(response).to have_http_status(:found)
@@ -96,7 +96,7 @@ RSpec.describe V0::SessionsController, type: :controller do
 
         context 'routes /sessions/signup/new to SessionsController#new' do
           it 'redirects' do
-            expect{ get(:new, params: { type: :signup, client_id: '123123' }) }
+            expect { get(:new, params: { type: :signup, client_id: '123123' }) }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ['context:signup'], **once)
             expect(response).to have_http_status(:found)
             expect(response.location)
@@ -170,7 +170,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           context "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             it 'redirects' do
               expect { get(:new, params: { type: type }) }
-              .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ["context:#{type}"], **once)
+                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ["context:#{type}"], **once)
               expect(response).to have_http_status(:found)
               expect(cookies['vagov_session_dev']).not_to be_nil unless type.in?(%w[mhv dslogon idme slo])
             end

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe V0::SessionsController, type: :controller do
     )
   end
 
+  let(:once) { { times: 1, value: 1 } }
+
   def verify_session_cookie
     token = session[:token]
     expect(token).to_not be_nil
@@ -80,7 +82,9 @@ RSpec.describe V0::SessionsController, type: :controller do
         %w[mhv dslogon idme].each do |type|
           context "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             it 'redirects' do
-              get(:new, params: { type: type, clientId: '123123' })
+              expect{ get(:new, params: { type: type, clientId: '123123' })}
+                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ["context:#{type}"], **once)
+
               expect(response).to have_http_status(:found)
               expect(response.location)
                 .to be_an_idme_saml_url('https://api.idmelabs.com/saml/SingleSignOnService?SAMLRequest=')
@@ -92,7 +96,8 @@ RSpec.describe V0::SessionsController, type: :controller do
 
         context 'routes /sessions/signup/new to SessionsController#new' do
           it 'redirects' do
-            get(:new, params: { type: :signup, client_id: '123123' })
+            expect{ get(:new, params: { type: :signup, client_id: '123123' }) }
+              .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ['context:signup'], **once)
             expect(response).to have_http_status(:found)
             expect(response.location)
               .to be_an_idme_saml_url('https://api.idmelabs.com/saml/SingleSignOnService?SAMLRequest=')
@@ -164,7 +169,8 @@ RSpec.describe V0::SessionsController, type: :controller do
 
           context "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             it 'redirects' do
-              get(:new, params: { type: type })
+              expect { get(:new, params: { type: type }) }
+              .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ["context:#{type}"], **once)
               expect(response).to have_http_status(:found)
               expect(cookies['vagov_session_dev']).not_to be_nil unless type.in?(%w[mhv dslogon idme slo])
             end
@@ -343,7 +349,6 @@ RSpec.describe V0::SessionsController, type: :controller do
           )
           expect(Raven).to receive(:tags_context).once
 
-          once = { times: 1, value: 1 }
           callback_tags = ['status:success', "context:#{LOA::IDME_LOA3}"]
 
           expect { post(:saml_callback) }
@@ -468,7 +473,6 @@ RSpec.describe V0::SessionsController, type: :controller do
 
         it 'increments the failed and total statsd counters' do
           allow(UserSessionForm).to receive(:new).and_raise(NoMethodError)
-          once = { times: 1, value: 1 }
           callback_tags = ['status:failure', 'context:unknown']
           failed_tags = ['error:unknown']
 
@@ -515,7 +519,6 @@ RSpec.describe V0::SessionsController, type: :controller do
         end
 
         it 'increments the failed and total statsd counters' do
-          once = { times: 1, value: 1 }
           callback_tags = ['status:failure', 'context:unknown']
           failed_tags = ['error:auth_too_early']
 
@@ -547,7 +550,6 @@ RSpec.describe V0::SessionsController, type: :controller do
         end
 
         it 'increments the failed and total statsd counters' do
-          once = { times: 1, value: 1 }
           callback_tags = ['status:failure', 'context:unknown']
           failed_tags = ['error:unknown']
 
@@ -582,7 +584,6 @@ RSpec.describe V0::SessionsController, type: :controller do
         end
 
         it 'increments the failed and total statsd counters' do
-          once = { times: 1, value: 1 }
           callback_tags = ['status:failure', 'context:unknown']
           failed_tags = ['error:clicked_deny']
 
@@ -602,7 +603,6 @@ RSpec.describe V0::SessionsController, type: :controller do
 
         it 'allows user to sign in even if user attributes are not available' do
           MVI::Configuration.instance.breakers_service.begin_forced_outage!
-          once = { times: 1, value: 1 }
           callback_tags = ['status:success', 'context:myhealthevet']
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
@@ -652,7 +652,6 @@ RSpec.describe V0::SessionsController, type: :controller do
         end
 
         it 'increments the failed and total statsd counters' do
-          once = { times: 1, value: 1 }
           callback_tags = ['status:failure', "context:#{LOA::IDME_LOA1}"]
           failed_tags = ['error:validations_failed']
 


### PR DESCRIPTION
## Description of change
Part 1 of "Automatically deploy/remove DS Logon outage banner" is collecting metrics on login attempts.  

We already collect metrics on SAML responses (success and failure) but we're missing metrics on authentication attempts.  

These metrics will not be precise, but they will give us a broad picture of troubles.  That is to say the [saml_callback context](http://grafana.vetsgov-internal/dashboard/db/site-authentication?panelId=12&fullscreen&orgId=1&from=now-24h&to=now) will not have a 1-1 correspondence with the login attempts metrics, but I think we'll be able to say broadly if we see a significant dip in success rate we should be alerted and put up a banner. 

## Testing done
specs

## Testing planned
view metrics in staging on new [Auth attempts by context](http://grafana.vetsgov-internal/dashboard/db/site-authentication?panelId=18&fullscreen&orgId=1&from=now-24h&to=now&var-data_source=Prometheus%20(Staging))

## Acceptance Criteria (Definition of Done)
Metrics visible in Grafana

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
