### PR TITLE
Reference URL fixes in API docs

### DIFF
--- a/modules/appeals_api/README.yml
+++ b/modules/appeals_api/README.yml
@@ -32,7 +32,7 @@ info:
 
       ## Reference
 
-      Raw Open API Spec: http://dev-api.va.gov/services/appeals/docs/v0/api
+      Raw Open API Spec: http://api.va.gov/services/appeals/docs/v0/api
 
   termsOfService: ''
   contact:

--- a/modules/appeals_api/README.yml
+++ b/modules/appeals_api/README.yml
@@ -32,7 +32,7 @@ info:
 
       ## Reference
 
-      Raw Open API Spec: http://api.va.gov/services/appeals/docs/v0/api
+      Raw Open API Spec: https://api.va.gov/services/appeals/docs/v0/api
 
   termsOfService: ''
   contact:

--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -39,7 +39,7 @@ info:
 
     ## Reference
 
-    - [Raw VA Facilities Open API Spec](http://dev-api.va.gov/services/va_facilities/docs/v1/api)
+    - [Raw VA Facilities Open API Spec](http://api.va.gov/services/va_facilities/docs/v1/api)
     - [GeoJSON Format](https://tools.ietf.org/html/rfc7946)
     - [JSON API Format](http://jsonapi.org/format/)
 

--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -39,9 +39,9 @@ info:
 
     ## Reference
 
-    - [Raw VA Facilities Open API Spec](http://api.va.gov/services/va_facilities/docs/v1/api)
+    - [Raw VA Facilities Open API Spec](https://api.va.gov/services/va_facilities/docs/v1/api)
     - [GeoJSON Format](https://tools.ietf.org/html/rfc7946)
-    - [JSON API Format](http://jsonapi.org/format/)
+    - [JSON API Format](https://jsonapi.org/format/)
 
   termsOfService: ''
   contact:

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -40,7 +40,7 @@ info:
 
     ## Reference
 
-    - [Raw VA Facilities Open API Spec](http://dev-api.va.gov/services/va_facilities/docs/v0/api)
+    - [Raw VA Facilities Open API Spec](http://api.va.gov/services/va_facilities/docs/v0/api)
     - [GeoJSON Format](https://tools.ietf.org/html/rfc7946)
     - [JSON API Format](http://jsonapi.org/format/)
 

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -40,9 +40,9 @@ info:
 
     ## Reference
 
-    - [Raw VA Facilities Open API Spec](http://api.va.gov/services/va_facilities/docs/v0/api)
+    - [Raw VA Facilities Open API Spec](https://api.va.gov/services/va_facilities/docs/v0/api)
     - [GeoJSON Format](https://tools.ietf.org/html/rfc7946)
-    - [JSON API Format](http://jsonapi.org/format/)
+    - [JSON API Format](https://jsonapi.org/format/)
 
   termsOfService: ''
   contact:

--- a/modules/vba_documents/app/swagger/description.md
+++ b/modules/vba_documents/app/swagger/description.md
@@ -48,4 +48,4 @@ Given the downstream connections of this API, we allow (**IN DEVELOPER ENVIRONME
 
 ## Reference
 
-Raw Open API Spec: http://api.va.gov/services/vba_documents/docs/v0/api
+Raw Open API Spec: https://api.va.gov/services/vba_documents/docs/v0/api

--- a/modules/vba_documents/app/swagger/description.md
+++ b/modules/vba_documents/app/swagger/description.md
@@ -48,4 +48,4 @@ Given the downstream connections of this API, we allow (**IN DEVELOPER ENVIRONME
 
 ## Reference
 
-Raw Open API Spec: http://dev-api.va.gov/services/vba_documents/docs/v0/api
+Raw Open API Spec: http://api.va.gov/services/vba_documents/docs/v0/api

--- a/modules/veteran_verification/DISABILITY_RATING.yml
+++ b/modules/veteran_verification/DISABILITY_RATING.yml
@@ -28,7 +28,7 @@ info:
 
     ## Reference
 
-    Raw Open API Spec: https://dev-api.va.gov/services/veteran_verification/docs/v0/api
+    Raw Open API Spec: https://api.va.gov/services/veteran_verification/docs/v0/api
 
   termsOfService: ''
   contact:

--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -34,7 +34,7 @@ info:
 
     ## Reference
 
-    Raw Open API Spec: http://dev-api.va.gov/services/veteran_verification/docs/v0/api
+    Raw Open API Spec: http://api.va.gov/services/veteran_verification/docs/v0/api
 
   termsOfService: ''
   contact:

--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -34,7 +34,7 @@ info:
 
     ## Reference
 
-    Raw Open API Spec: http://api.va.gov/services/veteran_verification/docs/v0/api
+    Raw Open API Spec: https://api.va.gov/services/veteran_verification/docs/v0/api
 
   termsOfService: ''
   contact:

--- a/modules/veteran_verification/VETERAN_CONFIRMATION.yml
+++ b/modules/veteran_verification/VETERAN_CONFIRMATION.yml
@@ -34,7 +34,7 @@ info:
 
     ## Reference
 
-    Raw Open API Spec: http://dev-api.va.gov/services/veteran_verification/docs/v0/status
+    Raw Open API Spec: http://api.va.gov/services/veteran_verification/docs/v0/status
 
   termsOfService: ''
   contact:

--- a/modules/veteran_verification/VETERAN_CONFIRMATION.yml
+++ b/modules/veteran_verification/VETERAN_CONFIRMATION.yml
@@ -34,7 +34,7 @@ info:
 
     ## Reference
 
-    Raw Open API Spec: http://api.va.gov/services/veteran_verification/docs/v0/status
+    Raw Open API Spec: https://api.va.gov/services/veteran_verification/docs/v0/status
 
   termsOfService: ''
   contact:


### PR DESCRIPTION
## Description of change
Fixes https://github.com/department-of-veterans-affairs/vets-contrib/issues/2527
Noticed that all of our API docs that contain a `Reference` section with the `Raw Open API Spec` URLs have links for *dev* instead of *prod*. Also some were `http` instead of `https`.

## Acceptance Criteria (Definition of Done)
- [x] All reference URLs use `https`
- [x] All reference URLs point to `prod`

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
