### PR TITLE
Rt 2500 state code validation

### DIFF
--- a/app/models/facilities_query/state_query.rb
+++ b/app/models/facilities_query/state_query.rb
@@ -4,7 +4,7 @@ module FacilitiesQuery
   class StateQuery < Base
     def run
       state = params[:state]
-      conditions = "address @> '{ \"physical\": {\"state\": \"#{state}\"}}'"
+      conditions = "address -> 'physical' ->> 'state' ilike '#{state}'"
       BaseFacility::TYPES.flat_map do |facility_type|
         get_facility_data(conditions, params[:type], facility_type, params[:services])
       end

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -122,7 +122,7 @@ paths:
         - name: state
           in: query
           description: |
-            Two character state code to search for VA Facilities.
+            State code to search for VA Facilities. Except in rare cases, this is two characters.
           required: false
           schema:
             type: string

--- a/modules/va_facilities/config/initializers/state_codes.rb
+++ b/modules/va_facilities/config/initializers/state_codes.rb
@@ -40,6 +40,8 @@ STATE_CODES = %w[
   OK
   OR
   PA
+  PH
+  PI
   RI
   SC
   SD
@@ -57,4 +59,6 @@ STATE_CODES = %w[
   MP
   GU
   AS
+  GUAM
+  APO
 ].freeze

--- a/modules/va_facilities/lib/va_facilities/param_validators.rb
+++ b/modules/va_facilities/lib/va_facilities/param_validators.rb
@@ -16,7 +16,7 @@ module VaFacilities
     end
 
     def validate_state_code
-      if params[:state] && STATE_CODES.exclude?(params[:state])
+      if params[:state] && STATE_CODES.exclude?(params[:state].upcase)
         raise Common::Exceptions::InvalidFieldValue.new('state', params[:state])
       end
     end

--- a/spec/models/facilities_query_spec.rb
+++ b/spec/models/facilities_query_spec.rb
@@ -50,8 +50,9 @@ RSpec.describe FacilitiesQuery do
         expect(FacilitiesQuery.generate_query(params2).run.size).to eq(5)
       end
 
-      it 'should find facility by state code' do
+      it 'should find facility by state code, regardless of case' do
         expect(FacilitiesQuery.generate_query(state: 'WA').run.size).to eq(2)
+        expect(FacilitiesQuery.generate_query(state: 'wa').run.size).to eq(2)
       end
 
       it 'should find facility by state code and type' do


### PR DESCRIPTION
## Description of change
Finishes [#2500](https://github.com/department-of-veterans-affairs/vets-contrib/issues/2500)

This PR does two things:
1. Adds state codes to the list that query params validate against
2. Allows for case insensitive state code queries

The list of codes to add came from the VA facilities we cache in Postgres that were not currently captured in the validation file. Finding those codes raised questions about some questions that are captured in the original issue.

## Testing done
- Added a new case-insensitive spec
- Manually validated new state codes work

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Users can use a state code to query any VA facility. 
- [x] That state code can be in any case.

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
