### PR TITLE
Changing Benefits Intake V1 to default

### DIFF
--- a/modules/vba_documents/app/controllers/vba_documents/metadata_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/metadata_controller.rb
@@ -11,14 +11,14 @@ module VBADocuments
             {
               version: '1.0.0',
               internal_only: false,
-              status: VERSION_STATUS[:draft],
+              status: VERSION_STATUS[:current],
               path: '/services/vba_documents/docs/v1/api',
               healthcheck: '/services/vba_documents/v1/healthcheck'
             },
             {
               version: '0.0.1',
               internal_only: false,
-              status: VERSION_STATUS[:current],
+              status: VERSION_STATUS[:previous],
               path: '/services/vba_documents/docs/v0/api',
               healthcheck: '/services/vba_documents/v0/healthcheck'
             }


### PR DESCRIPTION
## Description of change
Resolves Ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/2491

## Acceptance Criteria (Definition of Done)
- The 3 updates above (2 paths and 1 additional reference to the "vbms" status) are in place.
- v1 is listed as the current version of the Benefits Intake API, and 0.0.1 is marked as the previous version.
- Documentation for v1 is displayed by default on https://developer.va.gov/explore/benefits/docs/benefits.

#### Applies to all PRs

- [ ] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
