### PR TITLE
18950 dont retry ep codes

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -54,19 +54,26 @@ module EVSS
         raise NotImplementedError, 'Subclass of SubmitForm526 must implement #service'
       end
 
-      # Retries any errors caused by an upstream service from EVSS being unavailable or
-      # if getting a "PIF in use" error
+      # Retries any errors caused by an upstream service from EVSS being unavailable (unless the
+      # external serivce is caused by an invalid EP code) or if getting a "PIF in use" error
       # Otherwise it marks it as non-retryable and stops the job
       #
       # @param error [ErrorClass] An exception object of type {EVSS::DisabilityCompensationForm::ServiceException}
       #
       def retry_form526_error_handler!(error)
-        if error.key == 'evss.external_service_unavailable' ||
+        if (error.key == 'evss.external_service_unavailable' && ep_code_valid(error)) ||
            error.key == 'evss.disability_compensation_form.pif_in_use'
           retryable_error_handler(error)
         else
           non_retryable_error_handler(error)
         end
+      end
+
+      def ep_code_valid(error)
+        error.messages.each do |message|
+          return false if message['text'].include?('EP Code is not valid')
+        end
+        true
       end
     end
   end

--- a/spec/support/vcr_cassettes/evss/disability_compensation_form/submit_500_with_ep_not_valid.yml
+++ b/spec/support/vcr_cassettes/evss/disability_compensation_form/submit_500_with_ep_not_valid.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-form526-services-web/rest/form526/v1/submit"
+    body:
+      encoding: UTF-8
+      string: '{"form526":{"veteran":{"emailAddress":"string","alternateEmailAddress":"string","mailingAddress":{"addressLine1":"string","addressLine2":"string","addressLine3":"string","city":"string","state":"IL","zipFirstFive":"11111","zipLastFour":"1111","country":"string","militaryStateCode":"AA","militaryPostOfficeTypeCode":"APO","type":"DOMESTIC"},"forwardingAddress":{"addressLine1":"string","addressLine2":"string","addressLine3":"string","city":"string","state":"IL","zipFirstFive":"11111","zipLastFour":"1111","country":"string","militaryStateCode":"AA","militaryPostOfficeTypeCode":"APO","type":"DOMESTIC","effectiveDate":"2018-03-29T18:50:03.014Z"},"primaryPhone":{"areaCode":"202","phoneNumber":"4561111"},"homelessness":{"hasPointOfContact":false},"serviceNumber":"string"},"attachments":[],"militaryPayments":{"payments":[],"receiveCompensationInLieuOfRetired":false,"receivingInactiveDutyTrainingPay":false,"waveBenifitsToRecInactDutyTraiPay":false},"directDeposit":{"accountType":"CHECKING","accountNumber":"1234","bankName":"string","routingNumber":"123456789"},"serviceInformation":{"servicePeriods":[{"serviceBranch":"string","activeDutyBeginDate":"2018-03-29T18:50:03.015Z","activeDutyEndDate":"2018-03-29T18:50:03.015Z"}],"reservesNationalGuardService":{"title10Activation":{"title10ActivationDate":"2018-03-29T18:50:03.015Z","anticipatedSeparationDate":"2018-03-29T18:50:03.015Z"},"obligationTermOfServiceFromDate":"2018-03-29T18:50:03.015Z","obligationTermOfServiceToDate":"2018-03-29T18:50:03.015Z","unitName":"string","unitPhone":{"areaCode":"202","phoneNumber":"4561111"}},"servedInCombatZone":true,"separationLocationName":"OTHER","separationLocationCode":"SOME
+        VALUE","alternateNames":[{"firstName":"string","middleName":"string","lastName":"string"}],"confinements":[{"confinementBeginDate":"2018-03-29T18:50:03.015Z","confinementEndDate":"2018-03-29T18:50:03.015Z","verifiedIndicator":false}]},"disabilities":[{"diagnosticText":"Diabetes
+        mellitus","disabilityActionType":"INCREASE","decisionCode":"SVCCONNCTED","specialIssues":[{"code":"TRM","name":"Personal
+        Trauma PTSD"}],"ratedDisabilityId":"0","ratingDecisionId":63655,"diagnosticCode":5235,"secondaryDisabilities":[{"decisionCode":"","ratedDisabilityId":"","diagnosticText":"string","disabilityActionType":"NONE"}]}],"treatments":[],"specialCircumstances":[{"name":"string","code":"string","needed":false}]}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      va-eauth-csid:
+      - DSLogon
+      va-eauth-authenticationmethod:
+      - DSLogon
+      va-eauth-pnidtype:
+      - SSN
+      va-eauth-assurancelevel:
+      - '3'
+      va-eauth-firstName:
+      - Beyonce
+      va-eauth-lastName:
+      - Knowles
+      va-eauth-issueinstant:
+      - '2017-12-07T00:55:09Z'
+      va-eauth-dodedipnid:
+      - '4789224336'
+      va-eauth-birlsfilenumber:
+      - '796068948'
+      va-eauth-pid:
+      - '7420876015'
+      va-eauth-pnid:
+      - '796068949'
+      va-eauth-birthdate:
+      - '1959-10-24T00:00:00+00:00'
+      va-eauth-authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796068949","edi":"4789224336","firstName":"Beyonce","lastName":"Knowles","birthDate":"1959-10-24T00:00:00+00:00","gender":"FEMALE"}}'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 500
+      message: Server error
+    headers:
+      Date:
+      - Mon, 02 Apr 2018 22:46:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.02; path=/
+      - WSS-FORM526-SERVICES_JSESSIONID=RPeIimX_DLhskhO20bPzBmWWKGghuW-YlSjLgIX3nN28Adki1xRE!-1392655551;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "messages": [
+            {
+              "key": "form526.submit.establishClaim.serviceError",
+              "text": "Benefit Type, Payee code or EP Code is not valid.  Benefit Type must be CPD, Payee code must be 00, 10 - 29, 50, 60 or 70 - 78.",
+              "severity": "FATAL"
+            }
+          ]
+        }
+    http_version:
+  recorded_at: Mon, 02 Apr 2018 22:46:34 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
EVSS has confirmed that, on a form526 submission, if an `EP Code is not valid` service error is raised we should not be retrying them because no amount waiting will allow the submission to go through successfully. Currently all upstream service errors force the submission job to retry until timeout or success so this case needs to have an exception in the logic.

## Testing done
<!-- Please describe testing done to verify the changes. -->
spec tests.

## Testing planned
<!-- Please describe testing planned. -->
Attempt on staging... but hard to reproduce.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Create a non-retry exception for `EP is not valid` error

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
