### PR TITLE
18719 undefined method dig error

### DIFF
--- a/lib/evss/letters/service.rb
+++ b/lib/evss/letters/service.rb
@@ -50,9 +50,12 @@ module EVSS
 
       def handle_error(error)
         if error.is_a?(Common::Client::Errors::ClientError) && error.status != 403 && error.body.is_a?(Hash)
-          log_edipi if invalid_address_error?(e)
-          save_error_details(error)
-          raise EVSS::Letters::ServiceException, error.body
+          begin
+            log_edipi if invalid_address_error?(error)
+          ensure
+            save_error_details(error)
+            raise EVSS::Letters::ServiceException, error.body
+          end
         else
           super(error)
         end

--- a/lib/evss/letters/service.rb
+++ b/lib/evss/letters/service.rb
@@ -30,11 +30,7 @@ module EVSS
           EVSS::Letters::LettersResponse.new(raw_response.status, raw_response)
         end
       rescue StandardError => e
-        begin
-          log_edipi if invalid_address_error?(e)
-        ensure
-          handle_error(e)
-        end
+        handle_error(e)
       end
 
       ##
@@ -54,6 +50,7 @@ module EVSS
 
       def handle_error(error)
         if error.is_a?(Common::Client::Errors::ClientError) && error.status != 403 && error.body.is_a?(Hash)
+          log_edipi if invalid_address_error?(e)
           save_error_details(error)
           raise EVSS::Letters::ServiceException, error.body
         else
@@ -66,8 +63,7 @@ module EVSS
       end
 
       def invalid_address_error?(error)
-        return false unless error.is_a?(Common::Client::Errors::ClientError)
-        error&.body&.dig('messages')&.any? { |m| m['key'].include? INVALID_ADDRESS_ERROR }
+        error.body.dig('messages')&.any? { |m| m['key'].include? INVALID_ADDRESS_ERROR }
       end
     end
   end

--- a/spec/lib/evss/letters/service_spec.rb
+++ b/spec/lib/evss/letters/service_spec.rb
@@ -39,6 +39,16 @@ describe EVSS::Letters::Service do
           expect { subject.get_letters }.to raise_error(Common::Exceptions::GatewayTimeout)
         end
       end
+
+      context 'with an unknown error from EVSS' do
+        it 'raises a BackendServiceException' do
+          VCR.use_cassette('evss/letters/letters_unexpected_error') do
+            expect { subject.get_letters }.to raise_error(Common::Exceptions::BackendServiceException) do |e|
+              expect(e.message).to match(/EVSS502/)
+            end
+          end
+        end
+      end
     end
 
     describe '#get_letter_beneficiary' do

--- a/spec/support/vcr_cassettes/evss/letters/letters_unexpected_error.yml
+++ b/spec/support/vcr_cassettes/evss/letters/letters_unexpected_error.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<EVSS_BASE_URL>/wss-lettergenerator-services-web/rest/letters/v1"
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 07 Jun 2017 23:26:33 GMT
+      Va-Eauth-Csid:
+      - DSLogon
+      Va-Eauth-Authenticationmethod:
+      - DSLogon
+      Va-Eauth-Pnidtype:
+      - SSN
+      Va-Eauth-Assurancelevel:
+      - '3'
+      Va-Eauth-Firstname:
+      - abraham
+      Va-Eauth-Lastname:
+      - lincoln
+      Va-Eauth-Issueinstant:
+      - '2017-06-07T23:26:32Z'
+      Va-Eauth-Dodedipnid:
+      - '9294277224'
+      Va-Eauth-Pid:
+      - '9624259154'
+      Va-Eauth-Pnid:
+      - '272111863'
+      Va-Eauth-Authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"272111863","edi":"9294277224","firstName":"abraham","lastName":"lincoln"}}'
+  response:
+    status:
+      code: 500
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Jun 2017 23:26:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips
+      Content-Type:
+      - application/json
+      Set-Cookie:
+      - WLS_12.1_App1_Cluster_ROUTEID=.01; path=/
+      - WSS-LETTERGENERATION-SERVICES_JSESSIONID=ElGE4ZCAHEgV9sh_vzBiao0YKz3kjCwBueiB-kkmRy-pByPjBon2!1080345149;
+        path=/; HttpOnly
+      Via:
+      - 1.1 csraciapp6.evss.srarad.com
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: 'the server responded with status 500'
+    http_version:
+  recorded_at: Wed, 07 Jun 2017 23:26:33 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Sentry has been logging issues for when theres a `get_letters` request to EVSS. Some service errors returned are coming back as string and not json bodies. Normally, we would handle this as a default BackendServiceException but there is a `dig` method call being made on the error body that is a string causing cascading failures. This has been refactored to avoid this problem in the future.

## Testing done
<!-- Please describe testing done to verify the changes. -->
spec tests

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Move the `log_edipi` logic into the `handle_error` functionality (since it does the same checks anyways, including a check that makes sure the var is a Hash).

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
