### PR TITLE
Change internal only to false for v0.0.1 meta data

### DIFF
--- a/modules/va_facilities/app/controllers/va_facilities/metadata_controller.rb
+++ b/modules/va_facilities/app/controllers/va_facilities/metadata_controller.rb
@@ -17,7 +17,7 @@ module VaFacilities
             },
             {
               version: '0.0.1',
-              internal_only: true,
+              internal_only: false,
               status: VERSION_STATUS[:current],
               path: '/services/va_facilities/docs/v0/api',
               healthcheck: '/services/va_facilities/v0/healthcheck'


### PR DESCRIPTION
## Description of change
Removing internal only from the metadata controller for va facilities so the developer portal does not append the `internal only` label.  More info: https://github.com/department-of-veterans-affairs/vets-contrib/issues/2555

## Testing done
Manually checked the response from the metadata controller and ran the rspec files

## Acceptance Criteria (Definition of Done)
* `Internal Only` is removed from the VA facilities developer portal

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
