### PR TITLE
Art.revert v1 errors

### DIFF
--- a/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
@@ -34,8 +34,6 @@ module VBADocuments
 
         if submission.nil? || submission.status == 'expired'
           raise Common::Exceptions::RecordNotFound, params[:id]
-        elsif submission.status == 'error'
-          render json: to_json_api_errors(submission)
         else
           submission.refresh_status!
           render json: submission,
@@ -60,17 +58,6 @@ module VBADocuments
 
       def verify_settings
         render plain: 'Not found', status: 404 unless Settings.vba_documents.enable_download_endpoint
-      end
-
-      def to_json_api_errors(submission)
-        {
-          "errors": [
-            {
-              "status": '422',
-              "details": "#{submission.code} - #{submission.detail}"
-            }
-          ]
-        }
       end
     end
   end

--- a/modules/vba_documents/spec/factories/upload_submissions.rb
+++ b/modules/vba_documents/spec/factories/upload_submissions.rb
@@ -10,5 +10,11 @@ FactoryBot.define do
     trait :status_uploaded do
       status 'uploaded'
     end
+
+    trait :status_error do
+      status 'error'
+      code 'DOC104'
+      detail 'Upload rejected'
+    end
   end
 end

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
 
       it 'should return json api errors' do
         get "/services/vba_documents/v1/uploads/#{error_upload.guid}"
-        expect(JSON.parse(response.body)['errors'].length).to eq(1)
+        expect(JSON.parse(response.body)['data']['attributes']['status']).to eq('error')
       end
     end
 

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -82,6 +82,15 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
       end
     end
 
+    context 'with error status' do
+      let!(:error_upload) { FactoryBot.create(:upload_submission, :status_error) }
+
+      it 'should return json api errors' do
+        get "/services/vba_documents/v1/uploads/#{error_upload.guid}"
+        expect(JSON.parse(response.body)['errors'].length).to eq(1)
+      end
+    end
+
     it 'should allow updating of the status' do
       with_settings(
         Settings.vba_documents,


### PR DESCRIPTION
## Description of change
We came to the conclusion that we wanted to revert the way we handle errors back to the v0 style 

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/2641

## Testing done
- rspec

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable (happening in another pr)
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
