### PR TITLE
Add DRAFT to the summary for all unavailable Facilities v1 endpoints

### DIFF
--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -423,7 +423,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: "AVAILABLE: Query facilities based on drive time from a specified location"
+      summary: Query facilities based on drive time from a specified location
       description: |
         Retrieve all facilities contained within an isochrone (a polygon composed of the area 
         reachable in a certain amount of time from a central location) based on the passed 

--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -70,7 +70,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: Query facilities based on a geographic bounding box and optional attribute filters
+      summary: DRAFT: Query facilities based on a geographic bounding box and optional attribute filters
       description: |
         *This is a draft specification and not an available endpoint.*
         
@@ -293,7 +293,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: Retrieve a specific facility by ID
+      summary: DRAFT: Retrieve a specific facility by ID
       description: |
         *This is a draft specification and not an available endpoint.*
       operationId: getFacilityById
@@ -356,7 +356,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: Bulk download of all available facilities
+      summary: DRAFT: Bulk download of all available facilities
       description: |
         *This is a draft specification and not an available endpoint.*
 
@@ -423,7 +423,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: Query facilities based on drive time from a specified location
+      summary: AVAILABLE: Query facilities based on drive time from a specified location
       description: |
         Retrieve all facilities contained within an isochrone (a polygon composed of the area 
         reachable in a certain amount of time from a central location) based on the passed 
@@ -593,7 +593,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: Retrieve polygons of the drive time bands for facilities
+      summary: DRAFT: Retrieve polygons of the drive time bands for facilities
       description: |
         *This is a draft specification and not an available endpoint.*
         
@@ -706,7 +706,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: Retrieve polygons of the drive time bands for a facility by ID
+      summary: DRAFT: Retrieve polygons of the drive time bands for a facility by ID
       description: |
         *This is a draft specification and not an available endpoint.*
         
@@ -780,7 +780,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: Bulk download of all available facilities
+      summary: DRAFT: Bulk download of all available facilities
       description: |
         *This is a draft specification and not an available endpoint.*
         

--- a/modules/va_facilities/README.v1.yml
+++ b/modules/va_facilities/README.v1.yml
@@ -70,7 +70,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: DRAFT: Query facilities based on a geographic bounding box and optional attribute filters
+      summary: "DRAFT: Query facilities based on a geographic bounding box and optional attribute filters"
       description: |
         *This is a draft specification and not an available endpoint.*
         
@@ -293,7 +293,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: DRAFT: Retrieve a specific facility by ID
+      summary: "DRAFT: Retrieve a specific facility by ID"
       description: |
         *This is a draft specification and not an available endpoint.*
       operationId: getFacilityById
@@ -356,7 +356,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: DRAFT: Bulk download of all available facilities
+      summary: "DRAFT: Bulk download of all available facilities"
       description: |
         *This is a draft specification and not an available endpoint.*
 
@@ -423,7 +423,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: AVAILABLE: Query facilities based on drive time from a specified location
+      summary: "AVAILABLE: Query facilities based on drive time from a specified location"
       description: |
         Retrieve all facilities contained within an isochrone (a polygon composed of the area 
         reachable in a certain amount of time from a central location) based on the passed 
@@ -593,7 +593,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: DRAFT: Retrieve polygons of the drive time bands for facilities
+      summary: "DRAFT: Retrieve polygons of the drive time bands for facilities"
       description: |
         *This is a draft specification and not an available endpoint.*
         
@@ -706,7 +706,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: DRAFT: Retrieve polygons of the drive time bands for a facility by ID
+      summary: "DRAFT: Retrieve polygons of the drive time bands for a facility by ID"
       description: |
         *This is a draft specification and not an available endpoint.*
         
@@ -780,7 +780,7 @@ paths:
     get:
       tags:
         - facilities
-      summary: DRAFT: Bulk download of all available facilities
+      summary: "DRAFT: Bulk download of all available facilities"
       description: |
         *This is a draft specification and not an available endpoint.*
         


### PR DESCRIPTION
## Description of change
Fixes https://github.com/department-of-veterans-affairs/vets-contrib/issues/2662

This PR updates the `summary` fields for the Facilities v1 docs, to indicate that they are unavailable and in `DRAFT` status. This should make this distinction more prominent on the developer portal, and save the user from having to expand each one in order to view the status.

## Testing done
None (yet)

## Testing planned
@rtravitz Is it possible to see what these changes would look like on the developer portal before merging? Just want to be sure there won't be any weird text overflow issues.

## Acceptance Criteria (Definition of Done)
- [x] `DRAFT` added to all unavailable endpoints (all but `/nearby`)

#### Unique to this PR
None

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
