### PR TITLE
VBADocuments Payload Download Improving

### DIFF
--- a/modules/vba_documents/spec/request/v0/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v0/uploads_request_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
     let(:upload) { FactoryBot.create(:upload_submission) }
     let(:valid_doc) { get_fixture('valid_doc.pdf') }
     let(:valid_metadata) { get_fixture('valid_metadata.json').read }
+    let(:invalid_doc) { get_fixture('invalid_multipart_no_partname.blob') }
 
     let(:valid_parts) do
       { 'metadata' => valid_metadata,
@@ -124,6 +125,13 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
       allow(version).to receive(:last_modified).and_return(DateTime.now.utc)
       allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
 
+      get "/services/vba_documents/v0/uploads/#{upload.guid}/download"
+      expect(response.status).to eq(200)
+      expect(response.headers['Content-Type']).to eq('application/zip')
+    end
+
+    it 'should 200 even with an invalid doc' do
+      allow(VBADocuments::PayloadManager).to receive(:download_raw_file).and_return(invalid_doc)
       get "/services/vba_documents/v0/uploads/#{upload.guid}/download"
       expect(response.status).to eq(200)
       expect(response.headers['Content-Type']).to eq('application/zip')

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -139,6 +139,13 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
       expect(response.status).to eq(200)
       expect(response.headers['Content-Type']).to eq('application/zip')
     end
+
+    it 'should 200 even with an invalid doc' do
+      allow(VBADocuments::PayloadManager).to receive(:download_raw_file).and_return(invalid_doc)
+      get "/services/vba_documents/v0/uploads/#{upload.guid}/download"
+      expect(response.status).to eq(200)
+      expect(response.headers['Content-Type']).to eq('application/zip')
+    end
     # rubocop:enable Style/DateTime
   end
 end

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
     let(:upload) { FactoryBot.create(:upload_submission) }
     let(:valid_doc) { get_fixture('valid_doc.pdf') }
     let(:valid_metadata) { get_fixture('valid_metadata.json').read }
+    let(:invalid_doc) { get_fixture('invalid_multipart_no_partname.blob') }
 
     let(:valid_parts) do
       { 'metadata' => valid_metadata,


### PR DESCRIPTION
## Description of change
This will allow us to fall back to sending a download of the entire payload rather than erroring out. 

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/2677

## Testing done
- rspec

## Testing planned
- dev call

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
