### PR TITLE
Change mvi log level from error to info

### DIFF
--- a/lib/mvi/service.rb
+++ b/lib/mvi/service.rb
@@ -51,10 +51,10 @@ module MVI
       end
     rescue Breakers::OutageException => e
       Raven.extra_context(breakers_error_message: e.message)
-      log_console_and_sentry('MVI find_profile connection failed.', :info)
+      log_console_and_sentry('MVI find_profile connection failed.', :warn)
       mvi_profile_exception_response_for('MVI_503', e)
     rescue Faraday::ConnectionFailed => e
-      log_console_and_sentry("MVI find_profile connection failed: #{e.message}", :info)
+      log_console_and_sentry("MVI find_profile connection failed: #{e.message}", :warn)
       mvi_profile_exception_response_for('MVI_504', e)
     rescue Common::Client::Errors::ClientError, Common::Exceptions::GatewayTimeout => e
       log_console_and_sentry("MVI find_profile error: #{e.message}", :error)

--- a/lib/mvi/service.rb
+++ b/lib/mvi/service.rb
@@ -51,10 +51,10 @@ module MVI
       end
     rescue Breakers::OutageException => e
       Raven.extra_context(breakers_error_message: e.message)
-      log_console_and_sentry('MVI find_profile connection failed.', :error)
+      log_console_and_sentry('MVI find_profile connection failed.', :info)
       mvi_profile_exception_response_for('MVI_503', e)
     rescue Faraday::ConnectionFailed => e
-      log_console_and_sentry("MVI find_profile connection failed: #{e.message}", :error)
+      log_console_and_sentry("MVI find_profile connection failed: #{e.message}", :info)
       mvi_profile_exception_response_for('MVI_504', e)
     rescue Common::Client::Errors::ClientError, Common::Exceptions::GatewayTimeout => e
       log_console_and_sentry("MVI find_profile error: #{e.message}", :error)


### PR DESCRIPTION
## Description of change
### Context
https://github.com/department-of-veterans-affairs/va.gov-team/issues/271
In an effort to make our Sentry Alerting less noisy, we've decided to change the logging levels of connection problems to backend services from `ERROR` to `INFO`.

### Description
This changes two places where we log MVI connection problems as `ERROR` to `INFO`. [Sentry Alerted us](https://dsva.slack.com/archives/CJTDG22NM/p1563082714001000) of [`MVI find_profile connection failed.`](http://sentry.vfs.va.gov/vets-gov/platform-api-production/issues/46783)

## Testing done
Local rspecs.

## Testing planned
None.

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
