### PR TITLE
Validation Bug VBADocuments

### DIFF
--- a/modules/vba_documents/lib/vba_documents/multipart_parser.rb
+++ b/modules/vba_documents/lib/vba_documents/multipart_parser.rb
@@ -8,8 +8,8 @@ module VBADocuments
     LINE_BREAK = "\r\n"
 
     def self.parse(infile)
-      validate_size(infile)
       File.open(infile, 'rb') do |input|
+        validate_size(input)
         lines = input.each_line(LINE_BREAK).lazy.each_with_index
 
         parts = {}


### PR DESCRIPTION


## Description of change
Apparently this could be called with an object or path
Tests yielded false postivie because it was being called with a file
object.
In code we always pass path, which 'filepath'.size.positive? Is
basically always true

## Testing done
- rspec / local

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
