### PR TITLE
VBADocuments Submission Status Caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,6 @@ gem 'savon'
 gem 'sentry-raven', '2.9.0' # don't change gem version unless sentry server is also upgraded
 gem 'shrine'
 gem 'sidekiq-instrument'
-gem 'sidekiq-unique-jobs'
 gem 'staccato'
 gem 'statsd-instrument'
 gem 'swagger-blocks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -572,9 +572,6 @@ GEM
       rufus-scheduler (~> 3.2)
       sidekiq (>= 3)
       tilt (>= 1.4.0)
-    sidekiq-unique-jobs (5.0.10)
-      sidekiq (>= 4.0, <= 6.0)
-      thor (~> 0)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -750,7 +747,6 @@ DEPENDENCIES
   sidekiq-instrument
   sidekiq-pro!
   sidekiq-scheduler (~> 2.0)
-  sidekiq-unique-jobs
   simplecov
   socksify
   spring

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -109,6 +109,11 @@ VBADocuments::UploadRemover:
   class: VBADocuments::UploadRemover
   description: "Clean up submitted documents from S3"
 
+VBADocuments::UploadStatusUpdater:
+  every: "60m"
+  class: VBADocuments::UploadStatusUpdater
+  description: "Cache Statuses for VBA Documents"
+
 TransactionalEmailAnalyticsJob:
   cron: "0 1 * * * America/New_York"
   description: "posts Transactional email (HCA Failure and Direct Deposit Update) sends and failures to Google Analytics"

--- a/modules/vba_documents/app/controllers/vba_documents/v0/reports_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v0/reports_controller.rb
@@ -12,7 +12,7 @@ module VBADocuments
       ID_PARAM = 'ids'
 
       def create
-        statuses = VBADocuments::UploadSubmission.refresh_and_get_statuses!(params[ID_PARAM])
+        statuses = VBADocuments::UploadSubmission.where(guid: params[ID_PARAM])
         render json: with_spoofed(statuses),
                each_serializer: VBADocuments::UploadSerializer
       end

--- a/modules/vba_documents/app/controllers/vba_documents/v0/reports_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v0/reports_controller.rb
@@ -8,6 +8,7 @@ module VBADocuments
       skip_before_action(:authenticate)
       before_action :validate_params
 
+      MAX_REPORT_SIZE = 1000
       ID_PARAM = 'ids'
 
       def create
@@ -21,6 +22,8 @@ module VBADocuments
       def validate_params
         raise Common::Exceptions::ParameterMissing, ID_PARAM if params[ID_PARAM].nil?
         raise Common::Exceptions::InvalidFieldValue.new(ID_PARAM, params[ID_PARAM]) unless params[ID_PARAM].is_a?(Array)
+        raise Common::Exceptions::InvalidFieldValue.new(ID_PARAM, params[ID_PARAM]) if
+          params[ID_PARAM].size > MAX_REPORT_SIZE
       end
     end
   end

--- a/modules/vba_documents/app/controllers/vba_documents/v0/reports_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v0/reports_controller.rb
@@ -22,7 +22,7 @@ module VBADocuments
       def with_spoofed(statuses)
         guids = statuses.map(&:guid)
         missing = params[ID_PARAM] - guids
-        statuses.to_a + missing.map { |id| VBADocuments.fake_status(id) }
+        statuses.to_a + missing.map { |id| VBADocuments::UploadSubmission.fake_status(id) }
       end
 
       def validate_params

--- a/modules/vba_documents/app/controllers/vba_documents/v0/reports_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v0/reports_controller.rb
@@ -8,11 +8,10 @@ module VBADocuments
       skip_before_action(:authenticate)
       before_action :validate_params
 
-      MAX_REPORT_SIZE = 100
       ID_PARAM = 'ids'
 
       def create
-        statuses = VBADocuments::UploadSubmission.refresh_and_get_statuses!(params[ID_PARAM])
+        statuses = VBADocuments::UploadSubmission.where(guid: params[ID_PARAM])
         render json: statuses,
                each_serializer: VBADocuments::UploadSerializer
       end
@@ -22,8 +21,6 @@ module VBADocuments
       def validate_params
         raise Common::Exceptions::ParameterMissing, ID_PARAM if params[ID_PARAM].nil?
         raise Common::Exceptions::InvalidFieldValue.new(ID_PARAM, params[ID_PARAM]) unless params[ID_PARAM].is_a?(Array)
-        raise Common::Exceptions::InvalidFieldValue.new(ID_PARAM, params[ID_PARAM]) if
-          params[ID_PARAM].size > MAX_REPORT_SIZE
       end
     end
   end

--- a/modules/vba_documents/app/controllers/vba_documents/v0/reports_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v0/reports_controller.rb
@@ -12,12 +12,18 @@ module VBADocuments
       ID_PARAM = 'ids'
 
       def create
-        statuses = VBADocuments::UploadSubmission.where(guid: params[ID_PARAM])
-        render json: statuses,
+        statuses = VBADocuments::UploadSubmission.refresh_and_get_statuses!(params[ID_PARAM])
+        render json: with_spoofed(statuses),
                each_serializer: VBADocuments::UploadSerializer
       end
 
       private
+
+      def with_spoofed(statuses)
+        guids = statuses.map(&:guid)
+        missing = params[ID_PARAM] - guids
+        statuses.to_a + missing.map { |id| VBADocuments.fake_status(id) }
+      end
 
       def validate_params
         raise Common::Exceptions::ParameterMissing, ID_PARAM if params[ID_PARAM].nil?

--- a/modules/vba_documents/app/controllers/vba_documents/v1/reports_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v1/reports_controller.rb
@@ -8,11 +8,10 @@ module VBADocuments
       skip_before_action(:authenticate)
       before_action :validate_params
 
-      MAX_REPORT_SIZE = 100
       ID_PARAM = 'ids'
 
       def create
-        statuses = VBADocuments::UploadSubmission.refresh_and_get_statuses!(params[ID_PARAM])
+        statuses = VBADocuments::UploadSubmission.where(guid: params[ID_PARAM])
         render json: statuses,
                each_serializer: VBADocuments::V1::UploadSerializer
       end
@@ -22,8 +21,6 @@ module VBADocuments
       def validate_params
         raise Common::Exceptions::ParameterMissing, ID_PARAM if params[ID_PARAM].nil?
         raise Common::Exceptions::InvalidFieldValue.new(ID_PARAM, params[ID_PARAM]) unless params[ID_PARAM].is_a?(Array)
-        raise Common::Exceptions::InvalidFieldValue.new(ID_PARAM, params[ID_PARAM]) if
-          params[ID_PARAM].size > MAX_REPORT_SIZE
       end
     end
   end

--- a/modules/vba_documents/app/controllers/vba_documents/v1/reports_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v1/reports_controller.rb
@@ -8,6 +8,7 @@ module VBADocuments
       skip_before_action(:authenticate)
       before_action :validate_params
 
+      MAX_REPORT_SIZE = 1000
       ID_PARAM = 'ids'
 
       def create
@@ -21,6 +22,8 @@ module VBADocuments
       def validate_params
         raise Common::Exceptions::ParameterMissing, ID_PARAM if params[ID_PARAM].nil?
         raise Common::Exceptions::InvalidFieldValue.new(ID_PARAM, params[ID_PARAM]) unless params[ID_PARAM].is_a?(Array)
+        raise Common::Exceptions::InvalidFieldValue.new(ID_PARAM, params[ID_PARAM]) if
+          params[ID_PARAM].size > MAX_REPORT_SIZE
       end
     end
   end

--- a/modules/vba_documents/app/controllers/vba_documents/v1/reports_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v1/reports_controller.rb
@@ -12,7 +12,7 @@ module VBADocuments
       ID_PARAM = 'ids'
 
       def create
-        statuses = VBADocuments::UploadSubmission.refresh_and_get_statuses!(params[ID_PARAM])
+        statuses = VBADocuments::UploadSubmission.where(guid: params[ID_PARAM])
         render json: with_spoofed(statuses),
                each_serializer: VBADocuments::V1::UploadSerializer
       end
@@ -22,7 +22,7 @@ module VBADocuments
       def with_spoofed(statuses)
         guids = statuses.map(&:guid)
         missing = params[ID_PARAM] - guids
-        statuses.to_a + missing.map { |id| VBADocuments.fake_status(id) }
+        statuses.to_a + missing.map { |id| VBADocuments::UploadSubmission.fake_status(id) }
       end
 
       def validate_params

--- a/modules/vba_documents/app/controllers/vba_documents/v1/reports_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v1/reports_controller.rb
@@ -12,12 +12,18 @@ module VBADocuments
       ID_PARAM = 'ids'
 
       def create
-        statuses = VBADocuments::UploadSubmission.where(guid: params[ID_PARAM])
-        render json: statuses,
+        statuses = VBADocuments::UploadSubmission.refresh_and_get_statuses!(params[ID_PARAM])
+        render json: with_spoofed(statuses),
                each_serializer: VBADocuments::V1::UploadSerializer
       end
 
       private
+
+      def with_spoofed(statuses)
+        guids = statuses.map(&:guid)
+        missing = params[ID_PARAM] - guids
+        statuses.to_a + missing.map { |id| VBADocuments.fake_status(id) }
+      end
 
       def validate_params
         raise Common::Exceptions::ParameterMissing, ID_PARAM if params[ID_PARAM].nil?

--- a/modules/vba_documents/app/models/vba_documents/upload_submission.rb
+++ b/modules/vba_documents/app/models/vba_documents/upload_submission.rb
@@ -9,6 +9,8 @@ module VBADocuments
 
     IN_FLIGHT_STATUSES = %w[received processing success].freeze
 
+    scope :in_flight, -> { where(status: IN_FLIGHT_STATUSES) }
+
     after_save :report_errors
 
     def self.refresh_and_get_statuses!(guids)

--- a/modules/vba_documents/app/models/vba_documents/upload_submission.rb
+++ b/modules/vba_documents/app/models/vba_documents/upload_submission.rb
@@ -13,14 +13,6 @@ module VBADocuments
 
     after_save :report_errors
 
-    def self.refresh_and_get_statuses!(guids)
-      submissions = where(guid: guids)
-      in_flights = submissions.select { |sub| sub.send(:status_in_flight?) }
-      refresh_statuses!(in_flights)
-      missing = guids - submissions.map(&:guid)
-      submissions.to_a + missing.map { |id| fake_status(id) }
-    end
-
     def self.fake_status(guid)
       empty_submission = OpenStruct.new(guid: guid,
                                         status: 'error',

--- a/modules/vba_documents/app/serializers/vba_documents/upload_serializer.rb
+++ b/modules/vba_documents/app/serializers/vba_documents/upload_serializer.rb
@@ -6,7 +6,7 @@ module VBADocuments
   class UploadSerializer < ActiveModel::Serializer
     type 'document_upload'
 
-    attributes :guid, :status, :code, :detail, :location
+    attributes :guid, :status, :code, :detail, :location, :updated_at
 
     def id
       object.guid

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/status_attributes_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/status_attributes_swagger.rb
@@ -34,6 +34,13 @@ module VbaDocuments
           key :description, 'Human readable error detail. Only present if status = "error"'
           key :type, :string
         end
+
+        property :updated_at do
+          key :description, 'The last time the submission was updated'
+          key :type, :string
+          key :format, 'date-time'
+          key :example, '2018-07-30T17:31:15.958Z'
+        end
       end
     end
   end

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/v1/status_attributes_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/v1/status_attributes_swagger.rb
@@ -35,6 +35,13 @@ module VbaDocuments
             key :description, 'Human readable error detail. Only present if status = "error"'
             key :type, :string
           end
+
+          property :updated_at do
+            key :description, 'The last time the submission was updated'
+            key :type, :string
+            key :format, 'date-time'
+            key :example, '2018-07-30T17:31:15.958Z'
+          end
         end
       end
     end

--- a/modules/vba_documents/app/swagger/vba_documents/v0/description.md
+++ b/modules/vba_documents/app/swagger/vba_documents/v0/description.md
@@ -43,6 +43,13 @@ Allows a client to upload a document package (form + attachments + metadata).
     submitted payload. This can be compared to the submitted payload to ensure data
     integrity of the upload
 
+### Document Status Caching
+Due to current system limitations, data for the `/uploads/report` endpoint is cached for one hour.
+
+A request to the `/uploads/{id}` endpoint will return a real-time status for that GUID, and update its status in `/uploads/report`.
+
+The `updated_at` field indicates the last time the status for a given GUID was updated.
+
 ### Status Simulation
 Given the downstream connections of this API, we allow (**IN DEVELOPER ENVIRONMENT ONLY**) passing in a header `Status-Override` on the `/uploads/{id}` endpoint that will allow you to change the status of your submission to simulate the various scenarios. The available statuses are `pending`, `uploaded`, `received`, `processing`, `success`, `error`.
 

--- a/modules/vba_documents/app/swagger/vba_documents/v0/description.md
+++ b/modules/vba_documents/app/swagger/vba_documents/v0/description.md
@@ -1,24 +1,33 @@
-Veterans Benefits Administration (VBA) document uploads.
+# Benefits Intake API
+The Benefits Intake API allows authorized third-party systems used by Veteran Service Organizations and agencies to digitally submit claim documents directly to the Veterans Benefits Administration's (VBA) claims intake process.
 
-## Background
+This API provides a secure and efficient alternative to paper or fax document submissions. VBA can begin processing documents submitted through this API immediately, which ultimately allows VA to provide Veterans with claim decisions more quickly.
 
-The Veterans Affairs’ Benefits Intake API allows for the submission of forms and documents to VA for eventual processing by the Veteran Benefits Administration.
+It also saves users time by reporting documents' status until they reach Veterans Benefits Management System (VBMS), where the documents are reviewed. This eliminates the need for users to switch between systems to manually check whether documents have reached VBMS.
 
-Organizations external to the VA can these submit forms and supporting documentation on behalf of Veterans in PDF format and subsequently check the status of their submission to ensure acceptance and processing in the VA system of record for these forms. The process described below is specific to the Benefits Intake API and will be updated (with portions automated) for future APIs as VA iterates on this process.
+## Technical Summary
+The Benefits Intake API accepts a payload consisting of a document in PDF format, zero or more optional attachments in PDF format, and some JSON metadata. The metadata describes the document and attachments, and identifies the person for whom it is being submitted. This payload is encoded as multipart/form-data. A unique identifier supplied with the payload can subsequently be used to request the processing status of the uploaded document package.
 
-The Document Upload API passes data through to ICMHS aka Benefits Intake API. Benefits Intake API accepts a payload consisting of a document in PDF format, zero or more optional attachments in PDF format, and some JSON metadata. The metadata describes the document, attachments, and identifies the person that the document relates to. This payload is encoded as multipart/form-data. A unique identifier supplied with the payload can be used to subsequently request the processing status of the uploaded document package.
+API consumers are encouraged to validate the `zipcode` and `fileNumber` fields before submission according to their description in the DocumentUploadMetadata model.
 
-API consumers are encouraged to validate the zipCode and fileNumber fields before submission according to their description in the DocumentUploadMetadata model.
 
 ## Design
+### Attachment & File Size Limits
+There is not a limit on the number of documents that can be submitted at once, but file sizes can impact the number of documents accepted.
+
+The file size limit for each document is 100 MB. The entire package, which is all documents combined into one file, is limited to 5 GB.
+
+### Date of Receipt
+The date and time documents are submitted to the Benefits Intake API is used as the official VA date of receipt. However, note that until a document status of `received`, `processing`, `success`, or `vbms` is returned, a client cannot consider the document received by VA.
+
+A status of `received` means that the document package has been transmitted, but possibly not validated. Any errors with the document package (unreadable PDF, etc) may cause the status to change to `error`.
+
+If the document status is `error`, VA has not received the submission and cannot honor the submission date as the date of receipt.
 
 ### Authorization
-
-API requests are authorized by means of a symmetric API token, provided in an HTTP header
-with name "apikey".
+API requests are authorized by means of a symmetric API token, provided in an HTTP header with name `apikey`.
 
 ### Upload Operation
-
 Allows a client to upload a document package (form + attachments + metadata).
 
 1. Client Request: POST https://dev-api.va.gov/services/vba_documents/v0/
@@ -26,33 +35,24 @@ Allows a client to upload a document package (form + attachments + metadata).
 
 2. Service Response: A JSON API object with the following attributes:
     * `guid`: An identifier used for subsequent status requests
-    * `location`: A URL to which the actual document package payload can be submitted
-      in the next step. The URL is specific to this upload request and should not be
-      re-used for subsequent uploads. The URL is valid for 900 seconds (15 minutes)
-      from the time of this response. Once expired, status checks on the GUID will return a status of expired.
+    * `location`: A URL to which the actual document package payload can be submitted in the next step. The URL is specific to this upload request, and should not be re-used for subsequent uploads. The URL is valid for 900 seconds (15 minutes) from the time of this response. If the location is not used within 15 minutes, the GUID will expire. Once expired, status checks on the GUID will return a status of `error`, with a code and message indicating expiration.
 
-3. Client Request: PUT to the location URL returned in Step 2.
-    * Request body should be encoded as multipart/form-data, equivalent to that
-      generated by an HTML form submission or using “curl -F…”. The format is
-      described in more detail below.
-    * No `apikey` authorization header is required for this request, as authorization is
-      embedded in the signed location URL.
+ 3. Client Request: PUT to the location URL returned in Step 2.
+    * Request body should be encoded as multipart/form-data, equivalent to that generated by an HTML form submission or using “curl -F…”. The format is described in more detail below.
+    * No `apikey` authorization header is required for this request, as authorization is embedded in the signed location URL.
 
 4. Service Response: The HTTP status indicates whether the upload was successful.
-    Additionally, the response includes an ETag header containing an MD5 hash of the
-    submitted payload. This can be compared to the submitted payload to ensure data
-    integrity of the upload
+    * Additionally, the response includes an ETag header containing an MD5 hash of the submitted payload. This can be compared to the submitted payload to ensure data integrity of the upload.
 
-### Document Status Caching
+### Status Simulation
+Given the downstream connections of this API, we allow **(IN DEVELOPER ENVIRONMENT ONLY)** passing in a header `Status-Override` on the `/uploads/{id}` endpoint that will allow you to change the status of your submission to simulate the various scenarios. The available statuses are `pending`, `uploaded`, `received`, `processing`, `success`, `vbms`, and `error`. The meaning of the various statuses is listed below in Models under DocumentUploadStatusAttributes.
+
+### Status Caching
 Due to current system limitations, data for the `/uploads/report` endpoint is cached for one hour.
 
 A request to the `/uploads/{id}` endpoint will return a real-time status for that GUID, and update its status in `/uploads/report`.
 
 The `updated_at` field indicates the last time the status for a given GUID was updated.
 
-### Status Simulation
-Given the downstream connections of this API, we allow (**IN DEVELOPER ENVIRONMENT ONLY**) passing in a header `Status-Override` on the `/uploads/{id}` endpoint that will allow you to change the status of your submission to simulate the various scenarios. The available statuses are `pending`, `uploaded`, `received`, `processing`, `success`, `error`.
-
 ## Reference
-
-Raw Open API Spec: https://api.va.gov/services/vba_documents/docs/v0/api
+Raw Open API Spec: https://api.va.gov/services/vba_documents/docs/v1/api

--- a/modules/vba_documents/app/swagger/vba_documents/v1/description.md
+++ b/modules/vba_documents/app/swagger/vba_documents/v1/description.md
@@ -1,58 +1,57 @@
-Veterans Benefits Administration (VBA) document uploads.
+# Benefits Intake API
+The Benefits Intake API allows authorized third-party systems used by Veteran Service Organizations and agencies to digitally submit claim documents directly to the Veterans Benefits Administration's (VBA) claims intake process.
 
-## Background
+This API provides a secure and efficient alternative to paper or fax document submissions. VBA can begin processing documents submitted through this API immediately, which ultimately allows VA to provide Veterans with claim decisions more quickly.
 
-The Veterans Affairs’ Benefits Intake API allows for the submission of forms and documents to VA for eventual processing by the Veteran Benefits Administration.
 
-Organizations external to the VA can these submit forms and supporting documentation on behalf of Veterans in PDF format and subsequently check the status of their submission to ensure acceptance and processing in the VA system of record for these forms. The process described below is specific to the Benefits Intake API and will be updated (with portions automated) for future APIs as VA iterates on this process.
+## Technical Summary
+The Benefits Intake API accepts a payload consisting of a document in PDF format, zero or more optional attachments in PDF format, and some JSON metadata. The metadata describes the document and attachments, and identifies the person for whom it is being submitted. This payload is encoded as multipart/form-data. A unique identifier supplied with the payload can subsequently be used to request the processing status of the uploaded document package.
 
-The Document Upload API passes data through to ICMHS aka Benefits Intake API. Benefits Intake API accepts a payload consisting of a document in PDF format, zero or more optional attachments in PDF format, and some JSON metadata. The metadata describes the document, attachments, and identifies the person that the document relates to. This payload is encoded as multipart/form-data. A unique identifier supplied with the payload can be used to subsequently request the processing status of the uploaded document package.
+API consumers are encouraged to validate the `zipcode` and `fileNumber` fields before submission according to their description in the DocumentUploadMetadata model.
 
-API consumers are encouraged to validate the zipCode and fileNumber fields before submission according to their description in the DocumentUploadMetadata model.
 
 ## Design
+### Attachment & File Size Limits
+There is not a limit on the number of documents that can be submitted at once, but file sizes can impact the number of documents accepted.
+
+The file size limit for each document is 100 MB. The entire package, which is all documents combined into one file, is limited to 5 GB.
+
+### Date of Receipt
+The date and time documents are submitted to the Benefits Intake API is used as the official VA date of receipt. However, note that until a document status of `received`, `processing`, or `success` is returned, a client cannot consider the document received by VA.
+
+A status of `received` means that the document package has been transmitted, but possibly not validated. Any errors with the document package (unreadable PDF, etc) may cause the status to change to `error`.
+
+If the document status is `error`, VA has not received the submission and cannot honor the submission date as the date of receipt.
 
 ### Authorization
-
-API requests are authorized by means of a symmetric API token, provided in an HTTP header
-with name "apikey".
+API requests are authorized by means of a symmetric API token, provided in an HTTP header with name `apikey`.
 
 ### Upload Operation
-
 Allows a client to upload a document package (form + attachments + metadata).
 
-1. Client Request: POST https://dev-api.va.gov/services/vba_documents/v1/
+1. Client Request: POST https://dev-api.va.gov/services/vba_documents/v0/
     * No request body or parameters required
 
 2. Service Response: A JSON API object with the following attributes:
     * `guid`: An identifier used for subsequent status requests
-    * `location`: A URL to which the actual document package payload can be submitted
-      in the next step. The URL is specific to this upload request and should not be
-      re-used for subsequent uploads. The URL is valid for 900 seconds (15 minutes)
-      from the time of this response. Once expired, status checks on the GUID will return a status of expired.
+    * `location`: A URL to which the actual document package payload can be submitted in the next step. The URL is specific to this upload request, and should not be re-used for subsequent uploads. The URL is valid for 900 seconds (15 minutes) from the time of this response. If the location is not used within 15 minutes, the GUID will expire. Once expired, status checks on the GUID will return a status of `error`, with a code and message indicating expiration.
 
-3. Client Request: PUT to the location URL returned in Step 2.
-    * Request body should be encoded as multipart/form-data, equivalent to that
-      generated by an HTML form submission or using “curl -F…”. The format is
-      described in more detail below.
-    * No `apikey` authorization header is required for this request, as authorization is
-      embedded in the signed location URL.
+ 3. Client Request: PUT to the location URL returned in Step 2.
+    * Request body should be encoded as multipart/form-data, equivalent to that generated by an HTML form submission or using “curl -F…”. The format is described in more detail below.
+    * No `apikey` authorization header is required for this request, as authorization is embedded in the signed location URL.
 
 4. Service Response: The HTTP status indicates whether the upload was successful.
-    Additionally, the response includes an ETag header containing an MD5 hash of the
-    submitted payload. This can be compared to the submitted payload to ensure data
-    integrity of the upload
+    * Additionally, the response includes an ETag header containing an MD5 hash of the submitted payload. This can be compared to the submitted payload to ensure data integrity of the upload.
 
-### Document Status Caching
+### Status Simulation
+Given the downstream connections of this API, we allow **(IN DEVELOPER ENVIRONMENT ONLY)** passing in a header `Status-Override` on the `/uploads/{id}` endpoint that will allow you to change the status of your submission to simulate the various scenarios. The available statuses are `pending`, `uploaded`, `received`, `processing`, `success`, and `error`. The meaning of the various statuses is listed below in Models under DocumentUploadStatusAttributes.
+
+### Status Caching
 Due to current system limitations, data for the `/uploads/report` endpoint is cached for one hour.
 
 A request to the `/uploads/{id}` endpoint will return a real-time status for that GUID, and update its status in `/uploads/report`.
 
 The `updated_at` field indicates the last time the status for a given GUID was updated.
 
-### Status Simulation
-Given the downstream connections of this API, we allow (**IN DEVELOPER ENVIRONMENT ONLY**) passing in a header `Status-Override` on the `/uploads/{id}` endpoint that will allow you to change the status of your submission to simulate the various scenarios. The available statuses are `pending`, `uploaded`, `received`, `processing`, `success`, `vbms`, `error`.
-
 ## Reference
-
 Raw Open API Spec: https://api.va.gov/services/vba_documents/docs/v1/api

--- a/modules/vba_documents/app/swagger/vba_documents/v1/description.md
+++ b/modules/vba_documents/app/swagger/vba_documents/v1/description.md
@@ -43,6 +43,13 @@ Allows a client to upload a document package (form + attachments + metadata).
     submitted payload. This can be compared to the submitted payload to ensure data
     integrity of the upload
 
+### Document Status Caching
+Due to current system limitations, data for the `/uploads/report` endpoint is cached for one hour.
+
+A request to the `/uploads/{id}` endpoint will return a real-time status for that GUID, and update its status in `/uploads/report`.
+
+The `updated_at` field indicates the last time the status for a given GUID was updated.
+
 ### Status Simulation
 Given the downstream connections of this API, we allow (**IN DEVELOPER ENVIRONMENT ONLY**) passing in a header `Status-Override` on the `/uploads/{id}` endpoint that will allow you to change the status of your submission to simulate the various scenarios. The available statuses are `pending`, `uploaded`, `received`, `processing`, `success`, `vbms`, `error`.
 

--- a/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
@@ -6,20 +6,16 @@ module VBADocuments
   class UploadStatusUpdater
     include Sidekiq::Worker
 
-    sidekiq_options queue: 'vba_documents', retry: true
+    sidekiq_options(
+      queue: 'vba_documents',
+      retry: true,
+      unique_until: :success
+    )
 
     def perform
-      unless already_running?
-        VBADocuments::UploadSubmission.in_flight.order(created_at: :asc).find_in_batches(batch_size: 100).each do |batch|
-          VBADocuments::UploadSubmission.refresh_statuses!(batch)
-        end
+      VBADocuments::UploadSubmission.in_flight.order(created_at: :asc).find_in_batches(batch_size: 100).each do |batch|
+        VBADocuments::UploadSubmission.refresh_statuses!(batch)
       end
-    end
-
-    def already_running?
-      queue = Sidekiq::Queue.new('vba_documents')
-      job_classes = queue.map(&:klass)
-      job_classes.include? 'UploadStatusUpdater'
     end
   end
 end

--- a/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+
+module VBADocuments
+  class UploadStatusUpdater
+    include Sidekiq::Worker
+
+    sidekiq_options queue: 'vba_documents', retry: true
+
+    def perform
+      unless already_running?
+        VBADocuments::UploadSubmission.in_flight.order(created_at: :asc).find_in_batches(batch_size: 100).each do |batch|
+          VBADocuments::UploadSubmission.refresh_statuses!(batch)
+        end
+      end
+    end
+
+    def already_running?
+      queue = Sidekiq::Queue.new('vba_documents')
+      job_classes = queue.map{ |job| job.klass} 
+      job_classes.include? 'UploadStatusUpdater' 
+    end
+  end
+end

--- a/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
@@ -18,8 +18,8 @@ module VBADocuments
 
     def already_running?
       queue = Sidekiq::Queue.new('vba_documents')
-      job_classes = queue.map{ |job| job.klass} 
-      job_classes.include? 'UploadStatusUpdater' 
+      job_classes = queue.map(&:klass)
+      job_classes.include? 'UploadStatusUpdater'
     end
   end
 end

--- a/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
@@ -13,8 +13,10 @@ module VBADocuments
     )
 
     def perform
-      VBADocuments::UploadSubmission.in_flight.order(created_at: :asc).find_in_batches(batch_size: 100).each do |batch|
-        VBADocuments::UploadSubmission.refresh_statuses!(batch)
+      if Settings.vba_documents.updater_enabled
+        VBADocuments::UploadSubmission.in_flight.order(created_at: :asc).find_in_batches(batch_size: 100).each do |batch|
+          VBADocuments::UploadSubmission.refresh_statuses!(batch)
+        end
       end
     end
   end

--- a/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
@@ -14,7 +14,7 @@ module VBADocuments
 
     def perform
       if Settings.vba_documents.updater_enabled
-        VBADocuments::UploadSubmission.in_flight.order(created_at: :asc).find_in_batches(batch_size: 100).each do |batch|
+        VBADocuments::UploadSubmission.in_flight.order(created_at: :asc).find_in_batches(batch_size: 100) do |batch|
           VBADocuments::UploadSubmission.refresh_statuses!(batch)
         end
       end

--- a/modules/vba_documents/spec/factories/upload_submissions.rb
+++ b/modules/vba_documents/spec/factories/upload_submissions.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     consumer_id 'f7027a14-6abd-4087-b397-3d84d445f4c3'
     consumer_name 'adhoc'
 
+    trait :status_received do
+      status 'received'
+    end
+
     trait :status_uploaded do
       status 'uploaded'
     end

--- a/modules/vba_documents/spec/jobs/upload_status_updater_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_status_updater_spec.rb
@@ -21,10 +21,7 @@ RSpec.describe VBADocuments::UploadStatusUpdater, type: :job do
       in_process_element[0]['uuid'] = upload.guid
       expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
 
-      job = VBADocuments::UploadStatusUpdater.new
-      expect(job).to receive(:already_running?).and_return(false)
-
-      job.perform
+      VBADocuments::UploadStatusUpdater.new.perform
       upload.reload
       expect(upload.status).to eq('processing')
     end

--- a/modules/vba_documents/spec/jobs/upload_status_updater_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_status_updater_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VBADocuments::UploadStatusUpdater, type: :job do
+  let(:client_stub) { instance_double('CentralMail::Service') }
+  let(:upload) { FactoryBot.create(:upload_submission, :status_received) }
+  let(:faraday_response) { instance_double('Faraday::Response') }
+  let(:in_process_element) do
+    [{ "uuid": 'ignored',
+       "status": 'In Process',
+       "errorMessage": '',
+       "lastUpdated": '2018-04-25 00:02:39' }]
+  end
+
+  describe '#perform' do
+    it 'updates the status of an inflight submission' do
+      expect(CentralMail::Service).to receive(:new) { client_stub }
+      expect(client_stub).to receive(:status).and_return(faraday_response)
+      expect(faraday_response).to receive(:success?).and_return(true)
+      in_process_element[0]['uuid'] = upload.guid
+      expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
+
+      job = VBADocuments::UploadStatusUpdater.new
+      expect(job).to receive(:already_running?).and_return(false)
+
+      job.perform
+      upload.reload
+      expect(upload.status).to eq('processing')
+    end
+  end
+end

--- a/modules/vba_documents/spec/jobs/upload_status_updater_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_status_updater_spec.rb
@@ -21,9 +21,12 @@ RSpec.describe VBADocuments::UploadStatusUpdater, type: :job do
       in_process_element[0]['uuid'] = upload.guid
       expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
 
-      VBADocuments::UploadStatusUpdater.new.perform
-      upload.reload
-      expect(upload.status).to eq('processing')
+      with_settings(Settings.vba_documents,
+                    updater_enabled: true) do
+        VBADocuments::UploadStatusUpdater.new.perform
+        upload.reload
+        expect(upload.status).to eq('processing')
+      end
     end
   end
 end

--- a/modules/vba_documents/spec/request/v1/reports_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/reports_request_spec.rb
@@ -7,38 +7,9 @@ RSpec.describe 'VBA Document Uploads Report Endpoint', type: :request do
     let(:upload) { FactoryBot.create(:upload_submission) }
     let(:upload_received) { FactoryBot.create(:upload_submission, status: 'received') }
     let(:upload2_received) { FactoryBot.create(:upload_submission, guid: SecureRandom.uuid, status: 'received') }
-    let(:client_stub) { instance_double('CentralMail::Service') }
-    let(:faraday_response) { instance_double('Faraday::Response') }
-
-    let(:received_element) do
-      [{ "uuid": 'ignored',
-         "status": 'Received',
-         "errorMessage": '',
-         "lastUpdated": '2018-04-25 00:02:39' }]
-    end
-    let(:processing_element) do
-      [{ "uuid": 'ignored',
-         "status": 'In Process',
-         "errorMessage": '',
-         "lastUpdated": '2018-04-25 00:02:39' }]
-    end
-    let(:success_element) do
-      [{ "uuid": 'ignored',
-         "status": 'Success',
-         "errorMessage": '',
-         "lastUpdated": '2018-04-25 00:02:39' }]
-    end
 
     context 'with in-flight submissions' do
-      before(:each) do
-        expect(CentralMail::Service).to receive(:new) { client_stub }
-        expect(client_stub).to receive(:status).and_return(faraday_response)
-      end
-
       it 'should return status of a single upload submissions' do
-        expect(faraday_response).to receive(:success?).and_return(true)
-        received_element[0]['uuid'] = upload_received.guid
-        expect(faraday_response).to receive(:body).at_least(:once).and_return([received_element].to_json)
         params = [upload_received.guid]
         post '/services/vba_documents/v1/uploads/report', params: { ids: params }
         expect(response).to have_http_status(:ok)
@@ -50,11 +21,6 @@ RSpec.describe 'VBA Document Uploads Report Endpoint', type: :request do
       end
 
       it 'should return status of a multiple upload submissions' do
-        expect(faraday_response).to receive(:success?).and_return(true)
-        received_element[0]['uuid'] = upload_received.guid
-        processing_element[0]['uuid'] = upload2_received.guid
-        body = [received_element, processing_element].to_json
-        expect(faraday_response).to receive(:body).at_least(:once).and_return(body)
         params = [upload_received.guid, upload2_received.guid]
         post '/services/vba_documents/v1/uploads/report', params: { ids: params }
         expect(response).to have_http_status(:ok)
@@ -67,10 +33,6 @@ RSpec.describe 'VBA Document Uploads Report Endpoint', type: :request do
       end
 
       it 'should silently skip status not returned from central mail' do
-        expect(faraday_response).to receive(:success?).and_return(true)
-        received_element[0]['uuid'] = upload_received.guid
-        processing_element[0]['uuid'] = upload2_received.guid
-        expect(faraday_response).to receive(:body).at_least(:once).and_return([received_element, []].to_json)
         params = [upload_received.guid, upload2_received.guid]
         post '/services/vba_documents/v1/uploads/report', params: { ids: params }
         expect(response).to have_http_status(:ok)
@@ -81,22 +43,9 @@ RSpec.describe 'VBA Document Uploads Report Endpoint', type: :request do
         expect(ids).to include(upload_received.guid)
         expect(ids).to include(upload2_received.guid)
       end
-
-      it 'should raise an error if gateway unavailable' do
-        expect(faraday_response).to receive(:success?).and_return(false)
-        expect(faraday_response).to receive(:status).and_return(401)
-        expect(faraday_response).to receive(:body).at_least(:once).and_return('Unauthorized')
-        params = [upload_received.guid, upload2_received.guid]
-        post '/services/vba_documents/v1/uploads/report', params: { ids: params }
-        expect(response).to have_http_status(:bad_gateway)
-      end
     end
 
     context 'without in-flight submissions' do
-      before(:each) do
-        expect(CentralMail::Service).not_to receive(:new) { client_stub }
-      end
-
       it 'should not fetch status if no in-flight submissions' do
         params = [upload.guid]
         post '/services/vba_documents/v1/uploads/report', params: { ids: params }
@@ -133,7 +82,7 @@ RSpec.describe 'VBA Document Uploads Report Endpoint', type: :request do
       end
 
       it 'should return error if guids parameter has too many elements' do
-        params = Array.new(101, 'abcd-1234')
+        params = Array.new(1001, 'abcd-1234')
         post '/services/vba_documents/v1/uploads/report', params: { ids: params }
         expect(response).to have_http_status(:bad_request)
       end


### PR DESCRIPTION
## Description of change
In order to make the reports endpoint function quicker, deal with timeouts, and various other reasons we decided rather than hit central mail on every request to reports, we would instead asynchronously sync that status of submissions and return the current value. Allowing the consumer to manually update individual status if an immediate update is necessary.

although closed, resolves 100% https://github.com/department-of-veterans-affairs/vets-contrib/issues/930
resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/2676
resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/2578

## Testing done
- rspec

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- change in ideology in how we handle statuses for payloads

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
