### PR TITLE
Add pid to form526 rake

### DIFF
--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -63,6 +63,34 @@ namespace :form526 do
     print_total('Other Failures: ', other_errors)
   end
 
+  desc 'Show all v1 forms'
+  task show_v1: :environment do
+    def print_row(created_at, updated_at, id)
+      printf "%-24s %-24s %s\n", created_at, updated_at, id
+    end
+
+    def print_total(header, total)
+      printf "%-20s %s\n", header, total
+    end
+
+    progress_forms = InProgressForm.where(form_id: '21-526EZ').order(:created_at)
+
+    puts '------------------------------------------------------------'
+    print_row('created at:', 'updated at:', 'id:')
+
+    total_v1_forms = 0
+    progress_forms.each do |progress_form|
+      form_data = JSON.parse(progress_form.form_data)
+      if form_data['veteran'].present?
+        total_v1_forms += 1
+        print_row(progress_form.created_at, progress_form.updated_at, progress_form.id)
+      end
+    end
+
+    puts '------------------------------------------------------------'
+    print_total('Total V1 forms:', total_v1_forms)
+  end
+
   desc 'Get an error report within a given date period. [<start date: yyyy-mm-dd>,<end date: yyyy-mm-dd>]'
   task :errors, %i[start_date end_date] => [:environment] do |_, args|
     def print_row(sub_id, p_id, created_at)


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
To help with tracking submissions (and errors) for prod 526 submissions we want to display the users participant_id in the rake task when showing all submissions within a datetime period.

Also, to help debug v1 submissions and to verify we arent creating new v1 forms somehow, we want to include a rake task that displays all v1 forms' created/updated date and its respective form id.

## Testing done
<!-- Please describe testing done to verify the changes. -->
local runs.

## Testing planned
<!-- Please describe testing planned. -->
Run via jenkins on staging. Log into staging box and run `show_v1` task.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] add `participant_id` to submission rake task output
- [x] add `show_v1` rake task to display v1 526 forms
#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
