### PR TITLE
Update VETERAN_CONFIRMATION.yml

### DIFF
--- a/modules/veteran_verification/VETERAN_CONFIRMATION.yml
+++ b/modules/veteran_verification/VETERAN_CONFIRMATION.yml
@@ -27,7 +27,7 @@ info:
     Allows a third-party application to request the VA confirm the Veteran Status of an
     authorized individual:
 
-    1. Client Request: GET https://api.vets.gov/services/veteran_verification/v0/status
+    1. Client Request: GET https://api.va.gov/services/veteran_verification/v0/status
        * Provide the Bearer token as a header: `Authorization: Bearer <token>`
 
     2. Status Response: A JSON API object with the individual's veteran status


### PR DESCRIPTION
## Description of change
This PR fixes an old URL in the documentation for Veteran Confirmation (https://github.com/department-of-veterans-affairs/vets-contrib/issues/2754). The correct url is `https://api.va.gov/services/veteran_verification/v0/status` not `https://api.vets.gov/services/veteran_verification/v0/status`

## Acceptance Criteria (Definition of Done)
- [x] Changed the applicable broken url in the docs

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
