### PR TITLE
Fixes typos for Service History and Disability Rating

### DIFF
--- a/modules/veteran_verification/DISABILITY_RATING.yml
+++ b/modules/veteran_verification/DISABILITY_RATING.yml
@@ -21,14 +21,14 @@ info:
 
     Allows a third-party application to request a Veteran's disability rating with the authorization of the Veteran.
 
-    1. Client Request: GET https://dev-api.va.gov/services/veteran_verification/v0/diability_rating
+    1. Client Request: GET https://dev-api.va.gov/services/veteran_verification/v0/disability_rating
        *  Provide the Bearer token as a header: `Authorization: Bearer <token>`
 
     2. Service Response: A JSON API object with the Veteran's disability rating
 
     ## Reference
 
-    Raw Open API Spec: https://api.va.gov/services/veteran_verification/docs/v0/api
+    Raw Open API Spec: https://api.va.gov/services/veteran_verification/docs/v0/disability_rating
 
   termsOfService: ''
   contact:

--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -34,7 +34,7 @@ info:
 
     ## Reference
 
-    Raw Open API Spec: https://api.va.gov/services/veteran_verification/docs/v0/api
+    Raw Open API Spec: https://api.va.gov/services/veteran_verification/docs/v0/service_history
 
   termsOfService: ''
   contact:
@@ -120,7 +120,7 @@ components:
               description: |
                 Character of discharge from service episode. Possible values are:
 
-                Both "honorable-for-va-purposes" and "dishonorable-for-va-purposes" represent a change in character of discharge based on an administrative decision, for purposes of VA benefits administration. The original character of discharge for other purposes was either "bad-conduct" or "other-than-honorable". "honorable-absence-of-negative-report" represents a an unreported character of service that DoD classifies as honorable.
+                Both "honorable-for-va-purposes" and "dishonorable-for-va-purposes" represent a change in character of discharge based on an administrative decision, for purposes of VA benefits administration. The original character of discharge for other purposes was either "bad-conduct" or "other-than-honorable". "honorable-absence-of-negative-report" represents an unreported character of service that DoD classifies as honorable.
               enum:
                 - honorable
                 - general


### PR DESCRIPTION
## Description of change
This PR fixes https://github.com/department-of-veterans-affairs/vets-contrib/issues/2773.

## Acceptance Criteria (Definition of Done)
- [x] Typos fixed in Disability Rating
- [x] Typos fixed in Service History

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
