### PR TITLE
366 adds the database_cleaner gem and its configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,6 +129,7 @@ group :development, :test do
   gem 'brakeman'
   gem 'bundler-audit'
   gem 'byebug', platforms: :ruby # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'pry-byebug'
   gem 'rainbow' # Used to colorize output for rake tasks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    database_cleaner (1.7.0)
     date_validator (0.9.0)
       activemodel
       activesupport
@@ -673,6 +674,7 @@ DEPENDENCIES
   climate_control
   config
   connect_vbms!
+  database_cleaner
   date_validator
   dry-struct
   dry-types

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class DirtyDatabaseError < RuntimeError
+  def initialize(meta)
+    super "#{meta[:full_description]}\n\t#{meta[:location]}"
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:deletion)
+  end
+
+  config.before(:all, :cleaner_for_context) do
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.start
+  end
+
+  config.before(:each) do |example|
+    next if example.metadata[:cleaner_for_context]
+
+    DatabaseCleaner.strategy =
+      if example.metadata[:js]
+        :truncation
+      else
+        example.metadata[:strategy] || :transaction
+      end
+
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do |example|
+    next if example.metadata[:cleaner_for_context]
+
+    DatabaseCleaner.clean
+
+    # raise DirtyDatabaseError.new(example.metadata) if Record.count > 0
+  end
+
+  config.after(:all, :cleaner_for_context) do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
## Description of change
Reduces the rspec spec runtime by adding the DatabaseCleaner gem and its configuration under `spec/support/database_cleaner.rb` following the recommendations listed from this [article](https://devopsvoyage.com/2018/09/26/get-most-of-the-database-cleaner.html).

## Testing done
local specs

## Testing planned
jenkins specs

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Reduces the run time for rspec tests (by roughly a minute depending on the machine, for myself from 5m38s to 4m31s)

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
