### PR TITLE
526 validate doc fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,15 +81,15 @@ PATH
       sidekiq
 
 PATH
-  remote: modules/veteran_verification
-  specs:
-    veteran_verification (0.0.1)
-      rails (~> 5.2.3)
-
-PATH
   remote: modules/veteran
   specs:
     veteran (0.0.1)
+      rails (~> 5.2.3)
+
+PATH
+  remote: modules/veteran_verification
+  specs:
+    veteran_verification (0.0.1)
       rails (~> 5.2.3)
 
 GEM

--- a/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
@@ -208,14 +208,6 @@ module ClaimsApi
         end
 
         parameter do
-          key :name, 'apikey'
-          key :in, :header
-          key :description, 'API Key given to access data'
-          key :required, true
-          key :type, :string
-        end
-
-        parameter do
           key :name, 'X-VA-SSN'
           key :in, :header
           key :description, 'SSN of Veteran to fetch'

--- a/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_526_v1_controller_swagger.rb
@@ -200,6 +200,14 @@ module ClaimsApi
         ]
 
         parameter do
+          key :name, 'bearer_token'
+          key :in, :header
+          key :description, 'Oauth Token of Veteran requesting to access data'
+          key :required, true
+          key :type, :string
+        end
+
+        parameter do
           key :name, 'apikey'
           key :in, :header
           key :description, 'API Key given to access data'
@@ -211,7 +219,7 @@ module ClaimsApi
           key :name, 'X-VA-SSN'
           key :in, :header
           key :description, 'SSN of Veteran to fetch'
-          key :required, true
+          key :required, false
           key :type, :string
         end
 
@@ -219,7 +227,7 @@ module ClaimsApi
           key :name, 'X-VA-First-Name'
           key :in, :header
           key :description, 'First Name of Veteran to fetch'
-          key :required, true
+          key :required, false
           key :type, :string
         end
 
@@ -227,7 +235,7 @@ module ClaimsApi
           key :name, 'X-VA-Last-Name'
           key :in, :header
           key :description, 'Last Name of Veteran to fetch'
-          key :required, true
+          key :required, false
           key :type, :string
         end
 
@@ -235,7 +243,7 @@ module ClaimsApi
           key :name, 'X-VA-Birth-Date'
           key :in, :header
           key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
-          key :required, true
+          key :required, false
           key :type, :string
         end
 
@@ -251,7 +259,7 @@ module ClaimsApi
           key :name, 'X-VA-User'
           key :in, :header
           key :description, 'VA username of the person making the request'
-          key :required, true
+          key :required, false
           key :type, :string
         end
 

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/put_description.md
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/put_description.md
@@ -1,5 +1,5 @@
 Accepts document metadata, document binary, and attachment binaries.Full URL, including
-query parameters, provided from POST `/document_uploads`.
+query parameters, provided from POST `/uploads`.
 
 ## Example Payload
 

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/v1/status_attributes_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/v1/status_attributes_swagger.rb
@@ -18,7 +18,7 @@ module VbaDocuments
           property :status do
             key :description, File.read(VBADocuments::Engine.root.join('app', 'swagger', 'vba_documents', 'document_upload', 'v1', 'status_description.md'))
             key :type, :string
-            key :enum, %i[pending uploaded recieved processing success vbms error]
+            key :enum, %i[pending uploaded received processing success vbms error]
           end
 
           property :code do


### PR DESCRIPTION
## Description of change
This change updates the swagger doc headers for v1 of form 526 validation endpoint

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
