### PR TITLE
Make jobs process in the default queue

### DIFF
--- a/modules/vba_documents/app/workers/vba_documents/upload_status_batch.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_status_batch.rb
@@ -5,7 +5,6 @@ module VBADocuments
     include Sidekiq::Worker
 
     sidekiq_options(
-      queue: 'vba_documents',
       retry: true,
       unique_until: :success
     )

--- a/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_status_updater.rb
@@ -7,7 +7,6 @@ module VBADocuments
     include Sidekiq::Worker
 
     sidekiq_options(
-      queue: 'vba_documents',
       retry: true,
       unique_until: :success
     )


### PR DESCRIPTION
## Description of change
After improvements made to the status caching jobs, and understanding the sidekiq setup it makes sense to move this back to the default queue

