### PR TITLE
Reorder education form routing rules

### DIFF
--- a/app/workers/education_form/education_facility.rb
+++ b/app/workers/education_form/education_facility.rb
@@ -69,14 +69,17 @@ module EducationForm
       record = model.open_struct_form
       address = routing_address(record, form_type: model.form_type)
 
-      # special case Philippines
-      return :western if address&.country == 'PHL' || model.form_type == '0993'
+      # special case 0993
+      return :western if model.form_type == '0993'
 
       # special case 0994
       return :eastern if model.form_type == '0994'
 
       # special case 1995 STEM
       return :eastern if model.form_type == '1995' && record.isEdithNourseRogersScholarship
+
+      # special case Philippines
+      return :western if address&.country == 'PHL'
 
       check_area(address)
     end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe EducationForm::EducationFacility do
         education_benefits_claim.saved_claim.form_id = '22-1995'
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
-      it 'should route Philippines to Easter RPO' do
+      it 'should route Philippines to Eastern RPO' do
         form = education_benefits_claim.parsed_form
         form['isEdithNourseRogersScholarship'] = true
         form['newSchool'] = {

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -131,8 +131,19 @@ RSpec.describe EducationForm::EducationFacility do
           }
         }
         education_benefits_claim.saved_claim.form = form.to_json
-        education_benefits_claim.saved_claim.form_id = '22-1995'
+        education_benefits_claim.saved_claim.form_id = '22-1990'
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
+      end
+      it 'should route 1995 to Eestern RPO' do
+        form = education_benefits_claim.parsed_form
+        form['newSchool'] = {
+          'address' => {
+            'country': 'PHL'
+          }
+        }
+        education_benefits_claim.saved_claim.form = form.to_json
+        education_benefits_claim.saved_claim.form_id = '22-1995'
+        expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
     end
   end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -109,6 +109,18 @@ RSpec.describe EducationForm::EducationFacility do
         education_benefits_claim.saved_claim.form_id = '22-1995'
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
+      it 'should route Philippines to Easter RPO' do
+        form = education_benefits_claim.parsed_form
+        form['isEdithNourseRogersScholarship'] = true
+        form['newSchool'] = {
+          'address' => {
+            'country': 'PHL'
+          }
+        }
+        education_benefits_claim.saved_claim.form = form.to_json
+        education_benefits_claim.saved_claim.form_id = '22-1995'
+        expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
+      end
     end
     context '22-0994' do
       it 'should route to Eastern RPO' do
@@ -125,7 +137,7 @@ RSpec.describe EducationForm::EducationFacility do
     context 'address country Phillipines' do
       it 'should route to Western RPO' do
         form = education_benefits_claim.parsed_form
-        form['newSchool'] = {
+        form['educationProgram'] = {
           'address' => {
             'country': 'PHL'
           }
@@ -133,17 +145,6 @@ RSpec.describe EducationForm::EducationFacility do
         education_benefits_claim.saved_claim.form = form.to_json
         education_benefits_claim.saved_claim.form_id = '22-1990'
         expect(described_class.region_for(education_benefits_claim)).to eq(:western)
-      end
-      it 'should route 1995 to Eestern RPO' do
-        form = education_benefits_claim.parsed_form
-        form['newSchool'] = {
-          'address' => {
-            'country': 'PHL'
-          }
-        }
-        education_benefits_claim.saved_claim.form = form.to_json
-        education_benefits_claim.saved_claim.form_id = '22-1995'
-        expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
     end
   end


### PR DESCRIPTION
## Description of change
Reorder education form routing rules to prevent 1995 STEM from being sent to western RO for Philippines facilities

## Testing done
Unit tests updated and QA reviewed

## Testing planned
N/A

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] All 1995 STEM submissions are sent to the Buffalo RO

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
