### PR TITLE
Fixing production error being covered up by mocks

### DIFF
--- a/lib/evss/vso_search/service.rb
+++ b/lib/evss/vso_search/service.rb
@@ -19,7 +19,7 @@ module EVSS
       #
       def get_current_info(addtional_headers = {})
         with_monitoring_and_error_handling do
-          perform(:post, 'getCurrentInfo', nil, request_headers(addtional_headers)).body
+          perform(:post, 'getCurrentInfo', {}, request_headers(addtional_headers)).body
         end
       end
 

--- a/spec/lib/evss/vso_search/service_spec.rb
+++ b/spec/lib/evss/vso_search/service_spec.rb
@@ -5,9 +5,11 @@ require 'rails_helper'
 describe EVSS::VsoSearch::Service do
   let(:user) { create(:evss_user) }
   let(:service) { described_class.new(user) }
+  let(:response) { OpenStruct.new(body: get_fixture('json/veteran_with_poa')) }
 
-  def returns_form(response)
-    expect(response['submitProcess'].present?).to eq(true)
+  def it_returns_valid_payload(method, form = nil)
+    allow(service).to receive(:perform).and_return(response)
+    service.send(*[method, form].compact)
   end
 
   def it_handles_errors(method, form = nil, form_id = nil)
@@ -17,8 +19,12 @@ describe EVSS::VsoSearch::Service do
   end
 
   describe '#get_current_info' do
+    it 'with a valid evss response' do
+      it_returns_valid_payload(:get_current_info, response.body)
+    end
+
     it 'handles errors' do
-      it_handles_errors(:get_current_info, get_fixture('json/veteran_with_poa'))
+      it_handles_errors(:get_current_info, response.body)
     end
   end
 end


### PR DESCRIPTION
## Description of change
Seeing if this change fixes an error ocuring in production that all of our mocks and even staging masks from ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/2859

## Acceptance Criteria (Definition of Done)
- Makes sure that the VsoSearch doesn't return a 500 in production

#### Applies to all PRs

- [x] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
