### PR TITLE
Fixing rake db:migrate run through

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,6 @@ gem 'utf8-cleaner'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus'
 gem 'will_paginate'
-gem 'zero_downtime_migrations'
 
 group :development do
   gem 'benchmark-ips'
@@ -156,6 +155,7 @@ group :development, :test do
 end
 
 group :production do
+  gem 'zero_downtime_migrations'
   # sidekiq enterprise requires a license key to download but is only required in production.
   # for local dev environments, regular sidekiq works fine
   unless ENV['EXCLUDE_SIDEKIQ_ENTERPRISE'] == 'true'

--- a/db/migrate/20171229003530_change_form_attachments_type_null.rb
+++ b/db/migrate/20171229003530_change_form_attachments_type_null.rb
@@ -1,5 +1,5 @@
 class ChangeFormAttachmentsTypeNull < ActiveRecord::Migration[4.2]
-  safety_assured
+  # safety_assured
 
   def change
     FormAttachment.update_all(type: 'Preneeds::PreneedAttachment')

--- a/db/migrate/20180709214011_create_personal_information_logs_table.rb
+++ b/db/migrate/20180709214011_create_personal_information_logs_table.rb
@@ -1,5 +1,5 @@
 class CreatePersonalInformationLogsTable < ActiveRecord::Migration[4.2]
-  safety_assured
+  # safety_assured
 
   def change
     create_table :personal_information_logs do |t|

--- a/db/migrate/20180830212109_add_disability_contentions_medical_index.rb
+++ b/db/migrate/20180830212109_add_disability_contentions_medical_index.rb
@@ -1,6 +1,6 @@
 class AddDisabilityContentionsMedicalIndex < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
-  safety_assured
+  # safety_assured
 
   def up
     execute <<-SQL

--- a/db/migrate/20180830212116_add_disability_contentions_lay_index.rb
+++ b/db/migrate/20180830212116_add_disability_contentions_lay_index.rb
@@ -1,6 +1,6 @@
 class AddDisabilityContentionsLayIndex < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
-  safety_assured
+  # safety_assured
 
   def up
     execute <<-SQL

--- a/db/migrate/20181003213643_change_code_to_not_allow_null.rb
+++ b/db/migrate/20181003213643_change_code_to_not_allow_null.rb
@@ -1,7 +1,7 @@
 class ChangeCodeToNotAllowNull < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
   # At this point we shouldn't have any Preference records
-  safety_assured
+  # safety_assured
 
   def change
     # If we did have data, we'd check it first and assign unique values

--- a/db/migrate/20190702154242_create_flipper_tables.rb
+++ b/db/migrate/20190702154242_create_flipper_tables.rb
@@ -1,10 +1,12 @@
 class CreateFlipperTables < ActiveRecord::Migration[5.2]
+  safety_assured
+
   def self.up
     create_table :flipper_features do |t|
       t.string :key, null: false
       t.timestamps null: false
     end
-    safety_assured { add_index :flipper_features, :key, unique: true }
+    add_index :flipper_features, :key, unique: true
 
     create_table :flipper_gates do |t|
       t.string :feature_key, null: false
@@ -12,7 +14,7 @@ class CreateFlipperTables < ActiveRecord::Migration[5.2]
       t.string :value
       t.timestamps null: false
     end
-    safety_assured { add_index :flipper_gates, [:feature_key, :key, :value], unique: true }
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
   end
 
   def self.down

--- a/modules/claims_api/db/migrate/20190211163050_create_auto_established_claims.rb
+++ b/modules/claims_api/db/migrate/20190211163050_create_auto_established_claims.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateAutoEstablishedClaims < ActiveRecord::Migration
+class CreateAutoEstablishedClaims < ActiveRecord::Migration[5.1]
   def change
     enable_extension 'uuid-ossp'
 

--- a/modules/claims_api/db/migrate/20190305003907_add_md5_to_claims_api_auto_established_claims.rb
+++ b/modules/claims_api/db/migrate/20190305003907_add_md5_to_claims_api_auto_established_claims.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddMd5ToClaimsApiAutoEstablishedClaims < ActiveRecord::Migration
+class AddMd5ToClaimsApiAutoEstablishedClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims_api_auto_established_claims, :md5, :string
   end

--- a/modules/claims_api/db/migrate/20190306160555_create_supporting_documents.rb
+++ b/modules/claims_api/db/migrate/20190306160555_create_supporting_documents.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSupportingDocuments < ActiveRecord::Migration
+class CreateSupportingDocuments < ActiveRecord::Migration[4.2]
   def change
     create_table :claims_api_supporting_documents, id: :uuid do |t|
       t.string   :encrypted_file_data, null: false

--- a/modules/claims_api/db/migrate/20190408160432_change_column_supporting_documents.rb
+++ b/modules/claims_api/db/migrate/20190408160432_change_column_supporting_documents.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeColumnSupportingDocuments < ActiveRecord::Migration
+class ChangeColumnSupportingDocuments < ActiveRecord::Migration[4.2]
   def change
     remove_column :claims_api_supporting_documents, :auto_established_claim_id, :integer, null: false
     add_column :claims_api_supporting_documents, :auto_established_claim_id, :uuid

--- a/modules/va_facilities/db/migrate/20181017120746_enable_post_gis_extension.rb
+++ b/modules/va_facilities/db/migrate/20181017120746_enable_post_gis_extension.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EnablePostGisExtension < ActiveRecord::Migration
+class EnablePostGisExtension < ActiveRecord::Migration[4.2]
   def up
     enable_extension('postgis') unless extensions.include?('postgis')
   end

--- a/modules/va_facilities/db/migrate/20181017120747_add_location_to_base_facility.rb
+++ b/modules/va_facilities/db/migrate/20181017120747_add_location_to_base_facility.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddLocationToBaseFacility < ActiveRecord::Migration
+class AddLocationToBaseFacility < ActiveRecord::Migration[4.2]
   def change
     add_column :base_facilities, :location, :st_point, geographic: true
   end

--- a/modules/va_facilities/db/migrate/20181017123729_index_base_facilities_on_location.rb
+++ b/modules/va_facilities/db/migrate/20181017123729_index_base_facilities_on_location.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class IndexBaseFacilitiesOnLocation < ActiveRecord::Migration
+class IndexBaseFacilitiesOnLocation < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
 
   def change

--- a/modules/vba_documents/db/migrate/20180411001427_create_vba_documents_upload_submissions.rb
+++ b/modules/vba_documents/db/migrate/20180411001427_create_vba_documents_upload_submissions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateVBADocumentsUploadSubmissions < ActiveRecord::Migration
+class CreateVBADocumentsUploadSubmissions < ActiveRecord::Migration[4.2]
   def change
     create_table :vba_documents_upload_submissions do |t|
       t.uuid('guid', index: true, null: false)

--- a/modules/vba_documents/db/migrate/20180516184633_add_s3_deleted_to_upload_submissions.rb
+++ b/modules/vba_documents/db/migrate/20180516184633_add_s3_deleted_to_upload_submissions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddS3DeletedToUploadSubmissions < ActiveRecord::Migration
+class AddS3DeletedToUploadSubmissions < ActiveRecord::Migration[4.2]
   def change
     add_column :vba_documents_upload_submissions, :s3_deleted, :boolean
   end

--- a/modules/vba_documents/db/migrate/20180517171924_add_consumer_name_to_vba_documents_upload_submissions.rb
+++ b/modules/vba_documents/db/migrate/20180517171924_add_consumer_name_to_vba_documents_upload_submissions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddConsumerNameToVBADocumentsUploadSubmissions < ActiveRecord::Migration
+class AddConsumerNameToVBADocumentsUploadSubmissions < ActiveRecord::Migration[4.2]
   def change
     add_column :vba_documents_upload_submissions, :consumer_name, :string
   end

--- a/modules/vba_documents/db/migrate/20180626141145_add_consumer_id_to_upload_submission.rb
+++ b/modules/vba_documents/db/migrate/20180626141145_add_consumer_id_to_upload_submission.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddConsumerIdToUploadSubmission < ActiveRecord::Migration
+class AddConsumerIdToUploadSubmission < ActiveRecord::Migration[4.2]
   def change
     add_column :vba_documents_upload_submissions, :consumer_id, :uuid
   end

--- a/modules/veteran/db/migrate/20190313163050_create_veteran_service_objects.rb
+++ b/modules/veteran/db/migrate/20190313163050_create_veteran_service_objects.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateVeteranServiceObjects < ActiveRecord::Migration
+class CreateVeteranServiceObjects < ActiveRecord::Migration[4.2]
   def change
     create_table :veteran_organizations, id: false do |t|
       t.string :poa, limit: 3


### PR DESCRIPTION
## Description of change
Got tired of running through rake db:migrate and always having breaking stuff along the way, yes I know we can just run rake db:schema:load but we still had stuff that was never fixed with the 5.2 rails upgrade.

## Acceptance Criteria (Definition of Done)
- Get through a rake db:migrate of first to last migration without failing

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
