### PR TITLE
Add a scrub to prevent invalid byte sequence

### DIFF
--- a/modules/veteran/app/workers/veteran/vso_reloader.rb
+++ b/modules/veteran/app/workers/veteran/vso_reloader.rb
@@ -45,7 +45,7 @@ module Veteran
         doc.xpath('//table/tr').each do |row|
           tarray = []
           row.xpath('td').each do |cell|
-            tarray << cell.text
+            tarray << cell.text.scrub
           end
           csv << tarray
         end


### PR DESCRIPTION
## Description of change
This change fixes the Invalid Byte Sequence issue happening when pulling in OGC data

## Testing done
This was tested by making the change on the staging worker server directly

## Acceptance Criteria (Definition of Done)
- [x] OGC data pulls in correctly without error

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
