### PR TITLE
Add SSOe URL handler

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -7,7 +7,7 @@ require 'saml/responses/logout'
 
 module V0
   class SessionsController < ApplicationController
-    REDIRECT_URLS = %w[signup mhv dslogon idme mfa verify slo].freeze
+    REDIRECT_URLS = %w[signup mhv dslogon idme ssoe mfa verify slo].freeze
 
     STATSD_SSO_NEW_KEY = 'api.auth.new'
     STATSD_SSO_CALLBACK_KEY = 'api.auth.saml_callback'

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -69,6 +69,11 @@ module SAML
       build_sso_url('dslogon')
     end
 
+    def ssoe_url
+      @type = 'ssoe'
+      build_sso_url('ssoe')
+    end
+
     def idme_url
       @type = 'idme'
       build_sso_url(LOA::IDME_LOA1)

--- a/spec/lib/saml/url_service_spec.rb
+++ b/spec/lib/saml/url_service_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe SAML::URLService do
           .with_relay_state('originating_request_id' => '123', 'type' => 'idme')
       end
 
+      it 'has sign in url: ssoe_url' do
+        expect(subject.ssoe_url)
+          .to be_an_idme_saml_url('https://api.idmelabs.com/saml/SingleSignOnService?SAMLRequest=')
+          .with_relay_state('originating_request_id' => '123', 'type' => 'ssoe')
+      end
+
       it 'has sign up url: signup_url' do
         expect(subject.signup_url)
           .to be_an_idme_saml_url('https://api.idmelabs.com/saml/SingleSignOnService?SAMLRequest=')


### PR DESCRIPTION
## Description of change
Adds SSOe URL handler

enables the route `/sessions/ssoe/new` for triggering SSOe login flow

## Testing done
Add unit test for URL service

## Testing planned
Test in dev after ID.me enables new `ssoe` AuthN Context

## Acceptance Criteria (Definition of Done)

- [x] Appropriate logging
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
