### PR TITLE
Fix $ref to Deployment schema

### DIFF
--- a/modules/veteran_verification/SERVICE_HISTORY.yml
+++ b/modules/veteran_verification/SERVICE_HISTORY.yml
@@ -136,7 +136,7 @@ components:
             deployments:
               type: array
               items:
-                $ref: #/components/schemas/Deployment
+                $ref: '#/components/schemas/Deployment'
     Deployment:
       description: |
         Deployment during a service history episode


### PR DESCRIPTION
Missing single quotes around the value of $ref caused an error because the value was treated as a comment and thus $ref equaled null.

Verified update caused no errors using https://editor.swagger.io/.
