### PR TITLE
Add monitoring to Vso Document Upload

### DIFF
--- a/lib/vsopdf/vso_appointment_form.rb
+++ b/lib/vsopdf/vso_appointment_form.rb
@@ -5,6 +5,9 @@ require 'tempfile'
 require 'securerandom'
 
 class VsoAppointmentForm
+  include Common::Client::Monitoring
+  STATSD_KEY_PREFIX = 'api.vso_appoinment_form'
+
   def initialize(appt)
     @appt = appt
   end
@@ -86,6 +89,6 @@ class VsoAppointmentForm
       "metadata": get_metadata(path).to_json
     }
 
-    conn.post '/VADocument/upload', body
+    with_monitoring { conn.post '/VADocument/upload', body }
   end
 end


### PR DESCRIPTION
## Description of change
Adds monitoring to the `/VADocument/upload` transaction in `VsoAppointmentForm`

## Testing done
spec suite, manually verified in console

## Testing planned

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Transaction monitoring block added for post txn

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
