### PR TITLE
Make SAML initializer safe to missing SSOe cert/key files

### DIFF
--- a/config/initializers/saml.rb
+++ b/config/initializers/saml.rb
@@ -10,11 +10,19 @@ Settings.saml.certificate = File.read(File.expand_path(Settings.saml.cert_path))
 Settings.saml.key = File.read(File.expand_path(Settings.saml.key_path))
 Settings.saml.certificate_new = new_saml_cert_exists? ? File.read(File.expand_path(Settings.saml.cert_new_path)) : nil
 
+def saml_ssoe_cert_exists?
+  !Settings.saml_ssoe.cert_path.nil? && File.file?(File.expand_path(Settings.saml_ssoe.cert_path))
+end
+
+def saml_ssoe_key_exists?
+  !Settings.saml_ssoe.key_path.nil? && File.file?(File.expand_path(Settings.saml_ssoe.key_path))
+end
+
 def new_saml_ssoe_cert_exists?
   !Settings.saml_ssoe.cert_new_path.nil? && File.file?(File.expand_path(Settings.saml_ssoe.cert_new_path))
 end
 
-Settings.saml_ssoe.certificate = File.read(File.expand_path(Settings.saml_ssoe.cert_path))
-Settings.saml_ssoe.key = File.read(File.expand_path(Settings.saml_ssoe.key_path))
+Settings.saml_ssoe.certificate = saml_ssoe_cert_exists? ? File.read(File.expand_path(Settings.saml_ssoe.cert_path)) : nil
+Settings.saml_ssoe.key = saml_ssoe_key_exists? ? File.read(File.expand_path(Settings.saml_ssoe.key_path)) : nil
 Settings.saml_ssoe.certificate_new = new_saml_ssoe_cert_exists? ? File.read(File.expand_path(Settings.saml_ssoe.cert_new_path)) : nil
 # rubocop:enable Metrics/LineLength


### PR DESCRIPTION
## Description of change
Makes SAML initializer safe to missing key/cert files, for SSOe variants of those files. In response to issue where we were not injecting those files on worker instances. We will also make a change to inject those files, but this makes vets-api server/worker more robust.

## Testing done
Verified locally with dangling path references in settings.

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
