### PR TITLE
Remove unneeded request host mapping for SSOe SAML implementation

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -74,9 +74,6 @@ module V1
     private
 
     def saml_settings(options = {})
-      callback_url = URI.parse(Settings.saml_ssoe.callback_url)
-      callback_url.host = request.host
-      options.reverse_merge!(assertion_consumer_service_url: callback_url.to_s)
       SAML::SSOeSettingsService.saml_settings(options)
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   get '/v1/sessions/metadata', to: 'v1/sessions#metadata'
   get '/v1/sessions/logout', to: 'v1/sessions#saml_logout_callback'
-  post '/v1/sessions/callback', to: 'v1/sessions#callback', module: 'v1'
+  post '/v1/sessions/callback', to: 'v1/sessions#saml_callback', module: 'v1'
   get '/v1/sessions/:type/new',
       to: 'v1/sessions#new',
       constraints: ->(request) { V1::SessionsController::REDIRECT_URLS.include?(request.path_parameters[:type]) }


### PR DESCRIPTION
## Description of change
Removes the code that munges the configured SAML callback and sets the host part to request.host. That was only needed when straddling the vets.gov/va.gov world, and causes problems when configuring any alternate callback URL. 

Fixes mis-configured route->controller action mapping.

## Testing done
Tested locally, verified contents of generated SAML request. Verified callback endpoint responds. 

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)
#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
