### PR TITLE
don't rely on vets360 contact information for direct deposit update

### DIFF
--- a/app/controllers/v0/ppiu_controller.rb
+++ b/app/controllers/v0/ppiu_controller.rb
@@ -34,7 +34,13 @@ module V0
     end
 
     def current_user_email
-      current_user.vet360_contact_info&.email&.email_address || current_user.email
+      vet360_email =
+        begin
+          current_user.vet360_contact_info&.email&.email_address
+        rescue StandardError
+          nil
+        end
+      vet360_email || current_user.email
     end
 
     def pay_info

--- a/spec/controllers/v0/ppiu_controller_spec.rb
+++ b/spec/controllers/v0/ppiu_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V0::PPIUController, type: :controller do
+  let(:user) { create(:user, :loa3) }
+
+  describe '#current_user_email' do
+    context 'when vet360 is down' do
+      it 'should return user email' do
+        allow(controller).to receive(:current_user).and_return(user)
+        expect(user).to receive(:vet360_contact_info).and_raise('foo')
+
+        expect(controller.send(:current_user_email)).to eq(user.email)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
fail silently if vet360 raises an error and fall back on `current_user.email`
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19564
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

## Testing done
automated tests
<!-- Please describe testing done to verify the changes. -->

## Testing planned
test in staging
<!-- Please describe testing planned. -->

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
