### PR TITLE
Use `Rails.root` so the JSON::Validator can find the file

### DIFF
--- a/lib/appeals/responses/appeals.rb
+++ b/lib/appeals/responses/appeals.rb
@@ -26,7 +26,7 @@ module Appeals
       private
 
       def json_format_is_valid?(body)
-        schema_path = Rails.root.join('lib', 'appeals', 'schema', 'appeals.json')
+        schema_path = Rails.root.join('lib', 'appeals', 'schema', 'appeals.json').to_s
         JSON::Validator.validate!(schema_path, body, strict: false)
       end
     end


### PR DESCRIPTION
## Description of change
Use absolute file path for referencing schema.json on-disk. See [#1314](https://github.com/department-of-veterans-affairs/va.gov-team/issues/1314) for more details.

## Testing done
Checked locally and ensured the file exists in production as expected as well as works w/ Validator

## Testing planned
Watch Sentry

## Acceptance Criteria (Definition of Done)
- [x] path passed to validator is absolute
- [ ] error is not raised on transaction

#### Unique to this PR

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
