### PR TITLE
move email recipient to prod list

### DIFF
--- a/app/mailers/year_to_date_report_mailer.rb
+++ b/app/mailers/year_to_date_report_mailer.rb
@@ -26,6 +26,7 @@ class YearToDateReportMailer < ApplicationMailer
       222A.VBAVACO@va.gov
       Ricardo.DaSilva@va.gov
       peter.nastasi@va.gov
+      Lucas.Tickner@va.gov
     ]
   }.freeze
 
@@ -34,7 +35,6 @@ class YearToDateReportMailer < ApplicationMailer
       lihan@adhocteam.us
       Turner_Desiree@bah.com
       Delli-Gatti_Michael@bah.com
-      Lucas.Tickner@va.gov
     ]
   }.freeze
 

--- a/spec/mailers/year_to_date_report_mailer_spec.rb
+++ b/spec/mailers/year_to_date_report_mailer_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe YearToDateReportMailer, type: %i[mailer aws_helpers] do
             lihan@adhocteam.us
             Turner_Desiree@bah.com
             Delli-Gatti_Michael@bah.com
-            Lucas.Tickner@va.gov
           ]
         )
       end
@@ -66,6 +65,7 @@ RSpec.describe YearToDateReportMailer, type: %i[mailer aws_helpers] do
             222A.VBAVACO@va.gov
             Ricardo.DaSilva@va.gov
             peter.nastasi@va.gov
+            Lucas.Tickner@va.gov
           ]
         )
       end


### PR DESCRIPTION
## Description of change
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19517

## Testing done

## Testing planned
Confirm that Lucas Tickner has received YTD emails after PR has been merged.

## Acceptance Criteria (Definition of Done)
- [ ]  The following emails are included in the distribution for the 22-1995 Daily Fiscal YTD report in production: 
     - Lucas.Tickner@va.gov
- [ ]  The following emails are included in the distribution for the 22-1995 Daily YTD report in production: 
     - Lucas.Tickner@va.gov
- [ ]  The following emails are removed from the distribution for the 22-1995 Daily YTD report in staging: 
     - Lucas.Tickner@va.gov
- [ ] The following emails are removed from the distribution for the 22-1995 Daily YTD report in staging: 
     - Lucas.Tickner@va.gov

#### Unique to this PR
- [ ] Once PR is deployed to prod, we will have to confirm that  Lucas Tickner is receiving YTD emails.


#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
