### PR TITLE
Add Access To Care wait times FAQ link to Facilities v0 docs

### DIFF
--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -15,7 +15,7 @@ info:
     - Cemeteries
     - Vet Centers
 
-    Visit https://www.accesstocare.va.gov/PWT/SearchWaitTimes and click the "For more information" link for some FAQs on how wait times are calculated.
+    Visit https://www.accesstocare.va.gov/PWT/SearchWaitTimes and click the "For more information" link for an FAQ on how wait times are calculated.
 
     ## Design
 

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -15,6 +15,8 @@ info:
     - Cemeteries
     - Vet Centers
 
+    Visit https://www.accesstocare.va.gov/PWT/SearchWaitTimes and click the "For more information" link for some FAQs on how wait times are calculated.
+
     ## Design
 
     ### Authorization


### PR DESCRIPTION
## Description of change
This PR adds some instructions to the Facilities API v0 docs for where to find the FAQs on wait time calculation. This info is provided by Access To Care, and will give greater visibility from the source on how the wait times that are returned by the API are calculated. In the future, we may try and scrape the FAQ text or copy it over entirely.

## Acceptance Criteria (Definition of Done)
- [x] Add `Visit https://www.accesstocare.va.gov/PWT/SearchWaitTimes and click the "For more information" link for some FAQs on how wait times are calculated.` to the Facilities v0 API docs.

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
