### PR TITLE
Fix flipper initializer to allow for rake tasks pre-migration.

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -43,7 +43,8 @@ FLIPPER_FEATURE_CONFIG['features'].each_key do |feature|
       # default feautures to enabled for development and test only
       Flipper.enable(feature) if Rails.env.development? || Rails.env.test?
     end
-  rescue ActiveRecord::NoDatabaseError
+  rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
+    # make sure we can still run rake tasks before table has been created
     nil
   end
 end


### PR DESCRIPTION
## Description of change
fix the flipper initializer for developers who have not yet migrated the flipper tables but do already have a database.

````
michael@michael-Precision-T3600:~/oddball/vets-api$ rake db:setup --trace
** Invoke db:setup (first_time)
** Invoke db:schema:load_if_ruby (first_time)
** Invoke db:create (first_time)
** Invoke db:load_config (first_time)
** Invoke environment (first_time)
** Execute environment
rake aborted!
ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "flipper_features" does not exist
LINE 1: SELECT "flipper_features".* FROM "flipper_features"
                                         ^
: SELECT "flipper_features".* FROM "flipper_features"
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql_adapter.rb:611:in `async_exec'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql_adapter.rb:611:in `block (2 levels) in exec_no_cache'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql_adapter.rb:610:in `block in exec_no_cache'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:581:in `block (2 levels) in log'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:580:in `block in log'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `log'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql_adapter.rb:609:in `exec_no_cache'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql_adapter.rb:596:in `execute_and_clear'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:81:in `exec_query'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:482:in `select_prepared'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:68:in `select_all'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/query_cache.rb:106:in `select_all'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/querying.rb:41:in `find_by_sql'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/relation.rb:560:in `block in exec_queries'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/relation.rb:584:in `skip_query_cache_if_necessary'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/relation.rb:547:in `exec_queries'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/relation.rb:422:in `load'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/relation.rb:200:in `records'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activerecord-5.2.3/lib/active_record/relation/delegation.rb:71:in `each'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-active_record-0.16.2/lib/flipper/adapters/active_record.rb:51:in `map'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-active_record-0.16.2/lib/flipper/adapters/active_record.rb:51:in `features'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-active_support_cache_store-0.16.2/lib/flipper/adapters/active_support_cache_store.rb:110:in `block in read_feature_keys'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/cache.rb:323:in `block in fetch'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/cache.rb:694:in `block in save_block_result_to_cache'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/cache.rb:663:in `block in instrument'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/notifications.rb:170:in `instrument'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/cache.rb:663:in `instrument'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/cache.rb:693:in `save_block_result_to_cache'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/cache.rb:323:in `fetch'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-active_support_cache_store-0.16.2/lib/flipper/adapters/active_support_cache_store.rb:110:in `read_feature_keys'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-active_support_cache_store-0.16.2/lib/flipper/adapters/active_support_cache_store.rb:38:in `features'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-0.16.2/lib/flipper/adapters/memoizable.rb:42:in `features'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-0.16.2/lib/flipper/feature.rb:83:in `block in exist?'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-0.16.2/lib/flipper/feature.rb:376:in `block in instrument'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-0.16.2/lib/flipper/instrumenters/noop.rb:5:in `instrument'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-0.16.2/lib/flipper/feature.rb:373:in `instrument'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-0.16.2/lib/flipper/feature.rb:83:in `exist?'
/home/michael/.rvm/gems/ruby-2.4.5/gems/flipper-0.16.2/lib/flipper/dsl.rb:160:in `exist?'
/home/michael/oddball/vets-api/config/initializers/flipper.rb:41:in `block in <top (required)>'
/home/michael/oddball/vets-api/config/initializers/flipper.rb:39:in `each_key'
/home/michael/oddball/vets-api/config/initializers/flipper.rb:39:in `<top (required)>'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:285:in `load'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:285:in `block in load'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:285:in `load'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/engine.rb:657:in `block in load_config_initializer'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/notifications.rb:170:in `instrument'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/engine.rb:656:in `load_config_initializer'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/engine.rb:614:in `block (2 levels) in <class:Engine>'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/engine.rb:613:in `each'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/engine.rb:613:in `block in <class:Engine>'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/initializable.rb:32:in `instance_exec'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/initializable.rb:32:in `run'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/initializable.rb:61:in `block in run_initializers'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:228:in `block in tsort_each'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:422:in `block (2 levels) in each_strongly_connected_component_from'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:431:in `each_strongly_connected_component_from'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:421:in `block in each_strongly_connected_component_from'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/initializable.rb:50:in `each'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/initializable.rb:50:in `tsort_each_child'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:415:in `call'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:415:in `each_strongly_connected_component_from'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:349:in `block in each_strongly_connected_component'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:347:in `each'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:347:in `call'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:347:in `each_strongly_connected_component'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:226:in `tsort_each'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/tsort.rb:205:in `tsort_each'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/initializable.rb:60:in `run_initializers'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/application.rb:361:in `initialize!'
/home/michael/oddball/vets-api/config/environment.rb:7:in `<top (required)>'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
/home/michael/.rvm/gems/ruby-2.4.5/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/application.rb:337:in `require_environment!'
/home/michael/.rvm/gems/ruby-2.4.5/gems/railties-5.2.3/lib/rails/application.rb:520:in `block in run_tasks_blocks'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:273:in `block in execute'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:273:in `each'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:273:in `execute'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:214:in `block in invoke_with_call_chain'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:194:in `invoke_with_call_chain'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:238:in `block in invoke_prerequisites'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:236:in `each'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:236:in `invoke_prerequisites'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:213:in `block in invoke_with_call_chain'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:194:in `invoke_with_call_chain'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:238:in `block in invoke_prerequisites'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:236:in `each'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:236:in `invoke_prerequisites'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:213:in `block in invoke_with_call_chain'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:194:in `invoke_with_call_chain'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:238:in `block in invoke_prerequisites'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:236:in `each'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:236:in `invoke_prerequisites'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:213:in `block in invoke_with_call_chain'
/home/michael/.rvm/rubies/ruby-2.4.5/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:194:in `invoke_with_call_chain'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:238:in `block in invoke_prerequisites'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:236:in `each'
/home/michael/.rvm/gems/ruby-2.4.5/gems/rake-12.3.2/lib/rake/task.rb:236:in `invok...
````
## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
 specs


#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
