### PR TITLE
Rt/facilities websites

### DIFF
--- a/app/services/facilities/website_url_service.rb
+++ b/app/services/facilities/website_url_service.rb
@@ -4,13 +4,6 @@ require 'csv'
 
 module Facilities
   class WebsiteUrlService
-    FACILITY_TYPES = {
-      'va_benefits_facility' => 'VBA',
-      'va_health_facility' => 'VHA',
-      'va_cemetery' => 'NCA',
-      'vet_center' => 'VC'
-    }.freeze
-
     def initialize
       source = Rails.root.join('lib', 'facilities', 'website_data', 'websites.csv')
       station_websites = CSV.read(source, headers: true)

--- a/app/services/facilities/website_url_service.rb
+++ b/app/services/facilities/website_url_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module Facilities
+  class WebsiteUrlService
+    def initialize
+      source = Rails.root.join('lib', 'facilities', 'website_data', 'websites.csv')
+      station_websites = CSV.read(source, headers: true).to_h
+      @websites = map_websites_to_stations(station_websites)
+    end
+
+    def find_for_station(id)
+      entry = @websites[id]
+      entry.nil? ? '' : entry['Website_URL']
+    end
+
+    private
+
+    def map_websites_to_stations(station_websites)
+      station_websites.each_with_object({}) do |station, hash|
+        station_id = station['StationNum']
+        hash[station_id] = station['Website_URL']
+      end
+    end
+  end
+end

--- a/app/services/facilities/website_url_service.rb
+++ b/app/services/facilities/website_url_service.rb
@@ -4,23 +4,31 @@ require 'csv'
 
 module Facilities
   class WebsiteUrlService
+    FACILITY_TYPES = {
+      'va_benefits_facility' => 'VBA',
+      'va_health_facility' => 'VHA',
+      'va_cemetery' => 'NCA',
+      'vet_center' => 'VC'
+    }.freeze
+
     def initialize
       source = Rails.root.join('lib', 'facilities', 'website_data', 'websites.csv')
-      station_websites = CSV.read(source, headers: true).to_h
+      station_websites = CSV.read(source, headers: true)
       @websites = map_websites_to_stations(station_websites)
     end
 
-    def find_for_station(id)
-      entry = @websites[id]
-      entry.nil? ? '' : entry['Website_URL']
+    def find_for_station(id, type)
+      unique_id = "#{id}_#{FACILITY_TYPES[type]}"
+      entry = @websites[unique_id]
+      entry.nil? ? '' : entry
     end
 
     private
 
     def map_websites_to_stations(station_websites)
       station_websites.each_with_object({}) do |station, hash|
-        station_id = station['StationNum']
-        hash[station_id] = station['Website_URL']
+        unique_id = "#{station['StationNum']}_#{station['Org']}"
+        hash[unique_id] = station['Website_URL']
       end
     end
   end

--- a/app/services/facilities/website_url_service.rb
+++ b/app/services/facilities/website_url_service.rb
@@ -18,16 +18,16 @@ module Facilities
     end
 
     def find_for_station(id, type)
-      unique_id = "#{id}_#{FACILITY_TYPES[type]}"
-      entry = @websites[unique_id]
-      entry.nil? ? '' : entry
+      unique_id = "#{BaseFacility::PREFIX_MAP[type]}_#{id}"
+      @websites[unique_id]
     end
 
     private
 
     def map_websites_to_stations(station_websites)
       station_websites.each_with_object({}) do |station, hash|
-        unique_id = "#{station['StationNum']}_#{station['Org']}"
+        org = station['Org'].downcase unless station['Org'].nil?
+        unique_id = "#{org}_#{station['StationNum']}"
         hash[unique_id] = station['Website_URL']
       end
     end

--- a/lib/facilities/vha_facility.rb
+++ b/lib/facilities/vha_facility.rb
@@ -10,7 +10,16 @@ module Facilities
         sort_field = 'Sta_No'
         metadata = Facilities::GisMetadataClient.new.get_metadata(gis_type)
         max_record_count = metadata['maxRecordCount']
-        Facilities::GisClient.new.get_all_facilities(gis_type, sort_field, max_record_count).map(&method(:new))
+        resp = Facilities::GisClient.new.get_all_facilities(gis_type, sort_field, max_record_count).map(&method(:new))
+        add_websites(resp)
+      end
+
+      def add_websites(facilities)
+        service = Facilities::WebsiteUrlService.new
+        facilities.map do |fac|
+          fac.website = service.find_for_station(fac.unique_id, fac.facility_type)
+          fac
+        end
       end
 
       def service_list

--- a/spec/lib/facilities/vha_facility_spec.rb
+++ b/spec/lib/facilities/vha_facility_spec.rb
@@ -12,7 +12,7 @@ module Facilities
     end
 
     describe 'pull_source_data' do
-      it 'should pull data from ArcGIS endpoint' do
+      it 'should pull data from a GIS endpoint' do
         VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
           list = VHAFacility.pull_source_data
           expect(list.size).to eq(4)
@@ -56,6 +56,12 @@ module Facilities
         it 'should include zip +4 when available' do
           VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
             expect(facility_2.address['physical']['zip']).to eq('04330-6796')
+          end
+        end
+
+        it 'should include websites for facilities' do
+          VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
+            expect(facility_2.website).to eq('http://www.maine.va.gov/')
           end
         end
 

--- a/spec/lib/facilities/vha_facility_spec.rb
+++ b/spec/lib/facilities/vha_facility_spec.rb
@@ -3,121 +3,119 @@
 require 'rails_helper'
 require 'facilities/bulk_json_client'
 
-module Facilities
-  RSpec.describe VHAFacility do
-    before(:each) { BaseFacility.validate_on_load = false }
-    after(:each) { BaseFacility.validate_on_load = true }
-    it 'should be a VHAFacility object' do
-      expect(described_class.new).to be_a(VHAFacility)
+RSpec.describe Facilities::VHAFacility do
+  before(:each) { BaseFacility.validate_on_load = false }
+  after(:each) { BaseFacility.validate_on_load = true }
+  it 'should be a Facilities::VHAFacility object' do
+    expect(described_class.new).to be_a(Facilities::VHAFacility)
+  end
+
+  describe 'pull_source_data' do
+    it 'should pull data from a GIS endpoint' do
+      VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
+        list = Facilities::VHAFacility.pull_source_data
+        expect(list.size).to eq(4)
+        expect(list.all? { |item| item.is_a?(Facilities::VHAFacility) })
+      end
     end
 
-    describe 'pull_source_data' do
-      it 'should pull data from a GIS endpoint' do
+    context 'with single facility' do
+      let(:facilities) { Facilities::VHAFacility.pull_source_data }
+      let(:facility) { facilities.first }
+      let(:facility_2) { facilities.second }
+      it 'should parse hours correctly' do
         VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
-          list = VHAFacility.pull_source_data
-          expect(list.size).to eq(4)
-          expect(list.all? { |item| item.is_a?(VHAFacility) })
+          expect(facility.hours.values).to match_array(
+            ['730AM-430PM', '730AM-430PM', '730AM-430PM', '730AM-430PM', '730AM-430PM', 'Closed', 'Closed']
+          )
         end
       end
 
-      context 'with single facility' do
-        let(:facilities) { VHAFacility.pull_source_data }
-        let(:facility) { facilities.first }
-        let(:facility_2) { facilities.second }
-        it 'should parse hours correctly' do
-          VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
-            expect(facility.hours.values).to match_array(
-              ['730AM-430PM', '730AM-430PM', '730AM-430PM', '730AM-430PM', '730AM-430PM', 'Closed', 'Closed']
-            )
+      it 'should parse mailing address correctly' do
+        VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
+          expect(facility.address['mailing']).to eq({})
+        end
+      end
+
+      it 'should parse mailing address correctly' do
+        VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
+          expect(facility.address['physical']).to eq('address_1' => '1501 Roxas Boulevard',
+                                                     'address_2' => 'NOX3 Seafront Compound',
+                                                     'address_3' => nil, 'city' => 'Pasay City',
+                                                     'state' => 'PH', 'zip' => '01302')
+        end
+      end
+
+      it 'should include just be 5 digit if zip +4 is empty' do
+        VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
+          expect(facility.address['physical']['zip']).to eq('01302')
+        end
+      end
+
+      it 'should include zip +4 when available' do
+        VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
+          expect(facility_2.address['physical']['zip']).to eq('04330-6796')
+        end
+      end
+
+      it 'should include websites for facilities' do
+        VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
+          expect(facility_2.website).to eq('http://www.maine.va.gov/')
+        end
+      end
+
+      context 'services' do
+        let(:satisfaction_data) do
+          fixture_file_name = "#{::Rails.root}/spec/fixtures/facility_access/satisfaction_data.json"
+          File.open(fixture_file_name, 'rb') do |f|
+            JSON.parse(f.read)
           end
         end
 
-        it 'should parse mailing address correctly' do
-          VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
-            expect(facility.address['mailing']).to eq({})
+        let(:wait_time_data) do
+          fixture_file_name = "#{::Rails.root}/spec/fixtures/facility_access/wait_time_data.json"
+          File.open(fixture_file_name, 'rb') do |f|
+            JSON.parse(f.read)
           end
         end
 
-        it 'should parse mailing address correctly' do
-          VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
-            expect(facility.address['physical']).to eq('address_1' => '1501 Roxas Boulevard',
-                                                       'address_2' => 'NOX3 Seafront Compound',
-                                                       'address_3' => nil, 'city' => 'Pasay City',
-                                                       'state' => 'PH', 'zip' => '01302')
-          end
+        let(:sat_client_stub) { instance_double('Facilities::AccessSatisfactionClient') }
+        let(:wait_client_stub) { instance_double('Facilities::AccessWaitTimeClient') }
+
+        before(:each) do
+          allow(Facilities::AccessSatisfactionClient).to receive(:new) { sat_client_stub }
+          allow(Facilities::AccessWaitTimeClient).to receive(:new) { wait_client_stub }
+          allow(sat_client_stub).to receive(:download).and_return(satisfaction_data)
+          allow(wait_client_stub).to receive(:download).and_return(wait_time_data)
+          Facilities::AccessDataDownload.new.perform
         end
 
-        it 'should include just be 5 digit if zip +4 is empty' do
+        it 'should parse services' do
           VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
-            expect(facility.address['physical']['zip']).to eq('01302')
-          end
-        end
+            f1_services = facility.services
+            f2_services = facility_2.services
+            f1_health = f1_services['health']
+            f2_health = f2_services['health']
 
-        it 'should include zip +4 when available' do
-          VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
-            expect(facility_2.address['physical']['zip']).to eq('04330-6796')
-          end
-        end
+            expect(f1_services.keys).to match(%w[last_updated health other])
+            expect(f1_services['last_updated']).to eq('2019-07-09')
+            expect(f1_health.size).to eq(2)
+            expect(f1_health.first.keys).to eq(%w[sl1 sl2])
+            expect(f1_health.first.values).to eq([['PrimaryCare'], []])
+            expect(f1_health.second.keys).to eq(%w[sl1 sl2])
+            expect(f1_health.second.values).to eq([['MentalHealthCare'], []])
+            expect(f1_services['other']).to be_empty
 
-        it 'should include websites for facilities' do
-          VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
-            expect(facility_2.website).to eq('http://www.maine.va.gov/')
-          end
-        end
-
-        context 'services' do
-          let(:satisfaction_data) do
-            fixture_file_name = "#{::Rails.root}/spec/fixtures/facility_access/satisfaction_data.json"
-            File.open(fixture_file_name, 'rb') do |f|
-              JSON.parse(f.read)
-            end
-          end
-
-          let(:wait_time_data) do
-            fixture_file_name = "#{::Rails.root}/spec/fixtures/facility_access/wait_time_data.json"
-            File.open(fixture_file_name, 'rb') do |f|
-              JSON.parse(f.read)
-            end
-          end
-
-          let(:sat_client_stub) { instance_double('Facilities::AccessSatisfactionClient') }
-          let(:wait_client_stub) { instance_double('Facilities::AccessWaitTimeClient') }
-
-          before(:each) do
-            allow(Facilities::AccessSatisfactionClient).to receive(:new) { sat_client_stub }
-            allow(Facilities::AccessWaitTimeClient).to receive(:new) { wait_client_stub }
-            allow(sat_client_stub).to receive(:download).and_return(satisfaction_data)
-            allow(wait_client_stub).to receive(:download).and_return(wait_time_data)
-            Facilities::AccessDataDownload.new.perform
-          end
-
-          it 'should parse services' do
-            VCR.use_cassette('facilities/va/vha_facilities_limit_results') do
-              f1_services = facility.services
-              f2_services = facility_2.services
-              f1_health = f1_services['health']
-              f2_health = f2_services['health']
-
-              expect(f1_services.keys).to match(%w[last_updated health other])
-              expect(f1_services['last_updated']).to eq('2019-07-09')
-              expect(f1_health.size).to eq(2)
-              expect(f1_health.first.keys).to eq(%w[sl1 sl2])
-              expect(f1_health.first.values).to eq([['PrimaryCare'], []])
-              expect(f1_health.second.keys).to eq(%w[sl1 sl2])
-              expect(f1_health.second.values).to eq([['MentalHealthCare'], []])
-              expect(f1_services['other']).to be_empty
-
-              expect(f2_services.keys).to match(%w[last_updated health other])
-              expect(f2_services['last_updated']).to eq('2019-07-09')
-              expect(f2_health.size).to eq(2)
-              # expect(f2_health.size).to eq(3)
-              expect(f2_health.first.keys).to eq(%w[sl1 sl2])
-              expect(f2_health.second.keys).to eq(%w[sl1 sl2])
-              expect(f2_health.first.values).to eq([['PrimaryCare'], []])
-              expect(f2_health.second.values).to eq([['MentalHealthCare'], []])
-              # expect(f2_health.third.keys).to eq(%w[sl1 sl2])
-              # expect(f2_health.third.values).to eq([['DentalServices'], []])
-            end
+            expect(f2_services.keys).to match(%w[last_updated health other])
+            expect(f2_services['last_updated']).to eq('2019-07-09')
+            expect(f2_health.size).to eq(2)
+            # expect(f2_health.size).to eq(3)
+            expect(f2_health.first.keys).to eq(%w[sl1 sl2])
+            expect(f2_health.second.keys).to eq(%w[sl1 sl2])
+            expect(f2_health.first.values).to eq([['PrimaryCare'], []])
+            expect(f2_health.second.values).to eq([['MentalHealthCare'], []])
+            # expect(f2_health.third.keys).to eq(%w[sl1 sl2])
+            # expect(f2_health.third.values).to eq([['DentalServices'], []])
           end
         end
       end

--- a/spec/services/facilities/website_url_service_spec.rb
+++ b/spec/services/facilities/website_url_service_spec.rb
@@ -17,10 +17,9 @@ RSpec.describe Facilities::WebsiteUrlService do
     expect(benefits_url).to eq('http://www.benefits.va.gov/togus/')
   end
 
-  it 'provides an empty string when it does not know about a station id' do
+  it 'provides an nil when it does not know about a station id' do
     service = Facilities::WebsiteUrlService.new
     url = service.find_for_station('fAkE1D', 'va_health_facility')
-    expect(url).to eq('')
+    expect(url).to be_nil
   end
 end
-

--- a/spec/services/facilities/website_url_service_spec.rb
+++ b/spec/services/facilities/website_url_service_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Facilities::WebsiteUrlService do
+  it 'provides the url when it knows about a station id' do
+    service = Facilities::WebsiteUrlService.new
+    url = service.find_for_station('0231V')
+    expect(url).to eq('http://www.beckley.va.gov/')
+  end
+
+  it 'provides an empty string when it does not know about a station id' do
+    service = Facilities::WebsiteUrlService.new
+    url = service.find_for_station('fAkE1D')
+    expect(url).to eq('')
+  end
+end
+

--- a/spec/services/facilities/website_url_service_spec.rb
+++ b/spec/services/facilities/website_url_service_spec.rb
@@ -3,15 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe Facilities::WebsiteUrlService do
-  it 'provides the url when it knows about a station id' do
+  it 'provides the url when it knows about a station id and facility type' do
     service = Facilities::WebsiteUrlService.new
-    url = service.find_for_station('0231V')
+    url = service.find_for_station('0231V', 'va_health_facility')
     expect(url).to eq('http://www.beckley.va.gov/')
+  end
+
+  it 'provides the url for the correct type of facility' do
+    service = Facilities::WebsiteUrlService.new
+    health_url = service.find_for_station('402', 'va_health_facility')
+    benefits_url = service.find_for_station('402', 'va_benefits_facility')
+    expect(health_url).to eq('http://www.maine.va.gov/')
+    expect(benefits_url).to eq('http://www.benefits.va.gov/togus/')
   end
 
   it 'provides an empty string when it does not know about a station id' do
     service = Facilities::WebsiteUrlService.new
-    url = service.find_for_station('fAkE1D')
+    url = service.find_for_station('fAkE1D', 'va_health_facility')
     expect(url).to eq('')
   end
 end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
This PR finishes [#2692](https://github.com/department-of-veterans-affairs/vets-contrib/issues/2692). It makes it so that we pull website urls for VHA facilities from a static CSV. Other facility types continue pulling their website urls from the original locations.

## Testing done
- Added tests for the website url service
- Added a test for where the new website urls integrate with the rest of the vha facility data pull
- Confirmed that the website urls appear in Postgres after running the Sidekiq job to pull all facility data

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] VHA facilities have website URLs that come from the website URLs spreadsheet maintained by Lighthouse.

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
