### PR TITLE
Kr/get all vha services from redis

### DIFF
--- a/app/models/base_facility.rb
+++ b/app/models/base_facility.rb
@@ -11,10 +11,6 @@ class BaseFacility < ApplicationRecord
 
   YES = 'YES'
 
-  APPROVED_SERVICES = %w[
-    DentalServices
-  ].freeze
-
   HOURS_STANDARD_MAP = DateTime::DAYNAMES.each_with_object({}) { |d, h| h[d] = d }
 
   HEALTH = 'health'

--- a/lib/common/client/middleware/response/facility_parser.rb
+++ b/lib/common/client/middleware/response/facility_parser.rb
@@ -18,135 +18,154 @@ module Common
             path_test = env.url.path.match(/(FacilitySitePoint_\w{3})/) if path_test.nil?
             path_part = path_test[1]
             facility_map = facility_klass(path_part).attribute_map
-            env.body['features'].map { |location_data| build_facility_attributes(location_data, facility_map) }
-          end
-
-          def build_facility_attributes(location, mapping)
-            facility = { 'address' => {},
-                         'services' => {},
-                         'lat' => location['geometry']['y'],
-                         'long' => location['geometry']['x'] }
-            facility.merge!(make_direct_mappings(location, mapping))
-            facility.merge!(make_complex_mappings(location, mapping))
-            facility.merge!(make_address_mappings(location, mapping))
-            facility.merge!(map_benefits_services(location, mapping, facility['unique_id'])) if mapping['benefits']
-            facility.merge!(make_hours_mappings(location, mapping))
-            facility.merge!(map_health_services(location, mapping, facility['unique_id'])) if mapping['services']
-            facility
-          end
-
-          def make_direct_mappings(location, mapping)
-            %w[unique_id name classification website].each_with_object({}) do |name, attributes|
-              attributes[name] = strip(location['attributes'][mapping[name]])
-            end
-          end
-
-          def make_complex_mappings(location, mapping)
-            %w[access feedback phone].each_with_object({}) do |name, attributes|
-              attributes[name] = complex_mapping(mapping[name], location['attributes'])
-            end
-          end
-
-          def make_address_mappings(location, mapping)
-            attributes = {}
-            attributes['physical'] = complex_mapping(mapping['physical'], location['attributes'])
-            attributes['mailing'] = complex_mapping(mapping['mailing'], location['attributes'])
-            { 'address' => attributes }
-          end
-
-          def map_benefits_services(location, mapping, id)
-            attributes = {}
-            attributes['benefits'] = {
-              'standard' => clean_benefits(complex_mapping(mapping['benefits'], location['attributes'])),
-              'other' => location['attributes']['Other_Services']
-            }
-            attributes['benefits']['standard'] << 'Pensions' if BaseFacility::PENSION_LOCATIONS.include?(id)
-            { 'services' => attributes }
-          end
-
-          def make_hours_mappings(location, mapping)
-            attributes = {}
-            attributes['hours'] = complex_mapping(mapping['hours'], location['attributes'])
-            attributes['hours'].transform_values! do |hours|
-              if /closed/i.match(hours) || hours == '-'
-                'Closed'
-              else
-                hours
-              end
-            end
-            attributes
-          end
-
-          def map_health_services(location, mapping, id)
-            attributes = {}
-            attributes['last_updated'] = services_date(location['attributes'])
-            attributes['health'] = collect_health_services(id)
-            attributes['other'] = other_services(location['attributes'])
-            { 'services' => attributes }
-          end
-
-          def complex_mapping(item, attrs)
-            return {} unless item
-            item.each_with_object({}) do |(key, value), hash|
-              hash[key] = value.respond_to?(:call) ? value.call(attrs) : strip(attrs[value])
-            end
-          end
-
-          def clean_benefits(benefits_hash)
-            benefits_hash.keys.select { |key| benefits_hash[key] == BaseFacility::YES }
-          end
-
-          def strip(value)
-            value.respond_to?(:strip) ? value.strip : value
-          end
-
-          def services_date(attrs)
-            # Field for facilities coming from ArcGIS in string format
-            return Date.strptime(attrs['FacilityDataDate'], '%m-%d-%Y').iso8601 if attrs['FacilityDataDate']
-
-            # Field for facilities coming from gis.va.gov in unix timestamp
-            Time.at((attrs['LASTUPDATE'] / 1000)).utc.strftime('%Y-%m-%d') if attrs['LASTUPDATE']
-          end
-
-          def collect_health_services(id)
-            services = []
-
-            services << services_from_wait_time_data(id.upcase)
-            services << dental_services(id.upcase)
-
-            services.flatten
-          end
-
-          def other_services(attrs)
-            services = []
-            services << 'Online Scheduling' if attrs['DirectPatientSchedulingFlag'] == BaseFacility::YES
-            services
-          end
-
-          def services_from_wait_time_data(facility_id)
-            facility_wait_time = FacilityWaitTime.find(facility_id)
-            metric_keys = facility_wait_time&.metrics&.keys || []
-            services = []
-            services << { 'sl1' => ['EmergencyCare'], 'sl2' => [] } if facility_wait_time&.emergency_care&.any?
-            services << { 'sl1' => ['UrgentCare'], 'sl2' => [] } if facility_wait_time&.urgent_care&.any?
-            Facilities::AccessDataDownload::WT_KEY_MAP.each_value do |service|
-              services << { 'sl1' => [service.camelize], 'sl2' => [] } if metric_keys.include?(service)
-            end
-            services
-          end
-
-          def dental_services(facility_id)
-            services = []
-            if FacilityDentalService.exists?(facility_id)
-              services << { 'sl1' => ['DentalServices'], 'sl2' => [] }
-            end
-
-            services
+            env.body['features'].map { |location_data| TempFacility.new(location_data, facility_map).build_facility_attributes }
           end
 
           def facility_klass(path_part)
             BaseFacility::PATHMAP[path_part]
           end
+
+          class TempFacility
+            attr_accessor :facility, :location, :mapping
+
+            def initialize(location_data, facility_map)
+              @location = location_data
+              @mapping = facility_map
+
+              @facility = { 
+                'address' => {},
+                'services' => {},
+                'lat' => @location['geometry']['y'],
+                'long' => @location['geometry']['x'] 
+              }
+            end
+
+            def build_facility_attributes
+              make_direct_mappings
+              make_complex_mappings
+              @facility['address'] = make_address_mappings
+              @facility['services']['benefits'] = map_benefits_services if @mapping['benefits']
+              @facility['hours'] = make_hours_mappings
+              @facility['services'] = map_health_services if @mapping['services']
+              
+              @facility
+            end
+
+            def make_direct_mappings
+              %w[unique_id name classification website].each_with_object({}) do |name, attributes|
+                @facility[name] = strip(@location['attributes'][@mapping[name]])
+              end
+            end
+
+            def make_complex_mappings
+              %w[access feedback phone].each_with_object({}) do |name, attributes|
+                @facility[name] = complex_mapping(name)
+              end
+            end
+
+            def make_address_mappings
+              { 
+                'physical' => complex_mapping('physical'),
+                'mailing' => complex_mapping('mailing')
+              }
+            end
+
+            def map_benefits_services
+              {
+                'standard' => calculate_standard_benefits,
+                'other' => @location['attributes']['Other_Services']
+              }
+            end
+
+            def calculate_standard_benefits
+              cleaned_benefits = clean_benefits(complex_mapping('benefits'))
+              cleaned_benefits << 'Pensions' if has_pensions?
+              cleaned_benefits
+            end
+
+            def has_pensions?
+              BaseFacility::PENSION_LOCATIONS.include?(@facility['unique_id'])
+            end
+
+            def make_hours_mappings
+              hours_mapping = complex_mapping('hours')
+              hours_mapping.transform_values! do |hours|
+                if /closed/i.match(hours) || hours == '-'
+                  'Closed'
+                else
+                  hours
+                end
+              end
+
+              hours_mapping
+            end
+
+            def map_health_services
+              {
+                'last_updated' => services_date,
+                'health' => collect_health_services,
+                'other' => []
+              }
+            end
+
+            def complex_mapping(attr_name)
+              attrs = @location['attributes']
+              item = @mapping[attr_name]
+              return {} unless item
+              item.each_with_object({}) do |(key, value), hash|
+                hash[key] = value.respond_to?(:call) ? value.call(attrs) : strip(attrs[value])
+              end
+            end
+
+            def clean_benefits(benefits_hash)
+              benefits_hash.keys.select { |key| benefits_hash[key] == BaseFacility::YES }
+            end
+
+            def strip(value)
+              value.respond_to?(:strip) ? value.strip : value
+            end
+
+            def services_date
+              id = @facility['unique_id'].upcase
+              facility_wait_time = FacilityWaitTime.find(id)
+
+              if facility_wait_time&.source_updated.present?
+                Date.strptime(facility_wait_time&.source_updated).iso8601
+              end
+            end
+
+            def collect_health_services
+              services = []
+
+              id = @facility['unique_id'].upcase
+              services << services_from_wait_time_data(id)
+              services << dental_services(id)
+
+              services.flatten
+            end
+
+            def services_from_wait_time_data(facility_id)
+              facility_wait_time = FacilityWaitTime.find(facility_id)
+              metric_keys = facility_wait_time&.metrics&.keys || []
+              services = []
+              services << { 'sl1' => ['EmergencyCare'], 'sl2' => [] } if facility_wait_time&.emergency_care&.any?
+              services << { 'sl1' => ['UrgentCare'], 'sl2' => [] } if facility_wait_time&.urgent_care&.any?
+              Facilities::AccessDataDownload::WT_KEY_MAP.each_value do |service|
+                services << { 'sl1' => [service.camelize], 'sl2' => [] } if metric_keys.include?(service)
+              end
+              services
+            end
+
+            def dental_services(facility_id)
+              services = []
+              if FacilityDentalService.exists?(facility_id)
+                services << { 'sl1' => ['DentalServices'], 'sl2' => [] }
+              end
+
+              services
+            end
+          end
+
         end
       end
     end

--- a/lib/common/client/middleware/response/facility_parser.rb
+++ b/lib/common/client/middleware/response/facility_parser.rb
@@ -118,7 +118,8 @@ module Common
               end
               l << { 'sl1' => [k], 'sl2' => sl2 }
             end
-            services.concat(services_from_wait_time_data(id.upcase))
+            services_before_dental = services.concat(services_from_wait_time_data(id.upcase))
+            services_before_dental.concat(dental_services(id.upcase))
           end
 
           def other_services(attrs)
@@ -136,6 +137,15 @@ module Common
             Facilities::AccessDataDownload::WT_KEY_MAP.each_value do |service|
               services << { 'sl1' => [service.camelize], 'sl2' => [] } if metric_keys.include?(service)
             end
+            services
+          end
+
+          def dental_services(facility_id)
+            services = []
+            if FacilityDentalService.exists?(facility_id)
+              services << { 'sl1' => ['DentalServices'], 'sl2' => [] }
+            end
+
             services
           end
 

--- a/spec/lib/facilities/vha_facility_spec.rb
+++ b/spec/lib/facilities/vha_facility_spec.rb
@@ -83,6 +83,7 @@ module Facilities
             allow(sat_client_stub).to receive(:download).and_return(satisfaction_data)
             allow(wait_client_stub).to receive(:download).and_return(wait_time_data)
             Facilities::AccessDataDownload.new.perform
+            Facilities::DentalServiceReloadJob.new.perform
           end
 
           it 'should parse services' do
@@ -103,14 +104,13 @@ module Facilities
 
               expect(f2_services.keys).to match(%w[last_updated health other])
               expect(f2_services['last_updated']).to eq('2019-07-09')
-              expect(f2_health.size).to eq(2)
-              # expect(f2_health.size).to eq(3)
+              expect(f2_health.size).to eq(3)
               expect(f2_health.first.keys).to eq(%w[sl1 sl2])
               expect(f2_health.second.keys).to eq(%w[sl1 sl2])
               expect(f2_health.first.values).to eq([['PrimaryCare'], []])
               expect(f2_health.second.values).to eq([['MentalHealthCare'], []])
-              # expect(f2_health.third.keys).to eq(%w[sl1 sl2])
-              # expect(f2_health.third.values).to eq([['DentalServices'], []])
+              expect(f2_health.third.keys).to eq(%w[sl1 sl2])
+              expect(f2_health.third.values).to eq([['DentalServices'], []])
             end
           end
         end

--- a/spec/lib/facilities/vha_facility_spec.rb
+++ b/spec/lib/facilities/vha_facility_spec.rb
@@ -94,7 +94,7 @@ module Facilities
               f2_health = f2_services['health']
 
               expect(f1_services.keys).to match(%w[last_updated health other])
-              expect(f1_services['last_updated']).to eq('2019-07-09')
+              expect(f1_services['last_updated']).to eq('2017-03-31')
               expect(f1_health.size).to eq(2)
               expect(f1_health.first.keys).to eq(%w[sl1 sl2])
               expect(f1_health.first.values).to eq([['PrimaryCare'], []])
@@ -103,7 +103,7 @@ module Facilities
               expect(f1_services['other']).to be_empty
 
               expect(f2_services.keys).to match(%w[last_updated health other])
-              expect(f2_services['last_updated']).to eq('2019-07-09')
+              expect(f2_services['last_updated']).to eq('2017-03-31')
               expect(f2_health.size).to eq(3)
               expect(f2_health.first.keys).to eq(%w[sl1 sl2])
               expect(f2_health.second.keys).to eq(%w[sl1 sl2])


### PR DESCRIPTION
## Description of change
https://app.zenhub.com/workspaces/developervagov-5ac272fff41bfa50c0e46c48/issues/department-of-veterans-affairs/vets-contrib/2989

In the past, the services for a facility were acquired from an Arcgis endpoint and Access to Care. We are no longer using the Arcgis endpoint, and we will now be receiving services data from Access to Care. 

Changes in this PR:
- DentalServices is retrieved from a hard coded list through Redis
- The `services_from_gis` method in FacilityParser is no longer being used, so I renamed it. Its purpose is now to collect health services from both wait time data and the redis dental services. 
- The OnlineScheduling flag is no longer available, so it was taken out. We were not using this anyway.
- I refactored the Facility Parser class to include another class (TempFacility). Since `mapping` and `location` were being passed around so often, it was an indication that we were trying to capture state, and the best way to do this is through a class. Suggestions on this new class name are welcome. 

