### PR TITLE
Update metadata_swagger.rb

### DIFF
--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/metadata_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/metadata_swagger.rb
@@ -9,7 +9,7 @@ module VbaDocuments
         key :name, 'Metadata'
         key :type, :object
         key :description, 'Identifying properties about the document payload being submitted'
-        key :required, %i[veteranFirstName veteranLastName fileNumber zipCode]
+        key :required, %i[veteranFirstName veteranLastName fileNumber zipCode source]
 
         key :in, :formData
 


### PR DESCRIPTION
## Description of change
Updates Swagger doc to indicate that the `source` metadata field is required.  Our API does not yet validate this field, however the upstream provider (GDIT) does require this field to identify the source consumer.


## Testing done
none

## Testing planned
reviewer(s) please confirm I have done this correctly

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] `source` metadata field shows as required (with asterisk) in Swagger doc
#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
