### PR TITLE
Run specs for all modules with rake spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,5 +15,6 @@ unless Rails.env.production?
   task(:spec).clear
   RSpec::Core::RakeTask.new(:spec) do |t|
     t.pattern = Dir.glob(['spec/**/*_spec.rb', 'modules/*/spec/**/*_spec.rb'])
+    t.verbose = false
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -14,18 +14,6 @@ unless Rails.env.production?
   require 'rspec/core/rake_task'
   task(:spec).clear
   RSpec::Core::RakeTask.new(:spec) do |t|
-    t.pattern = Dir.glob(
-      [
-        'spec/**/*_spec.rb',
-        'modules/vba_documents/spec/**/*_spec.rb',
-        'modules/appeals_api/spec/**/*_spec.rb',
-        'modules/claims_api/spec/**/*_spec.rb',
-        'modules/va_facilities/spec/**/*_spec.rb',
-        'modules/veteran/spec/**/*_spec.rb',
-        'modules/veteran_verification/spec/**/*_spec.rb',
-        'modules/openid_auth/spec/**/*_spec.rb'
-      ]
-    )
-    t.verbose = false
+    t.pattern = Dir.glob(['spec/**/*_spec.rb', 'modules/*/spec/**/*_spec.rb'])
   end
 end


### PR DESCRIPTION
## Description of change
`rake spec` should run all module tests without requiring the developer to add a new module


#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
