### PR TITLE
Upgrade factory_bot to last version supporting static attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,11 +134,9 @@ group :development, :test do
   gem 'bundler-audit'
   gem 'byebug', platforms: :ruby # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'database_cleaner'
-  gem 'factory_bot_rails'
+  gem 'factory_bot_rails', '< 4.11'
   gem 'pry-byebug'
   gem 'rainbow' # Used to colorize output for rake tasks
-  # TODO: switch to a version number once that version is released
-  gem 'factory_bot', git: 'https://github.com/thoughtbot/factory_bot', ref: '50eeb67241ea78a6b138eea694a2a25413052f49'
   # CAUTION: faraday_curl may not provide all headers used in the actual faraday request. Be cautious if using this to
   # assist with debugging production issues (https://github.com/department-of-veterans-affairs/vets.gov-team/pull/6262)
   gem 'faraday_curl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,14 +40,6 @@ GIT
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 
-GIT
-  remote: https://github.com/thoughtbot/factory_bot
-  revision: 50eeb67241ea78a6b138eea694a2a25413052f49
-  ref: 50eeb67241ea78a6b138eea694a2a25413052f49
-  specs:
-    factory_bot (4.8.2)
-      activesupport (>= 3.0.0)
-
 PATH
   remote: modules/appeals_api
   specs:
@@ -273,8 +265,10 @@ GEM
       tzinfo
     ethon (0.10.1)
       ffi (>= 1.3.0)
-    factory_bot_rails (4.8.2)
-      factory_bot (~> 4.8.2)
+    factory_bot (4.10.0)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.10.0)
+      factory_bot (~> 4.10.0)
       railties (>= 3.0.0)
     faker (1.6.3)
       i18n (~> 0.5)
@@ -685,8 +679,7 @@ DEPENDENCIES
   date_validator
   dry-struct
   dry-types
-  factory_bot!
-  factory_bot_rails
+  factory_bot_rails (< 4.11)
   faker
   faker-medical
   fakeredis


### PR DESCRIPTION
## Description of change
Our code was locked to a specific SHA1 of the factory_bot repo with a TODO note to undo the change when
possible. This PR handles that TODO.

We *cannot* upgrade to the latest factory_bot (5.x) because it deprecates static attributes which are used in many of our specs. We can fix those in a later PR through the process outlined here:

https://thoughtbot.com/blog/deprecating-static-attributes-in-factory_bot-4-11

The version was locked to < 4.11 since 4.11 adds noisy deprecation warnings in preparation for FactoryBot 5.0 removal of static attributes. Those deprecations will be handled in 4.11 on the way to 5.0 in another PR

## Testing done
Specs pass after the changes

## Testing planned
<!-- Please describe testing planned. -->
Specs on staging should pass

## Acceptance Criteria (Definition of Done)
- [x] All specs pass

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)