### PR TITLE
small mvi rspec cleanup

### DIFF
--- a/spec/lib/mvi/service_spec.rb
+++ b/spec/lib/mvi/service_spec.rb
@@ -281,9 +281,6 @@ describe MVI::Service do
       let(:base_path) { MVI::Configuration.instance.base_path }
       it 'should raise a service error', :aggregate_failures do
         allow_any_instance_of(Faraday::Connection).to receive(:post).and_raise(Faraday::TimeoutError)
-        expect(Rails.logger).to receive(:warn).with(
-          'Could not load MVI SSL cert: No such file or directory @ rb_sysopen - /fake/client/cert/path'
-        )
         expect(subject).to receive(:log_console_and_sentry).with(
           'MVI find_profile error: Gateway timeout',
           :warn


### PR DESCRIPTION
Followup to https://github.com/department-of-veterans-affairs/vets-api/pull/3247

I'm still a bit baffled on this one. I'm guessing a config changed somewhere in the middle of testing, but this code seems to be not needed...