### PR TITLE
Remove unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,6 @@ end
 group :test do
   gem 'apivore'
   gem 'awrence'
-  gem 'climate_control'
   gem 'faker'
   gem 'faker-medical'
   gem 'fakeredis'

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'rails', '~> 5.2.3'
 # Gems with special version/repo needs
 gem 'active_model_serializers', '0.10.4' # breaking changed in 0.10.5 relating to .to_json
 gem 'carrierwave', '~> 0.11' # TODO: explanation
-gem 'sdoc', '~> 0.4.0', group: :doc # TODO: explanation
 gem 'sidekiq-scheduler', '~> 2.0' # TODO: explanation
 
 gem 'aasm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,8 +476,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rdoc (4.2.2)
-      json (~> 1.4)
     redis (3.3.5)
     redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
@@ -544,9 +542,6 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     script_utils (0.0.4)
-    sdoc (0.4.1)
-      json (~> 1.7, >= 1.7.7)
-      rdoc (~> 4.0)
     seedbank (0.5.0)
       rake (>= 10.0)
     semantic_logger (4.5.0)
@@ -744,7 +739,6 @@ DEPENDENCIES
   ruby-saml
   rubyzip (>= 1.0.0)
   savon
-  sdoc (~> 0.4.0)
   seedbank
   sentry-raven (= 2.9.0)
   shrine

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,6 @@ GEM
     childprocess (1.0.1)
       rake (< 13.0)
     clam_scan (0.0.2)
-    climate_control (0.1.0)
     cliver (0.3.2)
     coderay (1.1.2)
     coercible (1.0.0)
@@ -672,7 +671,6 @@ DEPENDENCIES
   carrierwave-aws
   claims_api!
   clam_scan
-  climate_control
   config
   connect_vbms!
   database_cleaner


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Two unused gems were removed from the Gemfile
## Testing done
<!-- Please describe testing done to verify the changes. -->
Verified Climate control was not used in the codebase
- `ClimateControl.modify` could not be found in a search
- Removing the gem did nothing to the specs

Removed unused group (`doc`) and `sdoc` gem
- likely leftover from the Rails 4.2.x `rails new` command, where this was part of the default Gemfile and removed in Rails 5.0+
- scanned Rake tasks for any doc-related tasks that used sdoc without finding any reference to `sdoc` command

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
Nothing Unique

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)