### PR TITLE
commit codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,47 @@
+version: "2"         # required to adjust maintainability checks
+checks:
+  argument-count:
+    config:
+      threshold: 4
+  complex-logic:
+    config:
+      threshold: 4
+  file-lines:
+    config:
+      threshold: 250
+  method-complexity:
+    config:
+      threshold: 5
+  method-count:
+    config:
+      threshold: 20
+  method-lines:
+    config:
+      threshold: 25
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 4
+  similar-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+  identical-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+plugins:
+  rubocop:
+    enabled: true
+    channel: rubocop-0-52
+  brakeman:
+    enabled: true
+  bundler-audit:
+    enabled: true
+exclude_patterns:
+  - 'config/'
+  - 'db/'
+  - 'features/'
+  - 'script/'
+  - '**/spec/'
+  - '**/vendor/'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -41,7 +41,6 @@ plugins:
 exclude_patterns:
   - 'config/'
   - 'db/'
-  - 'features/'
-  - 'script/'
   - '**/spec/'
-  - '**/vendor/'
+  - 'benchmark/'
+  - 'docs/'


### PR DESCRIPTION
Commit codeclimate config to .yml so that all who can write to the repo can modify config. 

I took codeclimate defaults + current plugin settings (though I did remove some unnecessary patterns from the `exclude_patterns`)