### PR TITLE
Fix locally broken spec

### DIFF
--- a/spec/controllers/v0/preneeds/preneed_attachments_controller_spec.rb
+++ b/spec/controllers/v0/preneeds/preneed_attachments_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe V0::Preneeds::PreneedAttachmentsController, type: :controller do
   describe '#create' do
     it 'uploads a preneed attachment' do
       post(:create, params: { preneed_attachment: {
-             file_data: fixture_file_upload('pdf_fill/extras.pdf')
+             file_data: fixture_file_upload('preneeds/extras.pdf', 'application/pdf')
            } })
 
       expect(JSON.parse(response.body)['data']['attributes']['guid']).to eq Preneeds::PreneedAttachment.last.guid


### PR DESCRIPTION
There is a repeatable and persistent spec failure on multiple (all?)
local Ruby installations in this location: `/spec/controllers/v0/preneeds/preneed_attachments_controller_spec.rb:7`

The stacktrace is
```
2019-09-18 09:49:15.919951 D [28322:70295016921020] V0::Preneeds::PreneedAttachmentsController -- Processing #create
2019-09-18 09:49:19.287652 E [28322:70295016921020 sentry_logging.rb:57] Rails -- Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: `identify /var/folders/yj/9j91j4gj2sqbkll8mrxy3h8r0000gn/T/mini_magick20190918-28322-1f7ayhd.pdf` failed with error:
.
2019-09-18 09:49:19.287793 E [28322:70295016921020 sentry_logging.rb:57] Rails -- /Users/johnpaul/work/oddball/vets-api/.bundle/gems/carrierwave-0.11.2/lib/carrierwave/processing/mini_magick.rb:273:in `rescue in manipulate!'
/Users/johnpaul/work/oddball/vets-api/.bundle/gems/carrierwave-0.11.2/lib/carrierwave/processing/mini_magick.rb:258:in `manipulate!'
/Users/johnpaul/work/oddball/vets-api/.bundle/gems/carrierwave-0.11.2/lib/carrierwave/processing/mini_magick.rb:108:in `convert'
/Users/johnpaul/work/oddball/vets-api/.bundle/gems/carrierwave-0.11.2/lib/carrierwave/uploader/processing.rb:84:in `block in process!'
/Users/johnpaul/work/oddball/vets-api/.bundle/gems/carrierwave-0.11.2/lib/carrierwave/uploader/processing.rb:76:in `each'
/Users/johnpaul/work/oddball/vets-api/.bundle/gems/carrierwave-0.11.2/lib/carrierwave/uploader/processing.rb:76:in `process!'
/Users/johnpaul/work/oddball/vets-api/.bundle/gems/carrierwave-0.11.2/lib/carrierwave/uploader/callbacks.rb:18:in `block in with_callbacks'
/Users/johnpaul/work/oddball/vets-api/.bundle/gems/carrierwave-0.11.2/lib/carrierwave/uploader/callbacks.rb:18:in `each'
/Users/johnpaul/work/oddball/vets-api/.bundle/gems/carrierwave-0.11.2/lib/carrierwave/uploader/callbacks.rb:18:in `with_callbacks'
/Users/johnpaul/work/oddball/vets-api/.bundle/gems/carrierwave-0.11.2/lib/carrierwave/uploader/cache.rb:134:in `cache!'
/Users/johnpaul/work/oddball/vets-api/.bundle/gems/carrierwave-0.11.2/lib/carrierwave/uploader/store.rb:56:in `store!'
/Users/johnpaul/work/oddball/vets-api/app/models/form_attachment.rb:15:in `set_file_data!'
/Users/johnpaul/work/oddball/vets-api/app/controllers/concerns/form_attachment_create.rb:14:in `create'
```

but the real issue stems from the `preneed_attachment_uploader`
```
  process(convert: 'pdf', if: :not_pdf?)
...
  def not_pdf?(file)
    file.content_type != 'application/pdf'
  end
```

This tries to process the uploaded file if its not a PDF. The fixture was
being uploaded without a specified type, which evaluated to `""` and triggered
the PDF conversion process. This process failed because the file was not an
image.

Staging possibly works because of a different minimagick/ImageMagick
version with different rules?


## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)