### PR TITLE
Base facilities migrations for `mobile` and `active_status` columns

### DIFF
--- a/db/migrate/20190912172742_add_mobile_flag_to_base_facilities.rb
+++ b/db/migrate/20190912172742_add_mobile_flag_to_base_facilities.rb
@@ -1,0 +1,5 @@
+class AddMobileFlagToBaseFacilities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :base_facilities, :mobile, :boolean
+  end
+end

--- a/db/migrate/20190912185242_add_active_status_to_base_facilities.rb
+++ b/db/migrate/20190912185242_add_active_status_to_base_facilities.rb
@@ -1,0 +1,5 @@
+class AddActiveStatusToBaseFacilities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :base_facilities, :active_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_04_156435) do
+ActiveRecord::Schema.define(version: 2019_09_12_185242) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -67,6 +67,8 @@ ActiveRecord::Schema.define(version: 2019_09_04_156435) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
+    t.boolean "mobile"
+    t.string "active_status"
     t.index ["location"], name: "index_base_facilities_on_location", using: :gist
     t.index ["name"], name: "index_base_facilities_on_name", using: :gin
     t.index ["unique_id", "facility_type"], name: "index_base_facilities_on_unique_id_and_facility_type", unique: true


### PR DESCRIPTION
## Description of change
This PR includes the migrations for department-of-veterans-affairs/vets-contrib/issues/2785 and department-of-veterans-affairs/vets-contrib/issues/2837. It will a `mobile` column and an `active_status` column to the `base_facilities` table. These migrations need to be merged into master before the code that references them to prevent errors before the migrations have run.

The code that will be using these new columns can been found in the PRs: department-of-veterans-affairs/vets-api/pull/3293 and department-of-veterans-affairs/vets-api/pull/3306.

## Testing done
- Verified that no errors occur when making a request to Facilities API after the migrations have been run

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Make database migration for adding `mobile` column to the base_facility model
- [x] Make database migration for adding `active_status` column to the base_facility model

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
