### PR TITLE
fixing documentation for 2122 payload

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/form_2122_v1_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/form_2122_v1_controller_swagger.rb
@@ -50,9 +50,9 @@ module ClaimsApi
       end
 
       operation :post do
-        key :summary, 'Accepts 0966 Intent to File form submission'
+        key :summary, 'Accepts 2122 Power of Power of Attorney payload'
         key :description, 'Accepts JSON payload. Full URL, including\nquery parameters.'
-        key :operationId, 'post0966itf'
+        key :operationId, 'post2122'
         key :tags, [
           'Power of Attorney'
         ]


### PR DESCRIPTION
## Description of change
This fix is to update documentation that was referencing wring form

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
