### PR TITLE
adding the rubocop yaml files to the codeclimate exclude patterns

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -44,4 +44,5 @@ exclude_patterns:
   - '**/spec/'
   - 'benchmark/'
   - 'docs/'
-  
+  - '.rubocop.yml'
+  - '.rubocop_todo.yml'


### PR DESCRIPTION
## Description of change
Adding the Rubocop yaml files to the codeclimate exclude_patterns so they won't be included in diff-coverage.