### PR TITLE
Move the "new" method call to the end of download chain

### DIFF
--- a/rakelib/jobs.rake
+++ b/rakelib/jobs.rake
@@ -21,7 +21,6 @@ namespace :jobs do
     Facilities::DentalServiceReloadJob.perform_async
   end
 
-
   desc 'Populate facility mental health data cache'
   task pull_facility_mental_health_phone: :environment do
     Facilities::MentalHealthReloadJob.perform_async


### PR DESCRIPTION
Move the call for `new` to the end of chain of methods that download and update facility objects. It needs to be moved because we want an accurate fingerprint on the attributes of the object. 