### PR TITLE
Handle lowercase station number in VHA website source

### DIFF
--- a/app/services/facilities/website_url_service.rb
+++ b/app/services/facilities/website_url_service.rb
@@ -20,7 +20,7 @@ module Facilities
     def map_websites_to_stations(station_websites)
       station_websites.each_with_object({}) do |station, hash|
         org = station['Org'].downcase unless station['Org'].nil?
-        unique_id = "#{org}_#{station['StationNum']}"
+        unique_id = "#{org}_#{station['StationNum'].upcase}"
         hash[unique_id] = station['Website_URL']
       end
     end

--- a/spec/services/facilities/website_url_service_spec.rb
+++ b/spec/services/facilities/website_url_service_spec.rb
@@ -22,4 +22,10 @@ RSpec.describe Facilities::WebsiteUrlService do
     url = service.find_for_station('fAkE1D', 'va_health_facility')
     expect(url).to be_nil
   end
+
+  it 'handles lowercase in StationNum column' do
+    service = Facilities::WebsiteUrlService.new
+    url = service.find_for_station('589GF', 'va_health_facility')
+    expect(url).to eq('http://www.columbiamo.va.gov/locations/Fort_Leonard_Wood.asp')
+  end
 end


### PR DESCRIPTION
## Description of change
In comparing the old and new VHA facilities responses, there were a few websites that were missing. The problem was that the letters at the end of some station numbers were lowercase. We currently own the CSV file that websites are populated from, so we could just change the case in the source, but that seems like a more brittle solution since in future we plan to offload the ownership of this data. 

## Testing done
- Added test to `website_url_service_spec.rb`

## Acceptance Criteria (Definition of Done)
- [x]  No missing websites compared to old data source
