### PR TITLE
Remove sql52 docker info

### DIFF
--- a/docs/setup/facilities_locator.md
+++ b/docs/setup/facilities_locator.md
@@ -7,6 +7,7 @@ done by appending the exported/downloaded certificate to
 
 #### Retrieving Mental Health Phone Numbers
 
-To retrieve mental health phone numbers, please run this rake job:
+To retrieve mental health phone numbers, run the `jobs:pull_facility_mental_health_phone` rake task
+E.g.,
 
 `bundle exec rake jobs:pull_facility_mental_health_phone`

--- a/docs/setup/facilities_locator.md
+++ b/docs/setup/facilities_locator.md
@@ -5,30 +5,8 @@ CA certificate to your trusted certificates. With `homebrew` this is typically
 done by appending the exported/downloaded certificate to
 `<HOMEBREW_DIR>/etc/openssl/cert.pem`.
 
-#### SQL52
+#### Retrieving Mental Health Phone Numbers
 
-When running facilities sidekiq jobs, mental health phone numbers depend on
-a database called SQL52 that is behind the VA network. To get around this
-locally you can run your own dockerized SQL52 container locally. The following
-instructions will help you run SQL52 locally:
+To retrieve mental health phone numbers, please run this rake job:
 
-1. `docker pull dsva/vets-api-sql52-stubbed:latest`
-1. `docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=password1! -p 1433:1433 -d dsva/vets-api-sql52-stubbed:latest`
-1. In `config/settings.local.yml`, you will also need to set these variables
-
-```yaml
-oit_lighthouse2:
-  sql52:
-    hostname: localhost
-    username: sql52user
-    password: sql52password!
-    port: 1433
-    facilities_mental_health:
-      database_name: SQL52
-      schema_name: A01
-      table_name: OMHSP_PERC_Share__DOEx__FieldDataEntry_MHPhone
-```
-
-If you would like to know more about how this image was put together, please
-go here: https://github.com/department-of-veterans-affairs/vets-api-sql52-stubbed-docker
-
+`bundle exec rake jobs:pull_facility_mental_health_phone`

--- a/spec/lib/facilities/vha_facility_spec.rb
+++ b/spec/lib/facilities/vha_facility_spec.rb
@@ -116,14 +116,14 @@ RSpec.describe Facilities::VHAFacility do
 
       context 'with services' do
         let(:satisfaction_data) do
-          fixture_file_name = ::Rails.root.join("/spec/fixtures/facility_access/satisfaction_data.json")
+          fixture_file_name = ::Rails.root.join('/spec/fixtures/facility_access/satisfaction_data.json')
           File.open(fixture_file_name, 'rb') do |f|
             JSON.parse(f.read)
           end
         end
 
         let(:wait_time_data) do
-          fixture_file_name = ::Rails.root.join("/spec/fixtures/facility_access/wait_time_data.json")
+          fixture_file_name = ::Rails.root.join('/spec/fixtures/facility_access/wait_time_data.json')
           File.open(fixture_file_name, 'rb') do |f|
             JSON.parse(f.read)
           end

--- a/spec/lib/facilities/vha_facility_spec.rb
+++ b/spec/lib/facilities/vha_facility_spec.rb
@@ -116,14 +116,14 @@ RSpec.describe Facilities::VHAFacility do
 
       context 'with services' do
         let(:satisfaction_data) do
-          fixture_file_name = ::Rails.root.join('/spec/fixtures/facility_access/satisfaction_data.json')
+          fixture_file_name = Rails.root.join('spec', 'fixtures', 'facility_access', 'satisfaction_data.json')
           File.open(fixture_file_name, 'rb') do |f|
             JSON.parse(f.read)
           end
         end
 
         let(:wait_time_data) do
-          fixture_file_name = ::Rails.root.join('/spec/fixtures/facility_access/wait_time_data.json')
+          fixture_file_name = Rails.root.join('spec', 'fixtures', 'facility_access', 'wait_time_data.json')
           File.open(fixture_file_name, 'rb') do |f|
             JSON.parse(f.read)
           end


### PR DESCRIPTION
## Description of change
Removes SQL52 docker information as that is not needed anymore.

## Acceptance Criteria (Definition of Done)
