### PR TITLE
update rubyzip to address CVE-2019-16892

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ gem 'redis'
 gem 'redis-namespace'
 gem 'restforce'
 gem 'ruby-saml'
-gem 'rubyzip', '>= 1.0.0'
+gem 'rubyzip', '>= 1.3.0'
 gem 'savon'
 gem 'sentry-raven', '2.9.0' # don't change gem version unless sentry server is also upgraded
 gem 'shrine'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -530,7 +530,7 @@ GEM
     ruby-saml (1.7.0)
       nokogiri (>= 1.5.10)
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
+    rubyzip (2.0.0)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
     safe_shell (1.0.3)
@@ -744,7 +744,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   ruby-saml
-  rubyzip (>= 1.0.0)
+  rubyzip (>= 1.3.0)
   savon
   seedbank
   sentry-raven (= 2.9.0)


### PR DESCRIPTION
## Description of change
Name: rubyzip
Version: 1.2.2
Advisory: CVE-2019-16892
Criticality: Unknown
URL: https://github.com/rubyzip/rubyzip/pull/403
Title: Denial of Service in rubyzip ("[zip bombs](https://en.wikipedia.org/wiki/Zip_bomb)")
Solution: upgrade to >= 1.3.0

## Testing done

## Testing planned

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
