### PR TITLE
Upgrade brakeman gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     benchmark-ips (2.7.2)
     bindex (0.8.1)
-    brakeman (4.4.0)
+    brakeman (4.6.1)
     breakers (0.2.4)
       faraday (>= 0.7.4, < 0.10)
       multi_json (~> 1.0)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,25 +1,38 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "File Access",
-      "warning_code": 16,
-      "fingerprint": "3ef9b86159537a2d9f2231f094acd66acf6543ebded519ff688b56e91cc02965",
-      "message": "Parameter value used in file name",
-      "file": "app/controllers/content/vic_local_uploads_controller.rb",
-      "line": 14,
-      "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(Rails.root.join(\"public\", sanitize(params[:path])), :disposition => \"inline\")",
+      "warning_type": "Missing Encryption",
+      "warning_code": 109,
+      "fingerprint": "6a26086cd2400fbbfb831b2f8d7291e320bcc2b36984d2abc359e41b3b63212b",
+      "check_name": "ForceSSL",
+      "message": "The application does not force use of HTTPS: `config.force_ssl` is not enabled",
+      "file": "config/environments/production.rb",
+      "line": 1,
+      "link": "https://brakemanscanner.org/docs/warning_types/missing_encryption/",
+      "code": null,
       "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Content::VICLocalUploadsController",
-        "method": "find_file"
-      },
-      "user_input": "params[:path]",
-      "confidence": "Weak",
-      "note": ""
+      "location": null,
+      "user_input": null,
+      "confidence": "High",
+      "note": "SSL is handled on our endpoints, not in the code."
+    },
+    {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 110,
+      "fingerprint": "d882f63ce96c28fb6c6e0982f2a171460e4b933bfd9b9a5421dca21eef3f76da",
+      "check_name": "CookieSerialization",
+      "message": "Use of unsafe cookie serialization strategy `:marshal` might lead to remote code execution",
+      "file": "config/initializers/cookies_serializer.rb",
+      "line": 7,
+      "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+      "code": "Rails.application.config.action_dispatch.cookies_serializer = :marshal",
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Medium",
+      "note": "We are using the cookie serialization default from Rails 4.x"
     }
   ],
-  "updated": "2018-02-08 09:52:28 -0800",
-  "brakeman_version": "3.4.1"
+  "updated": "2019-09-30 16:21:49 -0400",
+  "brakeman_version": "4.6.1"
 }


### PR DESCRIPTION
When the brakeman gem was updated, there was one old/obsolete brakeman.ignore entry that was removed

There is a new brakeman issue that is now in the ignore file. Basically, its encouraging us to move from the older Rails <~ 4.2 default of storing cookies as marshalled objects to using JSON.

This led me down a small rabbit hole into looking at the new options for encrypting Rails cookies introduced in Rails ~> 5.2 that might replace our custom cookie encryptor and further simplify the app. https://blog.bigbinary.com/2018/06/26/rails-5-2-uses-aes-256-gcm-authenticated-encryption-as-default-cipher-for-encrypting-messages.html


## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Gem was updated, ignore file was updated to match, allowing any existing issues that can't be clearly remediated to be skipped.

## Testing done
<!-- Please describe testing done to verify the changes. -->
Brakeman runs without additional warnings
## Testing planned
<!-- Please describe testing planned. -->
Brakeman runs without additional warnings on staging

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)