### PR TITLE
19740: STEM: Update 1995s descriptor in the YTD reports

### DIFF
--- a/app/models/education_benefits_claim.rb
+++ b/app/models/education_benefits_claim.rb
@@ -2,7 +2,7 @@
 
 require 'attr_encrypted'
 class EducationBenefitsClaim < ApplicationRecord
-  FORM_TYPES = %w[1990 1995 1990e 5490 5495 1990n 0993 0994 1995s].freeze
+  FORM_TYPES = %w[1990 1995 1990e 5490 5495 1990n 0993 0994 1995-STEM].freeze
 
   APPLICATION_TYPES = %w[
     chapter33
@@ -115,7 +115,7 @@ class EducationBenefitsClaim < ApplicationRecord
       return benefits
     when '0994'
       benefits['vettec'] = true
-    when '1995s'
+    when '1995-STEM'
       benefits['chapter33'] = true
     else
       benefit = parsed_form['benefit']&.underscore

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -84,7 +84,7 @@ class FormProfile
 
   MAPPINGS = Dir[Rails.root.join('config', 'form_profile_mappings', '*.yml')].map { |f| File.basename(f, '.*') }
 
-  EDU_FORMS = %w[22-1990 22-1990N 22-1990E 22-1995 22-1995S 22-5490
+  EDU_FORMS = %w[22-1990 22-1990N 22-1990E 22-1995 22-1995-STEM 22-5490
                  22-5495 22-0993 22-0994 FEEDBACK-TOOL].freeze
   EVSS_FORMS = ['21-526EZ'].freeze
   HCA_FORMS = ['1010ez'].freeze
@@ -98,7 +98,7 @@ class FormProfile
     '22-1990N' => ::FormProfiles::VA1990n,
     '22-1990E' => ::FormProfiles::VA1990e,
     '22-1995' => ::FormProfiles::VA1995,
-    '22-1995S' => ::FormProfiles::VA1995s,
+    '22-1995-STEM' => ::FormProfiles::VA1995s,
     '22-5490' => ::FormProfiles::VA5490,
     '22-5495' => ::FormProfiles::VA5495,
     '21P-530' => ::FormProfiles::VA21p530,

--- a/app/models/saved_claim/education_benefits/va1995s.rb
+++ b/app/models/saved_claim/education_benefits/va1995s.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class SavedClaim::EducationBenefits::VA1995s < SavedClaim::EducationBenefits
-  add_form_and_validation('22-1995S')
+  add_form_and_validation('22-1995-STEM')
 end

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
       let(:application_1606) { create(:va1995s_full_form).education_benefits_claim }
 
       it 'tracks the 1995s form' do
-        expect(subject).to receive(:track_form_type).with('22-1995s', 999)
+        expect(subject).to receive(:track_form_type).with('22-1995-STEM', 999)
         result = subject.format_application(application_1606, rpo: 999)
         expect(result).to be_a(EducationForm::Forms::VA1995s)
       end

--- a/spec/jobs/education_form/education_facility_spec.rb
+++ b/spec/jobs/education_form/education_facility_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe EducationForm::EducationFacility do
         form = education_benefits_claim.parsed_form
         form['isEdithNourseRogersScholarship'] = true
         education_benefits_claim.saved_claim.form = form.to_json
-        education_benefits_claim.saved_claim.form_id = '22-1995S'
+        education_benefits_claim.saved_claim.form_id = '22-1995-STEM'
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
       it 'should route Philippines to Eastern RPO' do
@@ -119,16 +119,16 @@ RSpec.describe EducationForm::EducationFacility do
           }
         }
         education_benefits_claim.saved_claim.form = form.to_json
-        education_benefits_claim.saved_claim.form_id = '22-1995S'
+        education_benefits_claim.saved_claim.form_id = '22-1995-STEM'
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
     end
 
-    context '22-1995S' do
+    context '22-1995-STEM' do
       it 'should route to Eastern RPO' do
         form = education_benefits_claim.parsed_form
         education_benefits_claim.saved_claim.form = form.to_json
-        education_benefits_claim.saved_claim.form_id = '22-1995S'
+        education_benefits_claim.saved_claim.form_id = '22-1995-STEM'
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
       it 'should route Philippines to Eastern RPO' do
@@ -139,7 +139,7 @@ RSpec.describe EducationForm::EducationFacility do
           }
         }
         education_benefits_claim.saved_claim.form = form.to_json
-        education_benefits_claim.saved_claim.form_id = '22-1995S'
+        education_benefits_claim.saved_claim.form_id = '22-1995-STEM'
         expect(described_class.region_for(education_benefits_claim)).to eq(:eastern)
       end
     end


### PR DESCRIPTION
## Description of change
As a developer, I need to update the report name for STEM1995 in the YTD report so that it is distinguished from real form names.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19740

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)
- [x] The 1995 STEM column header text "1995s" is replaced with the following: “1995 STEM”

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
