### PR TITLE
Sentry sign in tags must be strings, not a hash

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -133,18 +133,14 @@ class ApplicationController < ActionController::API
   end
 
   def tags_context
-    {
-      controller_name: controller_name,
-      sign_in_method: sign_in_method_for_tag
-    }
-  end
-
-  def sign_in_method_for_tag
-    if current_user.present?
-      # account_type is filtered by sentry, becasue in other contexts it refers to a bank account type
-      current_user.identity.sign_in.merge(acct_type: current_user.identity.sign_in[:account_type])
-    else
-      'not-signed-in'
+    { controller_name: controller_name }.tap do |tags|
+      if current_user.present?
+        tags[:sign_in_method] = current_user.identity.sign_in[:service_name]
+        # account_type is filtered by sentry, becasue in other contexts it refers to a bank account type
+        tags[:sign_in_acct_type] = current_user.identity.sign_in[:account_type]
+      else
+        tags[:sign_in_method] = 'not-signed-in'
+      end
     end
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -198,10 +198,8 @@ RSpec.describe ApplicationController, type: :controller do
           }]
         )
         # if authn_context is nil on current_user it means idme
-        expect(Raven).to receive(:tags_context).once.with(
-          controller_name: 'anonymous',
-          sign_in_method: { service_name: 'idme', acct_type: nil }
-        )
+        expect(Raven).to receive(:tags_context).once.with( controller_name: 'anonymous', sign_in_method: 'idme', sign_in_acct_type: nil)
+
         # since user IS signed in, this SHOULD get called
         expect(Raven).to receive(:user_context).with(
           uuid: user.uuid,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -198,7 +198,9 @@ RSpec.describe ApplicationController, type: :controller do
           }]
         )
         # if authn_context is nil on current_user it means idme
-        expect(Raven).to receive(:tags_context).once.with( controller_name: 'anonymous', sign_in_method: 'idme', sign_in_acct_type: nil)
+        expect(Raven).to receive(:tags_context).once.with(controller_name: 'anonymous',
+                                                          sign_in_method: 'idme',
+                                                          sign_in_acct_type: nil)
 
         # since user IS signed in, this SHOULD get called
         expect(Raven).to receive(:user_context).with(


### PR DESCRIPTION
## Description of change
we were sending a hash to sentry when it can only accept string values for tags. 
<img width="983" alt="Screen Shot 2019-10-03 at 5 13 19 PM" src="https://user-images.githubusercontent.com/19188/66164692-3b8d9100-e601-11e9-904d-9e9924f139d7.png">


## Testing done
specs

## Acceptance Criteria (Definition of Done)
sign_in_method is tagged in sentry

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
