### PR TITLE
remove EVSS prefix from source

### DIFF
--- a/lib/evss/service.rb
+++ b/lib/evss/service.rb
@@ -65,12 +65,12 @@ module EVSS
 
       case error
       when Faraday::ParsingError
-        raise_backend_exception('EVSS502', "#{self.class}")
+        raise_backend_exception('EVSS502', self.class)
       when Common::Client::Errors::ClientError
         Raven.extra_context(body: error.body)
         raise Common::Exceptions::Forbidden if error.status == 403
 
-        raise_backend_exception('EVSS400', "#{self.class}", error) if error.status == 400
+        raise_backend_exception('EVSS400', self.class, error) if error.status == 400
         raise_backend_exception('EVSS502', "#{self.class}", error)
       else
         raise error

--- a/lib/evss/service.rb
+++ b/lib/evss/service.rb
@@ -71,7 +71,7 @@ module EVSS
         raise Common::Exceptions::Forbidden if error.status == 403
 
         raise_backend_exception('EVSS400', self.class, error) if error.status == 400
-        raise_backend_exception('EVSS502', "#{self.class}", error)
+        raise_backend_exception('EVSS502', self.class, error)
       else
         raise error
       end

--- a/lib/evss/service.rb
+++ b/lib/evss/service.rb
@@ -65,13 +65,13 @@ module EVSS
 
       case error
       when Faraday::ParsingError
-        raise_backend_exception('EVSS502', "EVSS::#{self.class}")
+        raise_backend_exception('EVSS502', "#{self.class}")
       when Common::Client::Errors::ClientError
         Raven.extra_context(body: error.body)
         raise Common::Exceptions::Forbidden if error.status == 403
 
-        raise_backend_exception('EVSS400', "EVSS::#{self.class}", error) if error.status == 400
-        raise_backend_exception('EVSS502', "EVSS::#{self.class}", error)
+        raise_backend_exception('EVSS400', "#{self.class}", error) if error.status == 400
+        raise_backend_exception('EVSS502', "#{self.class}", error)
       else
         raise error
       end


### PR DESCRIPTION
## Description of change
This removes legacy code prepending a service name to the source parameter when calling the raise_backend_exception method in the EVSS service class.

Related to this PR: https://github.com/department-of-veterans-affairs/vets-api/pull/3376

Comment reference:
https://github.com/department-of-veterans-affairs/vets-api/pull/3376/files/4c352ec0bbc6da70ce9b911a2109433af5d4ffac#diff-8e31094ed3344aef2cba919eba435beeR68

## Testing done
Test Suite passing status

## Acceptance Criteria (Definition of Done)
- [x] Passing test suite


