### PR TITLE
Fixing Benefits Intake Uploader logic with retries

### DIFF
--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -26,7 +26,8 @@ module VBADocuments
 
     def perform(guid, retries = 0)
       @retries = retries
-      if upload = VBADocuments::UploadSubmission.where(status: 'uploaded').find_by(guid: guid)
+      upload = VBADocuments::UploadSubmission.where(status: 'uploaded').find_by(guid: guid)
+      if upload
         Rails.logger.info("VBADocuments: Start Processing: #{upload.inspect}")
         download_and_process(upload)
         Rails.logger.info("VBADocuments: Stop Processing: #{upload.inspect}")

--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -26,10 +26,11 @@ module VBADocuments
 
     def perform(guid, retries = 0)
       @retries = retries
-      upload = VBADocuments::UploadSubmission.where(status: 'uploaded').find_by(guid: guid)
-      Rails.logger.info("VBADocuments: Start Processing: #{upload.inspect}")
-      download_and_process(upload) if upload
-      Rails.logger.info("VBADocuments: Stop Processing: #{upload.inspect}")
+      if upload = VBADocuments::UploadSubmission.where(status: 'uploaded').find_by(guid: guid)
+        Rails.logger.info("VBADocuments: Start Processing: #{upload.inspect}")
+        download_and_process(upload)
+        Rails.logger.info("VBADocuments: Stop Processing: #{upload.inspect}")
+      end
     end
 
     private

--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -37,11 +37,9 @@ module VBADocuments
       begin
         Rails.logger.info("VBADocuments: Start Processing: #{upload.inspect}")
         parts = VBADocuments::MultipartParser.parse(tempfile.path)
-        validate_parts(parts)
-        validate_metadata(parts[META_PART_NAME])
+        validate_parts(parts) && validate_metadata(parts[META_PART_NAME])
         metadata = perfect_metadata(parts, upload, timestamp)
-        response = submit(metadata, parts)
-        process_response(response, upload)
+        process_response(submit(metadata, parts), upload)
         log_submission(metadata, upload)
       rescue VBADocuments::UploadError => e
         if e.code == 'DOC201' && @retries < RETRIES

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -315,13 +315,31 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
         allow(faraday_response).to receive(:success?).and_return(false)
       end
 
-      it 'sets error status for downstream server error' do
+      it 'does not set error status for downstream server error' do
         capture_body = nil
         expect(client_stub).to receive(:upload) { |arg|
           capture_body = arg
           faraday_response
         }
         described_class.new.perform(upload.guid)
+        expect(capture_body).to be_a(Hash)
+        expect(capture_body).to have_key('metadata')
+        expect(capture_body).to have_key('document')
+        metadata = JSON.parse(capture_body['metadata'])
+        expect(metadata['uuid']).to eq(upload.guid)
+        updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
+        expect(updated.status).not_to eq('error')
+        expect(updated.code).not_to eq('DOC201')
+      end
+
+      it 'sets error status for downstream server error after retries' do
+        capture_body = nil
+        after_retries = 4
+        expect(client_stub).to receive(:upload) { |arg|
+          capture_body = arg
+          faraday_response
+        }
+        described_class.new.perform(upload.guid, after_retries)
         expect(capture_body).to be_a(Hash)
         expect(capture_body).to have_key('metadata')
         expect(capture_body).to have_key('document')


### PR DESCRIPTION
## Description of change
For ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/3261

## Acceptance Criteria (Definition of Done)
- We've fixed and re-instituted our previous re-check logic
- The status we pass to consumers is not updated until we are done re-checking.

#### Applies to all PRs

- [ ] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
