### PR TITLE
Timecop fixes in specs

### DIFF
--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -355,6 +355,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
         Timecop.freeze(Time.zone.now)
         described_class.new.perform(upload.guid)
         expect(described_class.jobs.last['at']).to eq(30.minutes.from_now.to_f)
+        Timecop.return
       end
     end
 

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -307,10 +307,6 @@ RSpec.describe V0::SessionsController, type: :controller do
     end
 
     describe 'POST saml_callback' do
-      before(:each) do
-        allow(SAML::User).to receive(:new).and_return(saml_user)
-      end
-
       around(:each) do |example|
         Settings.sso.cookie_enabled = true
         example.run

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -307,10 +307,6 @@ RSpec.describe V1::SessionsController, type: :controller do
     end
 
     describe 'POST saml_callback' do
-      before(:each) do
-        allow(SAML::User).to receive(:new).and_return(saml_user)
-      end
-
       around(:each) do |example|
         Settings.sso.cookie_enabled = true
         example.run

--- a/spec/jobs/export_breaker_status_spec.rb
+++ b/spec/jobs/export_breaker_status_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe ExportBreakerStatus do
         Timecop.freeze(now)
         service.latest_outage.end!
         expect { subject.perform }.to trigger_statsd_gauge(metric, value: 1)
+        Timecop.return
       end
     end
   end

--- a/spec/lib/common/client/middleware/request/soap_headers_spec.rb
+++ b/spec/lib/common/client/middleware/request/soap_headers_spec.rb
@@ -22,6 +22,7 @@ describe Common::Client::Middleware::Request::SOAPHeaders do
         'Soapaction' => 'PRPA_IN201305UV02',
         'User-Agent' => 'Faraday v0.9.2'
       )
+      Timecop.return
     end
   end
 end

--- a/spec/request/breakers_integration_spec.rb
+++ b/spec/request/breakers_integration_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe 'breakers', type: :request do
       stub_varx_request(:get, 'mhv-api/patient/v1/prescription/getactiverx', active_rxs, status_code: 200)
       response = get '/v0/prescriptions'
       expect(response).to eq(200)
+      Timecop.return
     end
   end
 

--- a/spec/request/statsd_middleware_spec.rb
+++ b/spec/request/statsd_middleware_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe StatsdMiddleware, type: :request do
     Timecop.freeze(now)
   end
 
+  after { Timecop.return }
+
   it 'sends status data to statsd' do
     stub_varx_request(:get, 'mhv-api/patient/v1/prescription/gethistoryrx', history_rxs, status_code: 200)
     tags = %w[controller:v0/prescriptions action:index status:200]

--- a/spec/request/terms_and_conditions_request_spec.rb
+++ b/spec/request/terms_and_conditions_request_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe 'terms_and_conditions', type: :request do
           post "/v0/terms_and_conditions/#{terms2.name}/versions/latest/user_data"
           json = JSON.parse(response.body)
           expect(Time.zone.parse(json['data']['attributes']['created_at']).to_i).to eq(start_time.to_i)
+          Timecop.return
         end
       end
     end

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -231,6 +231,7 @@ RSpec.describe 'Fetching user data', type: :request do
         .and not_trigger_statsd_increment('api.external_http_request.MVI.failed')
       expect(response.status).to eq(200)
       expect(MVI::Configuration.instance.breakers_service.latest_outage.ended?).to eq(true)
+      Timecop.return
     end
   end
 


### PR DESCRIPTION
## Description of change
I found a number of `Timecop.freeze` calls that did not have corresponding `Timecop.return` calls.  
This was causing spec failures on certain runs.
Example:  
`rspec --seed 41882` resulted in [this expectation](https://github.com/department-of-veterans-affairs/vets-api/blob/a58358f8e2d57b242b6d04a2891c58d268f052c9/spec/controllers/v1/sessions_controller_spec.rb#L363) in `sessions_controller_spec` (wherein two timestamps were expected to be different) to fail because [this use of `Timecop.freeze`](https://github.com/department-of-veterans-affairs/vets-api/blob/a58358f8e2d57b242b6d04a2891c58d268f052c9/spec/request/user_request_spec.rb#L225) in 
`user_request_spec` was never unfrozen.

I also removed a couple of redundant method call stubs.

## Testing done
specs

## Testing planned
n/a

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Add missing `Timecop.return` calls to specs
- [x] remove unnecessary `before` block

#### Applies to all PRs

- [ ] ~~Appropriate logging~~
- [ ] ~~Swagger docs have been updated, if applicable~~
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] ~~Provide which alerts would indicate a problem with this functionality (if applicable)~~
