### PR TITLE
Add logout URL for SSOe flow

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -30,7 +30,7 @@ module V1
         reset_session
       elsif type == 'ssoe_slo'
         Rails.logger.info('SSOe: LOGOUT', sso_logging_info)
-        redirect_to(url_service.send(:ssoe_slo_url)) && return
+        reset_session
       end
       # clientId must be added at the end or the URL will be invalid for users using various "Do not track"
       # extensions with their browser.
@@ -38,7 +38,6 @@ module V1
     end
 
     def ssoe_slo_callback
-      reset_session
       redirect_to url_service.base_redirect_url
     end
 

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -31,7 +31,10 @@ module V1
         reset_session
       elsif type == 'ssoe_slo'
         Rails.logger.info('SSOe: LOGOUT', sso_logging_info)
-        reset_session
+if type == 'slo' || type == 'ssoe_slo'
+  Rails.logger.info("LOGOUT of type #{type}", sso_logging_info)
+  reset_session
+end
       end
       # clientId must be added at the end or the URL will be invalid for users using various "Do not track"
       # extensions with their browser.

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -26,7 +26,7 @@ module V1
       StatsD.increment(STATSD_SSO_NEW_KEY, tags: ["context:#{type}"])
       url = url_service.send("#{type}_url")
 
-      if type == 'slo' || type == 'ssoe_slo'
+      if %w[slo ssoe_slo].include?(type)
         Rails.logger.info("LOGOUT of type #{type}", sso_logging_info)
         reset_session
       end

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -7,7 +7,7 @@ require 'saml/responses/logout'
 
 module V1
   class SessionsController < ApplicationController
-    REDIRECT_URLS = %w[signup mhv dslogon idme mfa verify slo].freeze
+    REDIRECT_URLS = %w[signup mhv dslogon idme mfa verify slo ssoe_slo].freeze
 
     STATSD_SSO_NEW_KEY = 'api.auth.new'
     STATSD_SSO_CALLBACK_KEY = 'api.auth.saml_callback'

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -24,13 +24,22 @@ module V1
 
       StatsD.increment(STATSD_SSO_NEW_KEY, tags: ["context:#{type}"])
       url = url_service.send("#{type}_url")
+
       if type == 'slo'
         Rails.logger.info('SSO: LOGOUT', sso_logging_info)
         reset_session
+      elsif type == 'ssoe_slo'
+        Rails.logger.info('SSOe: LOGOUT', sso_logging_info)
+        redirect_to SAML::URLService::SSOE_LOGOUT_URL and return
       end
       # clientId must be added at the end or the URL will be invalid for users using various "Do not track"
       # extensions with their browser.
       redirect_to params[:client_id].present? ? url + "&clientId=#{params[:client_id]}" : url
+    end
+
+    def ssoe_slo_callback
+      reset_session
+      redirect_to url_service.base_redirect_url
     end
 
     def saml_logout_callback

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -26,15 +26,9 @@ module V1
       StatsD.increment(STATSD_SSO_NEW_KEY, tags: ["context:#{type}"])
       url = url_service.send("#{type}_url")
 
-      if type == 'slo'
-        Rails.logger.info('SSO: LOGOUT', sso_logging_info)
+      if type == 'slo' || type == 'ssoe_slo'
+        Rails.logger.info("LOGOUT of type #{type}", sso_logging_info)
         reset_session
-      elsif type == 'ssoe_slo'
-        Rails.logger.info('SSOe: LOGOUT', sso_logging_info)
-if type == 'slo' || type == 'ssoe_slo'
-  Rails.logger.info("LOGOUT of type #{type}", sso_logging_info)
-  reset_session
-end
       end
       # clientId must be added at the end or the URL will be invalid for users using various "Do not track"
       # extensions with their browser.

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -38,7 +38,7 @@ module V1
     end
 
     def ssoe_slo_callback
-      redirect_to url_service.base_redirect_url
+      redirect_to url_service.logout_redirect_url
     end
 
     def saml_logout_callback

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -30,7 +30,7 @@ module V1
         reset_session
       elsif type == 'ssoe_slo'
         Rails.logger.info('SSOe: LOGOUT', sso_logging_info)
-        redirect_to SAML::URLService::SSOE_LOGOUT_URL and return
+        redirect_to(url_service.send(:ssoe_slo_url)) && return
       end
       # clientId must be added at the end or the URL will be invalid for users using various "Do not track"
       # extensions with their browser.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,6 +273,7 @@ Rails.application.routes.draw do
     resource :sessions, only: [] do
       post :saml_callback, to: 'sessions#saml_callback'
       post :saml_slo_callback, to: 'sessions#saml_slo_callback'
+      get :ssoe_slo_callback, to: 'sessions#ssoe_slo_callback'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get '/v1/sessions/:type/new',
       to: 'v1/sessions#new',
       constraints: ->(request) { V1::SessionsController::REDIRECT_URLS.include?(request.path_parameters[:type]) }
+  get '/v1/sessions/ssoe_logout', to: 'v1/sessions#ssoe_slo_callback'
 
   namespace :v0, defaults: { format: 'json' } do
     resources :appointments, only: :index
@@ -273,7 +274,6 @@ Rails.application.routes.draw do
     resource :sessions, only: [] do
       post :saml_callback, to: 'sessions#saml_callback'
       post :saml_slo_callback, to: 'sessions#saml_slo_callback'
-      get :ssoe_slo_callback, to: 'sessions#ssoe_slo_callback'
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,6 +21,7 @@ saml_ssoe:
   key_path: config/certs/vetsgov-localhost.key
   issuer: https://ssoe-sp-dev.va.gov
   callback_url: http://localhost:3000/v1/sessions/callback
+  logout_url: https://int.eauth.va.gov/pkmslogout
 
 session_cookie:
   secure: false

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -14,8 +14,6 @@ module SAML
       'http://127.0.0.1:3000' => { base_redirect: 'http://127.0.0.1:3001' }
     }.freeze
 
-    SSOE_LOGOUT_URL = 'https://int.eauth.va.gov/pkmslogout'
-
     LOGIN_REDIRECT_PARTIAL = '/auth/login/callback'
     LOGOUT_REDIRECT_PARTIAL = '/logout/'
 
@@ -126,7 +124,7 @@ module SAML
 
     # logout URL for SSOe
     def ssoe_slo_url
-      SSOE_LOGOUT_URL
+      Settings.saml_ssoe.logout_url
     end
 
     private

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -126,7 +126,7 @@ module SAML
 
     # logout URL for SSOe
     def ssoe_slo_url
-
+      SSOE_LOGOUT_URL
     end
 
     private

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -14,6 +14,8 @@ module SAML
       'http://127.0.0.1:3000' => { base_redirect: 'http://127.0.0.1:3001' }
     }.freeze
 
+    SSOE_LOGOUT_URL = 'https://int.eauth.va.gov/pkmslogout'
+
     LOGIN_REDIRECT_PARTIAL = '/auth/login/callback'
     LOGOUT_REDIRECT_PARTIAL = '/logout/'
 
@@ -120,6 +122,11 @@ module SAML
       SingleLogoutRequest.create(uuid: logout_request.uuid, token: session.token)
       Rails.logger.info "New SP SLO having logout_request '#{logout_request.uuid}' for userid '#{session.uuid}'"
       logout_request.create(url_settings, RelayState: relay_state_params)
+    end
+
+    # logout URL for SSOe
+    def ssoe_slo_url
+
     end
 
     private


### PR DESCRIPTION
## Description of change
SSOe has a logout mechansim that is not based on SAML single logout. 

This PR adds logout routes and handling for the SSOe logout flow
- adds new route `v1/sessions/ssoe_slo/new` for SSOe logout
- adds callback route `/v1/sessions/ssoe_logout` as logout callback route
- adds handling for triggering logout flow with SSOe

Resolves https://github.com/department-of-veterans-affairs/va-sso/issues/32

This is an iterative change needed as part of debugging SSOe authentication. The complete flow can't be debugged locally because we don't have a VPN-enabled local development environment, and SSOe's dev environment is VPN-only.

## Testing done
n/a

## Testing planned
dev/staging

## Acceptance Criteria (Definition of Done)
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
