### PR TITLE
Implement Unsuccessful report and job on a schedule

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -281,6 +281,7 @@ preneeds:
 
 # Settings for VBA Document upload service module
 vba_documents:
+  unsuccessful_report_enabled: false
   location:
     prefix:  http://some.fakesite.com/path
     replacement: http://another.fakesite.com/rewrittenpath

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -124,6 +124,11 @@ VBADocuments::UploadStatusBatch:
   class: VBADocuments::UploadStatusBatch
   description: "Cache Statuses for VBA Documents"
 
+VBADocuments::ReportUnsuccessfulSubmissions:
+  cron: "0 * * * 1 America/New_York"
+  class: VBADocuments::ReportUnsuccessfulSubmissions
+  description: "Weekly report of unsuccessful submissions"
+
 TransactionalEmailAnalyticsJob:
   cron: "0 1 * * * America/New_York"
   description: "posts Transactional email (HCA Failure and Direct Deposit Update) sends and failures to Google Analytics"

--- a/modules/vba_documents/app/mailers/vba_documents/unsuccessful_report_mailer.rb
+++ b/modules/vba_documents/app/mailers/vba_documents/unsuccessful_report_mailer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module VBADocuments
+  class UnsuccessfulReportMailer < ApplicationMailer
+    RECIPIENTS = %w[
+      andrew.fichter@va.gov
+      michael.bastos@oddball.io
+      charley.stran@oddball.io
+      alex.teal@oddball.io
+      aubrey.suter@adhocteam.us
+      trista.rowan@adhocteam.us
+    ].freeze
+
+    def build(unsuccessful_submissions, date_from, date_to)
+      @unsuccessful_submissions = unsuccessful_submissions
+      @date_from = date_from
+      @date_to = date_to
+
+      path = VBADocuments::Engine.root.join('app', 'mailers', 'vba_documents', 'views', 'unsuccessful_report.erb')
+      template = File.read(path)
+
+      mail(
+        to: RECIPIENTS,
+        subject: 'Benefits Intake Unsuccessful Submission Report',
+        body: ERB.new(template).result(binding)
+      )
+    end
+  end
+end

--- a/modules/vba_documents/app/mailers/vba_documents/views/unsuccessful_report.erb
+++ b/modules/vba_documents/app/mailers/vba_documents/views/unsuccessful_report.erb
@@ -1,0 +1,27 @@
+<h1>Unsuccessful Submissions </h1>
+<hr />
+<h3>From <%= @date_form %> -- <%= @date_to %>
+<table>
+  <thead>
+    <tr>
+      <th>GUID</th>
+      <th>Consumer Name</th>
+      <th>Status</th>
+      <th>Code</th>
+      <th>Detail</th>
+      <th>Created At</th>
+      <th>Updated At</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @unsuccessful_submissions.each do |submission| %>
+      <td><%= submission.guid %></td>
+      <td><%= submission.consumer_name %></td>
+      <td><%= submission.status %></td>
+      <td><%= submission.code %></td>
+      <td><%= submission.detail %></td>
+      <td><%= submission.created_at %></td>
+      <td><%= submission.updated_at %></td>
+    <% end %>
+  </tbody>
+</table>

--- a/modules/vba_documents/app/mailers/vba_documents/views/unsuccessful_report.erb
+++ b/modules/vba_documents/app/mailers/vba_documents/views/unsuccessful_report.erb
@@ -1,6 +1,6 @@
 <h1>Unsuccessful Submissions </h1>
 <hr />
-<h3>From <%= @date_form %> -- <%= @date_to %>
+<h3>From <%= @date_form %> -- <%= @date_to %> </h3>
 <table>
   <thead>
     <tr>

--- a/modules/vba_documents/app/workers/vba_documents/report_unsuccessful_submissions.rb
+++ b/modules/vba_documents/app/workers/vba_documents/report_unsuccessful_submissions.rb
@@ -9,7 +9,7 @@ module VBADocuments
     def perform
       if Settings.vba_documents.unsuccessful_report_enabled
         from = 7.days.ago
-        to = Time.zone.today
+        to = Time.zone.now
         submissions = VBADocuments::UploadSubmission.where(
           created_at: from..to,
           status: %w[error expired]

--- a/modules/vba_documents/app/workers/vba_documents/report_unsuccessful_submissions.rb
+++ b/modules/vba_documents/app/workers/vba_documents/report_unsuccessful_submissions.rb
@@ -7,13 +7,15 @@ module VBADocuments
     include Sidekiq::Worker
 
     def perform
-      from = 7.days.ago
-      to = Time.zone.today
-      submissions = VBADocuments::UploadSubmission.where(
-        created_at: from..to,
-        status: %w[error expired]
-      )
-      VBADocuments::UnsuccessfulReportMailer.build(submissions, from, to).deliver_now
+      if Settings.vba_documents.unsuccessful_report_enabled
+        from = 7.days.ago
+        to = Time.zone.today
+        submissions = VBADocuments::UploadSubmission.where(
+          created_at: from..to,
+          status: %w[error expired]
+        )
+        VBADocuments::UnsuccessfulReportMailer.build(submissions, from, to).deliver_now
+      end
     end
   end
 end

--- a/modules/vba_documents/app/workers/vba_documents/report_unsuccessful_submissions.rb
+++ b/modules/vba_documents/app/workers/vba_documents/report_unsuccessful_submissions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+
+module VBADocuments
+  class ReportUnsuccessfulSubmissions
+    include Sidekiq::Worker
+
+    def perform
+      from = 7.days.ago
+      to = Time.zone.today
+      submissions = VBADocuments::UploadSubmission.where(
+        created_at: from..to,
+        status: %w[error expired]
+      )
+      VBADocuments::UnsuccessfulReportMailer.build(submissions, from, to).deliver_now
+    end
+  end
+end

--- a/modules/vba_documents/spec/jobs/report_unsuccessful_submissions_spec.rb
+++ b/modules/vba_documents/spec/jobs/report_unsuccessful_submissions_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VBADocuments::ReportUnsuccessfulSubmissions, type: :job do
+  let(:error_upload) { FactoryBot.create(:upload_submission, :status_error) }
+
+  describe '#perform' do
+    it 'sends mail' do
+      with_settings(Settings.vba_documents,
+                    unsuccessful_report_enabled: true) do
+        Timecop.freeze
+        from = 7.days.ago
+        to = Time.zone.now
+        expect(VBADocuments::UnsuccessfulReportMailer).to receive(:build).once.with(
+          VBADocuments::UploadSubmission.where(
+            created_at: from..to,
+            status: %w[error expired]
+          ),
+          7.days.ago,
+          Time.zone.now
+        ).and_return(double.tap do |mailer|
+                       expect(mailer).to receive(:deliver_now).once
+                     end)
+        described_class.new.perform
+        Timecop.return
+      end
+    end
+  end
+end

--- a/modules/vba_documents/spec/mailers/unsuccessful_report_mailer_spec.rb
+++ b/modules/vba_documents/spec/mailers/unsuccessful_report_mailer_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VBADocuments::UnsuccessfulReportMailer, type: [:mailer] do
+  let(:error_upload) { FactoryBot.create(:upload_submission, :status_error) }
+
+  describe '#build' do
+    subject do
+      described_class.build([error_upload], 7.days.ago, Date.today).deliver_now
+    end
+
+    it 'sends the email' do
+      expect(subject.subject).to eq('Benefits Intake Unsuccessful Submission Report')
+    end
+
+    it 'sends to the right people' do
+      expect(subject.to).to eq(
+        %w[
+          andrew.fichter@va.gov
+          michael.bastos@oddball.io
+          charley.stran@oddball.io
+          alex.teal@oddball.io
+          aubrey.suter@adhocteam.us
+          trista.rowan@adhocteam.us
+        ]
+      )
+    end
+  end
+end

--- a/modules/vba_documents/spec/mailers/unsuccessful_report_mailer_spec.rb
+++ b/modules/vba_documents/spec/mailers/unsuccessful_report_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe VBADocuments::UnsuccessfulReportMailer, type: [:mailer] do
 
   describe '#build' do
     subject do
-      described_class.build([error_upload], 7.days.ago, Time.zone.today).deliver_now
+      described_class.build([error_upload], 7.days.ago, Time.zone.now).deliver_now
     end
 
     it 'sends the email' do

--- a/modules/vba_documents/spec/mailers/unsuccessful_report_mailer_spec.rb
+++ b/modules/vba_documents/spec/mailers/unsuccessful_report_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe VBADocuments::UnsuccessfulReportMailer, type: [:mailer] do
 
   describe '#build' do
     subject do
-      described_class.build([error_upload], 7.days.ago, Date.today).deliver_now
+      described_class.build([error_upload], 7.days.ago, Time.zone.today).deliver_now
     end
 
     it 'sends the email' do


### PR DESCRIPTION
## Description of change
In order to track trends in unsuccessful reports more closely, this report will allow us to gather data on whats going on with unsuccessful submissions.

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/3321

## Testing done
- rspec

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
