### PR TITLE
LoA needs to be an integer going into the model

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -41,7 +41,7 @@ module ClaimsApi
     end
 
     def check_loa_level
-      unless header('X-VA-LOA') == '3'
+      unless header('X-VA-LOA').try(:to_i) == 3
         render json: [],
                serializer: ActiveModel::Serializer::CollectionSerializer,
                each_serializer: ClaimsApi::ClaimListSerializer,
@@ -67,8 +67,8 @@ module ClaimsApi
                   @current_user.loa
                 else
                   vet.loa = {
-                    current: header('X-VA-LOA'),
-                    highest: header('X-VA-LOA')
+                    current: header('X-VA-LOA').try(:to_i),
+                    highest: header('X-VA-LOA').try(:to_i)
                   }
                 end
       vet.mvi_record?


### PR DESCRIPTION
## Description of change
Importing LoA logic to be integer before going into MVI object, for ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/3332

## Acceptance Criteria (Definition of Done)
- Make importing LoA an actual integer

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
