### PR TITLE
Keeping PII out of production logs

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -41,7 +41,7 @@ module ClaimsApi
     end
 
     def check_loa_level
-      unless header('X-VA-LOA') == '3'
+      unless header('X-VA-LOA').try(:to_i) == 3
         render json: [],
                serializer: ActiveModel::Serializer::CollectionSerializer,
                each_serializer: ClaimsApi::ClaimListSerializer,
@@ -67,8 +67,8 @@ module ClaimsApi
                   @current_user.loa
                 else
                   vet.loa = {
-                    current: header('X-VA-LOA'),
-                    highest: header('X-VA-LOA')
+                    current: header('X-VA-LOA').try(:to_i),
+                    highest: header('X-VA-LOA').try(:to_i)
                   }
                 end
       vet.mvi_record?

--- a/modules/claims_api/app/controllers/claims_api/concerns/mvi_verification.rb
+++ b/modules/claims_api/app/controllers/claims_api/concerns/mvi_verification.rb
@@ -11,7 +11,7 @@ module ClaimsApi
         unless target_veteran.mvi_record?
           log_message_to_sentry('MVIError in claims',
                                 :warning,
-                                body: target_veteran.inspect)
+                                body: target_veteran.mvi&.response&.error&.inspect)
           render json: { errors: [{ detail: 'MVI user not found' }] },
                  status: :not_found
         end

--- a/modules/claims_api/app/controllers/claims_api/concerns/mvi_verification.rb
+++ b/modules/claims_api/app/controllers/claims_api/concerns/mvi_verification.rb
@@ -10,8 +10,8 @@ module ClaimsApi
       def verify_mvi
         unless target_veteran.mvi_record?
           log_message_to_sentry('MVIError in claims',
-                              :warning,
-                              body: target_veteran.inspect)
+                                :warning,
+                                body: target_veteran.inspect)
           render json: { errors: [{ detail: 'MVI user not found' }] },
                  status: :not_found
         end

--- a/modules/claims_api/app/controllers/claims_api/concerns/mvi_verification.rb
+++ b/modules/claims_api/app/controllers/claims_api/concerns/mvi_verification.rb
@@ -9,6 +9,9 @@ module ClaimsApi
 
       def verify_mvi
         unless target_veteran.mvi_record?
+          log_message_to_sentry('MVIError in claims',
+                              :warning,
+                              body: target_veteran.inspect)
           render json: { errors: [{ detail: 'MVI user not found' }] },
                  status: :not_found
         end


### PR DESCRIPTION
## Description of change
Last fix to MVI bug ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/3332

## Acceptance Criteria (Definition of Done)
- Remove potential PII concerns from production logs in MVI error

#### Applies to all PRs

- [x] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
