### PR TITLE
Add evss claims async to rack attack throttling

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -24,7 +24,7 @@ class Rack::Attack
     req.ip if req.path == '/v0/vic/vic_submissions' && req.post?
   end
 
-  throttle('evss_claims_async', limit: 10, period: 1.minute) do |req|
+  throttle('evss_claims_async', limit: 10, period: 60) do |req|
     req.ip if req.path == '/v0/evss_claims_async'
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -24,6 +24,10 @@ class Rack::Attack
     req.ip if req.path == '/v0/vic/vic_submissions' && req.post?
   end
 
+  throttle('evss_claims_async', limit: 10, period: 1.minute) do |req|
+    req.ip if req.path == '/v0/evss_claims_async'
+  end
+
   # Source: https://github.com/kickstarter/rack-attack#x-ratelimit-headers-for-well-behaved-clients
   Rack::Attack.throttled_response = lambda do |env|
     rate_limit = env['rack.attack.match_data']

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -24,7 +24,7 @@ class Rack::Attack
     req.ip if req.path == '/v0/vic/vic_submissions' && req.post?
   end
 
-  throttle('evss_claims_async', limit: 10, period: 60) do |req|
+  throttle('evss_claims_async', limit: 12, period: 60) do |req|
     req.ip if req.path == '/v0/evss_claims_async'
   end
 

--- a/spec/middleware/rack/attack_spec.rb
+++ b/spec/middleware/rack/attack_spec.rb
@@ -70,5 +70,14 @@ RSpec.describe Rack::Attack do
         expect(last_response.status).to eq(429)
       end
     end
+
+    context 'evss claims' do
+      let(:limit) { 10 }
+      let(:endpoint) { '/v0/evss_claims_async' }
+
+      it 'limits requests' do
+        expect(last_response.status).to eq(429)
+      end
+    end
   end
 end

--- a/spec/middleware/rack/attack_spec.rb
+++ b/spec/middleware/rack/attack_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Rack::Attack do
     end
 
     context 'evss claims' do
-      let(:limit) { 10 }
+      let(:limit) { 12 }
       let(:endpoint) { '/v0/evss_claims_async' }
 
       it 'limits requests' do


### PR DESCRIPTION
Rapid polling of the claims status endpoint is causing multiple issues. This PR hopes to slow down the polling by adding throttling to rack attack middleware.

https://dsva.slack.com/archives/C30LCU8S3/p1571673172048900