### PR TITLE
Omit caching from flipper in dev/test

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -24,8 +24,6 @@ Flipper.configure do |config|
   end
 end
 
-
-
 # Modify Flipper::UI::Configuration to accept a custom view path.
 Flipper::UI::Configuration.prepend(FlipperExtensions::ConfigurationPatch)
 
@@ -47,7 +45,6 @@ end
 #   user.respond_to?(:first_name) && user.first_name == 'HECTOR'
 # end
 
-#
 Flipper::UI.configuration.feature_creation_enabled = false
 # Make sure that each feature we reference in code is present in the UI, as long as we have a Database already
 FLIPPER_FEATURE_CONFIG['features'].each_key do |feature|

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -11,11 +11,11 @@ require 'flipper/instrumentation/event_subscriber'
 
 FLIPPER_FEATURE_CONFIG = YAML.safe_load(File.read(Rails.root.join('config', 'features.yml')))
 
-# Flipper settings will be stored in postgres and cached in memory for 1 minute
 Flipper.configure do |config|
   config.default do
     activerecord_adapter = Flipper::Adapters::ActiveRecord.new
     cache = ActiveSupport::Cache::MemoryStore.new
+    # Flipper settings will be stored in postgres and cached in memory for 1 minute in production/staging
     cached_adapter = Flipper::Adapters::ActiveSupportCacheStore.new(activerecord_adapter, cache, expires_in: 1.minute)
     adapter = Rails.env.development? || Rails.env.test? ? activerecord_adapter : cached_adapter
     instrumented = Flipper::Adapters::Instrumented.new(adapter, instrumenter: ActiveSupport::Notifications)
@@ -23,6 +23,8 @@ Flipper.configure do |config|
     Flipper.new(instrumented, instrumenter: ActiveSupport::Notifications)
   end
 end
+
+
 
 # Modify Flipper::UI::Configuration to accept a custom view path.
 Flipper::UI::Configuration.prepend(FlipperExtensions::ConfigurationPatch)
@@ -45,6 +47,8 @@ end
 #   user.respond_to?(:first_name) && user.first_name == 'HECTOR'
 # end
 
+#
+Flipper::UI.configuration.feature_creation_enabled = false
 # Make sure that each feature we reference in code is present in the UI, as long as we have a Database already
 FLIPPER_FEATURE_CONFIG['features'].each_key do |feature|
   begin

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -16,7 +16,8 @@ Flipper.configure do |config|
   config.default do
     activerecord_adapter = Flipper::Adapters::ActiveRecord.new
     cache = ActiveSupport::Cache::MemoryStore.new
-    adapter = Flipper::Adapters::ActiveSupportCacheStore.new(activerecord_adapter, cache, expires_in: 1.minute)
+    cached_adapter = Flipper::Adapters::ActiveSupportCacheStore.new(activerecord_adapter, cache, expires_in: 1.minute)
+    adapter = Rails.env.development? || Rails.env.test? ? activerecord_adapter : cached_adapter
     instrumented = Flipper::Adapters::Instrumented.new(adapter, instrumenter: ActiveSupport::Notifications)
     # pass adapter to handy DSL instance
     Flipper.new(instrumented, instrumenter: ActiveSupport::Notifications)


### PR DESCRIPTION
## Description of change
omit caching in development/test so that feature toggle values can be tested easier. 
This will mean that we can call `Flipper.enable('feature_name')` and `Feature.disable('feature_name')` in the setup/teardown of tests.

## Testing done
verified manuall