### PR TITLE
Fix sort order for facilities

### DIFF
--- a/app/models/facilities_query/radial_query.rb
+++ b/app/models/facilities_query/radial_query.rb
@@ -35,7 +35,7 @@ module FacilitiesQuery
         end
         facilities
       end
-      result_set.sort_by &:distance
+      result_set.sort_by(&:distance)
     end
     # rubocop:enable Metrics/ParameterLists
 

--- a/app/models/facilities_query/radial_query.rb
+++ b/app/models/facilities_query/radial_query.rb
@@ -21,7 +21,7 @@ module FacilitiesQuery
     def build_distance_result_set(lat, long, type, services, ids, limit = nil)
       conditions = limit.nil? ? {} : "where distance < #{limit}"
       ids_map = ids_for_types(ids) unless ids.nil?
-      BaseFacility::TYPES.flat_map do |facility_type|
+      result_set = BaseFacility::TYPES.flat_map do |facility_type|
         facilities = get_facility_data(
           conditions,
           type,
@@ -33,8 +33,9 @@ module FacilitiesQuery
           ids_for_type = ids_map[BaseFacility::PREFIX_MAP[BaseFacility::TYPE_NAME_MAP[facility_type]]]
           facilities = facilities.where(unique_id: ids_for_type)
         end
-        facilities.order('distance')
+        facilities
       end
+      result_set.sort_by &:distance
     end
     # rubocop:enable Metrics/ParameterLists
 

--- a/modules/va_facilities/spec/requests/facilities_request_spec.rb
+++ b/modules/va_facilities/spec/requests/facilities_request_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       expect(json['meta']['distances']).to eq([])
     end
 
-    it 'responds to GET #index with lat/long sorted by distance' do
+    it 'responds to GET #index with lat/long sorted by distance ascending' do
       setup_pdx
       get base_query_path + lat_long, params: nil, headers: accept_json
       expect(response).to be_successful
@@ -70,7 +70,7 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       expect(json['meta']['distances']).to eq(sorted_distances)
     end
 
-    it 'responds to GET #index with ids sorted by distance from lat/long' do
+    it 'responds to GET #index with ids and lat/long sorted by distance ascending' do
       setup_pdx
       get "#{base_query_path}#{ids_query}&lat=45.451913&long=-122.440689", params: nil, headers: accept_json
       expect(response).to be_successful

--- a/modules/va_facilities/spec/requests/facilities_request_spec.rb
+++ b/modules/va_facilities/spec/requests/facilities_request_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       json = JSON.parse(response.body)
       expect(json['data'].length).to eq(10)
       expect(json['meta']['distances'].length).to eq(10)
-      sorted_distances = json['meta']['distances'].sort_by {|obj| obj['distance']}
+      sorted_distances = json['meta']['distances'].sort_by { |obj| obj['distance'] }
       expect(json['meta']['distances']).to eq(sorted_distances)
     end
 
@@ -78,7 +78,7 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       json = JSON.parse(response.body)
       expect(json['data'].length).to eq(10)
       expect(json['meta']['distances'].length).to eq(10)
-      sorted_distances = json['meta']['distances'].sort_by {|obj| obj['distance']}
+      sorted_distances = json['meta']['distances'].sort_by { |obj| obj['distance'] }
       expect(json['meta']['distances']).to eq(sorted_distances)
     end
 

--- a/modules/va_facilities/spec/requests/facilities_request_spec.rb
+++ b/modules/va_facilities/spec/requests/facilities_request_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       expect(json['meta']['distances']).to eq([])
     end
 
-    it 'responds to GET #index with lat/long' do
+    it 'responds to GET #index with lat/long sorted by distance' do
       setup_pdx
       get base_query_path + lat_long, params: nil, headers: accept_json
       expect(response).to be_successful
@@ -66,6 +66,8 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       json = JSON.parse(response.body)
       expect(json['data'].length).to eq(10)
       expect(json['meta']['distances'].length).to eq(10)
+      sorted_distances = json['meta']['distances'].sort_by {|obj| obj['distance']}
+      expect(json['meta']['distances']).to eq(sorted_distances)
     end
 
     it 'responds to GET #index with ids sorted by distance from lat/long' do
@@ -76,6 +78,8 @@ RSpec.describe 'Facilities API endpoint', type: :request do
       json = JSON.parse(response.body)
       expect(json['data'].length).to eq(10)
       expect(json['meta']['distances'].length).to eq(10)
+      sorted_distances = json['meta']['distances'].sort_by {|obj| obj['distance']}
+      expect(json['meta']['distances']).to eq(sorted_distances)
     end
 
     it 'responds to GET #index with zip' do

--- a/modules/va_facilities/spec/requests/nearby_request_spec.rb
+++ b/modules/va_facilities/spec/requests/nearby_request_spec.rb
@@ -184,7 +184,6 @@ RSpec.describe 'Nearby Facilities API endpoint', type: :request do
         expect(response).to be_successful
         expect(response.body).to be_a(String)
         json = JSON.parse(response.body)
-        puts json
         expect(json['data'].length).to eq(3)
         expect(json['meta']['distances']).to eq([])
       end


### PR DESCRIPTION
## Description of change
When responding to a request which includes lat and long params, /facilities includes the distance from the lat/long and purports to be sorted by that distance. It was actually sorting by facility_type then by distance. That has been fixed.

For department-of-veterans-affairs/vets-contrib/issues/2501

## Testing done
Verified locally that response is sorted in correct order
Added expectations for the sort order to the appropriate tests

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Facilities return ordered by distance, regardless of type unless a type is specified, in a lat/long query

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
