### PR TITLE
Moving Service Object to fix Mock-Override

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
@@ -32,5 +32,17 @@ module ClaimsApi
         StatsD.increment STATSD_VALIDATION_FAIL_TYPE_KEY, tags: ["key: #{key}"]
       end
     end
+
+    def service(auth_headers)
+      if Settings.claims_api.disability_claims_mock_override && !auth_headers['Mock-Override']
+        ClaimsApi::DisabilityCompensation::MockOverrideService.new(
+          auth_headers
+        )
+      else
+        EVSS::DisabilityCompensationForm::ServiceAllClaim.new(
+          auth_headers
+        )
+      end
+    end
   end
 end

--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -37,7 +37,7 @@ module ClaimsApi
                      )
       if request.headers['Mock-Override'] &&
          Settings.claims_api.disability_claims_mock_override
-        evss_headers['Mock-Override'] = true
+        evss_headers['Mock-Override'] = request.headers['Mock-Override']
         Rails.logger.info('ClaimsApi: Mock Override Engaged')
       end
 


### PR DESCRIPTION
## Description of change
An attempt to finally fix the mock-override issue happening in staging, ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/3332

## Acceptance Criteria (Definition of Done)
- Get Mock-Override from hitting a 500 error in staging

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
