### PR TITLE
Remove Flipper toggle for MVI ID parser changes

### DIFF
--- a/lib/mvi/responses/id_parser.rb
+++ b/lib/mvi/responses/id_parser.rb
@@ -45,51 +45,20 @@ module MVI
       #                  processes to utilize the 1 active
       #              PCE = Pending Cat Edit correlations (unsure if this should be used, likely not)
 
-      # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/AbcSize
       def parse(ids)
         ids = ids.map(&:attributes)
-        if Flipper.enabled?('mvi_id_parser')
-          {
-            icn: select_ids(select_extension(ids, PERMANENT_ICN_REGEX, VA_ROOT_OID))&.first,
-            sec_id: select_ids(select_extension(ids, /^\w+\^PN\^200PROV\^USDVA\^A$/, VA_ROOT_OID))&.first,
-            mhv_ids: select_ids(select_extension(ids, /^\w+\^PI\^200MH.{0,1}\^\w+\^\w+$/, VA_ROOT_OID)),
-            active_mhv_ids: select_ids(select_extension(ids, /^\w+\^PI\^200MH.{0,1}\^\w+\^A$/, VA_ROOT_OID)),
-            edipi: select_ids(select_extension(ids, /^\w+\^NI\^200DOD\^USDOD\^A$/, DOD_ROOT_OID))&.first,
-            vba_corp_id: select_ids(select_extension(ids, /^\w+\^PI\^200CORP\^USVBA\^A$/, VA_ROOT_OID))&.first,
-            vha_facility_ids: select_facilities(select_extension(ids, /^\w+\^PI\^\w+\^USVHA\^\w+$/, VA_ROOT_OID)),
-            birls_id: select_ids(select_extension(ids, /^\w+\^PI\^200BRLS\^USVBA\^A$/, VA_ROOT_OID))&.first,
-            vet360_id: select_ids(select_extension(ids, /^\w+\^PI\^200VETS\^USDVA\^A$/, VA_ROOT_OID))&.first,
-            icn_with_aaid: ICNWithAAIDParser.new(full_icn_with_aaid(ids)).without_id_status
-          }
-        else
-          {
-            icn: select_ids(select_extension(ids, ICN_REGEX, VA_ROOT_OID))&.first,
-            sec_id: select_ids(select_extension(ids, /^\w+\^PN\^200PROV\^USDVA\^\w+$/, VA_ROOT_OID))&.first,
-            mhv_ids: select_ids(select_extension(ids, /^\w+\^PI\^200MH.{0,1}\^\w+\^\w+$/, VA_ROOT_OID)),
-            active_mhv_ids: select_ids(select_extension(ids, /^\w+\^PI\^200MH.{0,1}\^\w+\^A$/, VA_ROOT_OID)),
-            edipi: select_ids(select_extension(ids, /^\w+\^NI\^200DOD\^USDOD\^\w+$/, DOD_ROOT_OID))&.first,
-            vba_corp_id: select_ids_except(select_extension(ids, /^\w+\^PI\^200CORP\^USVBA\^\w+$/, VA_ROOT_OID),
-                                           %w[H L])&.first,
-            vha_facility_ids: select_facilities(select_extension(ids, /^\w+\^PI\^\w+\^USVHA\^\w+$/, VA_ROOT_OID)),
-            birls_id: select_ids(select_extension(ids, /^\w+\^PI\^200BRLS\^USVBA\^\w+$/, VA_ROOT_OID))&.first,
-            vet360_id: select_ids(select_extension(ids, /^\w+\^PI\^200VETS\^USDVA\^A$/, VA_ROOT_OID))&.first,
-            icn_with_aaid: ICNWithAAIDParser.new(full_icn_with_aaid(ids)).without_id_status
-          }
-        end
-      end
-      # rubocop:enable Metrics/MethodLength
-      # rubocop:enable Metrics/AbcSize
-
-      # TODO: remove when Flipper toggle is removed.
-      def select_ids_except(extensions, reject_status)
-        # ultaimately, I'd rather have a list complete list of statuses to accept, but for now we can reject
-        return nil if extensions.empty?
-
-        extensions.map do |e|
-          split_extension = e[:extension].split('^')
-          split_extension&.first unless split_extension[4] && reject_status.include?(split_extension[4])
-        end.compact
+        {
+          icn: select_ids(select_extension(ids, PERMANENT_ICN_REGEX, VA_ROOT_OID))&.first,
+          sec_id: select_ids(select_extension(ids, /^\w+\^PN\^200PROV\^USDVA\^A$/, VA_ROOT_OID))&.first,
+          mhv_ids: select_ids(select_extension(ids, /^\w+\^PI\^200MH.{0,1}\^\w+\^\w+$/, VA_ROOT_OID)),
+          active_mhv_ids: select_ids(select_extension(ids, /^\w+\^PI\^200MH.{0,1}\^\w+\^A$/, VA_ROOT_OID)),
+          edipi: select_ids(select_extension(ids, /^\w+\^NI\^200DOD\^USDOD\^A$/, DOD_ROOT_OID))&.first,
+          vba_corp_id: select_ids(select_extension(ids, /^\w+\^PI\^200CORP\^USVBA\^A$/, VA_ROOT_OID))&.first,
+          vha_facility_ids: select_facilities(select_extension(ids, /^\w+\^PI\^\w+\^USVHA\^\w+$/, VA_ROOT_OID)),
+          birls_id: select_ids(select_extension(ids, /^\w+\^PI\^200BRLS\^USVBA\^A$/, VA_ROOT_OID))&.first,
+          vet360_id: select_ids(select_extension(ids, /^\w+\^PI\^200VETS\^USDVA\^A$/, VA_ROOT_OID))&.first,
+          icn_with_aaid: ICNWithAAIDParser.new(full_icn_with_aaid(ids)).without_id_status
+        }
       end
 
       def select_ids_with_extension(ids, pattern, root)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,6 @@ unless ENV['NOCOVERAGE']
   SimpleCov.start 'rails' do
     track_files '**/{app,lib}/**/*.rb'
 
-    add_filter 'lib/mvi/responses/id_parser.rb' # TODO: remove when removing Flipper toggle in file.
     add_filter 'app/controllers/concerns/accountable.rb'
     add_filter 'config/initializers/clamscan.rb'
     add_filter 'lib/config_helper.rb'


### PR DESCRIPTION
## Description of change
Remove Flipper wrapping of MVI ID parser changes.

## Testing done
specs

## Testing planned
N/A - changes already live in production

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Remove Flipper toggle around MVI ID parser changes

#### Applies to all PRs

- [x] Appropriate logging
- [ ] ~~Swagger docs have been updated, if applicable~~
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] ~~Provide which alerts would indicate a problem with this functionality (if applicable)~~
