### PR TITLE
bump puma to current

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem 'veteran', path: 'modules/veteran'
 gem 'veteran_verification', path: 'modules/veteran_verification'
 
 # Anchored versions, do not change
-gem 'puma', '~> 3.12.0'
-gem 'puma-plugin-statsd', git: 'https://github.com/department-of-veterans-affairs/puma-plugin-statsd', branch: 'master'
+gem 'puma', '~> 4.2.1'
+gem 'puma-plugin-statsd', '~> 0.1.0'
 gem 'rails', '~> 5.2.3'
 
 # Gems with special version/repo needs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,15 +33,6 @@ GIT
       savon (~> 2.12)
 
 GIT
-  remote: https://github.com/department-of-veterans-affairs/puma-plugin-statsd
-  revision: 6faba90147cf6fbb6c1a6a0c6cd3ae88e888ca73
-  branch: master
-  specs:
-    puma-plugin-statsd (0.0.1)
-      json
-      puma (~> 3.12)
-
-GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
   revision: 8a74f697eba9c4d06951f5f6da4e42af6e21f2d5
   branch: master
@@ -479,7 +470,11 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     public_suffix (3.1.1)
-    puma (3.12.0)
+    puma (4.2.1)
+      nio4r (~> 2.0)
+    puma-plugin-statsd (0.1.0)
+      json
+      puma (>= 3.12, < 5)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     raabro (1.1.6)
@@ -781,8 +776,8 @@ DEPENDENCIES
   pg
   prawn
   pry-byebug
-  puma (~> 3.12.0)
-  puma-plugin-statsd!
+  puma (~> 4.2.1)
+  puma-plugin-statsd (~> 0.1.0)
   pundit
   rack-attack
   rack-cors


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

relates to: department-of-veterans-affairs/va.gov-team#2614

This bumps puma from 3.x to current 4.x and moves the statsd gem to current release.  This is in prep of trying to tune workers and threads on veta-api-server to address the behaviors we saw in department-of-veterans-affairs/va.gov-team#2633

## Testing done
<!-- Please describe testing done to verify the changes. -->
- `rspec ./specs`
- load status page

## Testing planned
<!-- Please describe testing planned. -->
Unsure here, this is my first PR to vets-api, would love some guidance specifically around running integration or e2e tests.

Things to look for in monitoring:
- site being served
- increase in sentry errors
- increase in cloudwatch logs
- per server cpu/memory usage
- api server throughput and timing

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] Prod running puma 4.2.1

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)