### PR TITLE
move faraday client configuration spec set up into shared helper

### DIFF
--- a/spec/lib/common/client/base_spec.rb
+++ b/spec/lib/common/client/base_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require './spec/support/default_configuration_helper'
 
 describe Common::Client::Base do
   module Specs

--- a/spec/lib/common/client/base_spec.rb
+++ b/spec/lib/common/client/base_spec.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require './spec/support/default_configuration_helper'
 
 describe Common::Client::Base do
   module Specs
     module Common
       module Client
-        class TestConfiguration < ::Common::Client::Configuration::REST
-          def connection
-            @conn ||= Faraday.new('http://example.com') do |faraday|
-              faraday.adapter :httpclient
-            end
+        class TestConfiguration < DefaultConfiguration
+          def adapter_only
+            true
           end
         end
 

--- a/spec/lib/common/client/concerns/log_as_warning_helpers_spec.rb
+++ b/spec/lib/common/client/concerns/log_as_warning_helpers_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require './spec/support/default_configuration_helper'
 
 describe Common::Client::Concerns::LogAsWarningHelpers do
   module Specs

--- a/spec/lib/common/client/concerns/log_as_warning_helpers_spec.rb
+++ b/spec/lib/common/client/concerns/log_as_warning_helpers_spec.rb
@@ -1,24 +1,13 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require './spec/support/default_configuration_helper'
 
 describe Common::Client::Concerns::LogAsWarningHelpers do
   module Specs
     module Common
       module Client
-        class DefaultConfiguration < ::Common::Client::Configuration::REST
-          def connection
-            @conn ||= Faraday.new('http://example.com') do |faraday|
-              faraday.adapter Faraday.default_adapter
-            end
-          end
-
-          def service_name
-            'foo'
-          end
-        end
-
-        class DefaultService < ::Common::Client::Base
+        class TestService < ::Common::Client::Base
           configuration DefaultConfiguration
           include ::Common::Client::Concerns::LogAsWarningHelpers
 
@@ -30,7 +19,7 @@ describe Common::Client::Concerns::LogAsWarningHelpers do
     end
   end
 
-  let(:service) { Specs::Common::Client::DefaultService.new }
+  let(:service) { Specs::Common::Client::TestService.new }
 
   context 'when request raises a 503 backend service exception' do
     it 'sets log_as_warning in raven extra context' do

--- a/spec/lib/common/client/middleware/request/remove_cookies_spec.rb
+++ b/spec/lib/common/client/middleware/request/remove_cookies_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require './spec/support/default_configuration_helper'
 
 describe Common::Client::Middleware::Request::RemoveCookies do
   module Specs

--- a/spec/lib/common/client/middleware/request/remove_cookies_spec.rb
+++ b/spec/lib/common/client/middleware/request/remove_cookies_spec.rb
@@ -1,25 +1,14 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require './spec/support/default_configuration_helper'
 
 describe Common::Client::Middleware::Request::RemoveCookies do
   module Specs
     module RemoveCookies
-      class TestConfiguration < ::Common::Client::Configuration::REST
-        def port
-          3010
-        end
-
-        def service_name
-          'TestClient'
-        end
-
-        def connection
-          @conn ||= Faraday.new("http://127.0.0.1:#{port}") do |faraday|
-            faraday.use :breakers
-            faraday.use :remove_cookies
-            faraday.adapter :httpclient
-          end
+      class TestConfiguration < Specs::Common::Client::DefaultConfiguration
+        def use_example_path
+          false
         end
       end
 

--- a/spec/lib/common/client/monitoring_spec.rb
+++ b/spec/lib/common/client/monitoring_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require './spec/support/default_configuration_helper'
 
 RSpec.describe Common::Client::Monitoring, type: :model do
   module Specs

--- a/spec/lib/common/client/monitoring_spec.rb
+++ b/spec/lib/common/client/monitoring_spec.rb
@@ -1,30 +1,16 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require './spec/support/default_configuration_helper'
 
 RSpec.describe Common::Client::Monitoring, type: :model do
   module Specs
     module Common
       module Client
-        class MonitoringTestConfiguration < ::Common::Client::Configuration::REST
-          def connection
-            @conn ||= Faraday.new('http://example.com') do |faraday|
-              faraday.use     :breakers
-              faraday.use     Faraday::Response::RaiseError
-              faraday.use     :remove_cookies
-              faraday.adapter :httpclient
-            end
-          end
-
-          def service_name
-            'foo'
-          end
-        end
-
         class MonitoringTestService < ::Common::Client::Base
           STATSD_KEY_PREFIX = 'fooservice'
-          configuration MonitoringTestConfiguration
           include ::Common::Client::Monitoring
+          configuration DefaultConfiguration
 
           def request(*args)
             with_monitoring { super }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,7 @@ require 'support/aws_helpers'
 require 'support/request_helper'
 require 'support/uploader_helpers'
 require 'common/exceptions'
+require './spec/support/default_configuration_helper'
 
 WebMock.disable_net_connect!(allow_localhost: true)
 

--- a/spec/support/default_configuration_helper.rb
+++ b/spec/support/default_configuration_helper.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'common/client/configuration/rest'
+
+module Specs
+  module Common
+    module Client
+      class DefaultConfiguration < ::Common::Client::Configuration::REST
+        def connection
+          @conn ||= Faraday.new(base_path) do |faraday|
+            unless adapter_only
+              faraday.use     :breakers
+              faraday.use     Faraday::Response::RaiseError
+              faraday.use     :remove_cookies
+            end
+            faraday.adapter :httpclient
+          end
+        end
+
+        def service_name
+          'foo'
+        end
+
+        def adapter_only
+          false
+        end
+
+        def port
+          3010
+        end
+
+        def use_example_path
+          true
+        end
+
+        def base_path
+          use_example_path ? 'http://example.com' : "http://127.0.0.1:#{port}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
To avoid module namespacing collisions and excessive setup/teardown, faraday configuration is now extracted into a shared helper for specs.

## Testing done
Spec tests pass

## Acceptance Criteria (Definition of Done)
- [x] Spec tests pass
- [x] Specs identified where we're using a configuration, and extraction pattern applied