### PR TITLE
update vso_search url

### DIFF
--- a/lib/evss/vso_search/configuration.rb
+++ b/lib/evss/vso_search/configuration.rb
@@ -13,7 +13,7 @@ module EVSS
       # @return [String] Base path for VSO search URLs.
       #
       def base_path
-        "#{Settings.evss.url}/wss-common-services-web-#{API_VERSION}/rest/vsoSearch/11.0/"
+        "#{Settings.evss.url}/wss-common-services-web-#{API_VERSION}/rest/vsoSearch/11.6/"
       end
 
       ##

--- a/spec/lib/evss/vso_search/configuration_spec.rb
+++ b/spec/lib/evss/vso_search/configuration_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe EVSS::VsoSearch::Configuration do
   describe '#base_path' do
     it 'has a base path' do
-      base_path = "#{Settings.evss.url}/wss-common-services-web-#{Settings.evss.versions.common}/rest/vsoSearch/11.0/"
+      base_path = "#{Settings.evss.url}/wss-common-services-web-#{Settings.evss.versions.common}/rest/vsoSearch/11.6/"
       expect(described_class.instance.base_path).to eq(base_path)
     end
   end


### PR DESCRIPTION
## Description of change
This branch updates the url used in the VSO search to use version 11.6 over 11.0

## Testing done
local testing

## Testing planned
checking on dev

## Acceptance Criteria (Definition of Done)
- [ ] Dev mocks work when using a vso search


#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
