### PR TITLE
19825: STEM: Remove Shay's email from staging distributions

### DIFF
--- a/app/mailers/spool_submissions_report_mailer.rb
+++ b/app/mailers/spool_submissions_report_mailer.rb
@@ -18,7 +18,6 @@ class SpoolSubmissionsReportMailer < ApplicationMailer
 
   STAGING_RECIPIENTS = %w[
     lihan@adhocteam.us
-    shay.norton-leonard@va.gov
   ].freeze
 
   STAGING_STEM_RECIPIENTS = %w[

--- a/app/mailers/year_to_date_report_mailer.rb
+++ b/app/mailers/year_to_date_report_mailer.rb
@@ -33,7 +33,6 @@ class YearToDateReportMailer < ApplicationMailer
   STAGING_RECIPIENTS = {
     to: %w[
       lihan@adhocteam.us
-      shay.norton-leonard@va.gov
     ]
   }.freeze
 

--- a/spec/mailers/spool_submissions_report_mailer_spec.rb
+++ b/spec/mailers/spool_submissions_report_mailer_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
         expect(mail.to).to eq(
           %w[
             lihan@adhocteam.us
-            shay.norton-leonard@va.gov
           ]
         )
       end
@@ -87,7 +86,6 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
         expect(mail.to).to eq(
           %w[
             lihan@adhocteam.us
-            shay.norton-leonard@va.gov
           ]
         )
       end

--- a/spec/mailers/year_to_date_report_mailer_spec.rb
+++ b/spec/mailers/year_to_date_report_mailer_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe YearToDateReportMailer, type: %i[mailer aws_helpers] do
         expect(mail.to).to eq(
           %w[
             lihan@adhocteam.us
-            shay.norton-leonard@va.gov
           ]
         )
       end


### PR DESCRIPTION
## Description of change
As a developer, I need to remove and email from the staging distributions so that the user does not receive unnecessary emails.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19825

## Testing done
Testing passes locally

## Testing planned
Assure that the email is no longer being sent

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] shay.norton-leonard@va.gov is not a recipient of the Spool report distribution on staging.
- [x] shay.norton-leonard@va.gov is not a recipient of the YTD report distribution on staging.


#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
