### PR TITLE
Create a whitelist of flipper admins

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -301,12 +301,7 @@ Rails.application.routes.draw do
   end
 
   require 'feature_flipper'
-  flipper_app = Flipper::UI.app(Flipper.instance) do |builder|
-    builder.use Rack::Auth::Basic do |username, password|
-      username == Settings.flipper.username && password == Settings.flipper.password
-    end
-  end
-  mount flipper_app, at: '/flipper'
+  mount Flipper::UI.app(Flipper.instance) => '/flipper', constraints: Flipper::AdminUserConstraint.new
 
   # This globs all unmatched routes and routes them as routing errors
   match '*path', to: 'application#routing_error', via: %i[get post put patch delete]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -395,8 +395,8 @@ bing:
   key: fake_key
 
 flipper:
-  username: SUPER_SECRET_USERNAME
-  password: SUPER_SECRET_PASSWORD
+  admin_user_emails:
+    - anna@adhoc.team
 
 bgs:
   application: ~

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -70,3 +70,7 @@ vba_documents:
 bgs:
   mock_response_location: /cache/bgs
   mock_responses: true
+
+flipper:
+  admin_user_emails:
+    - abraham.lincoln@vets.gov

--- a/lib/flipper/admin_user_constraint.rb
+++ b/lib/flipper/admin_user_constraint.rb
@@ -4,7 +4,12 @@ module Flipper
   class AdminUserConstraint
     def current_user_rack(request)
       if (session_token = request.session[:token]) && (session = Session.find(session_token))
-        User.find(session.uuid)
+        user = User.find(session.uuid)
+        # We've set this in a thread because we want to log who has made a change in
+        # Flipper::Instrumentation::EventSubscriber but at that point we don't have access to the request or session
+        # objects at that point and the request goint to a simple rack app.
+        Thread.current[:flipper_user_email_for_log] = user.email
+        user
       end
     end
 

--- a/lib/flipper/admin_user_constraint.rb
+++ b/lib/flipper/admin_user_constraint.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Flipper
+  class AdminUserConstraint
+    def current_user_rack(request)
+      if (session_token = request.session[:token]) && (session = Session.find(session_token))
+        User.find(session.uuid)
+      end
+    end
+
+    def matches?(request)
+      current_user = current_user_rack(request)
+      current_user && Settings.flipper.admin_user_emails.include?(current_user.email) && current_user.loa3?
+    end
+  end
+end

--- a/lib/flipper/instrumentation/event_subscriber.rb
+++ b/lib/flipper/instrumentation/event_subscriber.rb
@@ -15,7 +15,7 @@ module Flipper
                                     operation: operation,
                                     gate_name: event.payload[:gate_name],
                                     value: event.payload[:thing]&.value,
-                                    user: nil)
+                                    user: Thread.current[:flipper_user_email_for_log])
         end
       end
 

--- a/spec/request/flipper_request_spec.rb
+++ b/spec/request/flipper_request_spec.rb
@@ -3,13 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe 'Flipper UI', type: :request do
-  it 'Displays list of features' do
-    get '/flipper/features', params: nil, headers: { 'HTTP_AUTHORIZATION':
-          ActionController::HttpAuthentication::Basic.encode_credentials(
-            Settings.flipper.username,
-            Settings.flipper.password
-          ) }
+  context '#logged in ' do
+    let(:user) { build(:user, :loa3) }
 
-    assert_response :success
+    before do
+      sign_in_as(user)
+    end
+
+    it 'Displays list of features' do
+      get '/flipper/features', params: nil
+      assert_response :success
+    end
+  end
+
+  context '#not logged in ' do
+    it 'no Displays list of features' do
+      get '/flipper/features', params: nil
+      assert_response :missing
+    end
   end
 end

--- a/spec/request/flipper_request_spec.rb
+++ b/spec/request/flipper_request_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.describe 'Flipper UI', type: :request do
   context '#logged in ' do
     let(:user) { build(:user, :loa3) }
+    let(:token) { Rack::Protection::AuthenticityToken.random_token }
+    let(:session) do
+      { :csrf => token, 'csrf' => token, '_csrf_token' => token }
+    end
 
     before do
       sign_in_as(user)
@@ -13,6 +17,15 @@ RSpec.describe 'Flipper UI', type: :request do
     it 'Displays list of features' do
       get '/flipper/features', params: nil
       assert_response :success
+    end
+
+    it 'records the admin user when a toggle value is chaged' do
+      Flipper.enable('mvi_id_parser')
+      post '/flipper/features/mvi_id_parser/boolean',
+           params: { 'action' => 'Enable', 'authenticity_token' => token },
+           session: { 'rack.session' => session }
+      assert_response :redirect
+      expect(FeatureToggleEvent.last.user).to eq(user.email)
     end
   end
 


### PR DESCRIPTION
## Description of change
Limit access to Flipper to LOA3 users whose email is in the list at ` Settings.flipper.admin_user_emails`
## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
