### PR TITLE
fix local `make ci` run with docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
+      JENKINS_URL: "${JENKINS_URL}"
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
## Description of change
While running `make `commands locally using the `docker-compose.yml` file, you get this:
```
running danger...
Could not find the type of CI for Danger to run on.


Failed. Something went wrong while running danger-ruby
```
### The Fix
This PR adds the `JENKINS_URL` environment variable to the `vets-api` image inside the `docker-compose.yml` file. The Danger-ruby run requires this ENV var to be present while running - even if it is empty.

## Testing done
None

## Testing planned
@charleystran to test

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
