### PR TITLE
fix VSO loader to capture poa codes on attorney's and claim agents

### DIFF
--- a/modules/veteran/app/workers/veteran/base_reloader.rb
+++ b/modules/veteran/app/workers/veteran/base_reloader.rb
@@ -13,8 +13,8 @@ module Veteran
       rep = Veteran::Service::Representative.find_or_initialize_by(representative_id: hash_object['Registration Num'],
                                                                    first_name: hash_object['First Name'],
                                                                    last_name: hash_object['Last Name'])
-      poa_code = hash_object['POA Code'].gsub!(/\W/, '')
-      rep.poa_codes << poa_code unless rep.user_types.include?(poa_code)
+      poa_code = hash_object['POA Code'].gsub(/\W/, '')
+      rep.poa_codes << poa_code unless rep.poa_codes.include?(poa_code)
       rep.phone = hash_object['Phone']
       rep
     end

--- a/modules/veteran/spec/workers/veteran/vso_reloader_spec.rb
+++ b/modules/veteran/spec/workers/veteran/vso_reloader_spec.rb
@@ -22,5 +22,26 @@ RSpec.describe Veteran::VsoReloader, type: :job do
         expect(Veteran::Service::Representative.claim_agents.count).to eq 42
       end
     end
+
+    it 'loads attorneys with the poa codes loaded' do
+      VCR.use_cassette('veteran/ogc_attorney_data') do
+        Veteran::VsoReloader.new.reload_attorneys
+        expect(Veteran::Service::Representative.last.poa_codes).to include('9GB')
+      end
+    end
+
+    it 'loads a claim agent  with the poa code' do
+      VCR.use_cassette('veteran/ogc_claim_agent_data') do
+        Veteran::VsoReloader.new.reload_claim_agents
+        expect(Veteran::Service::Representative.last.poa_codes).to include('FDN')
+      end
+    end
+
+    it 'loads a vso rep with the poa code' do
+      VCR.use_cassette('veteran/ogc_vso_rep_data') do
+        Veteran::VsoReloader.new.reload_vso_reps
+        expect(Veteran::Service::Representative.last.poa_codes).to include('091')
+      end
+    end
   end
 end

--- a/spec/support/vcr_cassettes/veteran/ogc_attorney_data.yml
+++ b/spec/support/vcr_cassettes/veteran/ogc_attorney_data.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.va.gov/ogc/apps/accreditation/attorneyexcellist.asp
+    body:
+      encoding: UTF-8
+      string: id=frmExcelList&name=frmExcelList
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Oct 2019 13:12:55 GMT
+      Content-Type:
+      - application/vnd.ms-excel
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      Set-Cookie:
+      - ASPSESSIONIDAADQTSCD=BAHJFIJDDKIDGPIHGOKPCKNH; path=/
+      - TS016f4012=01c8917e48fc9b7b83805186cac3e4ea5caf12dcdd46348fabc3f20f7568f1ab8d4c78847035027e9ef4db3bb1118bdbf8dc942e3267785e414809408c5c3862e6662d46c4;
+        Max-Age=900; Path=/
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "\r\n<HTML>\r\n<BODY>\r\n\r\n\r\n<!-- Our table which will be translated
+        into an Excel spreadsheet -->\r\n<TABLE WIDTH=75% BORDER=1 CELLSPACING=1 CELLPADDING=1>\r\n<TR>\r\n
+        \  <td>Last Name</td>\r\n   <td>First Name</td>\r\n   <td>Date Accredited</td>\r\n
+        \  <td>Registration Num</td>\r\n   <td>POA Code</td>\r\n   <td>City</td>\r\n
+        \  <td>State</td>\r\n   <td>Zip</td>\r\n   <td>Phone</td>\r\n</TR>\r\n<!--
+        server-side loop adding Table entries -->\r\n\r\n<TR>\r\n   <TD>Rohrberger</TD>\r\n
+        \  <TD>Risa</TD>\r\n   <TD>6/5/2013</TD>\r\n   <TD>27840</TD>\r\n   <TD>9GB</TD>\r\n
+        \  <TD>Midland Park</TD>\r\n   <TD>NJ</TD>\r\n   <TD>'07432</TD>\r\n   <TD>201-932-1972</TD>\r\n</TR>\r\n\r\n
+        \  \r\n\r\n</TABLE>\r\n</BODY>\r\n</HTML>\r\n"
+    http_version: 
+  recorded_at: Tue, 29 Oct 2019 13:12:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/veteran/ogc_claim_agent_data.yml
+++ b/spec/support/vcr_cassettes/veteran/ogc_claim_agent_data.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.va.gov/ogc/apps/accreditation/caexcellist.asp
+    body:
+      encoding: UTF-8
+      string: id=frmExcelList&name=frmExcelList
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Oct 2019 13:32:37 GMT
+      Content-Type:
+      - application/vnd.ms-excel
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      Set-Cookie:
+      - ASPSESSIONIDSAAQRSCB=DKNDJIJDEDDEFALIHNAMONDB; path=/
+      - TS016f4012=01c8917e48435825e8cb5946eb5136f2705b2a2c628e232335515fd36dfe25b0551c236ecc1593756d006b5ae7705b54d6da33c639ece0bdbd2e441bdbcd37e6579fd2f21d;
+        Max-Age=900; Path=/
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "\r\n<HTML>\r\n<BODY>\r\n\r\n\r\n<!-- Our table which will be translated
+        into an Excel spreadsheet -->\r\n<TABLE WIDTH=75% BORDER=1 CELLSPACING=1 CELLPADDING=1>\r\n<TR>\r\n
+        \  <td>Last Name</td>\r\n   <td>First Name</td>\r\n   <td>Date Accredited</td>\r\n
+        \  <td>Registration Num</td>\r\n   <td>POA Code</td>\r\n   <td>City</td>\r\n
+        \  <td>State</td>\r\n   <td>Zip</td>\r\n   <td>Phone</td>\r\n</TR>\r\n<!--
+        server-side loop adding Table entries -->\r\n\r\n<TR>\r\n   <TD>Adams</TD>\r\n
+        \  <TD>David</TD>\r\n   <TD>1/23/2017</TD>\r\n   <TD>40537</TD>\r\n   <TD>EMK</TD>\r\n
+        \  <TD>Denver</TD>\r\n   <TD>CO</TD>\r\n   <TD>'80210</TD>\r\n   <TD>720-985-6747</TD>\r\n</TR>\r\n\r\n<TR>\r\n
+        \  <TD>Allen</TD>\r\n   <TD>Kelvin</TD>\r\n   <TD>8/21/2017</TD>\r\n   <TD>42535</TD>\r\n
+        \  <TD>FDN</TD>\r\n   <TD>Durham</TD>\r\n   <TD>NC</TD>\r\n   <TD>'27712</TD>\r\n
+        \  <TD>919-824-9873</TD>\r\n</TR>\r\n\r\n<TR>\r\n   <TD>Alston</TD>\r\n   <TD>James</TD>\r\n
+        \  <TD>12/20/2016</TD>\r\n   <TD>40393</TD>\r\n   <TD>ELC</TD>\r\n   <TD>Durham</TD>\r\n
+        \  <TD>NC</TD>\r\n   <TD>'27701</TD>\r\n   <TD>1-984-219-1580</TD>\r\n</TR>\r\n\r\n
+        \ </TABLE>\r\n</BODY>\r\n</HTML>\r\n"
+    http_version: 
+  recorded_at: Tue, 29 Oct 2019 13:32:38 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/veteran/ogc_vso_rep_data.yml
+++ b/spec/support/vcr_cassettes/veteran/ogc_vso_rep_data.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.va.gov/ogc/apps/accreditation/orgsexcellist.asp
+    body:
+      encoding: UTF-8
+      string: id=frmExcelList&name=frmExcelList
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Oct 2019 13:38:38 GMT
+      Content-Type:
+      - application/vnd.ms-excel
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      Set-Cookie:
+      - ASPSESSIONIDAACTTSBC=HJKIIHJDHDLFMGMCHLPKLMIG; path=/
+      - TS016f4012=01c8917e48fee352385163d68ffb91e97d3eaf0452338178d6d0f238434fc88c0576fa60d81a1c23b1724d026fa5b6d9b19946f1f126450ad49473c9fdc5bd3fc15d0962bf;
+        Max-Age=900; Path=/
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "\r\n<HTML>\r\n<BODY>\r\n\r\n\r\n<!-- Our table which will be translated
+        into an Excel spreadsheet -->\r\n<TABLE WIDTH=75% BORDER=1 CELLSPACING=1 CELLPADDING=1>\r\n<TR>\r\n
+        \  <td>Organization Name</td>\r\n   <td>POA</td>\r\n   <td>Org Phone</td>\r\n
+        \  <td>Org City</td>\r\n   <td>Org State</td>\r\n   <td>Representative</td>\r\n
+        \  <td>Rep City</td>\r\n   <td>Rep State</td>\r\n   <td>Rep Zip</td>\r\n   <td>Registration
+        Num</td>\r\n</TR>\r\n<!-- server-side loop adding Table entries -->\r\n\r\n<TR>\r\n
+        \  <TD>African American PTSD Association</TD>\r\n   <TD>'091</TD>\r\n   <TD>253-589-0766</TD>\r\n
+        \  <TD>Lakewood</TD>\r\n   <TD>WA</TD>\r\n   <TD>Anderson, Edgar B</TD>\r\n
+        \  <TD>Chicago</TD>\r\n   <TD>IL</TD>\r\n   <TD>'60635</TD>\r\n   <TD>8239</TD>\r\n</TR>\r\n\r\n</TABLE>\r\n</BODY>\r\n</HTML>\r\n"
+    http_version:
+  recorded_at: Mon, 15 Apr 2019 13:02:15 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Description of change
This PR fixes the issue with VSO Attorney and Claim agents not loading poa_codes

## Testing done
- [x] rspec

## Testing planned
running the job in dev and staging once merged

## Acceptance Criteria (Definition of Done)
- [x] When the loader is run, attorney and claims agents will have poa_codes on their records


#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] https://github.com/department-of-veterans-affairs/vets-contrib/issues/3408
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
