### PR TITLE
10795 Added feature flag for Receive Text Notifications checkbox on P…

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -11,6 +11,9 @@ features:
   profile_show_direct_deposit:
     description: >
       https://www.va.gov/profile/ show Direct Deposit
+  profile_show_receive_text_notifications:
+    description: >
+      https://www.va.gov/profile/ show Receive Text Notifications
   mvi_id_parser:
     description: >
       logic changes for parsing IDs from MVI responses


### PR DESCRIPTION
## Description of change

The VA.gov site administrator wants to be able to control who sees the Notifications checkbox on the profile page so that it can be turned off or on or only shown to a percentage of Veterans.

## Testing done

Local testing.

## Testing Planned

Test in Staging before introducing to production.

## Acceptance Criteria (Definition of Done)

- [ ] When the feature flag is enabled, all qualifying Veterans will be able to see the checkbox below the Mobile Phone number on the profile page and on the edit modal for the mobile phone number on the profile page.
- [ ] When the feature flag is disabled, no Veterans will be able to see the checkbox below the Mobile Phone Number anywhere.

