### PR TITLE
Add server section back to the Facilities API v0 docs now that curl builder needs it

### DIFF
--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -66,6 +66,22 @@ info:
 tags:
   - name: facilities
     description: VA Facilities API
+servers:
+- url: https://dev-api.va.gov/services/va_facilities/{version}
+description: VA.gov API development environment
+variables:
+  version:
+    default: v0
+- url: https://staging-api.va.gov/services/va_facilities/{version}
+description: VA.gov API staging environment
+variables:
+  version:
+    default: v0
+- url: https://api.va.gov/services/va_facilities/{version}
+description: VA.gov API production environment
+variables:
+  version:
+    default: v0
 paths:
   /facilities:
     get:

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -68,12 +68,12 @@ tags:
     description: VA Facilities API
 servers:
 - url: https://dev-api.va.gov/services/va_facilities/{version}
-  description: VA.gov API development environment
+  description: Development
   variables:
     version:
       default: v0
 - url: https://api.va.gov/services/va_facilities/{version}
-  description: VA.gov API production environment
+  description: Production
   variables:
     version:
       default: v0

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -68,20 +68,20 @@ tags:
     description: VA Facilities API
 servers:
 - url: https://dev-api.va.gov/services/va_facilities/{version}
-description: VA.gov API development environment
-variables:
-  version:
-    default: v0
+  description: VA.gov API development environment
+  variables:
+    version:
+      default: v0
 - url: https://staging-api.va.gov/services/va_facilities/{version}
-description: VA.gov API staging environment
-variables:
-  version:
-    default: v0
+  description: VA.gov API staging environment
+  variables:
+    version:
+      default: v0
 - url: https://api.va.gov/services/va_facilities/{version}
-description: VA.gov API production environment
-variables:
-  version:
-    default: v0
+  description: VA.gov API production environment
+  variables:
+    version:
+      default: v0
 paths:
   /facilities:
     get:

--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -72,11 +72,6 @@ servers:
   variables:
     version:
       default: v0
-- url: https://staging-api.va.gov/services/va_facilities/{version}
-  description: VA.gov API staging environment
-  variables:
-    version:
-      default: v0
 - url: https://api.va.gov/services/va_facilities/{version}
   description: VA.gov API production environment
   variables:


### PR DESCRIPTION
## Description of change
Add the `server` section back to the Facilities API v0 docs. This section is needed by the curl builder and will error if not present.

## Acceptance Criteria (Definition of Done)
- [ ] `server` section added back as it was

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
