### PR TITLE
add rian to feature toggle admins

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -399,6 +399,8 @@ flipper:
     - anna@adhoc.team
     - johnny@oddball.io
     - travis.hilton@oddball.io
+    - rian.fowler@adhoc.team
+    - rianfowler@outlook.com
 
 bgs:
   application: ~


### PR DESCRIPTION
adding rian as a feature toggle admin.  
Because he's a veteran he's using his personal email address for production and his work address for staging.