### PR TITLE
[2803] Appeals Response Validation BUGFIX

### DIFF
--- a/lib/appeals/schema/appeals.json
+++ b/lib/appeals/schema/appeals.json
@@ -192,7 +192,7 @@
                     "type": "boolean"
                   },
                   "switchDueDate": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   }
                 }
               },


### PR DESCRIPTION
[2803](https://github.com/department-of-veterans-affairs/va.gov-team/issues/2803)

## Description of change
switchDueDate is occasionally returned as null by the caseflow API, which would cause the appeals request to return a 500 error as the JSON validator within the service response class would flag at is not valid - this fixes that by allowing switchDueDate to be returned as null.

## Testing done
Change has been tested locally, appeals are returned successfully with change in place if switchDueDate is null, it returns a 500 while testing from master if switchDueDate is null

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
