### PR TITLE
PSSG Download: override default Cartesian factory

### DIFF
--- a/app/workers/facilities/pssg_download.rb
+++ b/app/workers/facilities/pssg_download.rb
@@ -58,7 +58,7 @@ module Facilities
 
     def extract_polygon(rings)
       geojson = "{\"type\":\"Polygon\",\"coordinates\":#{rings}}"
-      RGeo::GeoJSON.decode(geojson)
+      RGeo::GeoJSON.decode(geojson, geo_factory: RGeo::Geographic.spherical_factory(srid: 4326, uses_lenient_assertions: true))
     end
 
     def download_data

--- a/app/workers/facilities/pssg_download.rb
+++ b/app/workers/facilities/pssg_download.rb
@@ -58,7 +58,8 @@ module Facilities
 
     def extract_polygon(rings)
       geojson = "{\"type\":\"Polygon\",\"coordinates\":#{rings}}"
-      RGeo::GeoJSON.decode(geojson, geo_factory: RGeo::Geographic.spherical_factory(srid: 4326, uses_lenient_assertions: true))
+      spherical_factory = RGeo::Geographic.spherical_factory(srid: 4326, uses_lenient_assertions: true)
+      RGeo::GeoJSON.decode(geojson, geo_factory: spherical_factory)
     end
 
     def download_data


### PR DESCRIPTION
## Description of change
In looking through the code for the RGeo component [GeoJSON](https://github.com/rgeo/rgeo-geojson/blob/6028c8c7360f84727547d332907671dc901c351f/lib/rgeo/geo_json/interface.rb#L36) I found that it defaults to using a Cartesian coordinate system when decoding GeoJSON if you don't pass in factory. Specifying the spherical factory with the same options as the one used in our model greatly improves the decoding time. When run on my machine with the default factory it takes 139 seconds to decode the 30 features; with the spherical factory this was reduced to 9 seconds.

Part of department-of-veterans-affairs/vets-contrib/issues/3534.

## Testing done
Ran job locally

## Testing planned
Run job in dev to verify speed increase