### PR TITLE
add VAOS healthcheck and options to routes

### DIFF
--- a/modules/vaos/config/routes.rb
+++ b/modules/vaos/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 VAOS::Engine.routes.draw do
+  match '/metadata', to: 'metadata#index', via: [:get]
+  match '/v0/healthcheck', to: 'metadata#healthcheck', via: [:get]
+  match '/v0/*path', to: 'application#cors_preflight', via: [:options]
+
   namespace :v0, defaults: { format: 'json' } do
     resources :systems, only: :index
     get 'api', to: 'apidocs#index'


### PR DESCRIPTION
## Description of change
Adds health check and options routes for VAOS

## Testing done
N/A

## Testing planned
integration tests

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
