### PR TITLE
PSSG Download: stop drivetime_bands from being updated

### DIFF
--- a/app/workers/facilities/pssg_download.rb
+++ b/app/workers/facilities/pssg_download.rb
@@ -35,7 +35,10 @@ module Facilities
       return if facility.nil?
 
       name = attributes&.dig('Name')
-      drive_time_band = facility.drivetime_bands.find_or_initialize_by(vha_facility_id: id, name: name)
+      if facility.drivetime_bands.exists?(vha_facility_id: id, name: name)
+        Rails.logger.info "PSSG Band not updated: Facility #{id}. Band #{attributes&.dig('Name')}"
+      else
+        drive_time_band = facility.drivetime_bands.new(vha_facility_id: id, name: name)
       drive_time_band.unit = 'minutes'
       drive_time_band.min = round_band(attributes&.dig('FromBreak'))
       drive_time_band.max = round_band(attributes&.dig('ToBreak'))
@@ -46,6 +49,7 @@ module Facilities
       Rails.logger.info "PSSG Band successfully saved: #{name}" # temporary logging
       drive_time_band.save
       facility.save
+    end
     end
 
     def round_band(band)

--- a/app/workers/facilities/pssg_download.rb
+++ b/app/workers/facilities/pssg_download.rb
@@ -58,7 +58,8 @@ module Facilities
 
     def extract_polygon(rings)
       geojson = "{\"type\":\"Polygon\",\"coordinates\":#{rings}}"
-      RGeo::GeoJSON.decode(geojson)
+      spherical_factory = RGeo::Geographic.spherical_factory(srid: 4326, uses_lenient_assertions: true)
+      RGeo::GeoJSON.decode(geojson, geo_factory: spherical_factory)
     end
 
     def download_data

--- a/app/workers/facilities/pssg_download.rb
+++ b/app/workers/facilities/pssg_download.rb
@@ -57,17 +57,17 @@ module Facilities
       if facility.drivetime_bands.exists?(vha_facility_id: id, name: @band_name)
         Rails.logger.info "PSSG Band not updated: Facility #{id}. Band #{attributes&.dig('Name')}"
       else
-      drive_time_band = facility.drivetime_bands.new(vha_facility_id: id, name: @band_name)
-      drive_time_band.unit = 'minutes'
-      drive_time_band.min = round_band(attributes&.dig('FromBreak'))
-      drive_time_band.max = round_band(attributes&.dig('ToBreak'))
-      drive_time_band.name = @band_name
-      drive_time_band.polygon = extract_polygon(rings)
+        drive_time_band = facility.drivetime_bands.new(vha_facility_id: id, name: @band_name)
+        drive_time_band.unit = 'minutes'
+        drive_time_band.min = round_band(attributes&.dig('FromBreak'))
+        drive_time_band.max = round_band(attributes&.dig('ToBreak'))
+        drive_time_band.name = @band_name
+        drive_time_band.polygon = extract_polygon(rings)
 
-      Rails.logger.info "PSSG Band successfully saved: #{@band_name}" # temporary logging
-      drive_time_band.save
-      facility.save
-    end
+        Rails.logger.info "PSSG Band successfully saved: #{@band_name}" # temporary logging
+        drive_time_band.save
+        facility.save
+      end
     end
 
     def download_data

--- a/app/workers/facilities/pssg_download.rb
+++ b/app/workers/facilities/pssg_download.rb
@@ -27,11 +27,11 @@ module Facilities
       Rails.logger.info "PSSG Band not downloaded: Missing rings: #{attributes&.dig('Name')}" if rings.blank?
       return if rings.blank?
 
-      id = attributes&.dig('Sta_No')&.strip
-      facility = Facilities::VHAFacility.find_by(unique_id: id)
+      @id = attributes&.dig('Sta_No')&.strip
+      facility = Facilities::VHAFacility.find_by(unique_id: @id)
 
       # temporary logging
-      Rails.logger.info "PSSG Band not downloaded: Facility #{id} dne. Band #{attributes&.dig('Name')}" if facility.nil?
+      Rails.logger.info "PSSG Band not downloaded: Facility #{@id} dne. Band #{attributes&.dig('Name')}" if facility.nil?
       return if facility.nil?
 
       @band_name = attributes&.dig('Name')
@@ -54,10 +54,10 @@ module Facilities
     end
 
     def insert_or_update_band(facility)
-      if facility.drivetime_bands.exists?(vha_facility_id: id, name: @band_name)
-        Rails.logger.info "PSSG Band not updated: Facility #{id}. Band #{attributes&.dig('Name')}"
+      if facility.drivetime_bands.exists?(vha_facility_id: @id, name: @band_name)
+        Rails.logger.info "PSSG Band not updated: Facility #{@id}. Band #{attributes&.dig('Name')}"
       else
-        drive_time_band = facility.drivetime_bands.new(vha_facility_id: id, name: @band_name)
+        drive_time_band = facility.drivetime_bands.new(vha_facility_id: @id, name: @band_name)
         drive_time_band.unit = 'minutes'
         drive_time_band.min = round_band(attributes&.dig('FromBreak'))
         drive_time_band.max = round_band(attributes&.dig('ToBreak'))

--- a/app/workers/facilities/pssg_download.rb
+++ b/app/workers/facilities/pssg_download.rb
@@ -36,11 +36,7 @@ module Facilities
 
       @band_name = attributes&.dig('Name')
 
-      if facility.drivetime_bands.exists?(vha_facility_id: id, name: @band_name)
-        Rails.logger.info "PSSG Band not updated: Facility #{id}. Band #{attributes&.dig('Name')}"
-      else
-        insert_band(facility)
-      end
+      insert_or_update_band(facility)
     end
 
     def round_band(band)
@@ -57,7 +53,10 @@ module Facilities
       RGeo::GeoJSON.decode(geojson, geo_factory: spherical_factory)
     end
 
-    def insert_band(facility)
+    def insert_or_update_band(facility)
+      if facility.drivetime_bands.exists?(vha_facility_id: id, name: @band_name)
+        Rails.logger.info "PSSG Band not updated: Facility #{id}. Band #{attributes&.dig('Name')}"
+      else
       drive_time_band = facility.drivetime_bands.new(vha_facility_id: id, name: @band_name)
       drive_time_band.unit = 'minutes'
       drive_time_band.min = round_band(attributes&.dig('FromBreak'))
@@ -68,6 +67,7 @@ module Facilities
       Rails.logger.info "PSSG Band successfully saved: #{@band_name}" # temporary logging
       drive_time_band.save
       facility.save
+    end
     end
 
     def download_data

--- a/app/workers/facilities/pssg_download.rb
+++ b/app/workers/facilities/pssg_download.rb
@@ -19,6 +19,8 @@ module Facilities
 
     private
 
+    # this method is still under development, will remove this exception later
+    # rubocop:disable Metrics/MethodLength
     def create_and_save_drive_time_data(drive_time_data)
       attributes = drive_time_data&.dig('attributes')
       rings = drive_time_data&.dig('geometry', 'rings')
@@ -51,6 +53,7 @@ module Facilities
       facility.save
     end
     end
+    # rubocop:enable Metrics/MethodLength
 
     def round_band(band)
       if (band % 10).zero?

--- a/lib/appeals/schema/appeals.json
+++ b/lib/appeals/schema/appeals.json
@@ -192,7 +192,7 @@
                     "type": "boolean"
                   },
                   "switchDueDate": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   }
                 }
               },

--- a/spec/jobs/facilities/pssg_download_spec.rb
+++ b/spec/jobs/facilities/pssg_download_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Facilities::PSSGDownload, type: :job do
       expect(BaseFacility.find_facility_by_id('vha_648A4').drivetime_bands[0].name).to eql('648A4 : 0 - 10')
       expect(BaseFacility.find_facility_by_id('vha_648A4').drivetime_bands[0].unit).to eql('minutes')
       expect(DrivetimeBand.find_by(vha_facility_id: '648A4').name).to eql('648A4 : 0 - 10')
-      # expect(DrivetimeBand.find_by(vha_facility_id: '648A4').polygon.to_s).not_to eql(existing_drive_time.polygon.to_s)
-      # updates are currently turned off
+      #expect(DrivetimeBand.find_by(vha_facility_id: '648A4').polygon.to_s).not_to eql(existing_drive_time.polygon.to_s)
+      #updates are currently turned off
       expect(DrivetimeBand.find_by(vha_facility_id: '648A4').polygon.to_s).to eql(existing_drive_time.polygon.to_s)
     end
 

--- a/spec/jobs/facilities/pssg_download_spec.rb
+++ b/spec/jobs/facilities/pssg_download_spec.rb
@@ -53,8 +53,7 @@ RSpec.describe Facilities::PSSGDownload, type: :job do
       expect(BaseFacility.find_facility_by_id('vha_648A4').drivetime_bands[0].name).to eql('648A4 : 0 - 10')
       expect(BaseFacility.find_facility_by_id('vha_648A4').drivetime_bands[0].unit).to eql('minutes')
       expect(DrivetimeBand.find_by(vha_facility_id: '648A4').name).to eql('648A4 : 0 - 10')
-      #expect(DrivetimeBand.find_by(vha_facility_id: '648A4').polygon.to_s).not_to eql(existing_drive_time.polygon.to_s)
-      #updates are currently turned off
+      # updates are currently turned off once they are working this should be `.not_to eql`
       expect(DrivetimeBand.find_by(vha_facility_id: '648A4').polygon.to_s).to eql(existing_drive_time.polygon.to_s)
     end
 

--- a/spec/jobs/facilities/pssg_download_spec.rb
+++ b/spec/jobs/facilities/pssg_download_spec.rb
@@ -53,7 +53,9 @@ RSpec.describe Facilities::PSSGDownload, type: :job do
       expect(BaseFacility.find_facility_by_id('vha_648A4').drivetime_bands[0].name).to eql('648A4 : 0 - 10')
       expect(BaseFacility.find_facility_by_id('vha_648A4').drivetime_bands[0].unit).to eql('minutes')
       expect(DrivetimeBand.find_by(vha_facility_id: '648A4').name).to eql('648A4 : 0 - 10')
-      expect(DrivetimeBand.find_by(vha_facility_id: '648A4').polygon.to_s).not_to eql(existing_drive_time.polygon.to_s)
+      # expect(DrivetimeBand.find_by(vha_facility_id: '648A4').polygon.to_s).not_to eql(existing_drive_time.polygon.to_s)
+      # updates are currently turned off
+      expect(DrivetimeBand.find_by(vha_facility_id: '648A4').polygon.to_s).to eql(existing_drive_time.polygon.to_s)
     end
 
     it 'populates facility with drive time data' do


### PR DESCRIPTION
## Description of change
The PSSG download ran in dev for 90 minutes and inserted 11451 drive time bands (~10% of the total). The bands are being inserted into the table at a little over 2 per second, but updates are currently much slower than that. In the interest of getting all of the drive time bands into the table, I have modified the download to skip trying to update existing records for now. This will allow the job to insert more new records each time it runs instead of just checking for updates to the existing records the whole time.

Part of department-of-veterans-affairs/vets-contrib/issues/3534.

## Testing done
Ran locally

## Testing planned
Will run job in dev again to insert more records