### PR TITLE
Set PR jenkins job name to the branch name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,8 +20,11 @@ pipeline {
   }
 
   stages {
-    stage('Checkout Code') {
+    stage('Checkout Code & Set Job Name') {
       steps {
+        script {
+          currentBuild.displayName = THE_BRANCH
+        }
         checkout scm
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stage('Checkout Code & Set Job Name') {
       steps {
         script {
-          currentBuild.displayName = THE_BRANCH
+          currentBuild.projectName = THE_BRANCH
         }
         checkout scm
       }


### PR DESCRIPTION
## Description of change
Our jenkins PR job names take the form : `PR-<GITHUB_PR_ID>`, e.g.
![image](https://user-images.githubusercontent.com/3077884/68331038-3dd08880-00a2-11ea-8b61-60d44355f8b9.png)

This PR renames those jobs to instead take the form: `<BRANCH_NAME>`, so it will look like our "branches" jobs:
![image](https://user-images.githubusercontent.com/3077884/68331172-82f4ba80-00a2-11ea-87d6-3a1bf2045058.png)

The new job name is more human-readable.

## Testing done
None.

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
