### PR TITLE
Add bgs external key settings

### DIFF
--- a/config/initializers/bgs.rb
+++ b/config/initializers/bgs.rb
@@ -8,6 +8,8 @@ LighthouseBGS.configure do |config|
   config.client_station_id = Settings.bgs.client_station_id
   config.client_username = Settings.bgs.client_username
   config.env = Rails.env.to_s
+  config.external_uuid = Settings.bgs.external_uuid
+  config.external_key = Settings.bgs.external_key
   config.mock_response_location = Settings.bgs.mock_response_location
   config.mock_responses = Settings.bgs.mock_responses
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -406,6 +406,8 @@ bgs:
   application: ~
   client_station_id: ~
   client_username: ~
+  external_uuid: ~
+  external_key: ~
   mock_response_location: ~
   mock_responses: ~
 

--- a/token_creator.sh
+++ b/token_creator.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+#
+# JWT Encoder Bash Script
+#
+
+secret='L1ghth0us3B1p'
+
+# Static header fields.
+header='{
+	"typ": "JWT",
+	"alg": "HS256",
+	"kid": "0001",
+	"iss": "Bash JWT Generator"
+
+}'
+
+# Use jq to set the dynamic `iat` and `exp`
+# fields on the header using the current time.
+# `iat` is set to now, and `exp` is now + 1 second.
+header=$(
+	echo "${header}" | jq --arg time_str "$(date +%s)" \
+	'
+	($time_str | tonumber) as $time_num
+	| .iat=$time_num
+	| .exp=($time_num + 1)
+	'
+)
+payload='{
+  "iss": "va.gov",
+  "jti": "d3cf8355-7263-4c86-b413-1f476f54253b",
+  "assuranceLevel": 2,
+  "birthDate": "1978-05-20",
+  "correlationIds": [
+    "77779102^NI^200M^USVHA^P",
+    "912444689^PI^200BRLS^USVBA^A",
+    "6666345^PI^200CORP^USVBA^A",
+    "1105051936^NI^200DOD^USDOD^A",
+    "912444689^SS"
+  ],
+  "email": "jane.doe@va.gov",
+  "firstName": "JANE",
+  "gender": "FEMALE",
+  "lastName": "DOE",
+  "middleName": "M",
+  "prefix": "Ms",
+  "suffix": "S",
+  "user": "string"
+}'
+
+base64_encode()
+{
+	declare input=${1:-$(</dev/stdin)}
+	# Use `tr` to URL encode the output from base64.
+	printf '%s' "${input}" | base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n'
+}
+
+json() {
+	declare input=${1:-$(</dev/stdin)}
+	printf '%s' "${input}" | jq -c .
+}
+
+hmacsha256_sign()
+{
+	declare input=${1:-$(</dev/stdin)}
+	printf '%s' "${input}" | openssl dgst -binary -sha256 -hmac "${secret}"
+}
+
+header_base64=$(echo "${header}" | json | base64_encode)
+payload_base64=$(echo "${payload}" | json | base64_encode)
+
+header_payload=$(echo "${header_base64}.${payload_base64}")
+signature=$(echo "${header_payload}" | hmacsha256_sign | base64_encode)
+
+echo "${header_payload}.${signature}"


### PR DESCRIPTION
## Description of change
Add the settings for the BGS external keys to be sent to BGS Gem

## Testing done
Local testing

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)
- [ ] VetsApi can load and set the external uuid and external key for the bgs gem


#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
