### PR TITLE
First Adding 526 pdf database changes before code

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -100,6 +100,8 @@ ActiveRecord::Schema.define(version: 2019_11_06_190228) do
     t.datetime "updated_at", null: false
     t.string "md5"
     t.string "source"
+    t.string "encrypted_file_data"
+    t.string "encrypted_file_data_iv"
   end
 
   create_table "claims_api_power_of_attorneys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/modules/claims_api/db/migrate/20191101133920_add_526_file_data.rb
+++ b/modules/claims_api/db/migrate/20191101133920_add_526_file_data.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Add526FileData < ActiveRecord::Migration[5.2]
+  def change
+    add_column :claims_api_auto_established_claims, :encrypted_file_data, :string
+    add_column :claims_api_auto_established_claims, :encrypted_file_data_iv, :string
+  end
+end


### PR DESCRIPTION
## Description of change
Just the migration portion of ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/3435

## Acceptance Criteria (Definition of Done)
- Just creating migration for storing 526 pdf data in the disability table

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
