### PR TITLE
Update NearbyFacility min_time and max_time type in doc

### DIFF
--- a/modules/va_facilities/README.yml
+++ b/modules/va_facilities/README.yml
@@ -859,10 +859,10 @@ components:
             - max_time
           properties:
             min_time:
-              type: string
+              type: integer
               example: 10
             max_time:
-              type: string
+              type: integer
               example: 20
         relationships:
           type: object


### PR DESCRIPTION
## Description of change
Corrects `min_time` and `max_time` data type to be integer instead of string.

## Testing done
Verified that the type in the /nearby response for these two attributes is indeed an integer.

## Acceptance Criteria (Definition of Done)

- [ ] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
