### PR TITLE
fix faker issue

### DIFF
--- a/modules/vaos/spec/factories/vaos_users.rb
+++ b/modules/vaos/spec/factories/vaos_users.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'faker/medical'
-
 FactoryBot.modify do
   factory :user do
     trait :vaos do


### PR DESCRIPTION
## Description of change
fixes an issue affecting docker builds being unable to require a gem that is only available in the test environment per Gemfile.

## Testing done
manual

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
