### PR TITLE
Update Narin's email for flipper admin

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -405,7 +405,7 @@ flipper:
     - jeff@adhocteam.us
     - kam@adhocteam.us
     - alastair@adhocteam.us
-    - narin@adhocteam.us
+    - n.ratana@gmail.com
 
 bgs:
   application: ~


### PR DESCRIPTION
## Description of change
Originally tried using adhoc email, but I have already verified my identity using my personal email.  Changing email from narin@adhocteam.us to n.ratana@gmail.com
