### PR TITLE
Add additional admins for VAOS

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -415,6 +415,9 @@ flipper:
     - kam@adhocteam.us
     - alastair@adhocteam.us
     - narin@adhocteam.us
+    - mark.greenburg@adhocteam.us
+    - lauren.alexanderson@va.gov
+    - ryan.thurlwell@va.gov
 
 bgs:
   application: ~

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -405,19 +405,19 @@ bing:
 
 flipper:
   admin_user_emails:
+    - alastair@adhocteam.us
     - anna@adhoc.team
-    - johnny@oddball.io
-    - travis.hilton@oddball.io
-    - rian.fowler@adhoc.team
-    - rianfowler@outlook.com
     - jbalboni@gmail.com
     - jeff@adhocteam.us
+    - johnny@oddball.io
     - kam@adhocteam.us
-    - alastair@adhocteam.us
-    - narin@adhocteam.us
-    - mark.greenburg@adhocteam.us
     - lauren.alexanderson@va.gov
+    - mark.greenburg@adhocteam.us
+    - narin@adhocteam.us
+    - rian.fowler@adhoc.team
+    - rianfowler@outlook.com
     - ryan.thurlwell@va.gov
+    - travis.hilton@oddball.io
 
 bgs:
   application: ~


### PR DESCRIPTION
## Description of change
This adds additional users who should be able to control the feature flags for VAOS.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Admins are correctly specified

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
