### PR TITLE
Return empty result when nutrition and podiatry are provided

### DIFF
--- a/modules/va_facilities/spec/requests/nearby_request_spec.rb
+++ b/modules/va_facilities/spec/requests/nearby_request_spec.rb
@@ -101,6 +101,38 @@ RSpec.describe 'Nearby Facilities API endpoint', type: :request do
         .to include('current_page' => 1, 'per_page' => 20, 'total_pages' => 1, 'total_entries' => 1)
       expect(json['links']['related']).to eq('/services/va_facilities/v0/facilities?ids=vha_648')
     end
+
+    it 'temporarily returns no results for Podiatry' do
+      create_bands
+
+      get base_query_path,
+          params: { lat: 45.4967668, lng: -122.6832211,
+                    drive_time: '20', 'services[]': 'Podiatry' },
+          headers: { 'HTTP_ACCEPT' => 'application/json' }
+
+      expect(response).to be_successful
+      expect(response.body).to be_a(String)
+
+      json = JSON.parse(response.body)
+
+      expect(json['data'].length).to eq(0)
+    end
+
+    it 'temporarily returns no results for Nutrition' do
+      create_bands
+
+      get base_query_path,
+          params: { lat: 45.4967668, lng: -122.6832211,
+                    drive_time: '20', 'services[]': 'Nutrition' },
+          headers: { 'HTTP_ACCEPT' => 'application/json' }
+
+      expect(response).to be_successful
+      expect(response.body).to be_a(String)
+
+      json = JSON.parse(response.body)
+
+      expect(json['data'].length).to eq(0)
+    end
   end
 
   describe 'bing errors' do


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
This PR addresses [#3673](https://github.com/department-of-veterans-affairs/vets-contrib/issues/3673). It returns an empty response when `Nutrition` or `Podiatry` are provided as services to the `/nearby` endpoint. This is a temporary measure until the datasource for services is replaced in an upcoming epic. There is a team building against `/nearby` that will need to provide these services, and it makes more sense for our part of the stack to change now since it will provide them soon.

## Testing done
<!-- Please describe testing done to verify the changes. -->
- Added specs for providing the services and receiving empty responses

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] 200 response if for /nearby (nutrition and podiatry)

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
