### PR TITLE
VSA 3533

### DIFF
--- a/lib/vet360/address_validation/service.rb
+++ b/lib/vet360/address_validation/service.rb
@@ -1,5 +1,3 @@
-require 'pp'
-
 # frozen_string_literal: true
 
 module Vet360
@@ -13,25 +11,16 @@ module Vet360
         validate_res = validate(address)
         candidate_res = candidate(address)
 
-        # go through messages here first and check for errors
-        # pp validate_res
-        # pp candidate_res
         validation_key = validate_res['address_meta_data']['validation_key']
 
         validate_messages = validate_res['messages'] || []
-        pp validate_messages
         validate_messages.each do |message|
           if message['severity'] == 'ERROR'
             validation_key = nil
           end
         end
-        # binding.pry
 
         AddressSuggestionsResponse.new(candidate_res, validation_key)
-
-        # double check with vet360 to make sure that that's accurate
-        # test this in staging (via SSH), not dev
-        # AddressSuggestionsResponse.new(candidate_res, nil) <- removing validation_key
       end
 
       %w[validate candidate].each do |endpoint|
@@ -57,12 +46,6 @@ module Vet360
 
         save_error_details(error)
         raise_invalid_body(error, self.class) unless error.body.is_a?(Hash)
-
-        # error.body['messages']
-        # if there are fatal errors, make
-        # in the meeting tomorrow, ask more questions about the responses that vets360 will give
-        # - verify "if i check the messages hash and the severity is 'ERROR', is that all that's required?"
-        # - aka "how do I know that I can overwrite an error"
 
         raise Common::Exceptions::BackendServiceException.new(
           'VET360_AV_ERROR',

--- a/spec/lib/vet360/address_validation/service_spec.rb
+++ b/spec/lib/vet360/address_validation/service_spec.rb
@@ -23,10 +23,11 @@ describe Vet360::AddressValidation::Service do
     build(:vet360_address, :multiple_matches)
   end
 
+  # describe '#address_suggestions', :focus => true do
   describe '#address_suggestions' do
     context 'with a found address' do
       it 'returns suggested addresses' do
-        VCR.use_cassette(
+        VCR.use_cassette( 
           'vet360/address_validation/validate_match',
           VCR::MATCH_EVERYTHING
         ) do
@@ -66,6 +67,55 @@ describe Vet360::AddressValidation::Service do
                   { 'confidence_score' => 100.0, 'address_type' => 'Domestic',
                     'delivery_point_validation' => 'CONFIRMED', 'residential_delivery_indicator' => 'MIXED' } }],
               'validation_key' => 609_319_007
+            )
+          end
+        end
+      end
+    end
+
+    # context 'with an address containing a severity of "ERROR"' do
+    context 'with an address containing a severity of "ERROR"', :focus => true do
+      it 'returns suggested addresses stripped of validation keys' do
+        VCR.use_cassette( 
+          'vet360/address_validation/validate_match_with_error',
+          VCR::MATCH_EVERYTHING
+        ) do
+          VCR.use_cassette(
+            'vet360/address_validation/candidate_multiple_matches',
+            VCR::MATCH_EVERYTHING
+          ) do
+            res = described_class.new.address_suggestions(multiple_match_addr)
+            expect(JSON.parse(res.to_json)).to eq(
+              'addresses' =>
+               [{ 'address' =>
+                  { 'address_line1' => '37 N 1st St',
+                    'address_type' => 'DOMESTIC',
+                    'city' => 'Brooklyn',
+                    'country_name' => 'USA',
+                    'country_code_iso3' => 'USA',
+                    'county_code' => '36047',
+                    'county_name' => 'Kings',
+                    'state_code' => 'NY',
+                    'zip_code' => '11249',
+                    'zip_code_suffix' => '3939' },
+                  'address_meta_data' => { 'confidence_score' => 100.0,
+                                           'address_type' => 'Domestic',
+                                           'delivery_point_validation' => 'UNDELIVERABLE' } },
+                { 'address' =>
+                  { 'address_line1' => '37 S 1st St',
+                    'address_type' => 'DOMESTIC',
+                    'city' => 'Brooklyn',
+                    'country_name' => 'USA',
+                    'country_code_iso3' => 'USA',
+                    'county_code' => '36047',
+                    'county_name' => 'Kings',
+                    'state_code' => 'NY',
+                    'zip_code' => '11249',
+                    'zip_code_suffix' => '4101' },
+                  'address_meta_data' =>
+                  { 'confidence_score' => 100.0, 'address_type' => 'Domestic',
+                    'delivery_point_validation' => 'CONFIRMED', 'residential_delivery_indicator' => 'MIXED' } }],
+              'validation_key' => nil
             )
           end
         end

--- a/spec/lib/vet360/address_validation/service_spec.rb
+++ b/spec/lib/vet360/address_validation/service_spec.rb
@@ -26,7 +26,7 @@ describe Vet360::AddressValidation::Service do
   describe '#address_suggestions' do
     context 'with a found address' do
       it 'returns suggested addresses' do
-        VCR.use_cassette( 
+        VCR.use_cassette(
           'vet360/address_validation/validate_match',
           VCR::MATCH_EVERYTHING
         ) do

--- a/spec/lib/vet360/address_validation/service_spec.rb
+++ b/spec/lib/vet360/address_validation/service_spec.rb
@@ -23,7 +23,6 @@ describe Vet360::AddressValidation::Service do
     build(:vet360_address, :multiple_matches)
   end
 
-  # describe '#address_suggestions', :focus => true do
   describe '#address_suggestions' do
     context 'with a found address' do
       it 'returns suggested addresses' do
@@ -73,8 +72,7 @@ describe Vet360::AddressValidation::Service do
       end
     end
 
-    # context 'with an address containing a severity of "ERROR"' do
-    context 'with an address containing a severity of "ERROR"', :focus => true do
+    context 'with an address containing a message with severity of "ERROR"' do
       it 'returns suggested addresses stripped of validation keys' do
         VCR.use_cassette( 
           'vet360/address_validation/validate_match_with_error',

--- a/spec/support/vcr_cassettes/vet360/address_validation/validate_match_with_error.yml
+++ b/spec/support/vcr_cassettes/vet360/address_validation/validate_match_with_error.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://dev-api.va.gov/services/address_validation/v1/validate
+    body:
+      encoding: UTF-8
+      string: '{"requestAddress":{"addressLine1":"37 1st st","city":"Brooklyn","requestCountry":{"countryCode":"USA"},"stateProvince":{"code":"NY"},"zipCode5":"11249"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Cufsystemname:
+      - VETSGOV
+      Apikey:
+      - "<AV_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Tue, 15 Oct 2019 08:05:01 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - openresty
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      - no-cache
+      Vet360txauditid:
+      - 6bc084bf-69f5-4bd4-84d2-fce034e8ecfe
+      Via:
+      - kong/1.2.2
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Kong-Proxy-Latency:
+      - '8'
+      X-Kong-Upstream-Latency:
+      - '137'
+      X-Ratelimit-Limit-Edge-Gateway-Address-Validation-Vagovli-Address-V1-Validate-Address:
+      - '500'
+      X-Ratelimit-Limit-Minute:
+      - '60'
+      X-Ratelimit-Remaining-Edge-Gateway-Address-Validation-Vagovli-Address-V1-Validate-Address:
+      - '499'
+      X-Ratelimit-Remaining-Minute:
+      - '59'
+      X-Ratelimit-Reset-Edge-Gateway-Address-Validation-Vagovli-Address-V1-Validate-Address:
+      - '60000'
+      X-Ratelimit-Sla-Limit-Edge-Gateway-Address-Validation-Vagovli-Address-V1-Validate-Address:
+      - '250'
+      X-Ratelimit-Sla-Remaining-Edge-Gateway-Address-Validation-Vagovli-Address-V1-Validate-Address:
+      - '249'
+      X-Ua-Compatible:
+      - IE-edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cache-Control:
+      - no-cache, no-store
+    body:
+      encoding: ASCII-8BIT
+      string: '{"address":{"county":{"name":"Kings","countyFipsCode":"36047"},"stateProvince":{"name":"New
+        York","code":"NY"},"country":{"name":"USA","code":"USA","fipsCode":"US","iso2Code":"US","iso3Code":"USA"},"addressLine1":"37
+        S 1st St","city":"Brooklyn","zipCode5":"11249","zipCode4":"4101"},"geocode":{"calcDate":"2019-10-15T08:05:01+00:00","locationPrecision":31.0,"latitude":40.715383,"longitude":-73.965421},"addressMetaData":{"confidenceScore":97.0,"addressType":"Domestic","deliveryPointValidation":"CONFIRMED","residentialDeliveryIndicator":"MIXED","validationKey":609319007}, "messages":[{"code":"ADDRVAL112","key":"AddressCouldNotBeFound","severity":"ERROR","text":"The Address could not be found"}]}'
+    http_version: 
+  recorded_at: Tue, 15 Oct 2019 08:05:01 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
There are currently certain address suggestions return by the vet360 that are **not** overridable on our end. This PR strips such suggestions of their validation keys, removing the ability for the client to do so.
## Testing done
<!-- Please describe testing done to verify the changes. -->
Added a unit test that tests against a mock response from vet360

## Testing planned
<!-- Please describe testing planned. -->
A placeholder unit test has been added with the proposed change. However, it utilizes a copied and modified VCR cassette that is not reflective of a real test. This needs to be updated with actual response data

## Acceptance Criteria (Definition of Done)
- [ ] Update VCR with staging response data

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
