### PR TITLE
Correctly Increasing Bulk End Point maxItems docs to 1000

### DIFF
--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/status_guid_list_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/status_guid_list_swagger.rb
@@ -17,7 +17,7 @@ module VbaDocuments
             key :example, '6d8433c1-cd55-4c24-affd-f592287a7572'
           end
           key :minItems, 1
-          key :maxItems, 100
+          key :maxItems, 1000
         end
       end
     end


### PR DESCRIPTION
## Description of change
ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/3695

## Acceptance Criteria (Definition of Done)
- update: it is displayed in the DocumentUploadStatusGuidList model but incorrectly as maxItems: 100

#### Applies to all PRs

- [ ] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
