### PR TITLE
Updates VAOS JWT to support endpoints that depend on it

### DIFF
--- a/modules/vaos/app/services/vaos/jwt.rb
+++ b/modules/vaos/app/services/vaos/jwt.rb
@@ -2,6 +2,13 @@
 
 module VAOS
   class JWT
+    VERSION = 2.1
+    ISS = 'gov.va.vaos'
+    ID_TYPE = 'ICN'
+    AUTHORITY = 'gov.va.iam.ssoe.v1'
+
+    attr_reader :user
+
     def initialize(user)
       @user = user
     end
@@ -15,19 +22,59 @@ module VAOS
     def payload
       {
         authenticated: true,
-        sub: @user.icn,
-        idType: 'ICN',
-        iss: 'gov.va.vaos',
-        firstName: @user.first_name,
-        lastName: @user.last_name,
-        authenticationAuthority: 'gov.va.iam.ssoe.v1',
-        jti: SecureRandom.uuid,
+        sub: icn,
+        idType: ID_TYPE,
+        iss: ISS,
+        firstName: first_name,
+        lastName: last_name,
+        authenticationAuthority: AUTHORITY,
+        jti: SecureRandom.uuid, # TODO: need to capture this in logs as part of a middleware for each action invoked
         nbf: 1.minute.ago.to_i,
-        exp: 1.hour.from_now.to_i,
-        version: 1.0,
-        userType: 'VETERAN',
-        'vamf.auth.roles' => ['veteran']
+        exp: 15.minutes.from_now.to_i,
+        sst: 1.minute.ago.to_i + 50,
+        version: VERSION,
+        gender: gender,
+        dob: dob,
+        dateOfBirth: dob,
+        edipid: edipi,
+        ssn: ssn
       }
+    end
+
+    def icn
+      user.icn
+    end
+
+    def first_name
+      user.mvi&.profile&.given_names&.first
+    end
+
+    def last_name
+      user.mvi&.profile&.family_name
+    end
+
+    def gender
+      type = user.mvi&.profile&.gender
+      return '' unless type.is_a?(String)
+
+      case type.upcase[0, 1]
+      when 'M'
+        'MALE'
+      when 'F'
+        'FEMALE'
+      end
+    end
+
+    def dob
+      user.mvi&.profile&.birth_date
+    end
+
+    def edipi
+      user.mvi&.profile&.edipi
+    end
+
+    def ssn
+      user.mvi&.profile&.ssn
     end
 
     def rsa_private

--- a/modules/vaos/spec/services/jwt_spec.rb
+++ b/modules/vaos/spec/services/jwt_spec.rb
@@ -5,14 +5,58 @@ require 'rails_helper'
 describe VAOS::JWT do
   subject { VAOS::JWT.new(user) }
 
-  let(:user) { build(:user, :mhv) }
+  let(:user) { build(:user, :vaos) }
+  let(:rsa_private) { OpenSSL::PKey::RSA.generate(4096) }
+  let(:jwt_regex) { %r{^[A-Za-z0-9\-_=]+\.[A-Za-z0-9\-_=]+\.?[A-Za-z0-9\-_.+/=]*$} }
 
   describe '#token' do
-    it 'encodes a payload' do
-      rsa_private = OpenSSL::PKey::RSA.generate 4096
-      allow(File).to receive(:read).and_return(rsa_private)
-      decoded = JWT.decode(subject.token, rsa_private.public_key, true, algorithm: 'RS512').first
-      expect(decoded['firstName']).to eq(user.first_name)
+    before { allow(File).to receive(:read).and_return(rsa_private) }
+
+    it 'returns a JWT string' do
+      expect(subject.token).to be_a(String).and match(jwt_regex)
+    end
+
+    context 'decoded payload' do
+      let(:decoded_payload) { JWT.decode(subject.token, rsa_private.public_key, true, algorithm: 'RS512').first }
+
+      it 'includes a sub from MVI' do
+        expect(decoded_payload['sub']).to eq('1012845331V153043')
+      end
+
+      it 'includes a firstName from MVI' do
+        expect(decoded_payload['firstName']).to eq('Judy')
+      end
+
+      it 'includes a lastName from MVI' do
+        expect(decoded_payload['lastName']).to eq('Morrison')
+      end
+
+      it 'includes a gender DERIVED from MVI' do
+        expect(decoded_payload['gender']).to eq('FEMALE')
+      end
+
+      it 'includes a dob from MVI' do
+        expect(decoded_payload['dob']).to eq('1953-04-01')
+      end
+
+      it 'includes a dateOfBirth from MVI' do
+        expect(decoded_payload['dateOfBirth']).to eq('1953-04-01')
+      end
+
+      it 'includes a edipid from MVI' do
+        expect(decoded_payload['edipid']).to eq('1259897978')
+      end
+
+      it 'includes a ssn from MVI' do
+        expect(decoded_payload['ssn']).to eq('796061976')
+      end
+
+      it 'includes keys' do
+        expect(decoded_payload.keys).to contain_exactly(
+          'authenticated', 'sub', 'idType', 'iss', 'firstName', 'lastName', 'authenticationAuthority', 'jti', 'nbf',
+          'exp', 'sst', 'version', 'gender', 'dob', 'dateOfBirth', 'edipid', 'ssn'
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
It was recently discovered as part of https://github.com/department-of-veterans-affairs/vets-api/pull/3568 that the JWT we were previously using does not get a returned token from user_service that includes certain necessary parameters. Those `patient` parameters are only returned if JWT includes the parameters as part of the root payload. When it is verified and signed by the user_service, the attributes are added to a new patient object as part of the returned response.

## Testing done
Local and Integration testing on a dedicated staging sandbox.

## Testing planned
More smoke testing on actual staging.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
Improves the JWT and adds additional test coverage.

#### Applies to all PRs

- [x] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
