### PR TITLE
Fix appointment request strong params issue

### DIFF
--- a/modules/vaos/app/controllers/vaos/appointment_requests_controller.rb
+++ b/modules/vaos/app/controllers/vaos/appointment_requests_controller.rb
@@ -6,16 +6,18 @@ module VAOS
   class AppointmentRequestsController < ApplicationController
     before_action :validate_params, only: :index
 
-    MASS_ASSIGN_PARAMS_PUT = %i[
-      email phone_number option_date1 option_time1 option_date2 option_time2 option_date3 option_time3
-      status appointment_type visit_type text_messaging_allowed phone_number purpose_of_visit
-      other_purpose_of_visit purpose_of_visit provider_id second_request second_request_submitted
-      provider_name requested_phone_call type_of_care_id has_veteran_new_message has_provider_new_message
-      provider_seen_appointment_request requested_phone_call type_of_care_id created_date last_access_date
-      last_updated_date facility patient best_timeto_call appointment_request_detail_code
+    BASE_REQUIRED_PARAMS = %i[
+      option_date1 option_time1 option_date2 option_time2 option_date3 option_time3 status
+      appointment_type visit_type phone_number facility
     ].freeze
 
-    MASS_ASSIGN_PARAMS_POST = MASS_ASSIGN_PARAMS_PUT - %i[created_date last_access_date last_updated_date]
+    BASE_PARAMS_WHITELIST = [
+      :option_date1, :option_time1, :option_date2, :option_time2, :option_date3, :option_time3, :status,
+      :appointment_type, :visit_type, :phone_number, :email, :purpose_of_visit, :other_purpose_of_visit,
+      :provider_id, :provider_name, :second_request, :second_request_submitted, :requested_phone_call, :type_of_care_id,
+      :best_timeto_call, facility: %i[name facility_code state city parent_site_code object_type],
+                         appointment_request_detail_code: [], patient: %i[inpatient text_messaging_allowed]
+    ].freeze
 
     def index
       response = appointment_requests_service.get_requests(start_date, end_date)
@@ -23,12 +25,13 @@ module VAOS
     end
 
     def create
-      response = appointment_requests_service.post_request(params.permit(*MASS_ASSIGN_PARAMS_POST))
+      response = appointment_requests_service.post_request(post_params)
       render json: AppointmentRequestsSerializer.new(response[:data]), status: :created
     end
 
     def update
-      response = appointment_requests_service.put_request(id, params.permit(*MASS_ASSIGN_PARAMS_PUT))
+      binding.pry
+      response = appointment_requests_service.put_request(id, put_params)
       render json: AppointmentRequestsSerializer.new(response[:data])
     end
 
@@ -36,6 +39,18 @@ module VAOS
 
     def id
       params.require(:id)
+    end
+
+    def put_params
+      params.require(BASE_REQUIRED_PARAMS + [:created_date])
+      params[:facility].require(%i[name facility_code parent_site_code])
+      params.permit(*(BASE_PARAMS_WHITELIST + [:created_date]))
+    end
+
+    def post_params
+      params.require(BASE_REQUIRED_PARAMS)
+      params[:facility].require(%i[name facility_code parent_site_code])
+      params.permit(*BASE_PARAMS_WHITELIST)
     end
 
     def appointment_requests_service

--- a/modules/vaos/app/controllers/vaos/appointment_requests_controller.rb
+++ b/modules/vaos/app/controllers/vaos/appointment_requests_controller.rb
@@ -30,7 +30,6 @@ module VAOS
     end
 
     def update
-      binding.pry
       response = appointment_requests_service.put_request(id, put_params)
       render json: AppointmentRequestsSerializer.new(response[:data])
     end

--- a/modules/vaos/spec/request/appointment_requests_request_spec.rb
+++ b/modules/vaos/spec/request/appointment_requests_request_spec.rb
@@ -122,8 +122,10 @@ RSpec.describe 'vaos appointment requests', type: :request do
         last_access_date: last_access_date,
         last_updated_date:
         last_updated_date
-      ).params.merge(appointment_request_detail_code: ['DETCODE8'])
+      ).params
     end
+
+    let(:post_params) { params.merge(appointment_request_detail_code: ['DETCODE8']) }
 
     it 'creates a new appointment request' do
       VCR.use_cassette('vaos/appointment_requests/put_request', match_requests_on: %i[method uri]) do

--- a/modules/vaos/spec/request/appointment_requests_request_spec.rb
+++ b/modules/vaos/spec/request/appointment_requests_request_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'vaos appointment requests', type: :request do
         last_access_date: last_access_date,
         last_updated_date:
         last_updated_date
-      ).params
+      ).params.merge(appointment_request_detail_code: ['DETCODE8'])
     end
 
     it 'creates a new appointment request' do


### PR DESCRIPTION
## Description of change
This was a difficult thing to debug. Apparently strong parameters require nested hashes to be permitted individually. I did my best to write a spec for this change, but because of how we're using VCR it is a bit tricky. I'd need to verify that the form is properly serialized. I think I will verify validation of the form object in a separate PR, but this is needed urgently for FE to do their piece.

## Testing done
Locally including verifying the parameters are set.

## Testing planned
FE integration specs. Eventually when I add form validations, I'll write more comprehensive specs for the form and verify everything there is working as expected as well.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
