### PR TITLE
add elwood gary to flipper allowed list

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -428,6 +428,7 @@ flipper:
     - jeff@adhocteam.us
     - johnny@oddball.io
     - kam@adhocteam.us
+    - kenneth.gary@va.gov
     - lauren.alexanderson@va.gov
     - mark.greenburg@adhocteam.us
     - narin@adhocteam.us


### PR DESCRIPTION
## Description of change

Adds user @elwoodva to the allowed list for flipper admins 
