### PR TITLE
limit retries in pager_duty/poll_maintenance_windows

### DIFF
--- a/app/workers/pager_duty/poll_maintenance_windows.rb
+++ b/app/workers/pager_duty/poll_maintenance_windows.rb
@@ -6,7 +6,7 @@ module PagerDuty
   class PollMaintenanceWindows
     include Sidekiq::Worker
     include SentryLogging
-    sidekiq_options retry: 3
+    sidekiq_options retry: 1
 
     MESSAGE_INDICATOR = 'USER_MESSAGE:'
 

--- a/app/workers/pager_duty/poll_maintenance_windows.rb
+++ b/app/workers/pager_duty/poll_maintenance_windows.rb
@@ -6,6 +6,7 @@ module PagerDuty
   class PollMaintenanceWindows
     include Sidekiq::Worker
     include SentryLogging
+    sidekiq_options retry: 3
 
     MESSAGE_INDICATOR = 'USER_MESSAGE:'
 

--- a/spec/jobs/pager_duty/poll_maintenance_windows_spec.rb
+++ b/spec/jobs/pager_duty/poll_maintenance_windows_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'maintenance/poll_pagerduty'
+require 'pager_duty/poll_maintenance_windows'
 
 RSpec.describe PagerDuty::PollMaintenanceWindows, type: :job do
   let(:client_stub) { instance_double('PagerDuty::MaintenanceClient') }


### PR DESCRIPTION
## Description of change
Limit retries to 3-ish minutes since the job runs every three minutes.  

Sidekiq will retry failures with an exponential backoff using [the formula](https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry).  3 retries is roughly 2.5 miniutes. 

* rename the files to be consistent with the class name
