### PR TITLE
VAOS::BaseController instead of VAOS::ApplicationController

### DIFF
--- a/modules/vaos/app/controllers/vaos/apidocs_controller.rb
+++ b/modules/vaos/app/controllers/vaos/apidocs_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module VAOS
-  class ApidocsController < ApplicationController
+  class ApidocsController < VAOS::BaseController
     include Swagger::Blocks
     skip_before_action :authenticate
 

--- a/modules/vaos/app/controllers/vaos/appointment_requests_controller.rb
+++ b/modules/vaos/app/controllers/vaos/appointment_requests_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require_dependency 'vaos/application_controller'
-
 module VAOS
-  class AppointmentRequestsController < ApplicationController
+  class AppointmentRequestsController < VAOS::BaseController
     before_action :validate_params, only: :index
 
     BASE_REQUIRED_PARAMS = %i[

--- a/modules/vaos/app/controllers/vaos/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/appointments_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require_dependency 'vaos/application_controller'
-
 module VAOS
-  class AppointmentsController < ApplicationController
+  class AppointmentsController < VAOS::BaseController
     before_action :validate_params, only: :index
 
     def index

--- a/modules/vaos/app/controllers/vaos/available_appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/available_appointments_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require_dependency 'vaos/application_controller'
-
 module VAOS
-  class AvailableAppointmentsController < ApplicationController
+  class AvailableAppointmentsController < VAOS::BaseController
     def index
       response = systems_service.get_facility_available_appointments(
         facility_id, start_date, end_date, clinic_ids

--- a/modules/vaos/app/controllers/vaos/base_controller.rb
+++ b/modules/vaos/app/controllers/vaos/base_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module VAOS
-  class ApplicationController < ::ApplicationController
+  class BaseController < ::ApplicationController
     before_action :authorize
 
     protected

--- a/modules/vaos/app/controllers/vaos/cancel_reasons_controller.rb
+++ b/modules/vaos/app/controllers/vaos/cancel_reasons_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require_dependency 'vaos/application_controller'
-
 module VAOS
-  class CancelReasonsController < ApplicationController
+  class CancelReasonsController < VAOS::BaseController
     def index
       response = systems_service.get_cancel_reasons(params[:facility_id])
       render json: VAOS::CancelReasonSerializer.new(response)

--- a/modules/vaos/app/controllers/vaos/clinics_controller.rb
+++ b/modules/vaos/app/controllers/vaos/clinics_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require_dependency 'vaos/application_controller'
-
 module VAOS
-  class ClinicsController < ApplicationController
+  class ClinicsController < VAOS::BaseController
     def index
       response = systems_service.get_facility_clinics(
         clinics_params[:facility_id],

--- a/modules/vaos/app/controllers/vaos/direct_scheduling_facilities_controller.rb
+++ b/modules/vaos/app/controllers/vaos/direct_scheduling_facilities_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require_dependency 'vaos/application_controller'
-
 module VAOS
-  class DirectSchedulingFacilitiesController < ApplicationController
+  class DirectSchedulingFacilitiesController < VAOS::BaseController
     def index
       response = systems_service.get_system_facilities(
         facilities_params[:system_id],

--- a/modules/vaos/app/controllers/vaos/facilities_controller.rb
+++ b/modules/vaos/app/controllers/vaos/facilities_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require_dependency 'vaos/application_controller'
-
 module VAOS
-  class FacilitiesController < ApplicationController
+  class FacilitiesController < VAOS::BaseController
     def index
       response = systems_service.get_facilities(facilities_params)
       render json: VAOS::FacilitySerializer.new(response)

--- a/modules/vaos/app/controllers/vaos/limits_controller.rb
+++ b/modules/vaos/app/controllers/vaos/limits_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module VAOS
-  class LimitsController < ApplicationController
+  class LimitsController < VAOS::BaseController
     def index
       response = systems_service.get_facility_limits(
         facility_id,

--- a/modules/vaos/app/controllers/vaos/messages_controller.rb
+++ b/modules/vaos/app/controllers/vaos/messages_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require_dependency 'vaos/application_controller'
-
 module VAOS
-  class MessagesController < ApplicationController
+  class MessagesController < VAOS::BaseController
     def index
       render json: MessagesSerializer.new(messages[:data], meta: messages[:meta])
     end

--- a/modules/vaos/app/controllers/vaos/pact_controller.rb
+++ b/modules/vaos/app/controllers/vaos/pact_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module VAOS
-  class PactController < ApplicationController
+  class PactController < VAOS::BaseController
     def index
       response = systems_service.get_system_pact(system_id)
       render json: VAOS::SystemPactSerializer.new(response)

--- a/modules/vaos/app/controllers/vaos/preferences_controller.rb
+++ b/modules/vaos/app/controllers/vaos/preferences_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require_dependency 'vaos/application_controller'
-
 module VAOS
-  class PreferencesController < ApplicationController
+  class PreferencesController < VAOS::BaseController
     def index
       response = preferences_service.get_preferences(current_user)
       render json: VAOS::PreferencesSerializer.new(response)

--- a/modules/vaos/app/controllers/vaos/systems_controller.rb
+++ b/modules/vaos/app/controllers/vaos/systems_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require_dependency 'vaos/application_controller'
-
 module VAOS
-  class SystemsController < ApplicationController
+  class SystemsController < VAOS::BaseController
     def index
       response = systems_service.get_systems
       render json: VAOS::SystemSerializer.new(response)

--- a/modules/vaos/app/controllers/vaos/visits_controller.rb
+++ b/modules/vaos/app/controllers/vaos/visits_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module VAOS
-  class VisitsController < ApplicationController
+  class VisitsController < VAOS::BaseController
     SCHEDULE_TYPES = %w[direct request].freeze
 
     def index


### PR DESCRIPTION
## Description of change
Basically I noticed that we were requiring dependencies that shouldn't be required. They were required because we were not properly namespacing our parent version of ApplicationController. And if you didn't manually require the dependency it would resolve to its parent ApplicationController which wouldn't be as expected. This helps alleviate and ensures we're also always being explicit about the namespace for inherited class as well.

## Testing done
All specs passing is good enough for me.

## Testing planned
None

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
