### PR TITLE
exclude swagger from codeclimate similar code

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,7 +28,8 @@ checks:
     config:
       threshold: # language-specific defaults. an override will affect all languages.
     exclude_patterns:
-    - '*/engine.rb'
+      - '*/engine.rb'
+      - "**/swagger/**.rb"
   identical-code:
     config:
       threshold: # language-specific defaults. an override will affect all languages.


### PR DESCRIPTION
## Description of change
Codeclimate complains a lot about similar code, but swagger is more like documentation than code, so exclude it from duplication checks.

I think that this change will only take effect once it's on master.

https://codeclimate.com/github/department-of-veterans-affairs/vets-api/issues?category%5B%5D=duplication&page=2&status%5B%5D=&status%5B%5D=open
