### PR TITLE
Rename initializer to AppInfo

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -147,8 +147,8 @@ class ApplicationController < ActionController::API
   end
 
   def set_app_info_headers
-    headers['X-GitHub-Repository'] = 'https://github.com/department-of-veterans-affairs/vets-api'
-    headers['X-Git-SHA'] = AppInfo::GIT_REVISION
+    headers['X-Git-SHA']           = AppInfo::GIT_REVISION
+    headers['X-GitHub-Repository'] = AppInfo::GITHUB_URL
   end
 
   def saml_settings(options = {})

--- a/config/initializers/app_info.rb
+++ b/config/initializers/app_info.rb
@@ -2,4 +2,5 @@
 
 module AppInfo
   GIT_REVISION = `git rev-parse HEAD`&.chomp
+  GITHUB_URL   = 'https://github.com/department-of-veterans-affairs/vets-api'
 end


### PR DESCRIPTION
## Description of change
This is a simple changeset to rename the GitRevision module to more general `AppInfo` and move the string constant for GitHub url. 

## Testing done
CI build

## Testing planned

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

#### Applies to all PRs

- [x] ~Appropriate logging~
- [x] ~Swagger docs have been updated, if applicable~
- [x] ~Provide link to originating GitHub issue, or connected to it via ZenHub~
- [x] ~Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)~
- [x] ~Provide which alerts would indicate a problem with this functionality (if applicable)~
