### PR TITLE
MVI Find Profile by Attributes Spike

### DIFF
--- a/lib/mvi/service.rb
+++ b/lib/mvi/service.rb
@@ -89,7 +89,7 @@ module MVI
       log_console_and_sentry("MVI find_profile error: #{e.message}", :warn)
       mvi_profile_exception_response_for('MVI_504', e)
     rescue MVI::Errors::Base => e
-      mvi_error_handler(user_identity, e)
+      mvi_error_handler(nil, e)
       if e.is_a?(MVI::Errors::RecordNotFound)
         mvi_profile_exception_response_for('MVI_404', e, type: 'not_found')
       else
@@ -136,7 +136,7 @@ module MVI
         log_console_and_sentry('MVI Record Not Found')
       when MVI::Errors::InvalidRequestError
         # NOTE: ICN based lookups do not return RecordNotFound. They return InvalidRequestError
-        if user_identity.mhv_icn.present?
+        if icn_present?(user_identity)
           log_console_and_sentry('MVI Invalid Request (Possible RecordNotFound)', :error)
         else
           log_console_and_sentry('MVI Invalid Request', :error)
@@ -144,6 +144,10 @@ module MVI
       when MVI::Errors::FailedRequestError
         log_console_and_sentry('MVI Failed Request', :error)
       end
+    end
+
+    def icn_present?(user_identity)
+      user_identity.present? && user_identity.mhv_icn.present?
     end
 
     def log_console_and_sentry(message, sentry_classification = nil)

--- a/spec/lib/mvi/service_spec.rb
+++ b/spec/lib/mvi/service_spec.rb
@@ -435,6 +435,23 @@ describe MVI::Service do
       end
     end
   end
+
+  describe '.find_profile_from_attributes' do
+    context 'valid request' do
+      before do
+        expect(MVI::Messages::FindProfileMessage).to receive(:new).once.and_call_original
+      end
+
+      it 'calls the find_profile_with_attributes endpoint with a find candidate message' do
+        VCR.use_cassette('mvi/find_candidate/valid') do
+          response = subject.find_profile_from_attributes(user_hash)
+
+          expect(response.status).to eq('OK')
+          expect(response.profile).to have_deep_attributes(mvi_profile)
+        end
+      end
+    end
+  end
 end
 
 def server_error_502_expectations_for(response)


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
This PR is a proposal for how to add a public method to query MVI by attributes without passing in a User object created from authenticating with an identity provider. This type of querying is needed by as part of [#3655](https://github.com/department-of-veterans-affairs/vets-contrib/issues/3655), which is [part of a larger epic](https://github.com/department-of-veterans-affairs/vets-contrib/issues/3633) to add an API to Lighthouse that indicates status based on passed in identity traits. 

### More details
The new Veteran Confirmation API will be secured by an API key and have a `/status` endpoint which accepts attributes like name, birth date, and social security number in a POST body. That information will then be used to query MVI to retrieve an ICN, which can then be used to query eMIS. A response of "confirmed" or "not confirmed" is then returned to the end user. 

The `MVI::Service` currently assumes that a user object will be provided. This use-case deviates from that assumption and requires the additional public method.

### Notable changes
- Adds a new public method called `find_profile_by_attributes` to `MVI::Service`
- Modifies error reporting logic to not assume that a user identity will be provided

## Testing done
<!-- Please describe testing done to verify the changes. -->
- Replicates tests, including for the various MVI error cases from existing find profile implementation

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x]  A way to query MVI by user traits is created

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
