### PR TITLE
Refactor how we ignore gibs OutsideWorkingHours exception

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,8 +16,7 @@ class ApplicationController < ActionController::API
     Common::Exceptions::Unauthorized,
     Common::Exceptions::RoutingError,
     Common::Exceptions::Forbidden,
-    Breakers::OutageException,
-    EVSS::GiBillStatus::OutsideWorkingHours
+    Breakers::OutageException
   ].freeze
 
   VERSION_STATUS = {

--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -85,6 +85,10 @@ module V0
       Time.parse(user.va_profile.birth_date).iso8601
     end
 
+    def skip_sentry_exception_types
+      super + [EVSS::GiBillStatus::OutsideWorkingHours]
+    end
+
     def service
       EVSS::GiBillStatus::Service.new(@current_user)
     end


### PR DESCRIPTION
## Description of change
Overrides the `def skip_sentry_exception_types` in the controller rather than defining the skip exception type in `application_controller`. No feature added in this PR, only a refactor of what was already done here: https://github.com/department-of-veterans-affairs/vets-api/pull/3674

## Testing done
Specs

## Testing planned
None

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
