### PR TITLE
Fixing bad test sequence

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -38,7 +38,7 @@ module ClaimsApi
 
     def target_veteran(with_gender: false)
       if header_request?
-        headers_to_validate = %w[X-VA-SSN X-VA-First-Name X-VA-Last-Name X-VA-Birth-Date]
+        headers_to_validate = %w[X-VA-SSN X-VA-First-Name X-VA-Last-Name X-VA-Birth-Date X-Consumer-Username]
         headers_to_validate << 'X-VA-LOA' if v0?
         validate_headers(headers_to_validate)
         if v0?

--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -13,12 +13,6 @@ module ClaimsApi
 
     private
 
-    def poa_request?
-      # if any of the required headers are present we should attempt to use headers
-      headers_to_check = %w[HTTP_X_VA_SSN HTTP_X_Consumer_Username HTTP_X_VA_Birth_Date]
-      (request.headers.to_h.keys & headers_to_check).length.positive?
-    end
-
     def claims_service
       ClaimsApi::UnsynchronizedEVSSClaimService.new(target_veteran)
     end
@@ -29,7 +23,6 @@ module ClaimsApi
 
     def header_request?
       headers_to_check = %w[HTTP_X_VA_SSN
-                            HTTP_X_Consumer_Username
                             HTTP_X_VA_BIRTH_DATE
                             HTTP_X_VA_FIRST_NAME
                             HTTP_X_VA_LAST_NAME]

--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -15,7 +15,7 @@ module ClaimsApi
 
     def poa_request?
       # if any of the required headers are present we should attempt to use headers
-      headers_to_check = %w[HTTP_X_VA_SSN HTTP_X_VA_Consumer-Username HTTP_X_VA_Birth_Date]
+      headers_to_check = %w[HTTP_X_VA_SSN HTTP_X_Consumer_Username HTTP_X_VA_Birth_Date]
       (request.headers.to_h.keys & headers_to_check).length.positive?
     end
 
@@ -29,7 +29,7 @@ module ClaimsApi
 
     def header_request?
       headers_to_check = %w[HTTP_X_VA_SSN
-                            HTTP_X_VA_Consumer-Username
+                            HTTP_X_Consumer_Username
                             HTTP_X_VA_BIRTH_DATE
                             HTTP_X_VA_FIRST_NAME
                             HTTP_X_VA_LAST_NAME]

--- a/modules/claims_api/app/controllers/claims_api/concerns/poa_verification.rb
+++ b/modules/claims_api/app/controllers/claims_api/concerns/poa_verification.rb
@@ -5,7 +5,7 @@ module ClaimsApi
     extend ActiveSupport::Concern
 
     included do
-      before_action :verify_power_of_attorney, if: :poa_request?
+      before_action :verify_power_of_attorney, if: :header_request?
 
       def verify_power_of_attorney
         verifier = EVSS::PowerOfAttorneyVerifier.new(target_veteran)

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -57,7 +57,7 @@ module ClaimsApi
         private
 
         def source_name
-          user = poa_request? ? @current_user : target_veteran
+          user = header_request? ? @current_user : target_veteran
           "#{user.first_name} #{user.last_name}"
         end
 

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -26,7 +26,7 @@ module ClaimsApi
           power_of_attorney.save!
 
           # This job only occurs when a Veteran submits a PoA request, they are not required to submit a document.
-          ClaimsApi::PoaUpdater.perform_async(power_of_attorney.id) unless poa_request?
+          ClaimsApi::PoaUpdater.perform_async(power_of_attorney.id) unless header_request?
 
           render json: power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
         end
@@ -35,7 +35,7 @@ module ClaimsApi
           power_of_attorney = ClaimsApi::PowerOfAttorney.find_by(id: params[:id])
 
           # This job only occurs when a Representative submits a PoA request to ensure they've also uploaded a document.
-          ClaimsApi::PoaUpdater.perform_async(power_of_attorney.id) if poa_request?
+          ClaimsApi::PoaUpdater.perform_async(power_of_attorney.id) if header_request?
 
           power_of_attorney.set_file_data!(documents.first, params[:doc_type])
           power_of_attorney.status = 'submitted'
@@ -55,7 +55,7 @@ module ClaimsApi
         private
 
         def source_name
-          user = poa_request? ? @current_user : target_veteran
+          user = header_request? ? @current_user : target_veteran
           "#{user.first_name} #{user.last_name}"
         end
       end

--- a/modules/claims_api/spec/requests/v0/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/claims_request_spec.rb
@@ -6,14 +6,6 @@ require 'evss/request_decision'
 
 RSpec.describe 'EVSS Claims management', type: :request do
   include SchemaMatchers
-  VALID_HEADERS = {
-    'X-VA-SSN' => '111223333',
-    'X-VA-First-Name' => 'Test',
-    'X-VA-Last-Name' => 'Consumer',
-    'X-VA-Birth-Date' => '11-11-1111',
-    'X-Consumer-Username' => 'TestConsumer',
-    'X-VA-LOA' => '3'
-  }.freeze
 
   before do
     stub_mvi
@@ -107,11 +99,20 @@ RSpec.describe 'EVSS Claims management', type: :request do
   end
 
   context 'header validations' do
-    VALID_HEADERS.each_key do |header|
+    valid_headers = {
+      'X-VA-SSN' => '111223333',
+      'X-VA-First-Name' => 'Test',
+      'X-VA-Last-Name' => 'Consumer',
+      'X-VA-Birth-Date' => '11-11-1111',
+      'X-Consumer-Username' => 'TestConsumer',
+      'X-VA-LOA' => '3'
+    }
+  
+    valid_headers.each_key do |header|
       context "without #{header}" do
         it 'returns a bad request response' do
           VCR.use_cassette('evss/claims/claims') do
-            get '/services/claims/v0/claims', params: nil, headers: VALID_HEADERS.except(header)
+            get '/services/claims/v0/claims', params: nil, headers: valid_headers.except(header)
             expect(response).to have_http_status(:bad_request)
           end
         end
@@ -120,7 +121,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
 
     it 'returns error if loa is not 3' do
       VCR.use_cassette('evss/claims/claims') do
-        get '/services/claims/v0/claims', params: nil, headers: VALID_HEADERS.merge('X-VA-LOA' => 2)
+        get '/services/claims/v0/claims', params: nil, headers: valid_headers.merge('X-VA-LOA' => 2)
         expect(response).to have_http_status(:unauthorized)
       end
     end

--- a/modules/claims_api/spec/requests/v0/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/claims_request_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
       'X-Consumer-Username' => 'TestConsumer',
       'X-VA-LOA' => '3'
     }
-  
+
     valid_headers.each_key do |header|
       context "without #{header}" do
         it 'returns a bad request response' do

--- a/modules/claims_api/spec/requests/v1/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/claims_request_spec.rb
@@ -6,13 +6,6 @@ require 'evss/request_decision'
 
 RSpec.describe 'EVSS Claims management', type: :request do
   include SchemaMatchers
-  VALID_HEADERS = {
-    'X-VA-SSN' => '111223333',
-    'X-VA-First-Name' => 'Test',
-    'X-VA-Last-Name' => 'Consumer',
-    'X-VA-Birth-Date' => '11-11-1111',
-    'X-Consumer-Username' => 'TestConsumer'
-  }.freeze
 
   let(:request_headers) do
     {


### PR DESCRIPTION
## Description of change
Fixing test sequence fix, bad loading of the test was masking our lack of requiring X-Consumer-Username in the code, running the test individually like charlie did causes it to fail, running it as a group causes it to pass.

## Acceptance Criteria (Definition of Done)
- Fixed test sequence

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
