### PR TITLE
Get more info about token validation failures

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -15,7 +15,6 @@ class Token
   def payload
     @payload ||= if @token_string
                    pubkey = public_key
-                   return if pubkey.blank?
 
                    JWT.decode(@token_string, pubkey, true, algorithm: 'RS256')[0]
                  end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -30,7 +30,10 @@ class Token
     decoded_token = JWT.decode(@token_string, nil, false, algorithm: 'RS256')
     kid = decoded_token[1]['kid']
     key = OIDC::KeyService.get_key(kid)
-    raise error_klass("Public key not found for kid specified in token: '#{kid}'") if key.blank?
+    if key.blank?
+      Rails.logger.info("Public key not found", kid: kid, exp: decoded_token[0]['exp'])
+      raise error_klass("Public key not found for kid specified in token: '#{kid}'")
+    end
 
     key
   rescue JWT::DecodeError => e

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -31,7 +31,7 @@ class Token
     kid = decoded_token[1]['kid']
     key = OIDC::KeyService.get_key(kid)
     if key.blank?
-      Rails.logger.info("Public key not found", kid: kid, exp: decoded_token[0]['exp'])
+      Rails.logger.info('Public key not found', kid: kid, exp: decoded_token[0]['exp'])
       raise error_klass("Public key not found for kid specified in token: '#{kid}'")
     end
 

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -29,7 +29,11 @@ class Token
   def public_key
     decoded_token = JWT.decode(@token_string, nil, false, algorithm: 'RS256')
     kid = decoded_token[1]['kid']
-    OIDC::KeyService.get_key(kid)
+    key = OIDC::KeyService.get_key(kid)
+    if !key
+      raise error_klass("Public key not found for kid specified in token: '#{kid}'")
+    end
+    key
   rescue JWT::DecodeError => e
     raise error_klass("Validation error: #{e.message}")
   end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -30,9 +30,8 @@ class Token
     decoded_token = JWT.decode(@token_string, nil, false, algorithm: 'RS256')
     kid = decoded_token[1]['kid']
     key = OIDC::KeyService.get_key(kid)
-    if !key
-      raise error_klass("Public key not found for kid specified in token: '#{kid}'")
-    end
+    raise error_klass("Public key not found for kid specified in token: '#{kid}'") if key.blank?
+
     key
   rescue JWT::DecodeError => e
     raise error_klass("Unable to determine public key: #{e.message}")

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -22,6 +22,8 @@ class Token
   rescue JWT::ExpiredSignature => e
     Rails.logger.info(e.message, token: @token_string)
     raise error_klass("Validation error: #{e.message}")
+  rescue JWT::DecodeError => e
+    raise error_klass(e.message)
   end
 
   def public_key

--- a/lib/oidc/key_service.rb
+++ b/lib/oidc/key_service.rb
@@ -37,7 +37,7 @@ module OIDC
 
     def self.fetch_keys
       okta = Okta::Service.new
-      key_response = okta.keys
+      key_response = okta.oidc_jwks_keys
       key_response.body
     end
 

--- a/lib/oidc/key_service.rb
+++ b/lib/oidc/key_service.rb
@@ -37,9 +37,7 @@ module OIDC
 
     def self.fetch_keys
       okta = Okta::Service.new
-      metadata_response = okta.get_url_with_token Settings.oidc.auth_server_metadata_url
-      metadata = metadata_response.body
-      key_response = okta.get_url_with_token metadata['jwks_uri']
+      key_response = okta.keys
       key_response.body
     end
 

--- a/lib/okta/service.rb
+++ b/lib/okta/service.rb
@@ -52,7 +52,7 @@ module Okta
       end
     end
 
-    def keys
+    def oidc_jwks_keys
       url = metadata.body['jwks_uri']
       with_monitoring do
         get_url_with_token(url)

--- a/lib/okta/service.rb
+++ b/lib/okta/service.rb
@@ -22,12 +22,6 @@ module Okta
       end
     end
 
-    %i[get post put delete].each do |http_verb|
-      define_method("#{http_verb}_url_with_token".to_sym) do |url|
-        Okta::Response.new call_with_token(http_verb, url)
-      end
-    end
-
     def app(app_id)
       with_monitoring do
         get_url_with_token("#{APP_API_BASE_PATH}/#{app_id}")
@@ -49,6 +43,27 @@ module Okta
     def delete_grant(user_id, grant_id)
       with_monitoring do
         delete_url_with_token("#{USER_API_BASE_PATH}/#{user_id}/grants/#{grant_id}")
+      end
+    end
+
+    def metadata
+      with_monitoring do
+        get_url_with_token(Settings.oidc.auth_server_metadata_url)
+      end
+    end
+
+    def keys
+      url = metadata.body['jwks_uri']
+      with_monitoring do
+        get_url_with_token(url)
+      end
+    end
+
+    private
+
+    %i[get post put delete].each do |http_verb|
+      define_method("#{http_verb}_url_with_token".to_sym) do |url|
+        Okta::Response.new call_with_token(http_verb, url)
       end
     end
   end

--- a/spec/controllers/openid_application_controller_spec.rb
+++ b/spec/controllers/openid_application_controller_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe OpenidApplicationController, type: :controller do
   let(:kid) { token[1]['kid'] }
   let(:alg) { token[1]['alg'] }
 
-  def change_encoded_token_payload(options = {})
+  def change_encoded_token_payload(options = {}, new_kid = kid)
     new_payload = payload.merge(options)
-    @encoded_token = JWT.encode(new_payload, @public_key, alg, 'kid' => kid)
+    @encoded_token = JWT.encode(new_payload, @public_key, alg, 'kid' => new_kid)
     request.headers['Authorization'] = "Bearer #{@encoded_token}"
   end
 
@@ -22,6 +22,7 @@ RSpec.describe OpenidApplicationController, type: :controller do
         @encoded_token = JWT.encode(payload, @public_key, alg, 'kid' => kid)
         request.headers['Authorization'] = "Bearer #{@encoded_token}"
 
+        allow(OIDC::KeyService).to receive(:get_key).with(anything()).and_return(nil)
         allow(OIDC::KeyService).to receive(:get_key).with(kid).and_return(@public_key)
       end
 
@@ -40,11 +41,21 @@ RSpec.describe OpenidApplicationController, type: :controller do
         end
       end
 
-      it 'rejects access when the does not have the allowed scopes' do
+      it 'rejects access when the token does not have the allowed scopes' do
         with_okta_configured do
           change_encoded_token_payload('scp' => ['bad_scope'])
           get :index
           expect(response.status).to eq(401)
+        end
+      end
+
+      it 'rejects access when the public key is not found' do
+        with_okta_configured do
+          change_encoded_token_payload({}, 'bad kid value')
+          get :index
+          expect(response.status).to eq(401)
+          errors = JSON.parse(response.body)['errors']
+          expect(errors[0]['detail']).to eq("Public key not found for kid specified in token: 'bad kid value'")
         end
       end
 

--- a/spec/controllers/openid_application_controller_spec.rb
+++ b/spec/controllers/openid_application_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe OpenidApplicationController, type: :controller do
 
           expect(response.status).to eq(401)
           errors = JSON.parse(response.body)['errors']
-          expect(errors[0]['detail']).to eq('Validation error: Signature has expired')
+          expect(errors[0]['detail']).to eq('Signature has expired')
         end
       end
 

--- a/spec/controllers/openid_application_controller_spec.rb
+++ b/spec/controllers/openid_application_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe OpenidApplicationController, type: :controller do
         @encoded_token = JWT.encode(payload, @public_key, alg, 'kid' => kid)
         request.headers['Authorization'] = "Bearer #{@encoded_token}"
 
-        allow(OIDC::KeyService).to receive(:get_key).with(anything()).and_return(nil)
+        allow(OIDC::KeyService).to receive(:get_key).with(anything).and_return(nil)
         allow(OIDC::KeyService).to receive(:get_key).with(kid).and_return(@public_key)
       end
 


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/3982

The /internal/auth/v0/validation endpoint has started sending a lot of events to sentry: http://sentry.vfs.va.gov/vets-gov/platform-api-production/issues/88135/. The error message here isn't very clear, but it seems to indicate that the public key specified by the access tokens being validated isn't being found. This PR adds some additional monitoring and more specific error messages to help us test our theories as we debug this problem. 