### PR TITLE
Bugfix: NoSuchKey error

### DIFF
--- a/app/controllers/concerns/form_attachment_create.rb
+++ b/app/controllers/concerns/form_attachment_create.rb
@@ -11,10 +11,9 @@ module FormAttachmentCreate
     form_attachment_model = self.class::FORM_ATTACHMENT_MODEL
     form_attachment = form_attachment_model.new
     namespace = form_attachment_model.to_s.underscore.split('/').last
+    filtered_params = params.require(namespace).permit(:file_data)
 
-    file_data = params.require(namespace).permit(:file_data)
-
-    form_attachment.set_file_data!(file_data)
+    form_attachment.set_file_data!(filtered_params[:file_data])
     form_attachment.save!
     render(json: form_attachment)
   end

--- a/spec/controllers/v0/hca_attachments_controller_spec.rb
+++ b/spec/controllers/v0/hca_attachments_controller_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe V0::HcaAttachmentsController, type: :controller do
       post(:create, params: { hca_attachment: {
              file_data: fixture_file_upload('pdf_fill/extras.pdf')
            } })
-
-      expect(JSON.parse(response.body)['data']['attributes']['guid']).to eq HcaAttachment.last.guid
+      guid = JSON.parse(response.body)['data']['attributes']['guid']
+      expect(guid).to eq HcaAttachment.last.guid
+      expect(File).to exist("spec/support/uploads/hca_attachments/#{guid}")
     end
 
     it 'validates input parameters' do


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/4633

## Description of change
There was a bug introduced in https://github.com/department-of-veterans-affairs/vets-api/pull/3721 that attempted to save all of the parameters rather than just the file 

````
[1] pry(#<V0::HcaAttachmentsController>)> file_data
=> <ActionController::Parameters {"file_data"=>#<ActionDispatch::Http::UploadedFile:0x00007fdd6ded08f8 @tempfile=#<Tempfile:/var/folders/gs/qp8mkx392qjfgj22mv__h_br0000gn/T/RackMultipart20200107-29459-1gtucql.pdf>, @original_filename="extras.pdf", @content_type="", @headers="Content-Disposition: form-data; name=\"hca_attachment[file_data]\"; filename=\"extras.pdf\"\r\nContent-Type: \r\nContent-Length: 12161\r\n">} permitted: true>
````

## Testing done
specs

## Testing planned
upload in staging