### PR TITLE
Revert "Throttle okta public keys requests for kids that have failed …

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -30,7 +30,6 @@ class Token
     kid = decoded_token[1]['kid']
     key = OIDC::KeyService.get_key(kid)
     if key.blank?
-      StatsD.increment('okta_kid_lookup_failure', 1, ["kid:#{kid}"])
       Rails.logger.info('Public key not found', kid: kid, exp: decoded_token[0]['exp'])
       raise error_klass("Public key not found for kid specified in token: '#{kid}'")
     end

--- a/lib/oidc/key_service.rb
+++ b/lib/oidc/key_service.rb
@@ -7,43 +7,23 @@ module OIDC
     @mutex = Mutex.new
     # Map from kid to OpenSSL::RSA::PKey for all current keys
     @current_keys = {}
-    @cache_miss_kids = {}
-    KID_CACHE_PERIOD_SECS = 60
-    KID_CACHE_MAX_SIZE = 10
+
+    class << self
+      attr_reader :current_keys
+    end
 
     def self.get_key(expected_kid)
       found = @current_keys[expected_kid]
-      if found.nil? && should_refresh?(expected_kid)
+      if found.nil?
         refresh expected_kid
         found = @current_keys[expected_kid]
-        update_missing_kid_cache(expected_kid) if found.nil?
       end
       found
     end
 
-    def self.update_missing_kid_cache(kid)
-      if @cache_miss_kids.length >= KID_CACHE_MAX_SIZE && !@cache_miss_kids.key?(kid)
-        oldest_kid = @cache_miss_kids.min_by { |_, timestamp| timestamp }[0]
-        @cache_miss_kids.delete oldest_kid
-      end
-      @cache_miss_kids[kid] = Time.now.utc
-    end
-
-    def self.should_refresh?(kid)
-      last_miss = @cache_miss_kids[kid]
-      last_miss.nil? || Time.now.utc - last_miss > KID_CACHE_PERIOD_SECS
-    end
-
-    def self.reset!
-      @mutex.synchronize do
-        @current_keys = {}
-        @cache_miss_kids = {}
-      end
-    end
-
     def self.refresh(expected_kid)
       @mutex.synchronize do
-        break if @current_keys[expected_kid].present?
+        break if current_keys[expected_kid].present?
 
         jwks_result = fetch_keys
         new_keys = {}

--- a/spec/lib/oidc/key_service_spec.rb
+++ b/spec/lib/oidc/key_service_spec.rb
@@ -23,63 +23,26 @@ RSpec.describe OIDC::KeyService do
 
   describe '::get_key' do
     after do
-      described_class.reset!
+      described_class.instance_variable_set(:@current_key, {})
     end
 
     it 'returns the current key if it already exists' do
-      described_class.instance_variable_set(:@current_keys, 'key' => 'key')
+      described_class.current_keys['key'] = 'key'
       expect(described_class.get_key('key')).to eq 'key'
     end
 
-    it 'avoids upstream requests for repeated bad kids' do
-      expect(described_class).to receive(:refresh).once
-      described_class.get_key('bad kid')
-      described_class.get_key('bad kid')
-    end
-
-    it 'refreshes a bad kid after one minute' do
-      expect(described_class).to receive(:refresh).twice
-      described_class.get_key('bad kid')
-      Timecop.travel(Time.zone.now + 61)
-      described_class.get_key('bad kid')
-      Timecop.return
-    end
-
-    it 'limits the size of the bad kid cache' do
-      expect(described_class).to receive(:refresh).exactly(1002).times
-
-      # Add a kid with a timestamp in the past
-      Timecop.travel(Time.zone.now - 30)
-      described_class.get_key('oldest key')
-      Timecop.return
-
-      # Fill up the kid cache so the first key we've added is evicted
-      (0...1000).each do |x|
-        described_class.get_key(x)
-      end
-
-      # Since this key was evicted, this call will trigger the 1002nd refresh
-      described_class.get_key('oldest key')
-    end
-
-    context 'with okta api recordings' do
-      around do |example|
-        with_settings(
-          Settings.oidc,
-          auth_server_metadata_url: 'https://example.com/oauth2/default/.well-known/oauth-authorization-server',
-          issuer: 'https://example.com/oauth2/default',
-          base_api_url: 'https://example.com/',
-          base_api_token: 'token'
-        ) do
-          VCR.use_cassette('okta/keys') do
-            example.run
-          end
+    it 'downloads new keys if it does not exist' do
+      with_settings(
+        Settings.oidc,
+        auth_server_metadata_url: 'https://example.com/oauth2/default/.well-known/oauth-authorization-server',
+        issuer: 'https://example.com/oauth2/default',
+        base_api_url: 'https://example.com/',
+        base_api_token: 'token'
+      ) do
+        VCR.use_cassette('okta/keys') do
+          key = described_class.get_key('1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU')
+          expect(key).to be_a(OpenSSL::PKey::RSA)
         end
-      end
-
-      it 'downloads new keys if it does not exist' do
-        key = described_class.get_key('1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU')
-        expect(key).to be_a(OpenSSL::PKey::RSA)
       end
     end
   end


### PR DESCRIPTION
This reverts commit b030a9e5720216f15d404806a7bac87f5a9a5704.

It was causing 500 errors due to an exception raised by the statsd instrumentation.

Here's an example of the backtrace:

```
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/statsd-instrument-2.6.0/lib/statsd/instrument/backends/udp_backend.rb:101:in `collect_metric'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/statsd-instrument-2.6.0/lib/statsd/instrument.rb:632:in `collect_metric'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/statsd-instrument-2.6.0/lib/statsd/instrument.rb:432:in `increment'
/srv/vets-api/src/app/models/token.rb:33:in `public_key'
/srv/vets-api/src/app/models/token.rb:17:in `payload'
/srv/vets-api/src/app/models/token.rb:49:in `valid_issuer?'
/srv/vets-api/src/app/models/token.rb:44:in `validate_token'
/srv/vets-api/src/app/models/token.rb:8:in `initialize'
/srv/vets-api/src/app/controllers/openid_application_controller.rb:43:in `new'
/srv/vets-api/src/app/controllers/openid_application_controller.rb:43:in `token_from_request'
/srv/vets-api/src/app/controllers/openid_application_controller.rb:56:in `token'
/srv/vets-api/src/app/controllers/openid_application_controller.rb:30:in `authenticate_token'
/srv/vets-api/src/app/controllers/openid_application_controller.rb:26:in `authenticate'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/callbacks.rb:426:in `block in make_lambda'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/callbacks.rb:198:in `block (2 levels) in halting'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/abstract_controller/callbacks.rb:34:in `block (2 levels) in <module:Callbacks>'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/callbacks.rb:199:in `block in halting'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/callbacks.rb:513:in `block in invoke_before'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/callbacks.rb:513:in `each'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/callbacks.rb:513:in `invoke_before'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/callbacks.rb:107:in `block in run_callbacks'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/sentry-raven-2.9.0/lib/raven/integrations/rails/controller_transaction.rb:7:in `block in included'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/callbacks.rb:118:in `instance_exec'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/callbacks.rb:118:in `block in run_callbacks'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/callbacks.rb:136:in `run_callbacks'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/abstract_controller/callbacks.rb:41:in `process_action'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_controller/metal/rescue.rb:22:in `process_action'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/notifications.rb:168:in `block in instrument'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/notifications.rb:168:in `instrument'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_controller/metal/instrumentation.rb:32:in `process_action'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_controller/metal/params_wrapper.rb:256:in `process_action'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activerecord-5.2.4.1/lib/active_record/railties/controller_runtime.rb:24:in `process_action'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/abstract_controller/base.rb:134:in `process'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_controller/metal.rb:191:in `dispatch'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_controller/metal.rb:252:in `dispatch'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/routing/route_set.rb:52:in `dispatch'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/routing/route_set.rb:34:in `serve'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/journey/router.rb:52:in `block in serve'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/journey/router.rb:35:in `each'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/journey/router.rb:35:in `serve'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/routing/route_set.rb:840:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/railties-5.2.4.1/lib/rails/engine.rb:524:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/railties-5.2.4.1/lib/rails/railtie.rb:190:in `public_send'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/railties-5.2.4.1/lib/rails/railtie.rb:190:in `method_missing'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/routing/mapper.rb:48:in `serve'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/journey/router.rb:52:in `block in serve'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/journey/router.rb:35:in `each'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/journey/router.rb:35:in `serve'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/routing/route_set.rb:840:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rack-attack-6.2.1/lib/rack/attack.rb:156:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rack-2.0.8/lib/rack/session/abstract/id.rb:259:in `context'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rack-2.0.8/lib/rack/session/abstract/id.rb:253:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/middleware/cookies.rb:670:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rack-attack-6.2.1/lib/rack/attack.rb:170:in `call'
/srv/vets-api/src/lib/statsd_middleware.rb:64:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/olive_branch-2.0.0/lib/olive_branch/middleware.rb:14:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rack-2.0.8/lib/rack/etag.rb:25:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rack-2.0.8/lib/rack/conditional_get.rb:25:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rack-2.0.8/lib/rack/head.rb:12:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/callbacks.rb:98:in `run_callbacks'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/middleware/callbacks.rb:26:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/middleware/debug_exceptions.rb:61:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rails_semantic_logger-4.4.0/lib/rails_semantic_logger/rack/logger.rb:43:in `call_app'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rails_semantic_logger-4.4.0/lib/rails_semantic_logger/rack/logger.rb:26:in `block in call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/semantic_logger-4.5.0/lib/semantic_logger/semantic_logger.rb:374:in `named_tagged'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/semantic_logger-4.5.0/lib/semantic_logger/base.rb:194:in `tagged'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rails_semantic_logger-4.4.0/lib/rails_semantic_logger/rack/logger.rb:26:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/request_store-1.5.0/lib/request_store/middleware.rb:19:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/middleware/request_id.rb:27:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rack-2.0.8/lib/rack/runtime.rb:22:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/activesupport-5.2.4.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/actionpack-5.2.4.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rack-2.0.8/lib/rack/sendfile.rb:111:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/rack-cors-1.0.6/lib/rack/cors.rb:98:in `call'
/srv/vets-api/src/lib/http_method_not_allowed.rb:16:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/sentry-raven-2.9.0/lib/raven/integrations/rack.rb:51:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/utf8-cleaner-0.2.5/lib/utf8-cleaner/middleware.rb:21:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/railties-5.2.4.1/lib/rails/engine.rb:524:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/puma-4.3.1/lib/puma/configuration.rb:228:in `call'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/puma-4.3.1/lib/puma/server.rb:681:in `handle_request'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/puma-4.3.1/lib/puma/server.rb:472:in `process_client'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/puma-4.3.1/lib/puma/server.rb:328:in `block in run'
/srv/vets-api/src/vendor/bundle/ruby/2.4/gems/puma-4.3.1/lib/puma/thread_pool.rb:134:in `block in spawn_thread'
```
