### PR TITLE
add bah ID.me account to feature flags admins

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -443,6 +443,7 @@ flipper:
     - ryan.thurlwell@va.gov
     - travis.hilton@oddball.io
     - n.ratana@gmail.com
+    - zurbergram@gmail.com
 
 bgs:
   application: ~


### PR DESCRIPTION
## Description of change
Adding a BAH Team ID.me account to feature flags admins to be able to flip feature flag `gi_vet_tec_program_provider_filters`

Related to https://github.com/department-of-veterans-affairs/vets-api/pull/3605 and  https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19992

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
