### PR TITLE
Update Veteran Confirmation documentation route

### DIFF
--- a/modules/veteran_confirmation/app/controllers/veteran_confirmation/docs/v0/api_controller.rb
+++ b/modules/veteran_confirmation/app/controllers/veteran_confirmation/docs/v0/api_controller.rb
@@ -3,8 +3,8 @@
 module VeteranConfirmation
   module Docs
     module V0
-      class ApiController < ApplicationController
-        def status
+      class ApiController < VeteranConfirmation::ApplicationController
+        def index
           swagger = YAML.safe_load(File.read(VeteranConfirmation::Engine.root.join('VETERAN_CONFIRMATION.yml')))
           render json: swagger
         end

--- a/modules/veteran_confirmation/config/routes.rb
+++ b/modules/veteran_confirmation/config/routes.rb
@@ -9,7 +9,7 @@ VeteranConfirmation::Engine.routes.draw do
 
   namespace :docs do
     namespace :v0, defaults: { format: 'json' } do
-      get 'status', to: 'api#status'
+      get 'api', to: 'api#index'
     end
   end
 end

--- a/modules/veteran_confirmation/spec/requests/api_docs_request_spec.rb
+++ b/modules/veteran_confirmation/spec/requests/api_docs_request_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Veteran Confirmation Documentation Endpoints', type: :request do
   describe '#get /docs/v0/status' do
     it 'returns Open API Spec v3 JSON' do
-      get '/services/veteran_confirmation/docs/v0/status'
+      get '/services/veteran_confirmation/docs/v0/api'
       expect(response).to have_http_status(:ok)
       JSON.parse(response.body)
     end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
This update supports [#4022](https://github.com/department-of-veterans-affairs/vets-contrib/issues/4022). It fixes the route that serves the Open API Spec for the Veteran Confirmation API. At the moment, it sometimes loads the wrong ApplicationController and attempts to check authentication for incoming requests. Explicitly referencing `VeteranConfirmation::ApplicationController` uses the correct class. It also updates the route to be `/docs/v0/api`, which is in line with other Lighthouse documentation routes living in vets-api.

## Testing done
<!-- Please describe testing done to verify the changes. -->
- Modified test for documentation route (which no longer fails periodically based on load order)

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Fix route that serves Open API Spec

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
