### PR TITLE
Set default workers / threads

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -2,6 +2,6 @@
 
 plugin :statsd
 
-workers Integer(ENV.fetch("PUMA_WORKERS", 0))
-threads_count = Integer(ENV.fetch("PUMA_THREADS", 16))
+workers Integer(ENV.fetch('PUMA_WORKERS', 0))
+threads_count = Integer(ENV.fetch('PUMA_THREADS', 16))
 threads(threads_count, threads_count)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,7 @@
 # frozen_string_literal: true
 
 plugin :statsd
+
+workers Integer(ENV.fetch("PUMA_WORKERS", 0))
+threads_count = Integer(ENV.fetch("PUMA_THREADS", 16))
+threads(threads_count, threads_count)


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

I am hesitant to try this again due to what happened earlier in the week, but after talking with @wyattwalter and @johnpaulashenfelter, I think this will set a default in the Puma config to what is currently being used (meaning no changes should be seen by what is committed here) and allow for those configurations to be overwritten by environment variables. This would allow for us to do a dev-env deploy to test, allow for different settings dependent on environment, etc. 

Other than setting `- "-e PUMA_THREADS=16"` and `- "-e PUMA_WORKERS=1"` in the `docker_options` within the deployment configs, I am unsure what other changes would need to be made to align with the docker stuff @nathanhruby is working on. Any insight on that would be awesome.

In addition, I know there are some more settings like `preload_app!` and instructions for `on_worker_boot`, but a slower / more methodical approach with incremental changes is likely the safest route.