### PR TITLE
Use custom path for configuration file

### DIFF
--- a/lib/common/virus_scan.rb
+++ b/lib/common/virus_scan.rb
@@ -7,7 +7,8 @@ module Common
     def scan(file_path)
       # `clamd` runs within service group, needs group read
       File.chmod(0o640, file_path)
-      ClamScan::Client.scan(location: file_path)
+      args = ['--config', Rails.root.join('config', 'clamd.conf').to_s]
+      ClamScan::Client.scan(location: file_path, custom_args: args)
     end
   end
 end


### PR DESCRIPTION
## Description of change
After deploying dockerized vets-api to production, we noticed some issues in [Sentry](http://sentry.vfs.va.gov/vets-gov/platform-api-production/issues/92658/?referrer=slack) relating to ClamD scans failing - the cause of which is the config file is not correctly picked up.

This PR changes the scan command to utilize custom config location. This fix will mediate the bug and allow us time to reengineer how we scan for virii in general.

## Testing done
Locally, staging box.

