### PR TITLE
Use sed instead of ruby sub for memory performance

### DIFF
--- a/modules/vba_documents/lib/vba_documents/multipart_parser.rb
+++ b/modules/vba_documents/lib/vba_documents/multipart_parser.rb
@@ -40,9 +40,8 @@ module VBADocuments
     end
 
     def self.create_file_from_base64(infile)
-      content = File.read(infile)
       FileUtils.mkdir_p '/tmp/vets-api'
-      contents = content.sub %r{data:((multipart)/.{3,}),}, ''
+      contents = `sed -r 's/data:multipart\\/.{3,},//g' #{infile}`
       decoded_data = Base64.decode64(contents)
       filename = "temp_upload_#{Time.zone.now.to_i}"
 

--- a/modules/vba_documents/spec/lib/multipart_parser_spec.rb
+++ b/modules/vba_documents/spec/lib/multipart_parser_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe VBADocuments::MultipartParser do
 
   describe '#parse' do
     it 'parses a valid multipart payload' do
-      valid_doc = get_fixture('valid_multipart_pdf.blob')
+      valid_doc = get_fixture('valid_multipart_pdf.blob').path
       result = described_class.parse(valid_doc)
       expect(result.size).to eq(2)
       expect(result).to have_key('metadata')
@@ -20,7 +20,7 @@ RSpec.describe VBADocuments::MultipartParser do
     end
 
     it 'parses a valid multipart payload with attachments' do
-      valid_doc = get_fixture('valid_multipart_pdf_attachments.blob')
+      valid_doc = get_fixture('valid_multipart_pdf_attachments.blob').path
       result = described_class.parse(valid_doc)
       expect(result.size).to eq(3)
       expect(result).to have_key('metadata')
@@ -32,7 +32,7 @@ RSpec.describe VBADocuments::MultipartParser do
     end
 
     it 'raises on a malformed multipart payload' do
-      invalid_doc = get_fixture('invalid_multipart_no_boundary.blob')
+      invalid_doc = get_fixture('invalid_multipart_no_boundary.blob').path
       expect { described_class.parse(invalid_doc) }.to raise_error do |error|
         expect(error).to be_a(VBADocuments::UploadError)
         expect(error.code).to eq('DOC101')
@@ -40,7 +40,7 @@ RSpec.describe VBADocuments::MultipartParser do
     end
 
     it 'raises on a multipart with truncated content' do
-      invalid_doc = get_fixture('invalid_multipart_truncated.blob')
+      invalid_doc = get_fixture('invalid_multipart_truncated.blob').path
       expect { described_class.parse(invalid_doc) }.to raise_error do |error|
         expect(error).to be_a(VBADocuments::UploadError)
         expect(error.code).to eq('DOC101')
@@ -48,7 +48,7 @@ RSpec.describe VBADocuments::MultipartParser do
     end
 
     it 'raises on a multipart with non-JSON content' do
-      invalid_doc = get_fixture('invalid_multipart_non_json.blob')
+      invalid_doc = get_fixture('invalid_multipart_non_json.blob').path
       expect { described_class.parse(invalid_doc) }.to raise_error do |error|
         expect(error).to be_a(VBADocuments::UploadError)
         expect(error.code).to eq('DOC101')
@@ -57,7 +57,7 @@ RSpec.describe VBADocuments::MultipartParser do
     end
 
     it 'raises on a multipart with non-PDF content' do
-      invalid_doc = get_fixture('invalid_multipart_non_pdf.blob')
+      invalid_doc = get_fixture('invalid_multipart_non_pdf.blob').path
       expect { described_class.parse(invalid_doc) }.to raise_error do |error|
         expect(error).to be_a(VBADocuments::UploadError)
         expect(error.code).to eq('DOC101')
@@ -66,7 +66,7 @@ RSpec.describe VBADocuments::MultipartParser do
     end
 
     it 'raises on a multipart with a missing content-type header' do
-      invalid_doc = get_fixture('invalid_multipart_no_contenttype.blob')
+      invalid_doc = get_fixture('invalid_multipart_no_contenttype.blob').path
       expect { described_class.parse(invalid_doc) }.to raise_error do |error|
         expect(error).to be_a(VBADocuments::UploadError)
         expect(error.code).to eq('DOC101')
@@ -75,7 +75,7 @@ RSpec.describe VBADocuments::MultipartParser do
     end
 
     it 'raises on a multipart wtih a missing part name header' do
-      invalid_doc = get_fixture('invalid_multipart_no_partname.blob')
+      invalid_doc = get_fixture('invalid_multipart_no_partname.blob').path
       expect { described_class.parse(invalid_doc) }.to raise_error do |error|
         expect(error).to be_a(VBADocuments::UploadError)
         expect(error.code).to eq('DOC101')
@@ -84,7 +84,7 @@ RSpec.describe VBADocuments::MultipartParser do
     end
 
     it 'raises on an empty payload' do
-      empty_doc = get_fixture('emptyfile.blob')
+      empty_doc = get_fixture('emptyfile.blob').path
       expect { described_class.parse(empty_doc) }.to raise_error do |error|
         expect(error).to be_a(VBADocuments::UploadError)
         expect(error.code).to eq('DOC107')
@@ -93,7 +93,7 @@ RSpec.describe VBADocuments::MultipartParser do
     end
 
     it 'handles a base64 payload' do
-      valid_doc = get_fixture('base_64')
+      valid_doc = get_fixture('base_64').path
       result = described_class.parse(valid_doc)
       expect(result.size).to eq(2)
       expect(result).to have_key('metadata')


### PR DESCRIPTION
## Description of change
In production ruby's `sub` was failing due to memory with ~100mb base 64 payloads. Using sed is a bit more memory efficient

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/4016

## Testing done
- prod server + worker server console parsing

## Testing planned
- rerunning payloads once deployed


#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
