### PR TITLE
Ensure that the test environment is not using a real rails log

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,6 +43,8 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  config.logger = Logger.new(nil)
+  config.log_level = :fatal
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,8 +43,11 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  config.logger = Logger.new(nil)
-  config.log_level = :fatal
+  # Speed up specs by not writing logs during RSpec runs
+  unless ENV.fetch("RAILS_ENABLE_TEST_LOG", false)
+    config.logger = Logger.new(nil)
+    config.log_level = :fatal
+  end
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Speed up specs by not writing logs during RSpec runs
-  unless ENV.fetch("RAILS_ENABLE_TEST_LOG", false)
+  unless ENV.fetch('RAILS_ENABLE_TEST_LOG', false)
     config.logger = Logger.new(nil)
     config.log_level = :fatal
   end

--- a/spec/jobs/mhv/account_statistics_job_spec.rb
+++ b/spec/jobs/mhv/account_statistics_job_spec.rb
@@ -4,9 +4,29 @@ require 'rails_helper'
 
 RSpec.describe MHV::AccountStatisticsJob, type: :job do
   describe 'AccountStatisticsJob' do
-    it 'successfully runs the job' do
-      pending
-      expect(MHV::AccountStatisticsJob.new.perform).to eq(true)
+    it 'increments the StatsD.gauge for each statistic' do
+      allow(StatsD).to receive(:gauge)
+
+      MHV::AccountStatisticsJob.new.perform
+
+      expect(StatsD).to have_received(:gauge).with('mhv.account.created_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.existing_premium_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.existing_upgraded_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.existing_failed_upgrade_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.created_premium_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.created_failed_upgrade_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.created_and_upgraded_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.failed_create_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.total_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.active.created_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.active.existing_premium_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.active.existing_upgraded_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.active.existing_failed_upgrade_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.active.created_premium_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.active.created_failed_upgrade_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.active.created_and_upgraded_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.active.failed_create_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge).with('mhv.account.active.total_count', 0).exactly(1).time
     end
   end
 end

--- a/spec/jobs/mhv/account_statistics_job_spec.rb
+++ b/spec/jobs/mhv/account_statistics_job_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe MHV::AccountStatisticsJob, type: :job do
   describe 'AccountStatisticsJob' do
     it 'successfully runs the job' do
+      pending
       expect(MHV::AccountStatisticsJob.new.perform).to eq(true)
     end
   end

--- a/spec/jobs/mhv/account_statistics_job_spec.rb
+++ b/spec/jobs/mhv/account_statistics_job_spec.rb
@@ -9,24 +9,42 @@ RSpec.describe MHV::AccountStatisticsJob, type: :job do
 
       MHV::AccountStatisticsJob.new.perform
 
-      expect(StatsD).to have_received(:gauge).with('mhv.account.created_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.existing_premium_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.existing_upgraded_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.existing_failed_upgrade_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.created_premium_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.created_failed_upgrade_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.created_and_upgraded_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.failed_create_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.total_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.active.created_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.active.existing_premium_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.active.existing_upgraded_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.active.existing_failed_upgrade_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.active.created_premium_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.active.created_failed_upgrade_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.active.created_and_upgraded_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.active.failed_create_count', 0).exactly(1).time
-      expect(StatsD).to have_received(:gauge).with('mhv.account.active.total_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.created_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.existing_premium_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.existing_upgraded_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.existing_failed_upgrade_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.created_premium_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.created_failed_upgrade_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.created_and_upgraded_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.failed_create_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.total_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.active.created_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.active.existing_premium_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.active.existing_upgraded_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.active.existing_failed_upgrade_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.active.created_premium_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.active.created_failed_upgrade_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.active.created_and_upgraded_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.active.failed_create_count', 0).exactly(1).time
+      expect(StatsD).to have_received(:gauge)
+        .with('mhv.account.active.total_count', 0).exactly(1).time
     end
   end
 end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
There are a lot of logs written when running the specs, which are rarely useful. This
takes CPU and diskIO (since we're logging to file in the test environment). Occasionally in local
testing I've seen 

```
[42292:SemanticLogger::Appenders] SemanticLogger::Appenders -- Async: Appender thread has fallen behind by 61431867.117476 seconds with 1 messages queued up. Consider reducing the log level or changing the appenders
```

so I thought I'd try removing logging in the environment.

## Testing done
<!-- Please describe testing done to verify the changes. -->
After 5 test runs, I am no longer receiving that error (almost always received it previously)

Test runs are also now faster

* ~7.25m before
* ~6.25m After

That's ~15% savings in time. I'm verifying that on CI`.

Hat tip to https://jtway.co/speed-up-your-rails-test-suite-by-6-in-1-line-13fedb869ec4

## Testing planned
<!-- Please describe testing planned. -->
Testing time savings on CI

~One test fails, mostly because its testing the wrong thing. Talking to the
author and will likely rewrite that spec to be more accurate.~

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Add an ENV var to toggle back on in rare case its necessary

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)