### PR TITLE
Add optional fields to query Veteran Confirmation

### DIFF
--- a/modules/veteran_confirmation/VETERAN_CONFIRMATION.yml
+++ b/modules/veteran_confirmation/VETERAN_CONFIRMATION.yml
@@ -80,7 +80,6 @@ paths:
       security:
         - apikey: []
       requestBody:
-        description: ''
         required: true
         content:
           application/json:

--- a/modules/veteran_confirmation/VETERAN_CONFIRMATION.yml
+++ b/modules/veteran_confirmation/VETERAN_CONFIRMATION.yml
@@ -29,13 +29,13 @@ info:
     ## Authorization
     This API requires an API key in combination with identifiable information for the person being confirmed listed below. API requests are authorized through a symmetric API token provided in an HTTP header with name `apikey`. Including more information has a better chance of making a match and returning a Confirmed status. 
     #### Required information:
-    * First Name  
-    * Last Name  
-    * Date of Birth  
+    * First Name 
+    * Last Name 
+    * Date of Birth 
     * Social Security Number 
 
     #### Optional information:
-    * Middle Name  
+    * Middle Name
     * Gender
     
     ## Reference
@@ -80,7 +80,7 @@ paths:
       security:
         - apikey: []
       requestBody:
-        description: Optional description in *Markdown*
+        description: ''
         required: true
         content:
           application/json:
@@ -125,8 +125,13 @@ components:
       in: header
   schemas:
     VeteranStatusRequest:
-      description: Attributes required to retrieve a veteran's status
+      description: Attributes required to retrieve a Veteran's status
       type: object
+      required:
+        - ssn
+        - first_name
+        - last_name
+        - birth_date
       properties:
         ssn:
           type: string
@@ -144,6 +149,17 @@ components:
           type: string
           description: Birth date for the person of interest in any valid ISO8601 format
           example: "1965-01-01"
+        middle_name:
+          type: string
+          description: Optional middle name for the person of interest
+          example: "Theodore"
+        gender:
+          type: string
+          description: Optional gender of M or F for the person of interest
+          enum:
+            - M
+            - F
+          example: "M"
     VeteranStatusConfirmation:
       description: |
         Veteran status confirmation for an individual

--- a/modules/veteran_confirmation/app/controllers/veteran_confirmation/v0/veteran_status_controller.rb
+++ b/modules/veteran_confirmation/app/controllers/veteran_confirmation/v0/veteran_status_controller.rb
@@ -47,7 +47,7 @@ module VeteranConfirmation
       end
 
       def validate_gender
-        gender_options = %w(M F m f)
+        gender_options = %w[M F m f]
         no_matching_option = params['gender'] && !gender_options.include?(params['gender'])
 
         raise Common::Exceptions::InvalidFieldValue.new('gender', params['gender']) if no_matching_option

--- a/modules/veteran_confirmation/app/controllers/veteran_confirmation/v0/veteran_status_controller.rb
+++ b/modules/veteran_confirmation/app/controllers/veteran_confirmation/v0/veteran_status_controller.rb
@@ -11,8 +11,10 @@ module VeteranConfirmation
         status = StatusService.new.get_by_attributes(
           ssn: params['ssn'],
           first_name: params['first_name'],
+          middle_name: params['middle_name'],
           last_name: params['last_name'],
-          birth_date: params['birth_date']
+          birth_date: params['birth_date'],
+          gender: params['gender']
         )
 
         render json: { veteran_status: status }
@@ -27,6 +29,7 @@ module VeteranConfirmation
 
         validate_ssn_format
         vali_date
+        validate_gender
       end
 
       def validate_no_query_params
@@ -41,6 +44,13 @@ module VeteranConfirmation
 
       def valid_ssn?(ssn)
         ssn.is_a?(String) && (all_digits?(ssn) || all_digits_with_hyphens?(ssn))
+      end
+
+      def validate_gender
+        gender_options = %w(M F)
+        no_matching_option = params['gender'] && !gender_options.include?(params['gender'])
+
+        raise Common::Exceptions::InvalidFieldValue.new('gender', params['gender']) if no_matching_option
       end
 
       def all_digits?(ssn)

--- a/modules/veteran_confirmation/app/controllers/veteran_confirmation/v0/veteran_status_controller.rb
+++ b/modules/veteran_confirmation/app/controllers/veteran_confirmation/v0/veteran_status_controller.rb
@@ -14,7 +14,7 @@ module VeteranConfirmation
           middle_name: params['middle_name'],
           last_name: params['last_name'],
           birth_date: params['birth_date'],
-          gender: params['gender']
+          gender: params['gender'].upcase
         )
 
         render json: { veteran_status: status }
@@ -47,7 +47,7 @@ module VeteranConfirmation
       end
 
       def validate_gender
-        gender_options = %w(M F)
+        gender_options = %w(M F m f)
         no_matching_option = params['gender'] && !gender_options.include?(params['gender'])
 
         raise Common::Exceptions::InvalidFieldValue.new('gender', params['gender']) if no_matching_option

--- a/modules/veteran_confirmation/spec/requests/veteran_status_request_spec.rb
+++ b/modules/veteran_confirmation/spec/requests/veteran_status_request_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe 'Veteran Status API endpoint', type: :request, skip_emis: true do
     {
       ssn: '123456789',
       first_name: 'Mitchell',
+      middle_name: 'G',
       last_name: 'Jenkins',
-      birth_date: '1967-04-13'
+      birth_date: '1967-04-13',
+      gender: 'M'
     }
   end
 
@@ -90,6 +92,22 @@ RSpec.describe 'Veteran Status API endpoint', type: :request, skip_emis: true do
       expect(response).to have_http_status(:bad_request)
       error_detail = JSON.parse(response.body)['errors'].first['detail']
       expect(error_detail).to eq('"1967sep30th" is not a valid value for "birth_date"')
+    end
+
+    it 'throws an error when gender is invalid' do
+      invalid_gender_attributes = {
+        ssn: '123456789',
+        first_name: 'Mitchell',
+        last_name: 'Jenkins',
+        birth_date: '1967-04-13',
+        gender: 'randomstringhere',
+      }
+
+      post '/services/veteran_confirmation/v0/status', params: invalid_gender_attributes
+
+      expect(response).to have_http_status(:bad_request)
+      error_detail = JSON.parse(response.body)['errors'].first['detail']
+      expect(error_detail).to eq('"randomstringhere" is not a valid value for "gender"')
     end
   end
 end

--- a/modules/veteran_confirmation/spec/requests/veteran_status_request_spec.rb
+++ b/modules/veteran_confirmation/spec/requests/veteran_status_request_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'Veteran Status API endpoint', type: :request, skip_emis: true do
         first_name: 'Mitchell',
         last_name: 'Jenkins',
         birth_date: '1967-04-13',
-        gender: 'randomstringhere',
+        gender: 'randomstringhere'
       }
 
       post '/services/veteran_confirmation/v0/status', params: invalid_gender_attributes


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
This PR addresses [#4047](https://github.com/department-of-veterans-affairs/vets-contrib/issues/4047). 

### Notable changes
- Add two optional fields—`middle_name` and `gender`—to query the Veteran Confirmation `/status` endpoint. Having these optional fields present increases the likelihood of a successful MVI query for a given person of interest. 
- Update documentation to include the optional fields

## Testing done
<!-- Please describe testing done to verify the changes. -->
- Added both fields to the happy path payload for the request spec
- Add tests to validate the incoming gender field to comply with the enum that MVI expects

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] API is updated to allow `Gender` and `Middle Name` as optional parameters
- [x] Add and test validations for new optional params
- [x] API docs are updated on the developer portal to reflect this change

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
