### PR TITLE
Fix issue with upcasing an optional attribute

### DIFF
--- a/modules/veteran_confirmation/app/controllers/veteran_confirmation/v0/veteran_status_controller.rb
+++ b/modules/veteran_confirmation/app/controllers/veteran_confirmation/v0/veteran_status_controller.rb
@@ -47,12 +47,16 @@ module VeteranConfirmation
       end
 
       def validate_gender
+        return if params['gender'].nil?
+
         if params['gender'].is_a? String
           original_attr = params['gender']
           params['gender'] = params['gender'].upcase
           gender_options = %w[M F]
           no_matching_option = !gender_options.include?(params['gender'])
           raise Common::Exceptions::InvalidFieldValue.new('gender', original_attr) if no_matching_option
+        else
+          raise Common::Exceptions::InvalidFieldValue.new('gender', params['gender'])
         end
       end
 

--- a/modules/veteran_confirmation/app/controllers/veteran_confirmation/v0/veteran_status_controller.rb
+++ b/modules/veteran_confirmation/app/controllers/veteran_confirmation/v0/veteran_status_controller.rb
@@ -14,7 +14,7 @@ module VeteranConfirmation
           middle_name: params['middle_name'],
           last_name: params['last_name'],
           birth_date: params['birth_date'],
-          gender: params['gender'].upcase
+          gender: params['gender']
         )
 
         render json: { veteran_status: status }
@@ -47,10 +47,13 @@ module VeteranConfirmation
       end
 
       def validate_gender
-        gender_options = %w[M F m f]
-        no_matching_option = params['gender'] && !gender_options.include?(params['gender'])
-
-        raise Common::Exceptions::InvalidFieldValue.new('gender', params['gender']) if no_matching_option
+        if params['gender'].is_a? String
+          original_attr = params['gender']
+          params['gender'] = params['gender'].upcase
+          gender_options = %w[M F]
+          no_matching_option = !gender_options.include?(params['gender'])
+          raise Common::Exceptions::InvalidFieldValue.new('gender', original_attr) if no_matching_option
+        end
       end
 
       def all_digits?(ssn)

--- a/modules/veteran_confirmation/spec/requests/veteran_status_request_spec.rb
+++ b/modules/veteran_confirmation/spec/requests/veteran_status_request_spec.rb
@@ -15,12 +15,31 @@ RSpec.describe 'Veteran Status API endpoint', type: :request, skip_emis: true do
       gender: 'M'
     }
   end
+  let(:required_valid_attributes) do
+    {
+      ssn: '123456789',
+      first_name: 'Mitchell',
+      last_name: 'Jenkins',
+      birth_date: '1967-04-13'
+    }
+  end
 
   context 'with a valid user' do
     it 'returns confirmed if the veteran status is confirmed' do
       VCR.use_cassette('mvi/find_candidate/valid') do
         VCR.use_cassette('emis/get_veteran_status/valid_icn') do
           post '/services/veteran_confirmation/v0/status', params: valid_attributes
+
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)['veteran_status']).to eq('confirmed')
+        end
+      end
+    end
+
+    it 'can confirm without optional attributes' do
+      VCR.use_cassette('mvi/find_candidate/valid') do
+        VCR.use_cassette('emis/get_veteran_status/valid_icn') do
+          post '/services/veteran_confirmation/v0/status', params: required_valid_attributes
 
           expect(response).to have_http_status(:ok)
           expect(JSON.parse(response.body)['veteran_status']).to eq('confirmed')

--- a/modules/veteran_confirmation/spec/requests/veteran_status_request_spec.rb
+++ b/modules/veteran_confirmation/spec/requests/veteran_status_request_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'Veteran Status API endpoint', type: :request, skip_emis: true do
       expect(error_detail).to eq('"1967sep30th" is not a valid value for "birth_date"')
     end
 
-    it 'throws an error when gender is invalid' do
+    it 'throws an error when gender is an invalid string' do
       invalid_gender_attributes = {
         ssn: '123456789',
         first_name: 'Mitchell',
@@ -127,6 +127,22 @@ RSpec.describe 'Veteran Status API endpoint', type: :request, skip_emis: true do
       expect(response).to have_http_status(:bad_request)
       error_detail = JSON.parse(response.body)['errors'].first['detail']
       expect(error_detail).to eq('"randomstringhere" is not a valid value for "gender"')
+    end
+
+    it 'throws an error when gender is a number' do
+      invalid_gender_attributes = {
+        ssn: '123456789',
+        first_name: 'Mitchell',
+        last_name: 'Jenkins',
+        birth_date: '1967-04-13',
+        gender: 3
+      }
+
+      post '/services/veteran_confirmation/v0/status', params: invalid_gender_attributes
+
+      expect(response).to have_http_status(:bad_request)
+      error_detail = JSON.parse(response.body)['errors'].first['detail']
+      expect(error_detail).to eq('"3" is not a valid value for "gender"')
     end
   end
 end


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
This PR solves [#4065](https://github.com/department-of-veterans-affairs/vets-contrib/issues/4065). It addresses an issue introduced in PR #3787. The intent of the previous PR was to have `gender` be an optional attribute, but the controller validation for that attribute threw an exception because of the upcase method.

## Testing done
<!-- Please describe testing done to verify the changes. -->
- Added an additional spec verifying the happy path without optional attributes

## Testing planned
<!-- Please describe testing planned. -->
- Will verify expected results in DEV after deploy

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] API is updated to allow Gender and Middle Name as optional parameters

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
