### PR TITLE
Migration for the header_md5 that we want to use in searching POA

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "monthly"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_07_144615) do
+ActiveRecord::Schema.define(version: 2020_01_17_193734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -125,6 +125,8 @@ ActiveRecord::Schema.define(version: 2020_01_07_144615) do
     t.integer "vbms_upload_failure_count", default: 0
     t.string "encrypted_source_data"
     t.string "encrypted_source_data_iv"
+    t.string "header_md5"
+    t.index ["header_md5"], name: "index_claims_api_power_of_attorneys_on_header_md5"
   end
 
   create_table "claims_api_supporting_documents", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/modules/claims_api/db/migrate/20200117193734_add_headers_md5.rb
+++ b/modules/claims_api/db/migrate/20200117193734_add_headers_md5.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class AddHeadersMd5 < ActiveRecord::Migration[5.2]
   safety_assured
-  
+
   def change
     add_column :claims_api_power_of_attorneys, :header_md5, :string
     add_index :claims_api_power_of_attorneys, :header_md5

--- a/modules/claims_api/db/migrate/20200117193734_add_headers_md5.rb
+++ b/modules/claims_api/db/migrate/20200117193734_add_headers_md5.rb
@@ -1,0 +1,8 @@
+class AddHeadersMd5 < ActiveRecord::Migration[5.2]
+  safety_assured
+  
+  def change
+    add_column :claims_api_power_of_attorneys, :header_md5, :string
+    add_index :claims_api_power_of_attorneys, :header_md5
+  end
+end


### PR DESCRIPTION
## Description of change
Initial migration for PR https://github.com/department-of-veterans-affairs/vets-api/pull/3786

## Acceptance Criteria (Definition of Done)
- Migrate header_md5 string with index to power of attorney model

### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
