### PR TITLE
Use puma executable to start web application instead of bin/rails

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: bundle exec bin/rails s -b 0.0.0.0 -p 3000
+web: bundle exec puma -p 3000 -C ./config/puma.rb
 job: bundle exec sidekiq -q default -q critical -q tasker
 freshclam: /usr/bin/freshclam -d --config-file=config/freshclam.conf
 clamd: /usr/sbin/clamd -c config/clamd.conf


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
We have been using `bin/rails s` to start the rails server through foreman for quite some time, which is atypical. Typically the puma executable is used to start
the application (https://github.com/puma/puma#frameworks) so that its easier to configure. 

This wasn't a problem until we tried to use clustered mode to better use the capacity of our EC2 instances. Even running with a single worker in clustered mode,
no logfiles would be generated. Our production site experienced HUGE (2x+) memory usage and clear memory leakage that is 100% correlated with running in clustered
mode. Switching back to single mode in puma (PUMA_WORKERS=0) clearly put memory usage back in the normal range and restarted logfile collection. The "no logs"
problem was reproduced on staging and in local development, though no tests were run to check the memory usage.

@nathanruby did some initial work that indicates the issue is related to puma forking the process and handling stdout improperly.

Without digging deeply into the detailed "why" of the issue, the more standard configuration of using `puma` as the web runner in the Procfile definitely fixes the
logging issue. I expect that the memory issue will be fixed as well which will be verified in staging and production

## Testing done
<!-- Please describe testing done to verify the changes. -->
- [x] Verify logs work in development
- [x] Verify memory usage is back to normal in development

## Testing planned
<!-- Please describe testing planned. -->
- [ ] Verify logs work in staging
- [ ] Verify memory usage is back to normal in staging
- [ ] Verify logs work in production
- [ ] Verify memory usage is back to normal in production

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] Memory usage remains ~constant with PUMA_WORKERS=1 in staging and production

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)