### PR TITLE
Revert "Exposing proper EVSS errors when query is made for claim status."

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -7,9 +7,6 @@ require_dependency 'claims_api/concerns/json_format_validation'
 
 module ClaimsApi
   class ApplicationController < ::OpenidApplicationController
-    STATSD_VALIDATION_FAIL_KEY = 'api.claims_api.526.validation_fail'
-    STATSD_VALIDATION_FAIL_TYPE_KEY = 'api.claims_api.526.validation_fail_type'
-
     include ClaimsApi::MviVerification
     include ClaimsApi::HeaderValidation
     include ClaimsApi::JsonFormatValidation
@@ -18,21 +15,6 @@ module ClaimsApi
     before_action :validate_json_format, if: -> { request.post? }
 
     private
-
-    def format_evss_errors(errors)
-      errors.map do |error|
-        { status: 422, detail: "#{error['severity']} #{error['detail'] || error['text']}".squish, source: error['key'] }
-      end
-    end
-
-    def track_evss_validation_errors(errors)
-      StatsD.increment STATSD_VALIDATION_FAIL_KEY
-
-      errors.each do |error|
-        key = error['key'].gsub(/\[(.*?)\]/, '')
-        StatsD.increment STATSD_VALIDATION_FAIL_TYPE_KEY, tags: ["key: #{key}"]
-      end
-    end
 
     def claims_service
       ClaimsApi::UnsynchronizedEVSSClaimService.new(target_veteran)

--- a/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
@@ -2,6 +2,9 @@
 
 module ClaimsApi
   class BaseDisabilityCompensationController < ClaimsApi::BaseFormController
+    STATSD_VALIDATION_FAIL_KEY = 'api.claims_api.526.validation_fail'
+    STATSD_VALIDATION_FAIL_TYPE_KEY = 'api.claims_api.526.validation_fail_type'
+
     def upload_form_526
       pending_claim = ClaimsApi::AutoEstablishedClaim.pending?(params[:id])
       pending_claim.set_file_data!(documents.first, params[:doc_type])
@@ -22,8 +25,8 @@ module ClaimsApi
       service.validate_form526(auto_claim.to_internal)
       render json: valid_526_response
     rescue EVSS::ErrorMiddleware::EVSSError => e
-      track_evss_validation_errors(e.details)
-      render json: { errors: format_evss_errors(e.details) }, status: :unprocessable_entity
+      track_526_validation_errors(e.details)
+      render json: { errors: format_526_errors(e.details) }, status: :unprocessable_entity
     end
 
     private
@@ -37,6 +40,21 @@ module ClaimsApi
           }
         }
       }.to_json
+    end
+
+    def format_526_errors(errors)
+      errors.map do |error|
+        { status: 422, detail: "#{error['key']} #{error['detail']}", source: error['key'] }
+      end
+    end
+
+    def track_526_validation_errors(errors)
+      StatsD.increment STATSD_VALIDATION_FAIL_KEY
+
+      errors.each do |error|
+        key = error['key'].gsub(/\[(.*?)\]/, '')
+        StatsD.increment STATSD_VALIDATION_FAIL_TYPE_KEY, tags: ["key: #{key}"]
+      end
     end
 
     def service(auth_headers)

--- a/modules/claims_api/app/controllers/claims_api/v0/claims_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/claims_controller.rb
@@ -27,7 +27,8 @@ module ClaimsApi
                  serializer: ClaimsApi::AutoEstablishedClaimSerializer
         else
           begin
-            fetch_or_error_local_claim_id
+            evss_claim_id = ClaimsApi::AutoEstablishedClaim.evss_id_by_token(params[:id]) || params[:id]
+            fetch_and_render_evss_claim(evss_claim_id)
           rescue EVSS::ErrorMiddleware::EVSSError
             render json: { errors: [{ detail: 'Claim not found' }] },
                    status: :not_found
@@ -37,15 +38,9 @@ module ClaimsApi
 
       private
 
-      def fetch_or_error_local_claim_id
-        claim = ClaimsApi::AutoEstablishedClaim.find_by(id: params[:id])
-        if claim && claim.status == 'errored' && claim.evss_response.any?
-          render json: { errors: format_evss_errors(claim.evss_response['messages']) },
-                 status: :unprocessable_entity
-        else
-          claim = claims_service.update_from_remote(claim.try(:evss_id) || params[:id])
-          render json: claim, serializer: ClaimsApi::ClaimDetailSerializer
-        end
+      def fetch_and_render_evss_claim(id)
+        claim = claims_service.update_from_remote(id)
+        render json: claim, serializer: ClaimsApi::ClaimDetailSerializer
       end
     end
   end

--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -33,8 +33,8 @@ module ClaimsApi
 
           render json: auto_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
         rescue EVSS::ErrorMiddleware::EVSSError => e
-          track_evss_validation_errors(e.details)
-          render json: { errors: format_evss_errors(e.details) }, status: :unprocessable_entity
+          track_526_validation_errors(e.details)
+          render json: { errors: format_errors(e.details) }, status: :unprocessable_entity
         end
 
         def upload_supporting_documents

--- a/modules/claims_api/app/controllers/claims_api/v1/claims_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/claims_controller.rb
@@ -29,7 +29,8 @@ module ClaimsApi
                  serializer: ClaimsApi::AutoEstablishedClaimSerializer
         else
           begin
-            fetch_or_error_local_claim_id
+            evss_claim_id = ClaimsApi::AutoEstablishedClaim.evss_id_by_token(params[:id]) || params[:id]
+            fetch_and_render_evss_claim(evss_claim_id)
           rescue EVSS::ErrorMiddleware::EVSSError
             render json: { errors: [{ detail: 'Claim not found' }] },
                    status: :not_found
@@ -39,15 +40,9 @@ module ClaimsApi
 
       private
 
-      def fetch_or_error_local_claim_id
-        claim = ClaimsApi::AutoEstablishedClaim.find_by(id: params[:id])
-        if claim && claim.status == 'errored' && claim.evss_response.any?
-          render json: { errors: format_evss_errors(claim.evss_response['messages']) },
-                 status: :unprocessable_entity
-        else
-          claim = claims_service.update_from_remote(claim.try(:evss_id) || params[:id])
-          render json: claim, serializer: ClaimsApi::ClaimDetailSerializer
-        end
+      def fetch_and_render_evss_claim(id)
+        claim = claims_service.update_from_remote(id)
+        render json: claim, serializer: ClaimsApi::ClaimDetailSerializer
       end
     end
   end

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -36,8 +36,8 @@ module ClaimsApi
 
           render json: auto_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
         rescue EVSS::ErrorMiddleware::EVSSError => e
-          track_evss_validation_errors(e.details)
-          render json: { errors: format_evss_errors(e.details) }, status: :unprocessable_entity
+          track_526_validation_errors(e.details)
+          render json: { errors: format_errors(e.details) }, status: :unprocessable_entity
         end
 
         def upload_supporting_documents

--- a/modules/claims_api/spec/requests/v0/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/claims_request_spec.rb
@@ -70,34 +70,11 @@ RSpec.describe 'EVSS Claims management', type: :request do
         expect(response).to match_response_schema('claims_api/claim')
       end
     end
-
     context 'with errors' do
       it '404s' do
         VCR.use_cassette('evss/claims/claim_with_errors') do
           get '/services/claims/v0/claims/123123131', params: nil, headers: request_headers
           expect(response.status).to eq(404)
-        end
-      end
-
-      it 'shows a single Claim through auto established claims with a error', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
-        create(:auto_established_claim,
-               auth_headers: { some: 'data' },
-               evss_id: 600_118_851,
-               id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9',
-               status: 'errored',
-               evss_response: { 'messages' => [{ 'key' => 'Error', 'severity' => 'FATAL', 'text' => 'Failed' }] })
-        VCR.use_cassette('evss/claims/claim') do
-          get(
-            '/services/claims/v0/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
-            params: nil,
-            headers: {
-              'X-VA-SSN' => '796043735', 'X-VA-First-Name' => 'WESLEY',
-              'X-VA-Last-Name' => 'FORD', 'X-VA-EDIPI' => '1007697216',
-              'X-Consumer-Username' => 'TestConsumer', 'X-VA-User' => 'adhoc.test.user',
-              'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-VA-LOA' => '3'
-            }
-          )
-          expect(response.status).to eq(422)
         end
       end
     end

--- a/modules/claims_api/spec/requests/v1/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/claims_request_spec.rb
@@ -68,37 +68,12 @@ RSpec.describe 'EVSS Claims management', type: :request do
         end
       end
     end
-
     context 'with errors' do
       it '404s' do
         with_okta_user(scopes) do |auth_header|
           VCR.use_cassette('evss/claims/claim_with_errors') do
             get '/services/claims/v1/claims/123123131', params: nil, headers: request_headers.merge(auth_header)
             expect(response.status).to eq(404)
-          end
-        end
-      end
-
-      it 'shows a single Claim through auto established claims with a error', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
-        with_okta_user(scopes) do |auth_header|
-          create(:auto_established_claim,
-                 auth_headers: auth_header,
-                 evss_id: 600_118_851,
-                 id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9',
-                 status: 'errored',
-                 evss_response: { 'messages' => [{ 'key' => 'Error', 'severity' => 'FATAL', 'text' => 'Failed' }] })
-          VCR.use_cassette('evss/claims/claim') do
-            get(
-              '/services/claims/v0/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
-              params: nil,
-              headers: {
-                'X-VA-SSN' => '796043735', 'X-VA-First-Name' => 'WESLEY',
-                'X-VA-Last-Name' => 'FORD', 'X-VA-EDIPI' => '1007697216',
-                'X-Consumer-Username' => 'TestConsumer', 'X-VA-User' => 'adhoc.test.user',
-                'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-VA-LOA' => '3'
-              }
-            )
-            expect(response.status).to eq(422)
           end
         end
       end


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#3760

Talking to Tim they haven't been able to successfully test this in staging so we are going to revert for now before it makes it into production.