### PR TITLE
Increase read timeout to 60 seconds for problem endpoints

### DIFF
--- a/modules/vaos/app/services/vaos/appointment_service.rb
+++ b/modules/vaos/app/services/vaos/appointment_service.rb
@@ -6,7 +6,7 @@ module VAOS
       params = date_params(start_date, end_date).merge(page_params(pagination_params)).merge(other_params).compact
 
       with_monitoring do
-        response = perform(:get, get_appointments_base_url(type), params, headers, timeout: 60)
+        response = perform(:get, get_appointments_base_url(type), params, headers, timeout: 55)
         {
           data: deserialized_appointments(response.body, type),
           meta: pagination(pagination_params)

--- a/modules/vaos/app/services/vaos/appointment_service.rb
+++ b/modules/vaos/app/services/vaos/appointment_service.rb
@@ -6,7 +6,7 @@ module VAOS
       params = date_params(start_date, end_date).merge(page_params(pagination_params)).merge(other_params).compact
 
       with_monitoring do
-        response = perform(:get, get_appointments_base_url(type), params, headers)
+        response = perform(:get, get_appointments_base_url(type), params, headers, timeout: 60)
         {
           data: deserialized_appointments(response.body, type),
           meta: pagination(pagination_params)

--- a/modules/vaos/app/services/vaos/systems_service.rb
+++ b/modules/vaos/app/services/vaos/systems_service.rb
@@ -44,7 +44,7 @@ module VAOS
           'clinical-service' => type_of_care_id,
           'institution-code' => system_id
         }
-        response = perform(:get, url, url_params, headers)
+        response = perform(:get, url, url_params, headers, timeout: 60)
         response.body.map { |clinic| OpenStruct.new(clinic) }
       end
     end
@@ -84,7 +84,7 @@ module VAOS
       with_monitoring do
         url = "/var/VeteranAppointmentRequestService/v4/rest/direct-scheduling/site/#{system_id}" \
                 "/patient/ICN/#{@user.icn}/pact-team"
-        response = perform(:get, url, nil, headers)
+        response = perform(:get, url, nil, headers, timeout: 60)
         response.body.map { |pact| OpenStruct.new(pact) }
       end
     end

--- a/modules/vaos/app/services/vaos/systems_service.rb
+++ b/modules/vaos/app/services/vaos/systems_service.rb
@@ -44,7 +44,7 @@ module VAOS
           'clinical-service' => type_of_care_id,
           'institution-code' => system_id
         }
-        response = perform(:get, url, url_params, headers, timeout: 60)
+        response = perform(:get, url, url_params, headers, timeout: 55)
         response.body.map { |clinic| OpenStruct.new(clinic) }
       end
     end
@@ -84,7 +84,7 @@ module VAOS
       with_monitoring do
         url = "/var/VeteranAppointmentRequestService/v4/rest/direct-scheduling/site/#{system_id}" \
                 "/patient/ICN/#{@user.icn}/pact-team"
-        response = perform(:get, url, nil, headers, timeout: 60)
+        response = perform(:get, url, nil, headers, timeout: 55)
         response.body.map { |pact| OpenStruct.new(pact) }
       end
     end


### PR DESCRIPTION
## Description of change
During UAT it was identified that certain endpoints related to direct scheduling do not return a response in under 45 seconds. This change is to increase the timeout to ~60~ 55 seconds for these three endpoints. This will ensure that breakers does not cause a disruption across all of the other services as well. 

VAOS shared services team is actively looking at improving the latency upstream. This is just a temporary fix for UAT. We will not want to go live with these changes.

## Testing done
None

## Testing planned
Verify in staging that it's working.

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
