### PR TITLE
Add index to In progress forms

### DIFF
--- a/db/migrate/20200205145700_add_index_to_in_progress_forms.rb
+++ b/db/migrate/20200205145700_add_index_to_in_progress_forms.rb
@@ -1,0 +1,7 @@
+class AddIndexToInProgressForms < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :in_progress_forms, :user_uuid, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_17_193734) do
+ActiveRecord::Schema.define(version: 2020_02_05_145700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -333,6 +333,7 @@ ActiveRecord::Schema.define(version: 2020_01_17_193734) do
     t.json "metadata"
     t.datetime "expires_at"
     t.index ["form_id", "user_uuid"], name: "index_in_progress_forms_on_form_id_and_user_uuid", unique: true
+    t.index ["user_uuid"], name: "index_in_progress_forms_on_user_uuid"
   end
 
   create_table "invalid_letter_address_edipis", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Description of change
The query that takes the most time (total time) in our db is 
`SELECT "in_progress_forms".* FROM "in_progress_forms" WHERE "in_progress_forms"."user_uuid" = $1`
it averages 5ms but is called frequently. So, we should add an index.
