### PR TITLE
Add vssc_extract_date column to drivetime_bands

### DIFF
--- a/db/migrate/20200203191620_add_vssc_extract_date_to_drivetime_bands.rb
+++ b/db/migrate/20200203191620_add_vssc_extract_date_to_drivetime_bands.rb
@@ -1,0 +1,5 @@
+class AddVsscExtractDateToDrivetimeBands < ActiveRecord::Migration[5.2]
+  def change
+    add_column :drivetime_bands, :vssc_extract_date, :datetime
+  end
+end

--- a/db/migrate/20200205154839_update_vssc_extract_date_value.rb
+++ b/db/migrate/20200205154839_update_vssc_extract_date_value.rb
@@ -1,0 +1,8 @@
+class UpdateVsscExtractDateValue < ActiveRecord::Migration[5.2]
+    def up
+      DrivetimeBand.update_all("vssc_extract_date='2019-10-31 00:00:00'")
+    end
+  
+    def down
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_17_193734) do
+ActiveRecord::Schema.define(version: 2020_02_05_154839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -176,6 +176,7 @@ ActiveRecord::Schema.define(version: 2020_01_17_193734) do
     t.datetime "updated_at", null: false
     t.integer "min"
     t.integer "max"
+    t.datetime "vssc_extract_date"
     t.index ["polygon"], name: "index_drivetime_bands_on_polygon", using: :gist
   end
 


### PR DESCRIPTION
## Description of change
PSSG receives updated drivetime bands from VSSC at the end of each month and has promised to update their polygons by the 15th of the following month. Checking each of the 11,000 drivetime bands' polygons each day to see if they should be updated or just updating all polygon's everyday would be a slow process. PSSG agreed to expose the date that VSSC extracted the bands in their API so that we can use that date to check when band needs to be updated.

This PR creates a migration to add the new column `vssc_extract_date` is being added to the Postgres table `drivetime_bands`. I have included a second migration to fill in this new field with an estimated date for the original extract date for our current drivetime bands. This will reduce the complexity of the update function. A default value for this column is not useful going forward though as it needs to match the value in the PSSG API.

## Testing done
Ran migrations and verified that the new column exists locally and is filled in.

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

- [x] New column `vssc_extract_date` exists
- [x] New column `vssc_extract_date` has value of `10/31/2019 00:00:00`

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
