### PR TITLE
va.gov-team#2628: Tune sidekiq to only kick off 16 threads concurrently

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,2 @@
+---
+:concurrency: 16


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

Currently our sidekiq threads are ramping up to 25. We only allow 16 connections to a DB, so this could solve a problem. This change sets sidekiq to only allow up to 16. The default in v4 of sidekiq is 20 and in v5 was changed to 10. The current version is v6, so we are 2 major versions behind. Maybe it's time for an upgrade?

There is currently no metrics for sidekiq being tracked, and may need to be addressed in another issue. (SEE: https://github.com/mperham/sidekiq/wiki/Pro-Metrics)

SEE: https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/2628

## Testing done
<!-- Please describe testing done to verify the changes. -->
```
make up
docker exec -it 2cbfa98e7861 /bin/bash
ps aux | grep sidekiq

vets-api@2cbfa98e7861:~/src$ ps aux | grep sidekiq
vets-api    12  4.0 15.1 2153168 307676 pts/0  Sl+  20:19   0:23 sidekiq 4.2.10 src [0 of 16 busy]
vets-api   114  0.0  0.0  11112   968 pts/1    S+   20:29   0:00 grep sidekiq
```

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
