### PR TITLE
reduce puma threads in review instances a bit

### DIFF
--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -42,7 +42,7 @@ services:
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
-      PUMA_THREADS: "${PUMA_THREADS}:-4"
+      PUMA_THREADS: "${PUMA_THREADS:-4}"
     depends_on:
       - postgres
       - redis

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -42,6 +42,7 @@ services:
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
+      PUMA_THREADS: "${PUMA_THREADS}:-4"
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
Lowers the puma threads in review instances by default to 4. I just wanted to lower memory usage on these smaller instances and they shouldn't see much traffic. Does not affect production or any other environment besides review.

Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/4617

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->
- [x] ensure thread count is lowered in review instances

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->

#### Applies to all PRs

- [x] Appropriate logging - NA
- [x] Swagger docs have been updated, if applicable - NA
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable) - review instances wouldn't provision if this was a problem
