### PR TITLE
Veteran Verification API Public Keys Endpoint

### DIFF
--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/keys_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/keys_controller.rb
@@ -18,10 +18,11 @@ module VeteranVerification
           keys: [
             {
               kty: 'RSA',
-              use: 'sig',
               alg: 'RS256',
               kid: NOTARY.kid,
-              pem: Base64.urlsafe_encode64(NOTARY.public_key.to_pem)
+              pem: NOTARY.public_key.to_pem,
+              e: Base64.urlsafe_encode64(NOTARY.public_key.e.to_s(2)),
+              n: Base64.urlsafe_encode64(NOTARY.public_key.n.to_s(2))
             }
           ]
         }

--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/keys_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/keys_controller.rb
@@ -5,9 +5,11 @@ require_dependency 'notary'
 
 module VeteranVerification
   module V0
-    # KeysController returns a set of public keys as Base64URL encoded PEMs
+    # KeysController returns a JSON Web Key Set (JWKS) of public keys
     # that can be matched based on the kid (key id) and used to verify
     # payloads signed by the same Notary in other endpoints.
+    # In addition to the fields required for a JSON Web Key (JWK),
+    # a PEM-encoded key is included for ease of use.
     class KeysController < ApplicationController
       skip_before_action(:authenticate)
 

--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/keys_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/keys_controller.rb
@@ -14,8 +14,8 @@ module VeteranVerification
       NOTARY = VeteranVerification::Notary.new(Settings.vet_verification.key_path)
 
       def index
-        render json: { 
-          keys: [ 
+        render json: {
+          keys: [
             {
               kty: 'RSA',
               use: 'sig',
@@ -23,7 +23,7 @@ module VeteranVerification
               kid: NOTARY.kid,
               pem: Base64.urlsafe_encode64(NOTARY.public_key.to_pem)
             }
-          ] 
+          ]
         }
       end
     end

--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/keys_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/keys_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'base64'
+require_dependency 'notary'
+
+module VeteranVerification
+  module V0
+    # KeysController returns a set of public keys as Base64URL encoded PEMs
+    # that can be matched based on the kid (key id) and used to verify
+    # payloads signed by the same Notary in other endpoints.
+    class KeysController < ApplicationController
+      skip_before_action(:authenticate)
+
+      NOTARY = VeteranVerification::Notary.new(Settings.vet_verification.key_path)
+
+      def index
+        render json: { 
+          keys: [ 
+            {
+              kty: 'RSA',
+              use: 'sig',
+              alg: 'RS256',
+              kid: NOTARY.kid,
+              pem: Base64.urlsafe_encode64(NOTARY.public_key.to_pem)
+            }
+          ] 
+        }
+      end
+    end
+  end
+end

--- a/modules/veteran_verification/config/routes.rb
+++ b/modules/veteran_verification/config/routes.rb
@@ -6,6 +6,7 @@ VeteranVerification::Engine.routes.draw do
   namespace :v0 do
     resources :service_history, only: [:index]
     resources :disability_rating, only: [:index]
+    resources :keys, only: [:index]
     get 'status', to: 'veteran_status#index'
   end
 

--- a/modules/veteran_verification/spec/requests/keys_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/keys_request_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe 'Keys endpoint', type: :request do
 
     body = JSON.parse(response.body)
     pem = Base64.urlsafe_decode64(body['keys'].first['pem'])
-    
+
     expect(pem).to eq(original_keypair.public_key.to_pem)
   end
 end
-

--- a/modules/veteran_verification/spec/requests/keys_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/keys_request_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Keys endpoint', type: :request do
+  include SchemaMatchers
+
+  it 'returns an array of keys' do
+    get '/services/veteran_verification/v0/keys'
+
+    expect(response).to have_http_status(:ok)
+    expect(response).to match_response_schema('veteran_verification/keys')
+  end
+
+  it 'the pem field is a valid base64url encoded public key' do
+    original_pem = File.read(Settings.vet_verification.key_path)
+    original_keypair = OpenSSL::PKey::RSA.new(original_pem)
+
+    get '/services/veteran_verification/v0/keys'
+
+    body = JSON.parse(response.body)
+    pem = Base64.urlsafe_decode64(body['keys'].first['pem'])
+    
+    expect(pem).to eq(original_keypair.public_key.to_pem)
+  end
+end
+

--- a/spec/support/schemas/veteran_verification/keys.json
+++ b/spec/support/schemas/veteran_verification/keys.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "keys": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "kty": { 
+            "type": "string"
+          },
+          "use": { 
+            "type": "string"
+          },
+          "alg": { 
+            "type": "string"
+          },
+          "kid": { 
+            "type": "string"
+          },
+          "pem": { 
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas/veteran_verification/keys.json
+++ b/spec/support/schemas/veteran_verification/keys.json
@@ -10,9 +10,6 @@
           "kty": { 
             "type": "string"
           },
-          "use": { 
-            "type": "string"
-          },
           "alg": { 
             "type": "string"
           },
@@ -20,6 +17,12 @@
             "type": "string"
           },
           "pem": { 
+            "type": "string"
+          },
+          "e": { 
+            "type": "string"
+          },
+          "n": { 
             "type": "string"
           }
         }


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->
This PR supports [#3119](https://github.com/department-of-veterans-affairs/vets-contrib/issues/3119). It adds to functionality in PR #3858, which adds a service to sign Veteran Verification API responses with a JWS. This PR adds an endpoint to deliver public keys that can be used to verify those signatures.

#### Notable changes
- Adds a KeysController with one endpoint, which returns an array of keys. Each key contains information about the algorithm used, a `kid` (key id) to link it back to the JWTs that the corresponding private key signed, and a Base64URL encoded pem of the public key.

## Testing done
<!-- Please describe testing done to verify the changes. -->
- Adds specs to verify the `pem` field matches for a given public key and for the overall response schema

## Testing planned
<!-- Please describe testing planned. -->
- Verify in lower environments

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] Add endpoint to retrieve public keys that can verify a previously retrieved signed Veteran Verification response.

#### Applies to all PRs
- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
