### PR TITLE
Remove faker medical

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,8 +130,6 @@ end
 group :test do
   gem 'apivore', git: 'https://github.com/department-of-veterans-affairs/apivore', branch: 'master'
   gem 'awrence'
-  gem 'faker'
-  gem 'faker-medical'
   gem 'fakeredis'
   gem 'pdf-inspector'
   gem 'rspec-retry'
@@ -146,6 +144,7 @@ group :test do
   gem 'webrick'
 end
 
+# rubocop:disable Metrics/BlockLength
 group :development, :test do
   gem 'awesome_print', '~> 1.8' # Pretty print your Ruby objects in full color and with proper indentation
   gem 'brakeman', '~> 4.7'
@@ -154,6 +153,7 @@ group :development, :test do
   gem 'danger'
   gem 'database_cleaner'
   gem 'factory_bot_rails', '> 5'
+  gem 'faker'
   # CAUTION: faraday_curl may not provide all headers used in the actual faraday request. Be cautious if using this to
   # assist with debugging production issues (https://github.com/department-of-veterans-affairs/vets.gov-team/pull/6262)
   gem 'faraday_curl'
@@ -175,6 +175,7 @@ group :development, :test do
   gem 'webmock'
   gem 'yard'
 end
+# rubocop:enable Metrics/BlockLength
 
 # sidekiq enterprise requires a license key to download. In many cases, basic sidekiq is enough for local development
 if (Bundler::Settings.new(Bundler.app_config_path)['enterprise.contribsys.com'].nil? ||

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,8 +354,6 @@ GEM
       railties (>= 5.0.0)
     faker (2.13.0)
       i18n (>= 1.6, < 2)
-    faker-medical (0.5.2)
-      faker
     fakeredis (0.8.0)
       redis (~> 4.1)
     faraday (0.17.0)
@@ -828,7 +826,6 @@ DEPENDENCIES
   dry-types
   factory_bot_rails (> 5)
   faker
-  faker-medical
   fakeredis
   faraday
   faraday_curl

--- a/modules/vaos/spec/request/v1/patient_request_spec.rb
+++ b/modules/vaos/spec/request/v1/patient_request_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'faker/medical'
 
 RSpec.describe 'VAOS::V1::Patient', type: :request do
   include SchemaMatchers

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -40,9 +40,9 @@ FactoryBot.define do
     given_names { Array.new(2) { Faker::Name.first_name } }
     family_name { Faker::Name.last_name }
     suffix { Faker::Name.suffix }
-    gender { Faker::Medical::Patient.gender }
+    gender { %w[M F].sample }
     birth_date { Faker::Date.between(from: 80.years.ago, to: 30.years.ago).strftime('%Y%m%d') }
-    ssn { Faker::Medical::SSN.ssn.delete('-') }
+    ssn { Faker::IDNumber.valid.delete('-') }
     address { build(:mvi_profile_address) }
     home_phone { Faker::PhoneNumber.phone_number }
     full_mvi_ids {


### PR DESCRIPTION
## Description of change
Removed faker/medical, as it's barely used and an unneeded additional dependency. Moved Faker into development and test group instead of just test group. The reason being that its very handy to use FactoryBot to setup a user in development console and many of our factories depend on Faker.

## Testing done
Specs

## Testing planned
None

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [c] Provide which alerts would indicate a problem with this functionality (if applicable)
