### PR TITLE
cc_urgent_care needs to get posCode 17 and 20

### DIFF
--- a/app/controllers/v0/facilities/ccp_controller.rb
+++ b/app/controllers/v0/facilities/ccp_controller.rb
@@ -11,10 +11,8 @@ class V0::Facilities::CcpController < FacilitiesController
                       provider_search
                     when 'cc_pharmacy'
                       provider_search('services' => ['3336C0003X'])
-                    when 'cc_walkin'
-                      api.pos_locator(search_params, '17')
                     when 'cc_urgent_care'
-                      api.pos_locator(search_params, '20')
+                      api.pos_locator(search_params)
                     end
 
     start_ind = (page - 1) * BaseFacility.per_page

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -20,6 +20,11 @@ class Provider < Common::Base
   attribute :Latitude, Float
   attribute :Longitude, Float
   attribute :Miles, Float
+  attribute :posCodes, String
+
+  def <=>(other)
+    self.Miles <=> other.Miles
+  end
 
   def self.from_provloc(prov_loc)
     provider = Provider.new(prov_loc)

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -2,6 +2,7 @@
 
 class ProviderSerializer < ActiveModel::Serializer
   type 'cc_provider'
+
   def id
     "ccp_#{object.ProviderIdentifier}"
   end
@@ -39,6 +40,10 @@ class ProviderSerializer < ActiveModel::Serializer
     object.MainPhone
   end
 
+  def pos_codes
+    object.posCodes
+  end
+
   def caresite_phone
     object.CareSitePhoneNumber
   end
@@ -66,6 +71,18 @@ class ProviderSerializer < ActiveModel::Serializer
     end
   end
 
-  attributes :unique_id, :name, :address, :email, :phone, :fax, :lat, :long,
-             :pref_contact, :acc_new_patients, :gender, :specialty, :caresite_phone
+  attributes  :acc_new_patients,
+              :address,
+              :caresite_phone,
+              :email,
+              :fax,
+              :gender,
+              :lat,
+              :long,
+              :name,
+              :phone,
+              :pos_codes,
+              :pref_contact,
+              :specialty,
+              :unique_id
 end

--- a/lib/facilities/ppms/client.rb
+++ b/lib/facilities/ppms/client.rb
@@ -40,8 +40,7 @@ module Facilities
             provider.posCodes = request_params[:posCodes]
           end
           new_array.concat(providers)
-          new_array.sort!
-        end
+        end.sort!
       end
 
       # https://dev.dws.ppms.va.gov/swagger/ui/index#!/Providers/Providers_Get_0

--- a/lib/facilities/ppms/client.rb
+++ b/lib/facilities/ppms/client.rb
@@ -22,12 +22,26 @@ module Facilities
         Facilities::PPMS::Response.from_provider_locator(response, params)
       end
 
-      def pos_locator(params, pos_code)
-        qparams = pos_locator_params(params, pos_code)
-        response = perform(:get, 'v1.0/PlaceOfServiceLocator', qparams)
-        return [] if response.body.nil?
+      def pos_locator(params)
+        walkin_params = pos_locator_params(params, 17)
+        urgent_care_params = pos_locator_params(params, 20)
 
-        Facilities::PPMS::Response.from_provider_locator(response, params)
+        walkin_response = perform(:get, 'v1.0/PlaceOfServiceLocator', walkin_params)
+        urgent_care_response = perform(:get, 'v1.0/PlaceOfServiceLocator', urgent_care_params)
+
+        [
+          [walkin_params, walkin_response],
+          [urgent_care_params, urgent_care_response]
+        ].each_with_object([]) do |(request_params, response), new_array|
+          next if response.body.blank?
+
+          providers = Facilities::PPMS::Response.from_provider_locator(response, request_params)
+          providers.each do |provider|
+            provider.posCodes = request_params[:posCodes]
+          end
+          new_array.concat(providers)
+          new_array.sort!
+        end
       end
 
       # https://dev.dws.ppms.va.gov/swagger/ui/index#!/Providers/Providers_Get_0

--- a/lib/facilities/ppms/response.rb
+++ b/lib/facilities/ppms/response.rb
@@ -14,10 +14,12 @@ module Facilities
       end
 
       def self.from_provider_locator(response, params)
-        bbox_num = params[:bbox].map { |x| Float(x) }
-        response.body.select! do |provider|
-          provider['Latitude'] > bbox_num[1] && provider['Latitude'] < bbox_num[3] &&
-            provider['Longitude'] > bbox_num[0] && provider['Longitude'] < bbox_num[2]
+        if params[:bbox]
+          bbox_num = params[:bbox].map { |x| Float(x) }
+          response.body.select! do |provider|
+            provider['Latitude'] > bbox_num[1] && provider['Latitude'] < bbox_num[3] &&
+              provider['Longitude'] > bbox_num[0] && provider['Longitude'] < bbox_num[2]
+          end
         end
 
         response_body = map_provider_list(response.body)

--- a/spec/lib/facilities/ppms/client_spec.rb
+++ b/spec/lib/facilities/ppms/client_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Facilities::PPMS::Client do
   describe '#pos_locator' do
     it 'finds places of service' do
       VCR.use_cassette('facilities/va/ppms', match_requests_on: %i[path query]) do
-        r = Facilities::PPMS::Client.new.pos_locator(params, '17')
-        expect(r.length).to be 5
+        r = Facilities::PPMS::Client.new.pos_locator(params)
+        expect(r.length).to be 10
         expect(r[0]).to have_attributes(
           ProviderIdentifier: '1629245311',
           Name: 'MinuteClinic LLC',
@@ -84,7 +84,8 @@ RSpec.describe Facilities::PPMS::Client do
           ProviderSpecialties: [],
           Latitude: 33.275526,
           Longitude: -111.877057,
-          Miles: 0.79
+          Miles: 0.79,
+          posCodes: '17'
         )
       end
     end

--- a/spec/request/v0/facilities/ccp_request_spec.rb
+++ b/spec/request/v0/facilities/ccp_request_spec.rb
@@ -43,8 +43,9 @@ RSpec.describe 'Community Care Providers', type: :request do
 
         get '/v0/facilities/ccp', params: params.merge('type' => 'cc_provider', 'services' => ['213E00000X'])
         bod = JSON.parse(response.body)
-        expect(response).to be_successful
+
         expect(bod).to include(fake_providers_serializer(provider, provider_details))
+        expect(response).to be_successful
       end
     end
 
@@ -59,39 +60,24 @@ RSpec.describe 'Community Care Providers', type: :request do
 
         get '/v0/facilities/ccp', params: params.merge('type' => 'cc_pharmacy')
         bod = JSON.parse(response.body)
-        expect(response).to be_successful
+
         expect(bod).to include(fake_providers_serializer(provider))
-      end
-    end
-
-    context 'type=cc_walkin' do
-      it 'returns results from the pos_locator' do
-        expect_any_instance_of(Facilities::PPMS::Client).to receive(:pos_locator)
-          .with(strong_params(params.merge(type: 'cc_walkin')), '17')
-          .and_return([provider])
-
-        get '/v0/facilities/ccp', params: params.merge('type' => 'cc_walkin')
-
-        bod = JSON.parse(response.body)
         expect(response).to be_successful
-        expect(bod).to include(fake_providers_serializer(provider))
       end
     end
 
     context 'type=cc_urgent_care' do
       it 'returns results from the pos_locator' do
         expect_any_instance_of(Facilities::PPMS::Client).to receive(:pos_locator)
-          .with(
-            strong_params(params.merge(type: 'cc_urgent_care')),
-            '20'
-          )
+          .with(strong_params(params.merge(type: 'cc_urgent_care')))
           .and_return([provider])
 
         get '/v0/facilities/ccp', params: params.merge('type' => 'cc_urgent_care')
 
         bod = JSON.parse(response.body)
-        expect(response).to be_successful
+
         expect(bod).to include(fake_providers_serializer(provider))
+        expect(response).to be_successful
       end
     end
   end

--- a/spec/support/shared_contexts/facilities_ppms.rb
+++ b/spec/support/shared_contexts/facilities_ppms.rb
@@ -32,6 +32,7 @@ RSpec.shared_context 'Facilities PPMS' do
         'long' => attributes[:Longitude],
         'name' => attributes[:Name],
         'phone' => attributes[:MainPhone],
+        'pos_codes' => attributes[:posCodes],
         'pref_contact' => attributes[:ContactMethod],
         'specialty' => [],
         'unique_id' => attributes[:ProviderIdentifier]

--- a/spec/support/vcr_cassettes/facilities/va/ppms.yml
+++ b/spec/support/vcr_cassettes/facilities/va/ppms.yml
@@ -339,7 +339,7 @@
     recorded_at: Thu, 16 Jan 2020 20:16:23 GMT
   - request:
       method: get
-      uri: https://np.dws.ppms.va.gov/v1.0/PlaceOfServiceLocator?address=85286&driveTime=75&maxResults=5&network=0&posCodes=20&radius=25
+      uri: https://np.dws.ppms.va.gov/v1.0/PlaceOfServiceLocator?address='South%20Gilbert%20Road,%20Chandler,%20Arizona%2085286,%20United%20States'&driveTime=10000&maxResults=21&network=0&posCodes=20&radius=80.50410703808843
       body:
         encoding: US-ASCII
         string: ''


### PR DESCRIPTION
## Description of change

This is a quick change to get posCode 17 and 20

Since we want the backend to combine the results from both pos searches this looked like a quick way to get it done.
This needs more testing around

| Urgent Care | Walk-In | Results                 |
| ----------- | ------- | ----------------------- |
| yes         | yes     | Urgent Care and Walk-in |
| yes         | no      | only Urgent Care        |
| no          | yes     | only Walk-In            |
| no          | no      | Empty Array             |

since the client class is handling the merge the controller just needs to keep doing what its doing.

department-of-veterans-affairs/va.gov-team#5713

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

- [ ] Results should include Community Care (In Network) locations (PPMS Place of Service 17 and 20), differentiated by labels on the cards
- [ ] When Facility type = "Urgent care" and Service type = "Community urgent care providers (in VA’s network)", results should include only Community Care (In Network) locations (PPMS Place of Service 17 and 20)
- [ ] Result list contain a mix of POS=17 and POS= 20 locations (based on geography)
- [ ] Result list is sorted by proximity, closest location listed first 
- [ ] When POS code = 20 for a returned facility, the corresponding card displays Type of Facility: URGENT CARE
- [ ] When POS code = 17 for a returned facility, the corresponding card displays Type of Facility: RETAIL/WALK-IN CARE

All other functionality will be maintained 
 - [ ] When Facility type = "Urgent care" and Service type = "VA urgent care", results  include only VA urgent care facilities from Facilities API and card displays Type of Facility: URGENT CARE
 - [ ] When Facility type = "Community pharmacies (in VA’s network)", only community pharmacies should be returned and cards should display COMMUNITY PHARMACY (IN VA'S NETWORK)

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
