### PR TITLE
Adding valid_pdf boolean to Forms

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -509,7 +509,7 @@ ActiveRecord::Schema.define(version: 2020_02_13_160814) do
     t.string "sha256"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "valid_pdf", null: false
+    t.boolean "valid_pdf", default: false
     t.index ["valid_pdf"], name: "index_va_forms_forms_on_valid_pdf"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_05_154839) do
+ActiveRecord::Schema.define(version: 2020_02_13_160814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -509,6 +509,8 @@ ActiveRecord::Schema.define(version: 2020_02_05_154839) do
     t.string "sha256"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "valid_pdf", null: false
+    t.index ["valid_pdf"], name: "index_va_forms_forms_on_valid_pdf"
   end
 
   create_table "vba_documents_upload_submissions", id: :serial, force: :cascade do |t|

--- a/modules/va_forms/db/migrate/20200213160814_add_pdf_boolean_to_forms_api.rb
+++ b/modules/va_forms/db/migrate/20200213160814_add_pdf_boolean_to_forms_api.rb
@@ -1,0 +1,8 @@
+class AddPdfBooleanToFormsApi < ActiveRecord::Migration[5.2]  
+  safety_assured
+  
+  def change
+    add_column :va_forms_forms, :valid_pdf, :boolean, null: false
+    add_index :va_forms_forms, :valid_pdf
+  end
+end

--- a/modules/va_forms/db/migrate/20200213160814_add_pdf_boolean_to_forms_api.rb
+++ b/modules/va_forms/db/migrate/20200213160814_add_pdf_boolean_to_forms_api.rb
@@ -1,6 +1,8 @@
-class AddPdfBooleanToFormsApi < ActiveRecord::Migration[5.2]  
+# frozen_string_literal: true
+
+class AddPdfBooleanToFormsApi < ActiveRecord::Migration[5.2]
   safety_assured
-  
+
   def change
     add_column :va_forms_forms, :valid_pdf, :boolean, null: false
     add_index :va_forms_forms, :valid_pdf

--- a/modules/va_forms/db/migrate/20200213160814_add_pdf_boolean_to_forms_api.rb
+++ b/modules/va_forms/db/migrate/20200213160814_add_pdf_boolean_to_forms_api.rb
@@ -4,7 +4,7 @@ class AddPdfBooleanToFormsApi < ActiveRecord::Migration[5.2]
   safety_assured
 
   def change
-    add_column :va_forms_forms, :valid_pdf, :boolean, null: false
+    add_column :va_forms_forms, :valid_pdf, :boolean, default: false
     add_index :va_forms_forms, :valid_pdf
   end
 end


### PR DESCRIPTION
## Description of change
First PR for ticket https://github.com/department-of-veterans-affairs/vets-contrib/issues/4172 in attempting to give our API consumers a way to filter by whether pdf's are valid or not.

## Acceptance Criteria (Definition of Done)
- Creating migration to check boolean validity of PDF's

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
