### PR TITLE
Revert "require country_code_iso3 instead of country_name in contact info endpoint (#3911)"

### DIFF
--- a/app/controllers/v0/profile/addresses_controller.rb
+++ b/app/controllers/v0/profile/addresses_controller.rb
@@ -42,6 +42,8 @@ module V0
           :address_pou,
           :address_type,
           :city,
+          :country_name,
+          :country_code_iso2,
           :country_code_iso3,
           :county_code,
           :county_name,

--- a/app/swagger/schemas/vet360/contact_information.rb
+++ b/app/swagger/schemas/vet360/contact_information.rb
@@ -47,7 +47,9 @@ module Swagger
                            enum: ::Vet360::Models::Address::ADDRESS_TYPES,
                            example: ::Vet360::Models::Address::DOMESTIC
                   property :city, type: :string, example: 'Fulton'
-                  property :country_code_iso3, type: %i[string], example: 'USA'
+                  property :country_name, type: :string, example: 'United States of America'
+                  property :country_code_iso2, type: %i[string null], example: 'US'
+                  property :country_code_iso3, type: %i[string null], example: 'USA'
                   property :country_code_fips, type: %i[string null], example: 'US'
                   property :id, type: :integer, example: 123
                   property :international_postal_code, type: %i[string null], example: '54321'
@@ -89,7 +91,9 @@ module Swagger
                            enum: ::Vet360::Models::Address::ADDRESS_TYPES,
                            example: ::Vet360::Models::Address::DOMESTIC
                   property :city, type: :string, example: 'Fulton'
-                  property :country_code_iso3, type: %i[string], example: 'USA'
+                  property :country_name, type: :string, example: 'United States of America'
+                  property :country_code_iso2, type: %i[string null], example: 'US'
+                  property :country_code_iso3, type: %i[string null], example: 'USA'
                   property :country_code_fips, type: %i[string null], example: 'US'
                   property :id, type: :integer, example: 123
                   property :international_postal_code, type: %i[string null], example: '54321'

--- a/lib/vet360/models/address.rb
+++ b/lib/vet360/models/address.rb
@@ -4,6 +4,7 @@ module Vet360
   module Models
     class Address < BaseAddress
       validates(:source_date, presence: true)
+      validates(:country_name, presence: true)
 
       # Converts a decoded JSON response from Vet360 to an instance of the Address model
       # @param body [Hash] the decoded response body from Vet360

--- a/lib/vet360/models/base_address.rb
+++ b/lib/vet360/models/base_address.rb
@@ -92,8 +92,6 @@ module Vet360
         inclusion: { in: ADDRESS_TYPES }
       )
 
-      validates(:country_code_iso3, presence: true)
-
       with_options if: proc { |a| [DOMESTIC, MILITARY].include?(a.address_type) } do
         validates :state_code, presence: true
         validates :zip_code, presence: true

--- a/spec/lib/vet360/contact_information/service_spec.rb
+++ b/spec/lib/vet360/contact_information/service_spec.rb
@@ -132,18 +132,16 @@ describe Vet360::ContactInformation::Service, skip_vet360: true do
     let(:address) { build(:vet360_address, vet360_id: user.vet360_id, source_system_user: user.icn) }
 
     context 'with a validation key' do
-      let(:address) do
-        build(:vet360_address, :override, country_name: nil)
-      end
+      let(:address) { build(:vet360_address, :override) }
 
-      it 'will override the address error', run_at: '2020-02-14T00:19:15.000Z' do
+      it 'will override the address error', run_at: '2019-10-28 18:59:37 -0700' do
         VCR.use_cassette(
           'vet360/contact_information/put_address_override',
           VCR::MATCH_EVERYTHING
         ) do
           response = subject.put_address(address)
           expect(response.status).to eq(200)
-          expect(response.transaction.id).to eq('7f01230f-56e3-4289-97ed-6168d2d23722')
+          expect(response.transaction.id).to eq('1b5b82e7-909d-4ccc-a2db-ad60f1b502cf')
         end
       end
     end

--- a/spec/lib/vet360/models/address_spec.rb
+++ b/spec/lib/vet360/models/address_spec.rb
@@ -47,9 +47,9 @@ describe Vet360::Models::Address do
         expect(address.valid?).to eq(false)
       end
 
-      it 'country_code_iso3 is requred', :aggregate_failures do
+      it 'country_name is requred', :aggregate_failures do
         expect(address.valid?).to eq(true)
-        address.country_code_iso3 = ''
+        address.country_name = ''
         expect(address.valid?).to eq(false)
       end
 

--- a/spec/request/vet360/address_request_spec.rb
+++ b/spec/request/vet360/address_request_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'address', type: :request do
 
       context 'with a validation key' do
         let(:address) { build(:vet360_address, :override) }
-        let(:frozen_time) { Time.zone.parse('2020-02-14T00:19:15.000Z') }
+        let(:frozen_time) { Time.zone.parse('2019-10-28 18:59:37 -0700') }
 
         before do
           allow_any_instance_of(User).to receive(:vet360_id).and_return('1')
@@ -125,7 +125,7 @@ RSpec.describe 'address', type: :request do
             put('/v0/profile/addresses', params: address.to_json, headers: headers)
 
             expect(JSON.parse(response.body)['data']['attributes']['transaction_id']).to eq(
-              '7f01230f-56e3-4289-97ed-6168d2d23722'
+              '1b5b82e7-909d-4ccc-a2db-ad60f1b502cf'
             )
           end
         end
@@ -147,54 +147,48 @@ RSpec.describe 'address', type: :request do
     context 'when effective_end_date is included' do
       let(:address) do
         build(:vet360_address,
+              vet360_id: user.vet360_id,
               effective_end_date: Time.now.utc.iso8601)
+      end
+      let(:id_in_cassette) { 42 }
+
+      before do
+        allow_any_instance_of(User).to receive(:icn).and_return('1234')
+        address.id = id_in_cassette
+        address.address_line1 = '1493 Martin Luther King Rd'
+        address.city = 'Fulton'
+        address.state_code = 'MS'
+        address.zip_code = '38843'
       end
 
       it 'effective_end_date is NOT included in the request body', :aggregate_failures do
-        expect_any_instance_of(Vet360::ContactInformation::Service).to receive(:put_address) do |_, address|
-          expect(address.effective_end_date).to eq(nil)
+        VCR.use_cassette('vet360/contact_information/put_address_ignore_eed', VCR::MATCH_EVERYTHING) do
+          # The cassette we're using does not include the effectiveEndDate in the body.
+          # So this test ensures that it was stripped out
+          put('/v0/profile/addresses', params: address.to_json, headers: headers)
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_response_schema('vet360/transaction_response')
         end
-
-        put('/v0/profile/addresses', params: address.to_json, headers: headers)
       end
     end
   end
 
   describe 'DELETE /v0/profile/addresses' do
+    let(:address) do
+      build(:vet360_address, vet360_id: user.vet360_id)
+    end
+    let(:id_in_cassette) { 42 }
+
+    before do
+      allow_any_instance_of(User).to receive(:icn).and_return('64762895576664260')
+      address.id = id_in_cassette
+      address.address_line1 = '1493 Martin Luther King Rd'
+      address.city = 'Fulton'
+      address.state_code = 'MS'
+      address.zip_code = '38843'
+    end
+
     context 'when the method is DELETE' do
-      let(:frozen_time) { Time.zone.parse('2020-02-13T20:47:45.000Z') }
-      let(:address) do
-        { 'address_line1' => '4041 Victoria Way',
-          'address_line2' => nil,
-          'address_line3' => nil,
-          'address_pou' => 'CORRESPONDENCE',
-          'address_type' => 'DOMESTIC',
-          'city' => 'Lexington',
-          'country_code_iso3' => 'USA',
-          'country_code_fips' => nil,
-          'county_code' => '21067',
-          'county_name' => 'Fayette County',
-          'created_at' => '2019-10-25T17:06:15.000Z',
-          'effective_end_date' => nil,
-          'effective_start_date' => '2020-02-10T17:40:15.000Z',
-          'id' => 138_225,
-          'international_postal_code' => nil,
-          'province' => nil,
-          'source_system_user' => nil,
-          'state_code' => 'KY',
-          'transaction_id' => '537b388e-344a-474e-be12-08d43cf35d69',
-          'updated_at' => '2020-02-10T17:40:25.000Z',
-          'validation_key' => nil,
-          'vet360_id' => '1',
-          'zip_code' => '40515',
-          'zip_code_suffix' => '4655' }
-      end
-
-      before do
-        allow_any_instance_of(User).to receive(:vet360_id).and_return('1')
-        allow_any_instance_of(User).to receive(:icn).and_return('1234')
-      end
-
       it 'effective_end_date gets appended to the request body', :aggregate_failures do
         VCR.use_cassette('vet360/contact_information/delete_address_success', VCR::MATCH_EVERYTHING) do
           # The cassette we're using includes the effectiveEndDate in the body.

--- a/spec/support/vcr_cassettes/vet360/contact_information/put_address_ignore_eed.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/put_address_ignore_eed.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://int.vet360.va.gov/contact-information-hub/cuf/contact-information/v1/addresses
     body:
       encoding: UTF-8
-      string: '{"bio":{"addressId":42,"addressLine1":"1493 Martin Luther King Rd","addressLine2":null,"addressLine3":null,"addressPOU":"RESIDENCE/CHOICE","addressType":"DOMESTIC","cityName":"Fulton","countryCodeISO2":null,"countryCodeISO3":"USA","countryName":"USA","county":{"countyCode":null,"countyName":null},"intPostalCode":null,"provinceName":null,"stateCode":"MS","zipCode5":"38843","zipCode4":null,"originatingSourceSystem":"VETSGOV","sourceSystemUser":"64762895576664260","sourceDate":"2018-06-06T15:35:55.000Z","vet360Id":"123456789","effectiveStartDate":"2018-06-06T15:35:55.000Z","effectiveEndDate":"2018-06-06T15:35:55.000Z"}}'
+      string: '{"bio":{"addressId":42,"addressLine1":"1493 Martin Luther King Rd","addressLine2":null,"addressLine3":null,"addressPOU":"RESIDENCE/CHOICE","addressType":"DOMESTIC","cityName":"Fulton","countryCodeISO2":null,"countryCodeISO3":"USA","countryName":"USA","county":{"countyCode":null,"countyName":null},"intPostalCode":null,"provinceName":null,"stateCode":"MS","zipCode5":"38843","zipCode4":null,"originatingSourceSystem":"VETSGOV","sourceSystemUser":"1234","sourceDate":"2018-06-06T15:35:55.000Z","vet360Id":"123456789","effectiveStartDate":"2018-06-06T15:35:55.000Z","effectiveEndDate":null}}'
     headers:
       Accept:
       - application/json

--- a/spec/support/vcr_cassettes/vet360/contact_information/put_address_override.yml
+++ b/spec/support/vcr_cassettes/vet360/contact_information/put_address_override.yml
@@ -6,7 +6,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"bio":{"addressId":108347,"addressLine1":"1494 Martin Luther King
-        Rd","addressLine2":"c/o foo","addressLine3":null,"addressPOU":"CORRESPONDENCE","addressType":"DOMESTIC","cityName":"Fulton","countryCodeISO2":null,"countryCodeISO3":"USA","countryName":null,"county":{"countyCode":null,"countyName":null},"intPostalCode":null,"provinceName":null,"stateCode":"MS","zipCode5":"38843","zipCode4":null,"originatingSourceSystem":"VETSGOV","sourceSystemUser":"1234","sourceDate":"2020-02-14T00:19:15.000Z","vet360Id":"1","effectiveStartDate":"2020-02-14T00:19:15.000Z","effectiveEndDate":null,"validationKey":713117306,"overrideIndicator":true}}'
+        Rd","addressLine2":"c/o foo","addressLine3":null,"addressPOU":"CORRESPONDENCE","addressType":"DOMESTIC","cityName":"Fulton","countryCodeISO2":null,"countryCodeISO3":"USA","countryName":"USA","county":{"countyCode":null,"countyName":null},"intPostalCode":null,"provinceName":null,"stateCode":"MS","zipCode5":"38843","zipCode4":null,"originatingSourceSystem":"VETSGOV","sourceSystemUser":"1234","sourceDate":"2019-10-29T01:59:37.000Z","vet360Id":"1","effectiveStartDate":"2019-10-29T01:59:37.000Z","effectiveEndDate":null,"validationKey":713117306,"overrideIndicator":true}}'
     headers:
       Accept:
       - application/json
@@ -24,11 +24,11 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 14 Feb 2020 00:19:16 GMT
+      - Fri, 10 Jan 2020 20:54:32 GMT
       Expires:
       - '0'
       Vet360txauditid:
-      - 85e5e00f-e862-48d0-abc2-3961659ed04d
+      - 20883a1a-d3c0-4772-9e85-7a6f140ee442
       X-Frame-Options:
       - DENY
       Pragma:
@@ -45,10 +45,18 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '72'
+      - '832'
     body:
       encoding: UTF-8
-      string: '{"txAuditId":"7f01230f-56e3-4289-97ed-6168d2d23722","status":"RECEIVED"}'
+      string: '{"messages":[{"code":"CORE110","key":"_CUF_SOURCE_DATE_VERSION_VIOLATION","severity":"WARN","text":"Source
+        dates are outdated for Type AddressDio with a ID of 108347.  Previous source
+        date was 2019-12-06 15:22:44.0 but received new source date of Tue Oct 29
+        01:59:37 UTC 2019.  Source dates may not be null, and new must be greater
+        than the previous.  Please correct your request and try again!"},{"code":"CORE104","key":"_CUF_NO_CHANGES_DETECTED","severity":"INFO","text":"Your
+        request was received and processed without error, however no differences were
+        detected between current data and the data you sent.  This message is informational
+        only, please verify your request if you believe you sent actual changes that
+        should be applied."}],"txAuditId":"1b5b82e7-909d-4ccc-a2db-ad60f1b502cf","status":"COMPLETED_NO_CHANGES_DETECTED"}'
     http_version: 
-  recorded_at: Fri, 14 Feb 2020 00:19:15 GMT
+  recorded_at: Tue, 29 Oct 2019 01:59:37 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
This reverts commit 3daa4a729691a602e619466251a996de5907c79a.

The last commit seems to have introduced a breaking change that is preventing users from updating their addresses in the prod environment. Rolling this back as a short term fix.

## Description of change
<!-- Please include a description of the change. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary. This could include dependencies introduced, changes in behavior, pointers to more detailed documentation -->

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)