### PR TITLE
Pv unrevert sec id lookup

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'common/models/concerns/active_record_cache_aside'
+require 'sentry_logging'
 
 # Account's purpose is to correlate unique identifiers, and to
 # remove our dependency on third party services for a user's
@@ -10,12 +11,15 @@ require 'common/models/concerns/active_record_cache_aside'
 #
 class Account < ApplicationRecord
   include Common::ActiveRecordCacheAside
+  extend SentryLogging
 
   has_many :user_preferences, dependent: :destroy
   has_many :notifications, dependent: :destroy
 
   validates :uuid, presence: true, uniqueness: true
-  validates :idme_uuid, presence: true, uniqueness: true
+  validates :idme_uuid, uniqueness: true
+  validates :idme_uuid, presence: true, unless: -> { sec_id.present? }
+  validates :sec_id, presence: true, unless: -> { idme_uuid.present? }
 
   before_validation :initialize_uuid, on: :create
 
@@ -36,18 +40,56 @@ class Account < ApplicationRecord
   # @return [Account] A persisted instance of Account
   #
   def self.cache_or_create_by!(user)
-    return unless user.uuid
+    return unless user.uuid || user.sec_id
 
-    do_cached_with(key: user.uuid) do
+    # if possible use the idme uuid for the key, fallback to using the sec id otherwise
+    key = user.uuid || "sec:#{user.sec_id}"
+    acct = do_cached_with(key: key) do
       create_if_needed!(user)
     end
+    # Account.sec_id was added months after this class was built, thus
+    # the existing Account records (not new ones) need to have their
+    # sec_id value updated
+    update_if_needed!(acct, user)
   end
 
   def self.create_if_needed!(user)
-    find_or_create_by!(idme_uuid: user.uuid) do |account|
-      account.edipi = user&.edipi
-      account.icn   = user&.icn
+    attrs = account_attrs_from_user(user)
+
+    accts = where(idme_uuid: attrs[:idme_uuid])
+            .where.not(idme_uuid: nil)
+            .or(
+              where(sec_id: attrs[:sec_id])
+              .where.not(sec_id: nil)
+            )
+
+    if accts.length > 1
+      data = accts.map(&:attributes)
+      log_message_to_sentry('multiple Account records with matching ids', 'warning', data)
     end
+
+    accts.length.positive? ? accts[0] : create(**attrs)
+  end
+
+  def self.update_if_needed!(account, user)
+    # account has yet to be saved, no need to update
+    return account unless account.persisted?
+
+    # return account as is if all user attributes match up to be the same
+    attrs = account_attrs_from_user(user)
+    return account if attrs.all? { |k, v| account.send(k) == v }
+
+    diff = { account: account.attributes, user: attrs }
+    log_message_to_sentry('Account record does not match User', 'warning', diff)
+    update(account.id, **attrs)
+  end
+
+  # Build an account attribute hash from the given User attributes
+  #
+  # @return [Hash]
+  #
+  def self.account_attrs_from_user(user)
+    { idme_uuid: user.uuid, edipi: user.edipi, icn: user.icn, sec_id: user.sec_id }
   end
 
   # Determines if the associated Account record is cacheable. Required
@@ -58,6 +100,8 @@ class Account < ApplicationRecord
   def cache?
     persisted?
   end
+
+  private_class_method :account_attrs_from_user
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,6 +132,10 @@ class User < Common::RedisStore
     loa3? && dslogon_edipi.present? ? dslogon_edipi : mvi&.edipi
   end
 
+  def sec_id
+    va_profile&.sec_id
+  end
+
   def va_profile
     mvi.profile
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -93,6 +93,24 @@ FactoryBot.define do
       end
     end
 
+    trait :accountable_with_sec_id do
+      authn_context { LOA::IDME_LOA3_VETS }
+      uuid { SecureRandom.uuid }
+      callback(:after_build) do |user|
+        create(:account, sec_id: user.sec_id)
+      end
+
+      sign_in do
+        {
+          service_name: SAML::User::AUTHN_CONTEXTS[authn_context][:sign_in][:service_name]
+        }
+      end
+
+      loa do
+        { current: LOA::THREE, highest: LOA::THREE }
+      end
+    end
+
     trait :loa1 do
       authn_context { LOA::IDME_LOA1_VETS }
       sign_in do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -150,6 +150,17 @@ FactoryBot.define do
       end
     end
 
+    factory :user_with_no_secid, traits: [:loa3] do
+      after(:build) do
+        stub_mvi(
+          build(
+            :mvi_profile,
+            sec_id: nil
+          )
+        )
+      end
+    end
+
     factory :vets360_user, traits: [:loa3] do
       after(:build) do
         stub_mvi(

--- a/spec/lib/common/models/concerns/active_record_cache_aside_spec.rb
+++ b/spec/lib/common/models/concerns/active_record_cache_aside_spec.rb
@@ -16,7 +16,7 @@ describe Common::ActiveRecordCacheAside do
       end
 
       it 'retrieves the db record from the cache' do
-        expect(Marshal).to receive(:load).with(serialized_record)
+        expect(Marshal).to receive(:load).with(serialized_record) { Account.new(idme_uuid: user.uuid) }
 
         Account.cache_or_create_by! user
       end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -24,13 +24,73 @@ RSpec.describe Account, type: :model do
       end.to change(Account, :count).by(1)
     end
 
-    it 'does not create a second Account' do
+    it 'does not create a second Account, matched on idme uuid' do
       user = create(:user, :accountable)
       expect(Account.count).to eq 1
 
       expect do
         Account.create_if_needed!(user)
       end.not_to change(Account, :count)
+    end
+
+    it 'does not create a second Account, matched on sec id' do
+      user = create(:user, :accountable_with_sec_id)
+      expect(Account.count).to eq 1
+
+      expect do
+        Account.create_if_needed!(user)
+      end.not_to change(Account, :count)
+    end
+
+    it 'issues a warning with multiple matching Accounts' do
+      user = create(:user, :accountable)
+      create(:user, :accountable_with_sec_id)
+
+      expect(Account).to receive(:log_message_to_sentry)
+
+      expect do
+        Account.create_if_needed!(user)
+      end.not_to change(Account, :count)
+    end
+  end
+
+  describe '.update_if_needed!' do
+    it 'does not update an Account that has yet to be saved' do
+      expect(Account.count).to eq 0
+
+      user = create(:user, :loa3)
+
+      expect do
+        Account.update_if_needed!(Account.new, user)
+      end.not_to change(Account, :count)
+    end
+
+    it 'does not update the Account, as it hasnt changed' do
+      user = create(:user, :loa3)
+      acct = Account.create_if_needed!(user)
+
+      expect(Account.count).to eq 1
+      expect(Account).not_to receive(:log_message_to_sentry)
+      expect(Account).not_to receive(:update)
+
+      expect do
+        Account.update_if_needed!(acct, user)
+      end.not_to change(Account, :count)
+    end
+
+    it 'does update the Account' do
+      user = create(:user, :accountable)
+      acct = Account.first
+
+      expect(acct.edipi).to eq nil
+      expect(acct.icn).to eq nil
+      expect(acct.sec_id).to eq nil
+
+      acct = Account.update_if_needed!(acct, user)
+
+      expect(acct.edipi).to eq user.edipi
+      expect(acct.icn).to eq user.icn
+      expect(acct.sec_id).to eq user.sec_id
     end
   end
 
@@ -68,7 +128,7 @@ RSpec.describe Account, type: :model do
     let(:user) { build(:user, :loa3) }
 
     it 'first attempts to fetch the Account record from the Redis cache' do
-      expect(Account).to receive(:do_cached_with)
+      expect(Account).to receive(:do_cached_with) { Account.create(idme_uuid: user.uuid) }
 
       Account.cache_or_create_by! user
     end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -140,4 +140,21 @@ RSpec.describe Account, type: :model do
       expect(record.class).to eq Account
     end
   end
+
+  describe 'cache write-through on update' do
+    let(:user) { build(:user_with_no_secid) }
+    let(:new_secid) { '9999999' }
+    let(:user_delta) { build(:user, :loa3) }
+
+    it 'writes updates to database AND cache' do
+      original_acct = Account.cache_or_create_by! user
+      user.mvi.profile.sec_id = new_secid
+      updated_acct = Account.update_if_needed!(original_acct, user_delta)
+      expect(updated_acct.sec_id).to eq new_secid
+
+      # Use do_cached_with to fetch cached model only
+      cached_acct = Account.do_cached_with(key: user.uuid)
+      expect(cached_acct.sec_id).to eq new_secid
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -512,7 +512,7 @@ RSpec.describe User, type: :model do
       end
 
       it 'first attempts to fetch the Account record from the Redis cache' do
-        expect(Account).to receive(:do_cached_with)
+        expect(Account).to receive(:do_cached_with) { Account.create(idme_uuid: user.uuid) }
 
         user.account
       end


### PR DESCRIPTION
## Description of change
Puts back in place the sec_id lookup code in account with two modifications based on observed Sentry behavior:
- Tolerates old cached Account objects with no sec_id accessor, using `try`
- Writes through updates to both redis and the database, previous iteration was not writing back to redis.

## Testing done
Additional test cases

## Testing planned
I will execute login in dev/staging and ensure the observed errors don't re-occur.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
