### PR TITLE
Avoids overwriting account attributes with nil values

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -76,7 +76,7 @@ class Account < ApplicationRecord
     return account unless account.persisted?
 
     # return account as is if all non-nil user attributes match up to be the same
-    attrs = account_attrs_from_user(user).reject { |k, v| v.nil? }
+    attrs = account_attrs_from_user(user).reject { |_k, v| v.nil? }
 
     return account if attrs.all? { |k, v| account.try(k) == v }
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -75,8 +75,9 @@ class Account < ApplicationRecord
     # account has yet to be saved, no need to update
     return account unless account.persisted?
 
-    # return account as is if all user attributes match up to be the same
-    attrs = account_attrs_from_user(user)
+    # return account as is if all non-nil user attributes match up to be the same
+    attrs = account_attrs_from_user(user).reject { |k, v| v.nil? }
+
     return account if attrs.all? { |k, v| account.try(k) == v }
 
     diff = { account: account.attributes, user: attrs }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -156,5 +156,18 @@ RSpec.describe Account, type: :model do
       cached_acct = Account.do_cached_with(key: user.uuid)
       expect(cached_acct.sec_id).to eq new_secid
     end
+
+    it 'does not overwrite populated fields with nil values' do
+      original_acct = Account.cache_or_create_by! user_delta
+      #user.mvi.profile.sec_id = nil
+      updated_acct = Account.update_if_needed!(original_acct, user)
+      expect(updated_acct.sec_id).to be_present
+
+      # Use do_cached_with to fetch cached model only
+      cached_acct = Account.do_cached_with(key: user.uuid)
+      expect(cached_acct.sec_id).to be_present
+
+    end
+
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -159,15 +159,12 @@ RSpec.describe Account, type: :model do
 
     it 'does not overwrite populated fields with nil values' do
       original_acct = Account.cache_or_create_by! user_delta
-      #user.mvi.profile.sec_id = nil
       updated_acct = Account.update_if_needed!(original_acct, user)
       expect(updated_acct.sec_id).to be_present
 
       # Use do_cached_with to fetch cached model only
       cached_acct = Account.do_cached_with(key: user.uuid)
       expect(cached_acct.sec_id).to be_present
-
     end
-
   end
 end


### PR DESCRIPTION
AfterLoginJob/Account update happens on each callback so LOA1
logins should not overwrite previously established data with nil

## Description of change
Noticed in staging Sentry that account update warnings were flapping back and forth for a user between the LOA1/LOA3 logins.

Should not be a major impact because any LOA3-capable logins should wind up in the preferred state with all available data written, but we should avoid the flapping.

## Testing done
Unit testing, 

## Testing planned
Will observe in further in sentry.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
