### PR TITLE
[6413] MDOT Form Profile Mapping Schema Fix

### DIFF
--- a/config/form_profile_mappings/MDOT.yml
+++ b/config/form_profile_mappings/MDOT.yml
@@ -1,4 +1,4 @@
-veteranFullName: [identity_information, full_name]
+fullName: [identity_information, full_name]
 gender: [identity_information, gender]
 veteranAddress: [contact_information, address]
 email: [contact_information, email]

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -446,7 +446,7 @@ RSpec.describe FormProfile, type: :model do
 
   let(:vmdot_expected) do
     {
-      'veteranFullName' => {
+      'fullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.va_profile[:suffix]


### PR DESCRIPTION
## Description of change
Fixes schema mapping by changing `veteranFullName` to what the frontend is expecting: `fullName`

## Testing done
Tested locally

## Testing planned
None

## Acceptance Criteria (Definition of Done)
Schema updated to return full name in the `fullName` hash instead of `veteranFullName`

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
