### PR TITLE
adding a forceAuthn value to the SAML Settings

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -81,6 +81,9 @@ module V1
     private
 
     def saml_settings(options = {})
+      # add a forceAuthn value to the saml settings based on the initial options or
+      # the "force" value in the query params
+      options[:force_authn] = options[:force_authn] || params[:force]&.downcase == 'true'
       SAML::SSOeSettingsService.saml_settings(options)
     end
 


### PR DESCRIPTION
by default this will be set to "false", however if the request has explicitly set the `?force=true` query parameter, then it will be set to true

## Description of change

Adding a `forceAuthn` value to the SAML payload sent to eauth for the v1 sessions controller.  By default this value will be set to "false", however if the request has explicitly set the `?force=true` query parameter, then it will be set to true.

When a user has authenticated with eauth (IAM), before coming to va.gov, there will be cases when that user doesn't have the necessary ID.ME values in their profile.  In order to get those, we need to force eauth to reauthenticate with ID.ME to have those values set.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/5957

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
