### PR TITLE
MDOT Betamocks Config Update

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -2,7 +2,7 @@
 :services:
 
 - :name: 'MDOT'
-  :base_uri: <%= "#{URI(Settings.mdot.url)}" %>
+  :base_uri: <%= "#{URI(Settings.mdot.url).host}:#{URI(Settings.mdot.url).port}" %>
   :endpoints:
   - :method: :get
     :path: "/mdot/supplies"

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -1,6 +1,16 @@
 ---
 :services:
 
+- :name: 'MDOT'
+  :base_uri: <%= "#{URI(Settings.mdot.url)}" %>
+  :endpoints:
+  - :method: :get
+    :path: "/mdot/supplies"
+    :file_path: "mdot/supplies/index"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: 'veteranId'
+
 - :name: 'MHV_Rx'
   :base_uri: <%= "#{URI(Settings.mhv.rx.host).host}:#{URI(Settings.mhv.rx.host).port}" %>
   :endpoints:

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -10,6 +10,12 @@
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: 'veteranId'
+- :method: :post
+    :path: "/mdot/supplies"
+    :file_path: "mdot/supplies/index"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: 'veteranId'
 
 - :name: 'MHV_Rx'
   :base_uri: <%= "#{URI(Settings.mhv.rx.host).host}:#{URI(Settings.mhv.rx.host).port}" %>

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -12,7 +12,7 @@
       :uid_locator: 'veteranId'
 - :method: :post
     :path: "/mdot/supplies"
-    :file_path: "mdot/supplies/index"
+    :file_path: "mdot/supplies/create"
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: 'veteranId'


### PR DESCRIPTION
## Description of change
Adds configuration to allow MDOT endpoints to use betamocks.

Corresponding mocked data PR: [PR](https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/116)

## Testing done
Tested locally with betamocks framework

## Testing planned
None

## Acceptance Criteria (Definition of Done)
Configuration allows betamocks to be utilized with MDOT endpoints

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
