### PR TITLE
fix services_config.yml indent

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -10,7 +10,7 @@
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: 'veteranId'
-- :method: :post
+-   :method: :post
     :path: "/mdot/supplies"
     :file_path: "mdot/supplies/create"
     :cache_multiple_responses:


### PR DESCRIPTION
## Description of change
Was unable to sign in locally while running the APIs in Docker. This seems to fix it. More info in this thread https://dsva.slack.com/archives/CBU0KDSB1/p1583434294018300?thread_ts=1583432397.015700&cid=CBU0KDSB1
## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)