### PR TITLE
invalid Settings.hostname on staging instances causing Bad Requests

### DIFF
--- a/modules/vaos/app/services/vaos/base_service.rb
+++ b/modules/vaos/app/services/vaos/base_service.rb
@@ -27,7 +27,7 @@ module VAOS
     # Set the referrer (Referer header) to distinguish review instance, staging, etc from logs
     def referrer
       if Settings.hostname.ends_with?('.gov')
-        "https://#{Settings.hostname}"
+        "https://#{Settings.hostname}".gsub('vets', 'va')
       else
         'https://review-instance.va.gov' # VAMF rejects Referer that is not valid; such as those of review instances
       end


### PR DESCRIPTION
## Description of change
VAMF appears to be doing some kind of DNS resolution on the HTTP Referrer we pass. I would like to make the change in Settings.hostname changing 'staging-api.vets.gov' to be the correct 'staging-api.va.gov' but I'm afraid this change might break something with how ID.me is configured so for now I'm just going to do a gsub.

## Testing done
verified on staging instance that making this change does not result in a Bad Request.

## Testing planned
None

## Acceptance Criteria (Definition of Done)
None

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
