### PR TITLE
Lower only clinics and pact endpoints to 30s

### DIFF
--- a/modules/vaos/app/services/vaos/systems_service.rb
+++ b/modules/vaos/app/services/vaos/systems_service.rb
@@ -47,7 +47,7 @@ module VAOS
           'clinical-service' => type_of_care_id,
           'institution-code' => system_id
         }
-        response = perform(:get, url, url_params, headers, timeout: 55)
+        response = perform(:get, url, url_params, headers, timeout: 30)
         response.body.map { |clinic| OpenStruct.new(clinic) }
       end
     end
@@ -87,7 +87,7 @@ module VAOS
       with_monitoring do
         url = "/var/VeteranAppointmentRequestService/v4/rest/direct-scheduling/site/#{system_id}" \
                 "/patient/ICN/#{@user.icn}/pact-team"
-        response = perform(:get, url, nil, headers, timeout: 55)
+        response = perform(:get, url, nil, headers, timeout: 30)
         response.body.map { |pact| OpenStruct.new(pact) }
       end
     end


### PR DESCRIPTION
## Description of change
Lowers only the VAOS clinics and PACT endpoint timeouts to 30s. This PR is related, and will be merged in before, #4004. 

Issue: https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/6611

## Testing done
unit tests

## Testing planned
staging integration tests

## Acceptance Criteria (Definition of Done)
VAOS get_facility_clinics and get_system_pact have a custom 30s timeout.

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
