### PR TITLE
VAOS change breakers error_threshold to 90 instead of 50

### DIFF
--- a/lib/common/client/configuration/base.rb
+++ b/lib/common/client/configuration/base.rb
@@ -120,9 +120,14 @@ module Common
           )
         end
 
+
+        # The percentage of errors over which an outage will be reported as part of breakers gem
+        #
+        # @return [Integer] corresponding to percentage
         def breakers_error_threshold
           50
         end
+
 
         private
 

--- a/lib/common/client/configuration/base.rb
+++ b/lib/common/client/configuration/base.rb
@@ -108,11 +108,20 @@ module Common
             end
           end
 
-          @service = Breakers::Service.new(
+          @service = create_new_breakers_service(matcher, exception_handler)
+        end
+
+        def create_new_breakers_service(matcher, exception_handler)
+          Breakers::Service.new(
             name: service_name,
             request_matcher: matcher,
+            error_threshold: breakers_error_threshold,
             exception_handler: exception_handler
           )
+        end
+
+        def breakers_error_threshold
+          50
         end
 
         private

--- a/lib/common/client/configuration/base.rb
+++ b/lib/common/client/configuration/base.rb
@@ -120,14 +120,12 @@ module Common
           )
         end
 
-
         # The percentage of errors over which an outage will be reported as part of breakers gem
         #
         # @return [Integer] corresponding to percentage
         def breakers_error_threshold
           50
         end
-
 
         private
 

--- a/modules/vaos/app/services/vaos/configuration.rb
+++ b/modules/vaos/app/services/vaos/configuration.rb
@@ -23,10 +23,11 @@ module VAOS
     # Overridden from Configuration::Base
     # We want a custom error threshold for breakers outages to get triggered because the there are a large number
     # of endpoints and they all resolve to the same url so 50% might cause 1 or 2 endpoints to break the whole app.
-    # In the future we might look at playing around with the matcher based on client class names instead.
+    # In the future we might look at playing around with the matcher based on client class names instead instead of URI.
     #
     # @return Hash default request options.
     #
+    # rubocop:disable Metrics/MethodLength
     def breakers_service
       return @service if defined?(@service)
 
@@ -49,10 +50,11 @@ module VAOS
       @service = Breakers::Service.new(
         name: service_name,
         request_matcher: matcher,
-        error_threshold: 90, # this line here is the main line that is being modified
+        error_threshold: 90,
         exception_handler: exception_handler
       )
     end
+    # rubocop:enable Metrics/MethodLength
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|

--- a/modules/vaos/app/services/vaos/configuration.rb
+++ b/modules/vaos/app/services/vaos/configuration.rb
@@ -19,6 +19,41 @@ module VAOS
       @key ||= OpenSSL::PKey::RSA.new(File.read(Settings.va_mobile.key_path))
     end
 
+    ##
+    # Overridden from Configuration::Base
+    # We want a custom error threshold for breakers outages to get triggered because the there are a large number
+    # of endpoints and they all resolve to the same url so 50% might cause 1 or 2 endpoints to break the whole app.
+    # In the future we might look at playing around with the matcher based on client class names instead.
+    #
+    # @return Hash default request options.
+    #
+    def breakers_service
+      return @service if defined?(@service)
+
+      base_uri = URI.parse(base_path)
+      matcher = proc do |request_env|
+        request_env.url.host == base_uri.host && request_env.url.port == base_uri.port &&
+          request_env.url.path =~ /^#{base_uri.path}/
+      end
+
+      exception_handler = proc do |exception|
+        if exception.is_a?(Common::Exceptions::BackendServiceException)
+          (500..599).cover?(exception.response_values[:status])
+        elsif exception.is_a?(Common::Client::Errors::HTTPError)
+          (500..599).cover?(exception.status)
+        else
+          false
+        end
+      end
+
+      @service = Breakers::Service.new(
+        name: service_name,
+        request_matcher: matcher,
+        error_threshold: 90, # this line here is the main line that is being modified
+        exception_handler: exception_handler
+      )
+    end
+
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
         conn.use :breakers


### PR DESCRIPTION
## Description of change
Because VAOS makes calls out to a large number of different endpoints and they are all characterized as the same VAOS service name and all URI begin with the same hostname, there is greater risk that 1 or 2 of these endpoints might cause an outage across the entirety of the app.

As we continue to learn more we might look at coming up with custom matchers based on client class names that we use instead of URI. But for now, we just want to avoid this problem and we can do that by setting the error_threshold so high that it's unlikely to ever trigger a breakers outage without affecting all of the plugins such as STATSD and others which we depend on.

## Testing done
None

## Testing planned
None

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
I believe this is the the first time someone has changed the error_threshold for a client configuration breakers service, there should be a better way to do it by setting a method on Configuration::Base I would think.

#### Applies to all PRs

- [x] Appropriate logging
- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
