### PR TITLE
Add past appointments flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -52,6 +52,10 @@ features:
     actor_type: user
     description: >
       Allows veterans to directly schedule VA appointments
+  va_online_scheduling_past:
+    actor_type: user
+    description: >
+      Allows veterans to see past appointments
   va_global_downtime_notification:
     actor_type: user
     description: >


### PR DESCRIPTION
## Description of change
This adds a past appointments toggle for VAOS, so that we can commit that page without pushing it live.

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
