### PR TITLE
using the account_uuid as the redis cache index for user data

### DIFF
--- a/app/models/mvi.rb
+++ b/app/models/mvi.rb
@@ -130,7 +130,7 @@ class Mvi < Common::RedisStore
   private
 
   def response_from_redis_or_service
-    do_cached_with(key: user.uuid) do
+    do_cached_with(key: user.account_uuid) do
       mvi_service.find_profile(user)
     end
   end

--- a/app/models/vet360_redis/contact_information.rb
+++ b/app/models/vet360_redis/contact_information.rb
@@ -176,7 +176,7 @@ module Vet360Redis
     def response_from_redis_or_service
       return contact_info_service.get_person unless Settings.vet360.contact_information.cache_enabled
 
-      do_cached_with(key: @user.uuid) do
+      do_cached_with(key: @user.account_uuid) do
         contact_info_service.get_person
       end
     end


### PR DESCRIPTION
user.uuid will no longer be guaranteed when authenticating via SSOe

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/6061

## Testing done
<!-- Please describe testing done to verify the changes. -->

## Testing planned
<!-- Please describe testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
