### PR TITLE
Commenting out Last claims validation check because EVSS may no be able to handle request load

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
@@ -27,6 +27,12 @@ module ClaimsApi
     rescue EVSS::ErrorMiddleware::EVSSError => e
       track_526_validation_errors(e.details)
       render json: { errors: format_526_errors(e.details) }, status: :unprocessable_entity
+    rescue ::Common::Exceptions::GatewayTimeout, ::Timeout::Error, ::Faraday::TimeoutError => e
+      req = { auth: auth_headers, form: form_attributes, source: source_name, auto_claim: auto_claim.as_json }
+      PersonalInformationLog.create(
+        error_class: "submit_form_526 #{e.class.name}", data: { request: req, error: e.try(:as_json) || e }
+      )
+      raise e
     end
 
     private

--- a/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
@@ -30,7 +30,7 @@ module ClaimsApi
     rescue ::Common::Exceptions::GatewayTimeout, ::Timeout::Error, ::Faraday::TimeoutError => e
       req = { auth: auth_headers, form: form_attributes, source: source_name, auto_claim: auto_claim.as_json }
       PersonalInformationLog.create(
-        error_class: "submit_form_526 #{e.class.name}", data: { request: req, error: e.try(:as_json) || e }
+        error_class: "validate_form_526 #{e.class.name}", data: { request: req, error: e.try(:as_json) || e }
       )
       raise e
     end

--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -27,21 +27,9 @@ module ClaimsApi
           )
           auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5) unless auto_claim.id
 
-          # Removing final validation check because EVSS may not be able to handle request load
-          # service(auth_headers).validate_form526(auto_claim.to_internal)
-
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
 
           render json: auto_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
-        rescue EVSS::ErrorMiddleware::EVSSError => e
-          track_526_validation_errors(e.details)
-          render json: { errors: format_errors(e.details) }, status: :unprocessable_entity
-        rescue ::Common::Exceptions::GatewayTimeout, ::Timeout::Error, ::Faraday::TimeoutError => e
-          req = { auth: auth_headers, form: form_attributes, source: source_name, auto_claim: auto_claim.as_json }
-          PersonalInformationLog.create(
-            error_class: "submit_form_526 #{e.class.name}", data: { request: req, error: e.try(:as_json) || e }
-          )
-          raise e
         end
 
         def upload_supporting_documents

--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -19,7 +19,6 @@ module ClaimsApi
         skip_before_action :validate_json_format, only: %i[upload_supporting_documents]
 
         def submit_form_526
-          service_object = service(auth_headers)
           auto_claim = ClaimsApi::AutoEstablishedClaim.create(
             status: ClaimsApi::AutoEstablishedClaim::PENDING,
             auth_headers: auth_headers,
@@ -27,9 +26,9 @@ module ClaimsApi
             source: source_name
           )
           auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5) unless auto_claim.id
-          
+
           # Removing final validation check because EVSS may not be able to handle request load
-          # service_object.validate_form526(auto_claim.to_internal)
+          # service(auth_headers).validate_form526(auto_claim.to_internal)
 
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
 

--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -27,7 +27,9 @@ module ClaimsApi
             source: source_name
           )
           auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5) unless auto_claim.id
-          service_object.validate_form526(auto_claim.to_internal)
+          
+          # Removing final validation check because EVSS may not be able to handle request load
+          # service_object.validate_form526(auto_claim.to_internal)
 
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
 

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -30,7 +30,9 @@ module ClaimsApi
             source: source_name
           )
           auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5) unless auto_claim.id
-          service_object.validate_form526(auto_claim.to_internal)
+          
+          # Removing final validation check because EVSS may not be able to handle request load
+          # service_object.validate_form526(auto_claim.to_internal)
 
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
 

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -22,7 +22,6 @@ module ClaimsApi
         skip_before_action :validate_json_format, only: %i[upload_supporting_documents]
 
         def submit_form_526
-          service_object = service(auth_headers)
           auto_claim = ClaimsApi::AutoEstablishedClaim.create(
             status: ClaimsApi::AutoEstablishedClaim::PENDING,
             auth_headers: auth_headers,
@@ -30,9 +29,9 @@ module ClaimsApi
             source: source_name
           )
           auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5) unless auto_claim.id
-          
+
           # Removing final validation check because EVSS may not be able to handle request load
-          # service_object.validate_form526(auto_claim.to_internal)
+          # service(auth_headers).validate_form526(auto_claim.to_internal)
 
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
 

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -30,21 +30,9 @@ module ClaimsApi
           )
           auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5) unless auto_claim.id
 
-          # Removing final validation check because EVSS may not be able to handle request load
-          # service(auth_headers).validate_form526(auto_claim.to_internal)
-
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
 
           render json: auto_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
-        rescue EVSS::ErrorMiddleware::EVSSError => e
-          track_526_validation_errors(e.details)
-          render json: { errors: format_errors(e.details) }, status: :unprocessable_entity
-        rescue ::Common::Exceptions::GatewayTimeout, ::Timeout::Error, ::Faraday::TimeoutError => e
-          req = { auth: auth_headers, form: form_attributes, source: source_name, auto_claim: auto_claim.as_json }
-          PersonalInformationLog.create(
-            error_class: "submit_form_526 #{e.class.name}", data: { request: req, error: e.try(:as_json) || e }
-          )
-          raise e
         end
 
         def upload_supporting_documents

--- a/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe 'Disability Claims ', type: :request do
 
     it 'returns a successful response with all the data' do
       klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
-      allow_any_instance_of(klass).to receive(:validate_form526).and_return(true)
       post path, params: data, headers: headers
       parsed = JSON.parse(response.body)
       expect(parsed['data']['type']).to eq('claims_api_claim')
@@ -41,32 +40,14 @@ RSpec.describe 'Disability Claims ', type: :request do
       expect(response.status).to eq(404)
     end
 
-    context 'Timeouts are recorded (investigating)' do
-      [Common::Exceptions::GatewayTimeout, Timeout::Error, Faraday::TimeoutError].each do |error_klass|
-        context error_klass.to_s do
-          it 'is logged to PersonalInformationLog' do
-            allow_any_instance_of(ClaimsApi::DisabilityCompensation::MockOverrideService)
-              .to receive(:validate_form526).and_raise(error_klass)
-            allow_any_instance_of(EVSS::DisabilityCompensationForm::ServiceAllClaim)
-              .to receive(:validate_form526).and_raise(error_klass)
-            post path, params: data, headers: headers
-            expect(PersonalInformationLog.count).to be_positive
-            expect(PersonalInformationLog.last.error_class).to eq("submit_form_526 #{error_klass.name}")
-          end
-        end
-      end
-    end
-
     it 'creates the sidekick job' do
       klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
-      expect_any_instance_of(klass).to receive(:validate_form526).and_return(true)
       expect(ClaimsApi::ClaimEstablisher).to receive(:perform_async)
       post path, params: data, headers: headers
     end
 
     it 'sets the source' do
       klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
-      expect_any_instance_of(klass).to receive(:validate_form526).and_return(true)
       post path, params: data, headers: headers
       token = JSON.parse(response.body)['data']['attributes']['token']
       aec = ClaimsApi::AutoEstablishedClaim.find(token)
@@ -112,9 +93,11 @@ RSpec.describe 'Disability Claims ', type: :request do
     end
 
     context 'form 526 validation' do
+      let(:path) { '/services/claims/v0/forms/526/validate' }
+
       it 'returns a successful response when valid' do
         VCR.use_cassette('evss/disability_compensation_form/form_526_valid_validation') do
-          post '/services/claims/v0/forms/526/validate', params: data, headers: headers
+          post path, params: data, headers: headers
           parsed = JSON.parse(response.body)
           expect(parsed['data']['type']).to eq('claims_api_auto_established_claim_validation')
           expect(parsed['data']['attributes']['status']).to eq('valid')
@@ -123,7 +106,7 @@ RSpec.describe 'Disability Claims ', type: :request do
 
       it 'returns a list of errors when invalid hitting EVSS' do
         VCR.use_cassette('evss/disability_compensation_form/form_526_invalid_validation') do
-          post '/services/claims/v0/forms/526/validate', params: data, headers: headers
+          post path, params: data, headers: headers
           parsed = JSON.parse(response.body)
           expect(response.status).to eq(422)
           expect(parsed['errors'].size).to eq(2)
@@ -133,7 +116,7 @@ RSpec.describe 'Disability Claims ', type: :request do
       it 'increment counters for statsd' do
         VCR.use_cassette('evss/disability_compensation_form/form_526_invalid_validation') do
           expect(StatsD).to receive(:increment).at_least(:once)
-          post '/services/claims/v0/forms/526/validate', params: data, headers: headers
+          post path, params: data, headers: headers
         end
       end
 
@@ -141,10 +124,26 @@ RSpec.describe 'Disability Claims ', type: :request do
         json_data = JSON.parse data
         params = json_data
         params['data']['attributes']['veteran']['currentMailingAddress'] = {}
-        post '/services/claims/v0/forms/526/validate', params: params.to_json, headers: headers
+        post path, params: params.to_json, headers: headers
         parsed = JSON.parse(response.body)
         expect(response.status).to eq(422)
         expect(parsed['errors'].size).to eq(5)
+      end
+
+      context 'Timeouts are recorded (investigating)' do
+        [Common::Exceptions::GatewayTimeout, Timeout::Error, Faraday::TimeoutError].each do |error_klass|
+          context error_klass.to_s do
+            it 'is logged to PersonalInformationLog' do
+              allow_any_instance_of(ClaimsApi::DisabilityCompensation::MockOverrideService)
+                .to receive(:validate_form526).and_raise(error_klass)
+              allow_any_instance_of(EVSS::DisabilityCompensationForm::ServiceAllClaim)
+                .to receive(:validate_form526).and_raise(error_klass)
+              post path, params: data, headers: headers
+              expect(PersonalInformationLog.count).to be_positive
+              expect(PersonalInformationLog.last.error_class).to eq("submit_form_526 #{error_klass.name}")
+            end
+          end
+        end
       end
     end
   end

--- a/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'Disability Claims ', type: :request do
     end
 
     it 'returns a successful response with all the data' do
-      klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
       post path, params: data, headers: headers
       parsed = JSON.parse(response.body)
       expect(parsed['data']['type']).to eq('claims_api_claim')
@@ -41,13 +40,11 @@ RSpec.describe 'Disability Claims ', type: :request do
     end
 
     it 'creates the sidekick job' do
-      klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
       expect(ClaimsApi::ClaimEstablisher).to receive(:perform_async)
       post path, params: data, headers: headers
     end
 
     it 'sets the source' do
-      klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
       post path, params: data, headers: headers
       token = JSON.parse(response.body)['data']['attributes']['token']
       aec = ClaimsApi::AutoEstablishedClaim.find(token)
@@ -140,7 +137,7 @@ RSpec.describe 'Disability Claims ', type: :request do
                 .to receive(:validate_form526).and_raise(error_klass)
               post path, params: data, headers: headers
               expect(PersonalInformationLog.count).to be_positive
-              expect(PersonalInformationLog.last.error_class).to eq("submit_form_526 #{error_klass.name}")
+              expect(PersonalInformationLog.last.error_class).to eq("validate_form_526 #{error_klass.name}")
             end
           end
         end

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe 'Disability Claims ', type: :request do
     it 'returns a successful response with all the data' do
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('evss/claims/claims') do
-          klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
           post path, params: data, headers: headers.merge(auth_header)
           parsed = JSON.parse(response.body)
           expect(parsed['data']['type']).to eq('claims_api_claim')
@@ -48,7 +47,6 @@ RSpec.describe 'Disability Claims ', type: :request do
     it 'creates the sidekick job' do
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('evss/claims/claims') do
-          klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
           expect(ClaimsApi::ClaimEstablisher).to receive(:perform_async)
           post path, params: data, headers: headers.merge(auth_header)
         end
@@ -58,7 +56,6 @@ RSpec.describe 'Disability Claims ', type: :request do
     it 'assigns a source' do
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('evss/claims/claims') do
-          klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
           post path, params: data, headers: headers.merge(auth_header)
           token = JSON.parse(response.body)['data']['attributes']['token']
           aec = ClaimsApi::AutoEstablishedClaim.find(token)
@@ -178,7 +175,7 @@ RSpec.describe 'Disability Claims ', type: :request do
                     .to receive(:validate_form526).and_raise(error_klass)
                   post path, params: data, headers: headers.merge(auth_header)
                   expect(PersonalInformationLog.count).to be_positive
-                  expect(PersonalInformationLog.last.error_class).to eq("submit_form_526 #{error_klass.name}")
+                  expect(PersonalInformationLog.last.error_class).to eq("validate_form_526 #{error_klass.name}")
                 end
               end
             end

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe 'Disability Claims ', type: :request do
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('evss/claims/claims') do
           klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
-          expect_any_instance_of(klass).to receive(:validate_form526).and_return(true)
           post path, params: data, headers: headers.merge(auth_header)
           parsed = JSON.parse(response.body)
           expect(parsed['data']['type']).to eq('claims_api_claim')
@@ -46,31 +45,10 @@ RSpec.describe 'Disability Claims ', type: :request do
       end
     end
 
-    context 'Timeouts are recorded (investigating)' do
-      [Common::Exceptions::GatewayTimeout, Timeout::Error, Faraday::TimeoutError].each do |error_klass|
-        context error_klass.to_s do
-          it 'is logged to PersonalInformationLog' do
-            with_okta_user(scopes) do |auth_header|
-              VCR.use_cassette('evss/claims/claims') do
-                allow_any_instance_of(ClaimsApi::DisabilityCompensation::MockOverrideService)
-                  .to receive(:validate_form526).and_raise(error_klass)
-                allow_any_instance_of(EVSS::DisabilityCompensationForm::ServiceAllClaim)
-                  .to receive(:validate_form526).and_raise(error_klass)
-                post path, params: data, headers: headers.merge(auth_header)
-                expect(PersonalInformationLog.count).to be_positive
-                expect(PersonalInformationLog.last.error_class).to eq("submit_form_526 #{error_klass.name}")
-              end
-            end
-          end
-        end
-      end
-    end
-
     it 'creates the sidekick job' do
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('evss/claims/claims') do
           klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
-          expect_any_instance_of(klass).to receive(:validate_form526).and_return(true)
           expect(ClaimsApi::ClaimEstablisher).to receive(:perform_async)
           post path, params: data, headers: headers.merge(auth_header)
         end
@@ -81,7 +59,6 @@ RSpec.describe 'Disability Claims ', type: :request do
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('evss/claims/claims') do
           klass = EVSS::DisabilityCompensationForm::ServiceAllClaim
-          expect_any_instance_of(klass).to receive(:validate_form526).and_return(true)
           post path, params: data, headers: headers.merge(auth_header)
           token = JSON.parse(response.body)['data']['attributes']['token']
           aec = ClaimsApi::AutoEstablishedClaim.find(token)
@@ -139,12 +116,14 @@ RSpec.describe 'Disability Claims ', type: :request do
     end
 
     context 'form 526 validation' do
+      let(:path) { '/services/claims/v1/forms/526/validate' }
+
       it 'returns a successful response when valid' do
         VCR.use_cassette('evss/disability_compensation_form/form_526_valid_validation') do
           with_okta_user(scopes) do |auth_header|
             VCR.use_cassette('evss/claims/claims') do
               data = File.read(Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'form_526_json_api.json'))
-              post '/services/claims/v1/forms/526/validate', params: data, headers: headers.merge(auth_header)
+              post path, params: data, headers: headers.merge(auth_header)
               parsed = JSON.parse(response.body)
               expect(parsed['data']['type']).to eq('claims_api_auto_established_claim_validation')
               expect(parsed['data']['attributes']['status']).to eq('valid')
@@ -157,7 +136,7 @@ RSpec.describe 'Disability Claims ', type: :request do
         with_okta_user(scopes) do |auth_header|
           VCR.use_cassette('evss/disability_compensation_form/form_526_invalid_validation') do
             VCR.use_cassette('evss/claims/claims') do
-              post '/services/claims/v1/forms/526/validate', params: data, headers: headers.merge(auth_header)
+              post path, params: data, headers: headers.merge(auth_header)
               parsed = JSON.parse(response.body)
               expect(response.status).to eq(422)
               expect(parsed['errors'].size).to eq(2)
@@ -170,7 +149,7 @@ RSpec.describe 'Disability Claims ', type: :request do
         with_okta_user(scopes) do |auth_header|
           VCR.use_cassette('evss/disability_compensation_form/form_526_invalid_validation') do
             expect(StatsD).to receive(:increment).at_least(:once)
-            post '/services/claims/v1/forms/526/validate', params: data, headers: headers.merge(auth_header)
+            post path, params: data, headers: headers.merge(auth_header)
           end
         end
       end
@@ -180,10 +159,30 @@ RSpec.describe 'Disability Claims ', type: :request do
           json_data = JSON.parse data
           params = json_data
           params['data']['attributes']['veteran']['currentMailingAddress'] = {}
-          post '/services/claims/v1/forms/526/validate', params: params.to_json, headers: headers.merge(auth_header)
+          post path, params: params.to_json, headers: headers.merge(auth_header)
           parsed = JSON.parse(response.body)
           expect(response.status).to eq(422)
           expect(parsed['errors'].size).to eq(5)
+        end
+      end
+
+      context 'Timeouts are recorded (investigating)' do
+        [Common::Exceptions::GatewayTimeout, Timeout::Error, Faraday::TimeoutError].each do |error_klass|
+          context error_klass.to_s do
+            it 'is logged to PersonalInformationLog' do
+              with_okta_user(scopes) do |auth_header|
+                VCR.use_cassette('evss/claims/claims') do
+                  allow_any_instance_of(ClaimsApi::DisabilityCompensation::MockOverrideService)
+                    .to receive(:validate_form526).and_raise(error_klass)
+                  allow_any_instance_of(EVSS::DisabilityCompensationForm::ServiceAllClaim)
+                    .to receive(:validate_form526).and_raise(error_klass)
+                  post path, params: data, headers: headers.merge(auth_header)
+                  expect(PersonalInformationLog.count).to be_positive
+                  expect(PersonalInformationLog.last.error_class).to eq("submit_form_526 #{error_klass.name}")
+                end
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
### Description of change
Keeping the code and just commenting it out in the event that EVSS is able to improve their capacity down the line. For now though seems prudent to remove last check before submission.

Relates to ticket https://vasdvp.atlassian.net/secure/RapidBoard.jspa?rapidView=140&projectKey=DASH&modal=detail&selectedIssue=DASH-137&assignee=5e386d8f6061160ca042d953

The validate end point already exposes this particular feature and we should see more through put on our end but also more potential validation failures post submission in an errored claim potentially. This should increase our overall submissions though and sidekiq can handle the back end processing as well as retries if EVSS is down for any reason.

## Acceptance Criteria (Definition of Done)
- Commenting out attempt to use EVSS validation as a catch all in the submit

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
