### PR TITLE
Adds a centralized library for interacting with VBMS eFolder.

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -97,6 +97,12 @@ StatsD.increment("#{EMIS::Service::STATSD_KEY_PREFIX}.service_history", 0, tags:
 StatsD.increment("#{CentralMail::Service::STATSD_KEY_PREFIX}.upload.total", 0)
 StatsD.increment("#{CentralMail::Service::STATSD_KEY_PREFIX}.upload.fail", 0)
 
+# init VBMS::Efolder
+StatsD.increment("#{VBMS::Efolder::Service::STATSD_KEY_PREFIX}.token.success", 0)
+StatsD.increment("#{VBMS::Efolder::Service::STATSD_KEY_PREFIX}.token.fail", 0)
+StatsD.increment("#{VBMS::Efolder::Service::STATSD_KEY_PREFIX}.upload.success", 0)
+StatsD.increment("#{VBMS::Efolder::Service::STATSD_KEY_PREFIX}.upload.fail", 0)
+
 # init SentryJob error monitoring
 StatsD.increment(SentryJob::STATSD_ERROR_KEY, 0)
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -493,6 +493,8 @@ vbms:
   server_cert: vbms.aide.oit.va.gov.crt
   environment_directory: /srv/vets-api/secret
   env: test
+  efolder:
+    mock: true
 
 vet_verification:
   key_path: modules/veteran_verification/spec/fixtures/verification_test.pem

--- a/lib/vbms/efolder/configuration.rb
+++ b/lib/vbms/efolder/configuration.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module VBMS
+  module Efolder
+    class Configuration < Common::Client::Configuration::Base
+
+      def service_name
+        'vbms_efolder'
+      end
+
+      def base_path
+        Settings.vbms.url
+      end
+
+      # TODO: we are using connect_vbms gem for interaction with the vbms SOAP service, but we should
+      # define something here to add breakers functionality. Does vbms have a health check endpoint?
+      def connection
+        Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
+          faraday.use :breakers
+          faraday.request :json
+
+          faraday.response :raise_error, error_prefix: service_name
+          faraday.response :betamocks if mock_enabled?
+          faraday.response :json
+          faraday.adapter Faraday.default_adapter
+        end
+      end
+
+      ##
+      # @return [Boolean] Should the service use mock data in lower environments.
+      #
+      def mock_enabled?
+        [true, 'true'].include?(Settings.vbms.efolder.mock)
+      end
+    end
+  end
+
+end

--- a/lib/vbms/efolder/configuration.rb
+++ b/lib/vbms/efolder/configuration.rb
@@ -3,7 +3,6 @@
 module VBMS
   module Efolder
     class Configuration < Common::Client::Configuration::Base
-
       def service_name
         'vbms_efolder'
       end
@@ -34,5 +33,4 @@ module VBMS
       end
     end
   end
-
 end

--- a/lib/vbms/efolder/service.rb
+++ b/lib/vbms/efolder/service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module VBMS
+  module Efolder
+    class Service < Common::Client::Base
+      STATSD_KEY_PREFIX = 'api.vbms.efolder'
+      include Common::Client::Monitoring
+      configuration VBMS::Efolder::Configuration
+
+      private
+
+      def client
+        @client ||= VBMS::Client.from_env_vars(env_name: Settings.vbms.env)
+      end
+
+      # statsd helper methods - call increment_success(:foo) from a subclass. ie. Calling this method
+      # from VBMS::Efolder::UploadService would increment the key: #{STATSD_KEY_PREFIX}.upload_service.foo.success
+      def increment_success(*keys)
+        keys.each do |key|
+          StatsD.increment("#{STATSD_KEY_PREFIX}.#{self.class.name.demodulize.to_s.underscore}.#{key}.success")
+        end
+      end
+      
+      def increment_fail(*keys)
+        keys.each do |key|
+          StatsD.increment("#{STATSD_KEY_PREFIX}.#{self.class.name.demodulize.to_s.underscore}.#{key}.fail")
+        end
+      end
+    end
+  end
+end

--- a/lib/vbms/efolder/service.rb
+++ b/lib/vbms/efolder/service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module VBMS
   module Efolder
     class Service < Common::Client::Base
@@ -19,7 +20,7 @@ module VBMS
           StatsD.increment("#{STATSD_KEY_PREFIX}.#{self.class.name.demodulize.to_s.underscore}.#{key}.success")
         end
       end
-      
+
       def increment_fail(*keys)
         keys.each do |key|
           StatsD.increment("#{STATSD_KEY_PREFIX}.#{self.class.name.demodulize.to_s.underscore}.#{key}.fail")

--- a/lib/vbms/efolder/upload_service.rb
+++ b/lib/vbms/efolder/upload_service.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
+
 module VBMS
   module Efolder
     class UploadService < VBMS::Efolder::Service
-
       def initialize(file, metadata)
         case file.class.to_s
         when 'ClaimDocumentation::Uploader::UploadedFile'
@@ -13,7 +13,7 @@ module VBMS
           @filename = File.basename(file)
           @file = file
         else
-          raise "Could not process file of type #{file.class.to_s}"
+          raise "Could not process file of type #{file.class}"
         end
         metadata['content_hash'] = Digest::SHA1.hexdigest(@file.read)
         @filename = SecureRandom.uuid + '-' + @filename

--- a/lib/vbms/efolder/upload_service.rb
+++ b/lib/vbms/efolder/upload_service.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+module VBMS
+  module Efolder
+    class UploadService < VBMS::Efolder::Service
+
+      def initialize(file, metadata)
+        case file.class.to_s
+        when 'ClaimDocumentation::Uploader::UploadedFile'
+          # persistant attachment (shrine)
+          @filename = file.original_filename
+          @file = file.to_io
+        when 'File'
+          @filename = File.basename(file)
+          @file = file
+        else
+          raise "Could not process file of type #{file.class.to_s}"
+        end
+        metadata['content_hash'] = Digest::SHA1.hexdigest(@file.read)
+        @filename = SecureRandom.uuid + '-' + @filename
+        @metadata = metadata
+      end
+
+      def upload_file!
+        # uploading to efolder is a two call process: fetch_token and upload
+        token = fetch_upload_token
+        upload(token)
+        increment_success(:upload, :token) # statsd
+      rescue
+        increment_fail(:token) unless token
+        increment_fail(:upload)
+      end
+
+      private
+
+      def fetch_upload_token
+        request = initialize_upload
+        client.send_request(request) # returns a token
+      end
+
+      def initialize_upload
+        VBMS::Requests::InitializeUpload.new(
+          content_hash: @metadata['content_hash'],
+          filename: @filename,
+          file_number: @metadata['file_number'],
+          va_receive_date: @metadata['receive_date'],
+          doc_type: @metadata['doc_type'],
+          source: @metadata['source'],
+          subject: @metadata['source'] + '_' + @metadata['doc_type'], # TODO?
+          new_mail: @metadata['new_mail'] || true # TODO?
+        )
+      end
+
+      def upload(token)
+        upload_request = VBMS::Requests::UploadDocument.new(
+          upload_token: token,
+          filepath: @file.path
+        )
+        client.send_request(upload_request)
+      end
+    end
+  end
+end

--- a/spec/lib/vbms/efolder/configuration_spec.rb
+++ b/spec/lib/vbms/efolder/configuration_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe VBMS::Efolder::Configuration do
   subject { described_class }
-  
+
   it 'has a service name' do
     expect(described_class.instance.service_name).to eq('vbms_efolder')
   end

--- a/spec/lib/vbms/efolder/configuration_spec.rb
+++ b/spec/lib/vbms/efolder/configuration_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe VBMS::Efolder::Configuration do
+  subject { described_class }
+  
+  it 'has a service name' do
+    expect(described_class.instance.service_name).to eq('vbms_efolder')
+  end
+
+  describe '#mock_enabled?' do
+    context 'when Settings.vbms.efolder.mock is true' do
+      before { Settings.vbms.efolder.mock = 'true' }
+
+      it 'returns true' do
+        expect(described_class.instance).to be_mock_enabled
+      end
+    end
+
+    context 'when Settings.vbms.efolder.mock is false' do
+      before { Settings.vbms.efolder.mock = 'false' }
+
+      it 'returns false' do
+        expect(described_class.instance).not_to be_mock_enabled
+      end
+    end
+  end
+end

--- a/spec/lib/vbms/efolder/service_spec.rb
+++ b/spec/lib/vbms/efolder/service_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe VBMS::Efolder::Service do
     allow(VBMS::Client).to receive(:from_env_vars).and_return(vbms_client)
   end
 
-  it 'should configure statsd key prefix' do
-    expect(VBMS::Efolder::Service::STATSD_KEY_PREFIX).to eq('api.vbms.efolder')  
+  it 'configures statsd key prefix' do
+    expect(VBMS::Efolder::Service::STATSD_KEY_PREFIX).to eq('api.vbms.efolder')
   end
 
   describe '#client' do
-    it 'should return a VBMS::Client' do
+    it 'returns a VBMS::Client' do
       expect(service.client).to be(VBMS::Client)
     end
   end
@@ -24,10 +24,11 @@ RSpec.describe VBMS::Efolder::Service do
   describe 'statsd helper methods' do
     # set the class name to UploadService to ensure the incrementers convert and use upload_service as keyname
     before { allow(service).to receive(:class).and_return(VBMS::Efolder::UploadService) }
+
     upload_success_key = 'api.vbms.efolder.upload_service.upload.success'
     upload_fail_key = 'api.vbms.efolder.upload_service.upload.fail'
 
-    # ensure 
+    # ensure
     it '#increment_success triggers statsd with correct keyname' do
       expect { service.increment_success(:upload) }.to trigger_statsd_increment(upload_success_key)
       service.increment_success(:upload)

--- a/spec/lib/vbms/efolder/service_spec.rb
+++ b/spec/lib/vbms/efolder/service_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VBMS::Efolder::Service do
+  let(:service) { described_class.new }
+  let(:vbms_client) { VBMS::Client }
+
+  before do
+    service.class.send(:public, *described_class.private_instance_methods)
+    allow(VBMS::Client).to receive(:from_env_vars).and_return(vbms_client)
+  end
+
+  it 'should configure statsd key prefix' do
+    expect(VBMS::Efolder::Service::STATSD_KEY_PREFIX).to eq('api.vbms.efolder')  
+  end
+
+  describe '#client' do
+    it 'should return a VBMS::Client' do
+      expect(service.client).to be(VBMS::Client)
+    end
+  end
+
+  describe 'statsd helper methods' do
+    # set the class name to UploadService to ensure the incrementers convert and use upload_service as keyname
+    before { allow(service).to receive(:class).and_return(VBMS::Efolder::UploadService) }
+    upload_success_key = 'api.vbms.efolder.upload_service.upload.success'
+    upload_fail_key = 'api.vbms.efolder.upload_service.upload.fail'
+
+    # ensure 
+    it '#increment_success triggers statsd with correct keyname' do
+      expect { service.increment_success(:upload) }.to trigger_statsd_increment(upload_success_key)
+      service.increment_success(:upload)
+    end
+
+    it '#increment_fail should trigger statsd with correct keyname' do
+      expect { service.increment_fail(:upload) }.to trigger_statsd_increment(upload_fail_key)
+      service.increment_fail(:upload)
+    end
+  end
+end

--- a/spec/lib/vbms/efolder/upload_service_spec.rb
+++ b/spec/lib/vbms/efolder/upload_service_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VBMS::Efolder::UploadService do
+  let(:metadata) {{
+        'first_name' => 'Pat',
+        'last_name' => 'Doe',
+        'file_number' => '123-44-5678',
+        'receive_date' => Time.now.strftime('%Y-%m-%d %H:%M:%S'),
+        'guid' => pa.saved_claim.guid,
+        'zip_code' => '78504',
+        'source' => 'va.gov',
+        'doc_type' => pa.saved_claim.form_id
+  }}
+  let(:file) { fixture_file_upload(
+    "#{::Rails.root}/spec/fixtures/pension/attachment.pdf", 'application/pdf')
+  }
+  let(:file_hash) { "a83abce1fea679b6f49c8ccdc7fa947710645d0b" } # sha1.hexdigest of above file
+  let(:token) { "af022405-4e10-4025-b6f5-2f85570ccbb5" }
+  let(:vbms_client) { double(VBMS::Client)}
+  let(:vbms_init) { double(VBMS::Requests::InitializeUpload) }
+  let(:vbms_upload) { double(VBMS::Requests::UploadDocument)}
+  let(:pa) { build_stubbed(:pension_burial) } # a claim with persistent_attachments
+  let(:upload) { described_class.new(file, metadata) }
+
+  statsd = {
+    token_success: 'api.vbms.efolder.upload_service.token.success',
+    token_fail: 'api.vbms.efolder.upload_service.token.fail',
+    upload_success: 'api.vbms.efolder.upload_service.upload.success',
+    upload_fail: 'api.vbms.efolder.upload_service.upload.fail'
+  }
+
+  describe '#initialize' do
+    context 'with a ClaimDocumentation::Uploader::UploadedFile File' do
+      let(:claim_upload) { described_class.new(pa.file, metadata)}
+      let(:uploaded_file) { claim_upload.instance_variable_get(:@file)}
+      let(:filename) { claim_upload.instance_variable_get(:@filename)}
+      before do
+        allow(pa).to receive('file').and_return(file)
+        allow(pa.file).to receive('class').and_return('ClaimDocumentation::Uploader::UploadedFile')
+      end
+      it 'loads the file' do
+        expect(uploaded_file.path).to eq(pa.file.path)
+      end
+      it 'prepends the filename with a unique identifier' do
+        expect(filename).to match("^([a-z0-9]+-){5}attachment.pdf")
+      end
+    end
+
+    context 'with a PORO File' do
+      let(:uploaded_file) { upload.instance_variable_get(:@file)}
+      let(:filename) { upload.instance_variable_get(:@filename)}
+      before do
+        allow(file).to receive('class').and_return('File')
+      end
+      it 'loads the file' do
+        expect(uploaded_file.path).to eq(file.path)
+      end
+      it 'prepends the filename with a unique identifier' do
+        expect(filename).to match("^([a-z0-9]+-){5}#{File.basename(file.tempfile)}")
+      end
+    end
+
+    it 'hashes the file\'s content' do
+      allow(file).to receive('class').and_return('File')
+      content_hash = upload.instance_variable_get('@metadata')['content_hash']
+      expect(content_hash).to eq(file_hash)
+    end
+  end
+
+  describe '#upload_file' do
+    before do
+      allow(file).to receive('class').and_return('File')
+      allow(vbms_init).to receive('initialize')
+      allow(upload).to receive('client').and_return(vbms_client)
+    end
+    
+    it 'is called only once per file' do
+      expect(upload).to receive('upload_file!').once
+    end
+
+    it 'calls #fetch_upload_token once' do
+      allow(vbms_client).to receive('send_request')
+      expect(upload).to receive(:fetch_upload_token).once
+    end
+
+    it 'calls #upload with a token once' do
+      allow(upload).to receive(:fetch_upload_token).and_return(token)
+      allow(upload).to receive(:upload).with(:token)
+      expect(upload).to receive(:upload).with(token).once
+    end
+
+    describe 'fetching token from VBMS' do
+      it 'generates an upload request with file and metadata' do
+        allow(upload).to receive(:upload).and_return true
+        expect(vbms_client).to receive(:send_request) do |request|
+          expect(request.kind_of? VBMS::Requests::InitializeUpload).to be(true)
+          request.instance_values.each do |var, val|
+            expect(request.instance_values[var]).to_not be_nil
+          end
+          expect(request.instance_values['new_mail']).to be_truthy
+        end
+      end
+  
+      context 'increments statsd' do
+        it 'on success' do
+          allow(upload).to receive(:fetch_upload_token).and_return(token)
+          allow(upload).to receive(:upload).and_return(true)
+          expect { upload.upload_file! }.to trigger_statsd_increment(statsd[:token_success])
+        end
+        it 'on failure' do
+          allow(upload).to receive(:fetch_upload_token).and_raise('not found')
+          allow(upload).to receive(:upload).and_return(true)
+          expect { upload.upload_file! }.to trigger_statsd_increment(statsd[:token_fail])
+        end
+      end
+    end
+
+    describe 'uploading a file to VBMS' do
+      it 'uploads document to vbms with token and file' do
+        allow(upload).to receive(:fetch_upload_token).and_return(token)
+        expect(vbms_client).to receive(:send_request) do |request|
+          expect(request.kind_of? VBMS::Requests::UploadDocument).to be(true)
+          filepath = upload.instance_variable_get(:@file).tempfile.path
+          expect(request.instance_values['filepath']).to eq(filepath)
+          expect(request.instance_values['upload_token']).to eq(token)
+        end
+      end
+      context 'increments statsd' do
+        it 'on success' do
+          allow(upload).to receive(:fetch_upload_token).and_return(token)
+          allow(upload).to receive(:upload).and_return(true)
+          expect { upload.upload_file! }.to trigger_statsd_increment(statsd[:upload_success])
+        end
+        it 'on failure' do
+          allow(upload).to receive(:fetch_upload_token).and_return(token)
+          allow(upload).to receive(:upload).and_raise('500')
+          expect { upload.upload_file! }.to trigger_statsd_increment(statsd[:upload_fail])
+        end
+      end
+    end
+    
+    after do
+      upload.upload_file!
+    end
+  end
+end

--- a/spec/lib/vbms/efolder/upload_service_spec.rb
+++ b/spec/lib/vbms/efolder/upload_service_spec.rb
@@ -3,24 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe VBMS::Efolder::UploadService do
-  let(:metadata) {{
-        'first_name' => 'Pat',
-        'last_name' => 'Doe',
-        'file_number' => '123-44-5678',
-        'receive_date' => Time.now.strftime('%Y-%m-%d %H:%M:%S'),
-        'guid' => pa.saved_claim.guid,
-        'zip_code' => '78504',
-        'source' => 'va.gov',
-        'doc_type' => pa.saved_claim.form_id
-  }}
-  let(:file) { fixture_file_upload(
-    "#{::Rails.root}/spec/fixtures/pension/attachment.pdf", 'application/pdf')
-  }
-  let(:file_hash) { "a83abce1fea679b6f49c8ccdc7fa947710645d0b" } # sha1.hexdigest of above file
-  let(:token) { "af022405-4e10-4025-b6f5-2f85570ccbb5" }
-  let(:vbms_client) { double(VBMS::Client)}
+  let(:metadata) do
+    {
+      'first_name' => 'Pat',
+      'last_name' => 'Doe',
+      'file_number' => '123-44-5678',
+      'receive_date' => Time.zone.now.strftime('%Y-%m-%d %H:%M:%S'),
+      'guid' => pa.saved_claim.guid,
+      'zip_code' => '78504',
+      'source' => 'va.gov',
+      'doc_type' => pa.saved_claim.form_id
+    }
+  end
+  let(:file) do
+    fixture_file_upload(
+      "#{::Rails.root}/spec/fixtures/pension/attachment.pdf", 'application/pdf'
+    )
+  end
+  let(:file_hash) { 'a83abce1fea679b6f49c8ccdc7fa947710645d0b' } # sha1.hexdigest of above file
+  let(:token) { 'af022405-4e10-4025-b6f5-2f85570ccbb5' }
+  let(:vbms_client) { double(VBMS::Client) }
   let(:vbms_init) { double(VBMS::Requests::InitializeUpload) }
-  let(:vbms_upload) { double(VBMS::Requests::UploadDocument)}
+  let(:vbms_upload) { double(VBMS::Requests::UploadDocument) }
   let(:pa) { build_stubbed(:pension_burial) } # a claim with persistent_attachments
   let(:upload) { described_class.new(file, metadata) }
 
@@ -33,27 +37,31 @@ RSpec.describe VBMS::Efolder::UploadService do
 
   describe '#initialize' do
     context 'with a ClaimDocumentation::Uploader::UploadedFile File' do
-      let(:claim_upload) { described_class.new(pa.file, metadata)}
-      let(:uploaded_file) { claim_upload.instance_variable_get(:@file)}
-      let(:filename) { claim_upload.instance_variable_get(:@filename)}
+      let(:claim_upload) { described_class.new(pa.file, metadata) }
+      let(:uploaded_file) { claim_upload.instance_variable_get(:@file) }
+      let(:filename) { claim_upload.instance_variable_get(:@filename) }
+
       before do
         allow(pa).to receive('file').and_return(file)
         allow(pa.file).to receive('class').and_return('ClaimDocumentation::Uploader::UploadedFile')
       end
+
       it 'loads the file' do
         expect(uploaded_file.path).to eq(pa.file.path)
       end
       it 'prepends the filename with a unique identifier' do
-        expect(filename).to match("^([a-z0-9]+-){5}attachment.pdf")
+        expect(filename).to match('^([a-z0-9]+-){5}attachment.pdf')
       end
     end
 
     context 'with a PORO File' do
-      let(:uploaded_file) { upload.instance_variable_get(:@file)}
-      let(:filename) { upload.instance_variable_get(:@filename)}
+      let(:uploaded_file) { upload.instance_variable_get(:@file) }
+      let(:filename) { upload.instance_variable_get(:@filename) }
+
       before do
         allow(file).to receive('class').and_return('File')
       end
+
       it 'loads the file' do
         expect(uploaded_file.path).to eq(file.path)
       end
@@ -75,7 +83,11 @@ RSpec.describe VBMS::Efolder::UploadService do
       allow(vbms_init).to receive('initialize')
       allow(upload).to receive('client').and_return(vbms_client)
     end
-    
+
+    after do
+      upload.upload_file!
+    end
+
     it 'is called only once per file' do
       expect(upload).to receive('upload_file!').once
     end
@@ -95,14 +107,14 @@ RSpec.describe VBMS::Efolder::UploadService do
       it 'generates an upload request with file and metadata' do
         allow(upload).to receive(:upload).and_return true
         expect(vbms_client).to receive(:send_request) do |request|
-          expect(request.kind_of? VBMS::Requests::InitializeUpload).to be(true)
-          request.instance_values.each do |var, val|
-            expect(request.instance_values[var]).to_not be_nil
+          expect(request.is_a?(VBMS::Requests::InitializeUpload)).to be(true)
+          request.instance_values.each do |var, _val|
+            expect(request.instance_values[var]).not_to be_nil
           end
           expect(request.instance_values['new_mail']).to be_truthy
         end
       end
-  
+
       context 'increments statsd' do
         it 'on success' do
           allow(upload).to receive(:fetch_upload_token).and_return(token)
@@ -121,7 +133,7 @@ RSpec.describe VBMS::Efolder::UploadService do
       it 'uploads document to vbms with token and file' do
         allow(upload).to receive(:fetch_upload_token).and_return(token)
         expect(vbms_client).to receive(:send_request) do |request|
-          expect(request.kind_of? VBMS::Requests::UploadDocument).to be(true)
+          expect(request.is_a?(VBMS::Requests::UploadDocument)).to be(true)
           filepath = upload.instance_variable_get(:@file).tempfile.path
           expect(request.instance_values['filepath']).to eq(filepath)
           expect(request.instance_values['upload_token']).to eq(token)
@@ -139,10 +151,6 @@ RSpec.describe VBMS::Efolder::UploadService do
           expect { upload.upload_file! }.to trigger_statsd_increment(statsd[:upload_fail])
         end
       end
-    end
-    
-    after do
-      upload.upload_file!
     end
   end
 end


### PR DESCRIPTION
Service library for interacting with VBMS eFolder in support of automating burial claims in support of https://github.com/department-of-veterans-affairs/va.gov-team/issues/6931.

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR adds a centralized library for interacting with VBMS eFolder. It includes a generic VBMS::Efolder::UploadService for uploading unstructured documents, a base VBMS::Efolder::Service with some statsd helper methods, and specs for each. The goal of this library is to help centralize workflows around VBMS eFolder and is largely a wrapper around the connect_vbms gem.

<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Testing
Specs are included.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
