### PR TITLE
Log details for clinics who do not support VAOS

### DIFF
--- a/modules/vaos/app/services/vaos/appointment_service.rb
+++ b/modules/vaos/app/services/vaos/appointment_service.rb
@@ -44,7 +44,11 @@ module VAOS
       rescue Common::Exceptions::BackendServiceException => e
         # TODO: Reevaluate the need to log clinic data three months after launch (6/15/20)
         if e.key == 'VAOS_400'
-          Rails.logger.warn('Clinic does not support VAOS appointment cancel', clinic_id: params[:clinic_id], facility_id: params[:facility_id])
+          Rails.logger.warn(
+            'Clinic does not support VAOS appointment cancel',
+            clinic_id: params[:clinic_id],
+            facility_id: params[:facility_id]
+          )
         end
         raise e
       end

--- a/modules/vaos/app/services/vaos/appointment_service.rb
+++ b/modules/vaos/app/services/vaos/appointment_service.rb
@@ -25,6 +25,7 @@ module VAOS
           meta: {}
         }
       rescue Common::Exceptions::BackendServiceException => e
+        # TODO: Reevaluate the need to log clinic data three months after launch (6/15/20)
         if e.key == 'VAOS_400'
           Rails.logger.warn('Clinic does not support VAOS appointment create', clinic: params['clinic'])
         end
@@ -41,6 +42,7 @@ module VAOS
         perform(:put, put_appointment_url(site_code), params, headers)
         ''
       rescue Common::Exceptions::BackendServiceException => e
+        # TODO: Reevaluate the need to log clinic data three months after launch (6/15/20)
         if e.key == 'VAOS_400'
           Rails.logger.warn('Clinic does not support VAOS appointment cancel', clinic: params['clinic'])
         end

--- a/modules/vaos/app/services/vaos/appointment_service.rb
+++ b/modules/vaos/app/services/vaos/appointment_service.rb
@@ -44,7 +44,7 @@ module VAOS
       rescue Common::Exceptions::BackendServiceException => e
         # TODO: Reevaluate the need to log clinic data three months after launch (6/15/20)
         if e.key == 'VAOS_400'
-          Rails.logger.warn('Clinic does not support VAOS appointment cancel', clinic: params['clinic'])
+          Rails.logger.warn('Clinic does not support VAOS appointment cancel', clinic_id: params[:clinic_id], facility_id: params[:facility_id])
         end
         raise e
       end

--- a/modules/vaos/app/services/vaos/appointment_service.rb
+++ b/modules/vaos/app/services/vaos/appointment_service.rb
@@ -24,6 +24,11 @@ module VAOS
           data: OpenStruct.new(response.body),
           meta: {}
         }
+      rescue Common::Exceptions::BackendServiceException => e
+        if e.key == 'VAOS_400'
+          Rails.logger.warn('Clinic does not support VAOS appointment create', clinic: params['clinic'])
+        end
+        raise e
       end
     end
 
@@ -35,6 +40,11 @@ module VAOS
       with_monitoring do
         perform(:put, put_appointment_url(site_code), params, headers)
         ''
+      rescue Common::Exceptions::BackendServiceException => e
+        if e.key == 'VAOS_400'
+          Rails.logger.warn('Clinic does not support VAOS appointment cancel', clinic: params['clinic'])
+        end
+        raise e
       end
     rescue Common::Client::Errors::ClientError => e
       raise_backend_exception('VAOS_502', self.class, e)

--- a/modules/vaos/spec/request/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/appointments_request_spec.rb
@@ -283,7 +283,8 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
             expect(Rails.logger).to receive(:warn).with('VAOS service call failed!', any_args)
             expect(Rails.logger).to receive(:warn).with(
               'Clinic does not support VAOS appointment cancel',
-              clinic: request_body[:clinic]
+              clinic_id: request_body[:clinic_id],
+              facility_id: request_body[:facility_id]
             )
             put '/v0/vaos/appointments/cancel', params: request_body
 

--- a/modules/vaos/spec/request/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/appointments_request_spec.rb
@@ -214,8 +214,13 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
         it 'returns bad request with detail in errors' do
           VCR.use_cassette('vaos/appointments/post_appointment_400', match_requests_on: %i[method uri]) do
-            post '/v0/vaos/appointments', params: request_body
+            expect(Rails.logger).to receive(:warn).with('VAOS service call failed!', any_args)
+            expect(Rails.logger).to receive(:warn).with(
+              'Clinic does not support VAOS appointment create',
+              clinic: request_body[:clinic]
+            )
 
+            post '/v0/vaos/appointments', params: request_body
             expect(response).to have_http_status(:bad_request)
             expect(JSON.parse(response.body)['errors'].first['detail'])
               .to eq(error_detail)
@@ -275,6 +280,11 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
         it 'returns bad request with detail in errors' do
           VCR.use_cassette('vaos/appointments/put_cancel_appointment_400', match_requests_on: %i[method uri]) do
+            expect(Rails.logger).to receive(:warn).with('VAOS service call failed!', any_args)
+            expect(Rails.logger).to receive(:warn).with(
+              'Clinic does not support VAOS appointment cancel',
+              clinic: request_body[:clinic]
+            )
             put '/v0/vaos/appointments/cancel', params: request_body
 
             expect(response).to have_http_status(:bad_request)

--- a/modules/vaos/spec/request/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/appointments_request_spec.rb
@@ -217,10 +217,12 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
             expect(Rails.logger).to receive(:warn).with('VAOS service call failed!', any_args)
             expect(Rails.logger).to receive(:warn).with(
               'Clinic does not support VAOS appointment create',
-              clinic: request_body[:clinic]
+              clinic_id: request_body[:clinic]['clinic_id'],
+              site_code: request_body[:clinic]['site_code']
             )
 
             post '/v0/vaos/appointments', params: request_body
+
             expect(response).to have_http_status(:bad_request)
             expect(JSON.parse(response.body)['errors'].first['detail'])
               .to eq(error_detail)
@@ -284,7 +286,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
             expect(Rails.logger).to receive(:warn).with(
               'Clinic does not support VAOS appointment cancel',
               clinic_id: request_body[:clinic_id],
-              facility_id: request_body[:facility_id]
+              site_code: request_body[:facility_id]
             )
             put '/v0/vaos/appointments/cancel', params: request_body
 


### PR DESCRIPTION
## Description of change
Adds a log line that records clinic information for sites that don't support VAOS (use the `VAOS_400` key)

## Testing
Unit tests

## Acceptance Criteria (Definition of Done)
Adds a warn log line with the clinic details hash

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
