### PR TITLE
Move MHV constants to only class that uses them

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -185,10 +185,14 @@ class User < Common::RedisStore
   # Facilities in the defined range are treating facilities, indicating
   # that the user is a VA patient.
   def va_patient?
+    mhv_facility_range = [[358,718],[720,740],[742,758]].freeze
+    mhv_facility_specific = [['741MM']].freeze # 741 is excluded, but 741MM is included
+
+    # include ranges first, then individual exceptions to the ranges last.
     facilities = va_profile&.vha_facility_ids
     facilities.to_a.any? do |f|
-      Settings.mhv.facility_range.any? { |range| f.to_i.between?(*range) } ||
-        Settings.mhv.facility_specific.include?(f)
+      mhv_facility_range.any? { |range| f.to_i.between?(*range) } ||
+        mhv_facility_specific.include?(f)
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -226,9 +226,6 @@ ppms:
 
 # Settings for MyHealthEVet
 mhv:
-  # include ranges first, then individual exceptions to the ranges last.
-  facility_range: [[358,718],[720,740],[742,758]]
-  facility_specific: [['741MM']] # 741 is excluded, but 741MM is included
   rx:
     host: https://mhv-api.example.com
     app_token: fake-app-token


### PR DESCRIPTION
Found this as part of a code review. These two constants are in the settings file but only used in one file, for one method.
It seems like it makes sense to keep the information close together so its easier to understand what is going on as close to the
use of the values as possible

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Testing
<!-- Please describe testing done to verify the changes or any testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)