### PR TITLE
Cleanup StatsD breakers plugin, use histogram

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require 'appeals/configuration'
 require 'breakers/statsd_plugin'
+
+require 'appeals/configuration'
 require 'bb/configuration'
 require 'emis/military_information_configuration'
 require 'emis/payment_configuration'
@@ -11,62 +12,59 @@ require 'evss/common_service'
 require 'evss/documents_service'
 require 'evss/letters/service'
 require 'evss/gi_bill_status/service'
+require 'evss/letters/service'
 require 'facilities/bulk_configuration'
 require 'gi/configuration'
 require 'hca/configuration'
 require 'mhv_ac/configuration'
 require 'mvi/configuration'
+require 'okta/configuration'
 require 'preneeds/configuration'
 require 'rx/configuration'
 require 'sm/configuration'
 require 'search/configuration'
-require 'okta/configuration'
-
-require 'evss/claims_service'
-require 'evss/common_service'
-require 'evss/documents_service'
-require 'evss/letters/service'
 
 # Read the redis config, create a connection and a namespace for breakers
 redis_config = Rails.application.config_for(:redis).freeze
 redis = Redis.new(redis_config['redis'])
 redis_namespace = Redis::Namespace.new('breakers', redis: redis)
 
+
 services = [
   Appeals::Configuration.instance.breakers_service,
-  Rx::Configuration.instance.breakers_service,
   BB::Configuration.instance.breakers_service,
   EMIS::MilitaryInformationConfiguration.instance.breakers_service,
   EMIS::PaymentConfiguration.instance.breakers_service,
   EMIS::VeteranStatusConfiguration.instance.breakers_service,
   EVSS::ClaimsService.breakers_service,
   EVSS::CommonService.breakers_service,
+  EVSS::Dependents::Configuration.instance.breakers_service,
   EVSS::DocumentsService.breakers_service,
+  EVSS::GiBillStatus::Configuration.instance.breakers_service,
   EVSS::Letters::Configuration.instance.breakers_service,
   EVSS::PCIUAddress::Configuration.instance.breakers_service,
-  EVSS::GiBillStatus::Configuration.instance.breakers_service,
-  EVSS::Dependents::Configuration.instance.breakers_service,
-  Gibft::Configuration.instance.breakers_service,
-  VIC::Configuration.instance.breakers_service,
-  Facilities::AccessWaitTimeConfiguration.instance.breakers_service,
   Facilities::AccessSatisfactionConfiguration.instance.breakers_service,
+  Facilities::AccessWaitTimeConfiguration.instance.breakers_service,
   Facilities::PPMS::Configuration.instance.breakers_service,
-  VIC::Configuration.instance.breakers_service,
   GI::Configuration.instance.breakers_service,
+  Gibft::Configuration.instance.breakers_service,
   HCA::Configuration.instance.breakers_service,
   MHVAC::Configuration.instance.breakers_service,
   MVI::Configuration.instance.breakers_service,
-  Preneeds::Configuration.instance.breakers_service,
-  SM::Configuration.instance.breakers_service,
-  Vet360::ContactInformation::Configuration.instance.breakers_service,
-  Search::Configuration.instance.breakers_service,
   Okta::Configuration.instance.breakers_service,
-  VAOS::Configuration.instance.breakers_service
+  Preneeds::Configuration.instance.breakers_service,
+  Rx::Configuration.instance.breakers_service,
+  Search::Configuration.instance.breakers_service,
+  SM::Configuration.instance.breakers_service,
+  VAOS::Configuration.instance.breakers_service,
+  Vet360::ContactInformation::Configuration.instance.breakers_service,
+  VIC::Configuration.instance.breakers_service, # Not required?
+  VIC::Configuration.instance.breakers_service
 ]
 
 services << CentralMail::Configuration.instance.breakers_service if Settings.central_mail&.upload&.enabled
 
-plugin = Breakers::StatsdPlugin.new
+plugin = Breakers::StatsDPlugin.new
 
 client = Breakers::Client.new(
   redis_connection: redis_namespace,

--- a/lib/breakers/statsd_plugin.rb
+++ b/lib/breakers/statsd_plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Breakers
-  class StatsdPlugin
+  class StatsDPlugin
     def get_tags(request)
       tags = []
       if request
@@ -27,8 +27,9 @@ module Breakers
       tags = get_tags(request_env)
       metric_base = "api.external_http_request.#{service.name}."
       StatsD.increment(metric_base + status, 1, tags: tags)
+
       if response_env && response_env[:duration]
-        StatsD.measure(metric_base + 'time', response_env[:duration], tags: tags)
+        StatsD.histogram(metric_base + 'duration', response_env[:duration], tags: tags)
       end
     end
 


### PR DESCRIPTION
## Description of change
We're currently measuring the external HTTP request duration with a [summary observation](https://prometheus.io/docs/practices/histograms/#quantiles) and in order to aggregate and calculate accurate SLI distributions we need to utilize histograms.

This PR updates breakers to utilize a histogram and also renames the metric to `duration` rather than `time`.

More background [here](https://prometheus.io/docs/practices/histograms/), [here](http://work.haufegroup.io/calculating-slis-with-prometheus/) and [here](https://blog.pvincent.io/2017/12/prometheus-blog-series-part-2-metric-types/).

Corresponding devops PR is [here](https://github.com/department-of-veterans-affairs/devops/pull/6535)

## Testing
- [ ] Locally tested stats are measured as expected
- [ ] CI passes
- [ ] Devops repo checked for any alerting set on this particular metric name

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] External requests are utilizing histogram measurements over summary observations.

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
