### PR TITLE
Updates upleveling logic for SSOe DSLogon users

### DIFF
--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -63,25 +63,26 @@ module SAML
         safe_attr('va_eauth_dodedipnid')
       end
 
+      # va_eauth_credentialassurancelevel is supposed to roll up the
+      # federated assurance level from credential provider and broker.
+      # It is currently returning a value of "2" for DSLogon level 2
+      # so we are interpreting any value greater than 1 as "LOA 3".
       def loa_current
-        @loa_current ||= safe_attr('va_eauth_credentialassurancelevel')&.to_i
+        assurance = safe_attr('va_eauth_credentialassurancelevel')&.to_i
+        @loa_current ||= assurance.present? && assurance > 1 ? 3 : 1
       rescue NoMethodError, KeyError => e
         @warnings << "loa_current error: #{e.message}"
         @loa_current = 1
       end
 
       def mhv_loa_highest
-        if safe_attr('va_eauth_mhvassurance')
-          mhv_assurance = safe_attr('va_eauth_mhvassurance')
-          SAML::UserAttributes::MHV::PREMIUM_LOAS.include?(mhv_assurance) ? 3 : nil
-        end
+        mhv_assurance = safe_attr('va_eauth_mhvassurance')
+        SAML::UserAttributes::MHV::PREMIUM_LOAS.include?(mhv_assurance) ? 3 : nil
       end
 
       def dslogon_loa_highest
-        if safe_attr('va_eauth_dslogonassurance')
-          dslogon_assurance = safe_attr('va_eauth_dslogonassurance')
-          SAML:: UserAttributes::DSLogon::PREMIUM_LOAS.include?(dslogon_assurance) ? 3 : nil
-        end
+        dslogon_assurance = safe_attr('va_eauth_dslogonassurance')
+        SAML:: UserAttributes::DSLogon::PREMIUM_LOAS.include?(dslogon_assurance) ? 3 : nil
       end
 
       # This is the ID.me highest level of assurance attained

--- a/spec/factories/saml_attributes.rb
+++ b/spec/factories/saml_attributes.rb
@@ -704,4 +704,66 @@ FactoryBot.define do
 
     initialize_with { new(attributes.stringify_keys) }
   end
+
+  factory :ssoe_idme_dslogon_level2_singlefactor, class: OneLogin::RubySaml::Attributes do
+    transient do
+      authn_context { 'dslogon' }
+    end
+    va_eauth_aal_idme_highest { ['1'] }
+    va_eauth_icn { ['1013173963V366678'] }
+    va_eauth_ial_idme_highest { ['1'] }
+    va_eauth_dslogonassurance { ['2'] }
+    va_eauth_cspid { ['200VIDM_363761e8857642f7b77ef7d99200e711'] }
+    va_eauth_birthDate_v1 { ['19510604'] }
+    va_eauth_state { ['NOT_FOUND'] }
+    va_eauth_postalcode { ['NOT_FOUND'] }
+    va_eauth_csid { ['idme'] }
+    va_eauth_pid { ['NOT_FOUND'] }
+    va_eauth_pnidtype { ['SSN'] }
+    va_eauth_firstname { ['BRANDIN'] }
+    va_eauth_street { ['NOT_FOUND'] }
+    va_eauth_authenticationMethod { ['dslogon'] }
+    va_eauth_uid { ['363761e8857642f7b77ef7d99200e711'] }
+    va_eauth_isDelegate { ['false'] }
+    va_eauth_secid { ['1013173963'] }
+    va_eauth_persontype { ['NOT_FOUND'] }
+    va_eauth_multifactor { ['false'] }
+    va_eauth_street1 { ['NOT_FOUND'] }
+    va_eauth_phone { ['NOT_FOUND'] }
+    va_eauth_lastname { ['MILLER-NIETO'] }
+    va_eauth_ial { ['2'] }
+    va_eauth_city { ['NOT_FOUND'] }
+    va_eauth_country { ['NOT_FOUND'] }
+    va_eauth_csp_identifier { ['200VIDM'] }
+    va_eauth_gender { ['MALE'] }
+    va_eauth_street2 { ['NOT_FOUND'] }
+    va_eauth_aal { ['1'] }
+    va_eauth_csp_method { ['IDME_DSL'] }
+    va_eauth_dodedipnid { ['2106798217'] }
+    va_eauth_emailaddress { ['iam.tester@example.com'] }
+    va_eauth_authncontextclassref { ['dslogon'] }
+    va_eauth_dslogonuuid { ['2106798217'] }
+    va_eauth_issueinstant { ['2020-03-18T00:05:57Z'] }
+    va_eauth_middlename { ['BRANSON'] }
+    va_eauth_birlsfilenumber { ['NOT_FOUND'] }
+    va_eauth_street3 { ['NOT_FOUND'] }
+    va_eauth_proofingAuthority { ['DMDC'] }
+    va_eauth_credentialassurancelevel { ['2'] }
+    va_eauth_mcid { ['WSSOE2003172005598450418218420'] }
+    va_eauth_prefix { ['NOT_FOUND'] }
+    va_eauth_csponly { ['false'] }
+    va_eauth_pnid { ['666016789'] }
+    va_eauth_commonname { ['iam.tester@example.com'] }
+    va_eauth_transactionid { ['3oiTInhBKGiA/FbtYGVloGdOqUtvKCw4rcuchfwPNAo='] }
+    va_eauth_suffix { ['NOT_FOUND'] }
+    va_eauth_gcIds {
+      ['1013173963V366678^NI^200M^USVHA^P|'\
+       '363761e8857642f7b77ef7d99200e711^PN^200VIDM^USDVA^A|'\
+       '2106798217^NI^200DOD^USDOD^A|'\
+       '1013173963^PN^200PROV^USDVA^A']
+    }
+    va_eauth_mhv_ien { ['NOT_FOUND'] }
+
+    initialize_with { new(attributes.stringify_keys) }
+  end
 end

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -302,6 +302,41 @@ RSpec.describe SAML::User do
       end
     end
 
+    context 'DSLogon premium user without multifactor' do
+      let(:authn_context) { 'dslogon' }
+      let(:account_type) { '3' }
+      let(:highest_attained_loa) { '3' }
+      let(:multifactor) { true }
+      let(:saml_attributes) { build(:ssoe_idme_dslogon_level2_singlefactor) }
+
+      it 'has various important attributes' do
+        expect(subject.to_hash).to eq(
+          birth_date: '19510604',
+          authn_context: authn_context,
+          dslogon_edipi: '2106798217',
+          first_name: 'BRANDIN',
+          last_name: 'MILLER-NIETO',
+          middle_name: 'BRANSON',
+          gender: 'M',
+          ssn: '666016789',
+          zip: nil,
+          mhv_icn: '1013173963V366678',
+          mhv_correlation_id: nil,
+          uuid: '363761e8857642f7b77ef7d99200e711',
+          email: 'iam.tester@example.com',
+          loa: { current: 3, highest: 3 },
+          sign_in: { service_name: 'dslogon', account_type: 3 },
+          multifactor: false,
+          authenticated_by_ssoe: true
+        )
+      end
+
+      it 'does not trigger upleveling' do
+        loa = subject.to_hash[:loa]
+        expect((loa[:highest] > loa[:current])).to be false
+      end
+    end
+
     context 'DSLogon premium user' do
       let(:authn_context) { 'dslogon' }
       let(:account_type) { '3' }


### PR DESCRIPTION
The authentication flow was incorrectly triggering upleveling
for DSLogon levels because it was detecting  loa_current as 2
and loa_highest as 3. This fixes loa_current calculation to
treat anything > 1 as "loa3" for vets-api purposes.

The new factory represents an actually-captured inbound SAML assertion from SSOe so accurately represents the use case. 

Closes va.gov-team6991

## Testing
Will re-test with a DSLogon user in local env. 

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
