### PR TITLE
Remove config.cache_classes true (default to false) in test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,8 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
+  config.enable_dependency_loading = true
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,8 +11,6 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = false
-  config.enable_dependency_loading = true
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
# Description of change
I believe since the Rails 5 upgrade there's been an issue for those that develop against docker version of vets-api. A code change in-between rspec runs would cause a `LoadError` to occur. This made developing with docker much slower than native as you'd have to prepend `bin/spring stop && ` before each `bin/rspec ...` command to pick up any changes.

Removing `config.cache_classes = true` and using the default value of `false` fixes the issue 

## Testing
Local unit tests/code changes/unit tests with docker

## Acceptance Criteria (Definition of Done)
Docker rspec runs no longer throw LoadError when code changes

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
