### PR TITLE
Updated make command in README for Docker configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ VA.gov Team Engineers should follow instructions [here](https://github.com/depar
 
 Once you have the `EXCLUDE_SIDEKIQ_ENTERPRISE` set you can run the application with:
 ```
-make up
+env=dev make up
 ```
 
 You should then be able to navigate to [http://localhost:3000/v0/status](http://localhost:3000/v0/status) in your


### PR DESCRIPTION
## Description of change
After changes in #4029, running `make up` in the Docker configuration started causing issues with logins. This is because the default `make up` behavior starts a test environment, which doesn't create the `vets_api_development` database. It should be clear to developers using the Docker configuration for local development that they should run the following:

```
env=dev make up
```

## Testing
Ran `make up` with and without the environment variable and found that the `vets_api_development` DB only gets created when the environment is specified as `dev`.

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
