### PR TITLE
set default env to 'dev' in Makefile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,32 +32,32 @@ pipeline {
     stage('Build Docker Images'){
       steps {
         withCredentials([string(credentialsId: 'sidekiq-enterprise-license', variable: 'BUNDLE_ENTERPRISE__CONTRIBSYS__COM')]) {
-          sh 'make build'
+          sh 'env=$RAILS_ENV make build'
         }
       }
     }
 
     stage('Setup Testing DB') {
       steps {
-        sh 'make db'
+        sh 'env=$RAILS_ENV make db'
       }
     }
 
     stage('Lint') {
       steps {
-        sh 'make lint'
+        sh 'env=$RAILS_ENV make lint'
       }
     }
 
     stage('Security Scan') {
       steps {
-        sh 'make security'
+        sh 'env=$RAILS_ENV make security'
       }
     }
 
     stage('Run tests') {
       steps {
-        sh 'make spec'
+        sh 'env=$RAILS_ENV make spec'
       }
       post {
         success {
@@ -71,7 +71,7 @@ pipeline {
     stage('Run Danger Bot') {
       steps {
         withCredentials([string(credentialsId: 'danger-github-api-token',    variable: 'DANGER_GITHUB_API_TOKEN')]) {
-          sh 'make danger'
+          sh 'env=$RAILS_ENV make danger'
         }
       }
     }
@@ -144,7 +144,7 @@ pipeline {
   }
   post {
     always {
-      sh 'make down'
+      sh 'env=$RAILS_ENV make down'
       deleteDir() /* clean up our workspace */
     }
     failure {

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 $stdout.sync = true
 export VETS_API_USER_ID  := $(shell id -u)
 
-ENV_ARG      := $(env)
+ifdef env
+	ENV_ARG    := $(env)
+else
+	ENV_ARG		 := dev
+endif
 
 COMPOSE_DEV  := docker-compose
 COMPOSE_TEST := docker-compose -f docker-compose.test.yml

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 $stdout.sync = true
 export VETS_API_USER_ID  := $(shell id -u)
 
-ENV_ARG      := $(env)
+ifdef env
+	ENV_ARG    := $(env)
+else
+	ENV_ARG		 := dev
+endif
+
 COMPOSE_DEV  := docker-compose
 COMPOSE_TEST := docker-compose -f docker-compose.test.yml
 BASH         := run --rm --service-ports vets-api bash

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 $stdout.sync = true
 export VETS_API_USER_ID  := $(shell id -u)
 
-ifdef env
-	ENV_ARG    := $(env)
-else
-	ENV_ARG		 := dev
-endif
+# ifdef env
+# 	ENV_ARG    := $(env)
+# else
+# 	ENV_ARG		 := dev
+# endif
+ENV_ARG      := $(env)
 
 COMPOSE_DEV  := docker-compose
 COMPOSE_TEST := docker-compose -f docker-compose.test.yml

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ $stdout.sync = true
 export VETS_API_USER_ID  := $(shell id -u)
 
 ifdef env
-	ENV_ARG    := $(env)
+    ENV_ARG  := $(env)
 else
-	ENV_ARG	   := dev
+    ENV_ARG	 := dev
 endif
 
 COMPOSE_DEV  := docker-compose

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 $stdout.sync = true
 export VETS_API_USER_ID  := $(shell id -u)
 
-# ifdef env
-# 	ENV_ARG    := $(env)
-# else
-# 	ENV_ARG		 := dev
-# endif
-ENV_ARG      := $(env)
+ifdef env
+	ENV_ARG    := $(env)
+else
+	ENV_ARG	   := dev
+endif
 
+# ENV_ARG      := $(env)
 COMPOSE_DEV  := docker-compose
 COMPOSE_TEST := docker-compose -f docker-compose.test.yml
 BASH         := run --rm --service-ports vets-api bash

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ else
 	ENV_ARG	   := dev
 endif
 
-# ENV_ARG      := $(env)
 COMPOSE_DEV  := docker-compose
 COMPOSE_TEST := docker-compose -f docker-compose.test.yml
 BASH         := run --rm --service-ports vets-api bash

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,7 @@
 $stdout.sync = true
 export VETS_API_USER_ID  := $(shell id -u)
 
-ifdef env
-	ENV_ARG    := $(env)
-else
-	ENV_ARG		 := dev
-endif
+ENV_ARG      := $(env)
 
 COMPOSE_DEV  := docker-compose
 COMPOSE_TEST := docker-compose -f docker-compose.test.yml


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR sets the default `ENV_ARG` variable to 'dev' in the Makefile.
This allows those than run `vets-api` via Docker to _not_ have to set the variable explicitly.

## Testing
<!-- Please describe testing done to verify the changes or any testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Default value of `ENV_ARG` to 'dev' if no other value is provided

#### Applies to all PRs

- [ ] ~~Swagger docs have been updated, if applicable~~
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
