### PR TITLE
Update to Concatenate Pay Plan and Pay Grade

### DIFF
--- a/modules/veteran_verification/VETERAN_VERIFICATION.yml
+++ b/modules/veteran_verification/VETERAN_VERIFICATION.yml
@@ -267,6 +267,7 @@ components:
                  - ME (Enlisted)
                  - MO (Officer)
                  - MW (Warrant Officer)
+                 
                 Pay Grade Code is a value between 01 and 10.
                 Pay Plan Code is concatenated with Pay Grade Code to determine the full Pay Grade value, with the leading character (M or C) stripped from Pay Plan Code.
               example: "W01"

--- a/modules/veteran_verification/VETERAN_VERIFICATION.yml
+++ b/modules/veteran_verification/VETERAN_VERIFICATION.yml
@@ -260,15 +260,15 @@ components:
               description: |
                 Defines the level of compensation for a position, normalized across military branches
 
-                Possible values include the concatenation of Pay Plan and Pay Grade.
-                Pay Plan is represented as a two-character code, and can be one of five values:
+                Possible values include the concatenation of Pay Plan Code and Pay Grade Code.
+                Pay Plan Code is represented as a two-character code, and can be one of five values:
                  - CC (Commissioned Corps)
                  - MC (Cadet)
                  - ME (Enlisted)
                  - MO (Officer)
                  - MW (Warrant Officer)
-                Pay Grade is a value between 01 and 10.
-                Pay Plan needs to be concatenated with Pay Grade to determine the full grade, with the leading character (M or C) stripped from Pay Plan.
+                Pay Grade Code is a value between 01 and 10.
+                Pay Plan Code is concatenated with Pay Grade Code to determine the full Pay Grade value, with the leading character (M or C) stripped from Pay Plan Code.
               example: "W01"
             discharge_status:
               type: string

--- a/modules/veteran_verification/VETERAN_VERIFICATION.yml
+++ b/modules/veteran_verification/VETERAN_VERIFICATION.yml
@@ -12,10 +12,10 @@ info:
 
     ### 1. Get Access Credentials
 
-    Get started by filling out the form on the [Apply for VA Lighthouse Developer Access](/apply) page. 
-    
+    Get started by filling out the form on the [Apply for VA Lighthouse Developer Access](/apply) page.
+
     After submitting a request, you will receive your credentials for using the API in the Sandbox environment, which allows you to try it out with mock data before moving to the Production environment.
-    
+
     ### 2. Test the  API
 
     In the endpoint documentation below, we've provided a curl command builder for trying out the API before implementation with your app.
@@ -48,7 +48,7 @@ info:
 
     ### Sandbox vs. Production Data
     APIs accessed via the Sandbox environment are using the same underlying logic as VA’s production APIs; only the underlying data store is different.
-  
+
     ### Rate Limiting
     We implemented basic rate limiting of 60 requests per minute. If you exceed this quota, your request will return a 429 status code. You may petition for increased rate limits by emailing, and requests will be decided on a case by case basis.
 
@@ -255,10 +255,21 @@ components:
               type: string
               description: Branch of military including National Guard or Reserve status
               example: "Air Force"
-            pay_grade_code:
+            pay_grade:
               type: string
-              description: Defines the level of compensation for a position, normalized across military branches
-              example: "06"
+              description: |
+                Defines the level of compensation for a position, normalized across military branches
+
+                Possible values include the concatenation of Pay Plan and Pay Grade.
+                Pay Plan is represented as a two-character code, and can be one of five values:
+                 - CC (Commissioned Corps)
+                 - MC (Cadet)
+                 - ME (Enlisted)
+                 - MO (Officer)
+                 - MW (Warrant Officer)
+                Pay Grade is a value between 01 and 10.
+                Pay Plan needs to be concatenated with Pay Grade to determine the full grade, with the leading character (M or C) stripped from Pay Plan.
+              example: "W01"
             discharge_status:
               type: string
               description: |

--- a/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
+++ b/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
@@ -74,7 +74,11 @@ module VeteranVerification
     end
 
     def self.build_pay_grade(episode)
-      episode.pay_plan_code[1] + episode.pay_grade_code
+      if (episode.pay_plan_code.blank? || episode.pay_grade_code.blank?)
+        return 'unknown'
+      else
+        return episode.pay_plan_code[1] + episode.pay_grade_code
+      end
     end
   end
 end

--- a/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
+++ b/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
@@ -75,9 +75,9 @@ module VeteranVerification
 
     def self.build_pay_grade(episode)
       if (episode.pay_plan_code.blank? || episode.pay_grade_code.blank?)
-        return 'unknown'
+        'unknown'
       else
-        return episode.pay_plan_code[1] + episode.pay_grade_code
+        episode.pay_plan_code[1] + episode.pay_grade_code
       end
     end
   end

--- a/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
+++ b/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
@@ -74,7 +74,7 @@ module VeteranVerification
     end
 
     def self.build_pay_grade(episode)
-      if (episode.pay_plan_code.blank? || episode.pay_grade_code.blank?)
+      if episode.pay_plan_code.blank? || episode.pay_grade_code.blank?
         'unknown'
       else
         episode.pay_plan_code[1] + episode.pay_grade_code

--- a/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
+++ b/modules/veteran_verification/app/models/veteran_verification/service_history_episode.rb
@@ -13,7 +13,7 @@ module VeteranVerification
     attribute :deployments, Array
     attribute :discharge_type, String
     attribute :start_date, Date
-    attribute :pay_grade_code, String
+    attribute :pay_grade, String
     attribute :separation_reason, String
 
     def self.for_user(user)
@@ -42,7 +42,7 @@ module VeteranVerification
           deployments: deployments(emis, episode),
           discharge_type: episode.discharge_character_of_service_code,
           start_date: episode.begin_date,
-          pay_grade_code: episode.pay_grade_code,
+          pay_grade: build_pay_grade(episode),
           separation_reason: episode.narrative_reason_for_separation_txt
         )
       end
@@ -71,6 +71,10 @@ module VeteranVerification
 
     def discharge_status
       EMISRedis::MilitaryInformationV2::EXTERNAL_DISCHARGE_TYPES[discharge_type] || 'unknown'
+    end
+
+    def self.build_pay_grade(episode)
+      episode.pay_plan_code[1] + episode.pay_grade_code
     end
   end
 end

--- a/modules/veteran_verification/app/serializers/veteran_verification/service_history_serializer.rb
+++ b/modules/veteran_verification/app/serializers/veteran_verification/service_history_serializer.rb
@@ -2,7 +2,7 @@
 
 module VeteranVerification
   class ServiceHistorySerializer < ActiveModel::Serializer
-    attributes :branch_of_service, :start_date, :end_date, :pay_grade_code,
+    attributes :branch_of_service, :start_date, :end_date, :pay_grade,
                :discharge_status, :separation_reason, :deployments
     type 'service_history_episodes'
   end

--- a/modules/veteran_verification/spec/models/service_history_episode_spec.rb
+++ b/modules/veteran_verification/spec/models/service_history_episode_spec.rb
@@ -12,6 +12,7 @@ describe VeteranVerification::ServiceHistoryEpisode, skip_emis: true do
           result = described_class.for_user(user)
           expect(result.length).to eq(1)
           expect(result[0][:branch_of_service]).to eq('Army National Guard')
+          expect(result[0][:pay_grade]).to eq('W04')
           expect(result[0][:deployments][0][:location]).to eq('AX1')
         end
       end
@@ -23,6 +24,7 @@ describe VeteranVerification::ServiceHistoryEpisode, skip_emis: true do
           result = described_class.for_user(user)
           expect(result.length).to eq(2)
           expect(result[0][:branch_of_service]).to eq('Army National Guard')
+          expect(result[0][:pay_grade]).to eq('W04')
           expect(result[1][:deployments][0][:location]).to eq('AX1')
         end
       end

--- a/modules/veteran_verification/spec/models/service_history_episode_spec.rb
+++ b/modules/veteran_verification/spec/models/service_history_episode_spec.rb
@@ -29,5 +29,17 @@ describe VeteranVerification::ServiceHistoryEpisode, skip_emis: true do
         end
       end
     end
+
+    it 'returns service history and deployments but missing pay_grade' do
+      VCR.use_cassette('emis/get_deployment_v2/valid') do
+        VCR.use_cassette('emis/get_military_service_episodes_v2/invalid_missing_pay_plan') do
+          result = described_class.for_user(user)
+          expect(result.length).to eq(1)
+          expect(result[0][:branch_of_service]).to eq('Army National Guard')
+          expect(result[0][:pay_grade]).to eq('unknown')
+          expect(result[0][:deployments][0][:location]).to eq('AX1')
+        end
+      end
+    end
   end
 end

--- a/spec/support/schemas/service_and_deployment_history_response.json
+++ b/spec/support/schemas/service_and_deployment_history_response.json
@@ -18,7 +18,7 @@
               "end_date": {
                 "type": "string"
               },
-              "pay_grade_code": {
+              "pay_grade": {
                 "type": "string"
               },
               "separation_reason": {

--- a/spec/support/vcr_cassettes/emis/get_military_service_episodes_v2/invalid_missing_pay_plan.yml
+++ b/spec/support/vcr_cassettes/emis/get_military_service_episodes_v2/invalid_missing_pay_plan.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://vaausvrsapp81.aac.va.gov/VIERSService/eMIS/v2/MilitaryInformationService
+    body:
+      encoding: ASCII-8BIT
+      string: |2
+
+        <soap:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:v1="http://viers.va.gov/cdi/CDI/commonService/v2" xmlns:v12="http://viers.va.gov/cdi/eMIS/RequestResponse/v2" xmlns:v13="http://viers.va.gov/cdi/eMIS/commonService/v2" xmlns:v11="http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v2">
+          <soap:Header>
+            <v1:inputHeaderInfo>
+              <v1:userId>vets.gov</v1:userId>
+              <v1:sourceSystemName>vets.gov</v1:sourceSystemName>
+              <v1:transactionId>9eac7549-8c2e-4f83-8a5a-b33d326b0a6e</v1:transactionId>
+            </v1:inputHeaderInfo>
+          </soap:Header>
+          <soap:Body>
+            <v11:eMISserviceEpisodeRequest>
+              <v12:edipiORicn>
+                <v13:edipiORicnValue>1007697216</v13:edipiORicnValue>
+                <v13:inputType>EDIPI</v13:inputType>
+              </v12:edipiORicn>
+            </v11:eMISserviceEpisodeRequest>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Accept:
+      - text/xml;charset=UTF-8
+      Content-Type:
+      - text/xml;charset=UTF-8
+      User-Agent:
+      - Vets.gov Agent
+      Soapaction:
+      - http://viers.va.gov/cdi/eMIS/getMilitaryServiceEpisodes/v2
+      Date:
+      - Wed, 27 Nov 2019 19:29:58 GMT
+      Content-Length:
+      - '949'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Nov 2019 19:30:00 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Content-Length:
+      - '2246'
+      Cache-Control:
+      - max-age=0, no-store
+      Content-Type:
+      - application/soap+xml;charset=utf-8
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><NS1:Envelope xmlns:NS1="http://www.w3.org/2003/05/soap-envelope"><NS1:Header><NS2:essResponseCode
+        xmlns:NS2="http://va.gov/ess/message/v1">Success</NS2:essResponseCode><NS3:inputHeaderInfo
+        xmlns:NS3="http://viers.va.gov/cdi/CDI/commonService/v2"><NS3:userId>vets.gov</NS3:userId><NS3:sourceSystemName>vets.gov</NS3:sourceSystemName><NS3:transactionId>9eac7549-8c2e-4f83-8a5a-b33d326b0a6e</NS3:transactionId></NS3:inputHeaderInfo></NS1:Header><NS1:Body><NS4:eMISserviceEpisodeResponse
+        xmlns:NS4="http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v2"><NS5:militaryServiceEpisode
+        xmlns:NS5="http://viers.va.gov/cdi/eMIS/RequestResponse/v2"><NS6:edipi xmlns:NS6="http://viers.va.gov/cdi/eMIS/commonService/v2">1007697216</NS6:edipi><NS7:keyData
+        xmlns:NS7="http://viers.va.gov/cdi/eMIS/commonService/v2"><NS7:personnelOrganizationCode>51</NS7:personnelOrganizationCode><NS7:personnelCategoryTypeCode>N</NS7:personnelCategoryTypeCode><NS7:personnelSegmentIdentifier>1</NS7:personnelSegmentIdentifier></NS7:keyData><NS8:militaryServiceEpisodeData
+        xmlns:NS8="http://viers.va.gov/cdi/eMIS/commonService/v2"><NS8:serviceEpisodeStartDate>2002-02-02</NS8:serviceEpisodeStartDate><NS8:serviceEpisodeEndDate>2008-12-01</NS8:serviceEpisodeEndDate><NS8:serviceEpisodeTerminationReason>S</NS8:serviceEpisodeTerminationReason><NS8:branchOfServiceCode>A</NS8:branchOfServiceCode><NS8:dischargeCharacterOfServiceCode>B</NS8:dischargeCharacterOfServiceCode><NS8:personnelStatusChangeTransactionTypeCode>343</NS8:personnelStatusChangeTransactionTypeCode><NS8:narrativeReasonForSeparationCode>999</NS8:narrativeReasonForSeparationCode><NS8:narrativeReasonForSeparationTxt>UNKNOWN</NS8:narrativeReasonForSeparationTxt><NS8:mgadLossCategoryCode>11</NS8:mgadLossCategoryCode><NS8:payPlanCode></NS8:payPlanCode><NS8:payGradeCode>04</NS8:payGradeCode><NS8:serviceRankNameCode>CW4</NS8:serviceRankNameCode><NS8:serviceRankNameTxt>Chief
+        Warrant Officer</NS8:serviceRankNameTxt><NS8:payGradeDate>2002-02-02</NS8:payGradeDate><NS8:activeDutyServiceAgreementQuantity>1</NS8:activeDutyServiceAgreementQuantity></NS8:militaryServiceEpisodeData></NS5:militaryServiceEpisode></NS4:eMISserviceEpisodeResponse></NS1:Body></NS1:Envelope>
+    http_version:
+  recorded_at: Wed, 27 Nov 2019 19:29:59 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR supports https://vasdvp.atlassian.net/browse/IN-137.

In order to determine the grade for a military service member, a combination of Pay Plan Code and Pay Grade Code is needed.
Pay Grade is a value between 01 and 10.
Pay Plan is represented as a two-character code, and can be one of five values:

 - CC (Commissioned Corps)
 - MC (Cadet)
 - ME (Enlisted)
 - MO (Officer)
 - MW (Warrant Officer)

Pay Plan needs to be concatenated with Pay Grade to determine the full grade, with the leading character (M or C) stripped from Pay Plan. For example, if a service member had Pay Plan=MW and Pay Grade=01, the concatenated value to be returned in the API would be W01.

Pay Plan exists in the eMIS getMilitaryServiceEpisodes response, so there's no additional service connectivity needed. It needs to be mapped/translated as mentioned above, and the final value can remain in the existing API field being used for Pay Grade.

## Testing

Added an additional unit test based on the pay grade calculation.

## Acceptance Criteria (Definition of Done)

- `Pay Plan` and `Pay Grade` are concatenated in the `Pay Grade` field as described above.
- The API's documentation is updated to describe how this data is treated.

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Adds new `build_pay_grade` method that performs desired `pay_plan_code` & `pay_grade_code` concatenation. 

#### Applies to all PRs

- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
