### PR TITLE
fix: using "myvahealth" as the key for a login redirect

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,7 +37,7 @@ sso:
   cookie_secure: false
   cookie_domain: localhost
   ssoe_redirects:
-    cerner: https://ehrm-va-test.patientportal.us.healtheintent.com/
+    myvahealth: https://ehrm-va-test.patientportal.us.healtheintent.com/
 
 binaries:
   # you can specify a full path in settings.local.yml if necessary

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,7 +36,9 @@ sso:
   cookie_iv: A3C0567C78BEC6DDE75E2FEB92DE11AA
   cookie_secure: false
   cookie_domain: localhost
-  ssoe_redirects:
+
+ssoe:
+  redirects:
     myvahealth: https://ehrm-va-test.patientportal.us.healtheintent.com/
 
 binaries:

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -38,7 +38,7 @@ module SAML
       initialize_query_params(params)
       # the optional redirect_application is used to determine where to redirect
       # the user to after a successful login
-      @redirect_application = Settings.sso.ssoe_redirects[params[:application]]
+      @redirect_application = Settings.ssoe.redirects[params[:application]]
     end
 
     # REDIRECT_URLS

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -37,8 +37,10 @@ module SAML
       Raven.user_context(session: session, user: user)
       initialize_query_params(params)
       # the optional redirect_application is used to determine where to redirect
-      # the user to after a succesful login
-      @redirect_application = params[:application]
+      # the user to after a successful login
+      if Settings.sso.ssoe_redirects[params[:application]]
+        @redirect_application = params[:application]
+      end
     end
 
     # REDIRECT_URLS

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -38,9 +38,7 @@ module SAML
       initialize_query_params(params)
       # the optional redirect_application is used to determine where to redirect
       # the user to after a successful login
-      if Settings.sso.ssoe_redirects[params[:application]]
-        @redirect_application = params[:application]
-      end
+      @redirect_application = Settings.sso.ssoe_redirects[params[:application]]
     end
 
     # REDIRECT_URLS
@@ -54,7 +52,7 @@ module SAML
 
       return verify_url if auth == 'success' && user.loa[:current] < user.loa[:highest]
 
-      return Settings.sso.ssoe_redirects[@redirect_application] if @redirect_application
+      return @redirect_application if @redirect_application
 
       @query_params[:type] = type if type
       @query_params[:auth] = auth if auth == 'fail'

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -200,10 +200,10 @@ RSpec.describe V1::SessionsController, type: :controller do
 
       it 'redirect user to external site' do
         LoginRedirectApplication.create(
-          uuid: login_uuid, redirect_application: Settings.sso.ssoe_redirects['myvahealth']
+          uuid: login_uuid, redirect_application: Settings.ssoe.redirects['myvahealth']
         )
         allow(SAML::User).to receive(:new).and_return(saml_user)
-        expect(post(:saml_callback)).to redirect_to(Settings.sso.ssoe_redirects['myvahealth'])
+        expect(post(:saml_callback)).to redirect_to(Settings.ssoe.redirects['myvahealth'])
       end
     end
   end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -129,6 +129,19 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .with_params('clientId' => '123123')
               expect(LoginRedirectApplication.keys.length).to eq(1)
             end
+
+            it 'ignores invalid redirect application' do
+              expect { get(:new, params: { type: type, clientId: '123123', application: 'unknown' }) }
+                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
+                                             tags: ["context:#{type}", 'forceauthn:false'], **once)
+
+              expect(response).to have_http_status(:found)
+              expect(response.location)
+                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
+                .with_relay_state('originating_request_id' => nil, 'type' => type)
+                .with_params('clientId' => '123123')
+              expect(LoginRedirectApplication.keys.length).to eq(0)
+            end
           end
         end
 

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe V1::SessionsController, type: :controller do
             end
 
             it 'persists redirect application' do
-              expect { get(:new, params: { type: type, clientId: '123123', application: 'cerner' }) }
+              expect { get(:new, params: { type: type, clientId: '123123', application: 'myvahealth' }) }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                              tags: ["context:#{type}", 'forceauthn:false'], **once)
 
@@ -187,10 +187,10 @@ RSpec.describe V1::SessionsController, type: :controller do
 
       it 'redirect user to external site' do
         LoginRedirectApplication.create(
-          uuid: login_uuid, redirect_application: 'cerner'
+          uuid: login_uuid, redirect_application: 'myvahealth'
         )
         allow(SAML::User).to receive(:new).and_return(saml_user)
-        expect(post(:saml_callback)).to redirect_to(Settings.sso.ssoe_redirects['cerner'])
+        expect(post(:saml_callback)).to redirect_to(Settings.sso.ssoe_redirects['myvahealth'])
       end
     end
   end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe V1::SessionsController, type: :controller do
 
       it 'redirect user to external site' do
         LoginRedirectApplication.create(
-          uuid: login_uuid, redirect_application: 'myvahealth'
+          uuid: login_uuid, redirect_application: Settings.sso.ssoe_redirects['myvahealth']
         )
         allow(SAML::User).to receive(:new).and_return(saml_user)
         expect(post(:saml_callback)).to redirect_to(Settings.sso.ssoe_redirects['myvahealth'])


### PR DESCRIPTION
Instead of "cerner", use "myvahealth" as the application redirect value when a user lands on the standalone login page.

Also adding a check/spec for handling unknown application values.

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/6917

## Testing
- updated existing specs with new application key name
- added a new spec for ignoring unknown application redirect values

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
