### PR TITLE
install Sidekiq pro/ent if license is present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,9 @@ WORKDIR /srv/vets-api/src
 FROM base AS development
 
 ARG sidekiq_license
-ARG exclude_sidekiq_ent
 ARG rails_env=development
 
 ENV BUNDLE_ENTERPRISE__CONTRIBSYS__COM=$sidekiq_license
-ENV EXCLUDE_SIDEKIQ_ENTERPRISE=$exclude_sidekiq_ent
 ENV RAILS_ENV=$rails_env
 
 # only extra dev/build opts go here, common packages go in base 👆

--- a/Gemfile
+++ b/Gemfile
@@ -173,7 +173,7 @@ end
 group :production do
   # sidekiq enterprise requires a license key to download but is only required in production.
   # for local dev environments, regular sidekiq works fine
-  if Bundler::Settings.new['enterprise.contribsys.com'] || ENV['BUNDLE_ENTERPRISE__CONTRIBSYS__COM']
+  unless Bundler::Settings.new['enterprise.contribsys.com']&.empty? && ENV['BUNDLE_ENTERPRISE__CONTRIBSYS__COM']&.empty?
     source 'https://enterprise.contribsys.com/' do
       gem 'sidekiq-ent'
       gem 'sidekiq-pro'

--- a/Gemfile
+++ b/Gemfile
@@ -173,7 +173,7 @@ end
 group :production do
   # sidekiq enterprise requires a license key to download but is only required in production.
   # for local dev environments, regular sidekiq works fine
-  unless ENV['EXCLUDE_SIDEKIQ_ENTERPRISE'] == 'true'
+  if Bundler::Settings.new['enterprise.contribsys.com'] || ENV['BUNDLE_ENTERPRISE__CONTRIBSYS__COM']
     source 'https://enterprise.contribsys.com/' do
       gem 'sidekiq-ent'
       gem 'sidekiq-pro'

--- a/Gemfile
+++ b/Gemfile
@@ -173,7 +173,8 @@ end
 group :production do
   # sidekiq enterprise requires a license key to download but is only required in production.
   # for local dev environments, regular sidekiq works fine
-  unless Bundler::Settings.new['enterprise.contribsys.com']&.empty? && ENV['BUNDLE_ENTERPRISE__CONTRIBSYS__COM']&.empty?
+  unless Bundler::Settings.new['enterprise.contribsys.com']&.empty? &&
+         ENV.fetch('BUNDLE_ENTERPRISE__CONTRIBSYS__COM', '').empty?
     source 'https://enterprise.contribsys.com/' do
       gem 'sidekiq-ent'
       gem 'sidekiq-pro'

--- a/README.md
+++ b/README.md
@@ -39,22 +39,16 @@ saml:
 A Makefile provides shortcuts for interacting with the docker images. To run vets-api and its redis and postgres
 dependencies run the following command from within the repo you cloned in the above steps.
 
-### Authentication required for enterprise.contribsys.com
+### Sidekiq Enterprise
 
-```
-Authentication is required for enterprise.contribsys.com.
-Please supply credentials for this source. You can do this by running:
- bundle config enterprise.contribsys.com username:password
-ERROR: Service 'vets-api' failed to build: The command '/bin/bash --login -c bundle install -j4' returned a non-zero code: 17
-make: *** [db] Error 1
-```
+Sidekiq Enterprise is used for worker rate limiting and additional reliability.  
+Sidekiq Enterprise requires a license be configured on your development machine.  
+If you do not have license configured, Sidekiq Enterprise will simply not be installed during gem installation.
 
-Sidekiq Enterprise is used for worker rate limiting and additional reliability. Most
-developers can bypass the installation of Sidekiq Enterprise with
+VA.gov Team Engineers can follow instructions [here](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Platform/Vets-API/Sidekiq%20Enterprise%20Setup.md) to install the enterprise license on their systems.
 
-- `$ EXCLUDE_SIDEKIQ_ENTERPRISE=true make rebuild`
-
-VA.gov Team Engineers should follow instructions [here](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Platform/Vets-API/Sidekiq%20Enterprise%20Setup.md) to install the enterprise license on their systems.
+Unless you are sure you need a Sidekiq Enterprise feature, you are probably fine without configuring the license and running Sidekiq Enterprise.  
+Normal Sidekiq will still be installed and run.
 
 **DO NOT commit Gemfile modifications that result from local builds without sidekiq enterprise if you do not have it enabled on your development system**
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Sidekiq Enterprise is used for worker rate limiting and additional reliability.
 Sidekiq Enterprise requires a license be configured on your development machine.  
 If you do not have license configured, Sidekiq Enterprise will simply not be installed during gem installation.
 
-VA.gov Team Engineers can follow instructions [here](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Platform/Vets-API/Sidekiq%20Enterprise%20Setup.md) to install the enterprise license on their systems.
-
 Unless you are sure you need a Sidekiq Enterprise feature, you are probably fine without configuring the license and running Sidekiq Enterprise.  
 Normal Sidekiq will still be installed and run.
+
+If you do need Sidekiq Enterprise, VA.gov Team Engineers can follow instructions [here](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Platform/Vets-API/Sidekiq%20Enterprise%20Setup.md) to install the enterprise license on their systems.
 
 **DO NOT commit Gemfile modifications that result from local builds without sidekiq enterprise if you do not have it enabled on your development system**
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Normal Sidekiq will still be installed and run.
 
 **DO NOT commit Gemfile modifications that result from local builds without sidekiq enterprise if you do not have it enabled on your development system**
 
-Once you have the `EXCLUDE_SIDEKIQ_ENTERPRISE` set you can run the application with:
 ```
 make up
 ```

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -18,7 +18,6 @@ services:
       context: .
       target: development
       args:
-        exclude_sidekiq_ent: "${EXCLUDE_SIDEKIQ_ENTERPRISE:-false}"
         sidekiq_license: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
         userid: "${VETS_API_USER_ID}"
     command: >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       context: .
       target: development
       args:
-        exclude_sidekiq_ent: "${EXCLUDE_SIDEKIQ_ENTERPRISE:-false}"
         sidekiq_license: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
         userid: "${VETS_API_USER_ID}"
     image: "vets-api:${DOCKER_IMAGE:-latest}"


### PR DESCRIPTION
## Description of change
Changes Gemfile to install Sidekiq pro/ent if license is present
Removes need for `EXCLUDE_SIDEKIQ_ENTERPRISE` var

Developers often run into the scenario where they don't have the license set or the `EXCLUDE_SIDEKIQ_ENTERPRISE` variable set.  Then installation blows up when Bundler tries to install Sidekiq pro/ent.

With this change Sidekiq Pro/Ent gets installed if the license is present and it doesn't if the license is not present.  That's it.  No extra config.  No blow-ups.

TODO: Remove references to `EXCLUDE_SIDEKIQ_ENTERPRISE` from documentation.

## Testing
N/A

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Check for presence of Sidekiq Ent license before installing Sidekiq Pro/Ent gems

#### Applies to all PRs

- [ ] ~~Swagger docs have been updated, if applicable~~
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] ~~Provide which alerts would indicate a problem with this functionality (if applicable)~~
