### PR TITLE
Cleanup v1 logout api

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -53,8 +53,6 @@ module V0
 
     def saml_callback
       saml_response = SAML::Responses::Login.new(params[:SAMLResponse], settings: saml_settings)
-      Rails.logger.info('PVSAML: ' + saml_response.response)
-
 
       if saml_response.valid?
         user_login(saml_response)

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -53,6 +53,8 @@ module V0
 
     def saml_callback
       saml_response = SAML::Responses::Login.new(params[:SAMLResponse], settings: saml_settings)
+      Rails.logger.info('PVSAML: ' + saml_response.response)
+
 
       if saml_response.valid?
         user_login(saml_response)

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -22,12 +22,11 @@ module V1
     # For more details see SAML::SettingsService and SAML::URLService
     def new
       type = params[:type]
-      if type == 'slo'
-        type = 'ssoe_slo'
-       raise Common::Exceptions::RoutingError, params[:path] unless REDIRECT_URLS.include?(type)
+      raise Common::Exceptions::RoutingError, params[:path] unless REDIRECT_URLS.include?(type)
 
       StatsD.increment(STATSD_SSO_NEW_KEY,
                        tags: ["context:#{type}", "forceauthn:#{force_authn?}"])
+      type = 'ssoe_slo' if type == 'slo'
       url = url_service.send("#{type}_url")
 
       if type == 'ssoe_slo'

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -65,6 +65,7 @@ module V1
 
     private
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def redirect_url(type)
       case type
       when 'signup'
@@ -85,6 +86,7 @@ module V1
         raise Common::Exceptions::RoutingError, params[:path]
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def force_authn?
       params[:force]&.downcase == 'true'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,6 @@ Rails.application.routes.draw do
       constraints: ->(request) { V0::SessionsController::REDIRECT_URLS.include?(request.path_parameters[:type]) }
 
   get '/v1/sessions/metadata', to: 'v1/sessions#metadata'
-  get '/v1/sessions/logout', to: 'v1/sessions#saml_logout_callback'
   post '/v1/sessions/callback', to: 'v1/sessions#saml_callback', module: 'v1'
   get '/v1/sessions/:type/new',
       to: 'v1/sessions#new',

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -20,7 +20,8 @@ module SAML
     attr_reader :saml_settings, :session, :user, :authn_context, :type, :query_params, :redirect_application
 
     def initialize(saml_settings, session: nil, user: nil, params: {}, loa3_context: LOA::IDME_LOA3_VETS)
-      unless %w[new saml_callback saml_logout_callback].include?(params[:action])
+      binding.pry
+      unless %w[new saml_callback saml_logout_callback ssoe_slo_callback].include?(params[:action])
         raise Common::Exceptions::RoutingError, params[:path]
       end
 

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -20,7 +20,6 @@ module SAML
     attr_reader :saml_settings, :session, :user, :authn_context, :type, :query_params, :redirect_application
 
     def initialize(saml_settings, session: nil, user: nil, params: {}, loa3_context: LOA::IDME_LOA3_VETS)
-      binding.pry
       unless %w[new saml_callback saml_logout_callback ssoe_slo_callback].include?(params[:action])
         raise Common::Exceptions::RoutingError, params[:path]
       end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -228,12 +228,9 @@ RSpec.describe V1::SessionsController, type: :controller do
     end
 
     describe 'GET sessions/slo/new' do
-      let(:logout_request) { OneLogin::RubySaml::Logoutrequest.new }
-
       before do
         mhv_account = double('mhv_account', ineligible?: false, needs_terms_acceptance?: false, upgraded?: true)
         allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
-        allow(OneLogin::RubySaml::Logoutrequest).to receive(:new).and_return(logout_request)
         Session.find(token).to_hash.each { |k, v| session[k] = v }
         cookies['vagov_session_dev'] = 'bar'
       end
@@ -250,108 +247,23 @@ RSpec.describe V1::SessionsController, type: :controller do
           verify_session_cookie
           expect(User.find(uuid)).not_to be_nil
 
-          # this should not exist yet
-          expect(SingleLogoutRequest.find(logout_request.uuid)).to be_nil
           # it has the cookie set
           expect(cookies['vagov_session_dev']).not_to be_nil
           get(:new, params: { type: 'slo' })
           expect(response.location)
-            .to be_an_idme_saml_url('https://pint.eauth.va.gov/pkmslogout?SAMLRequest=')
-            .with_relay_state('originating_request_id' => nil, 'type' => 'slo')
+            .to eq('https://pint.eauth.va.gov/pkmslogout')
 
           # these should be destroyed.
           expect(Session.find(token)).to be_nil
           expect(session).to be_empty
           expect(User.find(uuid)).to be_nil
           expect(cookies['vagov_session_dev']).to be_nil
-
-          # this should be created in redis
-          expect(SingleLogoutRequest.find(logout_request.uuid)).not_to be_nil
         end
       end
     end
 
-    it 'redirects as success even when logout fails, but it logs the failure' do
-      expect(post(:saml_logout_callback)).to redirect_to(logout_redirect_url)
-    end
-
-    describe 'POST saml_logout_callback' do
-      let(:logout_relay_state_param) { '{"originating_request_id": "blah"}' }
-
-      before { SingleLogoutRequest.create(uuid: logout_uuid, token: token) }
-
-      context 'saml_logout_response is invalid' do
-        before do
-          allow(OneLogin::RubySaml::Logoutresponse).to receive(:new).and_return(invalid_logout_response)
-        end
-
-        it 'redirects as success and logs the failure' do
-          msg = "SLO callback response invalid for originating_request_id 'blah'"
-          expect_logger_msg(:info, msg)
-          expect(controller).to receive(:log_message_to_sentry)
-          expect(post(:saml_logout_callback, params: { SAMLResponse: '-', RelayState: logout_relay_state_param }))
-            .to redirect_to(logout_redirect_url)
-        end
-      end
-
-      context 'saml_logout_response is valid but saml_logout_request is not found' do
-        context 'saml_logout_response is success' do
-          before do
-            mhv_account = double('mhv_account', ineligible?: false, needs_terms_acceptance?: false, upgraded?: true)
-            allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
-            allow(SingleLogoutRequest).to receive(:find).with('1234').and_return(nil)
-            allow(OneLogin::RubySaml::Logoutresponse).to receive(:new).and_return(successful_logout_response)
-            Session.find(token).to_hash.each { |k, v| session[k] = v }
-          end
-
-          it 'redirects to success and destroys nothing' do
-            # these should have been destroyed in the initial call to sessions/logout, not in the callback.
-            verify_session_cookie
-            expect(User.find(uuid)).not_to be_nil
-            # this will be destroyed
-            expect(SingleLogoutRequest.find(successful_logout_response&.in_response_to)).to be_nil
-
-            msg = "SLO callback response could not resolve logout request for originating_request_id 'blah'"
-            expect_logger_msg(:info, msg)
-            expect(post(:saml_logout_callback, params: { SAMLResponse: '-', RelayState: logout_relay_state_param }))
-              .to redirect_to(logout_redirect_url)
-            # these should have been destroyed in the initial call to sessions/logout, not in the callback.
-            verify_session_cookie
-            expect(User.find(uuid)).not_to be_nil
-            # this should be destroyed
-            expect(SingleLogoutRequest.find(successful_logout_response&.in_response_to)).to be_nil
-          end
-        end
-      end
-
-      context 'saml_logout_response is success' do
-        before do
-          mhv_account = double('mhv_account', ineligible?: false, needs_terms_acceptance?: false, upgraded?: true)
-          allow(MhvAccount).to receive(:find_or_initialize_by).and_return(mhv_account)
-          allow(SingleLogoutRequest).to receive(:find).with('1234').and_call_original
-          allow(OneLogin::RubySaml::Logoutresponse).to receive(:new).and_return(successful_logout_response)
-          Session.find(token).to_hash.each { |k, v| session[k] = v }
-        end
-
-        it 'redirects to success and destroys only the logout request' do
-          # these should have been destroyed in the initial call to sessions/logout, not in the callback.
-          verify_session_cookie
-          expect(User.find(uuid)).not_to be_nil
-          # this will be destroyed
-          expect(SingleLogoutRequest.find(successful_logout_response&.in_response_to)).not_to be_nil
-
-          msg = "SLO callback response to '1234' for originating_request_id 'blah'"
-          expect_logger_msg(:info, msg)
-          expect(controller).not_to receive(:log_message_to_sentry)
-          expect(post(:saml_logout_callback, params: { SAMLResponse: '-', RelayState: logout_relay_state_param }))
-            .to redirect_to(logout_redirect_url)
-          # these should have been destroyed in the initial call to sessions/logout, not in the callback.
-          verify_session_cookie
-          expect(User.find(uuid)).not_to be_nil
-          # this should be destroyed
-          expect(SingleLogoutRequest.find(successful_logout_response&.in_response_to)).to be_nil
-        end
-      end
+    it 'redirects on callback from external logout' do
+      expect(get(:ssoe_slo_callback)).to redirect_to(logout_redirect_url)
     end
 
     describe 'POST saml_callback' do


### PR DESCRIPTION
## Description of change
Removes the SAML-based logout callback from v1 sessions controller, and cleans up extraneous routes and test cases. Also unifies the triggering URL for frontend to be `v1/sessions/slo/new` to match `v0/sessions/slo/new`.

SSOe does not implement SAML single logout, so we never expect a SAML response for a logout. Instead, they have a custom 'PKMS logout' endpoint that will terminate the IAM session and then redirect. back to an endpoint of your choosing via a simple redirect. The `ssoe_slo_callback` method is expected to receive that redirect and do the final additional redirect back to va.gov frontend.

Fixes va.gov-team#7137, but will need corresponding config change in devops repo to update pkms logout endpoint per-environment.

## Testing
Awaiting testing in conjunction with IAM team; require them to set a redirect after their PKMS logout endpoint completes.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] _Replace this line with individual tasks unique to your PR_

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
