### PR TITLE
fix Gemfile guard clause for installing Sidekiq Pro/Ent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -173,7 +173,7 @@ end
 group :production do
   # sidekiq enterprise requires a license key to download but is only required in production.
   # for local dev environments, regular sidekiq works fine
-  unless Bundler::Settings.new['enterprise.contribsys.com']&.empty? &&
+  unless Bundler::Settings.new['enterprise.contribsys.com'].nil? &&
          ENV.fetch('BUNDLE_ENTERPRISE__CONTRIBSYS__COM', '').empty?
     source 'https://enterprise.contribsys.com/' do
       gem 'sidekiq-ent'

--- a/Gemfile
+++ b/Gemfile
@@ -173,7 +173,8 @@ end
 group :production do
   # sidekiq enterprise requires a license key to download but is only required in production.
   # for local dev environments, regular sidekiq works fine
-  unless Bundler::Settings.new['enterprise.contribsys.com'].nil? &&
+  unless (Bundler::Settings.new['enterprise.contribsys.com'].nil? ||
+          Bundler::Settings.new['enterprise.contribsys.com']&.empty?) &&
          ENV.fetch('BUNDLE_ENTERPRISE__CONTRIBSYS__COM', '').empty?
     source 'https://enterprise.contribsys.com/' do
       gem 'sidekiq-ent'


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Got bit by using the safe operator on a `nil` value.
```ruby
''&.empty?     # true
 nil&.empty?   # nil, which is falsey
```
I need to check explicitly for `nil` and an empty string.
Why?
Natively, when you have no Sidekiq license config set:
```ruby
Bundler::Settings.new['enterprise.contribsys.com']
# => nil
```
However, if when you start up via Docker, it defaults the value of `BUNDLE_ENTERPRISE__CONTRIBSYS__COM` env variable to ''  and thus:
```ruby
Bundler::Settings.new['enterprise.contribsys.com']
# => ''
```

## Testing
<!-- Please describe testing done to verify the changes or any testing planned. -->

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Fix guard clause logic

#### Applies to all PRs

- [ ] ~~Swagger docs have been updated, if applicable~~
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] ~~Provide which alerts would indicate a problem with this functionality (if applicable)~~
