### PR TITLE
adding version tags to authentication StatsD metrics

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -17,6 +17,8 @@ module V0
     STATSD_LOGIN_STATUS = 'api.auth.login'
     STATSD_LOGIN_SHARED_COOKIE = 'api.auth.sso_shared_cookie'
 
+    VERSION_TAG = 'version:v0'
+
     # Collection Action: auth is required for certain types of requests
     # @type is set automatically by the routes in config/routes.rb
     # For more details see SAML::SettingsService and SAML::URLService
@@ -24,7 +26,7 @@ module V0
       type = params[:type]
       raise Common::Exceptions::RoutingError, params[:path] unless REDIRECT_URLS.include?(type)
 
-      StatsD.increment(STATSD_SSO_NEW_KEY, tags: ["context:#{type}"])
+      StatsD.increment(STATSD_SSO_NEW_KEY, tags: ["context:#{type}", VERSION_TAG])
       url = url_service.send("#{type}_url")
       if type == 'slo'
         Rails.logger.info('SSO: LOGOUT', sso_logging_info)
@@ -133,24 +135,27 @@ module V0
     def login_stats(status, saml_response, user_session_form = nil)
       case status
       when :success
-        StatsD.increment(STATSD_LOGIN_NEW_USER_KEY) if request_type == 'signup'
+        StatsD.increment(STATSD_LOGIN_NEW_USER_KEY, tags: [VERSION_TAG]) if request_type == 'signup'
         # track users who have a shared sso cookie
         if cookies.key?(Settings.sso.cookie_name)
           StatsD.increment(STATSD_LOGIN_SHARED_COOKIE,
                            tags: ["loa:#{@current_user.loa[:current]}",
-                                  "idp:#{@current_user.identity.sign_in[:service_name]}"])
+                                  "idp:#{@current_user.identity.sign_in[:service_name]}",
+                                  VERSION_TAG])
         end
         StatsD.increment(STATSD_LOGIN_STATUS,
                          tags: ['status:success',
                                 "idp:#{@current_user.identity.sign_in[:service_name]}",
-                                "context:#{saml_response.authn_context}"])
+                                "context:#{saml_response.authn_context}",
+                                VERSION_TAG])
         callback_stats(:success, saml_response)
       when :failure
         StatsD.increment(STATSD_LOGIN_STATUS,
                          tags: ['status:failure',
                                 "idp:#{params[:type]}",
                                 "context:#{saml_response.authn_context}",
-                                "error:#{user_session_form.error_instrumentation_code}"])
+                                "error:#{user_session_form.error_instrumentation_code}",
+                                VERSION_TAG])
         callback_stats(:failure, saml_response, user_session_form.error_instrumentation_code)
       end
     end
@@ -160,18 +165,22 @@ module V0
       case status
       when :success
         StatsD.increment(STATSD_SSO_CALLBACK_KEY,
-                         tags: ['status:success', "context:#{saml_response.authn_context}"])
+                         tags: ['status:success',
+                                "context:#{saml_response.authn_context}",
+                                VERSION_TAG])
         # track users who have a shared sso cookie
       when :failure
         StatsD.increment(STATSD_SSO_CALLBACK_KEY,
-                         tags: ['status:failure', "context:#{saml_response.authn_context}"])
-        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [failure_tag])
+                         tags: ['status:failure',
+                                "context:#{saml_response.authn_context}",
+                                VERSION_TAG])
+        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [failure_tag, VERSION_TAG])
       when :failed_unknown
         StatsD.increment(STATSD_SSO_CALLBACK_KEY,
-                         tags: ['status:failure', 'context:unknown'])
-        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: ['error:unknown'])
+                         tags: ['status:failure', 'context:unknown', VERSION_TAG])
+        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: ['error:unknown', VERSION_TAG])
       when :total
-        StatsD.increment(STATSD_SSO_CALLBACK_TOTAL_KEY)
+        StatsD.increment(STATSD_SSO_CALLBACK_TOTAL_KEY, tags: [VERSION_TAG])
       end
     end
 

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -159,13 +159,11 @@ module V1
         # track users who have a shared sso cookie
         StatsD.increment(STATSD_LOGIN_SHARED_COOKIE,
                          tags: ["loa:#{@current_user.loa[:current]}",
-                                "idp:#{@current_user.identity.sign_in[:service_name]}",
-                                VERSION_TAG])
+                                "idp:#{@current_user.identity.sign_in[:service_name]}", VERSION_TAG])
         StatsD.increment(STATSD_LOGIN_STATUS,
                          tags: ['status:success',
                                 "idp:#{@current_user.identity.sign_in[:service_name]}",
-                                "context:#{saml_response.authn_context}",
-                                VERSION_TAG])
+                                "context:#{saml_response.authn_context}", VERSION_TAG])
         callback_stats(:success, saml_response)
       when :failure
         StatsD.increment(STATSD_LOGIN_STATUS,

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -17,6 +17,8 @@ module V1
     STATSD_LOGIN_STATUS = 'api.auth.login'
     STATSD_LOGIN_SHARED_COOKIE = 'api.auth.sso_shared_cookie'
 
+    VERSION_TAG = 'version:v1'
+
     # Collection Action: auth is required for certain types of requests
     # @type is set automatically by the routes in config/routes.rb
     # For more details see SAML::SettingsService and SAML::URLService
@@ -25,7 +27,7 @@ module V1
       raise Common::Exceptions::RoutingError, params[:path] unless REDIRECT_URLS.include?(type)
 
       StatsD.increment(STATSD_SSO_NEW_KEY,
-                       tags: ["context:#{type}", "forceauthn:#{force_authn?}"])
+                       tags: ["context:#{type}", "forceauthn:#{force_authn?}", VERSION_TAG])
       url = url_service.send("#{type}_url")
 
       if %w[slo ssoe_slo].include?(type)
@@ -153,22 +155,25 @@ module V1
     def login_stats(status, saml_response, user_session_form = nil)
       case status
       when :success
-        StatsD.increment(STATSD_LOGIN_NEW_USER_KEY) if request_type == 'signup'
+        StatsD.increment(STATSD_LOGIN_NEW_USER_KEY, tags: [VERSION_TAG]) if request_type == 'signup'
         # track users who have a shared sso cookie
         StatsD.increment(STATSD_LOGIN_SHARED_COOKIE,
                          tags: ["loa:#{@current_user.loa[:current]}",
-                                "idp:#{@current_user.identity.sign_in[:service_name]}"])
+                                "idp:#{@current_user.identity.sign_in[:service_name]}",
+                                VERSION_TAG])
         StatsD.increment(STATSD_LOGIN_STATUS,
                          tags: ['status:success',
                                 "idp:#{@current_user.identity.sign_in[:service_name]}",
-                                "context:#{saml_response.authn_context}"])
+                                "context:#{saml_response.authn_context}",
+                                VERSION_TAG])
         callback_stats(:success, saml_response)
       when :failure
         StatsD.increment(STATSD_LOGIN_STATUS,
                          tags: ['status:failure',
                                 "idp:#{params[:type]}",
                                 "context:#{saml_response.authn_context}",
-                                "error:#{user_session_form.error_instrumentation_code}"])
+                                "error:#{user_session_form.error_instrumentation_code}",
+                                VERSION_TAG])
         callback_stats(:failure, saml_response, user_session_form.error_instrumentation_code)
       end
     end
@@ -177,18 +182,22 @@ module V1
       case status
       when :success
         StatsD.increment(STATSD_SSO_CALLBACK_KEY,
-                         tags: ['status:success', "context:#{saml_response.authn_context}"])
+                         tags: ['status:success',
+                                "context:#{saml_response.authn_context}",
+                                VERSION_TAG])
         # track users who have a shared sso cookie
       when :failure
         StatsD.increment(STATSD_SSO_CALLBACK_KEY,
-                         tags: ['status:failure', "context:#{saml_response.authn_context}"])
-        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [failure_tag])
+                         tags: ['status:failure',
+                                "context:#{saml_response.authn_context}",
+                                VERSION_TAG])
+        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [failure_tag, VERSION_TAG])
       when :failed_unknown
         StatsD.increment(STATSD_SSO_CALLBACK_KEY,
-                         tags: ['status:failure', 'context:unknown'])
-        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: ['error:unknown'])
+                         tags: ['status:failure', 'context:unknown', VERSION_TAG])
+        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: ['error:unknown', VERSION_TAG])
       when :total
-        StatsD.increment(STATSD_SSO_CALLBACK_TOTAL_KEY)
+        StatsD.increment(STATSD_SSO_CALLBACK_TOTAL_KEY, tags: [VERSION_TAG])
       end
     end
 

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           context "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             it 'redirects' do
               expect { get(:new, params: { type: type, clientId: '123123' }) }
-                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ["context:#{type}"], **once)
+                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ["context:#{type}", 'version:v0'], **once)
 
               expect(response).to have_http_status(:found)
               expect(response.location)
@@ -97,7 +97,7 @@ RSpec.describe V0::SessionsController, type: :controller do
         context 'routes /sessions/signup/new to SessionsController#new' do
           it 'redirects' do
             expect { get(:new, params: { type: :signup, client_id: '123123' }) }
-              .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ['context:signup'], **once)
+              .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ['context:signup', 'version:v0'], **once)
             expect(response).to have_http_status(:found)
             expect(response.location)
               .to be_an_idme_saml_url('https://api.idmelabs.com/saml/SingleSignOnService?SAMLRequest=')
@@ -170,7 +170,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           context "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             it 'redirects' do
               expect { get(:new, params: { type: type }) }
-                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ["context:#{type}"], **once)
+                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ["context:#{type}", 'version:v0'], **once)
               expect(response).to have_http_status(:found)
               expect(cookies['vagov_session_dev']).not_to be_nil unless type.in?(%w[mhv dslogon idme slo])
             end
@@ -341,7 +341,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           )
           expect(Raven).to receive(:tags_context).once
 
-          callback_tags = ['status:success', "context:#{LOA::IDME_LOA3_VETS}"]
+          callback_tags = ['status:success', "context:#{LOA::IDME_LOA3_VETS}", 'version:v0']
 
           Timecop.freeze(Time.current)
           cookie_expiration_time = 30.minutes.from_now.iso8601(0)
@@ -393,10 +393,10 @@ RSpec.describe V0::SessionsController, type: :controller do
 
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY,
-                                         tags: ['status:success', 'context:multifactor'], **once)
+                                         tags: ['status:success', 'context:multifactor', 'version:v0'], **once)
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)
             .and trigger_statsd_increment(described_class::STATSD_LOGIN_SHARED_COOKIE,
-                                          tags: ['loa:1', 'idp:idme'], **once)
+                                          tags: ['loa:1', 'idp:idme', 'version:v0'], **once)
 
           expect(cookies['vagov_session_dev']).not_to be_nil
           expect(JSON.parse(decrypter.decrypt(cookies['vagov_session_dev'])))
@@ -486,8 +486,8 @@ RSpec.describe V0::SessionsController, type: :controller do
 
         it 'increments the failed and total statsd counters' do
           allow(UserSessionForm).to receive(:new).and_raise(NoMethodError)
-          callback_tags = ['status:failure', 'context:unknown']
-          failed_tags = ['error:unknown']
+          callback_tags = ['status:failure', 'context:unknown', 'version:v0']
+          failed_tags = ['error:unknown', 'version:v0']
 
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
@@ -532,8 +532,8 @@ RSpec.describe V0::SessionsController, type: :controller do
         end
 
         it 'increments the failed and total statsd counters' do
-          callback_tags = ['status:failure', 'context:unknown']
-          failed_tags = ['error:auth_too_early']
+          callback_tags = ['status:failure', 'context:unknown', 'version:v0']
+          failed_tags = ['error:auth_too_early', 'version:v0']
 
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
@@ -563,8 +563,8 @@ RSpec.describe V0::SessionsController, type: :controller do
         end
 
         it 'increments the failed and total statsd counters' do
-          callback_tags = ['status:failure', 'context:unknown']
-          failed_tags = ['error:unknown']
+          callback_tags = ['status:failure', 'context:unknown', 'version:v0']
+          failed_tags = ['error:unknown', 'version:v0']
 
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
@@ -598,8 +598,8 @@ RSpec.describe V0::SessionsController, type: :controller do
         end
 
         it 'increments the failed and total statsd counters' do
-          callback_tags = ['status:failure', 'context:unknown']
-          failed_tags = ['error:clicked_deny']
+          callback_tags = ['status:failure', 'context:unknown', 'version:v0']
+          failed_tags = ['error:clicked_deny', 'version:v0']
 
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
@@ -617,12 +617,12 @@ RSpec.describe V0::SessionsController, type: :controller do
 
         it 'allows user to sign in even if user attributes are not available' do
           MVI::Configuration.instance.breakers_service.begin_forced_outage!
-          callback_tags = ['status:success', 'context:myhealthevet']
+          callback_tags = ['status:success', 'context:myhealthevet', 'version:v0']
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)
             .and trigger_statsd_increment(described_class::STATSD_LOGIN_SHARED_COOKIE,
-                                          tags: ['loa:3', 'idp:myhealthevet'], **once)
+                                          tags: ['loa:3', 'idp:myhealthevet', 'version:v0'], **once)
           expect(response.location).to start_with('http://127.0.0.1:3001/auth/login/callback')
           expect(cookies['vagov_session_dev']).not_to be_nil
           MVI::Configuration.instance.breakers_service.end_forced_outage!
@@ -668,8 +668,8 @@ RSpec.describe V0::SessionsController, type: :controller do
         end
 
         it 'increments the failed and total statsd counters' do
-          callback_tags = ['status:failure', "context:#{LOA::IDME_LOA1_VETS}"]
-          failed_tags = ['error:validations_failed']
+          callback_tags = ['status:failure', "context:#{LOA::IDME_LOA1_VETS}", 'version:v0']
+          failed_tags = ['error:validations_failed', 'version:v0']
 
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe V0::SessionsController, type: :controller do
           context "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             it 'redirects' do
               expect { get(:new, params: { type: type, clientId: '123123' }) }
-                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ["context:#{type}", 'version:v0'], **once)
+                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
+                                             tags: ["context:#{type}", 'version:v0'], **once)
 
               expect(response).to have_http_status(:found)
               expect(response.location)
@@ -97,7 +98,8 @@ RSpec.describe V0::SessionsController, type: :controller do
         context 'routes /sessions/signup/new to SessionsController#new' do
           it 'redirects' do
             expect { get(:new, params: { type: :signup, client_id: '123123' }) }
-              .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ['context:signup', 'version:v0'], **once)
+              .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
+                                           tags: ['context:signup', 'version:v0'], **once)
             expect(response).to have_http_status(:found)
             expect(response.location)
               .to be_an_idme_saml_url('https://api.idmelabs.com/saml/SingleSignOnService?SAMLRequest=')
@@ -170,7 +172,8 @@ RSpec.describe V0::SessionsController, type: :controller do
           context "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             it 'redirects' do
               expect { get(:new, params: { type: type }) }
-                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: ["context:#{type}", 'version:v0'], **once)
+                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
+                                             tags: ["context:#{type}", 'version:v0'], **once)
               expect(response).to have_http_status(:found)
               expect(cookies['vagov_session_dev']).not_to be_nil unless type.in?(%w[mhv dslogon idme slo])
             end


### PR DESCRIPTION
Adding 'version:v0' tags on the StatsD metrics coming from the v0 session controller and 'version:v1' tags on StatsD metrics coming from the v1 session controller.

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/7323

## Testing
- updated existing test cases to show that the tags are being sent

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
