### PR TITLE
Fix mhv account type attribute for v1 login

### DIFF
--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -17,6 +17,7 @@ class UserSessionForm
   def initialize(saml_response)
     @saml_uuid = saml_response.in_response_to
     saml_attributes = SAML::User.new(saml_response)
+    saml_attributes.validate!
     existing_user = User.find(saml_attributes.user_attributes.uuid)
     @user_identity = UserIdentity.new(saml_attributes.to_hash)
     @user = User.new(uuid: @user_identity.attributes[:uuid])

--- a/lib/saml/errors.rb
+++ b/lib/saml/errors.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module SAML
+  class UserAttributeError < StandardError
+  end
+end

--- a/lib/saml/user.rb
+++ b/lib/saml/user.rb
@@ -43,6 +43,10 @@ module SAML
       log_warnings_to_sentry
     end
 
+    def validate!
+      @user_attributes.validate!
+    end
+
     def changing_multifactor?
       return false if authn_context.nil?
 

--- a/lib/saml/user_attributes/base.rb
+++ b/lib/saml/user_attributes/base.rb
@@ -60,6 +60,9 @@ module SAML
         Hash[serializable_attributes.map { |k| [k, send(k)] }]
       end
 
+      # Raise any fatal exceptions due to validation issues
+      def validate!; end
+
       private
 
       def account_type

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -7,8 +7,8 @@ module SAML
     class SSOe
       include SentryLogging
       SERIALIZABLE_ATTRIBUTES = %i[email first_name middle_name last_name zip gender ssn birth_date
-                                   uuid idme_uuid sec_id mhv_icn mhv_correlation_id dslogon_edipi
-                                   loa sign_in multifactor].freeze
+                                   uuid idme_uuid sec_id mhv_icn mhv_correlation_id mhv_account_type
+                                   dslogon_edipi loa sign_in multifactor].freeze
       IDME_GCID_REGEX = /^(?<idme>\w+)\^PN\^200VIDM\^USDVA\^A$/.freeze
 
       attr_reader :attributes, :authn_context, :warnings
@@ -94,6 +94,10 @@ module SAML
         safe_attr('va_eauth_mhvien')
       end
 
+      def mhv_account_type
+        safe_attr('va_eauth_mhvassurance')
+      end
+
       def dslogon_edipi
         safe_attr('va_eauth_dodedipnid')
       end
@@ -133,7 +137,10 @@ module SAML
       end
 
       def account_type
-        loa_current
+        result = mhv_account_type
+        result ||= safe_attr('va_eauth_dslogonassurance')
+        result ||= 'N/A'
+        result
       end
 
       def loa

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe V0::SessionsController, type: :controller do
   let(:valid_saml_response) do
     build_saml_response(
       authn_context: authn_context,
-      account_type: 'N/A',
       level_of_assurance: ['3'],
       attributes: build(:idme_loa1, level_of_assurance: ['3'])
     )

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe V0::SessionsController, type: :controller do
     instance_double('SAML::User',
                     changing_multifactor?: false,
                     user_attributes: user_attributes,
-                    to_hash: saml_user_attributes)
+                    to_hash: saml_user_attributes,
+                    validate!: nil)
   end
 
   let(:request_host)        { '127.0.0.1:3000' }

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe V1::SessionsController, type: :controller do
   let(:valid_saml_response) do
     build_saml_response(
       authn_context: authn_context,
-      account_type: 'N/A',
       level_of_assurance: ['3'],
       attributes: build(:ssoe_idme_loa1, va_eauth_ial: 3),
       in_response_to: login_uuid

--- a/spec/factories/saml_attributes.rb
+++ b/spec/factories/saml_attributes.rb
@@ -345,7 +345,7 @@ FactoryBot.define do
     va_eauth_issueinstant { ['2020-02-26T04:07:03Z'] }
     va_eauth_middlename { ['NOT_FOUND'] }
     va_eauth_multifactor { ['true'] }
-    va_eauth_mhv_assurance { ['Basic'] }
+    va_eauth_mhvassurance { ['Basic'] }
 
     initialize_with { new(attributes.stringify_keys) }
   end
@@ -374,7 +374,7 @@ FactoryBot.define do
     va_eauth_issueinstant { ['2020-02-26T04:07:03Z'] }
     va_eauth_middlename { ['NOT_FOUND'] }
     va_eauth_multifactor { ['false'] }
-    va_eauth_mhv_assurance { ['Basic'] }
+    va_eauth_mhvassurance { ['Basic'] }
 
     initialize_with { new(attributes.stringify_keys) }
   end
@@ -402,7 +402,7 @@ FactoryBot.define do
     va_eauth_issueinstant { ['2020-02-26T04:07:03Z'] }
     va_eauth_middlename { ['NOT_FOUND'] }
     va_eauth_multifactor { ['true'] }
-    va_eauth_mhv_assurance { ['Basic'] }
+    va_eauth_mhvassurance { ['Basic'] }
 
     initialize_with { new(attributes.stringify_keys) }
   end

--- a/spec/lib/saml/dslogon_user_spec.rb
+++ b/spec/lib/saml/dslogon_user_spec.rb
@@ -10,14 +10,12 @@ RSpec.describe SAML::User do
     subject { described_class.new(saml_response) }
 
     let(:authn_context) { 'dslogon' }
-    let(:account_type)  { '1' }
     let(:highest_attained_loa) { '3' }
     let(:existing_saml_attributes) { nil }
 
     let(:saml_response) do
       build_saml_response(
         authn_context: authn_context,
-        account_type: account_type,
         level_of_assurance: [highest_attained_loa],
         attributes: saml_attributes,
         existing_attributes: existing_saml_attributes
@@ -121,7 +119,6 @@ RSpec.describe SAML::User do
     end
 
     context 'premium user' do
-      let(:account_type) { '2' }
       let(:highest_attained_loa) { nil }
       let(:saml_attributes) { build(:dslogon_level2, multifactor: [false], level_of_assurance: ['3']) }
 

--- a/spec/lib/saml/idme_user_spec.rb
+++ b/spec/lib/saml/idme_user_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe SAML::User do
     subject { described_class.new(saml_response) }
 
     let(:authn_context) { LOA::IDME_LOA1_VETS }
-    let(:account_type)  { 'N/A' }
     let(:highest_attained_loa) { '1' }
     let(:saml_attributes) { build(:idme_loa1) }
     let(:existing_saml_attributes) { nil }
@@ -18,7 +17,6 @@ RSpec.describe SAML::User do
     let(:saml_response) do
       build_saml_response(
         authn_context: authn_context,
-        account_type: account_type,
         level_of_assurance: [highest_attained_loa],
         attributes: saml_attributes,
         existing_attributes: existing_saml_attributes

--- a/spec/lib/saml/mhv_user_spec.rb
+++ b/spec/lib/saml/mhv_user_spec.rb
@@ -10,14 +10,12 @@ RSpec.describe SAML::User do
     subject { described_class.new(saml_response) }
 
     let(:authn_context) { 'myhealthevet' }
-    let(:account_type)  { 'Basic' }
     let(:highest_attained_loa) { '3' }
     let(:existing_saml_attributes) { nil }
 
     let(:saml_response) do
       build_saml_response(
         authn_context: authn_context,
-        account_type: account_type,
         level_of_assurance: [highest_attained_loa],
         attributes: saml_attributes,
         existing_attributes: existing_saml_attributes
@@ -81,7 +79,6 @@ RSpec.describe SAML::User do
 
       context 'verifying' do
         let(:authn_context) { 'myhealthevet_loa3' }
-        let(:account_type) { 'Advanced' }
         let(:saml_attributes) { build(:mhv_loa3, multifactor: [true], level_of_assurance: ['3']) }
         let(:existing_saml_attributes) { build(:mhv_advanced, multifactor: [true], level_of_assurance: ['3']) }
 
@@ -117,7 +114,6 @@ RSpec.describe SAML::User do
 
     context 'premium user' do
       let(:saml_attributes) { build(:mhv_premium, multifactor: [false], level_of_assurance: [highest_attained_loa]) }
-      let(:account_type) { 'Premium' }
 
       it 'has various important attributes' do
         expect(subject.to_hash).to eq(

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe SAML::User do
     subject { described_class.new(saml_response) }
 
     let(:authn_context) { LOA::IDME_LOA1_VETS }
-    let(:account_type)  { '1' }
     let(:highest_attained_loa) { '1' }
     let(:multifactor) { false }
     let(:existing_saml_attributes) { nil }
@@ -18,7 +17,6 @@ RSpec.describe SAML::User do
     let(:saml_response) do
       build_saml_response(
         authn_context: authn_context,
-        account_type: account_type,
         level_of_assurance: [highest_attained_loa],
         attributes: saml_attributes,
         existing_attributes: existing_saml_attributes,
@@ -72,13 +70,14 @@ RSpec.describe SAML::User do
           zip: nil,
           mhv_icn: nil,
           mhv_correlation_id: nil,
+          mhv_account_type: nil,
           dslogon_edipi: nil,
           uuid: '54e78de6140d473f87960f211be49c08',
           email: 'vets.gov.user+262@example.com',
           idme_uuid: '54e78de6140d473f87960f211be49c08',
           multifactor: false,
           loa: { current: 1, highest: 1 },
-          sign_in: { service_name: 'idme', account_type: 1 },
+          sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: nil,
           authenticated_by_ssoe: true
         )
@@ -104,13 +103,14 @@ RSpec.describe SAML::User do
           zip: nil,
           mhv_icn: nil,
           mhv_correlation_id: nil,
+          mhv_account_type: nil,
           dslogon_edipi: nil,
           uuid: '54e78de6140d473f87960f211be49c08',
           email: 'vets.gov.user+262@example.com',
           idme_uuid: '54e78de6140d473f87960f211be49c08',
           multifactor: true,
           loa: { current: 1, highest: 3 },
-          sign_in: { service_name: 'idme', account_type: 1 },
+          sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: nil,
           authenticated_by_ssoe: true
         )
@@ -137,13 +137,14 @@ RSpec.describe SAML::User do
           zip: nil,
           mhv_icn: '1008830476V316605',
           mhv_correlation_id: nil,
+          mhv_account_type: nil,
           dslogon_edipi: nil,
           uuid: '54e78de6140d473f87960f211be49c08',
           email: 'vets.gov.user+262@example.com',
           idme_uuid: '54e78de6140d473f87960f211be49c08',
           multifactor: true,
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'idme', account_type: 3 },
+          sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: '1008830476',
           authenticated_by_ssoe: true
         )
@@ -156,7 +157,6 @@ RSpec.describe SAML::User do
 
     context 'MHV non premium user' do
       let(:authn_context) { 'myhealthevet' }
-      let(:account_type) { '1' }
       let(:highest_attained_loa) { '3' }
       let(:saml_attributes) { build(:ssoe_idme_mhv_advanced) }
       let(:multifactor) { true }
@@ -174,21 +174,27 @@ RSpec.describe SAML::User do
           zip: nil,
           mhv_icn: nil,
           mhv_correlation_id: nil,
+          mhv_account_type: 'Advanced',
           uuid: '881571066e5741439652bc80759dd88c',
           email: 'alexmac_0@example.com',
           idme_uuid: '881571066e5741439652bc80759dd88c',
           loa: { current: 1, highest: 3 },
-          sign_in: { service_name: 'myhealthevet', account_type: 1 },
+          sign_in: { service_name: 'myhealthevet', account_type: 'Advanced' },
           sec_id: nil,
           multifactor: multifactor,
           authenticated_by_ssoe: true
+        )
+      end
+
+      it 'has an mhv_account_type set' do
+        expect(subject.to_hash).to include(
+          mhv_account_type: 'Advanced'
         )
       end
     end
 
     context 'MHV non premium user who verifies' do
       let(:authn_context) { 'myhealthevet_loa3' }
-      let(:account_type) { '1' }
       let(:highest_attained_loa) { '3' }
       let(:saml_attributes) { build(:ssoe_idme_mhv_loa3) }
       let(:multifactor) { true }
@@ -206,11 +212,12 @@ RSpec.describe SAML::User do
           zip: nil,
           mhv_icn: '1013183292V131165',
           mhv_correlation_id: nil,
+          mhv_account_type: 'Advanced',
           uuid: '881571066e5741439652bc80759dd88c',
           email: 'alexmac_0@example.com',
           idme_uuid: '881571066e5741439652bc80759dd88c',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'myhealthevet', account_type: 3 },
+          sign_in: { service_name: 'myhealthevet', account_type: 'Advanced' },
           sec_id: '1013183292',
           multifactor: multifactor,
           authenticated_by_ssoe: true
@@ -220,7 +227,6 @@ RSpec.describe SAML::User do
 
     context 'MHV non premium user who adds multifactor' do
       let(:authn_context) { 'myhealthevet_multifactor' }
-      let(:account_type) { '1' }
       let(:highest_attained_loa) { '1' }
       let(:saml_attributes) { build(:ssoe_idme_mhv_basic_multifactor) }
       let(:multifactor) { false }
@@ -239,11 +245,12 @@ RSpec.describe SAML::User do
           zip: nil,
           mhv_icn: nil,
           mhv_correlation_id: nil,
+          mhv_account_type: 'Basic',
           uuid: '72782a87a807407f83e8a052d804d7f7',
           email: 'pv+mhvtestb@example.com',
           idme_uuid: '72782a87a807407f83e8a052d804d7f7',
           loa: { current: 1, highest: 1 },
-          sign_in: { service_name: 'myhealthevet', account_type: 1 },
+          sign_in: { service_name: 'myhealthevet', account_type: 'Basic' },
           sec_id: nil,
           multifactor: true,
           authenticated_by_ssoe: true
@@ -257,7 +264,6 @@ RSpec.describe SAML::User do
 
     context 'MHV premium user' do
       let(:authn_context) { 'myhealthevet' }
-      let(:account_type) { '1' }
       let(:highest_attained_loa) { '3' }
       let(:saml_attributes) { build(:ssoe_idme_mhv_premium) }
       let(:multifactor) { true }
@@ -275,11 +281,12 @@ RSpec.describe SAML::User do
           zip: nil,
           mhv_icn: '1012853550V207686',
           mhv_correlation_id: nil,
+          mhv_account_type: 'Premium',
           uuid: '0e1bb5723d7c4f0686f46ca4505642ad',
           email: 'k+tristanmhv@example.com',
           idme_uuid: '0e1bb5723d7c4f0686f46ca4505642ad',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'myhealthevet', account_type: 3 },
+          sign_in: { service_name: 'myhealthevet', account_type: 'Premium' },
           sec_id: '1012853550',
           multifactor: multifactor,
           authenticated_by_ssoe: true
@@ -289,7 +296,6 @@ RSpec.describe SAML::User do
 
     context 'MHV premium user no idme uuid' do
       let(:authn_context) { 'myhealthevet' }
-      let(:account_type) { '1' }
       let(:highest_attained_loa) { '3' }
       let(:saml_attributes) do
         build(:ssoe_idme_mhv_premium,
@@ -312,11 +318,12 @@ RSpec.describe SAML::User do
           zip: nil,
           mhv_icn: '1012853550V207686',
           mhv_correlation_id: nil,
+          mhv_account_type: 'Premium',
           uuid: Digest::UUID.uuid_v3('sec-id', '1012853550').tr('-', ''),
           email: 'k+tristanmhv@example.com',
           idme_uuid: nil,
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'myhealthevet', account_type: 3 },
+          sign_in: { service_name: 'myhealthevet', account_type: 'Premium' },
           sec_id: '1012853550',
           multifactor: multifactor,
           authenticated_by_ssoe: true
@@ -326,7 +333,6 @@ RSpec.describe SAML::User do
 
     context 'DSLogon non premium user' do
       let(:authn_context) { 'dslogon' }
-      let(:account_type) { '1' }
       let(:highest_attained_loa) { '3' }
       let(:saml_attributes) { build(:ssoe_idme_dslogon_level1) }
 
@@ -343,11 +349,12 @@ RSpec.describe SAML::User do
           zip: nil,
           mhv_icn: nil,
           mhv_correlation_id: nil,
+          mhv_account_type: nil,
           uuid: '0e1bb5723d7c4f0686f46ca4505642ad',
           email: 'kam+tristanmhv@adhocteam.us',
           idme_uuid: '0e1bb5723d7c4f0686f46ca4505642ad',
           loa: { current: 1, highest: 3 },
-          sign_in: { service_name: 'dslogon', account_type: 1 },
+          sign_in: { service_name: 'dslogon', account_type: '1' },
           sec_id: nil,
           multifactor: multifactor,
           authenticated_by_ssoe: true
@@ -357,7 +364,6 @@ RSpec.describe SAML::User do
 
     context 'DSLogon premium user without multifactor' do
       let(:authn_context) { 'dslogon' }
-      let(:account_type) { '3' }
       let(:highest_attained_loa) { '3' }
       let(:multifactor) { true }
       let(:saml_attributes) { build(:ssoe_idme_dslogon_level2_singlefactor) }
@@ -375,11 +381,12 @@ RSpec.describe SAML::User do
           zip: nil,
           mhv_icn: '1013173963V366678',
           mhv_correlation_id: nil,
+          mhv_account_type: nil,
           uuid: '363761e8857642f7b77ef7d99200e711',
           email: 'iam.tester@example.com',
           idme_uuid: '363761e8857642f7b77ef7d99200e711',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'dslogon', account_type: 3 },
+          sign_in: { service_name: 'dslogon', account_type: '2' },
           sec_id: '1013173963',
           multifactor: false,
           authenticated_by_ssoe: true
@@ -394,7 +401,6 @@ RSpec.describe SAML::User do
 
     context 'DSLogon premium user' do
       let(:authn_context) { 'dslogon' }
-      let(:account_type) { '3' }
       let(:highest_attained_loa) { '3' }
       let(:multifactor) { true }
       let(:saml_attributes) { build(:ssoe_idme_dslogon_level2) }
@@ -412,11 +418,12 @@ RSpec.describe SAML::User do
           zip: '20571-0001',
           mhv_icn: '1012740600V714187',
           mhv_correlation_id: nil,
+          mhv_account_type: nil,
           uuid: '1655c16aa0784dbe973814c95bd69177',
           email: 'Test0206@gmail.com',
           idme_uuid: '1655c16aa0784dbe973814c95bd69177',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'dslogon', account_type: 3 },
+          sign_in: { service_name: 'dslogon', account_type: '2' },
           sec_id: '0000028007',
           multifactor: multifactor,
           authenticated_by_ssoe: true
@@ -426,7 +433,6 @@ RSpec.describe SAML::User do
 
     context 'DSLogon premium user with idme uuid in gcIds' do
       let(:authn_context) { 'dslogon' }
-      let(:account_type) { '3' }
       let(:highest_attained_loa) { '3' }
       let(:multifactor) { true }
       let(:saml_attributes) do
@@ -448,11 +454,12 @@ RSpec.describe SAML::User do
           zip: '20571-0001',
           mhv_icn: '1012740600V714187',
           mhv_correlation_id: nil,
+          mhv_account_type: nil,
           uuid: '1655c16aa0784dbe973814c95bd69177',
           email: 'Test0206@gmail.com',
           idme_uuid: '1655c16aa0784dbe973814c95bd69177',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'dslogon', account_type: 3 },
+          sign_in: { service_name: 'dslogon', account_type: '2' },
           sec_id: '0000028007',
           multifactor: multifactor,
           authenticated_by_ssoe: true

--- a/spec/support/saml/response_builder.rb
+++ b/spec/support/saml/response_builder.rb
@@ -9,10 +9,9 @@ module SAML
       ' Military Service Information"}}'
     ].freeze
 
-    def create_user_identity(authn_context:, account_type:, level_of_assurance:, attributes:, issuer: nil)
+    def create_user_identity(authn_context:, level_of_assurance:, attributes:, issuer: nil)
       saml = build_saml_response(
         authn_context: authn_context,
-        account_type: account_type,
         level_of_assurance: level_of_assurance,
         attributes: attributes,
         issuer: issuer
@@ -24,7 +23,7 @@ module SAML
 
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/ParameterLists, Metrics/AbcSize
     def build_saml_response(
-      authn_context:, account_type:, level_of_assurance:,
+      authn_context:, level_of_assurance:,
       attributes: nil, issuer: nil, existing_attributes: nil, in_response_to: nil
     )
       verifying = [LOA::IDME_LOA3, LOA::IDME_LOA3_VETS, 'myhealthevet_loa3', 'dslogon_loa3'].include?(authn_context)
@@ -34,7 +33,6 @@ module SAML
           previous_context = authn_context.gsub(/multifactor|_multifactor/, '').presence || LOA::IDME_LOA1_VETS
           create_user_identity(
             authn_context: previous_context,
-            account_type: account_type,
             level_of_assurance: level_of_assurance,
             attributes: existing_attributes,
             issuer: issuer
@@ -47,7 +45,6 @@ module SAML
                                           .gsub(%r{loa/3}, 'loa/1/vets')
           create_user_identity(
             authn_context: previous_context,
-            account_type: account_type,
             level_of_assurance: '1',
             attributes: existing_attributes,
             issuer: issuer


### PR DESCRIPTION
## Description of change
* Ensures that MHV account status and identifiers are mapped correctly into an identity object from the v1 session controller. SSOe user attribute class was missing the `mhv_account_type` attribute and was incorrectly populating the `sign_in` object. 
* An SSOe assertion has two potential sources for an MHV UUID; this change updates the class to read from either of them and throw a fatal login error in case of a mismatch. 

Fixes va.gov-team#7337

This PR is for merge to master but builds on top of https://github.com/department-of-veterans-affairs/vets-api/pull/4027. I will rebase this branch once that is merged but for now this diff is probably more illustrative:
https://github.com/department-of-veterans-affairs/vets-api/compare/eb-alternative-user-uuid...pv-fix-mhv-account-type-attribute


## Testing
Tested locally and ensured that a user with an MHV account is correctly granted access to health tools and eligible for account upgrade.

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
