### PR TITLE
StatsD PPMS response logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -159,6 +159,7 @@ group :development, :test do
   gem 'rack-test', require: 'rack/test'
   gem 'rack-vcr'
   gem 'rainbow' # Used to colorize output for rake tasks
+  gem 'rspec-instrumentation-matcher'
   gem 'rspec-rails', '~> 3.5'
   gem 'rubocop', require: false
   gem 'rubocop-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,6 +597,9 @@ GEM
     rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
+    rspec-instrumentation-matcher (0.0.9)
+      activesupport
+      rspec-expectations
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
@@ -855,6 +858,7 @@ DEPENDENCIES
   request_store
   restforce
   rgeo-geojson
+  rspec-instrumentation-matcher
   rspec-rails (~> 3.5)
   rspec_junit_formatter
   rubocop

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -134,5 +134,5 @@ ActiveSupport::Notifications.subscribe('facilities.ppms.request.faraday') do |_,
                 when /Providers\(\d+\)/
                   'facilities.ppms.providers'
                 end
-  StatsD.measure(measurement, duration, tags: ['facilities.ppms'])
+  StatsD.measure(measurement, duration, tags: ['facilities.ppms']) if measurement
 end

--- a/lib/facilities/ppms/configuration.rb
+++ b/lib/facilities/ppms/configuration.rb
@@ -30,7 +30,6 @@ module Facilities
       def connection
         Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
           conn.use :breakers
-          # conn.use :http_cache, Rails.cache, :logger => Rails.logger
           conn.use :instrumentation, name: 'facilities.ppms.request.faraday'
           conn.options.params_encoder = DoNotEncoder
 

--- a/lib/facilities/ppms/configuration.rb
+++ b/lib/facilities/ppms/configuration.rb
@@ -30,6 +30,8 @@ module Facilities
       def connection
         Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
           conn.use :breakers
+          # conn.use :http_cache, Rails.cache, :logger => Rails.logger
+          conn.use :instrumentation, name: 'facilities.ppms.request.faraday'
           conn.options.params_encoder = DoNotEncoder
 
           # Uncomment this if you want curl command equivalent or response output to log

--- a/spec/request/v0/facilities/ccp_request_spec.rb
+++ b/spec/request/v0/facilities/ccp_request_spec.rb
@@ -20,6 +20,30 @@ RSpec.describe 'Community Care Providers', type: :request, team: :facilities do
         }
       end
 
+      it "sends a 'facilities.ppms.request.faraday' notification to any subscribers listening" do
+        allow(StatsD).to receive(:measure)
+
+        expect(StatsD).to receive(:measure).with(
+          'facilities.ppms.provider_locator',
+          kind_of(Numeric),
+          hash_including(
+            tags: ['facilities.ppms']
+          )
+        )
+
+        expect(StatsD).to receive(:measure).with(
+          'facilities.ppms.providers',
+          kind_of(Numeric),
+          hash_including(
+            tags: ['facilities.ppms']
+          )
+        ).exactly(5).times
+
+        expect do
+          get '/v0/facilities/ccp', params: params
+        end.to instrument('facilities.ppms.request.faraday')
+      end
+
       [
         [1, 5],
         [2, 5],


### PR DESCRIPTION
department-of-veterans-affairs/va.gov-team#6675
## Description of change
Using Faraday Instrumentation and Active Support Notifications to measure how long each request to PPMS is taking

## Testing
We need to make sure the review instance works. Hopefully, they are set up so we can see some of the metrics.

## Acceptance Criteria (Definition of Done)
The time taken for each type of request to PPMS should show up in Prometheus

#### Applies to all PRs

- [X] Swagger docs have been updated, if applicable
- [X] Provide link to originating GitHub issue, or connected to it via ZenHub
- [X] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
