### PR TITLE
MDOT-DLC API Integration Fixes

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -9,13 +9,13 @@
     :file_path: "mdot/supplies/index"
     :cache_multiple_responses:
       :uid_location: header
-      :uid_locator: 'veteranId'
+      :uid_locator: 'va_veteran_id'
   - :method: :post
     :path: "/supplies"
     :file_path: "mdot/supplies/create"
     :cache_multiple_responses:
       :uid_location: header
-      :uid_locator: 'veteranId'
+      :uid_locator: 'va_veteran_id'
 
 - :name: 'MHV_Rx'
   :base_uri: <%= "#{URI(Settings.mhv.rx.host).host}:#{URI(Settings.mhv.rx.host).port}" %>

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -5,13 +5,13 @@
   :base_uri: <%= "#{URI(Settings.mdot.url).host}:#{URI(Settings.mdot.url).port}" %>
   :endpoints:
   - :method: :get
-    :path: "/mdot/supplies"
+    :path: "/supplies"
     :file_path: "mdot/supplies/index"
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: 'veteranId'
   - :method: :post
-    :path: "/mdot/supplies"
+    :path: "/supplies"
     :file_path: "mdot/supplies/create"
     :cache_multiple_responses:
       :uid_location: header

--- a/lib/mdot/client.rb
+++ b/lib/mdot/client.rb
@@ -25,7 +25,7 @@ module MDOT
 
     def initialize(current_user)
       @user = current_user
-      @supplies = 'mdot/supplies'
+      @supplies = 'supplies'
     end
 
     ##
@@ -59,7 +59,10 @@ module MDOT
     private
 
     def headers
-      { veteranId: @user.ssn }
+      { 
+        VA_VETERAN_ID: @user.ssn.split(//).last(4).join,
+        VA_VETERAN_BIRTH_DATE: @user.birth_date
+      }
     end
 
     def with_monitoring_and_error_handling

--- a/lib/mdot/client.rb
+++ b/lib/mdot/client.rb
@@ -59,7 +59,7 @@ module MDOT
     private
 
     def headers
-      { 
+      {
         VA_VETERAN_ID: @user.ssn.split(//).last(4).join,
         VA_VETERAN_BIRTH_DATE: @user.birth_date
       }

--- a/lib/mdot/client.rb
+++ b/lib/mdot/client.rb
@@ -60,7 +60,7 @@ module MDOT
 
     def headers
       {
-        VA_VETERAN_ID: @user.ssn.split(//).last(4).join,
+        VA_VETERAN_ID: @user.ssn.last(4),
         VA_VETERAN_BIRTH_DATE: @user.birth_date
       }
     end

--- a/lib/mdot/configuration.rb
+++ b/lib/mdot/configuration.rb
@@ -9,7 +9,7 @@ module MDOT
     end
 
     def self.base_request_headers
-      super.merge('apiKey' => Settings.mdot.api_key)
+      super.merge('VA_API_KEY' => Settings.mdot.api_key)
     end
 
     def base_path

--- a/lib/mdot/schemas/supplies.json
+++ b/lib/mdot/schemas/supplies.json
@@ -26,7 +26,7 @@
       }
     },
     "temporary_address": {
-      "type": "object",
+      "type": ["object", "null"],
       "street": {
         "type": "string"
       },
@@ -54,7 +54,7 @@
         "required": ["product_id"],
         "properties": {
           "device_name": {
-            "type": "string"
+            "type": ["string", "null"]
           },
           "product_name": {
             "type": "string"
@@ -78,7 +78,7 @@
             "type": "integer"
           },
           "size": {
-            "type": "string"
+            "type": ["string", "null"]
           }
         }
       }

--- a/spec/support/vcr_cassettes/mdot/get_supplies_200.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dlc-fake.fake.com/mdot/supplies
+    uri: https://dlc-fake.fake.com/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/get_supplies_404.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_404.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dlc-fake.fake.com/mdot/supplies
+    uri: https://dlc-fake.fake.com/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/get_supplies_502.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_502.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dlc-fake.fake.com/mdot/supplies
+    uri: https://dlc-fake.fake.com/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/post_supplies_202.yml
+++ b/spec/support/vcr_cassettes/mdot/post_supplies_202.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dlc-fake.fake.com/mdot/supplies
+    uri: https://dlc-fake.fake.com/supplies
     body:
       encoding: US-ASCII
       string: '{"useVeteranAddress":"true","useTemporaryAddress":"false","order":[{"productId":"1"},{"productId":"4"}],"additionalRequests":""}'

--- a/spec/support/vcr_cassettes/mdot/post_supplies_404.yml
+++ b/spec/support/vcr_cassettes/mdot/post_supplies_404.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dlc-fake.fake.com/mdot/supplies
+    uri: https://dlc-fake.fake.com/supplies
     body:
       encoding: US-ASCII
       string: '{"useVeteranAddress":"true","useTemporaryAddress":"false","order":[{"productId":"1"},{"productId":"4"}],"additionalRequests":""}'

--- a/spec/support/vcr_cassettes/mdot/post_supplies_422.yml
+++ b/spec/support/vcr_cassettes/mdot/post_supplies_422.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dlc-fake.fake.com/mdot/supplies
+    uri: https://dlc-fake.fake.com/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/post_supplies_502.yml
+++ b/spec/support/vcr_cassettes/mdot/post_supplies_502.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dlc-fake.fake.com/mdot/supplies
+    uri: https://dlc-fake.fake.com/supplies
     body:
       encoding: US-ASCII
       string: '{"useVeteranAddress":"true","useTemporaryAddress":"false","order":[{"productId":"1"},{"productId":"4"}],"additionalRequests":""}'

--- a/spec/support/vcr_cassettes/mdot/submit_order_202.yml
+++ b/spec/support/vcr_cassettes/mdot/submit_order_202.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dlc-fake.fake.com/mdot/supplies
+    uri: https://dlc-fake.fake.com/supplies
     body:
       encoding: UTF-8
       string: '{"fullName":{"first":"Greg","middle":"A","last":"Anderson"},"permanentAddress":{"street":"101 Example Street","street2":"Apt 2","city":"Kansas City","state":"MO","country":"USA","postalCode":"64117"},"order":[{"productId":"1"},{"productId":"4"}],"additionalRequests":""}'

--- a/spec/support/vcr_cassettes/mdot/submit_order_400.yml
+++ b/spec/support/vcr_cassettes/mdot/submit_order_400.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dlc-fake.fake.com/mdot/supplies
+    uri: https://dlc-fake.fake.com/supplies
     body:
       encoding: UTF-8
       string: '{}'

--- a/spec/support/vcr_cassettes/mdot/submit_order_502.yml
+++ b/spec/support/vcr_cassettes/mdot/submit_order_502.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dlc-fake.fake.com/mdot/supplies
+    uri: https://dlc-fake.fake.com/supplies
     body:
       encoding: UTF-8
       string: '{"veteranFullName":{"first":"Greg","middle":"A","last":"Anderson"},"veteranAddress":{"street":"101 Example Street","street2":"Apt 2","city":"Kansas City","state":"MO","country":"USA","postalCode":"64117"},"order":[{"productId":"1"},{"productId":"4"}],"additionalRequests":""}'


### PR DESCRIPTION
## Original Issue
[link to original issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/7507)

## Description of change
This PR includes a few changes to successfully connect with the stand-in DLC API. These changes include:

- Altering the `supplies.json` to allow some fields to be nullable, such as temporary address as not every veteran will have a temporary address.
- Changing the client connection URL to make calls to `/supplies` instead of `/mdot/supplies`

## Testing
Has been tested and verified using a locally running instance of vets-api

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] Calls made using the MDOT Client return data successfully when connected to the DLC stand-in API

#### Applies to all PRs

- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
