### PR TITLE
Fix VCR cassette name.

### DIFF
--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1055,7 +1055,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
       describe 'yellow_ribbon_programs' do
         describe 'index' do
           it 'supports showing a list of yellow_ribbon_programs' do
-            VCR.use_cassette('gi_client/get_yellow_ribbon_programs') do
+            VCR.use_cassette('gi_client/gets_yellow_ribbon_programs_search_results') do
               expect(subject).to validate(:get, '/v0/gi/yellow_ribbon_programs', 200)
             end
           end


### PR DESCRIPTION
## Description of change
Fix VCR cassette name.
Original name provided was for a cassette that did not exist.

## Testing
specs

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Fix cassette name

#### Applies to all PRs

- [ ] ~~Swagger docs have been updated, if applicable~~
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
