### PR TITLE
Add issue number link and clean up text on default pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ department-of-veterans-affairs/va.gov-team#0000
 * Are there additions to a `settings.yml` file? Do they vary by environment?
 * Is there a feature flag? What is it
 * Is there some sentry logging that was added? What alerts are relevant?
-* Are there any prometheus metrics being collected? What dashboard were they added do?
+* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
 * Are there Swagger docs that were updated?
 * Is there any PII concerns or questions?
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ department-of-veterans-affairs/va.gov-team#0000
 ## Things to know about this PR
 <!--
 * Are there additions to a `settings.yml` file? Do they vary by environment?
-* Is there a feature flag? What is it
+* Is there a feature flag? What is it?
 * Is there some Sentry logging that was added? What alerts are relevant?
 * Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
 * Are there Swagger docs that were updated?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ department-of-veterans-affairs/va.gov-team#0000
 <!--
 * Are there additions to a `settings.yml` file? Do they vary by environment?
 * Is there a feature flag? What is it
-* Is there some sentry logging that was added? What alerts are relevant?
+* Is there some Sentry logging that was added? What alerts are relevant?
 * Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
 * Are there Swagger docs that were updated?
 * Is there any PII concerns or questions?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,13 +6,15 @@
 ## Original issue(s)
 department-of-veterans-affairs/va.gov-team#0000
 
+## Things to know about this PR
+<!--
+* Is there a feature flag? What is it
+* Are there additions to a `settings.yml` file? Do they vary by environment?
+* Is there some sentry logging that was added?
+* Are there any prometheus metrics being collected? What dashboard were they added do?
+-->
 
-## Testing
 <!-- Please describe testing done to verify the changes or any testing planned. -->
-
-#### Unique to this PR
-<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
-- [ ] _Replace this line with individual tasks unique to your PR_
 
 #### Applies to all PRs
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,17 +8,12 @@ department-of-veterans-affairs/va.gov-team#0000
 
 ## Things to know about this PR
 <!--
-* Is there a feature flag? What is it
 * Are there additions to a `settings.yml` file? Do they vary by environment?
-* Is there some sentry logging that was added?
+* Is there a feature flag? What is it
+* Is there some sentry logging that was added? What alerts are relevant?
 * Are there any prometheus metrics being collected? What dashboard were they added do?
+* Are there Swagger docs that were updated?
+* Is there any PII concerns or questions?
 -->
 
 <!-- Please describe testing done to verify the changes or any testing planned. -->
-
-#### Applies to all PRs
-
-- [ ] Swagger docs have been updated, if applicable
-- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
-- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
-- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,13 +3,12 @@
 ## Description of change
 <!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
 
-## Original issue
+## Original issue(s)
 department-of-veterans-affairs/va.gov-team#0000
+
 
 ## Testing
 <!-- Please describe testing done to verify the changes or any testing planned. -->
-
-## Acceptance Criteria (Definition of Done)
 
 #### Unique to this PR
 <!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,9 @@
 ## Description of change
 <!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
 
+## Original issue
+department-of-veterans-affairs/va.gov-team#0000
+
 ## Testing
 <!-- Please describe testing done to verify the changes or any testing planned. -->
 


### PR DESCRIPTION
Our PR template hasn't been reviewed in a while. It is definitely helpful to reviewers to have a link to the
original issue, so there's now a default entry in the appropriate format to autolink to the va.gov-team repo.

We also had a lot of boilerplate that ended up adding to the content/description of the PR without adding a lot of real value. Revised, removed, and moved to comments depending on details
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
department-of-veterans-affairs/va.gov-team#7531

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it
* Is there some sentry logging that was added? What alerts are relevant?
* Are there any prometheus metrics being collected? What dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This changes the default template for all vets-api pull requests, based on feedback from the backend team reviewers.
<!-- Please describe testing done to verify the changes or any testing planned. -->