### PR TITLE
skip CSRF validation in PerformanceMonitoringsController

### DIFF
--- a/app/controllers/v0/performance_monitorings_controller.rb
+++ b/app/controllers/v0/performance_monitorings_controller.rb
@@ -3,6 +3,7 @@
 # rubocop:disable Layout/LineLength
 module V0
   class PerformanceMonitoringsController < ApplicationController
+    skip_before_action :verify_authenticity_token
     skip_before_action :authenticate
 
     # Calls StatsD.measure for a given whitelisted path, and set of metrics data.


### PR DESCRIPTION
## Description of change
We've identified a route that doesn't need CSRF protection.
It's also been determined that this route is no longer necessary at all.
We'll skip CSRF validation for now, and remove it altogether later after it's first been removed from the FE.

Pertains to department-of-veterans-affairs/va.gov-team-sensitive#61
## Testing
specs

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] `skip_before_action :verify_authenticity_token` in `PerformanceMonitoringsController`
#### Applies to all PRs

- [ ] ~~Swagger docs have been updated, if applicable~~
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
