### PR TITLE
[7559] Deceased Veteran Error Handling for MDOT

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -1930,6 +1930,12 @@ en:
         detail: User is forbidden from accessing this resource
         code: MDOT_forbidden
         status: 403
+      MDOT_deceased_veteran:
+        <<: *defaults
+        title: Veteran is Deceased
+        detail: The veteran is deceased; supplies cannot be ordered
+        code: MDOT_deceased_veteran
+        status: 403
       MDOT_veteran_not_found:
         <<: *defaults
         title: Veteran Not Found


### PR DESCRIPTION
## Original Issue
[7559](https://github.com/department-of-veterans-affairs/va.gov-team/issues/7559)

## Description of change
Adds an exception within exceptions.en.yml to handle scenarios where a veteran is deceased and a 403 error is returned to vets-api from the DLC.

## Testing
Has been tested and verified locally

## Acceptance Criteria (Definition of Done)
Error exception is added and when a deceased veteran attempts to call the API a 403 is returned.

#### Applies to all PRs

- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
