### PR TITLE
7056 pass lat long to ppms

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -16,6 +16,15 @@ features:
     description: >
       On https://www.va.gov/find-locations/ enable veterans to search for Community care by showing that option in the "Search for" box.
       This toggle is owned by Rian
+  facility_locator_ppms_location_query:
+    actor_type: user
+    description: Use the Lat/Long instead of an address
+  facility_locator_ppms_suppress_drive_time:
+    actor_type: user
+    description: Include driveTime = 10_000 in new PPMS query    
+  facility_locator_ppms_suppress_extra_params:
+    actor_type: user
+    description: Include specialtycode2 to specialtycode4, network, gender primartycare, and acceptingnewpatients in new PPMS query
   profile_schema_forms:
     actor_type: user
     description: >

--- a/config/features.yml
+++ b/config/features.yml
@@ -19,12 +19,6 @@ features:
   facility_locator_ppms_location_query:
     actor_type: user
     description: Use the Lat/Long instead of an address
-  facility_locator_ppms_suppress_drive_time:
-    actor_type: user
-    description: Include driveTime = 10_000 in new PPMS query    
-  facility_locator_ppms_suppress_extra_params:
-    actor_type: user
-    description: Include specialtycode2 to specialtycode4, network, gender primartycare, and acceptingnewpatients in new PPMS query
   profile_schema_forms:
     actor_type: user
     description: >

--- a/lib/facilities/ppms/client.rb
+++ b/lib/facilities/ppms/client.rb
@@ -150,7 +150,11 @@ module Facilities
 
         projection = RGeo::Geographic::ProjectedWindow.new(regeo_factory, x_min, y_min, x_max, y_max)
         lat, lon = projection.center_xy
-        rad = (projection.height * longitude_degree_distance(lat)).round(2)
+        rad = [
+          (projection.height * latitude_degree_distance).round(2),
+          (projection.width * longitude_degree_distance(lat)).round(2)
+        ].max
+        
         {
           latitude: lat,
           longitude: lon,
@@ -222,13 +226,15 @@ module Facilities
         query_params[:radius] = cnr[:radius]
         query_params[:driveTime] = 10_000 unless Flipper.enabled?(:facility_locator_ppms_suppress_drive_time)
         query_params[:specialtycode1] = specialty
-        query_params[:specialtycode2] = 'null'  unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
-        query_params[:specialtycode3] = 'null'  unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
-        query_params[:specialtycode4] = 'null'  unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
-        query_params[:network] = 0              unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
-        query_params[:gender] = 0               unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
-        query_params[:primarycare] = 0          unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
-        query_params[:acceptingnewpatients] = 0 unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
+        unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
+          query_params[:specialtycode2] = 'null'
+          query_params[:specialtycode3] = 'null'
+          query_params[:specialtycode4] = 'null'
+          query_params[:network] = 0
+          query_params[:gender] = 0
+          query_params[:primarycare] = 0
+          query_params[:acceptingnewpatients] = 0
+        end
         query_params[:maxResults] = per_page * page + 1
 
         query_params

--- a/lib/facilities/ppms/client.rb
+++ b/lib/facilities/ppms/client.rb
@@ -154,7 +154,7 @@ module Facilities
           (projection.height * latitude_degree_distance).round(2),
           (projection.width * longitude_degree_distance(lat)).round(2)
         ].max
-        
+
         {
           latitude: lat,
           longitude: lon,

--- a/lib/facilities/ppms/client.rb
+++ b/lib/facilities/ppms/client.rb
@@ -127,11 +127,43 @@ module Facilities
         response
       end
 
+      EARTH_RADIUS = 3_958.8
+
+      def regeo_factory
+        RGeo::Geographic.spherical_factory
+      end
+
+      # Distance spanned by one degree of latitude in the given units.
+      def latitude_degree_distance
+        2 * Math::PI * EARTH_RADIUS / 360
+      end
+
+      # Distance spanned by one degree of longitude at the given latitude.
+      # This ranges from around 69 miles at the equator to zero at the poles.
+      def longitude_degree_distance(latitude)
+        (latitude_degree_distance * Math.cos(latitude * (Math::PI / 180))).abs
+      end
+
+      def center_and_radius(bbox)
+        bbox_num = bbox.map { |x| Float(x) }
+        x_min, y_min, x_max, y_max = bbox_num.values_at(1, 0, 3, 2)
+
+        projection = RGeo::Geographic::ProjectedWindow.new(regeo_factory, x_min, y_min, x_max, y_max)
+        lat, lon = projection.center_xy
+        rad = (projection.height * longitude_degree_distance(lat)).round(2)
+        {
+          latitude: lat,
+          longitude: lon,
+          radius: rad
+        }
+      end
+
       def radius(bbox)
         # more estimation fun about 69 miles between latitude lines, <= 69 miles between long lines
         bbox_num = bbox.map { |x| Float(x) }
+
         lats = bbox_num.values_at(1, 3)
-        longs = bbox_num.values_at(2, 0)
+        longs = bbox_num.values_at(0, 2)
         xlen = (lats.max - lats.min) * 69 / 2
         ylen = (longs.max - longs.min) * 69 / 2
         Math.sqrt(xlen * xlen + ylen * ylen) * 1.1 # go a little bit beyond the corner;
@@ -151,6 +183,14 @@ module Facilities
       end
 
       def provider_locator_params(params)
+        if Flipper.enabled?(:facility_locator_ppms_location_query)
+          provider_locator_location_params(params)
+        else
+          provider_locator_address_params(params)
+        end
+      end
+
+      def provider_locator_address_params(params)
         page = Integer(params[:page] || 1)
         per_page = Integer(params[:per_page] || BaseFacility.per_page)
         specialty = "'#{params[:services] ? params[:services][0] : 'null'}'"
@@ -168,6 +208,30 @@ module Facilities
           acceptingnewpatients: 0,
           maxResults: per_page * page + 1
         }
+      end
+
+      def provider_locator_location_params(params)
+        page = Integer(params[:page] || 1)
+        per_page = Integer(params[:per_page] || BaseFacility.per_page)
+        specialty = "'#{params[:services] ? params[:services][0] : 'null'}'"
+        cnr = center_and_radius(params[:bbox])
+
+        query_params = {}
+
+        query_params[:address] = [cnr[:latitude], cnr[:longitude]].join(',')
+        query_params[:radius] = cnr[:radius]
+        query_params[:driveTime] = 10_000       unless Flipper.enabled?(:facility_locator_ppms_suppress_drive_time)
+        query_params[:specialtycode1] = specialty
+        query_params[:specialtycode2] = 'null'  unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
+        query_params[:specialtycode3] = 'null'  unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
+        query_params[:specialtycode4] = 'null'  unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
+        query_params[:network] = 0              unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
+        query_params[:gender] = 0               unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
+        query_params[:primarycare] = 0          unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
+        query_params[:acceptingnewpatients] = 0 unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
+        query_params[:maxResults] = per_page * page + 1
+
+        query_params
       end
     end
   end

--- a/lib/facilities/ppms/client.rb
+++ b/lib/facilities/ppms/client.rb
@@ -167,7 +167,7 @@ module Facilities
         bbox_num = bbox.map { |x| Float(x) }
 
         lats = bbox_num.values_at(1, 3)
-        longs = bbox_num.values_at(0, 2)
+        longs = bbox_num.values_at(2, 0)
         xlen = (lats.max - lats.min) * 69 / 2
         ylen = (longs.max - longs.min) * 69 / 2
         Math.sqrt(xlen * xlen + ylen * ylen) * 1.1 # go a little bit beyond the corner;

--- a/lib/facilities/ppms/client.rb
+++ b/lib/facilities/ppms/client.rb
@@ -220,7 +220,7 @@ module Facilities
 
         query_params[:address] = [cnr[:latitude], cnr[:longitude]].join(',')
         query_params[:radius] = cnr[:radius]
-        query_params[:driveTime] = 10_000       unless Flipper.enabled?(:facility_locator_ppms_suppress_drive_time)
+        query_params[:driveTime] = 10_000 unless Flipper.enabled?(:facility_locator_ppms_suppress_drive_time)
         query_params[:specialtycode1] = specialty
         query_params[:specialtycode2] = 'null'  unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
         query_params[:specialtycode3] = 'null'  unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)

--- a/lib/facilities/ppms/client.rb
+++ b/lib/facilities/ppms/client.rb
@@ -223,7 +223,15 @@ module Facilities
         {
           address: [cnr[:latitude], cnr[:longitude]].join(','),
           radius: cnr[:radius],
+          driveTime: 10_000,
           specialtycode1: specialty,
+          specialtycode2: 'null',
+          specialtycode3: 'null',
+          specialtycode4: 'null',
+          network: 0,
+          gender: 0,
+          primarycare: 0,
+          acceptingnewpatients: 0,
           maxResults: per_page * page + 1
         }
       end

--- a/lib/facilities/ppms/client.rb
+++ b/lib/facilities/ppms/client.rb
@@ -220,24 +220,12 @@ module Facilities
         specialty = "'#{params[:services] ? params[:services][0] : 'null'}'"
         cnr = center_and_radius(params[:bbox])
 
-        query_params = {}
-
-        query_params[:address] = [cnr[:latitude], cnr[:longitude]].join(',')
-        query_params[:radius] = cnr[:radius]
-        query_params[:driveTime] = 10_000 unless Flipper.enabled?(:facility_locator_ppms_suppress_drive_time)
-        query_params[:specialtycode1] = specialty
-        unless Flipper.enabled?(:facility_locator_ppms_suppress_extra_params)
-          query_params[:specialtycode2] = 'null'
-          query_params[:specialtycode3] = 'null'
-          query_params[:specialtycode4] = 'null'
-          query_params[:network] = 0
-          query_params[:gender] = 0
-          query_params[:primarycare] = 0
-          query_params[:acceptingnewpatients] = 0
-        end
-        query_params[:maxResults] = per_page * page + 1
-
-        query_params
+        {
+          address: [cnr[:latitude], cnr[:longitude]].join(','),
+          radius: cnr[:radius],
+          specialtycode1: specialty,
+          maxResults: per_page * page + 1
+        }
       end
     end
   end

--- a/lib/facilities/ppms/client.rb
+++ b/lib/facilities/ppms/client.rb
@@ -129,7 +129,7 @@ module Facilities
 
       EARTH_RADIUS = 3_958.8
 
-      def regeo_factory
+      def rgeo_factory
         RGeo::Geographic.spherical_factory
       end
 
@@ -148,7 +148,7 @@ module Facilities
         bbox_num = bbox.map { |x| Float(x) }
         x_min, y_min, x_max, y_max = bbox_num.values_at(1, 0, 3, 2)
 
-        projection = RGeo::Geographic::ProjectedWindow.new(regeo_factory, x_min, y_min, x_max, y_max)
+        projection = RGeo::Geographic::ProjectedWindow.new(rgeo_factory, x_min, y_min, x_max, y_max)
         lat, lon = projection.center_xy
         rad = [
           (projection.height * latitude_degree_distance).round(2),

--- a/spec/lib/facilities/ppms/client_spec.rb
+++ b/spec/lib/facilities/ppms/client_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Facilities::PPMS::Client, team: :facilities do
     end
   end
 
-  describe '#provider_locator' do 
+  describe '#provider_locator' do
     it 'returns a list of providers' do
       Flipper.enable(:facility_locator_ppms_location_query, false)
       Flipper.enable(:facility_locator_ppms_suppress_drive_time, false)
@@ -66,14 +66,14 @@ RSpec.describe Facilities::PPMS::Client, team: :facilities do
       end
     end
 
-    context '#provider_locator_params' do
-      subject(:provider_locator_params) { 
+    describe '#provider_locator_params' do
+      subject(:provider_locator_params) do
         Facilities::PPMS::Client.new.send(
           :provider_locator_params,
           params.merge(services: ['213E00000X'])
         )
-      }
-    
+      end
+
       # | location_query | suppress_drive_time | suppress_extra_params | expected_keys                             |
       # | -------------- | ------------------- | --------------------- | ----------------------------------------- |
       # | false          | false               | false                 | location_keys, drive_time_key, extra_keys |
@@ -81,52 +81,55 @@ RSpec.describe Facilities::PPMS::Client, team: :facilities do
       # | true           | true                | false                 | location_keys, extra_keys                 |
       # | true           | false               | true                  | location_keys, drive_time_key             |
       # | true           | false               | false                 | location_keys, drive_time_key, extra_keys |
-    
-    
-      let(:location_hash) {{
-        address: '33.28,-111.79',
-        radius: 86.64,
-        specialtycode1: "'213E00000X'",
-        maxResults: 11
-      }}
-    
-      let(:drive_time_hash) {{
-        driveTime: 10_000
-      }}
-    
-      let(:extras_hash) {{
-        specialtycode2: 'null',
-        specialtycode3: 'null',
-        specialtycode4: 'null',
-        network: 0,
-        gender: 0,
-        primarycare: 0,
-        acceptingnewpatients: 0
-      }}
-      
-      context "old address query" do
 
-        before(:each) do
+      let(:location_hash) do
+        {
+          address: '33.28,-111.79',
+          radius: 86.64,
+          specialtycode1: "'213E00000X'",
+          maxResults: 11
+        }
+      end
+
+      let(:drive_time_hash) do
+        {
+          driveTime: 10_000
+        }
+      end
+
+      let(:extras_hash) do
+        {
+          specialtycode2: 'null',
+          specialtycode3: 'null',
+          specialtycode4: 'null',
+          network: 0,
+          gender: 0,
+          primarycare: 0,
+          acceptingnewpatients: 0
+        }
+      end
+
+      context 'old address query' do
+        before do
           Flipper.enable(:facility_locator_ppms_location_query, false)
         end
 
         it 'uses lat/long for an address' do
           expect(provider_locator_params[:address]).to eql("'South Gilbert Road, Chandler, Arizona 85286, United States'")
         end
-
       end
 
-      context "new location query" do
-        before(:each) do
+      context 'new location query' do
+        before do
           Flipper.enable(:facility_locator_ppms_location_query, true)
         end
-        
+
         let(:api_client) { Facilities::PPMS::Client.new }
 
         it 'uses lat/long for an address' do
           expect(provider_locator_params[:address]).to eql('33.28,-111.79')
         end
-    
+
         [
           { suppress_drive_time: false, suppress_extra_params: false  },
           { suppress_drive_time: true,  suppress_extra_params: true   },
@@ -135,25 +138,24 @@ RSpec.describe Facilities::PPMS::Client, team: :facilities do
         ].each do |feature_flags|
           context feature_flags.to_s do
             feature_flags.each do |(flag_name, enabled)|
-              before(:each) do
+              before do
                 Flipper.enable("facility_locator_ppms_#{flag_name}".to_sym, enabled)
               end
             end
 
-            it { is_expected.to include(location_hash)}
-            
+            it { is_expected.to include(location_hash) }
+
             if feature_flags[:suppress_drive_time]
-              it { is_expected.not_to include(drive_time_hash)}
+              it { is_expected.not_to include(drive_time_hash) }
             else
-              it { is_expected.to include(drive_time_hash)}
+              it { is_expected.to include(drive_time_hash) }
             end
 
             if feature_flags[:suppress_extra_params]
-              it { is_expected.not_to include(extras_hash)}
+              it { is_expected.not_to include(extras_hash) }
             else
-              it { is_expected.to include(extras_hash)}
+              it { is_expected.to include(extras_hash) }
             end
-
           end
         end
       end

--- a/spec/lib/facilities/ppms/client_spec.rb
+++ b/spec/lib/facilities/ppms/client_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe Facilities::PPMS::Client, team: :facilities do
           expect(provider_locator_params[:address]).to eql('33.28,-111.79')
         end
       end
-      
     end
   end
 

--- a/spec/lib/facilities/ppms/client_spec.rb
+++ b/spec/lib/facilities/ppms/client_spec.rb
@@ -37,8 +37,6 @@ RSpec.describe Facilities::PPMS::Client, team: :facilities do
   describe '#provider_locator' do
     it 'returns a list of providers' do
       Flipper.enable(:facility_locator_ppms_location_query, false)
-      Flipper.enable(:facility_locator_ppms_suppress_drive_time, false)
-      Flipper.enable(:facility_locator_ppms_suppress_extra_params, false)
       VCR.use_cassette('facilities/va/ppms', match_requests_on: %i[path query]) do
         r = Facilities::PPMS::Client.new.provider_locator(params.merge(services: ['213E00000X']))
         name = 'Freed, Lewis'

--- a/spec/lib/facilities/ppms/client_spec.rb
+++ b/spec/lib/facilities/ppms/client_spec.rb
@@ -74,38 +74,12 @@ RSpec.describe Facilities::PPMS::Client, team: :facilities do
         )
       end
 
-      # | location_query | suppress_drive_time | suppress_extra_params | expected_keys                             |
-      # | -------------- | ------------------- | --------------------- | ----------------------------------------- |
-      # | false          | false               | false                 | location_keys, drive_time_key, extra_keys |
-      # | true           | true                | true                  | location_keys, extra_keys                 |
-      # | true           | true                | false                 | location_keys, extra_keys                 |
-      # | true           | false               | true                  | location_keys, drive_time_key             |
-      # | true           | false               | false                 | location_keys, drive_time_key, extra_keys |
-
       let(:location_hash) do
         {
           address: '33.28,-111.79',
           radius: 103.64,
           specialtycode1: "'213E00000X'",
           maxResults: 11
-        }
-      end
-
-      let(:drive_time_hash) do
-        {
-          driveTime: 10_000
-        }
-      end
-
-      let(:extras_hash) do
-        {
-          specialtycode2: 'null',
-          specialtycode3: 'null',
-          specialtycode4: 'null',
-          network: 0,
-          gender: 0,
-          primarycare: 0,
-          acceptingnewpatients: 0
         }
       end
 
@@ -131,36 +105,8 @@ RSpec.describe Facilities::PPMS::Client, team: :facilities do
         it 'uses lat/long for an address' do
           expect(provider_locator_params[:address]).to eql('33.28,-111.79')
         end
-
-        [
-          { suppress_drive_time: false, suppress_extra_params: false  },
-          { suppress_drive_time: true,  suppress_extra_params: true   },
-          { suppress_drive_time: false, suppress_extra_params: true   },
-          { suppress_drive_time: true,  suppress_extra_params: false  }
-        ].each do |feature_flags|
-          context feature_flags.to_s do
-            feature_flags.each do |(flag_name, enabled)|
-              before do
-                Flipper.enable("facility_locator_ppms_#{flag_name}".to_sym, enabled)
-              end
-            end
-
-            it { is_expected.to include(location_hash) }
-
-            if feature_flags[:suppress_drive_time]
-              it { is_expected.not_to include(drive_time_hash) }
-            else
-              it { is_expected.to include(drive_time_hash) }
-            end
-
-            if feature_flags[:suppress_extra_params]
-              it { is_expected.not_to include(extras_hash) }
-            else
-              it { is_expected.to include(extras_hash) }
-            end
-          end
-        end
       end
+      
     end
   end
 

--- a/spec/lib/facilities/ppms/client_spec.rb
+++ b/spec/lib/facilities/ppms/client_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Facilities::PPMS::Client, team: :facilities do
       let(:location_hash) do
         {
           address: '33.28,-111.79',
-          radius: 86.64,
+          radius: 103.64,
           specialtycode1: "'213E00000X'",
           maxResults: 11
         }
@@ -115,7 +115,9 @@ RSpec.describe Facilities::PPMS::Client, team: :facilities do
         end
 
         it 'uses lat/long for an address' do
-          expect(provider_locator_params[:address]).to eql("'South Gilbert Road, Chandler, Arizona 85286, United States'")
+          expect(provider_locator_params[:address]).to eql(
+            "'South Gilbert Road, Chandler, Arizona 85286, United States'"
+          )
         end
       end
 

--- a/spec/request/v0/facilities/ccp_request_spec.rb
+++ b/spec/request/v0/facilities/ccp_request_spec.rb
@@ -4,9 +4,11 @@ require 'rails_helper'
 
 RSpec.describe 'Community Care Providers', type: :request, team: :facilities do
   around do |example|
-    VCR.use_cassette('facilities/va/ppms', match_requests_on: %i[path query], allow_playback_repeats: true) do
-      example.run
-    end
+    VCR.insert_cassette('facilities/va/ppms', match_requests_on: %i[path query], allow_playback_repeats: true)
+    VCR.insert_cassette('facilities/va/ppms_new_query', match_requests_on: %i[path query], allow_playback_repeats: true)
+    example.run
+    VCR.eject_cassette('facilities/va/ppms_new_query')
+    VCR.eject_cassette('facilities/va/ppms')
   end
 
   describe '#index' do

--- a/spec/request/v0/facilities/va_request_spec.rb
+++ b/spec/request/v0/facilities/va_request_spec.rb
@@ -152,6 +152,12 @@ RSpec.describe 'VA GIS Integration', type: :request, team: :facilities do
   end
 
   context 'Community Care (PPMS)' do
+    around do |example|
+      VCR.use_cassette('facilities/va/ppms', match_requests_on: %i[path query], allow_playback_repeats: true) do
+        example.run
+      end
+    end
+
     let(:params) do
       {
         address: 'South Gilbert Road, Chandler, Arizona 85286, United States',
@@ -160,7 +166,7 @@ RSpec.describe 'VA GIS Integration', type: :request, team: :facilities do
     end
 
     it 'responds to GET #index with bbox, address, and ccp type' do
-      VCR.use_cassette('facilities/va/ppms', match_requests_on: %i[path query], allow_playback_repeats: true) do
+      VCR.use_cassette('facilities/va/ppms_new_query', match_requests_on: %i[path query], allow_playback_repeats: true) do
         get '/v0/facilities/va', params: params.merge('type' => 'cc_provider', 'services' => ['213E00000X'])
         expect(response).to be_successful
         expect(response.body).to be_a(String)

--- a/spec/request/v0/facilities/va_request_spec.rb
+++ b/spec/request/v0/facilities/va_request_spec.rb
@@ -166,7 +166,11 @@ RSpec.describe 'VA GIS Integration', type: :request, team: :facilities do
     end
 
     it 'responds to GET #index with bbox, address, and ccp type' do
-      VCR.use_cassette('facilities/va/ppms_new_query', match_requests_on: %i[path query], allow_playback_repeats: true) do
+      VCR.use_cassette(
+        'facilities/va/ppms_new_query',
+        match_requests_on: %i[path query],
+        allow_playback_repeats: true
+      ) do
         get '/v0/facilities/va', params: params.merge('type' => 'cc_provider', 'services' => ['213E00000X'])
         expect(response).to be_successful
         expect(response.body).to be_a(String)

--- a/spec/support/vcr_cassettes/facilities/va/ppms_new_query.yml
+++ b/spec/support/vcr_cassettes/facilities/va/ppms_new_query.yml
@@ -55,13 +55,13 @@
     recorded_at: Thu, 16 Jan 2020 20:16:26 GMT
   - request:
       <<: *base_request
-      uri: https://np.dws.ppms.va.gov/v1.0/ProviderLocator?address=33.28,-111.79&maxResults=11&radius=86.64&specialtycode1=%27213E00000X%27
+      uri: https://np.dws.ppms.va.gov/v1.0/ProviderLocator?address=33.28,-111.79&maxResults=11&radius=103.64&specialtycode1=%27213E00000X%27
     response:
       <<: *base_response
     recorded_at: Thu, 16 Jan 2020 20:16:26 GMT
   - request:
       <<: *base_request
-      uri: https://np.dws.ppms.va.gov/v1.0/ProviderLocator?address=33.28,-111.79&maxResults=11&radius=86.64&specialtycode1=%273336C0003X%27
+      uri: https://np.dws.ppms.va.gov/v1.0/ProviderLocator?address=33.28,-111.79&maxResults=11&radius=103.64&specialtycode1=%273336C0003X%27
     response:
       <<: *base_response
     recorded_at: Thu, 16 Jan 2020 20:16:26 GMT

--- a/spec/support/vcr_cassettes/facilities/va/ppms_new_query.yml
+++ b/spec/support/vcr_cassettes/facilities/va/ppms_new_query.yml
@@ -1,0 +1,67 @@
+---
+  http_interactions:
+  - request: &base_request
+      method: get
+      uri: https://np.dws.ppms.va.gov/v1.0/ProviderLocator?address=%27South%20Gilbert%20Road,%20Chandler,%20Arizona%2085286,%20United%20States%27&radius=80.50410703808843&driveTime=10000&specialtycode1=%27213E00000X%27&specialtycode2=null&specialtycode3=null&specialtycode4=null&network=0&gender=0&primarycare=0&acceptingnewpatients=0&maxResults=11
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        User-Agent:
+        - Faraday v1.0.0
+        Accept:
+        - application/json
+    response: &base_response
+      status:
+        code: 200
+        message: OK
+      headers:
+        cache-control:
+        - no-cache
+        pragma:
+        - no-cache
+        content-length:
+        - '1237'
+        content-type:
+        - application/json; odata.metadata=minimal
+        expires:
+        - "-1"
+        vary:
+        - Accept-Encoding
+        server:
+        - Microsoft-IIS/10.0
+        odata-version:
+        - '4.0'
+        x-aspnet-version:
+        - 4.0.30319
+        request-context:
+        - appId=cid-v1:eb19c193-bb35-487a-bd34-bf11c4cecb5f
+        access-control-expose-headers:
+        - Request-Context
+        x-powered-by:
+        - ASP.NET
+        x-content-type-options:
+        - nosniff
+        set-cookie:
+        - ARRAffinity=3d15955dbb3ae948d97f99668b2f8e7d0da69760a7a60c59ac60dcf8438af508;Path=/;HttpOnly;Domain=np.dws.ppms.va.gov
+        date:
+        - Thu, 16 Jan 2020 20:16:26 GMT
+        connection:
+        - close
+      body:
+        encoding: ASCII-8BIT
+        string: '{"@odata.context":"https://dws.ppms.va.gov/v1.0/$metadata#Collection(PpmsDataWebService.Models.ProviderLocatorResult)","value":[{"Miles":2.302,"Minutes":5.433,"ProviderName":"Freed, Lewis ","ProviderSpecialty":"Podiatrist","SpecialtyCode":"213E00000X","PreferredMeansReceivingReferralHSRM":false,"PreferredMeansReceivingReferralSecuredEmail":false,"PreferredMeansReceivingReferralMail":false,"PreferredMeansReceivingReferralDirectMessaging":false,"PreferredMeansReceivingReferralFax":false,"HPP":"Unknown","CareSite":"Lewis H Freed DPM PC","CareSiteAddress":"3195 S Price Rd Ste 148 Chandler, AZ 85248","CareSiteAddressStreet":"3195 S Price Rd Ste 148","CareSiteAddressCity":"Chandler","CareSiteAddressState":"AZ","CareSiteAddressZipCode":"85248","CareSitePhoneNumber":"4807057300","WorkHours":null,"ProviderGender":"Male","ProviderNetwork":"TriWest - Choice","NetworkId":null,"ProviderAcceptingNewPatients":true,"ProviderPrimaryCare":false,"QualityRanking":null,"ProviderIdentifier":"1407842941","Latitude":33.258135,"Longitude":-111.887927},{"Miles":2.302,"Minutes":5.317,"ProviderName":"Freed, Lewis ","ProviderSpecialty":"Podiatrist","SpecialtyCode":"213E00000X","PreferredMeansReceivingReferralHSRM":false,"PreferredMeansReceivingReferralSecuredEmail":false,"PreferredMeansReceivingReferralMail":false,"PreferredMeansReceivingReferralDirectMessaging":false,"PreferredMeansReceivingReferralFax":false,"HPP":"Unknown","CareSite":"Lewis H Freed DPM PC","CareSiteAddress":"3195 S Price Rd Ste 148 Chandler, AZ 85248","CareSiteAddressStreet":"3195 S Price Rd Ste 148","CareSiteAddressCity":"Chandler","CareSiteAddressState":"AZ","CareSiteAddressZipCode":"85248","CareSitePhoneNumber":"4807057300","WorkHours":null,"ProviderGender":"Male","ProviderNetwork":"TriWest - Choice","NetworkId":null,"ProviderAcceptingNewPatients":true,"ProviderPrimaryCare":false,"QualityRanking":null,"ProviderIdentifier":"1407842941","Latitude":33.258135,"Longitude":-111.887927},{"Miles":2.302,"Minutes":5.2,"ProviderName":"Freed, Lewis ","ProviderSpecialty":"Podiatrist","SpecialtyCode":"213E00000X","PreferredMeansReceivingReferralHSRM":false,"PreferredMeansReceivingReferralSecuredEmail":false,"PreferredMeansReceivingReferralMail":false,"PreferredMeansReceivingReferralDirectMessaging":false,"PreferredMeansReceivingReferralFax":false,"HPP":"Unknown","CareSite":"Lewis H Freed DPM PC","CareSiteAddress":"3195 S Price Rd Ste 148 Chandler, AZ 85248","CareSiteAddressStreet":"3195 S Price Rd Ste 148","CareSiteAddressCity":"Chandler","CareSiteAddressState":"AZ","CareSiteAddressZipCode":"85248","CareSitePhoneNumber":"4807057300","WorkHours":null,"ProviderGender":"Male","ProviderNetwork":"TriWest - Choice","NetworkId":null,"ProviderAcceptingNewPatients":true,"ProviderPrimaryCare":false,"QualityRanking":null,"ProviderIdentifier":"1407842941","Latitude":33.258135,"Longitude":-111.887927},{"Miles":2.302,"Minutes":5.083,"ProviderName":"Freed, Lewis ","ProviderSpecialty":"Podiatrist","SpecialtyCode":"213E00000X","PreferredMeansReceivingReferralHSRM":false,"PreferredMeansReceivingReferralSecuredEmail":false,"PreferredMeansReceivingReferralMail":false,"PreferredMeansReceivingReferralDirectMessaging":false,"PreferredMeansReceivingReferralFax":false,"HPP":"Unknown","CareSite":"Lewis H Freed DPM PC","CareSiteAddress":"3195 S Price Rd Ste 148 Chandler, AZ 85248","CareSiteAddressStreet":"3195 S Price Rd Ste 148","CareSiteAddressCity":"Chandler","CareSiteAddressState":"AZ","CareSiteAddressZipCode":"85248","CareSitePhoneNumber":"4807057300","WorkHours":null,"ProviderGender":"Male","ProviderNetwork":"TriWest - Choice","NetworkId":null,"ProviderAcceptingNewPatients":true,"ProviderPrimaryCare":false,"QualityRanking":null,"ProviderIdentifier":"1407842941","Latitude":33.258135,"Longitude":-111.887927},{"Miles":2.302,"Minutes":4.967,"ProviderName":"Freed, Lewis ","ProviderSpecialty":"Podiatrist","SpecialtyCode":"213E00000X","PreferredMeansReceivingReferralHSRM":false,"PreferredMeansReceivingReferralSecuredEmail":false,"PreferredMeansReceivingReferralMail":false,"PreferredMeansReceivingReferralDirectMessaging":false,"PreferredMeansReceivingReferralFax":false,"HPP":"Unknown","CareSite":"Lewis H Freed DPM PC","CareSiteAddress":"3195 S Price Rd Ste 148 Chandler, AZ 85248","CareSiteAddressStreet":"3195 S Price Rd Ste 148","CareSiteAddressCity":"Chandler","CareSiteAddressState":"AZ","CareSiteAddressZipCode":"85248","CareSitePhoneNumber":"4807057300","WorkHours":null,"ProviderGender":"Male","ProviderNetwork":"TriWest - Choice","NetworkId":null,"ProviderAcceptingNewPatients":true,"ProviderPrimaryCare":false,"QualityRanking":null,"ProviderIdentifier":"1407842941","Latitude":33.258135,"Longitude":-111.887927}]}'
+      http_version:
+    recorded_at: Thu, 16 Jan 2020 20:16:26 GMT
+  - request:
+      <<: *base_request
+      uri: https://np.dws.ppms.va.gov/v1.0/ProviderLocator?address=33.28,-111.79&maxResults=11&radius=86.64&specialtycode1=%27213E00000X%27
+    response:
+      <<: *base_response
+    recorded_at: Thu, 16 Jan 2020 20:16:26 GMT
+  - request:
+      <<: *base_request
+      uri: https://np.dws.ppms.va.gov/v1.0/ProviderLocator?address=33.28,-111.79&maxResults=11&radius=86.64&specialtycode1=%273336C0003X%27
+    response:
+      <<: *base_response
+    recorded_at: Thu, 16 Jan 2020 20:16:26 GMT

--- a/spec/support/vcr_cassettes/facilities/va/ppms_new_query.yml
+++ b/spec/support/vcr_cassettes/facilities/va/ppms_new_query.yml
@@ -55,13 +55,13 @@
     recorded_at: Thu, 16 Jan 2020 20:16:26 GMT
   - request:
       <<: *base_request
-      uri: https://np.dws.ppms.va.gov/v1.0/ProviderLocator?address=33.28,-111.79&maxResults=11&radius=103.64&specialtycode1=%27213E00000X%27
+      uri: https://some.fakesite.com/v1.0/ProviderLocator?acceptingnewpatients=0&address=33.28,-111.79&driveTime=10000&gender=0&maxResults=11&network=0&primarycare=0&radius=103.64&specialtycode1=%27213E00000X%27&specialtycode2=null&specialtycode3=null&specialtycode4=null
     response:
       <<: *base_response
     recorded_at: Thu, 16 Jan 2020 20:16:26 GMT
   - request:
       <<: *base_request
-      uri: https://np.dws.ppms.va.gov/v1.0/ProviderLocator?address=33.28,-111.79&maxResults=11&radius=103.64&specialtycode1=%273336C0003X%27
+      uri: https://some.fakesite.com/v1.0/ProviderLocator?acceptingnewpatients=0&address=33.28,-111.79&driveTime=10000&gender=0&maxResults=11&network=0&primarycare=0&radius=103.64&specialtycode1=%273336C0003X%27&specialtycode2=null&specialtycode3=null&specialtycode4=null
     response:
       <<: *base_response
     recorded_at: Thu, 16 Jan 2020 20:16:26 GMT


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
department-of-veterans-affairs/va.gov-team#7056
PPMS has added support for latitude/longitude in the address field. With this change, the number of mandatory fields has been reduced to `address`, `radius`, and `specialtycode1`.

Feature flags have been added to use the new search functionality and to suppress the unused parameters. 

## Testing
This will be tested on the review instance to verify that we are getting responses.

## Acceptance Criteria (Definition of Done)
When this is rolled out to production this needs to have the feature flags enabled.

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [ ] Enable `facility_locator_ppms_location_query`

#### Applies to all PRs

- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
