### PR TITLE
Add X-Request-ID to each VAOS request

### DIFF
--- a/modules/vaos/app/services/vaos/base_service.rb
+++ b/modules/vaos/app/services/vaos/base_service.rb
@@ -21,7 +21,7 @@ module VAOS
 
     def headers
       session_token = user_service.session
-      { 'Referer' => referrer, 'X-VAMF-JWT' => session_token }
+      { 'Referer' => referrer, 'X-VAMF-JWT' => session_token, 'X-Request-ID' => RequestStore.store['request_id'] }
     end
 
     # Set the referrer (Referer header) to distinguish review instance, staging, etc from logs

--- a/modules/vaos/spec/services/base_service_spec.rb
+++ b/modules/vaos/spec/services/base_service_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe VAOS::BaseService do
+  let(:klass) do
+    Class.new(VAOS::BaseService) do
+      def get_systems
+        perform(:get, '/mvi/v1/patients/session/identifiers.json', nil, headers)
+      end
+    end
+  end
+  let(:user) { build(:user, :vaos) }
+  let(:request_id) { SecureRandom.uuid }
+  let(:expected_request_headers) do
+    {
+      'Accept' => 'application/json',
+      'Content-Type' => 'application/json',
+      'Referer' => 'https://review-instance.va.gov',
+      'User-Agent' => 'Vets.gov Agent',
+      'X-Request-ID' => request_id,
+      'X-VAMF-JWT' => 'stubbed_token'
+    }
+  end
+
+  before do
+    RequestStore['request_id'] = request_id
+    allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
+  end
+
+  describe 'headers' do
+    it 'includes Referer, X-VAMF-JWT and X-Request-ID headers in each request' do
+      VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method uri]) do
+        response = klass.new(user).get_systems
+        expect(response.request_headers).to eq(expected_request_headers)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Adds a `X-Request-ID` to each VAOS request so we can correlate vets-api cloudwatch logs with VAOS logs in Kibana.

## Testing
unit tests, local integration tests

## Acceptance Criteria (Definition of Done)
all VAOS requests include a `X-Request-ID` header

#### Applies to all PRs

- [ ] Swagger docs have been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
