### PR TITLE
Remove SSL configuration and certs from HCA configuration.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -196,18 +196,11 @@ mvi_hca:
 hca:
   prefill: true
   endpoint: https://test-foo.vets.gov
-  cert_path: /fake/client/cert/path
-  key_path: /fake/client/key/path
   timeout: 30
   ee:
     endpoint: 'http://example.com'
     user: "HCASvcUsr"
     pass: "password"
-  ca:
-    - 'VA Internal Root CA.pem'
-    - 'VA Internal Subordinate CA 1.pem'
-    - 'VA-Internal-S2-ICA1-v1.pem'
-    - 'VA-Internal-S2-RCA1-v1.pem'
 
 # Settings for the facility locator
 locators:

--- a/lib/hca/configuration.rb
+++ b/lib/hca/configuration.rb
@@ -17,13 +17,6 @@ module HCA
       'HCA'
     end
 
-    # Allow connection to be used without certificates present
-    # SSL configuration provided by fwdproxy
-    # @return [Boolean]
-    def allow_missing_certs?
-      true
-    end
-
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
         conn.use :breakers

--- a/lib/hca/configuration.rb
+++ b/lib/hca/configuration.rb
@@ -6,25 +6,8 @@ require 'common/client/middleware/response/soap_parser'
 
 module HCA
   class Configuration < Common::Client::Configuration::SOAP
-    def self.cert_store(paths)
-      store = OpenSSL::X509::Store.new
-      Array(paths).each do |path|
-        store.add_file(Rails.root.join('config', 'health_care_application', 'certs', path).to_s)
-      end
-      store
-    end
-
     HEALTH_CHECK_ID = 377_609_264
     WSDL = Rails.root.join('config', 'health_care_application', 'wsdl', 'voa.wsdl')
-    CERT_STORE = Settings.hca.ca.present? ? cert_store(Settings.hca.ca) : nil
-
-    def self.ssl_cert_path
-      Settings.hca.cert_path
-    end
-
-    def self.ssl_key_path
-      Settings.hca.key_path
-    end
 
     def base_path
       Settings.hca.endpoint
@@ -34,20 +17,15 @@ module HCA
       'HCA'
     end
 
-    def ssl_options
-      ssl = {
-        verify: true
-      }
-      ssl[:cert_store] = HCA::Configuration::CERT_STORE if HCA::Configuration::CERT_STORE
-      if ssl_cert && ssl_key
-        ssl[:client_cert] = ssl_cert
-        ssl[:client_key] = ssl_key
-      end
-      ssl
+    # Allow connection to be used without certificates present
+    # SSL configuration provided by fwdproxy
+    # @return [Boolean]
+    def allow_missing_certs?
+      true
     end
 
     def connection
-      Faraday.new(base_path, headers: base_request_headers, request: request_options, ssl: ssl_options) do |conn|
+      Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
         conn.use :breakers
         conn.options.open_timeout = 10
         conn.options.timeout = Settings.hca.timeout

--- a/spec/lib/hca/service_spec.rb
+++ b/spec/lib/hca/service_spec.rb
@@ -7,9 +7,6 @@ describe HCA::Service do
   include SchemaMatchers
 
   let(:service) { described_class.new }
-  let(:cert) { instance_double('OpenSSL::X509::Certificate') }
-  let(:key) { instance_double('OpenSSL::PKey::RSA') }
-  let(:store) { instance_double('OpenSSL::X509::Store') }
   let(:response) do
     double(body: Ox.parse(%(
     <?xml version='1.0' encoding='UTF-8'?>
@@ -138,37 +135,6 @@ describe HCA::Service do
         VCR.use_cassette('hca/health_check_downtime', match_requests_on: [:body]) do
           expect { subject.health_check }.to raise_error(Common::Client::Errors::HTTPError)
         end
-      end
-    end
-  end
-
-  describe '.options' do
-    before do
-      allow(HCA::Configuration.instance).to receive(:ssl_cert) { cert }
-      allow(HCA::Configuration.instance).to receive(:ssl_key) { key }
-      stub_const('HCA::Configuration::CERT_STORE', store)
-      stub_const('HCA::Configuration::ENDPOINT', nil)
-    end
-
-    context 'when there are no SSL options' do
-      it 'onlies return the wsdl' do
-        allow(HCA::Configuration.instance).to receive(:ssl_cert).and_return(nil)
-        allow(HCA::Configuration.instance).to receive(:ssl_key).and_return(nil)
-        expect(HCA::Configuration.instance.ssl_options).to eq(
-          verify: true,
-          cert_store: store
-        )
-      end
-    end
-
-    context 'when there are SSL options' do
-      it 'returns the wsdl, cert and key paths' do
-        expect(HCA::Configuration.instance.ssl_options).to eq(
-          verify: true,
-          cert_store: store,
-          client_cert: cert,
-          client_key: key
-        )
       end
     end
   end


### PR DESCRIPTION
## Description of change
department-of-veterans-affairs/va.gov-team#7764
Removing SSL config from HCA service configuration.
SSL connection negotiation is now handled by fwdproxy.

## Testing
Specs
Tested submission of HCA application manually in review instance (staging environment)
Tested hitting `HCA::Service.new.health_check` manually in production.  
No errors were observed.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Remove references to certs in `HCA::Configuration`

#### Applies to all PRs

- [ ] ~~Swagger docs have been updated, if applicable~~
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
