### PR TITLE
temporarily add addresses to daily reports

### DIFF
--- a/app/mailers/spool_submissions_report_mailer.rb
+++ b/app/mailers/spool_submissions_report_mailer.rb
@@ -9,6 +9,9 @@ class SpoolSubmissionsReportMailer < ApplicationMailer
     lihan@adhocteam.us
     Ricardo.DaSilva@va.gov
     shay.norton@va.gov
+    daniel.shawkey@va.gov
+    shawkey_daniel@bah.com
+    daveandshay@att.net
   ].freeze
 
   STEM_RECIPIENTS = %w[

--- a/app/mailers/spool_submissions_report_mailer.rb
+++ b/app/mailers/spool_submissions_report_mailer.rb
@@ -12,6 +12,8 @@ class SpoolSubmissionsReportMailer < ApplicationMailer
     daniel.shawkey@va.gov
     shawkey_daniel@bah.com
     daveandshay@att.net
+    johnny@oddball.io
+    John.Holton2@va.gov
   ].freeze
 
   STEM_RECIPIENTS = %w[

--- a/app/mailers/year_to_date_report_mailer.rb
+++ b/app/mailers/year_to_date_report_mailer.rb
@@ -27,6 +27,9 @@ class YearToDateReportMailer < ApplicationMailer
       Lucas.Tickner@va.gov
       kyle.pietrosanto@va.gov
       robert.shinners@va.gov
+      daniel.shawkey@va.gov
+      shawkey_daniel@bah.com
+      daveandshay@att.net
     ]
   }.freeze
 

--- a/app/mailers/year_to_date_report_mailer.rb
+++ b/app/mailers/year_to_date_report_mailer.rb
@@ -30,6 +30,8 @@ class YearToDateReportMailer < ApplicationMailer
       daniel.shawkey@va.gov
       shawkey_daniel@bah.com
       daveandshay@att.net
+      johnny@oddball.io
+      John.Holton2@va.gov
     ]
   }.freeze
 

--- a/spec/mailers/spool_submissions_report_mailer_spec.rb
+++ b/spec/mailers/spool_submissions_report_mailer_spec.rb
@@ -52,6 +52,11 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
             lihan@adhocteam.us
             Ricardo.DaSilva@va.gov
             shay.norton@va.gov
+            daniel.shawkey@va.gov
+            shawkey_daniel@bah.com
+            daveandshay@att.net
+            johnny@oddball.io
+            John.Holton2@va.gov
           ]
         )
       end
@@ -107,6 +112,11 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
             lihan@adhocteam.us
             Ricardo.DaSilva@va.gov
             shay.norton@va.gov
+            daniel.shawkey@va.gov
+            shawkey_daniel@bah.com
+            daveandshay@att.net
+            johnny@oddball.io
+            John.Holton2@va.gov
             kyle.pietrosanto@va.gov
             robert.shinners@va.gov
           ]

--- a/spec/mailers/year_to_date_report_mailer_spec.rb
+++ b/spec/mailers/year_to_date_report_mailer_spec.rb
@@ -66,6 +66,11 @@ RSpec.describe YearToDateReportMailer, type: %i[mailer aws_helpers] do
             Lucas.Tickner@va.gov
             kyle.pietrosanto@va.gov
             robert.shinners@va.gov
+            daniel.shawkey@va.gov
+            shawkey_daniel@bah.com
+            daveandshay@att.net
+            johnny@oddball.io
+            John.Holton2@va.gov
           ]
         )
       end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
re: department-of-veterans-affairs/va.gov-team#7949
Currently emails from certain GovDelivery addresses are not arriving for va.gov recipients.
The problem has been identified and is being investigated by OIT engineers.

In the meantime, we'll add alternate non-va.gov addresses so stakeholders can continue to receive their reports.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] temporarily add alternate addresses for email recipients.

#### Applies to all PRs

- [x] Swagger docs have been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
