### PR TITLE
Piv 310 veteran verification health check endpoint

### DIFF
--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/health_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/health_controller.rb
@@ -1,0 +1,15 @@
+
+module VeteranVerification
+  module V0
+    # HealthController returns a simple health response
+    class HealthController < ApplicationController
+      skip_before_action(:authenticate)
+
+      def index
+        render json: {
+          UP: true
+        }
+      end
+    end
+  end
+end

--- a/modules/veteran_verification/app/controllers/veteran_verification/v0/health_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v0/health_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module VeteranVerification
   module V0

--- a/modules/veteran_verification/config/routes.rb
+++ b/modules/veteran_verification/config/routes.rb
@@ -7,6 +7,7 @@ VeteranVerification::Engine.routes.draw do
     resources :service_history, only: [:index]
     resources :disability_rating, only: [:index]
     resources :keys, only: [:index]
+    resources :health, only: [:index]
     get 'status', to: 'veteran_status#index'
   end
 

--- a/modules/veteran_verification/spec/requests/health_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/health_request_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Veteran Verification Documentation Endpoints', type: :request do
+  describe '#get /veteran_verification/v0/health' do
+    it 'returns health status in JSON' do
+      get '/services/veteran_verification/v0/health'
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      status = body['UP']
+      expect(status).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Creates a health endpoint for Veteran Verification in the style of health-api’s actuator endpoint. The endpoint should indicate the availability of the application (e.g. healthy/true if the endpoint is accessible).

https://vasdvp.atlassian.net/browse/PIV-310

Testing completed locally and new spec added for the controller addition.
