### PR TITLE
[8087] Add lastFourSsn Field to MDOT Form Profile Mapping

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,10 +34,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 448c1990dae9aa3485753987ed8cdcd88b9faaa6
+  revision: 9b5769e3bb45c511faef521003fee451724d6b18
   branch: master
   specs:
-    vets_json_schema (3.144.2)
+    vets_json_schema (3.145.0)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -64,6 +64,10 @@ class FormIdentityInformation
   def hyphenated_ssn
     StringHelpers.hyphenated_ssn(ssn)
   end
+
+  def ssn_last_four
+    ssn.last(4)
+  end
 end
 
 class FormContactInformation

--- a/config/form_profile_mappings/MDOT.yml
+++ b/config/form_profile_mappings/MDOT.yml
@@ -1,7 +1,7 @@
 fullName: [identity_information, full_name]
 permanentAddress: [mdot_contact_information, permanent_address]
 temporaryAddress: [mdot_contact_information, temporary_address]
-lastFourSsn: [identity_information, ssn_last_four]
+ssnLastFour: [identity_information, ssn_last_four]
 gender: [identity_information, gender]
 email: [contact_information, email]
 dateOfBirth: [identity_information, date_of_birth]

--- a/config/form_profile_mappings/MDOT.yml
+++ b/config/form_profile_mappings/MDOT.yml
@@ -1,6 +1,7 @@
 fullName: [identity_information, full_name]
 permanentAddress: [mdot_contact_information, permanent_address]
 temporaryAddress: [mdot_contact_information, temporary_address]
+lastFourSsn: [identity_information, ssn_last_four]
 gender: [identity_information, gender]
 email: [contact_information, email]
 dateOfBirth: [identity_information, date_of_birth]

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -466,6 +466,7 @@ RSpec.describe FormProfile, type: :model do
         'country' => 'USA',
         'postalCode' => '77550'
       },
+      'ssnLastFour' => user.ssn.last(4)
       'gender' => user.gender,
       'email' => user.pciu_email,
       'dateOfBirth' => user.birth_date,

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -466,7 +466,7 @@ RSpec.describe FormProfile, type: :model do
         'country' => 'USA',
         'postalCode' => '77550'
       },
-      'ssnLastFour' => user.ssn.last(4)
+      'ssnLastFour' => user.ssn.last(4),
       'gender' => user.gender,
       'email' => user.pciu_email,
       'dateOfBirth' => user.birth_date,


### PR DESCRIPTION
## Description of change
Adds a field to the MDOT form profile mapping that shows the veterans last four digits of their social security number.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/8087
