### PR TITLE
Temporarily log CSRF response token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,9 @@ class ApplicationController < ActionController::API
   attr_reader :current_user
 
   def set_csrf_header
-    response.set_header('X-CSRF-Token', form_authenticity_token)
+    token = form_authenticity_token
+    response.set_header('X-CSRF-Token', token)
+    Rails.logger.info("CSRF response token", { csrf_token: token })
   end
 
   # returns a Bad Request if the incoming host header is unsafe.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,7 +60,7 @@ class ApplicationController < ActionController::API
   def set_csrf_header
     token = form_authenticity_token
     response.set_header('X-CSRF-Token', token)
-    Rails.logger.info("CSRF response token", { csrf_token: token })
+    Rails.logger.info('CSRF response token', { csrf_token: token })
   end
 
   # returns a Bad Request if the incoming host header is unsafe.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,7 +60,7 @@ class ApplicationController < ActionController::API
   def set_csrf_header
     token = form_authenticity_token
     response.set_header('X-CSRF-Token', token)
-    Rails.logger.info('CSRF response token', { csrf_token: token })
+    Rails.logger.info('CSRF response token', csrf_token: token)
   end
 
   # returns a Bad Request if the incoming host header is unsafe.


### PR DESCRIPTION
## Description of change
Temporarily log CSRF token in response header

## Original issue(s)
department-of-veterans-affairs/va.gov-team-sensitive#44
department-of-veterans-affairs/va.gov-team-sensitive#42
department-of-veterans-affairs/va.gov-team-sensitive#61

## Things to know about this PR
I want to temporarily log the CSRF token in the response headers so I can accurately paint a picture of the flow of tokens from server to client while I debug seemingly erroneous CSRF violations.

<!-- Please describe testing done to verify the changes or any testing planned. -->
