### PR TITLE
move flipper sign in link to top

### DIFF
--- a/lib/flipper/views/features.erb
+++ b/lib/flipper/views/features.erb
@@ -2,6 +2,9 @@
   <div class="vads-l-col">
     <table class="vads-u-margin-top--0">
       <caption class="vads-u-font-size--xl">Features</caption>
+      <% if RequestStore.store[:flipper_user_email_for_log].blank? &&  !Rails.env.development? %>
+        <a href ="<%= SAML::URLService::VIRTUAL_HOST_MAPPINGS.dig(request.base_url, :base_redirect) %>">Sign in</a> with an identity-verified admin account to edit feagure toggles.
+      <% end %>
       <thead>
         <tr>
           <th>Status</th>
@@ -35,9 +38,5 @@
         <% end %>
       </tbody>
     </table>
-
-    <% if RequestStore.store[:flipper_user_email_for_log].blank? &&  !Rails.env.development? %>
-      <a href ="<%= SAML::URLService::VIRTUAL_HOST_MAPPINGS.dig(request.base_url, :base_redirect) %>">Sign in</a> with an identity-verified admin account to edit feagure toggles.
-    <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Description of change
Move the sign in prompt from the bottom to the top of the page in the flipper admin screen so that it is more visible to users who need to log in or are not identity-verified.
before
<img width="745" alt="Screen Shot 2020-04-17 at 10 41 01 AM" src="https://user-images.githubusercontent.com/19188/79581802-f0b50180-8098-11ea-954a-d16bfbe35cfa.png">
After
<img width="763" alt="Screen Shot 2020-04-17 at 10 45 35 AM" src="https://user-images.githubusercontent.com/19188/79581831-f7dc0f80-8098-11ea-826f-b4ce5d5af728.png">


