### PR TITLE
Add sidekiq admin rack application

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ web: bundle exec puma -p 3000 -C ./config/puma.rb
 job: bundle exec sidekiq -q default -q critical -q tasker
 freshclam: /usr/bin/freshclam -d --config-file=config/freshclam.conf
 clamd: /usr/sbin/clamd -c config/clamd.conf
-sidekiq-admin: bundle exec rackup sidekiq-admin.ru
+sidekiq-admin: bundle exec rackup sidekiq-admin.ru -p 9292 -s puma

--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,3 @@ web: bundle exec puma -p 3000 -C ./config/puma.rb
 job: bundle exec sidekiq -q default -q critical -q tasker
 freshclam: /usr/bin/freshclam -d --config-file=config/freshclam.conf
 clamd: /usr/sbin/clamd -c config/clamd.conf
-sidekiq-admin: bundle exec rackup sidekiq-admin.ru -p 9292 -s puma

--- a/Procfile
+++ b/Procfile
@@ -2,3 +2,4 @@ web: bundle exec puma -p 3000 -C ./config/puma.rb
 job: bundle exec sidekiq -q default -q critical -q tasker
 freshclam: /usr/bin/freshclam -d --config-file=config/freshclam.conf
 clamd: /usr/sbin/clamd -c config/clamd.conf
+sidekiq-admin: bundle exec rackup sidekiq-admin.ru

--- a/sidekiq-admin.ru
+++ b/sidekiq-admin.ru
@@ -1,4 +1,5 @@
-# this code goes in your config.ru
+# Run sidekiq-admin: `bundle exec rackup sidekiq-admin.ru -p 9292 -s puma`
+
 require 'sidekiq'
 require 'sidekiq-pro'
 require 'sidekiq-scheduler/web'

--- a/sidekiq-admin.ru
+++ b/sidekiq-admin.ru
@@ -1,0 +1,23 @@
+# this code goes in your config.ru
+require 'sidekiq'
+require 'sidekiq-pro'
+require 'sidekiq-scheduler/web'
+require 'sidekiq/pro/web'
+
+Sidekiq.configure_client do |config|
+  config.redis = { :size => 1 }
+end
+
+map '/sidekiq' do
+  use Rack::Auth::Basic, "Protected Area" do |username, password|
+    # Protect against timing attacks:
+    # - See https://codahale.com/a-lesson-in-timing-attacks/
+    # - See https://thisdata.com/blog/timing-attacks-against-string-comparison/
+    # - Use & (do not use &&) so that it doesn't short circuit.
+    # - Use digests to stop length information leaking
+    Rack::Utils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
+      Rack::Utils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))
+  end
+
+  run Sidekiq::Web
+end

--- a/sidekiq-admin.ru
+++ b/sidekiq-admin.ru
@@ -1,4 +1,4 @@
-# Run sidekiq-admin: `SIDEKIQ_USERNAME=foo SIDEKIQ_PASSWORD=bar b bundle exec rackup sidekiq-admin.ru -p 9292`
+# Run sidekiq-admin: `SIDEKIQ_USERNAME=foo SIDEKIQ_PASSWORD=bar REDIS_URL=redis://some.elasticache.aws.url bundle exec rackup sidekiq-admin.ru -p 3000 -o 0.0.0.0`
 
 require 'sidekiq'
 require 'sidekiq-pro'

--- a/sidekiq-admin.ru
+++ b/sidekiq-admin.ru
@@ -1,4 +1,4 @@
-# Run sidekiq-admin: `bundle exec rackup sidekiq-admin.ru -p 9292 -s puma`
+# Run sidekiq-admin: `SIDEKIQ_USERNAME=foo SIDEKIQ_PASSWORD=bar b bundle exec rackup sidekiq-admin.ru -p 9292`
 
 require 'sidekiq'
 require 'sidekiq-pro'
@@ -11,11 +11,6 @@ end
 
 map '/sidekiq' do
   use Rack::Auth::Basic, "Protected Area" do |username, password|
-    # Protect against timing attacks:
-    # - See https://codahale.com/a-lesson-in-timing-attacks/
-    # - See https://thisdata.com/blog/timing-attacks-against-string-comparison/
-    # - Use & (do not use &&) so that it doesn't short circuit.
-    # - Use digests to stop length information leaking
     Rack::Utils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
       Rack::Utils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))
   end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

Allow sidekiq-admin to be run with basic authentication in any environment, including production

~`SIDEKIQ_USERNAME=foo SIDEKIQ_PASSWORD=bar bundle exec foreman s sidekiq-admin`~
 `SIDEKIQ_USERNAME=foo SIDEKIQ_PASSWORD=bar REDIS_URL=redis://some.elasticache.aws.url bundle exec rackup sidekiq-admin.ru -p 3000 -o 0.0.0.0`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#8151

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
There are additional PRs to be done in the department-of-veterans-affairs/devops repo and credstash to add:

- [x] Add a firewall rule to the SOCKS proxy for port 9292 (department-of-veterans-affairs/va.gov-team#8189)
- [x] Configure foreman to start up an instance in production ~*only on workers*~ only on demand
- [x] Add environment variables to `credstash` and relevant startup scripts

<!-- Please describe testing done to verify the changes or any testing planned. -->
Not user-facing, so outside of ensuring that this does not run by default in any environment when using foreman, there's no more formal testing.

Tested on staging and production. It can take *minutes* to load the data, so be prepared.