### PR TITLE
Fixed typo in call to Covid Chatbot settings

### DIFF
--- a/app/controllers/v0/coronavirus_chatbot/tokens_controller.rb
+++ b/app/controllers/v0/coronavirus_chatbot/tokens_controller.rb
@@ -19,7 +19,7 @@ module V0
       def token_payload
         {
           locale: params[:locale],
-          directLineURI: Settings.coronavirus_chatbot.directLine_uri,
+          directLineURI: Settings.coronavirus_chatbot.directline_uri,
           connectorToken: fetch_connector_token,
           userId: chat_bot_user_id
         }

--- a/spec/controllers/v0/coronavirus_chatbot/tokens_controller_spec.rb
+++ b/spec/controllers/v0/coronavirus_chatbot/tokens_controller_spec.rb
@@ -18,8 +18,10 @@ RSpec.describe V0::CoronavirusChatbot::TokensController, type: :controller do
         'v3BMCk6fJqHW53h7X0rIyRXlDS6CymY6qypQwkh1RQGgVR62C7X_RdVp1JQdSynYuecxc9un3adY-lEwku-AbLhWv-fxRT9Onxb-nQf-6RtL' \
         'OAaWNfhzBR3lmCABHiTyuILsg-qP-b3kagfWQuNd10Sw3eK3NuXzDjFns6Bpv9mZz6-pshYgwXkJJlTNb8Qzw'
       end
+      let(:directline_uri) { Settings.coronavirus_chatbot.directline_uri }
 
       before do
+        expect(directline_uri).not_to be_nil
         allow(SecureRandom).to receive(:hex).and_return(user_id)
       end
 
@@ -33,7 +35,7 @@ RSpec.describe V0::CoronavirusChatbot::TokensController, type: :controller do
 
         expect(token_data['userId']).to eq user_id
         expect(token_data['locale']).to eq locale
-        expect(token_data['directLineURI']).to eq Settings.coronavirus_chatbot.directLine_uri
+        expect(token_data['directLineURI']).to eq directline_uri
         expect(token_data['connectorToken']).to eq recorded_token
       end
     end


### PR DESCRIPTION
## Description of change
There was a typo in a call to settings.

## Original issue(s)
N/A

## Things to know about this PR
None.


An assert was added to prevent this as a future regression
