### PR TITLE
[8081 ] Add isMilitaryBase to MDOT Prefill Address

### DIFF
--- a/lib/mdot/address.rb
+++ b/lib/mdot/address.rb
@@ -10,6 +10,6 @@ module MDOT
     attribute :state, String
     attribute :country, String
     attribute :postal_code, String
-    attribute :is_military_address, Boolean, default: false
+    attribute :is_military_base, Boolean, default: false
   end
 end

--- a/lib/mdot/address.rb
+++ b/lib/mdot/address.rb
@@ -10,5 +10,6 @@ module MDOT
     attribute :state, String
     attribute :country, String
     attribute :postal_code, String
+    attribute :is_military_address, Boolean, default: false
   end
 end

--- a/lib/mdot/schemas/submit.json
+++ b/lib/mdot/schemas/submit.json
@@ -1,12 +1,18 @@
 {
   "$schema" : "http://json-schema.org/draft-04/schema#",
   "type" : "object",
-  "required": ["status", "order_id"],
+  "required": ["use_temporary_address", "status", "order_id"],
   "properties": {
+    "use_temporary_address": {
+      "type": "boolean"
+    },
     "status": {
       "type": "string"
     },
     "order_id": {
+      "type": "string"
+    },
+    "additional_requests": {
       "type": "string"
     }
   }

--- a/lib/mdot/schemas/supplies.json
+++ b/lib/mdot/schemas/supplies.json
@@ -23,6 +23,9 @@
       },
       "postal_code": {
         "type": "string"
+      },
+      "is_military_base": {
+        "type": "boolean"
       }
     },
     "temporary_address": {
@@ -44,6 +47,9 @@
       },
       "postal_code": {
         "type": "string"
+      },
+      "is_military_base": {
+        "type": "boolean"
       }
     },
     "supplies": {
@@ -78,6 +84,9 @@
             "type": "integer"
           },
           "size": {
+            "type": ["string", "null"]
+          },
+          "prescribed_date": {
             "type": ["string", "null"]
           }
         }

--- a/lib/mdot/supply.rb
+++ b/lib/mdot/supply.rb
@@ -13,5 +13,6 @@ module MDOT
     attribute :next_availability_date, Date
     attribute :quantity, Integer
     attribute :size, String
+    attribute :prescribed_date, Date
   end
 end

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -480,7 +480,8 @@ RSpec.describe FormProfile, type: :model do
           'lastOrderDate' => '2020-01-01',
           'nextAvailabilityDate' => '2020-09-01',
           'quantity' => 60,
-          'size' => ''
+          'size' => '',
+          'prescribedDate' => '2019-12-25'
         },
         {
           'deviceName' => '',

--- a/spec/support/vcr_cassettes/mdot/get_supplies_200.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_200.yml
@@ -76,14 +76,16 @@ http_interactions:
             "city": "Kansas City",
             "state": "MO",
             "country": "USA",
-            "postal_code": "64117"
+            "postal_code": "64117",
+            "is_military_base": false
           },
           "temporary_address": {
             "street": "201 Example Street",
             "city": "Galveston",
             "state": "TX",
             "country": "USA",
-            "postal_code": "77550"
+            "postal_code": "77550",
+            "is_military_base": false
           },
           "supplies": [
             {

--- a/spec/support/vcr_cassettes/mdot/get_supplies_200.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_200.yml
@@ -95,15 +95,17 @@ http_interactions:
               "product_group": "hearing aid batteries",
               "product_id": "1",
               "product_name": "ZA1239",
-              "quantity": 60
+              "quantity": 60,
+              "prescribed_date": "2019-12-25"
             }, 
             {
               "available_for_reorder": true,
               "last_order_date": "2019-06-30",
               "next_availability_date": "2019-12-15",
               "product_group": "hearing aid accessories",
-              "product_id": "3", "productName": "DOME", 
-              "quantity": 10, 
+              "product_id": "3",
+              "productName": "DOME",
+              "quantity": 10,
               "size": "6mm"
             },
             {
@@ -113,7 +115,8 @@ http_interactions:
               "product_group": "hearing aid accessories",
               "product_id": "4",
               "product_name": "DOME",
-              "quantity": 10, "size": "7mm"
+              "quantity": 10,
+              "size": "7mm"
             }, 
             {
               "available_for_reorder": true,


### PR DESCRIPTION
## Description of change
This adds a field to the MDOT prefill for `is_military_base` which is attached to either a permanent or temporary address. This field signifies to the DLC that the incoming address is on a US military base.

Another field has also been added for `prescribedDate` - this will allow the veteran to see when their hearing aid was prescribed.

## Original issue(s)
[8081](https://github.com/department-of-veterans-affairs/va.gov-team/issues/8180)
[7304](https://github.com/department-of-veterans-affairs/va.gov-team/issues/7304)