### PR TITLE
Bah 7272 Addition and Removal of Emails from Report Mailers 

### DIFF
--- a/app/mailers/spool_submissions_report_mailer.rb
+++ b/app/mailers/spool_submissions_report_mailer.rb
@@ -9,8 +9,6 @@ class SpoolSubmissionsReportMailer < ApplicationMailer
     lihan@adhocteam.us
     Ricardo.DaSilva@va.gov
     shay.norton@va.gov
-    daniel.shawkey@va.gov
-    shawkey_daniel@bah.com
     daveandshay@att.net
     johnny@oddball.io
     John.Holton2@va.gov
@@ -23,9 +21,13 @@ class SpoolSubmissionsReportMailer < ApplicationMailer
 
   STAGING_RECIPIENTS = %w[
     lihan@adhocteam.us
+    Delli-Gatti_Michael@bah.com
+    sonntag_adam@bah.com
   ].freeze
 
   STAGING_STEM_RECIPIENTS = %w[
+    Delli-Gatti_Michael@bah.com
+    sonntag_adam@bah.com
   ].freeze
 
   def add_stem_recipients

--- a/app/mailers/year_to_date_report_mailer.rb
+++ b/app/mailers/year_to_date_report_mailer.rb
@@ -27,8 +27,6 @@ class YearToDateReportMailer < ApplicationMailer
       Lucas.Tickner@va.gov
       kyle.pietrosanto@va.gov
       robert.shinners@va.gov
-      daniel.shawkey@va.gov
-      shawkey_daniel@bah.com
       daveandshay@att.net
       johnny@oddball.io
       John.Holton2@va.gov
@@ -38,6 +36,8 @@ class YearToDateReportMailer < ApplicationMailer
   STAGING_RECIPIENTS = {
     to: %w[
       lihan@adhocteam.us
+      Delli-Gatti_Michael@bah.com
+      sonntag_adam@bah.com
     ]
   }.freeze
 

--- a/spec/mailers/spool_submissions_report_mailer_spec.rb
+++ b/spec/mailers/spool_submissions_report_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
+RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers], focus: true do
   describe '#build' do
     subject do
       stub_reports_s3(filename) do
@@ -91,6 +91,8 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
         expect(mail.to).to eq(
           %w[
             lihan@adhocteam.us
+            Delli-Gatti_Michael@bah.com
+            sonntag_adam@bah.com
             Delli-Gatti_Michael@bah.com
             sonntag_adam@bah.com
           ]

--- a/spec/mailers/spool_submissions_report_mailer_spec.rb
+++ b/spec/mailers/spool_submissions_report_mailer_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
         expect(mail.to).to eq(
           %w[
             lihan@adhocteam.us
+            Delli-Gatti_Michael@bah.com
+            sonntag_adam@bah.com
           ]
         )
       end
@@ -52,8 +54,6 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
             lihan@adhocteam.us
             Ricardo.DaSilva@va.gov
             shay.norton@va.gov
-            daniel.shawkey@va.gov
-            shawkey_daniel@bah.com
             daveandshay@att.net
             johnny@oddball.io
             John.Holton2@va.gov
@@ -91,6 +91,8 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
         expect(mail.to).to eq(
           %w[
             lihan@adhocteam.us
+            Delli-Gatti_Michael@bah.com
+            sonntag_adam@bah.com
           ]
         )
       end
@@ -112,8 +114,6 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
             lihan@adhocteam.us
             Ricardo.DaSilva@va.gov
             shay.norton@va.gov
-            daniel.shawkey@va.gov
-            shawkey_daniel@bah.com
             daveandshay@att.net
             johnny@oddball.io
             John.Holton2@va.gov

--- a/spec/mailers/spool_submissions_report_mailer_spec.rb
+++ b/spec/mailers/spool_submissions_report_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers], focus: true do
+RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
   describe '#build' do
     subject do
       stub_reports_s3(filename) do

--- a/spec/mailers/year_to_date_report_mailer_spec.rb
+++ b/spec/mailers/year_to_date_report_mailer_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe YearToDateReportMailer, type: %i[mailer aws_helpers] do
         expect(mail.to).to eq(
           %w[
             lihan@adhocteam.us
+            Delli-Gatti_Michael@bah.com
+            sonntag_adam@bah.com
           ]
         )
       end
@@ -66,8 +68,6 @@ RSpec.describe YearToDateReportMailer, type: %i[mailer aws_helpers] do
             Lucas.Tickner@va.gov
             kyle.pietrosanto@va.gov
             robert.shinners@va.gov
-            daniel.shawkey@va.gov
-            shawkey_daniel@bah.com
             daveandshay@att.net
             johnny@oddball.io
             John.Holton2@va.gov


### PR DESCRIPTION
## Description of change
In order to test the validity of the YTD and Spool reports after making changes to them for [7272](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7272) Two additional emails must be added to the staging recipients list.

## Original issue(s)
[7272](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7272)

## Things to know about this PR
This is just a change to add two additional email addresses to the staging recipients. Additionally, while making this change we are removing an email address for one of our team members from the production recipients list.

Testing passes locally and specs have been updated to reflect the appropriate email addresses. 
