### PR TITLE
add config.hosts variable for rails 6

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,8 @@ module VetsAPI
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.hosts = Settings.virtual_hosts
+    
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,7 @@ module VetsAPI
     # the framework and any gems in your application.
 
     config.hosts = Settings.virtual_hosts
-    
+
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

I don't know if this is a good way to do this, but it looks like Rails 6 added a `config.hosts` variable that we need to set. We already were doing this through `Settings.virtual_hosts` in config, so just doing this addresses the immediate problem. I'd defer to anyone else's knowledge of Rails if there's a better way here.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
This is using files form settings.local.yml in a different way. I noticed this was broken in a review instance when I tried to start one today.
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Tested in a review instance so far to great success.