### PR TITLE
Remove explicit 'rails' dependency from modules/appeals_api

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,6 @@ PATH
   remote: modules/appeals_api
   specs:
     appeals_api (0.0.1)
-      rails (~> 5.2.3)
       sidekiq
 
 PATH

--- a/modules/appeals_api/appeals_api.gemspec
+++ b/modules/appeals_api/appeals_api.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '~> 5.2.3'
   s.add_dependency 'sidekiq'
 
   s.add_development_dependency 'factory_bot_rails'


### PR DESCRIPTION
## Description of change
We just upgraded to Rails 6.
Since all of our `modules` only live inside of `vets-api` (as opposed to being extracted as gems), specifying a rails version in the modules isn't necessary.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
