### PR TITLE
adding a new ssoe_ebenefits_links feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -90,3 +90,7 @@ features:
     actor_type: user
     description: >
       Allows veterans to access form526 as an original claims user. Owned by va-benefits-memorial-1 team.
+  ssoe_ebenefits_links:
+    actor_type: user
+    description: >
+      Enable eBenefits links to be proxied through eauth.va.gov, this allows users with SSOe sessions to stay logged in.


### PR DESCRIPTION
eBenefits is currently working on a change that will allow users with an
SSOe session to stay authenticated when navigating over. However this
will only work if the user is proxied via the eauth.va.gov domain.  This
flag will be used within the vets-website to determine the URL format
that should be used when linking a user to eBenefits.

references https://github.com/department-of-veterans-affairs/va.gov-team/issues/8291
