### PR TITLE
remove redundant redis conflig load calls

### DIFF
--- a/lib/common/models/concerns/active_record_cache_aside.rb
+++ b/lib/common/models/concerns/active_record_cache_aside.rb
@@ -17,8 +17,6 @@ module Common
   module ActiveRecordCacheAside
     extend ActiveSupport::Concern
 
-    REDIS_CONFIG = Rails.application.config_for(:redis).freeze
-
     included do
       unless self < ActiveRecord::Base
         raise ArgumentError, 'Class composing Common::ActiveRecordCacheAside must be an ActiveRecord'

--- a/lib/common/models/concerns/cache_aside.rb
+++ b/lib/common/models/concerns/cache_aside.rb
@@ -10,8 +10,6 @@ module Common
   module CacheAside
     extend ActiveSupport::Concern
 
-    REDIS_CONFIG = Rails.application.config_for(:redis).freeze
-
     included do
       unless self < Common::RedisStore
         raise ArgumentError, 'Class composing Common::CacheAside must be a Common::RedisStore'


### PR DESCRIPTION
## Description of change
Removes duplicate calls to 

```ruby
Rails.application.config_for(:redis)
```
since this is [already done in the `01_redis.rb` initializer](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/initializers/01_redis.rb#L4).

## Original issue(s)
- department-of-veterans-affairs/va.gov-team#6865
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/6262

## Things to know about this PR
This PR closes out a few places that were forgotton in the main PR to consolidate redis config declarations here: https://github.com/department-of-veterans-affairs/vets-api/pull/4182

<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
