### PR TITLE
Bah remove personal email

### DIFF
--- a/app/mailers/spool_submissions_report_mailer.rb
+++ b/app/mailers/spool_submissions_report_mailer.rb
@@ -9,7 +9,6 @@ class SpoolSubmissionsReportMailer < ApplicationMailer
     lihan@adhocteam.us
     Ricardo.DaSilva@va.gov
     shay.norton@va.gov
-    daveandshay@att.net
     johnny@oddball.io
     John.Holton2@va.gov
   ].freeze

--- a/app/mailers/spool_submissions_report_mailer.rb
+++ b/app/mailers/spool_submissions_report_mailer.rb
@@ -4,7 +4,6 @@ class SpoolSubmissionsReportMailer < ApplicationMailer
   REPORT_TEXT = 'Spool submissions report'
   RECIPIENTS = %w[
     dana.kuykendall@va.gov
-    Darla.VanNieukerk@va.gov
     Jennifer.Waltz2@va.gov
     lihan@adhocteam.us
     Ricardo.DaSilva@va.gov

--- a/app/mailers/year_to_date_report_mailer.rb
+++ b/app/mailers/year_to_date_report_mailer.rb
@@ -16,7 +16,6 @@ class YearToDateReportMailer < ApplicationMailer
       John.McNeal@va.gov
       Anne.kainic@va.gov
       ian@adhocteam.us
-      Darla.VanNieukerk@va.gov
       Brandon.Scott2@va.gov
       224C.VBAVACO@va.gov
       peter.chou1@va.gov

--- a/app/mailers/year_to_date_report_mailer.rb
+++ b/app/mailers/year_to_date_report_mailer.rb
@@ -27,7 +27,6 @@ class YearToDateReportMailer < ApplicationMailer
       Lucas.Tickner@va.gov
       kyle.pietrosanto@va.gov
       robert.shinners@va.gov
-      daveandshay@att.net
       johnny@oddball.io
       John.Holton2@va.gov
     ]

--- a/spec/mailers/spool_submissions_report_mailer_spec.rb
+++ b/spec/mailers/spool_submissions_report_mailer_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
         expect(mail.to).to eq(
           %w[
             dana.kuykendall@va.gov
-            Darla.VanNieukerk@va.gov
             Jennifer.Waltz2@va.gov
             lihan@adhocteam.us
             Ricardo.DaSilva@va.gov
@@ -110,7 +109,6 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
         expect(mail.to).to eq(
           %w[
             dana.kuykendall@va.gov
-            Darla.VanNieukerk@va.gov
             Jennifer.Waltz2@va.gov
             lihan@adhocteam.us
             Ricardo.DaSilva@va.gov

--- a/spec/mailers/spool_submissions_report_mailer_spec.rb
+++ b/spec/mailers/spool_submissions_report_mailer_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
             lihan@adhocteam.us
             Ricardo.DaSilva@va.gov
             shay.norton@va.gov
-            daveandshay@att.net
             johnny@oddball.io
             John.Holton2@va.gov
           ]
@@ -116,7 +115,6 @@ RSpec.describe SpoolSubmissionsReportMailer, type: %i[mailer aws_helpers] do
             lihan@adhocteam.us
             Ricardo.DaSilva@va.gov
             shay.norton@va.gov
-            daveandshay@att.net
             johnny@oddball.io
             John.Holton2@va.gov
             kyle.pietrosanto@va.gov

--- a/spec/mailers/year_to_date_report_mailer_spec.rb
+++ b/spec/mailers/year_to_date_report_mailer_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe YearToDateReportMailer, type: %i[mailer aws_helpers] do
             Lucas.Tickner@va.gov
             kyle.pietrosanto@va.gov
             robert.shinners@va.gov
-            daveandshay@att.net
             johnny@oddball.io
             John.Holton2@va.gov
           ]

--- a/spec/mailers/year_to_date_report_mailer_spec.rb
+++ b/spec/mailers/year_to_date_report_mailer_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe YearToDateReportMailer, type: %i[mailer aws_helpers] do
             John.McNeal@va.gov
             Anne.kainic@va.gov
             ian@adhocteam.us
-            Darla.VanNieukerk@va.gov
             Brandon.Scott2@va.gov
             224C.VBAVACO@va.gov
             peter.chou1@va.gov


### PR DESCRIPTION
## Description of change
Removing personal email added as a workaround for issue blocking VA.gov emails. Also, removing client email who no longer wishes to receive these reports.

## Original issue(s)
N/A

## Things to know about this PR
N/A

Build and deploy locally
