### PR TITLE
add timecop.return after saml request tracker specs that shift time

### DIFF
--- a/spec/models/saml_request_tracker_spec.rb
+++ b/spec/models/saml_request_tracker_spec.rb
@@ -4,10 +4,15 @@ require 'rails_helper'
 
 RSpec.describe SAMLRequestTracker, type: :model do
   describe '#save' do
-    it 'sets created_at when missing' do
-      Timecop.freeze(Time.zone.parse('2020-01-01T08:00:00Z'))
-      tracker = SAMLRequestTracker.create(uuid: 1, payload: {})
-      expect(tracker.created_at).to eq(1_577_865_600)
+    context 'with a datetime of 2020-01-01T08:00:00Z' do
+      before { Timecop.freeze(Time.zone.parse('2020-01-01T08:00:00Z')) }
+
+      after { Timecop.return }
+
+      it 'sets created_at when missing' do
+        tracker = SAMLRequestTracker.create(uuid: 1, payload: {})
+        expect(tracker.created_at).to eq(1_577_865_600)
+      end
     end
 
     it 'leaves created_at untouched when already set' do
@@ -39,16 +44,23 @@ RSpec.describe SAMLRequestTracker, type: :model do
   end
 
   describe '#age' do
-    it '0 when not set' do
-      tracker = SAMLRequestTracker.new
-      expect(tracker.age).to eq(0)
+    context 'when age is not set' do
+      it 'returns 0' do
+        tracker = SAMLRequestTracker.new
+        expect(tracker.age).to eq(0)
+      end
     end
 
-    it 'correct age when set' do
-      Timecop.freeze(Time.zone.parse('2020-01-01T08:00:00Z'))
-      tracker = SAMLRequestTracker.create(uuid: 1, payload: {})
-      Timecop.freeze(Time.zone.parse('2020-01-01T08:03:00Z'))
-      expect(tracker.age).to eq(180)
+    context 'when age is set' do
+      before { Timecop.freeze(Time.zone.parse('2020-01-01T08:00:00Z')) }
+
+      after { Timecop.return }
+
+      it 'returns the set age' do
+        tracker = SAMLRequestTracker.create(uuid: 1, payload: {})
+        Timecop.freeze(Time.zone.parse('2020-01-01T08:03:00Z'))
+        expect(tracker.age).to eq(180)
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
Fixes an issue where, with certain seeds e.g. `bin/rspec spec --seed 18337`, a rspec test [was failing](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-api/detail/PR-4167/7/pipeline/) because of a timecop shift in another spec. Big ups 👍to @SMLuthi who figured out why the in_progress_form_cleaner_spec.rb was cleaning too many things.

## Things to know about this PR
local unit tests run with seed and without (a random one)
