### PR TITLE
Add feature flag for sso auto-login/logout

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -94,7 +94,7 @@ features:
     actor_type: user
     description: >
       Enable eBenefits links to be proxied through eauth.va.gov, this allows users with SSOe sessions to stay logged in.
-  ssoe_auto_login:
+  ssoe_inbound:
     actor_type: user
     description: >
       Enables automatic establishment/disconnection of vets-api session based on a user's SSOe session status

--- a/config/features.yml
+++ b/config/features.yml
@@ -94,3 +94,7 @@ features:
     actor_type: user
     description: >
       Enable eBenefits links to be proxied through eauth.va.gov, this allows users with SSOe sessions to stay logged in.
+  ssoe_auto_login:
+    actor_type: user
+    description: >
+      Enables automatic establishment/disconnection of vets-api session based on a user's SSOe session status


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This adds a feature flag specifically to toggle automatic establishment/disconnection of a `vets-api` session based on a user's SSOe session status. This is intended to be temporary so debugging this feature isn't a blocker to SSO as a whole.
<!-- Please describe testing done to verify the changes or any testing planned. -->
