### PR TITLE
Separate Sidekiq Redis URL from caching/primary Redis URL

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,7 +3,7 @@
 Sidekiq::Enterprise.unique! if Rails.env.production?
 
 Sidekiq.configure_server do |config|
-  config.redis = REDIS_CONFIG[:redis]
+  config.redis = REDIS_CONFIG[:sidekiq]
   # super_fetch! is only available in sidekiq-pro and will cause
   #   "undefined method `super_fetch!'"
   # for those using regular sidekiq
@@ -26,7 +26,7 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = REDIS_CONFIG[:redis]
+  config.redis = REDIS_CONFIG[:sidekiq]
 
   config.client_middleware do |chain|
     chain.add SidekiqStatsInstrumentation::ClientMiddleware

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,6 +1,8 @@
 development: &defaults
   redis:
     url: <%= Settings.redis.app_data.url %>
+  sidekiq:
+    url: <%= Settings.redis_sidekiq.url %>
   # DO NOT CHANGE BELOW TTL (We have agreement with MHV on this for SSO)
   session_store:
     namespace: vets-api-session

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -2,7 +2,7 @@ development: &defaults
   redis:
     url: <%= Settings.redis.app_data.url %>
   sidekiq:
-    url: <%= Settings.redis_sidekiq.url %>
+    url: <%= Settings.redis.sidekiq.url %>
   # DO NOT CHANGE BELOW TTL (We have agreement with MHV on this for SSO)
   session_store:
     namespace: vets-api-session

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -376,6 +376,9 @@ redis:
   sidekiq:
     url: redis://localhost:6379
 
+redis_sidekiq:
+  url: redis://localhost:6379
+
 # Settings for GovDelivery (email delivery)
 govdelivery:
   staging_service: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -376,9 +376,6 @@ redis:
   sidekiq:
     url: redis://localhost:6379
 
-redis_sidekiq:
-  url: redis://localhost:6379
-
 # Settings for GovDelivery (email delivery)
 govdelivery:
   staging_service: true


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Our AWS architecture currently uses a single Elasticache Redis instance for both ephemeral
caching data and more mission-critical/persistent Sidekiq async jobs and scheduled tasks. The recommended configuration for Sidekiq includes a dedicated Redis instance (https://github.com/mperham/sidekiq/wiki/Using-Redis#multiple-redis-instances) which is exactly what this PR sets the stage to support.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#8149

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
By default, the settings file _uses the same Redis url for both caching and Sidekiq_ so on the surface, nothing has changed. Configuration of a 2nd instance requires changes to the `settings.yml` files created as part of the deployment process.

Developers can set up two local Redis instances by using a `settings.local.yml` file and using another local Redis database (eg /1) or potentially an entirely separate local Redis instance. 

```
redis_sidekiq:
  url: redis://localhost:6379/1
```

Docker containers will use the default settings (Sidekiq and caching both using the configured single Redis instance) but can be overridden in a similar way.

<!-- Please describe testing done to verify the changes or any testing planned. -->
Tests continue to run fine because this is almost entirely a configuration change. Local testing showed jobs queued into the Redis instance specified by the URL, and could be verified through SidekiqUI or a Redis visualization tool (eg Redis-commander).

Once devops repos have been updated with new configuration, this will be tested on staging before a coordinated rollout on production.