### PR TITLE
VAOS - Urgent Fix for 404 routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -330,9 +330,9 @@ Rails.application.routes.draw do
   get '/v0/vaos/community_care/eligibility/:service_type', to: 'vaos/v0/cc_eligibility#show', defaults: { format: :json }
   get '/v0/vaos/community_care/supported_sites', to: 'vaos/v0/cc_supported_sites#index', defaults: { format: :json }
   get '/v0/vaos/systems', to: 'vaos/v0/systems#index', defaults: { format: :json }
-  get '/v0/vaos/systems/direct_scheduling_facilities', to: 'vaos/v0/direct_scheduling_facilities#index', defaults: { format: :json }
-  get '/v0/vaos/systems/pact', to: 'vaos/v0/pact#index', defaults: { format: :json }
-  get '/v0/vaos/systems/clinic_institutions', to: 'vaos/v0/clinic_institutions#index', defaults: { format: :json }
+  get '/v0/vaos/systems/:system_id/direct_scheduling_facilities', to: 'vaos/v0/direct_scheduling_facilities#index', defaults: { format: :json }
+  get '/v0/vaos/systems/:system_id/pact', to: 'vaos/v0/pact#index', defaults: { format: :json }
+  get '/v0/vaos/systems/:system_id/clinic_institutions', to: 'vaos/v0/clinic_institutions#index', defaults: { format: :json }
   get '/v0/vaos/facilities', to: 'vaos/v0/facilities#index', defaults: { format: :json }
   get '/v0/vaos/facilities/:facility_id/clinics', to: 'vaos/v0/clinics#index', defaults: { format: :json }
   get '/v0/vaos/facilities/:facility_id/cancel_reasons', to: 'vaos/v0/cancel_reasons#index', defaults: { format: :json }

--- a/modules/vaos/spec/routing/vaos_routing_spec.rb
+++ b/modules/vaos/spec/routing/vaos_routing_spec.rb
@@ -19,6 +19,41 @@ RSpec.describe 'routes for Session', type: :routing do
     )
   end
 
+  it 'routes to the systems index' do
+    expect(get('/v0/vaos/systems')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/systems',
+      action: 'index'
+    )
+  end
+
+  it 'routes to the systems direct_scheduling_facilities index' do
+    expect(get('/v0/vaos/systems/983/direct_scheduling_facilities')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/direct_scheduling_facilities',
+      action: 'index',
+      system_id: '983'
+    )
+  end
+
+  it 'routes to the systems pact index' do
+    expect(get('/v0/vaos/systems/983/pact')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/pact',
+      action: 'index',
+      system_id: '983'
+    )
+  end
+
+  it 'routes to the systems clinic_institutions index' do
+    expect(get('/v0/vaos/systems/983/clinic_institutions')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/clinic_institutions',
+      action: 'index',
+      system_id: '983'
+    )
+  end
+
   it 'routes to the facility available appointments index' do
     expect(get('/v0/vaos/facilities/123/available_appointments')).to route_to(
       format: :json,

--- a/modules/vaos/spec/routing/vaos_routing_spec.rb
+++ b/modules/vaos/spec/routing/vaos_routing_spec.rb
@@ -81,12 +81,4 @@ RSpec.describe 'routes for Session', type: :routing do
       service_type: 'PrimaryCare'
     )
   end
-
-  it 'routes to the systems index' do
-    expect(get('/v0/vaos/systems')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/systems',
-      action: 'index'
-    )
-  end
 end


### PR DESCRIPTION
## Description of change
There is no specific issue -- this was something quickly identified as an issue while regression testing.

**IMPORTANT:** These changes must go out before the next production deploy, or we'd have to rollback previous changes.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/7823

## Things to know about this PR
Fixes one of the custom nested resource routes to correctly set the :system_id

<!-- Please describe testing done to verify the changes or any testing planned. -->
Added a few specs. The issue was identified when encountering 404 on staging during a quick regression test.
