### PR TITLE
VAOS - urgent More 404 routing issues

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -324,6 +324,7 @@ Rails.application.routes.draw do
   put '/v0/vaos/appointments/cancel', to: 'vaos/v0/appointments#cancel', defaults: { format: :json }
   get '/v0/vaos/appointment_requests', to: 'vaos/v0/appointment_requests#index', defaults: { format: :json }
   put '/v0/vaos/appointment_requests/:id', to: 'vaos/v0/appointment_requests#update', defaults: { format: :json }
+  patch '/v0/vaos/appointment_requests/:id', to: 'vaos/v0/appointment_requests#update', defaults: { format: :json }
   post '/v0/vaos/appointment_requests', to: 'vaos/v0/appointment_requests#create', defaults: { format: :json }
   get '/v0/vaos/appointment_requests/:appointment_request_id/messages', to: 'vaos/v0/messages#index', defaults: { format: :json }
   post '/v0/vaos/appointment_requests/:appointment_request_id/messages', to: 'vaos/v0/messages#create', defaults: { format: :json }
@@ -354,5 +355,5 @@ Rails.application.routes.draw do
   mount Flipper::UI.app(Flipper.instance) => '/flipper', constraints: Flipper::AdminUserConstraint.new
 
   # This globs all unmatched routes and routes them as routing errors
-  #match '*path', to: 'application#routing_error', via: %i[get post put patch delete]
+  match '*path', to: 'application#routing_error', via: %i[get post put patch delete]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -323,8 +323,8 @@ Rails.application.routes.draw do
   post '/v0/vaos/appointments', to: 'vaos/v0/appointments#create', defaults: { format: :json }
   put '/v0/vaos/appointments/cancel', to: 'vaos/v0/appointments#cancel', defaults: { format: :json }
   get '/v0/vaos/appointment_requests', to: 'vaos/v0/appointment_requests#index', defaults: { format: :json }
+  put '/v0/vaos/appointment_requests/:id', to: 'vaos/v0/appointment_requests#update', defaults: { format: :json }
   post '/v0/vaos/appointment_requests', to: 'vaos/v0/appointment_requests#create', defaults: { format: :json }
-  put '/v0/vaos/appointment_requests', to: 'vaos/v0/appointment_requests#update', defaults: { format: :json }
   get '/v0/vaos/appointment_requests/:appointment_request_id/messages', to: 'vaos/v0/messages#index', defaults: { format: :json }
   post '/v0/vaos/appointment_requests/:appointment_request_id/messages', to: 'vaos/v0/messages#create', defaults: { format: :json }
   get '/v0/vaos/community_care/eligibility/:service_type', to: 'vaos/v0/cc_eligibility#show', defaults: { format: :json }
@@ -341,6 +341,7 @@ Rails.application.routes.draw do
   get '/v0/vaos/facilities/:facility_id/visits/:schedule_type', to: 'vaos/v0/visits#index', defaults: { format: :json }
   get '/v0/vaos/preferences', to: 'vaos/v0/preferences#show', defaults: { format: :json }
   put '/v0/vaos/preferences', to: 'vaos/v0/preferences#update', defaults: { format: :json }
+  patch '/v0/vaos/preferences', to: 'vaos/v0/preferences#update', defaults: { format: :json }
   # rubocop:enable Layout/LineLength
   # TEMPORARILY SUPPORT THE ABOVE REWRITE RULES
 
@@ -353,5 +354,5 @@ Rails.application.routes.draw do
   mount Flipper::UI.app(Flipper.instance) => '/flipper', constraints: Flipper::AdminUserConstraint.new
 
   # This globs all unmatched routes and routes them as routing errors
-  match '*path', to: 'application#routing_error', via: %i[get post put patch delete]
+  #match '*path', to: 'application#routing_error', via: %i[get post put patch delete]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -319,14 +319,14 @@ Rails.application.routes.draw do
 
   # TEMPORARILY SUPPORT THE BELOW REWRITE RULES
   # rubocop:disable Layout/LineLength
-  get '/v0/vaos/appointments', controller: 'vaos/v0/appointments', action: 'index', defaults: { format: :json }
-  post '/v0/vaos/appointments', controller: 'vaos/v0/appointments', action: 'create', defaults: { format: :json }
-  put '/v0/vaos/appointments/cancel', controller: 'vaos/v0/appointments', defaults: { format: :json }
-  get '/v0/vaos/appointment_requests', controller: 'vaos/v0/appointment_requests', action: 'index', defaults: { format: :json }
-  post '/v0/vaos/appointment_requests', controller: 'vaos/v0/appointment_requests', action: 'create', defaults: { format: :json }
-  put '/v0/vaos/appointment_requests', controller: 'vaos/v0/appointment_requests', action: 'update', defaults: { format: :json }
-  get '/v0/vaos/appointment_requests/:appointment_request_id/messages', controller: 'vaos/v0/messages', action: 'index', defaults: { format: :json }
-  post '/v0/vaos/appointment_requests/:appointment_request_id/messages', controller: 'vaos/v0/messages', action: 'create', defaults: { format: :json }
+  get '/v0/vaos/appointments', to: 'vaos/v0/appointments#index', defaults: { format: :json }
+  post '/v0/vaos/appointments', to: 'vaos/v0/appointments#create', defaults: { format: :json }
+  put '/v0/vaos/appointments/cancel', to: 'vaos/v0/appointments#cancel', defaults: { format: :json }
+  get '/v0/vaos/appointment_requests', to: 'vaos/v0/appointment_requests#index', defaults: { format: :json }
+  post '/v0/vaos/appointment_requests', to: 'vaos/v0/appointment_requests#create', defaults: { format: :json }
+  put '/v0/vaos/appointment_requests', to: 'vaos/v0/appointment_requests#update', defaults: { format: :json }
+  get '/v0/vaos/appointment_requests/:appointment_request_id/messages', to: 'vaos/v0/messages#index', defaults: { format: :json }
+  post '/v0/vaos/appointment_requests/:appointment_request_id/messages', to: 'vaos/v0/messages#create', defaults: { format: :json }
   get '/v0/vaos/community_care/eligibility/:service_type', to: 'vaos/v0/cc_eligibility#show', defaults: { format: :json }
   get '/v0/vaos/community_care/supported_sites', to: 'vaos/v0/cc_supported_sites#index', defaults: { format: :json }
   get '/v0/vaos/systems', to: 'vaos/v0/systems#index', defaults: { format: :json }

--- a/modules/vaos/spec/routing/vaos_routing_spec.rb
+++ b/modules/vaos/spec/routing/vaos_routing_spec.rb
@@ -3,6 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe 'routes for Session', type: :routing do
+  it 'routes to the appointments index' do
+    expect(get('/v0/vaos/appointments')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/appointments',
+      action: 'index'
+    )
+  end
+
+  it 'routes to the appointments create' do
+    expect(post('/v0/vaos/appointments')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/appointments',
+      action: 'create'
+    )
+  end
+
+  it 'routes to the appointments cancel' do
+    expect(put('/v0/vaos/appointments/cancel')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/appointments',
+      action: 'cancel'
+    )
+  end
+
   it 'routes to the appointment requests index' do
     expect(get('/v0/vaos/appointment_requests')).to route_to(
       format: :json,
@@ -11,10 +35,53 @@ RSpec.describe 'routes for Session', type: :routing do
     )
   end
 
-  it 'routes to the appointments index' do
-    expect(get('/v0/vaos/appointments')).to route_to(
+  it 'routes to the appointment requests create' do
+    expect(post('/v0/vaos/appointment_requests')).to route_to(
       format: :json,
-      controller: 'vaos/v0/appointments',
+      controller: 'vaos/v0/appointments_requests',
+      action: 'create'
+    )
+  end
+
+  it 'routes to the appointment requests update (cancel)' do
+    expect(put('/v0/vaos/appointments_requests')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/appointment_requests',
+      action: 'update'
+    )
+  end
+
+  it 'routes to the appointment requests messages index' do
+    expect(get('/v0/vaos/appointments_requests/123/messages')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/messages',
+      action: 'index',
+      appointment_request_id: '123'
+    )
+  end
+
+  it 'routes to the appointment requests messages create' do
+    expect(post('/v0/vaos/appointments_requests/123/messages')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/messages',
+      action: 'create',
+      appointment_request_id: '123'
+    )
+  end
+
+  it 'routes to the community care eligibilty endpoint' do
+    expect(get('/v0/vaos/community_care/eligibility/PrimaryCare')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/cc_eligibility',
+      action: 'show',
+      service_type: 'PrimaryCare'
+    )
+  end
+
+  it 'routes to the community care supported_sites endpoint' do
+    expect(get('/v0/vaos/community_care/supported_sites')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/cc_supported_sites',
       action: 'index'
     )
   end
@@ -54,6 +121,32 @@ RSpec.describe 'routes for Session', type: :routing do
     )
   end
 
+  it 'routes to the facilities index action' do
+    expect(get('/v0/vaos/facilities')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/facilities',
+      action: 'index'
+    )
+  end
+
+  it 'routes to the facility clinics index' do
+    expect(get('/v0/vaos/facilities/123/clinics')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/clinics',
+      action: 'index',
+      facility_id: '123'
+    )
+  end
+
+  it 'routes to the facility cancel_reasons index' do
+    expect(get('/v0/vaos/facilities/123/cancel_reasons')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/cancel_reasons',
+      action: 'index',
+      facility_id: '123'
+    )
+  end
+
   it 'routes to the facility available appointments index' do
     expect(get('/v0/vaos/facilities/123/available_appointments')).to route_to(
       format: :json,
@@ -63,7 +156,16 @@ RSpec.describe 'routes for Session', type: :routing do
     )
   end
 
-  it 'routes to the pact endpoint' do
+  it 'routes to the facility limits index' do
+    expect(get('/v0/vaos/facilities/123/limits')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/limits',
+      action: 'index',
+      facility_id: '123'
+    )
+  end
+
+  it 'routes to the facility visits (pact) index' do
     expect(get('/v0/vaos/facilities/688/visits/direct')).to route_to(
       format: :json,
       controller: 'vaos/v0/visits',
@@ -73,12 +175,19 @@ RSpec.describe 'routes for Session', type: :routing do
     )
   end
 
-  it 'routes to the community care eligibilty endpoint' do
-    expect(get('/v0/vaos/community_care/eligibility/PrimaryCare')).to route_to(
+  it 'routes to the preferences show action' do
+    expect(get('/v0/vaos/preferences')).to route_to(
       format: :json,
-      controller: 'vaos/v0/cc_eligibility',
-      action: 'show',
-      service_type: 'PrimaryCare'
+      controller: 'vaos/v0/preferences',
+      action: 'show'
+    )
+  end
+
+  it 'routes to the preferences update action' do
+    expect(put('/v0/vaos/preferences')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/preferences',
+      action: 'update'
     )
   end
 end

--- a/modules/vaos/spec/routing/vaos_routing_spec.rb
+++ b/modules/vaos/spec/routing/vaos_routing_spec.rb
@@ -2,192 +2,196 @@
 
 require 'rails_helper'
 
-RSpec.describe 'routes for Session', type: :routing do
-  it 'routes to the appointments index' do
-    expect(get('/v0/vaos/appointments')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/appointments',
-      action: 'index'
-    )
-  end
+RSpec.describe 'VAOS routing configuration', type: :routing do
+  # Temporarily supporting '/v0/vaos' but also '/vaos/v0'
+  ['/v0/vaos', '/vaos/v0'].each do |partial_route|
+    it "routes #{partial_route}/route to the appointments index" do
+      expect(get("#{partial_route}/appointments")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/appointments',
+        action: 'index'
+      )
+    end
 
-  it 'routes to the appointments create' do
-    expect(post('/v0/vaos/appointments')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/appointments',
-      action: 'create'
-    )
-  end
+    it "routes #{partial_route}/route to the appointments create" do
+      expect(post("#{partial_route}/appointments")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/appointments',
+        action: 'create'
+      )
+    end
 
-  it 'routes to the appointments cancel' do
-    expect(put('/v0/vaos/appointments/cancel')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/appointments',
-      action: 'cancel'
-    )
-  end
+    it "routes #{partial_route}/route to the appointments cancel" do
+      expect(put("#{partial_route}/appointments/cancel")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/appointments',
+        action: 'cancel'
+      )
+    end
 
-  it 'routes to the appointment requests index' do
-    expect(get('/v0/vaos/appointment_requests')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/appointment_requests',
-      action: 'index'
-    )
-  end
+    it "routes #{partial_route}/route to the appointment requests index" do
+      expect(get("#{partial_route}/appointment_requests")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/appointment_requests',
+        action: 'index'
+      )
+    end
 
-  it 'routes to the appointment requests create' do
-    expect(post('/v0/vaos/appointment_requests')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/appointments_requests',
-      action: 'create'
-    )
-  end
+    it "routes #{partial_route}/route to the appointment requests create" do
+      expect(post("#{partial_route}/appointment_requests")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/appointment_requests',
+        action: 'create'
+      )
+    end
 
-  it 'routes to the appointment requests update (cancel)' do
-    expect(put('/v0/vaos/appointments_requests')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/appointment_requests',
-      action: 'update'
-    )
-  end
+    it "routes #{partial_route}/route to the appointment requests update (cancel)" do
+      expect(put("#{partial_route}/appointment_requests/123")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/appointment_requests',
+        action: 'update',
+        id: '123'
+      )
+    end
 
-  it 'routes to the appointment requests messages index' do
-    expect(get('/v0/vaos/appointments_requests/123/messages')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/messages',
-      action: 'index',
-      appointment_request_id: '123'
-    )
-  end
+    it "routes #{partial_route}/route to the appointment requests messages index" do
+      expect(get("#{partial_route}/appointment_requests/123/messages")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/messages',
+        action: 'index',
+        appointment_request_id: '123'
+      )
+    end
 
-  it 'routes to the appointment requests messages create' do
-    expect(post('/v0/vaos/appointments_requests/123/messages')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/messages',
-      action: 'create',
-      appointment_request_id: '123'
-    )
-  end
+    it "routes #{partial_route}/route to the appointment requests messages create" do
+      expect(post("#{partial_route}/appointment_requests/123/messages")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/messages',
+        action: 'create',
+        appointment_request_id: '123'
+      )
+    end
 
-  it 'routes to the community care eligibilty endpoint' do
-    expect(get('/v0/vaos/community_care/eligibility/PrimaryCare')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/cc_eligibility',
-      action: 'show',
-      service_type: 'PrimaryCare'
-    )
-  end
+    it "routes #{partial_route}/route to the community care eligibilty endpoint" do
+      expect(get("#{partial_route}/community_care/eligibility/PrimaryCare")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/cc_eligibility',
+        action: 'show',
+        service_type: 'PrimaryCare'
+      )
+    end
 
-  it 'routes to the community care supported_sites endpoint' do
-    expect(get('/v0/vaos/community_care/supported_sites')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/cc_supported_sites',
-      action: 'index'
-    )
-  end
+    it "routes #{partial_route}/route to the community care supported_sites endpoint" do
+      expect(get("#{partial_route}/community_care/supported_sites")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/cc_supported_sites',
+        action: 'index'
+      )
+    end
 
-  it 'routes to the systems index' do
-    expect(get('/v0/vaos/systems')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/systems',
-      action: 'index'
-    )
-  end
+    it "routes #{partial_route}/route to the systems index" do
+      expect(get("#{partial_route}/systems")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/systems',
+        action: 'index'
+      )
+    end
 
-  it 'routes to the systems direct_scheduling_facilities index' do
-    expect(get('/v0/vaos/systems/983/direct_scheduling_facilities')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/direct_scheduling_facilities',
-      action: 'index',
-      system_id: '983'
-    )
-  end
+    it "routes #{partial_route}/route to the systems direct_scheduling_facilities index" do
+      expect(get("#{partial_route}/systems/983/direct_scheduling_facilities")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/direct_scheduling_facilities',
+        action: 'index',
+        system_id: '983'
+      )
+    end
 
-  it 'routes to the systems pact index' do
-    expect(get('/v0/vaos/systems/983/pact')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/pact',
-      action: 'index',
-      system_id: '983'
-    )
-  end
+    it "routes #{partial_route}/route to the systems pact index" do
+      expect(get("#{partial_route}/systems/983/pact")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/pact',
+        action: 'index',
+        system_id: '983'
+      )
+    end
 
-  it 'routes to the systems clinic_institutions index' do
-    expect(get('/v0/vaos/systems/983/clinic_institutions')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/clinic_institutions',
-      action: 'index',
-      system_id: '983'
-    )
-  end
+    it "routes #{partial_route}/route to the systems clinic_institutions index" do
+      expect(get("#{partial_route}/systems/983/clinic_institutions")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/clinic_institutions',
+        action: 'index',
+        system_id: '983'
+      )
+    end
 
-  it 'routes to the facilities index action' do
-    expect(get('/v0/vaos/facilities')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/facilities',
-      action: 'index'
-    )
-  end
+    it "routes #{partial_route}/route to the facilities index action" do
+      expect(get("#{partial_route}/facilities")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/facilities',
+        action: 'index'
+      )
+    end
 
-  it 'routes to the facility clinics index' do
-    expect(get('/v0/vaos/facilities/123/clinics')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/clinics',
-      action: 'index',
-      facility_id: '123'
-    )
-  end
+    it "routes #{partial_route}/route to the facility clinics index" do
+      expect(get("#{partial_route}/facilities/123/clinics")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/clinics',
+        action: 'index',
+        facility_id: '123'
+      )
+    end
 
-  it 'routes to the facility cancel_reasons index' do
-    expect(get('/v0/vaos/facilities/123/cancel_reasons')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/cancel_reasons',
-      action: 'index',
-      facility_id: '123'
-    )
-  end
+    it "routes #{partial_route}/route to the facility cancel_reasons index" do
+      expect(get("#{partial_route}/facilities/123/cancel_reasons")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/cancel_reasons',
+        action: 'index',
+        facility_id: '123'
+      )
+    end
 
-  it 'routes to the facility available appointments index' do
-    expect(get('/v0/vaos/facilities/123/available_appointments')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/available_appointments',
-      action: 'index',
-      facility_id: '123'
-    )
-  end
+    it "routes #{partial_route}/route to the facility available appointments index" do
+      expect(get("#{partial_route}/facilities/123/available_appointments")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/available_appointments',
+        action: 'index',
+        facility_id: '123'
+      )
+    end
 
-  it 'routes to the facility limits index' do
-    expect(get('/v0/vaos/facilities/123/limits')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/limits',
-      action: 'index',
-      facility_id: '123'
-    )
-  end
+    it "routes #{partial_route}/route to the facility limits index" do
+      expect(get("#{partial_route}/facilities/123/limits")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/limits',
+        action: 'index',
+        facility_id: '123'
+      )
+    end
 
-  it 'routes to the facility visits (pact) index' do
-    expect(get('/v0/vaos/facilities/688/visits/direct')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/visits',
-      action: 'index',
-      facility_id: '688',
-      schedule_type: 'direct'
-    )
-  end
+    it "routes #{partial_route}/route to the facility visits (pact) index" do
+      expect(get("#{partial_route}/facilities/688/visits/direct")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/visits',
+        action: 'index',
+        facility_id: '688',
+        schedule_type: 'direct'
+      )
+    end
 
-  it 'routes to the preferences show action' do
-    expect(get('/v0/vaos/preferences')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/preferences',
-      action: 'show'
-    )
-  end
+    it "routes #{partial_route}/route to the preferences show action" do
+      expect(get("#{partial_route}/preferences")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/preferences',
+        action: 'show'
+      )
+    end
 
-  it 'routes to the preferences update action' do
-    expect(put('/v0/vaos/preferences')).to route_to(
-      format: :json,
-      controller: 'vaos/v0/preferences',
-      action: 'update'
-    )
+    it "routes #{partial_route}/route to the preferences update action" do
+      expect(put("#{partial_route}/preferences")).to route_to(
+        format: :json,
+        controller: 'vaos/v0/preferences',
+        action: 'update'
+      )
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Found a few more 404 errors. This should be the last time this is an issue, because I took my own advice and introduced comprehensive specs for every single one of the 22 request types, and tested them both for /v0/vaos and /vaos/v0

Sorry for the grief on this one -- still need this urgently to avoid blowing up production.

All 44 specs are passing. I'm satisfied. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-api/pull/4130/files

## Things to know about this PR
Nothing not already described above.
