### PR TITLE
Add 10-10CG Feature Flags

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -6,7 +6,9 @@ module V0
     skip_before_action(:authenticate)
 
     def create
-      submission = service.submit_claim!(claim_params)
+      return service_unavailable unless Flipper.enabled?(:allow_online_10_10cg_submissions)
+
+      submission = service.submit_claim!(form: form_submission)
       render json: submission, serializer: ::Form1010cg::SubmissionSerializer
     end
 
@@ -16,8 +18,12 @@ module V0
       @service ||= ::Form1010cg::Service.new
     end
 
-    def claim_params
-      params.require(:caregivers_assistance_claim).permit(:form)
+    def form_submission
+      params.require(:caregivers_assistance_claim).require(:form)
+    end
+
+    def service_unavailable
+      render status: :service_unavailable
     end
   end
 end

--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -23,7 +23,7 @@ module V0
     end
 
     def service_unavailable
-      render status: :service_unavailable
+      render nothing: true, status: :service_unavailable, as: :json
     end
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -98,3 +98,11 @@ features:
     actor_type: user
     description: >
       Enables automatic establishment/disconnection of vets-api session based on a user's SSOe session status
+  allow_online_10_10cg_submissions:
+    actor_type: cookie_id
+    description: >
+      Allows (unauthenticated) users to submit a 10-10CG through VA.gov. This feature is also known as a Caregivers Assistance Claim.
+  stub_carma_responses:
+    actor_type: cookie_id
+    description: >
+      All 10-10CG submissions (Caregivers Assistance Claims) will not hit CARMA and instead return a dubmmy response.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,8 +69,7 @@ Rails.application.routes.draw do
 
     resource :hca_attachments, only: :create
 
-    # Excluding this feature until external service (CARMA) is connected
-    resources :caregivers_assistance_claims, only: :create unless Rails.env.production?
+    resources :caregivers_assistance_claims, only: :create
 
     resources :dependents_applications, only: %i[create show] do
       collection do

--- a/lib/carma/models/submission.rb
+++ b/lib/carma/models/submission.rb
@@ -32,7 +32,11 @@ module CARMA
       def submit!
         raise 'This submission has already been submitted to CARMA' if submitted?
 
-        response = client.create_submission(to_request_payload)
+        response =  if Flipper.enabled?(:stub_carma_responses)
+                      client.create_submission_stub(to_request_payload)
+                    else
+                      client.create_submission(to_request_payload)
+                    end
 
         @carma_case_id = response['data']['carmacase']['id']
         @submitted_at = response['data']['carmacase']['createdAt']

--- a/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
+++ b/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
+  it 'inherits from ActionController::API' do
+    expect(described_class.ancestors).to include(ActionController::API)
+  end
+
+  describe '#create' do
+    it 'requires "caregivers_assistance_claim" param' do
+      expect(Flipper).to receive(:enabled?).with(:allow_online_10_10cg_submissions).and_return(true)
+      expect_any_instance_of(Form1010cg::Service).not_to receive(:submit_claim!)
+
+      post :create, params: {}
+
+      expect(response).to have_http_status(:bad_request)
+
+      res_body = JSON.parse(response.body)
+
+      expect(res_body['errors'].size).to eq(1)
+      expect(res_body['errors'][0]).to eq(
+        {
+          'title' => 'Missing parameter',
+          'detail' => 'The required parameter "caregivers_assistance_claim", is missing',
+          'code' => '108',
+          'status' => '400'
+        }
+      )
+    end
+
+    it 'requires "caregivers_assistance_claim.form" param' do
+      expect(Flipper).to receive(:enabled?).with(:allow_online_10_10cg_submissions).and_return(true)
+      expect_any_instance_of(Form1010cg::Service).not_to receive(:submit_claim!)
+
+      post :create, params: { caregivers_assistance_claim: { form: nil } }
+
+      expect(response).to have_http_status(:bad_request)
+
+      res_body = JSON.parse(response.body)
+
+      expect(res_body['errors'].size).to eq(1)
+      expect(res_body['errors'][0]).to eq(
+        {
+          'title' => 'Missing parameter',
+          'detail' => 'The required parameter "form", is missing',
+          'code' => '108',
+          'status' => '400'
+        }
+      )
+    end
+
+    context 'when Flipper :allow_online_10_10cg_submissions is' do
+      context 'disabled' do
+        it 'renders :service_unavailable' do
+          expect(Flipper).to receive(:enabled?).with(:allow_online_10_10cg_submissions).and_return(false)
+          expect_any_instance_of(Form1010cg::Service).not_to receive(:submit_claim!)
+
+          post :create, params: { caregivers_assistance_claim: { form: '{ "my": "data" }' } }
+
+          expect(response).to have_http_status(:service_unavailable)
+        end
+      end
+
+      context 'enabled' do
+        it 'submits claim with Form1010cg::Service' do
+          expected = {
+            carma_case_id: 'A_123',
+            submitted_at: DateTime.now.iso8601,
+            form_data: '{ "my": "data" }'
+          }
+
+          submission = double(
+            carma_case_id: expected[:carma_case_id],
+            submitted_at: expected[:submitted_at]
+          )
+
+          expect(Flipper).to receive(:enabled?).with(:allow_online_10_10cg_submissions).and_return(true)
+          expect_any_instance_of(Form1010cg::Service).to receive(
+            :submit_claim!
+          ).with(
+            form: expected[:form_data]
+          ).and_return(
+            submission
+          )
+
+          post :create, params: { caregivers_assistance_claim: { form: expected[:form_data] } }
+
+          expect(response).to have_http_status(:ok)
+
+          res_body = JSON(response.body)
+
+          expect(res_body['data']).to be_present
+          expect(res_body['data']['id']).to eq('')
+          expect(res_body['data']['attributes']).to be_present
+          expect(res_body['data']['attributes']['confirmation_number']).to eq(expected[:carma_case_id])
+          expect(res_body['data']['attributes']['submitted_at']).to eq(expected[:submitted_at])
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
+++ b/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
           post :create, params: { caregivers_assistance_claim: { form: '{ "my": "data" }' } }
 
           expect(response).to have_http_status(:service_unavailable)
+          expect(response.body).to eq(' ')
         end
       end
 

--- a/spec/lib/carma/models/submission_spec.rb
+++ b/spec/lib/carma/models/submission_spec.rb
@@ -293,12 +293,6 @@ RSpec.describe CARMA::Models::Submission, type: :model do
         expect(Flipper).to receive(:enabled?).with(:stub_carma_responses).and_return(false)
         expect_any_instance_of(CARMA::Client::Client).not_to receive(:create_submission_stub)
 
-        expect_any_instance_of(CARMA::Client::Client).to receive(
-          :create_submission
-        ).and_return(
-          expected_carma_body
-        )
-
         expect(submission.carma_case_id).to eq(nil)
         expect(submission.submitted_at).to eq(nil)
         expect(submission.submitted?).to eq(false)


### PR DESCRIPTION
## Description of change
Add two feature flags:

**allow_online_10_10cg_submissions**
Will enable and diable to the ability to submit a caregiver's assistance claim (10-10cg).

**stub_carma_responses**
When enabled, this will prevent external requests to CARMA on 10-10cg submissions, and instead, use a stubbed CARMA response.

When disabled, this will push 10-10cg submission to CARMA.

## Original issue(s)
N/A

## Things to know about this PR
Caregivers Assistance Claims (online 10-10cg submission) is a feature that has not been released yet. Disabling this functionality will not affect any users or existing services on va.gov.

## After Merging
Please enable these defaults when deployed:

**Staging**
- [ ] `allow_online_10_10cg_submissions: true`
- [ ] `stub_carma_responses: false`

**Production**
- [ ] `allow_online_10_10cg_submissions: false`
- [ ] `stub_carma_responses: false`