### PR TITLE
[Lighthouse Forms] Update migration script to account for removed forms

### DIFF
--- a/lib/forms/schemas/forms.json
+++ b/lib/forms/schemas/forms.json
@@ -34,6 +34,9 @@
               "pages": {
                 "type": "number"
               },
+              "valid_pdf": {
+                "type": "boolean"
+              },
               "sha256": {
                 "type":"string"
               }

--- a/modules/va_forms/app/models/va_forms/form.rb
+++ b/modules/va_forms/app/models/va_forms/form.rb
@@ -8,7 +8,7 @@ module VaForms
     validates :form_name, presence: true, uniqueness: true
     validates :url, presence: true
     validates :sha256, presence: true
-    validates :valid_pdf, presence: true
+    validates :valid_pdf, inclusion: { in: [true, false] }
 
     before_save :set_revision
 

--- a/modules/va_forms/app/models/va_forms/form.rb
+++ b/modules/va_forms/app/models/va_forms/form.rb
@@ -8,6 +8,7 @@ module VaForms
     validates :form_name, presence: true, uniqueness: true
     validates :url, presence: true
     validates :sha256, presence: true
+    validates :valid_pdf, presence: true
 
     before_save :set_revision
 

--- a/modules/va_forms/app/serializers/va_forms/form_detail_serializer.rb
+++ b/modules/va_forms/app/serializers/va_forms/form_detail_serializer.rb
@@ -5,7 +5,7 @@ module VaForms
     type :va_form
 
     attributes :form_name, :url, :title, :first_issued_on,
-               :last_revision_on, :pages, :sha256, :versions
+               :last_revision_on, :pages, :sha256, :versions, :valid_pdf
 
     def id
       object.form_name

--- a/modules/va_forms/app/serializers/va_forms/form_list_serializer.rb
+++ b/modules/va_forms/app/serializers/va_forms/form_list_serializer.rb
@@ -5,7 +5,7 @@ module VaForms
     type :va_form
 
     attributes :form_name, :url, :title, :first_issued_on,
-               :last_revision_on, :pages, :sha256
+               :last_revision_on, :pages, :sha256, :valid_pdf
 
     def id
       object.form_name

--- a/modules/va_forms/app/swagger/va_forms/forms/form_swagger.rb
+++ b/modules/va_forms/app/swagger/va_forms/forms/form_swagger.rb
@@ -57,6 +57,12 @@ module VaForms
               key :example, 3
             end
 
+            property :valid_pdf do
+              key :description, 'A flag indicating whether the form url was confirmed as a valid download'
+              key :type, :boolean
+              key :example, 3
+            end
+
             property :sha256 do
               key :description, 'A sha256 hash of the form contents'
               key :type, :string

--- a/modules/va_forms/app/workers/va_forms/form_reloader.rb
+++ b/modules/va_forms/app/workers/va_forms/form_reloader.rb
@@ -20,9 +20,11 @@ module VaForms
     def mark_stale_forms
       processed_form_names = @processed_forms.map { |f| f['form_name'] }
       missing_forms = VaForms::Form.where.not(form_name: processed_form_names)
-      # rubocop:disable Rails/SkipsModelValidations
-      missing_forms.update_all(valid_pdf: false)
-      # rubocop:enable Rails/SkipsModelValidations
+      missing_forms.find_each do |form|
+        form.update(valid_pdf: false)
+      rescue
+        Rails.logger.warn "VA Forms failed to mark form as invalid: #{form.form_name}"
+      end
     end
 
     def load_page(current_page: 0)

--- a/modules/va_forms/app/workers/va_forms/form_reloader.rb
+++ b/modules/va_forms/app/workers/va_forms/form_reloader.rb
@@ -22,6 +22,7 @@ module VaForms
       missing_forms = VaForms::Form.where.not(form_name: processed_form_names)
       # rubocop:disable Rails/SkipsModelValidations
       missing_forms.update_all(valid_pdf: false)
+      # rubocop:enable Rails/SkipsModelValidations
     end
 
     def load_page(current_page: 0)

--- a/modules/va_forms/app/workers/va_forms/form_reloader.rb
+++ b/modules/va_forms/app/workers/va_forms/form_reloader.rb
@@ -20,11 +20,8 @@ module VaForms
     def mark_stale_forms
       processed_form_names = @processed_forms.map { |f| f['form_name'] }
       missing_forms = VaForms::Form.where.not(form_name: processed_form_names)
-
-      missing_forms.each do |form|
-        puts "VA Form #{form.form_name} not found. Marking PDF as invalid..."
-        form.update_column(:valid_pdf, false)
-      end
+      # rubocop:disable Rails/SkipsModelValidations
+      missing_forms.update_all(valid_pdf: false)
     end
 
     def load_page(current_page: 0)

--- a/modules/va_forms/app/workers/va_forms/form_reloader.rb
+++ b/modules/va_forms/app/workers/va_forms/form_reloader.rb
@@ -21,10 +21,7 @@ module VaForms
       processed_form_names = @processed_forms.map { |f| f['form_name'] }
       missing_forms = VaForms::Form.where.not(form_name: processed_form_names)
       missing_forms.find_each do |form|
-        form.update(valid_pdf: false)
-      rescue
-        Rails.logger.warn "VA Forms failed to mark form as invalid: #{form.form_name}"
-      end
+      form.update(valid_pdf: false)
     end
 
     def load_page(current_page: 0)

--- a/modules/va_forms/app/workers/va_forms/form_reloader.rb
+++ b/modules/va_forms/app/workers/va_forms/form_reloader.rb
@@ -8,8 +8,23 @@ module VaForms
 
     BASE_URL = 'https://www.va.gov'
 
+    def initialize
+      @processed_forms = []
+    end
+
     def perform
       load_page(current_page: 0)
+      mark_stale_forms
+    end
+
+    def mark_stale_forms
+      processed_form_names = @processed_forms.map { |f| f['form_name'] }
+      missing_forms = VaForms::Form.where.not(form_name: processed_form_names)
+
+      missing_forms.each do |form|
+        puts "VA Form #{form.form_name} not found. Marking PDF as invalid..."
+        form.update_column(:valid_pdf, false)
+      end
     end
 
     def load_page(current_page: 0)
@@ -55,6 +70,7 @@ module VaForms
     def parse_form_row(line, url)
       form_name = line.css('a').first.text
       form = VaForms::Form.find_or_initialize_by form_name: form_name
+      @processed_forms.push(form)
       current_sha256 = form.sha256
       form.title = line.css('font').text
       revision_string = line.css('td:nth-child(4)').text

--- a/modules/va_forms/app/workers/va_forms/form_reloader.rb
+++ b/modules/va_forms/app/workers/va_forms/form_reloader.rb
@@ -21,7 +21,8 @@ module VaForms
       processed_form_names = @processed_forms.map { |f| f['form_name'] }
       missing_forms = VaForms::Form.where.not(form_name: processed_form_names)
       missing_forms.find_each do |form|
-      form.update(valid_pdf: false)
+        form.update(valid_pdf: false)
+      end
     end
 
     def load_page(current_page: 0)

--- a/modules/va_forms/spec/factories/forms.rb
+++ b/modules/va_forms/spec/factories/forms.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     first_issued_on { Time.zone.today - 1.day }
     last_revision_on { Time.zone.today }
     pages { 2 }
+    valid_pdf { true }
     sha256 { 'somelongsha' }
   end
 end

--- a/modules/va_forms/spec/models/form_spec.rb
+++ b/modules/va_forms/spec/models/form_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe VaForms::Form, type: :model do
       form.first_issued_on = Time.zone.today - 1.day
       form.pages = 2
       form.sha256 = 'somelongsha'
+      form.valid_pdf = true
       form.save
       form.reload
       expect(form.last_revision_on).to eq(form.first_issued_on)

--- a/modules/va_forms/spec/workers/form_reloader_spec.rb
+++ b/modules/va_forms/spec/workers/form_reloader_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe VaForms::FormReloader, type: :job do
         VCR.use_cassette('va_forms/forms-missing-26-8736a') do
           form_reloader.load_page(current_page: 0)
           # Confirm that a model in the va_forms/forms cassette but not the second cassette has valid_pdf = false
-          missing_form = VaForms::Form.where(form_name: '26-8736a')
+          missing_form = VaForms::Form.find(form_name: '26-8736a')
           expect(missing_form.valid_pdf).to eq(false)
         end
       end

--- a/modules/va_forms/spec/workers/form_reloader_spec.rb
+++ b/modules/va_forms/spec/workers/form_reloader_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe VaForms::FormReloader, type: :job do
       expect(final_url).to eq('https://www.va.gov/vaforms/medical/pdf/vha10-10171-fill.pdf')
     end
 
+    it 'marks missing forms as invalid' do
+      # Todo
+    end
+
     describe 'date parsing checks' do
       it 'parses date when month day year' do
         date_string = '7/30/2018'

--- a/modules/va_forms/spec/workers/form_reloader_spec.rb
+++ b/modules/va_forms/spec/workers/form_reloader_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe VaForms::FormReloader, type: :job do
         VCR.use_cassette('va_forms/forms-missing-26-8736a') do
           form_reloader.load_page(current_page: 0)
           # Confirm that a model in the va_forms/forms cassette but not the second cassette has valid_pdf = false
-          missing_form = VaForms::Form.find(form_name: '26-8736a')
+          missing_form = VaForms::Form.find('26-8736a')
           expect(missing_form.valid_pdf).to eq(false)
         end
       end

--- a/spec/support/schemas/va_forms/form.json
+++ b/spec/support/schemas/va_forms/form.json
@@ -27,7 +27,7 @@
             "first_issued_on": { "type": ["string", "null"] },
             "last_revision_on": { "type": ["string", "null"] },
             "pages": { "type": "integer" },
-            "boolean": { "type": "boolean" },
+            "valid_pdf": { "type": "boolean" },
             "sha256": { "type": "string" },
             "versions": {
               "type": "array",

--- a/spec/support/schemas/va_forms/form.json
+++ b/spec/support/schemas/va_forms/form.json
@@ -27,8 +27,9 @@
             "first_issued_on": { "type": ["string", "null"] },
             "last_revision_on": { "type": ["string", "null"] },
             "pages": { "type": "integer" },
+            "boolean": { "type": "boolean" },
             "sha256": { "type": "string" },
-            "versions": { 
+            "versions": {
               "type": "array",
               "items": {
                 "sha256": { "type": "string" },

--- a/spec/support/schemas/va_forms/forms.json
+++ b/spec/support/schemas/va_forms/forms.json
@@ -30,6 +30,7 @@
               "first_issued_on": { "type": ["string", "null"] },
               "last_revision_on": { "type": ["string", "null"] },
               "pages": { "type": "integer" },
+              "valid_pdf": { "type": "boolean" },
               "sha256": { "type": "string" }
             }
           }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->


## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

The Lighthouse service VA Forms generates a local DB via a `form_reloader` script that scrapes va.gov/vaforms/ to build a local DB. However, sometimes forms are deleted entirely off of va.gov/vaforms/. Currently, this change isn't reflected at all in the Lighthouse Forms DB. There isn't a "deleted" flag. However, there is a "valid_pdf" flag. This PR makes use of that by flipping the "valid_pdf" to false for all forms that are in the internal DB but not found during the latest scrape. It also exposes `valid_pdf` for each form model in `/services/va_forms/v0/forms` (Lighthouse) and `/v0/forms` (Vets-API standard route). During the next scrape, this should set about 50-100 forms to `valid_pdf: false` because a bunch of forms were removed off of `/vaforms` recently.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/8647
https://github.com/department-of-veterans-affairs/va.gov-team/issues/8648

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- This change is specifically visible when the build job that runs `form_reloader` is executed

<!-- Please describe testing done to verify the changes or any testing planned. -->
- Will need to make sure I didn't break anything in Dev/Staging
- This should set `valid_pdf` to false for about 50-100 forms that were removed off of va.gov/vaforms a couple weeks ago