### PR TITLE
Override Redis configuration for development Docker container

### DIFF
--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -34,8 +34,8 @@ services:
     environment:
       "Settings.database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
       "Settings.test_database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}?pool=4"
-      "Settings.redis.host": "redis"
-      "Settings.redis.port": "6379"
+      "Settings.redis.app_data.url": "redis://redis:6379"
+      "Settings.redis.sidekiq.url": "redis://redis:6379"
       "Settings.binaries.clamdscan": "clamscan" # Not running a separate process within the container for clamdscan, so we use clamscan which requires no daemon
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -23,8 +23,6 @@ services:
       "Settings.test_database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}?pool=4"
       "Settings.saml.cert_path": "/srv/vets-api/src/spec/support/certificates/ruby-saml.crt"
       "Settings.saml.key_path": "/srv/vets-api/src/spec/support/certificates/ruby-saml.key"
-      "Settings.redis.host": "redis"
-      "Settings.redis.port": "6379"
       "Settings.binaries.clamdscan": "clamscan"           # Not running a separate process within the container for clamdscan, so we use clamscan which requires no daemon
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
       "Settings.test_database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}?pool=4"
       "Settings.saml.cert_path": "/srv/vets-api/src/config/certs/vetsgov-localhost.crt"
       "Settings.saml.key_path": "/srv/vets-api/src/config/certs/vetsgov-localhost.key"
-      "Settings.redis.host": "redis"
-      "Settings.redis.port": "6379"
+      "Settings.redis.app_data.url": "redis://redis:6379"
+      "Settings.redis.sidekiq.url": "redis://redis:6379"
       "Settings.binaries.clamdscan": "clamscan" # Not running a separate process within the container for clamdscan, so we use clamscan which requires no daemon
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->
After releasing #4219 there were issues with starting the local Docker instance used for development:

```
rails aborted!
Errno::EADDRNOTAVAIL: Cannot assign requested address - connect(2) for [::1]:6379
/usr/local/bundle/gems/redis-3.3.5/lib/redis/connection/ruby.rb:199:in `connect_addrinfo'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/connection/ruby.rb:239:in `block in connect'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/connection/ruby.rb:237:in `each'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/connection/ruby.rb:237:in `each_with_index'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/connection/ruby.rb:237:in `connect'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/connection/ruby.rb:313:in `connect'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/client.rb:336:in `establish_connection'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/client.rb:101:in `block in connect'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/client.rb:293:in `with_reconnect'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/client.rb:100:in `connect'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/client.rb:364:in `ensure_connected'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/client.rb:221:in `block in process'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/client.rb:306:in `logging'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/client.rb:220:in `process'
/usr/local/bundle/gems/redis-3.3.5/lib/redis/client.rb:120:in `call'
/usr/local/bundle/gems/redis-3.3.5/lib/redis.rb:514:in `block in keys'
/usr/local/bundle/gems/redis-3.3.5/lib/redis.rb:58:in `block in synchronize'
/usr/local/bundle/gems/redis-3.3.5/lib/redis.rb:58:in `synchronize'
/usr/local/bundle/gems/redis-3.3.5/lib/redis.rb:513:in `keys'
/usr/local/bundle/gems/redis-namespace-1.7.0/lib/redis/namespace.rb:469:in `call_with_namespace'
/usr/local/bundle/gems/redis-namespace-1.7.0/lib/redis/namespace.rb:288:in `keys'
/srv/vets-api/src/lib/common/models/redis_store.rb:80:in `keys'
```

Verified the issue 
## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

The Redis server in the Docker container does not expose ports externally and with the new URL syntax, is unable to be reached by the Rails server. Testing with a local override showed that the right format for the Redis URL includes the Docker container/network/hostname (redis) instead of the previous "localhost". Not sure why the previous version worked but assuming Docker magic 😄 

Since there is a configuration for the Redis settings directly in the docker-compose file, the configuration can be specified only for this Docker instance successfully.

## Original issue(s)
Direct support issue, related to #4219 

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
