### PR TITLE
Expose redis port for Docker development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3.4'
 services:
   redis:
     image: redis:5.0-alpine
+    ports:
+      - "63790:6379"
   postgres:
     image: mdillon/postgis:11-alpine
     environment:


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Our Docker container for development exports the Postgresql port on a non-standard local port so it can be accessed during development. We do not do the same for Redis until now.

This PR exposes Redis using a similar manner to what we currently do with Postgresql -- adding a zero to the standard port number `6379` + `0` => `63790`
  
## Original issue(s)
None, but noticed as part of working on #4229 

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
