### PR TITLE
Handles and validates multi-value fields in SSOe

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -55,6 +55,10 @@ module V1
         redirect_to url_service.login_redirect_url(auth: 'fail', code: auth_error_code(saml_response.error_code))
         callback_stats(:failure, saml_response, saml_response.error_instrumentation_code)
       end
+    rescue SAML::UserAttributeError => e
+      log_message_to_sentry(e.message, {}, {}, :warning)
+      redirect_to url_service.login_redirect_url(auth: 'fail', code: e.code)
+      callback_stats(:failure, saml_response, e.tag)
     rescue => e
       log_exception_to_sentry(e, {}, {}, :error)
       redirect_to url_service.login_redirect_url(auth: 'fail', code: '007') unless performed?

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -56,7 +56,7 @@ module V1
         callback_stats(:failure, saml_response, saml_response.error_instrumentation_code)
       end
     rescue SAML::UserAttributeError => e
-      log_message_to_sentry(e.message, {}, {}, :warning)
+      log_message_to_sentry(e.message, :warning)
       redirect_to url_service.login_redirect_url(auth: 'fail', code: e.code)
       callback_stats(:failure, saml_response, e.tag)
     rescue => e

--- a/lib/saml/errors.rb
+++ b/lib/saml/errors.rb
@@ -2,5 +2,22 @@
 
 module SAML
   class UserAttributeError < StandardError
+    MULTIPLE_MHV_IDS = { code: '101',
+                         tag: :multiple_mhv_ids,
+                         message: 'User attributes contain multiple distinct MHV ID values' }.freeze
+    MULTIPLE_EDIPIS = { code: '102',
+                        tag: :multiple_edipis,
+                        message: 'User attributes contain multiple distinct EDIPI values' }.freeze
+    MHV_ICN_MISMATCH = { code: '103',
+                         tag: :mhv_icn_mismatch,
+                         message: 'MHV credential ICN does not match MPI record' }.freeze
+
+    attr_reader :code, :tag
+
+    def initialize(message:, code:, tag:)
+      @code = code
+      @tag = tag
+      super(message)
+    end
   end
 end

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -429,8 +429,7 @@ RSpec.describe SAML::User do
         it 'does not validate' do
           expect { subject.validate! }.to raise_error { |error|
             expect(error).to be_a(SAML::UserAttributeError)
-            expect(error.message).to
-            eq('MHV credential ICN does not match MPI record')
+            expect(error.message).to eq('MHV credential ICN does not match MPI record')
           }
         end
       end
@@ -513,11 +512,11 @@ RSpec.describe SAML::User do
           end
 
           it 'does not validate' do
-            expect { subject.validate! }.to raise_error { |error|
-                                              expect(error).to be_a(SAML::UserAttributeError)
-                                              expect(error.message).to
-                                              eq('User attributes contain multiple distinct MHV ID values')
-                                            }
+            expect { subject.validate! }
+              .to raise_error { |error|
+                    expect(error).to be_a(SAML::UserAttributeError)
+                    expect(error.message).to eq('User attributes contain multiple distinct MHV ID values')
+                  }
           end
         end
 
@@ -526,11 +525,11 @@ RSpec.describe SAML::User do
           let(:ien) { '999888,888777' }
 
           it 'does not validate' do
-            expect { subject.validate! }.to raise_error { |error|
-                                              expect(error).to be_a(SAML::UserAttributeError)
-                                              expect(error.message).to
-                                              eq('User attributes contain multiple distinct MHV ID values')
-                                            }
+            expect { subject.validate! }
+              .to raise_error { |error|
+                    expect(error).to be_a(SAML::UserAttributeError)
+                    expect(error.message).to eq('User attributes contain multiple distinct MHV ID values')
+                  }
           end
         end
       end
@@ -546,11 +545,11 @@ RSpec.describe SAML::User do
         let(:edipi) { '0123456789,0000000054' }
 
         it 'does not validate' do
-          expect { subject.validate! }.to raise_error { |error|
-                                            expect(error).to be_a(SAML::UserAttributeError)
-                                            expect(error.message).to
-                                            eq('User attributes contain multiple distinct EDIPI values')
-                                          }
+          expect { subject.validate! }
+            .to raise_error { |error|
+                  expect(error).to be_a(SAML::UserAttributeError)
+                  expect(error.message).to eq('User attributes contain multiple distinct EDIPI values')
+                }
         end
       end
 


### PR DESCRIPTION
SSOe may provide comma-separated multivalue attributes for some fields.
This makes the parsing code robust to that, and also enforces validation
on the MHV ID, EDIPI, and ICN fields to ensure that there are no
conflicting values.

## Description of change
- Parses comma-separated values in the mhvien and dodedipnid attributes from SSOe SAML
- Validates that there is one and only one value present for MHV ID, EDIPI, and ICN across all the fields where those values may appear.
- Prevents login if above is not true.
- Adds new "auth failed" codes that can be consumed by frontend (TBD) to present a more specific message to the user. Content for those messages will be borrowed from the current MHV-specific errors when multiple MHV IDs are present, and then submitted to appropriate website/content teams for review.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#8820

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Added robust specs; I do have a staging user who I can use to verify this against originally-reported issue but that user doesn't work against localhost (because not present in MHV/SSOe environments other than staging). 