### PR TITLE
remove redis from testing docker compose

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,5 @@
 version: '3.4'
 services:
-  redis:
-    image: redis:5.0-alpine
   postgres:
     image: mdillon/postgis:11-alpine
     environment:
@@ -37,9 +35,7 @@ services:
       DANGER_GITHUB_API_TOKEN: "${DANGER_GITHUB_API_TOKEN}"
     depends_on:
       - postgres
-      - redis
     links:
       - postgres
-      - redis
 volumes:
   test_bundle:


### PR DESCRIPTION
## Description of change
CI uses the `docker-compose.test.yml` file to run. Running our specs uses fakeredis which basically stores everything in memory w/o the need for an actual redis instance.

## Original issue(s)
None.

## Some Extra Context
[This PR](https://github.com/department-of-veterans-affairs/vets-api/pull/4219/files) that changed how we configured redis, [broke some local developer environments using docker](https://dsva.slack.com/archives/CBU0KDSB1/p1588769539100500). Reason being that the redis settings in the docker-compose.yml file were not updated to reflect the latest changes to settings.yml.

That led us to [updating said docker-compose.yml environment settings](https://github.com/department-of-veterans-affairs/vets-api/pull/4229/files).

In all of that☝️, CI never failed. It doesn't need redis at all to run. It's probably best to remove it so as not to cause confusion later on.