### PR TITLE
Resolve Rails 6.1 deprecation warning for ActiveSupport::OrderedOptions

### DIFF
--- a/app/models/evss_claims_sync_status_tracker.rb
+++ b/app/models/evss_claims_sync_status_tracker.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class EVSSClaimsSyncStatusTracker < Common::RedisStore
-  redis_store REDIS_CONFIG['evss_claims_store']['namespace']
-  redis_ttl REDIS_CONFIG['evss_claims_store']['each_ttl']
+  redis_store REDIS_CONFIG[:evss_claims_store][:namespace]
+  redis_ttl REDIS_CONFIG[:evss_claims_store][:each_ttl]
   redis_key :user_uuid
 
   attribute :user_uuid, String

--- a/config/initializers/01_redis.rb
+++ b/config/initializers/01_redis.rb
@@ -3,5 +3,4 @@
 # environment specific redis host and port (see: config/redis.yml)
 REDIS_CONFIG = Rails.application.config_for(:redis).freeze
 # set the current global instance of Redis based on environment specific config
-# This is raising deprecation warnings because a ActiveSupport::OrderedOptions won't support string keys in Rails 6.1
-Redis.current = Redis.new(REDIS_CONFIG[:redis])
+Redis.current = Redis.new(REDIS_CONFIG[:redis].to_hash)


### PR DESCRIPTION
Rails 6.1 will not support accessing values from the `Rails.application.config_for` with strings.
* changed `01_redis` initializer to pass `Redis.new` a plain hash instead of the `Rails::Application::NonSymbolAccessDeprecatedHash` generated from `ActiveSupport::OrderedOptions`
* changed `EVSSClaimsSyncStatusTracker` where it was using string keys for redis config