### PR TITLE
Update link to Sidekiq Enterprise instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you do not have license configured, Sidekiq Enterprise will simply not be ins
 Unless you are sure you need a Sidekiq Enterprise feature, you are probably fine without configuring the license and running Sidekiq Enterprise.
 Normal Sidekiq will still be installed and run.
 
-If you do need Sidekiq Enterprise, VA.gov Team Engineers can follow instructions [here](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Platform/Vets-API/Sidekiq%20Enterprise%20Setup.md) to install the enterprise license on their systems.
+If you do need Sidekiq Enterprise, VA.gov Team Engineers can follow instructions [here](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/platform/engineering/sidekiq-enterprise-setup.md) to install the enterprise license on their systems.
 
 **DO NOT commit Gemfile modifications that result from local builds without sidekiq enterprise if you do not have it enabled on your development system**
 


### PR DESCRIPTION
## Description of change

The Sidekiq Enterprise setup instructions have been migrated from `vets.gov-team` to `va.gov-team-sensitive`. This PR updates the link to the Sidekiq Enterprise setup instructions.

## Original issue(s)

https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/8334

## References

Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8334

PR to delete content from vets.gov-team: https://github.com/department-of-veterans-affairs/vets.gov-team/pull/20117

PR to add content to va.gov-team-sensitive: https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/pull/102

PR to update link in vets-api: https://github.com/department-of-veterans-affairs/vets-api/pull/4239