### PR TITLE
[Bugfix] For user attributes, first look at the identity provider, then MVI

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,27 +76,27 @@ class User < Common::RedisStore
   end
 
   def middle_name
-    identity.middle_name || (mhv_icn.present? ? mvi&.profile&.given_names.to_a[1..-1]&.join(' ').presence : nil)
+    identity.middle_name.presence || mvi&.profile&.given_names.to_a[1..-1]&.join(' ').presence
   end
 
   def last_name
-    identity.last_name || (mhv_icn.present? ? mvi&.profile&.family_name : nil)
+    identity.last_name.presence || mvi&.profile&.family_name
   end
 
   def gender
-    identity.gender || (mhv_icn.present? ? mvi&.profile&.gender : nil)
+    identity.gender.presence || mvi&.profile&.gender
   end
 
   def birth_date
-    identity.birth_date || (mhv_icn.present? ? mvi&.profile&.birth_date : nil)
+    identity.birth_date.presence || mvi&.profile&.birth_date
   end
 
   def zip
-    identity.zip || (mhv_icn.present? ? mvi&.profile&.address&.postal_code : nil)
+    identity.zip.presence || mvi&.profile&.address&.postal_code
   end
 
   def ssn
-    identity.ssn || (mhv_icn.present? ? mvi&.profile&.ssn : nil)
+    identity.ssn.presence || mvi&.profile&.ssn
   end
 
   def mhv_correlation_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < Common::RedisStore
   end
 
   def first_name
-    identity.first_name || (mhv_icn.present? ? mvi&.profile&.given_names&.first : nil)
+    identity.first_name.presence || mvi&.profile&.given_names&.first
   end
 
   def full_name_normalized
@@ -76,7 +76,7 @@ class User < Common::RedisStore
   end
 
   def middle_name
-    identity.middle_name.presence || mvi&.profile&.given_names.to_a[1..-1]&.join(' ').presence
+    identity.middle_name || (mhv_icn.present? ? mvi&.profile&.given_names.to_a[1..-1]&.join(' ').presence : nil)
   end
 
   def last_name

--- a/spec/lib/mvi/messages/add_person_message_spec.rb
+++ b/spec/lib/mvi/messages/add_person_message_spec.rb
@@ -105,6 +105,7 @@ describe MVI::Messages::AddPersonMessage do
       end
 
       it 'throws an argument error' do
+        user.va_profile.ssn = nil
         expect do
           xml
         end.to raise_error(ArgumentError, 'User missing attributes')

--- a/spec/policies/mvi_policy_spec.rb
+++ b/spec/policies/mvi_policy_spec.rb
@@ -38,30 +38,35 @@ describe MviPolicy do
 
         it 'is not queryable without a ssn' do
           user.identity.ssn = nil
+          user.va_profile.ssn = nil
 
           expect(subject).not_to permit(user, :mvi)
         end
 
         it 'is not queryable without a first_name' do
           user.identity.first_name = nil
+          user.va_profile.given_names = nil
 
           expect(subject).not_to permit(user, :mvi)
         end
 
         it 'is not queryable without a last_name' do
           user.identity.last_name = nil
+          user.va_profile.family_name = nil
 
           expect(subject).not_to permit(user, :mvi)
         end
 
         it 'is not queryable without a birth_date' do
           user.identity.birth_date = nil
+          user.va_profile.birth_date = nil
 
           expect(subject).not_to permit(user, :mvi)
         end
 
         it 'is not queryable without a gender' do
           user.identity.gender = nil
+          user.va_profile.gender = nil
 
           expect(subject).not_to permit(user, :mvi)
         end


### PR DESCRIPTION
## Description of change
We were troubleshooting an disability claim with a veteran and we were unable to retrieve a veteran's rated disability from evss because we were sending a nil value to evss for gender. The veteran had a gender in MVI, but gender was nil from the identity provider (id.me).  

https://github.com/department-of-veterans-affairs/vets-api/pull/1666 changed the order of presedence for the data. 

MHV gives us a limited subset of the attributes that the other identity providers so we were using `mhv_icn.present?` as a way to determine if the user logged in with MHV (and therefore we'd need to look up all the attributes in MVI). But now, there's no reason not to use the identity provider's data first, and MVI's data second (note: we only do MVI lookups for LOA3 users).
## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/8908