### PR TITLE
user email is now optional

### DIFF
--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -37,7 +37,7 @@ module V0
         raise EVSS::GiBillStatus::ExternalServiceUnavailable
       when EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS[:vet_not_found]
         log_vet_not_found(@current_user, response.timestamp)
-        raise Common::Exceptions::RecordNotFound, @current_user.email
+        raise Common::Exceptions::RecordNotFound, @current_user.common_name
       when EVSS::GiBillStatus::GiBillStatusResponse::KNOWN_ERRORS[:invalid_auth]
         # 403
         raise Common::Exceptions::UnexpectedForbidden, detail: 'Missing correlation id'

--- a/app/models/id_card_attributes.rb
+++ b/app/models/id_card_attributes.rb
@@ -19,7 +19,7 @@ class IdCardAttributes
       'city' => @user.va_profile&.address&.city || '',
       'state' => @user.va_profile&.address&.state || '',
       'zip' => @user.va_profile&.address&.postal_code || '',
-      'email' => @user.email,
+      'email' => @user.email || '',
       'phone' => @user.va_profile&.home_phone || '',
       'title38status' => title38_status_code,
       'branchofservice' => branches_of_service,

--- a/app/models/id_card_attributes.rb
+++ b/app/models/id_card_attributes.rb
@@ -9,7 +9,8 @@ class IdCardAttributes
     id_attributes
   end
 
-  ## Return dict of traits in canonical order
+  # Return dict of traits in canonical order
+  # rubocop:disable Metrics/CyclomaticComplexity
   def traits
     {
       'edipi' => @user.edipi,
@@ -26,6 +27,7 @@ class IdCardAttributes
       'dischargetype' => discharge_types
     }
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,6 +117,7 @@ class User < Common::RedisStore
   delegate :idme_uuid, to: :identity, allow_nil: true
   delegate :dslogon_edipi, to: :identity, allow_nil: true
   delegate :authenticated_by_ssoe, to: :identity, allow_nil: true
+  delegate :common_name, to: :identity, allow_nil: true
 
   # mvi attributes
   delegate :birls_id, to: :mvi

--- a/app/models/user_identity.rb
+++ b/app/models/user_identity.rb
@@ -17,6 +17,7 @@ class UserIdentity < Common::RedisStore
   attribute :first_name
   attribute :middle_name
   attribute :last_name
+  attribute :common_name
   attribute :gender
   attribute :birth_date
   attribute :zip
@@ -34,7 +35,6 @@ class UserIdentity < Common::RedisStore
   attribute :authenticated_by_ssoe, Boolean
 
   validates :uuid, presence: true
-  validates :email, presence: true
   validates :loa, presence: true
   validate  :loa_highest_present
 

--- a/app/services/bgs/dependent_service.rb
+++ b/app/services/bgs/dependent_service.rb
@@ -5,7 +5,7 @@ module BGS
     def get_dependents(current_user)
       service = LighthouseBGS::Services.new(
         external_uid: current_user.icn,
-        external_key: current_user.email
+        external_key: current_user.common_name
       )
 
       service.claimants.find_dependents_by_participant_id(current_user.participant_id, current_user.ssn)

--- a/lib/evss/jwt.rb
+++ b/lib/evss/jwt.rb
@@ -30,7 +30,6 @@ module EVSS
 
         # custom claims
         assuranceLevel: @user.loa[:current],
-        email: @user.email,
         firstName: @user.first_name,
         middleName: @user.middle_name,
         lastName: @user.last_name,
@@ -39,7 +38,8 @@ module EVSS
         prefix: '', # TODO: i thought we had these in mvi...
         suffix: '',
         correlationIds: @user.mvi&.profile&.full_mvi_ids
-      }
+        # only include the email address if its not nil
+      }.merge({ email: @user.email }.compact)
     end
   end
 end

--- a/lib/saml/user_attributes/base.rb
+++ b/lib/saml/user_attributes/base.rb
@@ -32,6 +32,10 @@ module SAML
         attributes['email']
       end
 
+      def common_name
+        email
+      end
+
       # ID.me level of assurance, provided by all authn_contexts
       def idme_loa
         attributes['level_of_assurance']&.to_i

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -7,7 +7,7 @@ module SAML
   module UserAttributes
     class SSOe
       include SentryLogging
-      SERIALIZABLE_ATTRIBUTES = %i[email first_name middle_name last_name zip gender ssn birth_date
+      SERIALIZABLE_ATTRIBUTES = %i[email first_name middle_name last_name common_name zip gender ssn birth_date
                                    uuid idme_uuid sec_id mhv_icn mhv_correlation_id mhv_account_type
                                    dslogon_edipi loa sign_in multifactor].freeze
       IDME_GCID_REGEX = /^(?<idme>\w+)\^PN\^200VIDM\^USDVA\^A$/.freeze
@@ -32,6 +32,10 @@ module SAML
 
       def last_name
         safe_attr('va_eauth_lastname')
+      end
+
+      def common_name
+        safe_attr('va_eauth_commonname')
       end
 
       def zip

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
       search_token { nil }
       icn_with_aaid { nil }
       authenticated_by_ssoe { false }
+      common_name { nil }
 
       sign_in do
         {
@@ -57,7 +58,8 @@ FactoryBot.define do
                              mhv_correlation_id: t.mhv_correlation_id,
                              mhv_account_type: t.mhv_account_type,
                              dslogon_edipi: t.dslogon_edipi,
-                             sign_in: t.sign_in)
+                             sign_in: t.sign_in,
+                             common_name: t.common_name)
       user.instance_variable_set(:@identity, user_identity)
     end
 

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: nil,
           authenticated_by_ssoe: true,
-          common_name: nil,
+          common_name: nil
         )
       end
 
@@ -296,7 +296,7 @@ RSpec.describe SAML::User do
           sec_id: '1012853550',
           multifactor: multifactor,
           authenticated_by_ssoe: true,
-          common_name: 'k+tristan@example.com',
+          common_name: 'k+tristan@example.com'
         )
       end
     end

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -79,7 +79,8 @@ RSpec.describe SAML::User do
           loa: { current: 1, highest: 1 },
           sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: nil,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: nil,
         )
       end
 
@@ -112,7 +113,8 @@ RSpec.describe SAML::User do
           loa: { current: 1, highest: 3 },
           sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: nil,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: nil
         )
       end
 
@@ -146,7 +148,8 @@ RSpec.describe SAML::User do
           loa: { current: 3, highest: 3 },
           sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: '1008830476',
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: 'vets.gov.user+262@example.com'
         )
       end
 
@@ -182,7 +185,8 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'myhealthevet', account_type: 'Advanced' },
           sec_id: nil,
           multifactor: multifactor,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: nil
         )
       end
 
@@ -220,7 +224,8 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'myhealthevet', account_type: 'Advanced' },
           sec_id: '1013183292',
           multifactor: multifactor,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: 'alexmac_0@example.com'
         )
       end
     end
@@ -253,7 +258,8 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'myhealthevet', account_type: 'Basic' },
           sec_id: nil,
           multifactor: true,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: nil
         )
       end
 
@@ -289,7 +295,8 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'myhealthevet', account_type: 'Premium' },
           sec_id: '1012853550',
           multifactor: multifactor,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: 'k+tristan@example.com',
         )
       end
     end
@@ -326,7 +333,8 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'myhealthevet', account_type: 'Premium' },
           sec_id: '1012853550',
           multifactor: multifactor,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: 'k+tristan@example.com'
         )
       end
     end
@@ -470,7 +478,8 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'dslogon', account_type: '2' },
           sec_id: '1013173963',
           multifactor: false,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: 'iam.tester@example.com'
         )
       end
 
@@ -507,7 +516,8 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'dslogon', account_type: '2' },
           sec_id: '0000028007',
           multifactor: multifactor,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: 'dslogon10923109@gmail.com'
         )
       end
     end
@@ -543,7 +553,8 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'dslogon', account_type: '2' },
           sec_id: '0000028007',
           multifactor: multifactor,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: 'dslogon10923109@gmail.com'
         )
       end
     end
@@ -578,7 +589,8 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'dslogon', account_type: 'N/A' },
           sec_id: '1012779219',
           multifactor: multifactor,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: 'SOFIA MCKIBBENS'
         )
       end
     end
@@ -613,7 +625,8 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'myhealthevet', account_type: 'N/A' },
           sec_id: '1013062086',
           multifactor: multifactor,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: 'mhvzack@mhv.va.gov'
         )
       end
     end
@@ -648,7 +661,8 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: '1012827134',
           multifactor: multifactor,
-          authenticated_by_ssoe: true
+          authenticated_by_ssoe: true,
+          common_name: 'vets.gov.user+262@gmail.com'
         )
       end
     end


### PR DESCRIPTION
The prominent change is making email optional in the `UserIdentity` class, this will allow access for inbound SSOe users that do not have an email address on file.

There are a few cases in the vets-api where `user.email` is expected to always have a value.  To remedey this we've introduced a new `common_name` attribute that will be set to the `va_eauth_commonname` value when authenticated via SSOe and the user's email when not using SSOe.

In the cases where an email address is optional, we've updated the code to use `user.email` or an empty string.  In the cases where its required, we've found that the caller just needs a unique identifier, so we've updated those cases to use the new `common_name` attribute.

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/8305