### PR TITLE
VAOS - removing the temporary 'v0/vaos' routing.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -316,35 +316,6 @@ Rails.application.routes.draw do
 
   mount VAOS::Engine, at: '/vaos'
 
-  # TEMPORARILY SUPPORT THE BELOW REWRITE RULES
-  # rubocop:disable Layout/LineLength
-  get '/v0/vaos/appointments', to: 'vaos/v0/appointments#index', defaults: { format: :json }
-  post '/v0/vaos/appointments', to: 'vaos/v0/appointments#create', defaults: { format: :json }
-  put '/v0/vaos/appointments/cancel', to: 'vaos/v0/appointments#cancel', defaults: { format: :json }
-  get '/v0/vaos/appointment_requests', to: 'vaos/v0/appointment_requests#index', defaults: { format: :json }
-  put '/v0/vaos/appointment_requests/:id', to: 'vaos/v0/appointment_requests#update', defaults: { format: :json }
-  patch '/v0/vaos/appointment_requests/:id', to: 'vaos/v0/appointment_requests#update', defaults: { format: :json }
-  post '/v0/vaos/appointment_requests', to: 'vaos/v0/appointment_requests#create', defaults: { format: :json }
-  get '/v0/vaos/appointment_requests/:appointment_request_id/messages', to: 'vaos/v0/messages#index', defaults: { format: :json }
-  post '/v0/vaos/appointment_requests/:appointment_request_id/messages', to: 'vaos/v0/messages#create', defaults: { format: :json }
-  get '/v0/vaos/community_care/eligibility/:service_type', to: 'vaos/v0/cc_eligibility#show', defaults: { format: :json }
-  get '/v0/vaos/community_care/supported_sites', to: 'vaos/v0/cc_supported_sites#index', defaults: { format: :json }
-  get '/v0/vaos/systems', to: 'vaos/v0/systems#index', defaults: { format: :json }
-  get '/v0/vaos/systems/:system_id/direct_scheduling_facilities', to: 'vaos/v0/direct_scheduling_facilities#index', defaults: { format: :json }
-  get '/v0/vaos/systems/:system_id/pact', to: 'vaos/v0/pact#index', defaults: { format: :json }
-  get '/v0/vaos/systems/:system_id/clinic_institutions', to: 'vaos/v0/clinic_institutions#index', defaults: { format: :json }
-  get '/v0/vaos/facilities', to: 'vaos/v0/facilities#index', defaults: { format: :json }
-  get '/v0/vaos/facilities/:facility_id/clinics', to: 'vaos/v0/clinics#index', defaults: { format: :json }
-  get '/v0/vaos/facilities/:facility_id/cancel_reasons', to: 'vaos/v0/cancel_reasons#index', defaults: { format: :json }
-  get '/v0/vaos/facilities/:facility_id/available_appointments', to: 'vaos/v0/available_appointments#index', defaults: { format: :json }
-  get '/v0/vaos/facilities/:facility_id/limits', to: 'vaos/v0/limits#index', defaults: { format: :json }
-  get '/v0/vaos/facilities/:facility_id/visits/:schedule_type', to: 'vaos/v0/visits#index', defaults: { format: :json }
-  get '/v0/vaos/preferences', to: 'vaos/v0/preferences#show', defaults: { format: :json }
-  put '/v0/vaos/preferences', to: 'vaos/v0/preferences#update', defaults: { format: :json }
-  patch '/v0/vaos/preferences', to: 'vaos/v0/preferences#update', defaults: { format: :json }
-  # rubocop:enable Layout/LineLength
-  # TEMPORARILY SUPPORT THE ABOVE REWRITE RULES
-
   if Rails.env.development? || Settings.sidekiq_admin_panel
     require 'sidekiq/web'
     require 'sidekiq-scheduler/web'

--- a/modules/vaos/spec/routing/vaos_routing_spec.rb
+++ b/modules/vaos/spec/routing/vaos_routing_spec.rb
@@ -3,195 +3,192 @@
 require 'rails_helper'
 
 RSpec.describe 'VAOS routing configuration', type: :routing do
-  # Temporarily supporting '/v0/vaos' but also '/vaos/v0'
-  ['/v0/vaos', '/vaos/v0'].each do |partial_route|
-    it "routes #{partial_route}/route to the appointments index" do
-      expect(get("#{partial_route}/appointments")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/appointments',
-        action: 'index'
-      )
-    end
+  it 'routes to the appointments index' do
+    expect(get('/vaos/v0/appointments')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/appointments',
+      action: 'index'
+    )
+  end
 
-    it "routes #{partial_route}/route to the appointments create" do
-      expect(post("#{partial_route}/appointments")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/appointments',
-        action: 'create'
-      )
-    end
+  it 'routes to the appointments create' do
+    expect(post('/vaos/v0/appointments')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/appointments',
+      action: 'create'
+    )
+  end
 
-    it "routes #{partial_route}/route to the appointments cancel" do
-      expect(put("#{partial_route}/appointments/cancel")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/appointments',
-        action: 'cancel'
-      )
-    end
+  it 'routes to the appointments cancel' do
+    expect(put('/vaos/v0/appointments/cancel')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/appointments',
+      action: 'cancel'
+    )
+  end
 
-    it "routes #{partial_route}/route to the appointment requests index" do
-      expect(get("#{partial_route}/appointment_requests")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/appointment_requests',
-        action: 'index'
-      )
-    end
+  it 'routes to the appointment requests index' do
+    expect(get('/vaos/v0/appointment_requests')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/appointment_requests',
+      action: 'index'
+    )
+  end
 
-    it "routes #{partial_route}/route to the appointment requests create" do
-      expect(post("#{partial_route}/appointment_requests")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/appointment_requests',
-        action: 'create'
-      )
-    end
+  it 'routes to the appointment requests create' do
+    expect(post('/vaos/v0/appointment_requests')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/appointment_requests',
+      action: 'create'
+    )
+  end
 
-    it "routes #{partial_route}/route to the appointment requests update (cancel)" do
-      expect(put("#{partial_route}/appointment_requests/123")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/appointment_requests',
-        action: 'update',
-        id: '123'
-      )
-    end
+  it 'routes to the appointment requests update (cancel)' do
+    expect(put('/vaos/v0/appointment_requests/123')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/appointment_requests',
+      action: 'update',
+      id: '123'
+    )
+  end
 
-    it "routes #{partial_route}/route to the appointment requests messages index" do
-      expect(get("#{partial_route}/appointment_requests/123/messages")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/messages',
-        action: 'index',
-        appointment_request_id: '123'
-      )
-    end
+  it 'routes to the appointment requests messages index' do
+    expect(get('/vaos/v0/appointment_requests/123/messages')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/messages',
+      action: 'index',
+      appointment_request_id: '123'
+    )
+  end
 
-    it "routes #{partial_route}/route to the appointment requests messages create" do
-      expect(post("#{partial_route}/appointment_requests/123/messages")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/messages',
-        action: 'create',
-        appointment_request_id: '123'
-      )
-    end
+  it 'routes to the appointment requests messages create' do
+    expect(post('/vaos/v0/appointment_requests/123/messages')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/messages',
+      action: 'create',
+      appointment_request_id: '123'
+    )
+  end
 
-    it "routes #{partial_route}/route to the community care eligibilty endpoint" do
-      expect(get("#{partial_route}/community_care/eligibility/PrimaryCare")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/cc_eligibility',
-        action: 'show',
-        service_type: 'PrimaryCare'
-      )
-    end
+  it 'routes to the community care eligibilty endpoint' do
+    expect(get('/vaos/v0/community_care/eligibility/PrimaryCare')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/cc_eligibility',
+      action: 'show',
+      service_type: 'PrimaryCare'
+    )
+  end
 
-    it "routes #{partial_route}/route to the community care supported_sites endpoint" do
-      expect(get("#{partial_route}/community_care/supported_sites")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/cc_supported_sites',
-        action: 'index'
-      )
-    end
+  it 'routes to the community care supported_sites endpoint' do
+    expect(get('/vaos/v0/community_care/supported_sites')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/cc_supported_sites',
+      action: 'index'
+    )
+  end
 
-    it "routes #{partial_route}/route to the systems index" do
-      expect(get("#{partial_route}/systems")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/systems',
-        action: 'index'
-      )
-    end
+  it 'routes to the systems index' do
+    expect(get('/vaos/v0/systems')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/systems',
+      action: 'index'
+    )
+  end
 
-    it "routes #{partial_route}/route to the systems direct_scheduling_facilities index" do
-      expect(get("#{partial_route}/systems/983/direct_scheduling_facilities")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/direct_scheduling_facilities',
-        action: 'index',
-        system_id: '983'
-      )
-    end
+  it 'routes to the systems direct_scheduling_facilities index' do
+    expect(get('/vaos/v0/systems/983/direct_scheduling_facilities')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/direct_scheduling_facilities',
+      action: 'index',
+      system_id: '983'
+    )
+  end
 
-    it "routes #{partial_route}/route to the systems pact index" do
-      expect(get("#{partial_route}/systems/983/pact")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/pact',
-        action: 'index',
-        system_id: '983'
-      )
-    end
+  it 'routes to the systems pact index' do
+    expect(get('/vaos/v0/systems/983/pact')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/pact',
+      action: 'index',
+      system_id: '983'
+    )
+  end
 
-    it "routes #{partial_route}/route to the systems clinic_institutions index" do
-      expect(get("#{partial_route}/systems/983/clinic_institutions")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/clinic_institutions',
-        action: 'index',
-        system_id: '983'
-      )
-    end
+  it 'routes to the systems clinic_institutions index' do
+    expect(get('/vaos/v0/systems/983/clinic_institutions')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/clinic_institutions',
+      action: 'index',
+      system_id: '983'
+    )
+  end
 
-    it "routes #{partial_route}/route to the facilities index action" do
-      expect(get("#{partial_route}/facilities")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/facilities',
-        action: 'index'
-      )
-    end
+  it 'routes to the facilities index action' do
+    expect(get('/vaos/v0/facilities')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/facilities',
+      action: 'index'
+    )
+  end
 
-    it "routes #{partial_route}/route to the facility clinics index" do
-      expect(get("#{partial_route}/facilities/123/clinics")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/clinics',
-        action: 'index',
-        facility_id: '123'
-      )
-    end
+  it 'routes to the facility clinics index' do
+    expect(get('/vaos/v0/facilities/123/clinics')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/clinics',
+      action: 'index',
+      facility_id: '123'
+    )
+  end
 
-    it "routes #{partial_route}/route to the facility cancel_reasons index" do
-      expect(get("#{partial_route}/facilities/123/cancel_reasons")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/cancel_reasons',
-        action: 'index',
-        facility_id: '123'
-      )
-    end
+  it 'routes to the facility cancel_reasons index' do
+    expect(get('/vaos/v0/facilities/123/cancel_reasons')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/cancel_reasons',
+      action: 'index',
+      facility_id: '123'
+    )
+  end
 
-    it "routes #{partial_route}/route to the facility available appointments index" do
-      expect(get("#{partial_route}/facilities/123/available_appointments")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/available_appointments',
-        action: 'index',
-        facility_id: '123'
-      )
-    end
+  it 'routes to the facility available appointments index' do
+    expect(get('/vaos/v0/facilities/123/available_appointments')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/available_appointments',
+      action: 'index',
+      facility_id: '123'
+    )
+  end
 
-    it "routes #{partial_route}/route to the facility limits index" do
-      expect(get("#{partial_route}/facilities/123/limits")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/limits',
-        action: 'index',
-        facility_id: '123'
-      )
-    end
+  it 'routes to the facility limits index' do
+    expect(get('/vaos/v0/facilities/123/limits')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/limits',
+      action: 'index',
+      facility_id: '123'
+    )
+  end
 
-    it "routes #{partial_route}/route to the facility visits (pact) index" do
-      expect(get("#{partial_route}/facilities/688/visits/direct")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/visits',
-        action: 'index',
-        facility_id: '688',
-        schedule_type: 'direct'
-      )
-    end
+  it 'routes to the facility visits (pact) index' do
+    expect(get('/vaos/v0/facilities/688/visits/direct')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/visits',
+      action: 'index',
+      facility_id: '688',
+      schedule_type: 'direct'
+    )
+  end
 
-    it "routes #{partial_route}/route to the preferences show action" do
-      expect(get("#{partial_route}/preferences")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/preferences',
-        action: 'show'
-      )
-    end
+  it 'routes to the preferences show action' do
+    expect(get('/vaos/v0/preferences')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/preferences',
+      action: 'show'
+    )
+  end
 
-    it "routes #{partial_route}/route to the preferences update action" do
-      expect(put("#{partial_route}/preferences")).to route_to(
-        format: :json,
-        controller: 'vaos/v0/preferences',
-        action: 'update'
-      )
-    end
+  it 'routes to the preferences update action' do
+    expect(put('/vaos/v0/preferences')).to route_to(
+      format: :json,
+      controller: 'vaos/v0/preferences',
+      action: 'update'
+    )
   end
 end


### PR DESCRIPTION
## Description of change
The vets-website has merged their changes and are now using the new 'vaos/v0' routing convention instead of the 'v0/vaos' so these rewrite rules can now safely be removed.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/8620

## Things to know about this PR
Nothing of note.

Have verified that the new routes are working as expected on staging and production and we have comprehensive test coverage of all of those routes in `vaos_routing_spec.rb`
