### PR TITLE
Add veteran verification to 10-10CG submissions

### DIFF
--- a/app/services/form1010cg/service.rb
+++ b/app/services/form1010cg/service.rb
@@ -44,7 +44,7 @@ module Form1010cg
       )
     end
 
-    # Will raise an error unless the veteran specified on the claim's data, (1) can be found in MVI, (2) has an ICN,
+    # Will raise an error unless the veteran specified on the claim's data (1) can be found in MVI, (2) has an ICN,
     # and (3) has been confirmed as a legitimate veteran (via eMIS).
     #
     # @return [nil]
@@ -56,7 +56,6 @@ module Form1010cg
     # Returns a metadata hash:
     #
     # {
-    #   claim_id: Integer | nil,
     #   veteran: {
     #     is_veteran: true | false | nil,
     #     icn: String | nil
@@ -82,10 +81,8 @@ module Form1010cg
       metadata
     end
 
-    # Will search MVI for the provided form subject and return the matching profile's ICN or `NOT_FOUND`.
-    # Submitting a 10-10cg where the veteran specified on the form, is not a veteran, should result in a client error.
-    #
-    # The result will be cached and subsequent calls will return the cached value, preventing additional api request.
+    # Will search MVI for the provided form subject and return (1) the matching profile's ICN or (2) `NOT_FOUND`.
+    # The result will be cached and subsequent calls will return the cached value, preventing additional api requests.
     #
     # @param form_subject [String] The key in the claim's data that contains this person's info (ex: "veteran")
     # @return [String | NOT_FOUND] Returns `true` if the form subject is a veteran and NOT_CONFIRMED otherwise.
@@ -103,12 +100,10 @@ module Form1010cg
     end
 
     # Will search eMIS for the provided form subject and return `true` if the subject is a verteran.
-    # Submitting a 10-10cg where the veteran specified on the form, is not a veteran, should result in a client error.
-    #
-    # The result will be cached and subsequent calls will return the cached value, preventing additional api request.
+    # The result will be cached and subsequent calls will return the cached value, preventing additional api requests.
     #
     # @param form_subject [String] The key in the claim's data that contains this person's info (ex: "veteran")
-    # @return [true | NOT_CONFIRMED] Returns `true` if the form subject is a veteran and NOT_CONFIRMED otherwise.
+    # @return [true | NOT_CONFIRMED] Returns `true` if the form subject is a veteran and `NOT_CONFIRMED` otherwise.
     def is_veteran(form_subject) # rubocop:disable Naming/PredicateName
       cached_veteran_status = @cache[:veteran_statuses][form_subject]
       return cached_veteran_status unless cached_veteran_status.nil?

--- a/spec/lib/emis/veteran_status_service_spec.rb
+++ b/spec/lib/emis/veteran_status_service_spec.rb
@@ -49,6 +49,9 @@ describe EMIS::VeteranStatusService do
         VCR.use_cassette('emis/get_veteran_status/bad_edipi') do
           response = subject.get_veteran_status(edipi: bad_edipi)
           expect(response).not_to be_ok
+          expect(response.error?).to eq(true)
+          expect(response.error).to be_a(EMIS::Errors::ServiceError)
+          expect(response.error.message).to eq('MIS-ERR-005 EDIPI_BAD_FORMAT EDIPI incorrectly formatted')
         end
       end
     end
@@ -59,6 +62,8 @@ describe EMIS::VeteranStatusService do
           response = subject.get_veteran_status(edipi: missing_edipi)
           expect(response).not_to be_ok
           expect(response).to be_empty
+          expect(response.error?).to eq(false)
+          expect(response.error).to eq(nil)
         end
       end
     end
@@ -94,6 +99,7 @@ describe EMIS::BrokenVeteranStatusService do
       response = subject.get_veteran_status(edipi: edipi)
       expect(response).to be_an_instance_of(EMIS::Responses::ErrorResponse)
       expect(response.error).to be_an_instance_of(Common::Client::Errors::HTTPError)
+      expect(response.error.message).to be('SOAP HTTP call failed')
     end
   end
 end

--- a/spec/request/caregivers_assistance_claims_request_spec.rb
+++ b/spec/request/caregivers_assistance_claims_request_spec.rb
@@ -88,10 +88,12 @@ RSpec.describe 'Caregivers Assistance Claims', type: :request do
         body = { caregivers_assistance_claim: { form: form_data.to_json } }.to_json
 
         VCR.use_cassette 'mvi/find_candidate/valid' do
-          VCR.use_cassette 'mvi/find_candidate/valid_icn_ni_only' do
-            VCR.use_cassette 'mvi/find_candidate/valid_no_gender' do
-              VCR.use_cassette 'carma/submissions/create/201' do
-                post endpoint, params: body, headers: headers
+          VCR.use_cassette 'emis/get_veteran_status/valid' do
+            VCR.use_cassette 'mvi/find_candidate/valid_icn_ni_only' do
+              VCR.use_cassette 'mvi/find_candidate/valid_no_gender' do
+                VCR.use_cassette 'carma/submissions/create/201' do
+                  post endpoint, params: body, headers: headers
+                end
               end
             end
           end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -145,19 +145,21 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
 
     it 'supports adding an caregiver\'s assistance claim' do
       VCR.use_cassette 'mvi/find_candidate/valid' do
-        VCR.use_cassette 'mvi/find_candidate/valid_icn_ni_only' do
-          VCR.use_cassette 'mvi/find_candidate/valid_no_gender' do
-            VCR.use_cassette 'carma/submissions/create/201' do
-              expect(subject).to validate(
-                :post,
-                '/v0/caregivers_assistance_claims',
-                200,
-                '_data' => {
-                  'caregivers_assistance_claim' => {
-                    'form' => build(:caregivers_assistance_claim).form
+        VCR.use_cassette 'emis/get_veteran_status/valid' do
+          VCR.use_cassette 'mvi/find_candidate/valid_icn_ni_only' do
+            VCR.use_cassette 'mvi/find_candidate/valid_no_gender' do
+              VCR.use_cassette 'carma/submissions/create/201' do
+                expect(subject).to validate(
+                  :post,
+                  '/v0/caregivers_assistance_claims',
+                  200,
+                  '_data' => {
+                    'caregivers_assistance_claim' => {
+                      'form' => build(:caregivers_assistance_claim).form
+                    }
                   }
-                }
-              )
+                )
+              end
             end
           end
         end

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -532,7 +532,7 @@ RSpec.describe Form1010cg::Service do
   end
 
   describe '#build_metadata' do
-    it 'returns the icn for each subject on the form and the veterans status' do
+    it 'returns the icn for each subject on the form and the veteran\'s status' do
       %w[veteran primaryCaregiver secondaryCaregiverOne].each_with_index do |form_subject, index|
         return_value = form_subject == 'secondaryCaregiverOne' ? 'NOT_FOUND' : "ICN_#{index}".to_sym
         expect(subject).to receive(:icn_for).with(form_subject).and_return(return_value)
@@ -585,7 +585,7 @@ RSpec.describe Form1010cg::Service do
       end
     end
 
-    it 'will raise error if veteran\'s is confirmed as not a veteran' do
+    it 'will raise an error if the veteran status is confirmed as false' do
       expect(subject).to receive(:icn_for).with('veteran').and_return(:ICN_123)
       expect(subject).to receive(:is_veteran).with('veteran').and_return(false)
 


### PR DESCRIPTION
Resolves: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8870

## Description of change
Add veteran verification to form 10-10cg submission. Send the veteran status with the submission to CARMA. Raise client error if veteran status cannot be confirmed.

## Technical Description
- `Form1010cg::Service` has a new method called `:is_veteran` which takes a provided form subject and checks `eMIS` for their veteran status.
- `Form1010cg::Service#assert_veteran_status` now raises a client error if the veteran specified on the form cannot be verified as a veteran in `eMIS`.
- `Form1010cg::Service#build_metadata` returns an additional value in the `:veteran` namespace.

## Things to know about this PR
- It is considered a client error if the 10-10CG submission has a person in the veteran section who cannot be confirmed. These users will be directed to submit a paper form (this was the requirement from the Caregiver Program).
- The front-end has been notified of this specific client error and how to handle it after submission.

## Testing
- [x] Added unit test for the new method `:is_veteran` on `Form1010cg::Service`
  - [x] Tests if Title 38 status is `V1`
  - [x] Tests if Title 38 status is not `V1`
  - [x] Tests if Title 38 is not present
  - [x] Test that it raises error if search fails
- [x] Added unit test for new functionality on `Form1010cg::Service#assert_veteran_status`
- [x] Added unit test for new values returned in `Form1010cg::Service#build_metadata`
- [x] Update request spec with new external API call
- [x] Update swagger request spec with new external API call
