### PR TITLE
Disable rubocop, brakeman, and bundler-audit CodeClimate plugins

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,4 @@
-version: "2"         # required to adjust maintainability checks
+version: '2'         # required to adjust maintainability checks
 checks:
   argument-count:
     config:
@@ -9,6 +9,9 @@ checks:
   file-lines:
     config:
       threshold: 250
+  identical-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
   method-complexity:
     config:
       threshold: 5
@@ -29,23 +32,11 @@ checks:
       threshold: # language-specific defaults. an override will affect all languages.
     exclude_patterns:
       - '*/engine.rb'
-      - "**/swagger/**.rb"
-  identical-code:
-    config:
-      threshold: # language-specific defaults. an override will affect all languages.
+      - '**/swagger/**.rb'
 plugins:
-  rubocop:
-    enabled: true
-    channel: rubocop-0-78
   brakeman:
-    enabled: true
+    enabled: false
   bundler-audit:
-    enabled: true
-exclude_patterns:
-  - 'config/'
-  - 'db/'
-  - '**/spec/'
-  - 'benchmark/'
-  - 'docs/'
-  - '.rubocop.yml'
-  - '.rubocop_todo.yml'
+    enabled: false
+  rubocop:
+    enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ inherit_from: .rubocop_todo.yml
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-thread_safety
 
 AllCops:
   TargetRailsVersion: 6.0

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -7,16 +7,14 @@ desc 'shortcut to run all linting tools, at the same time.'
 task lint: :environment do
   require 'rainbow'
 
-  opts = '-r rubocop-thread_safety '
-
-  opts += if ENV['CI']
-            "-r rubocop/formatter/junit_formatter.rb \
+  opts = if ENV['CI']
+           "-r rubocop/formatter/junit_formatter.rb \
             --format RuboCop::Formatter::JUnitFormatter --out log/rubocop.xml \
             --format clang \
             --parallel"
-          else
-            '--display-cop-names --auto-correct'
-          end
+         else
+           '--display-cop-names --auto-correct'
+         end
 
   puts 'running rubocop...'
   rubocop_result = ShellCommand.run("rubocop #{opts} --color")


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
We already run rubocop through overcommit locally and as part of the CI process. The run on CodeClimate is duplicative *and* requires keeping up the version from a separate configuration which over time has drifter (v0.82 in code, v0.78 configured in CodeClimate config). 

Furthermore, the `rubocop-thread_safety` gem isn't well supported and has led to the situation where to make CodeClimate work, we've made it harder to run rubocop locally (without the -r flag to manually include the thread safety gem) *and* made it impossible to run our current configuration of `guard`.

This PR removes the duplicative plugins in CodeClimate in favor of running them in our CI environment.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Before:
```
vets-api (master) $ bundle exec rubocop
Error: unrecognized cop ThreadSafety/ClassAndModuleAttributes found in .rubocop_todo.yml, unrecognized cop ThreadSafety/InstanceVariableInClassMethod found in .rubocop_todo.yml, unrecognized cop ThreadSafety/NewThread found in .rubocop_todo.yml
```

and

```
vets-api (master) $ bundle exec guard
09:23:49 - INFO - Guard::RSpec is running
09:23:49 - INFO - Guard is now watching at '/Users/johnpaul/work/oddball/vets-api'
09:24:01 - INFO - Running: spec/controllers/application_controller_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 20018
............................

Finished in 1.88 seconds (files took 10.54 seconds to load)
28 examples, 0 failures

Randomized with seed 20018


09:24:14 - INFO - Inspecting Ruby code style: spec/controllers/application_controller_spec.rb
Error: unrecognized cop ThreadSafety/ClassAndModuleAttributes found in .rubocop_todo.yml, unrecognized cop ThreadSafety/InstanceVariableInClassMethod found in .rubocop_todo.yml, unrecognized cop ThreadSafety/NewThread found in .rubocop_todo.yml
```

After
```
vets-api (master) $ bundle exec rubocop
Inspecting 2384 files
.................................................................................2384 files inspected, no offenses detected
```

and

```
$ bundle exec guard
09:27:15 - INFO - Guard::RSpec is running
09:27:15 - INFO - Guard is now watching at '/Users/johnpaul/work/oddball/vets-api'
09:27:18 - INFO - Running: spec/controllers/application_controller_spec.rb

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 7202
............................

Finished in 1.81 seconds (files took 10.04 seconds to load)
28 examples, 0 failures

Randomized with seed 7202


09:27:30 - INFO - Inspecting Ruby code style: spec/controllers/application_controller_spec.rb
 1/1 file |===================================================== 100 =====================================================>| Time: 00:00:00

1 file inspected, no offenses detected
```
