### PR TITLE
Add backend tools engineers to flipper admin

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -454,6 +454,7 @@ flipper:
   admin_user_emails:
     - alastair@adhocteam.us
     - anna@adhoc.team
+    - bill.ryan@adhocteam.us
     - dan.hinze@adhocteam.us
     - delli-gatti_michael@bah.com
     - devinmccurdy@gmail.com
@@ -463,17 +464,20 @@ flipper:
     - jeff@adhocteam.us
     - johnny@oddball.io
     - johnpaul.ashenfelter@oddball.io
-    - kam@adhocteam.us
     - kabrown@thoughtworks.com
+    - kam@adhocteam.us
+    - keifer@oddball.io
     - kenneth.gary@va.gov
     - kmircovich@governmentcio.com
     - lauren.alexanderson@va.gov
+    - lindsey.hattamer@oddball.io
     - mark.greenburg@adhocteam.us
     - n.ratana@gmail.com
     - narin@adhocteam.us
     - osanchez@governmentcio.com
     - patrick@adhocteam.us
     - patrick.bateman@va.gov
+    - philip.becker@oddball.io
     - regarr@gmail.com # Robin Garrison - AdHoc
     - rian.fowler@adhoc.team
     - rianfowler@outlook.com


### PR DESCRIPTION
## Description of change
Add backend tools engineers as flipper admins.
