### PR TITLE
Remove vet verification on 10-10cg submissions. Update related specs.

### DIFF
--- a/app/services/form1010cg/service.rb
+++ b/app/services/form1010cg/service.rb
@@ -44,13 +44,11 @@ module Form1010cg
       )
     end
 
-    # Will raise an error unless the veteran specified on the claim's data (1) can be found in MVI, (2) has an ICN,
-    # and (3) has been confirmed as a legitimate veteran (via eMIS).
+    # Will raise an error unless the veteran specified on the claim's data can be found in MVI
     #
     # @return [nil]
     def assert_veteran_status
       raise_unprocessable if icn_for('veteran') == NOT_FOUND
-      raise_unprocessable unless is_veteran('veteran') == true
     end
 
     # Returns a metadata hash:
@@ -75,8 +73,8 @@ module Form1010cg
       end
 
       # Set the veteran status on the :veteran namespace of metadata
-      veteran_status = is_veteran('veteran')
-      metadata[:veteran][:is_veteran] = veteran_status == NOT_CONFIRMED ? nil : veteran_status
+      # Set as nil so CARMA knows we did not run a veteran verification on the veteran form subject
+      metadata[:veteran][:is_veteran] = nil
 
       metadata
     end

--- a/spec/request/caregivers_assistance_claims_request_spec.rb
+++ b/spec/request/caregivers_assistance_claims_request_spec.rb
@@ -88,12 +88,10 @@ RSpec.describe 'Caregivers Assistance Claims', type: :request do
         body = { caregivers_assistance_claim: { form: form_data.to_json } }.to_json
 
         VCR.use_cassette 'mvi/find_candidate/valid' do
-          VCR.use_cassette 'emis/get_veteran_status/valid' do
-            VCR.use_cassette 'mvi/find_candidate/valid_icn_ni_only' do
-              VCR.use_cassette 'mvi/find_candidate/valid_no_gender' do
-                VCR.use_cassette 'carma/submissions/create/201' do
-                  post endpoint, params: body, headers: headers
-                end
+          VCR.use_cassette 'mvi/find_candidate/valid_icn_ni_only' do
+            VCR.use_cassette 'mvi/find_candidate/valid_no_gender' do
+              VCR.use_cassette 'carma/submissions/create/201' do
+                post endpoint, params: body, headers: headers
               end
             end
           end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -145,21 +145,19 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
 
     it 'supports adding an caregiver\'s assistance claim' do
       VCR.use_cassette 'mvi/find_candidate/valid' do
-        VCR.use_cassette 'emis/get_veteran_status/valid' do
-          VCR.use_cassette 'mvi/find_candidate/valid_icn_ni_only' do
-            VCR.use_cassette 'mvi/find_candidate/valid_no_gender' do
-              VCR.use_cassette 'carma/submissions/create/201' do
-                expect(subject).to validate(
-                  :post,
-                  '/v0/caregivers_assistance_claims',
-                  200,
-                  '_data' => {
-                    'caregivers_assistance_claim' => {
-                      'form' => build(:caregivers_assistance_claim).form
-                    }
+        VCR.use_cassette 'mvi/find_candidate/valid_icn_ni_only' do
+          VCR.use_cassette 'mvi/find_candidate/valid_no_gender' do
+            VCR.use_cassette 'carma/submissions/create/201' do
+              expect(subject).to validate(
+                :post,
+                '/v0/caregivers_assistance_claims',
+                200,
+                '_data' => {
+                  'caregivers_assistance_claim' => {
+                    'form' => build(:caregivers_assistance_claim).form
                   }
-                )
-              end
+                }
+              )
             end
           end
         end

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -538,12 +538,12 @@ RSpec.describe Form1010cg::Service do
         expect(subject).to receive(:icn_for).with(form_subject).and_return(return_value)
       end
 
-      expect(subject).to receive(:is_veteran).with('veteran').and_return(true)
+      expect(subject).not_to receive(:is_veteran)
 
       expect(subject.build_metadata).to eq(
         veteran: {
           icn: :ICN_0,
-          is_veteran: true
+          is_veteran: nil
         },
         primaryCaregiver: {
           icn: :ICN_1
@@ -570,39 +570,9 @@ RSpec.describe Form1010cg::Service do
       end
     end
 
-    it 'will raise error if veteran\'s status can not be confirmed' do
+    it 'will not raise error if veteran\'s icn is found' do
       expect(subject).to receive(:icn_for).with('veteran').and_return(:ICN_123)
-      expect(subject).to receive(:is_veteran).with('veteran').and_return('NOT_CONFIRMED')
-
-      expect { subject.assert_veteran_status }.to raise_error do |e|
-        expect(e).to be_a(Common::Exceptions::ValidationErrors)
-        expect(e.errors.size).to eq(1)
-        expect(e.errors[0].code).to eq('100')
-        expect(e.errors[0].source[:pointer]).to eq('data/attributes/base')
-        expect(e.errors[0].detail).to eq('base - Unable to process submission digitally')
-        expect(e.errors[0].status).to eq('422')
-        expect(e.errors[0].title).to eq('Unable to process submission digitally')
-      end
-    end
-
-    it 'will raise an error if the veteran status is confirmed as false' do
-      expect(subject).to receive(:icn_for).with('veteran').and_return(:ICN_123)
-      expect(subject).to receive(:is_veteran).with('veteran').and_return(false)
-
-      expect { subject.assert_veteran_status }.to raise_error do |e|
-        expect(e).to be_a(Common::Exceptions::ValidationErrors)
-        expect(e.errors.size).to eq(1)
-        expect(e.errors[0].code).to eq('100')
-        expect(e.errors[0].source[:pointer]).to eq('data/attributes/base')
-        expect(e.errors[0].detail).to eq('base - Unable to process submission digitally')
-        expect(e.errors[0].status).to eq('422')
-        expect(e.errors[0].title).to eq('Unable to process submission digitally')
-      end
-    end
-
-    it 'will not raise error if veteran\'s icn is found and their veteran status is confirmed' do
-      expect(subject).to receive(:icn_for).with('veteran').and_return(:ICN_123)
-      expect(subject).to receive(:is_veteran).with('veteran').and_return(true)
+      expect(subject).not_to receive(:is_veteran)
 
       expect(subject.assert_veteran_status).to eq(nil)
     end


### PR DESCRIPTION
Resolves: https://github.com/department-of-veterans-affairs/va.gov-team/issues/9117

## Description of change
Remove the veteran verification on 10-10cg form submissions. Allow a submission to be submitted and flow to CARMA as long as the veteran on the form is in MPI.