### PR TITLE
Revise AppInfo to get ref from env

### DIFF
--- a/config/initializers/app_info.rb
+++ b/config/initializers/app_info.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module AppInfo
-  GIT_REVISION = Env.fetch('GIT_REVISION', 'ABC1234')
+  GIT_REVISION = ENV.fetch('GIT_REVISION', 'MISSING_GIT_REVISION')
   GITHUB_URL   = 'https://github.com/department-of-veterans-affairs/vets-api'
 end

--- a/config/initializers/app_info.rb
+++ b/config/initializers/app_info.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module AppInfo
-  GIT_REVISION = `git rev-parse HEAD`&.chomp
+  GIT_REVISION = ENV['GIT_REVISION']
   GITHUB_URL   = 'https://github.com/department-of-veterans-affairs/vets-api'
 end

--- a/config/initializers/app_info.rb
+++ b/config/initializers/app_info.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module AppInfo
-  GIT_REVISION = ENV['GIT_REVISION']
+  GIT_REVISION = Env.fetch('GIT_REVISION', 'ABC1234')
   GITHUB_URL   = 'https://github.com/department-of-veterans-affairs/vets-api'
 end


### PR DESCRIPTION
## Description of change

We used to have the current SHA of the release available in the initializer. This was broken when infra moved to Docker.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#9131

## Things to know about this PR
- Associated `devops` [pull request](https://github.com/department-of-veterans-affairs/devops/pull/6945)
