### PR TITLE
disable saml logout request signing

### DIFF
--- a/lib/saml/settings_service.rb
+++ b/lib/saml/settings_service.rb
@@ -104,13 +104,9 @@ module SAML
         settings.assertion_consumer_service_url = Settings.saml.callback_url
         settings.certificate_new = Settings.saml.certificate_new
 
-        settings.security[:authn_requests_signed] = if Settings.saml.authn_requests_signed.nil?
-                                                      true
-                                                    else
-                                                      Settings.saml.authn_requests_signed
-                                                    end
+        settings.security[:authn_requests_signed] = Settings.saml.authn_requests_signed
+        settings.security[:logout_requests_signed] = Settings.saml.authn_requests_signed
 
-        settings.security[:logout_requests_signed] = true
         settings.security[:embed_sign] = false
         settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA1
 


### PR DESCRIPTION
## Description of change
- Disables SAML logout request signing
  - Removes goofy / defensive if-else logic that existed just in case the setting was `nil`

## Original issue(s)
It came up in slack: https://dsva.slack.com/archives/CBU0KDSB1/p1589503609124800?thread_ts=1589487196.108100&cid=CBU0KDSB1

## Things to know about this PR
Re-uses an existing settings.yml setting (`Settings.saml. authn_requests_signed `) to also toggle the signing of saml logout requests.