### PR TITLE
Skip :verify_authenticity_token for 10-10CG Submissions

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -4,6 +4,7 @@ module V0
   # Application for the Program of Comprehensive Assistance for Family Caregivers (Form 10-10CG)
   class CaregiversAssistanceClaimsController < ApplicationController
     skip_before_action(:authenticate)
+    skip_before_action(:verify_authenticity_token)
 
     def create
       return service_unavailable unless Flipper.enabled?(:allow_online_10_10cg_submissions)


### PR DESCRIPTION
## Description of change
An attempt to fix `500` errors on staging for `POST v0/caregivers_assistance_claims`