### PR TITLE
return 403 status code for CSRF token violations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::API
   SKIP_SENTRY_EXCEPTION_TYPES = [
     Common::Exceptions::Unauthorized,
     Common::Exceptions::RoutingError,
-    Common::Exceptions::Forbidden,
+    # Common::Exceptions::Forbidden,
     Breakers::OutageException
   ].freeze
 
@@ -97,6 +97,9 @@ class ApplicationController < ActionController::API
       case exception
       when Pundit::NotAuthorizedError
         Common::Exceptions::Forbidden.new(detail: 'User does not have access to the requested resource')
+      when ActionController::InvalidAuthenticityToken
+        Common::Exceptions::Forbidden.new(detail: 'Invalid Authenticity Token')
+        # raise "THIS IS A TEST"
       when Common::Exceptions::TokenValidationError
         Common::Exceptions::Unauthorized.new(detail: exception.detail)
       when ActionController::ParameterMissing

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::API
   SKIP_SENTRY_EXCEPTION_TYPES = [
     Common::Exceptions::Unauthorized,
     Common::Exceptions::RoutingError,
-    # Common::Exceptions::Forbidden,
+    Common::Exceptions::Forbidden,
     Breakers::OutageException
   ].freeze
 
@@ -99,7 +99,6 @@ class ApplicationController < ActionController::API
         Common::Exceptions::Forbidden.new(detail: 'User does not have access to the requested resource')
       when ActionController::InvalidAuthenticityToken
         Common::Exceptions::Forbidden.new(detail: 'Invalid Authenticity Token')
-        # raise "THIS IS A TEST"
       when Common::Exceptions::TokenValidationError
         Common::Exceptions::Unauthorized.new(detail: exception.detail)
       when ActionController::ParameterMissing

--- a/spec/request/csrf_request_spec.rb
+++ b/spec/request/csrf_request_spec.rb
@@ -78,14 +78,14 @@ RSpec.describe 'CSRF scenarios', type: :request do
       context 'v0' do
         it 'does not raise an error' do
           post(auth_saml_callback_path)
-          expect(response.body).not_to match(/ActionController::InvalidAuthenticityToken/)
+          expect(response.body).not_to match(/Invalid Authenticity Token/)
         end
       end
 
       context 'v1' do
         it 'does not raise an error' do
           post(v1_sessions_callback_path)
-          expect(response.body).not_to match(/ActionController::InvalidAuthenticityToken/)
+          expect(response.body).not_to match(/Invalid Authenticity Token/)
         end
       end
     end
@@ -109,7 +109,7 @@ RSpec.describe 'CSRF scenarios', type: :request do
     it 'skips CSRF validation' do
       post path, params: data, headers: headers
       expect(response.status).to eq(200)
-      expect(response.body).not_to match(/ActionController::InvalidAuthenticityToken/)
+      expect(response.body).not_to match(/Invalid Authenticity Token/)
     end
   end
 end

--- a/spec/request/csrf_request_spec.rb
+++ b/spec/request/csrf_request_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe 'CSRF scenarios', type: :request do
         context 'without a CSRF token present' do
           it 'raises an exception' do
             send(verb, '/csrf_test')
-            expect(response.status).to eq 500
-            expect(response.body).to match(/ActionController::InvalidAuthenticityToken/)
+            expect(response.status).to eq 403
+            expect(response.body).to match(/Invalid Authenticity Token/)
           end
         end
 


### PR DESCRIPTION
## Description of change
CSRF violations are currently returning 500 errors to the frontend.
This changes that behavior to return a 403 Forbidden response instead.

Tested on a review instance to verify that `ActionController::InvalidAuthenticityToken` events will [still be visible in Sentry](http://sentry.vfs.va.gov/vets-gov/platform-api-development/issues/120619/).

Response includes messaging to indicate that an invalid authenticity token is the reason for the 403.
Sample response:
`{"errors":[{"title":"Forbidden","detail":"Invalid Authenticity Token","code":"403","status":"403"}]}`

## Original issue(s)
department-of-veterans-affairs/va.gov-team-sensitive#44
department-of-veterans-affairs/va.gov-team-sensitive#42
department-of-veterans-affairs/va.gov-team-sensitive#61

## Things to know about this PR
N/A

