### PR TITLE
Decision Reviews API - Anchor Area Code Regex

### DIFF
--- a/modules/appeals_api/config/schemas/200996.json
+++ b/modules/appeals_api/config/schemas/200996.json
@@ -137,7 +137,7 @@
       "type": "object",
       "properties": {
         "countryCode":     { "type": "string", "pattern": "^[0-9]+$" },
-        "areaCode":        { "type": "string", "pattern": "[2-9][0-9]{2}" },
+        "areaCode":        { "type": "string", "pattern": "^[2-9][0-9]{2}$" },
         "phoneNumber":     { "type": "string", "pattern": "^[0-9]{1,14}$" },
         "phoneNumberExt":  { "type": "string", "pattern": "^[a-zA-Z0-9]{1,10}$" }
       },


### PR DESCRIPTION
resolves https://vajira.max.gov/browse/API-935

forgot to anchor the area code regex with `^$`