### PR TITLE
Add patient info to profile

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,6 +107,14 @@ class User < Common::RedisStore
     identity.mhv_account_type || MhvAccountTypeService.new(self).mhv_account_type
   end
 
+  def mhv_account_state
+    return 'DEACTIVATED' if (va_profile.mhv_ids.to_a - va_profile.active_mhv_ids.to_a).any?
+    return 'MULTIPLE' if va_profile.active_mhv_ids.size > 1
+    return 'NONE' if mhv_correlation_id.blank?
+
+    'OK'
+  end
+
   def loa
     identity&.loa || {}
   end

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -72,9 +72,7 @@ module Users
         multifactor: user.multifactor,
         verified: user.loa3?,
         sign_in: user.identity.sign_in,
-        authn_context: user.authn_context,
-        va_patient: user.va_patient?,
-        mhv_account_state: user.mhv_account_state
+        authn_context: user.authn_context
       }
     end
 
@@ -109,7 +107,9 @@ module Users
           gender: user.va_profile.gender,
           given_names: user.va_profile.given_names,
           is_cerner_patient: !user.va_profile.cerner_id.nil?,
-          facilities: user.va_treatment_facility_ids.map { |id| facility(id) }
+          facilities: user.va_treatment_facility_ids.map { |id| facility(id) },
+          va_patient: user.va_patient?,
+          mhv_account_state: user.mhv_account_state
         }
       else
         scaffold.errors << Users::ExceptionHandler.new(user.va_profile_error, 'MVI').serialize_error

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -72,7 +72,9 @@ module Users
         multifactor: user.multifactor,
         verified: user.loa3?,
         sign_in: user.identity.sign_in,
-        authn_context: user.authn_context
+        authn_context: user.authn_context,
+        va_patient: user.va_patient?,
+        mhv_account_state: user.mhv_account_state
       }
     end
 

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -61,6 +61,56 @@ RSpec.describe 'Fetching user data', type: :request do
       expect(va_profile['facilities']).to match_array([{ 'facility_id' => '358', 'is_cerner' => false }])
     end
 
+    it 'returns patient status' do
+      va_profile = JSON.parse(response.body)['data']['attributes']['va_profile']
+      expect(va_profile['va_patient']).to be true
+    end
+
+    it 'returns mhv account state info' do
+      va_profile = JSON.parse(response.body)['data']['attributes']['va_profile']
+      expect(va_profile['mhv_account_state']).to eq('OK')
+    end
+
+    context 'with deactivated MHV account' do
+      let(:mvi_profile) do
+        build(:mvi_profile,
+              mhv_ids: %w[12345 67890],
+              active_mhv_ids: ['12345'])
+      end
+      let(:mhv_user) { build(:user, :mhv) }
+
+      before do
+        stub_mvi(mvi_profile)
+        sign_in_as(mhv_user)
+        get v0_user_url, params: nil
+      end
+
+      it 'returns deactivated mhv account state info' do
+        va_profile = JSON.parse(response.body)['data']['attributes']['va_profile']
+        expect(va_profile['mhv_account_state']).to eq('DEACTIVATED')
+      end
+    end
+
+    context 'with multiple MHV accounts' do
+      let(:mvi_profile) do
+        build(:mvi_profile,
+              mhv_ids: %w[12345 67890],
+              active_mhv_ids: %w[12345 67890])
+      end
+      let(:mhv_user) { build(:user, :mhv) }
+
+      before do
+        stub_mvi(mvi_profile)
+        sign_in_as(mhv_user)
+        get v0_user_url, params: nil
+      end
+
+      it 'returns multiple mhv account state' do
+        va_profile = JSON.parse(response.body)['data']['attributes']['va_profile']
+        expect(va_profile['mhv_account_state']).to eq('MULTIPLE')
+      end
+    end
+
     context 'with an error from a 503 raised by Vet360::ContactInformation::Service#get_person', skip_vet360: true do
       before do
         exception  = 'the server responded with status 503'

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -111,6 +111,20 @@ RSpec.describe 'Fetching user data', type: :request do
       end
     end
 
+    context 'for non VA patient' do
+      let(:mhv_user) { build(:user, :mhv, va_patient: false) }
+
+      before do
+        sign_in_as(mhv_user)
+        get v0_user_url, params: nil
+      end
+
+      it 'returns patient status correctly' do
+        va_profile = JSON.parse(response.body)['data']['attributes']['va_profile']
+        expect(va_profile['va_patient']).to be false
+      end
+    end
+
     context 'with an error from a 503 raised by Vet360::ContactInformation::Service#get_person', skip_vet360: true do
       before do
         exception  = 'the server responded with status 503'

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -96,7 +96,9 @@
                     "gender": { "type": "string" },
                     "is_cerner_patient": { "type": "boolean" },
                     "facilities": { "type": "array" },
-                    "given_names": { "type": "array" }
+                    "given_names": { "type": "array" },
+                    "va_patient": { "type": "boolean" },
+                    "mhv_account_state": { "type": "string" }
                   }
                 }
               ]


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Provides indicators for conditions around MHV access eligibility in the user profile:
- va_patient - whether the user has registered identifiers at any VA treating facility
- mhv_account_state - whether the user has correlated MHV account identifiers in their MVI profile.

These are used by the frontend to gate access to MHV, in conjunction with https://github.com/department-of-veterans-affairs/vets-website/pull/12624. That PR eliminates the calls to create/upgrade MHV accounts when SSOe is used, in favor of sending the user to MHV to register/upgrade their account there. 

Eventually, these new profile attributes can replace the separate call to the mhv_account API endpoint, and all the complexity of tracking mhv account state can be eliminated. vets-api will do some basic eligibility/soundness checks, and then send the user to MHV to modify their account if needed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#8405

## Things to know about this PR
No config changes/feature flags. This is using/aggregating some existing data from MVI. 


