### PR TITLE
Downgrade simplecov to < 0.18 due to bug with reporting to CodeClimate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,7 +134,7 @@ group :test do
   gem 'rspec_junit_formatter'
   gem 'rubocop-junit-formatter'
   gem 'shrine-memory'
-  gem 'simplecov', require: false
+  gem 'simplecov', '< 0.18', require: false
   gem 'super_diff'
   gem 'vcr'
   gem 'webrick'

--- a/Gemfile
+++ b/Gemfile
@@ -134,6 +134,8 @@ group :test do
   gem 'rspec_junit_formatter'
   gem 'rubocop-junit-formatter'
   gem 'shrine-memory'
+  # < 0.18 required due to bug with reporting to CodeClimate
+  # https://github.com/codeclimate/test-reporter/issues/418
   gem 'simplecov', '< 0.18', require: false
   gem 'super_diff'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -706,10 +706,11 @@ GEM
       sidekiq (>= 3)
       thwait
       tilt (>= 1.4.0)
-    simplecov (0.18.5)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     socksify (1.7.1)
     spring (2.1.0)
     spring-commands-rspec (1.0.4)
@@ -904,7 +905,7 @@ DEPENDENCIES
   sidekiq-ent!
   sidekiq-pro!
   sidekiq-scheduler (~> 3.0)
-  simplecov
+  simplecov (< 0.18)
   socksify
   spring
   spring-commands-rspec


### PR DESCRIPTION
## Description of change
Downgrade simplecov to < 0.18 due to bug with reporting to CodeClimate
https://github.com/codeclimate/test-reporter/issues/418

With `simplecov` v0.18:
```
[2020-05-19T22:12:14.445Z] Finished in 9 minutes 6 seconds (files took 13.95 seconds to load)
[2020-05-19T22:12:14.445Z] 5593 examples, 0 failures, 8 pending
[2020-05-19T22:12:14.699Z] 
[2020-05-19T22:12:14.699Z] Randomized with seed 7883
[2020-05-19T22:12:14.699Z] 
[2020-05-19T22:12:17.952Z] Coverage report generated for RSpec to /srv/vets-api/src/coverage. 32767 / 33066 LOC (99.1%) covered.
[2020-05-19T22:12:17.952Z] reporting coverage to CodeClimate
[2020-05-19T22:12:17.952Z] Error: json: cannot unmarshal object into Go struct field input.coverage of type []formatters.NullInt
[2020-05-19T22:12:17.952Z] Usage:
[2020-05-19T22:12:17.952Z]   cc-test-reporter after-build [flags]
[2020-05-19T22:12:17.952Z] 
[2020-05-19T22:12:17.952Z] Flags:
[2020-05-19T22:12:17.952Z]   -s, --batch-size int               batch size for source files (default 500)
[2020-05-19T22:12:17.952Z]   -e, --coverage-endpoint string     endpoint to upload coverage information to (default "https://api.codeclimate.com/v1/test_reports")
[2020-05-19T22:12:17.952Z]   -t, --coverage-input-type string   type of input source to use [clover, cobertura, coverage.py, excoveralls, gcov, gocov, jacoco, lcov, simplecov, xccov]
[2020-05-19T22:12:17.952Z]       --exit-code int                exit code of the test run
[2020-05-19T22:12:17.952Z]   -r, --id string                    reporter identifier (default "0c396adc254b0317e2c3a89a1c929fd61270b133c944d3e9c0f13b3937a7ce45")
[2020-05-19T22:12:17.952Z]       --insecure                     send coverage insecurely (without HTTPS)
[2020-05-19T22:12:17.952Z]   -p, --prefix string                the root directory where the coverage analysis was performed (default "/srv/vets-api/src")
[2020-05-19T22:12:17.952Z] 
[2020-05-19T22:12:17.952Z] Global Flags:
[2020-05-19T22:12:17.952Z]   -d, --debug   run in debug mode
```
With `simplecov` v0.17
```
[2020-05-20T00:12:10.510Z] Finished in 8 minutes 43 seconds (files took 13.62 seconds to load)
[2020-05-20T00:12:10.510Z] 5593 examples, 0 failures, 8 pending
[2020-05-20T00:12:10.510Z] 
[2020-05-20T00:12:10.510Z] Randomized with seed 11991
[2020-05-20T00:12:10.510Z] 
[2020-05-20T00:12:13.761Z] Coverage report generated for RSpec to /srv/vets-api/src/coverage. 32766 / 33065 LOC (99.1%) covered.
[2020-05-20T00:12:13.761Z] reporting coverage to CodeClimate
[2020-05-20T00:12:17.013Z] Test report uploaded successfully to Code Climate
```

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
