### PR TITLE
Additional redirect parameter 

### DIFF
--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -56,7 +56,7 @@ module SAML
       if auth == 'success'
         return verify_url if user.loa[:current] < user.loa[:highest]
 
-        redirect_target = build_tracked_url
+        redirect_target = @tracker&.payload_attr(:redirect)
         return redirect_target if redirect_target.present?
       end
 
@@ -71,16 +71,6 @@ module SAML
       end
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-
-    def build_tracked_url
-      return nil unless @tracker&.payload_attr(:redirect)
-
-      prefix = @tracker&.payload_attr(:redirect)
-      prefix = prefix.delete_suffix('/')
-      suffix = @tracker&.payload_attr(:to) || ''
-      suffix = suffix.delete_prefix('/').gsub('\r\n', '')
-      [prefix, suffix].join('/')
-    end
 
     def logout_redirect_url
       "#{base_redirect_url}#{LOGOUT_REDIRECT_PARTIAL}"
@@ -202,17 +192,26 @@ module SAML
       end
     end
 
+    def build_redirect(params)
+      default = Settings.ssoe.redirects[params[:application]]
+      return default unless default && params[:to]
+
+      Rails.logger.info("PV: redirect to param is #{params[:to]}")
+      prefix = default.delete_suffix('/')
+      suffix = params[:to].delete_prefix('/').gsub("\r\n", '')
+      [prefix, suffix].join('/')
+    end
+
     # Initialize a new SAMLRequestTracker, if a valid previous SAML UUID is
     # given, copy over the redirect and created_at timestamp.  This is useful
     # for a user that has to go through the upleveling process.
     def initialize_tracker(params, previous_saml_uuid: nil)
       previous = previous_saml_uuid && SAMLRequestTracker.find(previous_saml_uuid)
-      redirect = previous&.payload_attr(:redirect) || Settings.ssoe.redirects[params[:application]]
-      to = previous&.payload_attr(:to) || params[:to]
+      redirect = previous&.payload_attr(:redirect) || build_redirect(params)
       # if created_at is set to nil (meaning no previous tracker to use), it
       # will be initialized to the current time when it is saved
       SAMLRequestTracker.new(
-        payload: redirect ? { redirect: redirect, to: to } : {},
+        payload: redirect ? { redirect: redirect } : {},
         created_at: previous&.created_at
       )
     end

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -53,11 +53,12 @@ module SAML
 
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def login_redirect_url(auth: 'success', code: nil)
-      return verify_url if auth == 'success' && user.loa[:current] < user.loa[:highest]
+      if auth == 'success'
+        return verify_url if user.loa[:current] < user.loa[:highest]
 
-      return @tracker&.payload_attr(:redirect) if @tracker&.payload_attr(:redirect)
-      redirect_target = build_tracked_url
-      return redirect_target if redirect_target.present?
+        redirect_target = build_tracked_url
+        return redirect_target if redirect_target.present?
+      end
 
       @query_params[:type] = type if type
       @query_params[:auth] = auth if auth == 'fail'
@@ -73,11 +74,12 @@ module SAML
 
     def build_tracked_url
       return nil unless @tracker&.payload_attr(:redirect)
+
       prefix = @tracker&.payload_attr(:redirect)
-      prefix = result.delete_suffix('/')
+      prefix = prefix.delete_suffix('/')
       suffix = @tracker&.payload_attr(:to) || ''
-      suffix = suffix.delete_prefix('/').gsub('\r\n','')
-      return [prefix,suffix].join('/')
+      suffix = suffix.delete_prefix('/').gsub('\r\n', '')
+      [prefix, suffix].join('/')
     end
 
     def logout_redirect_url
@@ -210,7 +212,7 @@ module SAML
       # if created_at is set to nil (meaning no previous tracker to use), it
       # will be initialized to the current time when it is saved
       SAMLRequestTracker.new(
-        payload: redirect ? { redirect: redirect, to: to} : {},
+        payload: redirect ? { redirect: redirect, to: to } : {},
         created_at: previous&.created_at
       )
     end

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -196,7 +196,6 @@ module SAML
       default = Settings.ssoe.redirects[params[:application]]
       return default unless default && params[:to]
 
-      Rails.logger.info("PV: redirect to param is #{params[:to]}")
       prefix = default.delete_suffix('/')
       suffix = params[:to].delete_prefix('/').gsub("\r\n", '')
       [prefix, suffix].join('/')

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -160,6 +160,63 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .to eq({ redirect: 'https://ehrm-va-test.patientportal.us.healtheintent.com/' })
             end
 
+            it 'adds to parameter to application redirect' do
+              expect do
+                get(:new, params: { type: type, clientId: '123123',
+                                    application: 'myvahealth', to: '/session-api/realm/realm_uuid' })
+              end
+                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
+                                             tags: ["context:#{type}", 'version:v1'], **once)
+
+              expect(response).to have_http_status(:found)
+              expect(response.location)
+                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
+                .with_relay_state('originating_request_id' => nil, 'type' => type)
+                .with_params('clientId' => '123123')
+              expect(SAMLRequestTracker.keys.length).to eq(1)
+              expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload)
+                .to eq({ redirect: 'https://ehrm-va-test.patientportal.us.healtheintent.com'\
+                        + '/session-api/realm/realm_uuid' })
+            end
+
+            it 'allows nested to parameter' do
+              expect do
+                get(:new, params: { type: type, clientId: '123123',
+                                    application: 'myvahealth',
+                                    to: '/session-api/realm/realm_uuid?to=https://ehrm.example.com' })
+              end
+                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
+                                             tags: ["context:#{type}", 'version:v1'], **once)
+
+              expect(response).to have_http_status(:found)
+              expect(response.location)
+                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
+                .with_relay_state('originating_request_id' => nil, 'type' => type)
+                .with_params('clientId' => '123123')
+              expect(SAMLRequestTracker.keys.length).to eq(1)
+              expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload)
+                .to eq({ redirect: 'https://ehrm-va-test.patientportal.us.healtheintent.com'\
+                        + '/session-api/realm/realm_uuid?to=https://ehrm.example.com' })
+            end
+
+            it 'strips CRLF characters from to parameter' do
+              expect do
+                get(:new, params: { type: type, clientId: '123123',
+                                    application: 'myvahealth', to: CGI.unescape('/foo/bar%0D%0ASplitHeader') })
+              end
+                .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
+                                             tags: ["context:#{type}", 'version:v1'], **once)
+
+              expect(response).to have_http_status(:found)
+              expect(response.location)
+                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
+                .with_relay_state('originating_request_id' => nil, 'type' => type)
+                .with_params('clientId' => '123123')
+              expect(SAMLRequestTracker.keys.length).to eq(1)
+              expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload)
+                .to eq({ redirect: 'https://ehrm-va-test.patientportal.us.healtheintent.com/foo/barSplitHeader' })
+            end
+
             it 'ignores invalid redirect application' do
               expect { get(:new, params: { type: type, clientId: '123123', application: 'unknown' }) }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,


### PR DESCRIPTION

## Description of change
Adds support for an additional parameter `to` that can be specified along with `application` in the signin process. The to parameter is intended as a relative path that gets tacked on to the redirect URL derived from `application`, to construct a complete redirect URL. 



## Original issue(s)
department-of-veterans-affairs/va.gov-team#8587

## Things to know about this PR
No feature flags or additional settings.

Allowing our system to redirect based on user input presents some risk, as described in https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html

We mitigate  this by:
- Not letting the caller specify the entire URL, but only the path part - the base URL/domain is derived from the `application` parameter whose configuration we control.
- Ensuring that we join the base URL and `to` parameter with a `/` to avoid domain extension
- Stripping any CRLF characters to avoid header splitting attacks.



<!-- Please describe testing done to verify the changes or any testing planned. -->
