### PR TITLE
Updated disability-rating yml documentation for response type.

### DIFF
--- a/modules/veteran_verification/VETERAN_VERIFICATION.yml
+++ b/modules/veteran_verification/VETERAN_VERIFICATION.yml
@@ -175,7 +175,7 @@ components:
         type:
           description: JSON API type specification
           type: string
-          example: 'document_upload'
+          example: 'disability-rating'
         attributes:
           $ref: '#/components/schemas/DisabilityRatingAttributes'
     DisabilityRatingAttributes:


### PR DESCRIPTION
Minor update to correct documentation yml return type of the disability rating endpoint.

## Original issue(s)
https://vajira.max.gov/browse/API-661

![disability-rating-correction](https://user-images.githubusercontent.com/43859081/82454709-152d4080-9a80-11ea-9af8-bdbbdcb126c9.PNG)
