### PR TITLE
Validating JSON object instead of JSON content

### DIFF
--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -107,9 +107,9 @@ module VBADocuments
         raise VBADocuments::UploadError.new(code: 'DOC102',
                                             detail: 'Non-numeric or invalid-length fileNumber')
       end
-    rescue JSON::ParserError
+    rescue JSON::ParserError, NoMethodError
       raise VBADocuments::UploadError.new(code: 'DOC102',
-                                          detail: 'Invalid JSON content')
+                                          detail: 'Invalid JSON object')
     end
 
     def perfect_metadata(parts, timestamp)

--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -93,23 +93,22 @@ module VBADocuments
 
     def validate_metadata(metadata_input)
       metadata = JSON.parse(metadata_input)
+      raise VBADocuments::UploadError.new(code: 'DOC102', detail: 'Invalid JSON object') unless metadata.is_a?(Hash)
+
       missing_keys = REQUIRED_KEYS - metadata.keys
       if missing_keys.present?
-        raise VBADocuments::UploadError.new(code: 'DOC102',
-                                            detail: "Missing required keys: #{missing_keys.join(',')}")
+        raise VBADocuments::UploadError.new(code: 'DOC102', detail: "Missing required keys: #{missing_keys.join(',')}")
       end
-      non_string_vals = REQUIRED_KEYS.reject { |k| metadata[k].is_a? String }
-      if non_string_vals.present?
-        raise VBADocuments::UploadError.new(code: 'DOC102',
-                                            detail: "Non-string values for keys: #{non_string_vals.join(',')}")
+
+      rejected = REQUIRED_KEYS.reject { |k| metadata[k].is_a? String }
+      if rejected.present?
+        raise VBADocuments::UploadError.new(code: 'DOC102', detail: "Non-string values for keys: #{rejected.join(',')}")
       end
       if (FILE_NUMBER_REGEX =~ metadata['fileNumber']).nil?
-        raise VBADocuments::UploadError.new(code: 'DOC102',
-                                            detail: 'Non-numeric or invalid-length fileNumber')
+        raise VBADocuments::UploadError.new(code: 'DOC102', detail: 'Non-numeric or invalid-length fileNumber')
       end
-    rescue JSON::ParserError, NoMethodError
-      raise VBADocuments::UploadError.new(code: 'DOC102',
-                                          detail: 'Invalid JSON object')
+    rescue JSON::ParserError
+      raise VBADocuments::UploadError.new(code: 'DOC102', detail: 'Invalid JSON object')
     end
 
     def perfect_metadata(parts, timestamp)

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
 
     it 'sets error status for parsable JSON metadata but not an object' do
       allow(VBADocuments::MultipartParser).to receive(:parse) {
-        { 'metadata' => [valid_doc], 'content' => valid_doc }
+        { 'metadata' => [], 'content' => valid_doc }
       }
       described_class.new.perform(upload.guid)
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -133,6 +133,16 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       expect(updated.code).to eq('DOC102')
     end
 
+    it 'sets error status for parsable JSON metadata but not an object' do
+      allow(VBADocuments::MultipartParser).to receive(:parse) {
+        { 'metadata' => [valid_doc], 'content' => valid_doc }
+      }
+      described_class.new.perform(upload.guid)
+      updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
+      expect(updated.status).to eq('error')
+      expect(updated.code).to eq('DOC102')
+    end
+
     it 'sets error status for too-short fileNumber metadata' do
       md = JSON.parse(valid_metadata)
       md['fileNumber'] = '123456'

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
       expect(updated.status).to eq('error')
       expect(updated.code).to eq('DOC102')
+      expect(updated.detail).to eq('Incorrect content-type for metdata part')
     end
 
     it 'sets error status for unparseable JSON metadata part' do
@@ -131,6 +132,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
       expect(updated.status).to eq('error')
       expect(updated.code).to eq('DOC102')
+      expect(updated.detail).to eq('Invalid JSON object')
     end
 
     it 'sets error status for parsable JSON metadata but not an object' do
@@ -141,6 +143,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
       expect(updated.status).to eq('error')
       expect(updated.code).to eq('DOC102')
+      expect(updated.detail).to eq('Incorrect content-type for metdata part')
     end
 
     it 'sets error status for too-short fileNumber metadata' do
@@ -153,6 +156,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
       expect(updated.status).to eq('error')
       expect(updated.code).to eq('DOC102')
+      expect(updated.detail).to eq('Non-numeric or invalid-length fileNumber')
     end
 
     it 'sets error status for too-long fileNumber metadata' do
@@ -165,6 +169,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
       expect(updated.status).to eq('error')
       expect(updated.code).to eq('DOC102')
+      expect(updated.detail).to eq('Non-numeric or invalid-length fileNumber')
     end
 
     it 'sets error status for non-numeric fileNumber metadata' do
@@ -177,6 +182,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
       expect(updated.status).to eq('error')
       expect(updated.code).to eq('DOC102')
+      expect(updated.detail).to eq('Non-numeric or invalid-length fileNumber')
     end
 
     it 'sets error status for dashes in fileNumber metadata' do
@@ -189,6 +195,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
       expect(updated.status).to eq('error')
       expect(updated.code).to eq('DOC102')
+      expect(updated.detail).to eq('Non-numeric or invalid-length fileNumber')
     end
 
     it 'sets error status for non-PDF document parts' do
@@ -217,6 +224,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
       expect(updated.status).to eq('error')
       expect(updated.code).to eq('DOC102')
+      expect(updated.detail).to eq('Missing required keys: fileNumber')
     end
 
     it 'sets error status for out-of-spec JSON metadata' do
@@ -225,6 +233,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
       expect(updated.status).to eq('error')
       expect(updated.code).to eq('DOC102')
+      expect(updated.detail).to eq('Non-string values for keys: fileNumber')
     end
 
     it 'sets error status for missing metadata part' do
@@ -235,6 +244,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
       expect(updated.status).to eq('error')
       expect(updated.code).to eq('DOC102')
+      expect(updated.detail).to eq('No metadata part present')
     end
 
     it 'sets error status for missing document part' do

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -137,13 +137,13 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
 
     it 'sets error status for parsable JSON metadata but not an object' do
       allow(VBADocuments::MultipartParser).to receive(:parse) {
-        { 'metadata' => [], 'content' => valid_doc }
+        { 'metadata' => [valid_metadata].to_json, 'content' => valid_doc }
       }
       described_class.new.perform(upload.guid)
       updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
       expect(updated.status).to eq('error')
       expect(updated.code).to eq('DOC102')
-      expect(updated.detail).to eq('Incorrect content-type for metdata part')
+      expect(updated.detail).to eq('Invalid JSON object')
     end
 
     it 'sets error status for too-short fileNumber metadata' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
One of our consumers sent us an array of json objects instead of just an actual json object which we never validated against so this PR fixes that and ensures we fail invalid non json objects for metadat in the future.

## Original issue(s)
https://vajira.max.gov/browse/API-946

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
