### PR TITLE
Appeals API - Pull Our Settings Out of `decision_review`

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -133,9 +133,12 @@ mdot:
 # Settings for Decision Reviews
 decision_review:
   prefill: true
-  url: https://sandbox-api.va.gov/services/appeals/v3/decision_review
+  url: https://sandbox-api.va.gov/services/appeals/v1/decision_review
   api_key: abcd1234abcd1234abcd1234abcd1234abcd1234
   mock: false
+
+# Settings for modules/appeals_api
+modules_appeals_api:
   higher_level_review_updater_enabled: true
   schema_dir: config/schemas
 

--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_upload_status_batch.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_upload_status_batch.rb
@@ -29,7 +29,7 @@ module AppealsApi
     end
 
     def enabled?
-      Settings.decision_review.higher_level_review_updater_enabled
+      Settings.modules_appeals_api.higher_level_review_updater_enabled
     end
   end
 end

--- a/modules/appeals_api/lib/appeals_api/form_schemas.rb
+++ b/modules/appeals_api/lib/appeals_api/form_schemas.rb
@@ -5,7 +5,7 @@ require 'json_schema/form_schemas'
 module AppealsApi
   class FormSchemas < JsonSchema::FormSchemas
     def base_dir
-      Rails.root.join('modules', 'appeals_api', Settings.decision_review.schema_dir)
+      Rails.root.join('modules', 'appeals_api', Settings.modules_appeals_api.schema_dir)
     end
   end
 end

--- a/modules/appeals_api/spec/workers/higher_level_review_upload_status_batch_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_upload_status_batch_spec.rb
@@ -21,7 +21,7 @@ describe AppealsApi::HigherLevelReviewUploadStatusBatch, type: :job do
       in_process_element[0]['uuid'] = upload.id
       expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
 
-      with_settings(Settings.decision_review, higher_level_review_updater_enabled: true) do
+      with_settings(Settings.modules_appeals_api, higher_level_review_updater_enabled: true) do
         Sidekiq::Testing.inline! { AppealsApi::HigherLevelReviewUploadStatusBatch.new.perform }
         upload.reload
         expect(upload.status).to eq('processing')

--- a/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
@@ -21,7 +21,7 @@ describe AppealsApi::HigherLevelReviewUploadStatusUpdater, type: :job do
       in_process_element[0]['uuid'] = upload.id
       expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
 
-      with_settings(Settings.decision_review, higher_level_review_updater_enabled: true) do
+      with_settings(Settings.modules_appeals_api, higher_level_review_updater_enabled: true) do
         AppealsApi::HigherLevelReviewUploadStatusUpdater.new.perform([upload])
         upload.reload
         expect(upload.status).to eq('processing')

--- a/spec/support/vcr_cassettes/decision_review/200_contestable_issues.yml
+++ b/spec/support/vcr_cassettes/decision_review/200_contestable_issues.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/contestable_issues
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/contestable_issues
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/decision_review/200_intake_status.yml
+++ b/spec/support/vcr_cassettes/decision_review/200_intake_status.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/intake_statuses/1234567890
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/intake_statuses/1234567890
     body:
       encoding: UTF-8
       string: ''

--- a/spec/support/vcr_cassettes/decision_review/200_review.yml
+++ b/spec/support/vcr_cassettes/decision_review/200_review.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews/4bc96bee-c6a3-470e-b222-66a47629dc20
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews/4bc96bee-c6a3-470e-b222-66a47629dc20
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/decision_review/202_intake_status.yml
+++ b/spec/support/vcr_cassettes/decision_review/202_intake_status.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews
     body:
       encoding: UTF-8
       string: '{"data":{"type":"HigherLevelReview","attributes":{"receiptDate":"2019-07-10","informalConference":true,"sameOffice":false,"legacyOptInApproved":true,"benefitType":"compensation"},"relationships":{"veteran":{"data":{"type":"Veteran","id":"888451301"}}}},"included":[{"type":"RequestIssue","attributes":{"decisionIssueId":2}}]}'

--- a/spec/support/vcr_cassettes/decision_review/202_review.yml
+++ b/spec/support/vcr_cassettes/decision_review/202_review.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews
     body:
       encoding: UTF-8
       string: '{"data":{"type":"HigherLevelReview","attributes":{"receiptDate":"2019-07-10","informalConference":true,"sameOffice":false,"legacyOptInApproved":true,"benefitType":"compensation"},"relationships":{"veteran":{"data":{"type":"Veteran","id":"888451301"}}}},"included":[{"type":"RequestIssue","attributes":{"decisionIssueId":2}}]}'

--- a/spec/support/vcr_cassettes/decision_review/303_intake_status.yml
+++ b/spec/support/vcr_cassettes/decision_review/303_intake_status.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/intake_statuses/1234567890
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/intake_statuses/1234567890
     body:
       encoding: UTF-8
       string: ''
@@ -46,7 +46,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Location:
-      - https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews/1234567890
+      - https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews/1234567890
     body:
       encoding: ASCII-8BIT
       string: '{"data":{"type":"HigherLevelReview","id":"944f2578-8eca-4f43-9570-69d0807367ef","attributes":{"status":"processed"}}}'

--- a/spec/support/vcr_cassettes/decision_review/400_contestable_issues.yml
+++ b/spec/support/vcr_cassettes/decision_review/400_contestable_issues.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/contestable_issues
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/contestable_issues
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/decision_review/400_intake_status.yml
+++ b/spec/support/vcr_cassettes/decision_review/400_intake_status.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews
     body:
       encoding: UTF-8
       string: "{}"

--- a/spec/support/vcr_cassettes/decision_review/400_review.yml
+++ b/spec/support/vcr_cassettes/decision_review/400_review.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews
     body:
       encoding: UTF-8
       string: "{}"

--- a/spec/support/vcr_cassettes/decision_review/403_intake_status.yml
+++ b/spec/support/vcr_cassettes/decision_review/403_intake_status.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews
     body:
       encoding: UTF-8
       string: '{"data":{"type":"HigherLevelReview","attributes":{"receiptDate":"2019-07-10","informalConference":true,"sameOffice":false,"legacyOptInApproved":true,"benefitType":"compensation"},"relationships":{"veteran":{"data":{"type":"Veteran","id":"00000000"}}}},"included":[{"type":"RequestIssue","attributes":{"decisionIssueId":2}}]}'

--- a/spec/support/vcr_cassettes/decision_review/404_contestable_issues.yml
+++ b/spec/support/vcr_cassettes/decision_review/404_contestable_issues.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/contestable_issues
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/contestable_issues
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/decision_review/404_get_intake_status.yml
+++ b/spec/support/vcr_cassettes/decision_review/404_get_intake_status.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/intake_statuses/1234
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/intake_statuses/1234
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/decision_review/404_intake_status.yml
+++ b/spec/support/vcr_cassettes/decision_review/404_intake_status.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews
     body:
       encoding: UTF-8
       string: '{"data":{"type":"HigherLevelReview","attributes":{"receiptDate":"2019-07-10","informalConference":true,"sameOffice":false,"legacyOptInApproved":true,"benefitType":"compensation"},"relationships":{"veteran":{"data":{"type":"Veteran","id":"00000000"}}}},"included":[{"type":"RequestIssue","attributes":{"decisionIssueId":2}}]}'

--- a/spec/support/vcr_cassettes/decision_review/404_review.yml
+++ b/spec/support/vcr_cassettes/decision_review/404_review.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews/1234
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews/1234
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/decision_review/409_intake_status.yml
+++ b/spec/support/vcr_cassettes/decision_review/409_intake_status.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews
     body:
       encoding: UTF-8
       string: '{"data":{"type":"HigherLevelReview","attributes":{"receiptDate":"2019-07-10","informalConference":true,"sameOffice":false,"legacyOptInApproved":true,"benefitType":"compensation"},"relationships":{"veteran":{"data":{"type":"Veteran","id":"00000000"}}}},"included":[{"type":"RequestIssue","attributes":{"decisionIssueId":2}}]}'

--- a/spec/support/vcr_cassettes/decision_review/422_contestable_issues.yml
+++ b/spec/support/vcr_cassettes/decision_review/422_contestable_issues.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/contestable_issues
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/contestable_issues
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/decision_review/422_intake_status.yml
+++ b/spec/support/vcr_cassettes/decision_review/422_intake_status.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews
     body:
       encoding: UTF-8
       string: '{"data":{"type":"HigherLevelReview","attributes":{"receiptDate":"2019-07-10","informalConference":true,"sameOffice":false,"legacyOptInApproved":true,"benefitType":"compensation"},"relationships":{"veteran":{"data":{"type":"Veteran","id":"00000000"}}}},"included":[{"type":"RequestIssue","attributes":{"decisionIssueId":2}}]}'

--- a/spec/support/vcr_cassettes/decision_review/502_contestable_issues.yml
+++ b/spec/support/vcr_cassettes/decision_review/502_contestable_issues.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/contestable_issues
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/contestable_issues
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/decision_review/502_intake_status.yml
+++ b/spec/support/vcr_cassettes/decision_review/502_intake_status.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/intake_statuses/1234
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/intake_statuses/1234
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/decision_review/502_review.yml
+++ b/spec/support/vcr_cassettes/decision_review/502_review.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/appeals/v3/decision_review/higher_level_reviews/1234
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_review/higher_level_reviews/1234
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
This comment https://github.com/department-of-veterans-affairs/vets-api/pull/4293#discussion_r427291436
prompted me to look at `lib/decision_review` and realize that, at some point, we started putting our settings under `decision_review` ***which is not owned by the Lighthouse Appeals API team***. My best guess is that the va.gov front-end team (which will eventually be consuming the Appeals API) owns `decision_review` in `settings.yml`
