### PR TITLE
Only call EVSS - PCIU endpoints for LOA3 users with an edipi

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,15 +47,15 @@ class User < Common::RedisStore
   end
 
   def pciu_email
-    pciu.get_email_address.email
+    pciu&.get_email_address&.email
   end
 
   def pciu_primary_phone
-    pciu.get_primary_phone.to_s
+    pciu&.get_primary_phone&.to_s
   end
 
   def pciu_alternate_phone
-    pciu.get_alternate_phone.to_s
+    pciu&.get_alternate_phone&.to_s
   end
 
   def first_name
@@ -318,6 +318,6 @@ class User < Common::RedisStore
   private
 
   def pciu
-    @pciu ||= EVSS::PCIU::Service.new self
+    @pciu ||= EVSS::PCIU::Service.new self if loa3? && edipi.present?
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -514,6 +514,44 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#pciu' do
+    context 'when user is LOA3 and has an edipi' do
+      let(:user) { build(:user, :loa3) }
+
+      before do
+        stub_evss_pciu(user)
+      end
+
+      it 'returns pciu_email' do
+        expect(user.pciu_email).to eq 'test2@test1.net'
+      end
+
+      it 'returns pciu_primary_phone' do
+        expect(user.pciu_primary_phone).to eq '14445551212'
+      end
+
+      it 'returns pciu_alternate_phone' do
+        expect(user.pciu_alternate_phone).to eq '1'
+      end
+    end
+
+    context 'when user is LOA1' do
+      let(:user) { build(:user, :loa1) }
+
+      it 'returns blank pciu_email' do
+        expect(user.pciu_email).to eq nil
+      end
+
+      it 'returns blank pciu_primary_phone' do
+        expect(user.pciu_primary_phone).to eq nil
+      end
+
+      it 'returns blank pciu_alternate_phone' do
+        expect(user.pciu_alternate_phone).to eq nil
+      end
+    end
+  end
+
   describe '#account' do
     context 'when user has an existing Account record' do
       let(:user) { create :user, :accountable }


### PR DESCRIPTION
## Description of change
Only call EVSS PCIU endpoints for LOA3 users with and EDIPI.  EVSS requires an EDIPI 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/8676

