### PR TITLE
fix for when active_mhv_ids is nil

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,7 +109,7 @@ class User < Common::RedisStore
 
   def mhv_account_state
     return 'DEACTIVATED' if (va_profile.mhv_ids.to_a - va_profile.active_mhv_ids.to_a).any?
-    return 'MULTIPLE' if va_profile.active_mhv_ids.size > 1
+    return 'MULTIPLE' if va_profile.active_mhv_ids.to_a.size > 1
     return 'NONE' if mhv_correlation_id.blank?
 
     'OK'

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -131,8 +131,6 @@ RSpec.describe 'Fetching user data', type: :request do
       end
     end
 
-
-
     context 'for non VA patient' do
       let(:mhv_user) { build(:user, :mhv, va_patient: false) }
 

--- a/spec/request/user_request_spec.rb
+++ b/spec/request/user_request_spec.rb
@@ -111,6 +111,28 @@ RSpec.describe 'Fetching user data', type: :request do
       end
     end
 
+    context 'with missing MHV accounts' do
+      let(:mvi_profile) do
+        build(:mvi_profile_response,
+              :missing_attrs)
+      end
+      let(:mhv_user) { build(:user, :mhv) }
+
+      before do
+        allow_any_instance_of(MVI::Models::MviProfile).to receive(:active_mhv_ids).and_return(nil)
+        stub_mvi(mvi_profile)
+        sign_in_as(mhv_user)
+        get v0_user_url, params: nil
+      end
+
+      it 'returns none mhv account state' do
+        va_profile = JSON.parse(response.body)['data']['attributes']['va_profile']
+        expect(va_profile['mhv_account_state']).to eq('NONE')
+      end
+    end
+
+
+
     context 'for non VA patient' do
       let(:mhv_user) { build(:user, :mhv, va_patient: false) }
 


### PR DESCRIPTION
When `va_profile.active_mhv_ids` is `nil` the `mhv_account_state` method can result in an error.

http://sentry.vfs.va.gov/vets-gov/platform-api-staging/issues/120906/?query=is%3Aunresolved
