### PR TITLE
reworking session controllers statsd init

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -136,12 +136,7 @@ module V0
 
     def login_stats_success(saml_response, user_session_form = nil)
       tracker = url_service(user_session_form&.saml_uuid).tracker
-      tags = [
-        "loa:#{@current_user.loa[:current]}",
-        "idp:#{@current_user.identity.sign_in[:service_name]}",
-        "context:#{saml_response.authn_context}",
-        VERSION_TAG
-      ]
+      tags = ["context:#{saml_response.authn_context}", VERSION_TAG]
       StatsD.increment(STATSD_LOGIN_NEW_USER_KEY, tags: [VERSION_TAG]) if request_type == 'signup'
       StatsD.increment(STATSD_LOGIN_SHARED_COOKIE, tags: tags) if cookies.key?(Settings.sso.cookie_name)
       StatsD.increment(STATSD_LOGIN_STATUS, tags: tags + ['status:success'])
@@ -156,9 +151,7 @@ module V0
       when :failure
         StatsD.increment(STATSD_LOGIN_STATUS,
                          tags: ['status:failure',
-                                "idp:#{params[:type]}",
                                 "context:#{saml_response.authn_context}",
-                                "error:#{user_session_form.error_instrumentation_code}",
                                 VERSION_TAG])
         callback_stats(:failure, saml_response, user_session_form.error_instrumentation_code)
       end

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -33,14 +33,10 @@ module V1
 
       StatsD.increment(STATSD_SSO_NEW_KEY,
                        tags: ["context:#{type}", VERSION_TAG])
-      if force_authn?
-        StatsD.increment(STATSD_SSO_NEW_FORCEAUTH,
-                         tags: ["context:#{type}", VERSION_TAG])
-      end
-      if inbound_ssoe?
-        StatsD.increment(STATSD_SSO_NEW_INBOUND,
-                         tags: ["context:#{type}", VERSION_TAG])
-      end
+      StatsD.increment(STATSD_SSO_NEW_FORCEAUTH,
+                       tags: ["context:#{type}", VERSION_TAG]) if force_authn?
+      StatsD.increment(STATSD_SSO_NEW_INBOUND,
+                       tags: ["context:#{type}", VERSION_TAG]) if inbound_ssoe?
       url = redirect_url(type)
 
       if type == 'slo'

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -31,11 +31,7 @@ module V1
       type = params[:type]
       raise Common::Exceptions::RoutingError, params[:path] unless REDIRECT_URLS.include?(type)
 
-      tags = ["context:#{type}", VERSION_TAG]
-      StatsD.increment(STATSD_SSO_NEW_KEY, tags: tags)
-      StatsD.increment(STATSD_SSO_NEW_FORCEAUTH, tags: tags) if force_authn?
-      StatsD.increment(STATSD_SSO_NEW_INBOUND, tags: tags) if inbound_ssoe?
-
+      new_stats(type)
       url = redirect_url(type)
 
       if type == 'slo'
@@ -184,6 +180,13 @@ module V1
       StatsD.increment(STATSD_LOGIN_STATUS, tags: tags + ['status:success'])
       StatsD.measure(STATSD_LOGIN_LATENCY, tracker.age, tags: tags)
       callback_stats(:success, saml_response)
+    end
+
+    def new_stats(type)
+      tags = ["context:#{type}", VERSION_TAG]
+      StatsD.increment(STATSD_SSO_NEW_KEY, tags: tags)
+      StatsD.increment(STATSD_SSO_NEW_FORCEAUTH, tags: tags) if force_authn?
+      StatsD.increment(STATSD_SSO_NEW_INBOUND, tags: tags) if inbound_ssoe?
     end
 
     def login_stats(status, saml_response, user_session_form = nil)

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -31,12 +31,11 @@ module V1
       type = params[:type]
       raise Common::Exceptions::RoutingError, params[:path] unless REDIRECT_URLS.include?(type)
 
-      StatsD.increment(STATSD_SSO_NEW_KEY,
-                       tags: ["context:#{type}", VERSION_TAG])
-      StatsD.increment(STATSD_SSO_NEW_FORCEAUTH,
-                       tags: ["context:#{type}", VERSION_TAG]) if force_authn?
-      StatsD.increment(STATSD_SSO_NEW_INBOUND,
-                       tags: ["context:#{type}", VERSION_TAG]) if inbound_ssoe?
+      tags = ["context:#{type}", VERSION_TAG]
+      StatsD.increment(STATSD_SSO_NEW_KEY, tags: tags)
+      StatsD.increment(STATSD_SSO_NEW_FORCEAUTH, tags: tags) if force_authn?
+      StatsD.increment(STATSD_SSO_NEW_INBOUND, tags: tags) if inbound_ssoe?
+
       url = redirect_url(type)
 
       if type == 'slo'

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -10,32 +10,33 @@ StatsD.backend = if host.present? && port.present?
                  end
 
 # Initialize session controller metric counters at 0
-
-StatsD.increment(V0::SessionsController::STATSD_SSO_CALLBACK_TOTAL_KEY, 0)
-StatsD.increment(V0::SessionsController::STATSD_LOGIN_NEW_USER_KEY, 0)
-StatsD.increment(V1::SessionsController::STATSD_LOGIN_STATUS, 0)
-StatsD.increment(V1::SessionsController::STATSD_LOGIN_SHARED_COOKIE, 0)
-
-SAML::Responses::Base::ERRORS.merge(UserSessionForm::ERRORS).each_value do |known_error|
-  StatsD.increment(V0::SessionsController::STATSD_SSO_CALLBACK_FAILED_KEY, 0, tags: ["error:#{known_error[:tag]}"])
-end
-
-%w[success failure].each do |s|
-  (SAML::User::AUTHN_CONTEXTS.keys + [SAML::User::UNKNOWN_AUTHN_CONTEXT]).each do |ctx|
-    StatsD.increment(
-      V0::SessionsController::STATSD_SSO_CALLBACK_KEY,
-      0,
-      tags: ["status:#{s}", "context:#{ctx}"]
-    )
+%w[v0 v1].each do |v|
+  StatsD.increment(V1::SessionsController::STATSD_SSO_CALLBACK_TOTAL_KEY, 0,
+                   tags: ["version:#{v}"])
+  StatsD.increment(V1::SessionsController::STATSD_LOGIN_NEW_USER_KEY, 0,
+                   tags: ["version:#{v}"])
+  V1::SessionsController::REDIRECT_URLS.each do |t|
+    StatsD.increment(V1::SessionsController::STATSD_SSO_NEW_KEY, 0,
+                     tags: ["version:#{v}", "context:#{t}"])
+    StatsD.increment(V1::SessionsController::STATSD_SSO_NEW_FORCEAUTH, 0,
+                     tags: ["version:#{v}", "context:#{t}"])
+    StatsD.increment(V1::SessionsController::STATSD_SSO_NEW_INBOUND, 0,
+                     tags: ["version:#{v}", "context:#{t}"])
   end
-end
-
-V0::SessionsController::REDIRECT_URLS.each do |ctx|
-  StatsD.increment(
-    V0::SessionsController::STATSD_SSO_NEW_KEY,
-    0,
-    tags: ["context:#{ctx}"]
-  )
+  %w[success failure].each do |s|
+    (SAML::User::AUTHN_CONTEXTS.keys + [SAML::User::UNKNOWN_AUTHN_CONTEXT]).each do |ctx|
+      StatsD.increment(V1::SessionsController::STATSD_SSO_CALLBACK_KEY, 0,
+                       tags: ["version:#{v}", "status:#{s}", "context:#{ctx}"])
+      StatsD.increment(V1::SessionsController::STATSD_LOGIN_STATUS, 0,
+                       tags: ["version:#{v}", "status:#{s}", "context:#{ctx}"])
+      StatsD.increment(V1::SessionsController::STATSD_LOGIN_SHARED_COOKIE, 0,
+                       tags: ["version:#{v}", "context:#{ctx}"])
+    end
+  end
+  SAML::Responses::Base::ERRORS.merge(UserSessionForm::ERRORS).each_value do |known_error|
+    StatsD.increment(V1::SessionsController::STATSD_SSO_CALLBACK_FAILED_KEY, 0,
+                     tags: ["version:#{v}", "error:#{known_error[:tag]}"])
+  end
 end
 
 # init GiBillStatus stats to 0

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe V0::SessionsController, type: :controller do
                                          tags: ['status:success', 'context:multifactor', 'version:v0'], **once)
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)
             .and trigger_statsd_increment(described_class::STATSD_LOGIN_SHARED_COOKIE,
-                                          tags: ['loa:1', 'idp:idme', 'context:multifactor', 'version:v0'], **once)
+                                          tags: ['context:multifactor', 'version:v0'], **once)
 
           expect(cookies['vagov_session_dev']).not_to be_nil
           expect(JSON.parse(decrypter.decrypt(cookies['vagov_session_dev'])))
@@ -625,7 +625,7 @@ RSpec.describe V0::SessionsController, type: :controller do
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)
             .and trigger_statsd_increment(described_class::STATSD_LOGIN_SHARED_COOKIE,
-                                          tags: ['loa:3', 'idp:myhealthevet', 'context:myhealthevet', 'version:v0'],
+                                          tags: ['context:myhealthevet', 'version:v0'],
                                           **once)
           expect(response.location).to start_with('http://127.0.0.1:3001/auth/login/callback')
           expect(cookies['vagov_session_dev']).not_to be_nil

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                              tags: ["context:#{type}", 'version:v1'], **once)
                 .and not_trigger_statsd_increment(described_class::STATSD_SSO_NEW_FORCEAUTH,
-                                             tags: ["context:#{type}", 'version:v1'])
+                                                  tags: ["context:#{type}", 'version:v1'])
 
               expect(response).to have_http_status(:found)
               expect(response.location)
@@ -112,7 +112,7 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                              tags: ["context:#{type}", 'version:v1'], **once)
                 .and trigger_statsd_increment(described_class::STATSD_SSO_NEW_FORCEAUTH,
-                                             tags: ["context:#{type}", 'version:v1'], **once)
+                                              tags: ["context:#{type}", 'version:v1'], **once)
 
               expect(response).to have_http_status(:found)
               expect(response.location)


### PR DESCRIPTION
New tags have been added to track differences between v0 and v1 sessions, however the current statsd initialization code doesn't address all the new combinations of tags in use.  This PR addresses that, so we can accurately track increases in grafana.

refs https://github.com/department-of-veterans-affairs/va.gov-team/issues/9428