### PR TITLE
Redis duplication bug fix

### DIFF
--- a/config/initializers/01_redis.rb
+++ b/config/initializers/01_redis.rb
@@ -11,6 +11,7 @@ class RedisDuplicator < Redis
   end
 
   def set(key, value, options = {})
+    byebug
     @secondary_redis.set(key, value, options)
     super
   end
@@ -27,7 +28,7 @@ class RedisDuplicator < Redis
 end
 
 Redis.current = if Settings.redis.app_data.key?(:secondary_url)
-                  secondary_redis = Redis.new(url: Settings.redis.app_data.url)
+                  secondary_redis = Redis.new(url: Settings.redis.app_data.secondary_url)
                   RedisDuplicator.new(secondary_redis, REDIS_CONFIG[:redis].to_hash)
                 else
                   Redis.new(REDIS_CONFIG[:redis].to_hash)

--- a/config/initializers/01_redis.rb
+++ b/config/initializers/01_redis.rb
@@ -11,7 +11,6 @@ class RedisDuplicator < Redis
   end
 
   def set(key, value, options = {})
-    byebug
     @secondary_redis.set(key, value, options)
     super
   end


### PR DESCRIPTION
## Description of change
As part of duplicating our redis application data the VAEC redis instance, we accidentally configured the secondary to be the primary... so rather than duplicating data, we've been just calling commands twice on the same redis. 😊 😬 

- We've been doing this in `dev` since 👉 https://github.com/department-of-veterans-affairs/vets-api/pull/4210
- We've been doing this in `prod` since 👉 https://github.com/department-of-veterans-affairs/devops/pull/6967

## In This PR
Make the proper config change.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/6865

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
