### PR TITLE
Allow regex for allowed CORS origin domains

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,8 @@ module VetsAPI
     # CORS configuration; see also cors_preflight route
     config.middleware.insert_before 0, Rack::Cors, logger: (-> { Rails.logger }) do
       allow do
-        origins { |source, _env| Settings.web_origin.split(',').include?(source) }
+        regex = Regexp.new(Settings.web_origin_regex)
+        origins { |source, _env| Settings.web_origin.split(',').include?(source) || source.match?(regex) }
         resource '*', headers: :any,
                       methods: :any,
                       credentials: true,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,7 @@ virtual_hosts: ["127.0.0.1", "localhost"] # Safe host names
 
 # For CORS requests; separate multiple origins with a comma
 web_origin: http://localhost:3000,http://localhost:3001,http://127.0.0.1:3000,http://127.0.0.1:3001,null
+web_origin_regex: \Ahttps?:\/\/www\.va\.gov\z
 
 # Settings for SAML authentication
 saml:


### PR DESCRIPTION
## Description of change
Allows for configuration of allowed CORS origin domains using regex

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/9445

## Things to know about this PR
A default allowed value of `https://www.va.gov` is provided in `settings.yml`.
This will ensure that `Settings.web_origin_regex` is never `nil` and thus the evaluation of `Regexp.new(Settings.web_origin_regex)` won't raise an exception.