### PR TITLE
CT-103: Remove 'eduSection103' Feature Flag #8201

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -102,10 +102,6 @@ features:
     actor_type: user
     description: >
       Enables STEM scholarship functionality
-  edu_section_103:
-    actor_type: user
-    description: >
-      Enables section 103 content
   gibct_estimate_your_benefits:
     actor_type: user
     description: >


### PR DESCRIPTION
## Description of change
https://github.com/department-of-veterans-affairs/va.gov-team/issues/8201
https://github.com/department-of-veterans-affairs/vets-website/pull/12838 removes usages of the feature flag

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
