### PR TITLE
BUG FIX- Form 526: Part 2, Remove mult whitespace from treatmentCenterName

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -381,6 +381,8 @@ module EVSS
       def translate_treatments
         return {} if input_form['vaTreatmentFacilities'].blank?
 
+        # treatmentCenterName clean up is an approximation of evss regex
+        # validation ([a-zA-Z0-9"\/&\(\)\-'.#]([a-zA-Z0-9(\)\-'.# ])?)+$
         treatments = input_form['vaTreatmentFacilities'].map do |treatment|
           {
             'startDate' => approximate_date(treatment['treatmentDateRange']['from']),

--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -387,7 +387,7 @@ module EVSS
             'endDate' => approximate_date(treatment['treatmentDateRange']['to']),
             'treatedDisabilityNames' => treatment['treatedDisabilityNames'],
             'center' => {
-              'name' => treatment['treatmentCenterName'].gsub(/[^a-zA-Z0-9 .()#&'"-]+/, '').strip
+              'name' => treatment['treatmentCenterName'].gsub(/[^a-zA-Z0-9 .()#&'"-]+/, '').gsub(/\s+/,' ').strip
             }.merge(treatment['treatmentCenterAddress'])
           }.compact
         end

--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -387,7 +387,7 @@ module EVSS
             'endDate' => approximate_date(treatment['treatmentDateRange']['to']),
             'treatedDisabilityNames' => treatment['treatedDisabilityNames'],
             'center' => {
-              'name' => treatment['treatmentCenterName'].gsub(/[^a-zA-Z0-9 .()#&'"-]+/, '').gsub(/\s+/,' ').strip
+              'name' => treatment['treatmentCenterName'].gsub(/[^a-zA-Z0-9 .()#&'"-]+/, '').gsub(/\s\s+/, ' ').strip
             }.merge(treatment['treatmentCenterAddress'])
           }.compact
         end

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -816,7 +816,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
                   'from' => '2018-01-01',
                   'to' => '2018-02-XX'
                 },
-                'treatmentCenterName' => 'Super _,!?Hospital \'&\' "More" (#2.0)',
+                'treatmentCenterName' => 'Super  _,!?Hospital    \'&\' "More" (#2.0)',
                 'treatmentCenterAddress' => {
                   'country' => 'USA',
                   'city' => 'Portland',


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

https://github.com/department-of-veterans-affairs/vets-api/pull/4302 significantly lowered our error rate for regex validations on the `treatmentCenterName` but didn't go far enough.  @annaswims figured out that mult spaces were also a cause for rejection.  This PR replaces mult whitespace characters with a single space.

Last 2 weeks of regex errors, blue line is deployment of PR 4302
![Screen Shot 2020-05-29 at 12 10 19 PM](https://user-images.githubusercontent.com/9893700/83286377-6a1a3680-a1a5-11ea-8d27-9b40d63ba1b0.png)
http://grafana.vfs.va.gov/d/000000066/evss-526-submissions?panelId=16&fullscreen&orgId=1&from=now-15d&to=now
## Original issue(s)
second PR for department-of-veterans-affairs/va.gov-team/issues/9121

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] added regex gsub method and strip to mult whitespace chars from `treatmentCenterName`
- Instead of adding to that gsub line, I added a second gsub method- I thought this would make this mess more readable
- [x] changed preexisting test to ensure double and triple spaces were removed from `treatmentCenterName`