### PR TITLE
exempt unknown routes from CSRF verification

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,7 @@ class ApplicationController < ActionController::API
   prepend_before_action :block_unknown_hosts, :set_app_info_headers
   # Also see AuthenticationAndSSOConcerns for more before filters
   skip_before_action :authenticate, only: %i[cors_preflight routing_error]
+  skip_before_action :verify_authenticity_token, only: :routing_error
   before_action :set_tags_and_extra_context
 
   def cors_preflight

--- a/spec/request/csrf_request_spec.rb
+++ b/spec/request/csrf_request_spec.rb
@@ -112,4 +112,12 @@ RSpec.describe 'CSRF scenarios', type: :request do
       expect(response.body).not_to match(/Invalid Authenticity Token/)
     end
   end
+
+  describe 'unknown route' do
+    it 'skips CSRF validation' do
+      post '/non_existent_route'
+      expect(response.status).to eq(404)
+      expect(response.body).to match(/There are no routes matching your request/)
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
non-GET/non-HEAD unknown routes are resulting in CSRF violations.
This obscures what the root problem is (route is unkown).

[Sentry example.](http://sentry.vfs.va.gov/vets-gov/platform-api-staging/issues/120232)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
