### PR TITLE
add EVSS/AWS/ReferenceData to breakers

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -45,6 +45,7 @@ services = [
   EVSS::PCIUAddress::Configuration.instance.breakers_service,
   EVSS::GiBillStatus::Configuration.instance.breakers_service,
   EVSS::Dependents::Configuration.instance.breakers_service,
+  EVSS::ReferenceData::Configuration.instance.breakers_service,
   Gibft::Configuration.instance.breakers_service,
   VIC::Configuration.instance.breakers_service,
   Facilities::AccessWaitTimeConfiguration.instance.breakers_service,

--- a/lib/evss/reference_data/configuration.rb
+++ b/lib/evss/reference_data/configuration.rb
@@ -27,10 +27,6 @@ module EVSS
         # TODO: create mock data
         false
       end
-
-      def self.breakers_service
-        BaseService.create_breakers_service(name: service_name, url: base_path)
-      end
     end
   end
 end

--- a/lib/evss/reference_data/configuration.rb
+++ b/lib/evss/reference_data/configuration.rb
@@ -27,6 +27,10 @@ module EVSS
         # TODO: create mock data
         false
       end
+
+      def self.breakers_service
+        BaseService.create_breakers_service(name: service_name, url: base_path)
+      end
     end
   end
 end

--- a/spec/lib/evss/reference_data/service_spec.rb
+++ b/spec/lib/evss/reference_data/service_spec.rb
@@ -11,9 +11,11 @@ describe EVSS::ReferenceData::Service do
     context 'with a 200 response' do
       it 'returns a list of countries' do
         VCR.use_cassette('evss/reference_data/countries') do
-          response = subject.get_countries
-          expect(response).to be_ok
-          expect(response.countries[0...10]).to eq(
+          expect do
+            @response = subject.get_countries
+          end.to trigger_statsd_increment('api.external_http_request.EVSS/AWS/ReferenceData.success', times: 1)
+          expect(@response).to be_ok
+          expect(@response.countries[0...10]).to eq(
             %w[Afghanistan Albania Algeria Angola Anguilla Antigua Antigua\ and\ Barbuda Argentina Armenia Australia]
           )
         end


### PR DESCRIPTION
## Description of change
configure breakers so that we can see stats for EVSS reference data stats in [Backend Service Report ](http://grafana.vfs.va.gov/d/000000050/backend-service-report?orgId=1)


https://github.com/department-of-veterans-affairs/va.gov-team/issues/8387