### PR TITLE
require websocket-extensions to be >= 0.1.5 for security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source 'https://rubygems.org'
 
 ruby '2.6.6'
 
+# temp fix for security vulnerability, hopefulle we can remove this line with the next rails patch
+# https://blog.jcoglan.com/2020/06/02/redos-vulnerability-in-websocket-extensions/
+gem 'websocket-extensions', '>= 0.1.5'
+
 # Modules
 gem 'appeals_api', path: 'modules/appeals_api'
 gem 'claims_api', path: 'modules/claims_api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -773,7 +773,7 @@ GEM
     webrick (1.6.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     will_paginate (3.1.0)
     xmldsig (0.3.2)
       nokogiri
@@ -937,6 +937,7 @@ DEPENDENCIES
   web-console
   webmock
   webrick
+  websocket-extensions (>= 0.1.5)
   will_paginate
   yard
   zero_downtime_migrations


### PR DESCRIPTION
Vulnerability described here https://blog.jcoglan.com/2020/06/02/redos-vulnerability-in-websocket-extensions/

called out by dependabot here https://github.com/department-of-veterans-affairs/vets-api/network/alert/Gemfile.lock/websocket-extensions/open