### PR TITLE
fix sidekiq batch loading

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -172,16 +172,6 @@ RSpec.configure do |config|
     request.host = Settings.hostname
   end
 
-  config.before(:all) do
-    Sidekiq::Batch = Class.new do
-      def on(_callback, _klass, _options) end
-
-      def jobs
-        yield
-      end
-    end
-  end
-
   config.before do |example|
     stub_mvi unless example.metadata[:skip_mvi]
     stub_emis unless example.metadata[:skip_emis]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ require 'support/spool_helpers'
 require 'support/fixture_helpers'
 require 'support/spec_temp_files'
 require 'support/silence_stream'
+require 'sidekiq-pro' if Gem.loaded_specs.key?('sidekiq-pro')
+require 'support/sidekiq/batch'
 require 'support/stub_emis'
 require 'support/stub_evss_pciu'
 require 'support/vet360/stub_vet360'

--- a/spec/support/sidekiq/batch.rb
+++ b/spec/support/sidekiq/batch.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  class Batch
+    attr_accessor :description
+    attr_reader :bid
+
+    def initialize(bid = nil)
+      @bid = bid || SecureRandom.hex(8)
+      @callbacks = []
+    end
+
+    def status
+      nil
+    end
+
+    def on(*args)
+      @callbacks << args
+    end
+
+    def jobs(*)
+      yield
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
in https://github.com/department-of-veterans-affairs/vets-api/pull/4345 I intended to load the new `Sidekiq::Batch` definition once, after sidekiq-pro was loaded.  but I goofed. `before(:all)` ran not just once before all tests.  this fixes that.