### PR TITLE
Add missing reason for visit field

### DIFF
--- a/modules/vaos/app/models/vaos/appointment_request_form.rb
+++ b/modules/vaos/app/models/vaos/appointment_request_form.rb
@@ -16,6 +16,7 @@ module VAOS
     attribute :status, String
     attribute :appointment_type, String
     attribute :visit_type, String
+    attribute :reason_for_visit, String
     attribute :text_messaging_allowed, Boolean
     attribute :phone_number, String
     attribute :purpose_of_visit, String

--- a/modules/vaos/app/serializers/vaos/v0/appointment_requests_serializer.rb
+++ b/modules/vaos/app/serializers/vaos/v0/appointment_requests_serializer.rb
@@ -37,6 +37,7 @@ module VAOS
                  :status,
                  :appointment_type,
                  :visit_type,
+                 :reason_for_visit,
                  :email,
                  :text_messaging_allowed,
                  :phone_number,

--- a/modules/vaos/spec/models/cc_appointment_request_form_spec.rb
+++ b/modules/vaos/spec/models/cc_appointment_request_form_spec.rb
@@ -49,6 +49,7 @@ describe VAOS::CCAppointmentRequestForm, type: :model do
         :provider_name,
         :provider_seen_appointment_request,
         :purpose_of_visit,
+        :reason_for_visit,
         :requested_phone_call,
         :second_request,
         :second_request_submitted,

--- a/spec/support/schemas/vaos/appointment_request.json
+++ b/spec/support/schemas/vaos/appointment_request.json
@@ -19,7 +19,7 @@
         "status": { "type": "string" },
         "appointment_type": { "type": "string" },
         "visit_type": { "type": "string" },
-        "reason_for_visit": { "type": "string" },
+        "reason_for_visit": { "type": ["string", null] },
         "facility": {
           "type": "object",
           "properties": {

--- a/spec/support/schemas/vaos/appointment_request.json
+++ b/spec/support/schemas/vaos/appointment_request.json
@@ -19,6 +19,7 @@
         "status": { "type": "string" },
         "appointment_type": { "type": "string" },
         "visit_type": { "type": "string" },
+        "reason_for_visit": { "type": "string" },
         "facility": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
## Description of change
This adds the reason_for_visit field to the appointment request form. This field holds the reason that users select when they make an express care appointment. It's unused for regular requests.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#9976

Verified that this change fixes the issue on a review instance and resolves the error in Scheduling Manager.
