### PR TITLE
[VSP] fix for 'accessing hashes by non-symbol keys' warnings

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -28,7 +28,9 @@ require 'evss/documents_service'
 require 'evss/letters/service'
 
 # Read the redis config, create a connection and a namespace for breakers
-redis_namespace = Redis::Namespace.new('breakers', redis: Redis.new(REDIS_CONFIG[:redis]))
+# .to_h because hashes from config_for don't support non-symbol keys
+redis_options = REDIS_CONFIG[:redis].to_h
+redis_namespace = Redis::Namespace.new('breakers', redis: Redis.new(redis_options))
 
 services = [
   Debts::Configuration.instance.breakers_service,

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class Rack::Attack
-  Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(Redis.new(REDIS_CONFIG[:redis]))
+  # .to_h because hashes from config_for don't support non-symbol keys
+  redis_options = REDIS_CONFIG[:redis].to_h
+  Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(Redis.new(redis_options))
 
   throttle('example/ip', limit: 1, period: 5.minutes) do |req|
     req.ip if req.path == '/v0/limited'


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change

Fix ~40 lines of `DEPRECATION WARNINGS` when running specs.

## Original issue(s)

N/A, or none that I'm aware of yet.

## Things to know about this PR

Before:

```
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/breakers.rb:31)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from new at /srv/vets-api/src/config/initializers/rack_attack.rb:4)
```

After: There are plenty of other warnings regarding re-defined constants (which I hope the zeitwerk fixes will reduce 🙏 ), but the above warnings are gone when running `make spec` or `rake spec`.