### PR TITLE
Add Optional Base64 encoding blurb

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/description/v1.md
+++ b/modules/claims_api/app/swagger/claims_api/description/v1.md
@@ -63,5 +63,13 @@ By default, the API generates PDFs of form 21-526 based on incoming data, and th
 
 If you are filing an original claim, and the filer is **not** the veteran (the oauth token is not the veteran’s), see the [PUT /forms/526/{id}](#operations-Disability-upload526Attachment) endpoint.
 
+###  Optional Base64 Encoding
+
+We allow Base64 encoding to convert binary data into text format for secure transmission. You will need to encode each _individual_ 526 form. 
+
+- See cURL example in [PUT /forms/526/{id}](#operations-Disability-upload526Attachment) endpoint. 
+
+- [See raw Base64 example](https://raw.githubusercontent.com/department-of-veterans-affairs/vets-api/master/modules/claims_api/spec/fixtures/base64pdf) 
+
 ### Mock Data in Test Environments 
 Mock data is used for all forms in the Development environment, and for 21-526 submissions in the Staging environment.

--- a/modules/claims_api/app/swagger/claims_api/description/v1.md
+++ b/modules/claims_api/app/swagger/claims_api/description/v1.md
@@ -1,10 +1,10 @@
-The Benefits Claims API allows authenticated, authorized individuals (Veterans or their representatives) to digitally submit and automatically establish certain claims, along with supporting documentation. It also allows those users to see information about current claims, including their status.
+The Benefits Claims API allows authenticated individuals (Veterans or their authorized representatives) to digitally submit and automatically establish certain claims, along with supporting documentation. It also allows those users to see information about current claims, including their status.
 
 Internal VA consumers, such as mail processing vendors, can use an organizational token to establish disability compensation claims automatically.
 
-Whereas the Benefits Intake API is primarily for forwarding PDFs to the Centralized Mail Portal, the Benefits Claims API can accept JSON for automatically establishing claims. Automatic establishment helps eligible Veterans receive their benefits more quickly by:
+Whereas the [Benefits Intake API](https://developer.va.gov/explore/benefits/docs/benefits?version=current) is primarily for uploading claim-related PDFs to the Centralized Mail Portal, the Benefits Claims API can accept JSON for automatically establishing claims. Automatic establishment helps eligible Veterans receive their benefits more quickly by:
 
-1) shaving off days of processing time
+1) reducing processing time by a number of days
 2) making claims immediately accessible to Veteran Service Representatives (VSRs) using the Veterans Benefits Management System (VBMS)
 
 
@@ -28,17 +28,17 @@ API consumers are encouraged to validate the JSON Schema before submission, acco
 ## Design
 
 ### Authentication
-In order to make an API request, individuals must first go through our OAuth SAML Proxy and scoping process. They will then receive the required API key. 
+In order to make an API request, individuals must first [authenticate](https://developer.va.gov/explore/health/docs/authorization) via our OAuth SAML Proxy and scoping process. They will then receive the required authentication token to access the API. 
 
 If the OAuth token belongs to the **Veteran**, only the token is required to access all data related to that Veteran. 
 
-If the token belongs to a **Veteran Representative**, the individual must be accredited by the organization who holds Power of Attorney (POA) for the Veteran, or be appointed directly. The API compares the authenticated individual's accreditations or POA codes with the Office of General Council's database, in order to validate that the Representative's POA codes match the code for the Veteran's current POA. When a Representative is the authenticated user type, the API also requires the Veteran's SSN, first name, last name, and date of birth. 
+If the token belongs to a **Veteran Representative**, the individual must be [accredited](https://www.va.gov/ogc/apps/accreditation/index.asp) by the organization who holds Power of Attorney (PoA) for the Veteran, or be appointed directly. The API compares the authenticated individual's accreditations or PoA codes with the Office of General Council's database, in order to validate that the Representative's PoA codes match the code for the Veteran's current PoA. When a Representative authenticates, the API also requires the Veteran's SSN, first name, last name, and date of birth. 
 
 **Internal** VA users (such as mail processing vendors) authenticate using an API key issued at the organizational level. Currently, this authentication model is only supported in V0. To learn more about this authentication path, select Version 0.0.1 from the drop-down menu above.
 
 
 #### Additional Resources
-*   A guide to [getting started with OAuth](https://developer.va.gov/explore/health/docs/authorization)
+*   A guide to [OAuth (OpenID Connect) for VA Lighthouse APIs](https://developer.va.gov/explore/health/docs/authorization)
 *   [Sample applications](https://github.com/department-of-veterans-affairs/vets-api-clients/tree/master/samples) showing this authentication model in use
 
 
@@ -53,7 +53,7 @@ If the token belongs to a **Veteran Representative**, the individual must be acc
 
 Uploaded documents cannot be larger than 11" x 11".
 
-A payload of documents cannot exceed 5 GB, and no single file in a payload can exceed 100 MB. There is no limit on the _number_ of files that can be contained in one payload (only the aforementioned size limitations).
+A payload of documents cannot exceed 5 GB, and no single file in a payload can exceed 100 MB. There is no limit on the _number_ of files that can be contained in one payload, only the aforementioned size limitations.
 
 
 ### Original Claims and 21-526 PDF Generation
@@ -61,15 +61,15 @@ A payload of documents cannot exceed 5 GB, and no single file in a payload can e
 
 By default, the API generates PDFs of form 21-526 based on incoming data, and the OAuth token of either the Veteran or their representative is used to represent electronic authorization of submitted documents. However, when a previous claim does not exist for a given Veteran, and a 21-526 is filed by anyone other than the Veteran, the API requires that PDF generation be disabled, and that a signed copy of the 21-526 is attached in addition to the required fields in the payload.
 
-If you are filing an original claim, and the filer is **not** the veteran (the oauth token is not the veteran’s), see the [PUT /forms/526/{id}](#operations-Disability-upload526Attachment) endpoint.
+If an authorized representative is filing an original claim, rather than the Veteran (i.e. the OAuth token is not the Veteran’s), use the [PUT /forms/526/{id}](#operations-Disability-upload526Attachment) endpoint to upload a scanned PDF of the form signed in ink by the Veteran.
 
 ###  Optional Base64 Encoding
 
-We allow Base64 encoding to convert binary data into text format for secure transmission. You will need to encode each _individual_ 526 form. 
+We allow Base64 encoding to convert binary data into text format for secure transmission. You will need to encode each _individual_ 526 form rather than the whole payload.  This differs from base64 encoding for the Benefits Intake API.
 
-- See cURL example in [PUT /forms/526/{id}](#operations-Disability-upload526Attachment) endpoint. 
+- There is a cURL example in the documentation for the [PUT /forms/526/{id}](#operations-Disability-upload526Attachment) endpoint. 
 
-- [See raw Base64 example](https://raw.githubusercontent.com/department-of-veterans-affairs/vets-api/master/modules/claims_api/spec/fixtures/base64pdf) 
+-  If you would prefer to see a test payload, there is a [raw Base64 example](https://raw.githubusercontent.com/department-of-veterans-affairs/vets-api/master/modules/claims_api/spec/fixtures/base64pdf) you can decode and reverse engineer using the following header: `Content-Type: multipart/form-data; boundary=WebKitFormBoundaryVfOwzCyvug0JmWYo` Important note: the binary file is encoded within this base64 payload as well.
 
 ### Mock Data in Test Environments 
-Mock data is used for all forms in the Development environment, and for 21-526 submissions in the Staging environment.
+Mock data is used for all forms in the sandbox environment, and for 21-526 submissions in the Staging environment.  (Access to the Staging environment is only provided by special arrangement; the typical onboarding process goes directly from sandbox to the production API environment.)


### PR DESCRIPTION
Update description with optional Base64 instructions and links to cURL and raw Base64 examples for individual PDFs. 

The team decided to call out this option in the description because it works differently from the benefits-intake API and it generated some confusion among users. The proposed change addresses the issue. 

@bastosmichael feel free to change write-up if we need to add any more details.