### PR TITLE
Adds help target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,20 +17,26 @@ DB		     := "bin/rails db:setup db:migrate"
 LINT    	 := "bin/rails lint"
 DOWN         := down
 SECURITY     := "bin/rails security"
+.DEFAULT_GOAL := ci
 
-.PHONY: default
-default: ci
+
+# cribbed from https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html and https://news.ycombinator.com/item?id=11195539
+help:  ## Prints out documentation for available commands
+	@awk -F ':|##' \
+		'/^[^\t].+?:.*?##/ {\
+			printf "\033[36m%-30s\033[0m %s\n", $$1, $$NF \
+		}' $(MAKEFILE_LIST)
 
 .PHONY: ci
-ci:
+ci:  ## Sets up databases and runs tests for ci
 	@$(BASH_TEST) "bin/rails db:setup db:migrate ci"
 
 .PHONY: bash
-bash:
+bash:  ## Starts a bash shell inside the docker container
 	@$(COMPOSE_DEV) $(BASH)
 
 .PHONY: build
-build:
+build:  ## Builds the api
 ifeq ($(ENV_ARG), dev)
 	$(COMPOSE_DEV) build
 else
@@ -39,7 +45,7 @@ endif
 
 
 .PHONY: db
-db:
+db:  ## Sets up database and runs migrations
 ifeq ($(ENV_ARG), dev)
 	@$(BASH_DEV) $(DB)
 else
@@ -48,7 +54,7 @@ endif
 
 
 .PHONY: lint
-lint:
+lint:  ## runs the linter
 ifeq ($(ENV_ARG), dev)
 	@$(BASH_DEV) $(LINT)
 else
@@ -56,19 +62,19 @@ else
 endif
 
 .PHONY: console
-console:
+console:  ## Starts a rails console
 	@$(BASH_DEV) "bundle exec rails c"
 
 .PHONY: danger
-danger:
+danger:  ## Runs the danger static analysis
 	@$(BASH_TEST) "bundle exec danger --verbose"
 
 .PHONY: docker-clean
-docker-clean:
+docker-clean:  ## Removes all docker images and volumes associated with vets-api
 	@$(COMPOSE_DEV) down --rmi all --volumes
 
 .PHONY: down
-down:
+down:  ## Stops all docker services
 ifeq ($(ENV_ARG), dev)
 	@$(COMPOSE_DEV) $(DOWN)
 else
@@ -76,19 +82,19 @@ else
 endif
 
 .PHONY: guard
-guard:
+guard:  ## Runs guard
 	@$(BASH_DEV) "bundle exec guard"
 
 .PHONY: migrate
-migrate:
+migrate:  ## Runs the database migrations
 	@$(BASH_DEV) "bin/rails db:migrate"
 
 .PHONY: rebuild
-rebuild: down
+rebuild: down  ## Stops the docker services and builds the api
 	@$(COMPOSE_DEV) build
 
 .PHONY: security
-security:
+security:  ## Runs security scans
 ifeq ($(ENV_ARG), dev)
 	@$(BASH_DEV) $(SECURITY)
 else
@@ -96,11 +102,11 @@ else
 endif
 
 .PHONY: server
-server:
+server:  ## Starts the server (natively)
 	@$(BASH_DEV) "rm -f tmp/pids/server.pid && bundle exec rails server"
 
 .PHONY: spec
-spec:
+spec:  ## Runs spec tests
 ifeq ($(ENV_ARG), dev)
 	@$(BASH_DEV) "bin/rspec ${SPEC_PATH}"
 else
@@ -108,5 +114,5 @@ else
 endif
 
 .PHONY: up
-up: db
+up: db  ## Starts the server and associated services with docker-compose
 	@$(BASH_DEV) "rm -f tmp/pids/server.pid && foreman start -m all=1,clamd=0,freshclam=0"

--- a/README.md
+++ b/README.md
@@ -41,9 +41,16 @@ To start, fetch this code:
 
 ## Running the app
 
-A Makefile provides shortcuts for interacting with the docker images. To run vets-api and its redis and postgres
-dependencies run the following command from within the repo you cloned in the above steps.
+A Makefile provides shortcuts for interacting with the docker images. 
 
+You can see all of the targets and an explanation of what they do with: 
+
+```
+make help
+```
+
+To run vets-api and its redis and postgres dependencies run the following command from within the repo you cloned 
+in the above steps.
 
 ```
 make up


### PR DESCRIPTION


<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

This change adds a target that allows you to get a `help` from the makefile with inline documentation explaining what each of the targets do.

It also uses a more canonical way of setting a default target for the makefile for gnu make.

## Original issue(s)
n/a

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Tested running the target locally.