### PR TITLE
Remove PUMA_PRELOAD environment var guard clause

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,11 +6,9 @@ workers Integer(ENV.fetch('PUMA_WORKERS', 0))
 threads_count = Integer(ENV.fetch('PUMA_THREADS', 16))
 threads(threads_count, threads_count)
 
-if ENV.fetch('PUMA_PRELOAD', false)
-  preload_app!
+preload_app!
 
-  on_worker_boot do
-    SemanticLogger.reopen
-    ActiveRecord::Base.establish_connection
-  end
+on_worker_boot do
+  SemanticLogger.reopen
+  ActiveRecord::Base.establish_connection
 end


### PR DESCRIPTION
## Description of change

During the work to scale puma, the PUMA_PRELOAD environment variable
was added to make it easier to toggle application preloading in the
staging and production environments. With months of successful running
with this variable being TRUE in staging and production it is long past
time to clean up this env var here and in the devops repo.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#3849

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is effectively _removing_ a feature flag set by the devops configuration of environment variables in 
```
/ansible/deployment/config/vets-api-server-vagov-staging.yml
/ansible/deployment/config/vets-api-server-vagov-production.yml
```

Once this is merged, please also ensure the environment variables are removed from the devops repo by merging the following PR

- [ ] https://github.com/department-of-veterans-affairs/devops/pull/7111

<!-- Please describe testing done to verify the changes or any testing planned. -->
Will monitor staging after deployed, but expecting no difference.