### PR TITLE
Temporarily ignore CVE-2020-8184 in `rack` while waiting on fix

### DIFF
--- a/rakelib/security.rake
+++ b/rakelib/security.rake
@@ -14,7 +14,7 @@ task security: :environment do
 
   puts 'running bundle-audit to check for insecure dependencies...'
   exit!(1) unless ShellCommand.run('bundle-audit update')
-  audit_result = ShellCommand.run('bundle-audit check --ignore CVE-2020-8161')
+  audit_result = ShellCommand.run('bundle-audit check --ignore CVE-2020-8161 CVE-2020-8184')
 
   puts "\n"
   if brakeman_result && audit_result


### PR DESCRIPTION
We are blocked from upgrading `rack` because of a dependency conflict
with Sidekiq5 (which is in the long process of being upgraded in #XXXX)

While we get a fix in for this specific issue in rack through a patch,
we want to avoid breaking the build for the next day or so until a fix
is implemented. This PR temporarily ignores the vulnerability check for
this CVE.

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
