### PR TITLE
Lighthouse Appeals API - Contestable Issues Mock Data

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -448,6 +448,12 @@
       :uid_location: header
       :uid_locator: ssn
   - :method: :get
+    :path: "/api/v3/decision_review/contestable_issues"
+    :file_path: "modules_appeals_api/contestable_issues"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: X-VA-SSN
+  - :method: :get
     :path: "/health-check"
     :file_path: "appeals/health-check"
 


### PR DESCRIPTION
Add the routes for `/contestable_issues` endpoint mock data (vets-api-mockdata) to Betamocks services_config.yaml

[Related vets-api-mockdata PR](https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/139)