### PR TITLE
Timeout Exception was logging base_path instead of actual path (fixed)

### DIFF
--- a/lib/common/client/base.rb
+++ b/lib/common/client/base.rb
@@ -110,7 +110,7 @@ module Common
           e.key, e.response_values, e.original_status, e.original_body
         )
       rescue Timeout::Error, Faraday::TimeoutError => e
-        Raven.extra_context(service_name: config.service_name, url: config.base_path)
+        Raven.extra_context(service_name: config.service_name, url: path)
         raise Common::Exceptions::GatewayTimeout, e.class.name
       rescue Faraday::ClientError => e
         error_class = case e


### PR DESCRIPTION
## Description of change
I was trying to understand why the following Sentry issue (http://sentry.vfs.va.gov/vets-gov/platform-api-production/issues/121637/?query=vaos) is showing the wrong url, or more importantly why the URL doesn't make any sense. Then I came a cross this line of code that I committed 3 years ago and somehow no one has identified as broken. 

It's come full circle :)

## Original issue(s)
No issue, just quick PR

## Things to know about this PR
Simple fix for Sentry extra_context logs.