### PR TITLE
adding metrics to track inbound ssoe success/failure responses

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -21,6 +21,7 @@ module V1
     STATSD_LOGIN_NEW_USER_KEY = 'api.auth.new_user'
     STATSD_LOGIN_STATUS_SUCCESS = 'api.auth.login.success'
     STATSD_LOGIN_STATUS_FAILURE = 'api.auth.login.failure'
+    STATSD_LOGIN_INBOUND = 'api.auth.login.inbound'
     STATSD_LOGIN_SHARED_COOKIE = 'api.auth.sso_shared_cookie'
     STATSD_LOGIN_LATENCY = 'api.auth.latency'
 
@@ -168,6 +169,7 @@ module V1
     def login_stats(status, _saml_response, user_session_form)
       tracker = url_service(user_session_form&.saml_uuid).tracker
       type = tracker.payload_attr(:type)
+      inbound = tracker.payload_attr(:inbound_ssoe)
       tags = ["context:#{type}", VERSION_TAG]
       case status
       when :success
@@ -175,9 +177,11 @@ module V1
         # track users who have a shared sso cookie
         StatsD.increment(STATSD_LOGIN_SHARED_COOKIE, tags: tags)
         StatsD.increment(STATSD_LOGIN_STATUS_SUCCESS, tags: tags)
+        StatsD.increment(STATSD_LOGIN_INBOUND, tags: tags + ["status:success"]) if inbound
         StatsD.measure(STATSD_LOGIN_LATENCY, tracker.age, tags: tags)
       when :failure
         StatsD.increment(STATSD_LOGIN_STATUS_FAILURE, tags: tags)
+        StatsD.increment(STATSD_LOGIN_INBOUND, tags: tags + ["status:failure"]) if inbound
       end
     end
 

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -177,11 +177,11 @@ module V1
         # track users who have a shared sso cookie
         StatsD.increment(STATSD_LOGIN_SHARED_COOKIE, tags: tags)
         StatsD.increment(STATSD_LOGIN_STATUS_SUCCESS, tags: tags)
-        StatsD.increment(STATSD_LOGIN_INBOUND, tags: tags + ["status:success"]) if inbound
+        StatsD.increment(STATSD_LOGIN_INBOUND, tags: tags + ['status:success']) if inbound
         StatsD.measure(STATSD_LOGIN_LATENCY, tracker.age, tags: tags)
       when :failure
         StatsD.increment(STATSD_LOGIN_STATUS_FAILURE, tags: tags)
-        StatsD.increment(STATSD_LOGIN_INBOUND, tags: tags + ["status:failure"]) if inbound
+        StatsD.increment(STATSD_LOGIN_INBOUND, tags: tags + ['status:failure']) if inbound
       end
     end
 

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -26,6 +26,10 @@ StatsD.backend = if host.present? && port.present?
                      tags: ["version:#{v}", "context:#{t}"])
     StatsD.increment(V1::SessionsController::STATSD_LOGIN_STATUS_FAILURE, 0,
                      tags: ["version:#{v}", "context:#{t}"])
+    %w[success failure].each do |s|
+      StatsD.increment(V1::SessionsController::STATSD_LOGIN_STATUS_FAILURE, 0,
+                       tags: ["version:#{v}", "context:#{t}", "status:#{s}"])
+    end
   end
   %w[success failure].each do |s|
     (SAML::User::AUTHN_CONTEXTS.keys + [SAML::User::UNKNOWN_AUTHN_CONTEXT]).each do |ctx|

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -27,7 +27,7 @@ StatsD.backend = if host.present? && port.present?
     StatsD.increment(V1::SessionsController::STATSD_LOGIN_STATUS_FAILURE, 0,
                      tags: ["version:#{v}", "context:#{t}"])
     %w[success failure].each do |s|
-      StatsD.increment(V1::SessionsController::STATSD_LOGIN_STATUS_FAILURE, 0,
+      StatsD.increment(V1::SessionsController::STATSD_LOGIN_INBOUND, 0,
                        tags: ["version:#{v}", "context:#{t}", "status:#{s}"])
     end
   end

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -213,7 +213,7 @@ module SAML
     def initialize_tracker(params, previous_saml_uuid: nil)
       previous = previous_saml_uuid && SAMLRequestTracker.find(previous_saml_uuid)
       redirect = previous&.payload_attr(:redirect) || build_redirect(params)
-      inbound = previous&.payload_attr(:inbound) || params[:inbound]
+      inbound = previous&.payload_attr(:inbound_ssoe) || params[:inbound]
       type = previous&.payload_attr(:type) || params[:type]
       # if created_at is set to nil (meaning no previous tracker to use), it
       # will be initialized to the current time when it is saved

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -311,8 +311,8 @@ RSpec.describe V1::SessionsController, type: :controller do
         )
         allow(SAML::User).to receive(:new).and_return(saml_user)
         expect { post(:saml_callback) }
-                .to trigger_statsd_increment(described_class::STATSD_LOGIN_INBOUND,
-                                             tags: ["context:mhv", 'version:v1', 'status:success'])
+          .to trigger_statsd_increment(described_class::STATSD_LOGIN_INBOUND,
+                                       tags: ['context:mhv', 'version:v1', 'status:success'])
       end
 
       context 'for a user with semantically invalid SAML attributes' do

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -304,6 +304,17 @@ RSpec.describe V1::SessionsController, type: :controller do
         expect(post(:saml_callback)).to redirect_to(Settings.ssoe.redirects['myvahealth'])
       end
 
+      it 'logs inbound stat when set in the tracker' do
+        SAMLRequestTracker.create(
+          uuid: login_uuid,
+          payload: { inbound_ssoe: 'true', type: 'mhv' }
+        )
+        allow(SAML::User).to receive(:new).and_return(saml_user)
+        expect { post(:saml_callback) }
+                .to trigger_statsd_increment(described_class::STATSD_LOGIN_INBOUND,
+                                             tags: ["context:mhv", 'version:v1', 'status:success'])
+      end
+
       context 'for a user with semantically invalid SAML attributes' do
         let(:invalid_attributes) do
           build(:ssoe_idme_mhv_loa3,


### PR DESCRIPTION
We have statsd counters to track all the new inbound requests we receive, however we don't have a good way to account for which SAML responses come back from SSOe that are for inbound requests.  Adding these metrics will allow us to track that.