### PR TITLE
add more context to EVSS gender error

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,7 +84,7 @@ class User < Common::RedisStore
   end
 
   def gender
-    identity.gender || (mhv_icn.present? ? mvi&.profile&.gender : nil)
+    identity.gender.presence || (mhv_icn.present? ? mvi&.profile&.gender : nil)
   end
 
   def birth_date

--- a/lib/evss/disability_compensation_auth_headers.rb
+++ b/lib/evss/disability_compensation_auth_headers.rb
@@ -36,9 +36,12 @@ module EVSS
       when 'M'
         'MALE'
       else
+        Raven.extra_context(identity_gender: @user.identity.gender,
+                            mvi_gender: @user.mvi&.profile&.gender)
         raise Common::Exceptions::UnprocessableEntity,
               detail: 'Gender is required & must be "F" or "M"',
-              source: self.class, event_id: Raven.last_event_id
+              source: self.class,
+              event_id: Raven.last_event_id
       end
     end
 

--- a/spec/lib/evss/disability_compensation_auth_headers_spec.rb
+++ b/spec/lib/evss/disability_compensation_auth_headers_spec.rb
@@ -20,6 +20,7 @@ describe EVSS::DisabilityCompensationAuthHeaders do
   # rubocop:enable all
 
   it 'raises an error if gender is not included' do
+    expect(Raven).to receive(:extra_context).with(identity_gender: '', mvi_gender: nil)
     expect { invalid_headers.add_headers(auth_headers) }.to raise_error(Common::Exceptions::UnprocessableEntity)
   end
 end


### PR DESCRIPTION
## Description of change
In http://sentry.vfs.va.gov/vets-gov/platform-api-production/issues/116861/events/e03b48e06b74481d800f42663229dee7/ we see veterans where user.gender is nil/blank/ or something other than 'M' or 'F' this will help us understand whether the issue is with the identity provider or MVI. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10400
