### PR TITLE
temporarily skip CVE-2020-8185

### DIFF
--- a/rakelib/security.rake
+++ b/rakelib/security.rake
@@ -14,7 +14,7 @@ task security: :environment do
 
   puts 'running bundle-audit to check for insecure dependencies...'
   exit!(1) unless ShellCommand.run('bundle-audit update')
-  audit_result = ShellCommand.run('bundle-audit check --ignore CVE-2020-8161 CVE-2020-8184')
+  audit_result = ShellCommand.run('bundle-audit check --ignore CVE-2020-8161 CVE-2020-8184 CVE-2020-8185')
 
   puts "\n"
   if brakeman_result && audit_result


### PR DESCRIPTION
## Description of change
CVE - https://groups.google.com/forum/#!searchin/rubyonrails-security/CVE-2020-8185%7Csort:date/rubyonrails-security/pAe9EV8gbM0/6JpbOZUSBAAJ

untrusted users can run migrations. I think we're fine to skip in the short term as we wouldn't have migrations in master that aren't ok to run.  

I'm making this PR to unblock myself but I don't intend to do the follow-up work. 
