### PR TITLE
[10403] 422 No Supplies Selected Error Handling & 503 Service Unavailable Error Handling

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -1947,6 +1947,12 @@ en:
         detail: Received an an invalid response from the upstream server
         code: MDOT_502
         status: 502
+      MDOT_service_unavailable:
+        <<: *defaults
+        title: Service Unavailable
+        detail: The DLC API is currently unavailable
+        code: MDOT_service_unavailable
+        status: 503
       MDOT_malformed_request:
         <<: *defaults
         title: Malformed Request

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -1970,7 +1970,7 @@ en:
         title: Veteran Not Found
         detail: The veteran could not be found
         code: MDOT_invalid
-        status: 422
+        status: 404
       MDOT_supplies_not_found:
         <<: *defaults
         title: Supplies Not Found

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -1977,6 +1977,12 @@ en:
         detail: The medical supplies could not be found
         code: MDOT_supplies_not_found
         status: 404
+      MDOT_supplies_not_selected:
+        <<: *defaults
+        title: Supplies Not Selected
+        detail: No supplies were selected to order
+        code: MDOT_supplies_not_selected
+        status: 422
       MDOT_unprocessable_entity:
         <<: *defaults
         title: Order unable to be processed

--- a/lib/mdot/client.rb
+++ b/lib/mdot/client.rb
@@ -84,6 +84,10 @@ module MDOT
       }
     end
 
+    def service_unavailable?(error)
+      error.status == '503'
+    end
+
     def with_monitoring_and_error_handling
       with_monitoring(2) do
         yield
@@ -127,7 +131,7 @@ module MDOT
 
     def handle_client_error(error)
       save_error_details(error)
-      code = error.body['result'].downcase
+      code = error&.status != '503' ? error.body['result'].downcase : '503'
 
       raise_backend_exception(
         MDOT::ExceptionKey.new("MDOT_#{code}"),

--- a/lib/mdot/client.rb
+++ b/lib/mdot/client.rb
@@ -84,10 +84,6 @@ module MDOT
       }
     end
 
-    def service_unavailable?(error)
-      error.status == '503'
-    end
-
     def with_monitoring_and_error_handling
       with_monitoring(2) do
         yield
@@ -131,7 +127,7 @@ module MDOT
 
     def handle_client_error(error)
       save_error_details(error)
-      code = error&.status != '503' ? error.body['result'].downcase : '503'
+      code = error&.status != 503 ? error.body['result'].downcase : 'service_unavailable'
 
       raise_backend_exception(
         MDOT::ExceptionKey.new("MDOT_#{code}"),

--- a/lib/mdot/client.rb
+++ b/lib/mdot/client.rb
@@ -52,6 +52,14 @@ module MDOT
     #
     def submit_order(request_body)
       request_body.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
+
+      if request_body['order'].empty?
+        raise_backend_exception(
+          MDOT::ExceptionKey.new('MDOT_supplies_not_selected'),
+          self.class
+        )
+      end
+
       with_monitoring_and_error_handling do
         perform(:post, @supplies, request_body, submission_headers).body
       end

--- a/spec/lib/mdot/client_spec.rb
+++ b/spec/lib/mdot/client_spec.rb
@@ -148,7 +148,7 @@ describe MDOT::Client, type: :mdot_helpers do
         VCR.use_cassette('mdot/submit_order_400') do
           expect(StatsD).to receive(:increment).once.with(
             'api.mdot.submit_order.fail', tags: [
-              'error:Common::Client::Errors::ClientError', 'status:400'
+              'error:Common::Client::Errors::ClientError', 'status:422'
             ]
           )
           expect(StatsD).to receive(:increment).once.with('api.mdot.submit_order.total')

--- a/spec/lib/mdot/client_spec.rb
+++ b/spec/lib/mdot/client_spec.rb
@@ -170,12 +170,6 @@ describe MDOT::Client, type: :mdot_helpers do
 
     context 'with an malformed order' do
       it 'returns a 422 error' do
-        expect(StatsD).to receive(:increment).once.with(
-          'api.mdot.submit_order.fail', tags: [
-            'error:Common::Client::Errors::ClientError', 'status:422'
-          ]
-        )
-        expect(StatsD).to receive(:increment).once.with('api.mdot.submit_order.total')
         set_mdot_token_for(user)
         expect { subject.submit_order(invalid_order) }.to raise_error(MDOT::ServiceException)
       end

--- a/spec/lib/mdot/client_spec.rb
+++ b/spec/lib/mdot/client_spec.rb
@@ -59,8 +59,7 @@ describe MDOT::Client, type: :mdot_helpers do
           expect(StatsD).to receive(:increment).once.with(
             'api.mdot.submit_order.total'
           )
-          set_mdot_token_for(user)
-          expect { subject.submit_order(valid_order) }.to raise_error(
+          expect { subject.get_supplies }.to raise_error(
             MDOT::ServiceException
           ) do |e|
             expect(e.message).to match(/MDOT_service_unavailable/)

--- a/spec/lib/mdot/client_spec.rb
+++ b/spec/lib/mdot/client_spec.rb
@@ -52,12 +52,12 @@ describe MDOT::Client, type: :mdot_helpers do
       it 'raises a 503' do
         VCR.use_cassette('mdot/get_supplies_503') do
           expect(StatsD).to receive(:increment).once.with(
-            'api.mdot.submit_order.fail', tags: [
+            'api.mdot.get_supplies.fail', tags: [
               'error:Common::Client::Errors::ClientError', 'status:503'
             ]
           )
           expect(StatsD).to receive(:increment).once.with(
-            'api.mdot.submit_order.total'
+            'api.mdot.get_supplies.total'
           )
           expect { subject.get_supplies }.to raise_error(
             MDOT::ServiceException

--- a/spec/support/vcr_cassettes/mdot/get_supplies_503.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_503.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Va-Veteran-First-Name:
+      - Breg
+      Va-Veteran-Last-Name:
+      - Branderson
+      Va-Veteran-Id:
+      - '0237'
+      Va-Veteran-Birth-Date:
+      - '1991-04-05'
+      Va-Icn:
+      - 11263043341512898
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 503
+      message: Service Unavailable
+    headers:
+      Date:
+      - Tue, 11 Feb 2020 17:50:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"d007e863ef32711c2efe07a644667be4"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - kong/1.2.2
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Kong-Proxy-Latency:
+      - '1'
+      X-Kong-Upstream-Latency:
+      - '2490'
+      X-Ratelimit-Limit-Minute:
+      - '60'
+      X-Ratelimit-Remaining-Minute:
+      - '59'
+      X-Request-Id:
+      - a4929381-02cd-4700-9c70-e1be2725f4ba
+      X-Runtime:
+      - '2.169886'
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - TS016f4012=01c8917e487bbf38c00f14ca80f4784d99a3d50aa7a8d286fc2ec7369620d39329b185854384eb94e09090c3f636c0aa0d4179b75e;
+        Max-Age=900; Path=/
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"timestamp":"2020-06-18T20:00:33.014+0000","message":"Service Unavailable","details":"uri=/supplies","result":"503"}'
+    http_version:
+  recorded_at: Thu, 18 Jun 2020 20:00:32 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Description of change
- Adds exception handling for 503 errors. If the DLC API is unavailable, this will be relayed to the frontend via a 503 error.
- Adds a 422 error response for handling submissions which have no supplies selected.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10403
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10024

## Testing
- 503 Error was mimicked locally using https://stat.us/503
- 422 error handling was tested locally via the ordering tool
