### PR TITLE
Zeitwerk Prep - use VSO inflection

### DIFF
--- a/app/controllers/v0/vso_appointments_controller.rb
+++ b/app/controllers/v0/vso_appointments_controller.rb
@@ -3,13 +3,13 @@
 require 'vsopdf/vso_appointment_form'
 
 module V0
-  class VsoAppointmentsController < ApplicationController
+  class VSOAppointmentsController < ApplicationController
     include ActionController::ParamsWrapper
 
-    wrap_parameters VsoAppointment, format: :json
+    wrap_parameters VSOAppointment, format: :json
 
     def appt_params
-      params.permit(VsoAppointment.attribute_set.map(&:name) + [
+      params.permit(VSOAppointment.attribute_set.map(&:name) + [
         veteran_full_name: %i[first middle last suffix],
         claimant_full_name: %i[first middle last suffix],
         claimant_address: %i[street street2 city country state postal_code]
@@ -17,10 +17,10 @@ module V0
     end
 
     def create
-      appt = VsoAppointment.new(appt_params)
+      appt = VSOAppointment.new(appt_params)
       raise Common::Exceptions::ParameterMissing, appt.errors.messages.keys.first.to_s unless appt.valid?
 
-      form = VsoAppointmentForm.new appt
+      form = VSOAppointmentForm.new appt
       resp = form.send_pdf
 
       if resp.status == 200

--- a/app/models/vso_appointment.rb
+++ b/app/models/vso_appointment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class VsoAppointment
+class VSOAppointment
   extend ActiveModel::Callbacks
 
   include ActiveModel::Validations

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,5 +16,6 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'VAOS'
   inflect.acronym 'VBA'
   inflect.acronym 'VIC'
+  inflect.acronym 'VSO'
   inflect.uncountable 'terms_and_conditions'
 end

--- a/lib/evss/vso_search/configuration.rb
+++ b/lib/evss/vso_search/configuration.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module EVSS
-  module VsoSearch
+  module VSOSearch
     ##
-    # HTTP client configuration for the {VsoSearch::Service},
+    # HTTP client configuration for the {VSOSearch::Service},
     # sets the base path and a service name for breakers and metrics.
     #
     class Configuration < EVSS::Configuration
@@ -20,11 +20,11 @@ module EVSS
       # @return [String] Service name to use in breakers and metrics.
       #
       def service_name
-        'EVSS/VsoSearch'
+        'EVSS/VSOSearch'
       end
 
       ##
-      # HTTP client configuration for the {VsoSearch::Service},
+      # HTTP client configuration for the {VSOSearch::Service},
       # sets the base path, a default timeout, and a service name for breakers and metrics.
       #
       def mock_enabled?

--- a/lib/evss/vso_search/service.rb
+++ b/lib/evss/vso_search/service.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 module EVSS
-  module VsoSearch
+  module VSOSearch
     ##
     # Proxy Service for VSO search
     #
     # @example Create a service and fetching current info for a user
-    #   vso_search_response = VsoSearch::Service.new.get_current_info
+    #   vso_search_response = VSOSearch::Service.new.get_current_info
     #
     class Service < EVSS::Service
-      configuration EVSS::VsoSearch::Configuration
+      configuration EVSS::VSOSearch::Configuration
 
       ##
       # Returns current info for a user by their SSN

--- a/lib/vsopdf/vso_appointment_form.rb
+++ b/lib/vsopdf/vso_appointment_form.rb
@@ -4,7 +4,7 @@ require 'pdf_forms'
 require 'tempfile'
 require 'securerandom'
 
-class VsoAppointmentForm
+class VSOAppointmentForm
   include Common::Client::Monitoring
   STATSD_KEY_PREFIX = 'api.vso_appoinment_form'
 

--- a/modules/claims_api/spec/unsynchronized_evss_claims_service_spec.rb
+++ b/modules/claims_api/spec/unsynchronized_evss_claims_service_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe ClaimsApi::UnsynchronizedEVSSClaimService, type: :model do
   let(:auth_headers) { EVSS::AuthHeaders.new(user).to_h }
 
   before do
-    @client_stub = instance_double('EVSS::VsoSearch::Service')
-    allow(EVSS::VsoSearch::Service).to receive(:new).with(user) { @client_stub }
+    @client_stub = instance_double('EVSS::VSOSearch::Service')
+    allow(EVSS::VSOSearch::Service).to receive(:new).with(user) { @client_stub }
     allow(@client_stub).to receive(:get_current_info) { get_fixture('json/veteran_with_poa') }
     @veteran = Veteran::User.new(user)
     @veteran.power_of_attorney = PowerOfAttorney.new(ssn: '123456789')

--- a/modules/veteran/app/models/veteran/user.rb
+++ b/modules/veteran/app/models/veteran/user.rb
@@ -19,7 +19,7 @@ module Veteran
 
     def initialize(user)
       @user = user
-      build_from_json(EVSS::VsoSearch::Service.new(user).get_current_info(auth_headers))
+      build_from_json(EVSS::VSOSearch::Service.new(user).get_current_info(auth_headers))
     end
 
     def build_from_json(json_data)

--- a/modules/veteran/app/workers/veteran/vso_reloader.rb
+++ b/modules/veteran/app/workers/veteran/vso_reloader.rb
@@ -3,7 +3,7 @@
 require 'sidekiq'
 
 module Veteran
-  class VsoReloader < BaseReloader
+  class VSOReloader < BaseReloader
     def perform
       array_of_organizations = reload_representatives
       # This Where Not statement is for removing anyone no longer on the lists pulled down from OGC

--- a/modules/veteran/lib/tasks/veteran_tasks.rake
+++ b/modules/veteran/lib/tasks/veteran_tasks.rake
@@ -5,7 +5,7 @@ namespace :veteran do
   desc 'Reload VSO Information'
   task reload_vso_data: :environment do
     puts 'Loading VSO data from OGC'
-    Veteran::VsoReloader.perform_async
+    Veteran::VSOReloader.perform_async
     puts "#{Veteran::Service::Organization.count} Organizations loaded"
     puts "#{Veteran::Service::Representative.count} Representatives loaded"
   end

--- a/modules/veteran/spec/models/veteran/user_spec.rb
+++ b/modules/veteran/spec/models/veteran/user_spec.rb
@@ -8,8 +8,8 @@ describe Veteran::User do
     let(:auth_headers) { EVSS::AuthHeaders.new(user).to_h }
 
     before do
-      @client_stub = instance_double('EVSS::VsoSearch::Service')
-      allow(EVSS::VsoSearch::Service).to receive(:new).with(user) { @client_stub }
+      @client_stub = instance_double('EVSS::VSOSearch::Service')
+      allow(EVSS::VSOSearch::Service).to receive(:new).with(user) { @client_stub }
     end
 
     it 'initializes from a user' do

--- a/modules/veteran/spec/workers/veteran/vso_reloader_spec.rb
+++ b/modules/veteran/spec/workers/veteran/vso_reloader_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'sidekiq/testing'
 Sidekiq::Testing.fake!
 
-RSpec.describe Veteran::VsoReloader, type: :job do
+RSpec.describe Veteran::VSOReloader, type: :job do
   subject { described_class }
 
   before do
@@ -14,7 +14,7 @@ RSpec.describe Veteran::VsoReloader, type: :job do
   describe 'importer' do
     it 'reloads data from pulldown' do
       VCR.use_cassette('veteran/ogc_poa_data') do
-        Veteran::VsoReloader.new.perform
+        Veteran::VSOReloader.new.perform
         expect(Veteran::Service::Representative.count).to eq 435
         expect(Veteran::Service::Organization.count).to eq 3
         expect(Veteran::Service::Representative.attorneys.count).to eq 241
@@ -25,21 +25,21 @@ RSpec.describe Veteran::VsoReloader, type: :job do
 
     it 'loads attorneys with the poa codes loaded' do
       VCR.use_cassette('veteran/ogc_attorney_data') do
-        Veteran::VsoReloader.new.reload_attorneys
+        Veteran::VSOReloader.new.reload_attorneys
         expect(Veteran::Service::Representative.last.poa_codes).to include('9GB')
       end
     end
 
     it 'loads a claim agent  with the poa code' do
       VCR.use_cassette('veteran/ogc_claim_agent_data') do
-        Veteran::VsoReloader.new.reload_claim_agents
+        Veteran::VSOReloader.new.reload_claim_agents
         expect(Veteran::Service::Representative.last.poa_codes).to include('FDN')
       end
     end
 
     it 'loads a vso rep with the poa code' do
       VCR.use_cassette('veteran/ogc_vso_rep_data') do
-        Veteran::VsoReloader.new.reload_vso_reps
+        Veteran::VSOReloader.new.reload_vso_reps
         expect(Veteran::Service::Representative.last.poa_codes).to include('091')
       end
     end

--- a/spec/controllers/v0/vso_appointments_controller_spec.rb
+++ b/spec/controllers/v0/vso_appointments_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe V0::VsoAppointmentsController, type: :controller do
+RSpec.describe V0::VSOAppointmentsController, type: :controller do
   context 'before login' do
     it 'rejects a post' do
       post :create, params: { 'beep': 'boop' }
@@ -24,7 +24,7 @@ RSpec.describe V0::VsoAppointmentsController, type: :controller do
 
     it 'balks at a bunch of garbage values' do
       payload = {}
-      VsoAppointment.attribute_set.each { |attr| payload[attr.name.to_s] = 'beep' }
+      VSOAppointment.attribute_set.each { |attr| payload[attr.name.to_s] = 'beep' }
       %w[claimant_full_name veteran_full_name claimant_address].each do |attr|
         payload.delete(attr)
       end
@@ -37,7 +37,7 @@ RSpec.describe V0::VsoAppointmentsController, type: :controller do
       VCR.use_cassette('vso_appointments/upload') do
         # fill in everything with junk by default
         payload = {}
-        VsoAppointment.attribute_set.each { |attr| payload[attr.name.to_s] = 'beep' }
+        VSOAppointment.attribute_set.each { |attr| payload[attr.name.to_s] = 'beep' }
 
         # This will actually accept camel case, but /shrug
         payload = payload.merge(

--- a/spec/lib/evss/power_of_attorney_verifier_spec.rb
+++ b/spec/lib/evss/power_of_attorney_verifier_spec.rb
@@ -9,8 +9,8 @@ describe EVSS::PowerOfAttorneyVerifier do
   let(:identity) { FactoryBot.create(:user_identity) }
 
   before do
-    @client_stub = instance_double('EVSS::VsoSearch::Service')
-    allow(EVSS::VsoSearch::Service).to receive(:new).with(user) { @client_stub }
+    @client_stub = instance_double('EVSS::VSOSearch::Service')
+    allow(EVSS::VSOSearch::Service).to receive(:new).with(user) { @client_stub }
     allow(@client_stub).to receive(:get_current_info) { get_fixture('json/veteran_with_poa') }
     @veteran = Veteran::User.new(user)
     @veteran.power_of_attorney = PowerOfAttorney.new(ssn: '123456789')

--- a/spec/lib/evss/vso_search/configuration_spec.rb
+++ b/spec/lib/evss/vso_search/configuration_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe EVSS::VsoSearch::Configuration do
+describe EVSS::VSOSearch::Configuration do
   describe '#base_path' do
     it 'has a base path' do
       version = Settings.evss.versions.common
@@ -13,7 +13,7 @@ describe EVSS::VsoSearch::Configuration do
 
   describe '#service_name' do
     it 'has the expected service name' do
-      expect(described_class.instance.service_name).to eq('EVSS/VsoSearch')
+      expect(described_class.instance.service_name).to eq('EVSS/VSOSearch')
     end
   end
 

--- a/spec/lib/evss/vso_search/service_spec.rb
+++ b/spec/lib/evss/vso_search/service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe EVSS::VsoSearch::Service do
+describe EVSS::VSOSearch::Service do
   let(:user) { create(:evss_user) }
   let(:service) { described_class.new(user) }
   let(:response) { OpenStruct.new(body: get_fixture('json/veteran_with_poa')) }

--- a/spec/lib/vsopdf/vso_appointment_form_spec.rb
+++ b/spec/lib/vsopdf/vso_appointment_form_spec.rb
@@ -4,10 +4,10 @@ require 'pdf_forms'
 require 'rails_helper'
 require 'vsopdf/vso_appointment_form'
 
-describe VsoAppointmentForm do
+describe VSOAppointmentForm do
   include SchemaMatchers
 
-  form = VsoAppointmentForm.new(VsoAppointment.new(
+  form = VSOAppointmentForm.new(VSOAppointment.new(
                                   veteran_full_name: {
                                     first: 'Graham',
                                     last: 'Test'
@@ -30,7 +30,7 @@ describe VsoAppointmentForm do
                                   disclosure_exception_hiv: true
                                 ))
 
-  it 'translates a VsoAppointment object' do
+  it 'translates a VSOAppointment object' do
     # Spot check the arg translation
     args = form.to_pdf_args
 


### PR DESCRIPTION
## Description of change
Introduce VSO inflection as part of prep-work for enabling zeitwerk.  All references to `Vso` have become `VSO`.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10165