### PR TITLE
Add Filip Fafara to flipper admin list

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -465,6 +465,7 @@ flipper:
     - devinmccurdy@gmail.com
     - eric.buckley@adhocteam.us
     - erik@adhocteam.us
+    - filip.fafara@gmail.com
     - grodriguez@governmentcio.com
     - hughes_dustin@bah.com
     - jbalboni@gmail.com


### PR DESCRIPTION
This adds Filip Fafara from ThoughtWorks team to the list of flipper admins in preparation for VANotify (notifications engine) integration.