### PR TITLE
don't ignore CVE-2020-8184 in bundle-audit; fix is merged

### DIFF
--- a/rakelib/security.rake
+++ b/rakelib/security.rake
@@ -14,7 +14,7 @@ task security: :environment do
 
   puts 'running bundle-audit to check for insecure dependencies...'
   exit!(1) unless ShellCommand.run('bundle-audit update')
-  audit_result = ShellCommand.run('bundle-audit check --ignore CVE-2020-8161 CVE-2020-8184')
+  audit_result = ShellCommand.run('bundle-audit check --ignore CVE-2020-8161')
 
   puts "\n"
   if brakeman_result && audit_result


### PR DESCRIPTION
Now that https://github.com/department-of-veterans-affairs/vets-api/pull/4394 has been merged, `bundle-audit` does not need to ignore CVE-2020-8184.