### PR TITLE
Pv saml post binding

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -9,7 +9,6 @@ require 'saml/responses/logout'
 module V1
   class SessionsController < ApplicationController
     skip_before_action :verify_authenticity_token
-    # before_action :enable_post_view
 
     REDIRECT_URLS = %w[signup mhv dslogon idme custom mfa verify slo].freeze
 

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -127,7 +127,7 @@ module V1
     end
 
     def render_login(type, previous_saml_uuid = nil)
-      post_params, login_url = login_params(type, previous_saml_uuid)
+      login_url, post_params = login_params(type, previous_saml_uuid)
       renderer = ActionController::Base.renderer
       renderer.controller.prepend_view_path(Rails.root.join('lib', 'saml', 'templates'))
       result = renderer.render template: 'sso_post_form',

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -139,7 +139,8 @@ module V1
     def login_params(type, previous_saml_uuid = nil)
       raise Common::Exceptions::RoutingError, type unless REDIRECT_URLS.include?(type)
 
-      helper = url_service(previous_saml_uuid)
+      force = (type != 'custom')
+      helper = url_service(previous_saml_uuid, force)
       case type
       when 'signup'
         helper.signup_url
@@ -250,8 +251,8 @@ module V1
       'UNKNOWN'
     end
 
-    def url_service(previous_saml_uuid = nil)
-      SAML::PostURLService.new(saml_settings,
+    def url_service(previous_saml_uuid = nil, force_authn = false)
+      SAML::PostURLService.new(saml_settings(force_authn: force_authn),
                                session: @session_object,
                                user: current_user,
                                params: params,

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -8,7 +8,11 @@ require 'saml/responses/logout'
 
 module V1
   class SessionsController < ApplicationController
+    include ActionController::Rendering
+    include ActionView::Layouts
+
     skip_before_action :verify_authenticity_token
+    before_action :enable_post_view
 
     REDIRECT_URLS = %w[signup mhv dslogon idme custom mfa verify slo].freeze
 
@@ -33,16 +37,19 @@ module V1
     def new
       type = params[:type]
 
-      url = redirect_url(type)
       new_stats(type)
 
       if type == 'slo'
         Rails.logger.info("LOGOUT of type #{type}", sso_logging_info)
         reset_session
+        url = url_service.ssoe_slo_url 
+        # due to shared url service implementation
+        # clientId must be added at the end or the URL will be invalid for users using various "Do not track"
+        # extensions with their browser.
+        redirect_to params[:client_id].present? ? url + "&clientId=#{params[:client_id]}" : url
+      else
+        render_login(type)
       end
-      # clientId must be added at the end or the URL will be invalid for users using various "Do not track"
-      # extensions with their browser.
-      redirect_to params[:client_id].present? ? url + "&clientId=#{params[:client_id]}" : url
     end
 
     def ssoe_slo_callback
@@ -72,33 +79,6 @@ module V1
     end
 
     private
-
-    # rubocop:disable Metrics/CyclomaticComplexity
-    def redirect_url(type)
-      raise Common::Exceptions::RoutingError, type unless REDIRECT_URLS.include?(type)
-
-      case type
-      when 'signup'
-        url_service.signup_url
-      when 'mhv'
-        url_service.mhv_url
-      when 'dslogon'
-        url_service.dslogon_url
-      when 'idme'
-        url_service.idme_url
-      when 'mfa'
-        url_service.mfa_url
-      when 'verify'
-        url_service.verify_url
-      when 'custom'
-        raise Common::Exceptions::ParameterMissing, 'authn' if params[:authn].blank?
-
-        url_service.custom_url params[:authn]
-      when 'slo'
-        url_service.ssoe_slo_url # due to shared url service implementation
-      end
-    end
-    # rubocop:enable Metrics/CyclomaticComplexity
 
     def force_authn?
       params[:force]&.downcase == 'true'
@@ -141,14 +121,43 @@ module V1
       @current_user, @session_object = user_session_form.persist
       set_cookies
       after_login_actions
-      redirect_to url_service(user_session_form.saml_uuid).login_redirect_url
-      if location.start_with?(url_service.base_redirect_url)
-        # only record login stats if the user is being redirect to the site
-        # some users will need to be up-leveled and this will be redirected
-        # back to the identity provider
+      helper = url_service(user_session_form.saml_uuid)
+      if helper.should_uplevel?
+        render_login('verify')
+      else
+        redirect_to helper.login_redirect_url
         login_stats(:success, saml_response, user_session_form)
       end
     end
+
+    def render_login(type, previous_saml_uuid = nil)
+      post_params, login_url = login_params(type, previous_saml_uuid)
+      render template: 'sso_post_form', locals: { url: login_url, params: post_params }
+    end
+
+    # rubocop:disable Metrics/CyclomaticComplexity
+    def login_params(type, previous_saml_uuid = nil)
+      raise Common::Exceptions::RoutingError, type unless REDIRECT_URLS.include?(type)
+      helper = url_service(previous_saml_uuid)
+      case type
+      when 'signup'
+        helper.signup_url
+      when 'mhv'
+        helper.mhv_url
+      when 'dslogon'
+        helper.dslogon_url
+      when 'idme'
+        helper.idme_url
+      when 'mfa'
+        helper.mfa_url
+      when 'verify'
+        helper.verify_url
+      when 'custom'
+        raise Common::Exceptions::ParameterMissing, 'authn' if params[:authn].blank?
+        helper.custom_url params[:authn]
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def user_logout(saml_response)
       logout_request = SingleLogoutRequest.find(saml_response&.in_response_to)
@@ -240,12 +249,16 @@ module V1
     end
 
     def url_service(previous_saml_uuid = nil)
-      SAML::URLService.new(saml_settings,
-                           session: @session_object,
-                           user: current_user,
-                           params: params,
-                           loa3_context: LOA::IDME_LOA3,
-                           previous_saml_uuid: previous_saml_uuid)
+      SAML::PostURLService.new(saml_settings,
+                               session: @session_object,
+                               user: current_user,
+                               params: params,
+                               loa3_context: LOA::IDME_LOA3,
+                               previous_saml_uuid: previous_saml_uuid)
+    end
+
+    def enable_post_view
+      prepend_view_path(Rails.root.join('lib', 'saml', 'templates'))
     end
   end
 end

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -8,7 +8,6 @@ require 'saml/responses/logout'
 
 module V1
   class SessionsController < ApplicationController
-
     skip_before_action :verify_authenticity_token
     # before_action :enable_post_view
 
@@ -35,20 +34,18 @@ module V1
     def new
       type = params[:type]
 
-
       if type == 'slo'
         Rails.logger.info("LOGOUT of type #{type}", sso_logging_info)
         reset_session
-        url = url_service.ssoe_slo_url 
+        url = url_service.ssoe_slo_url
         # due to shared url service implementation
         # clientId must be added at the end or the URL will be invalid for users using various "Do not track"
         # extensions with their browser.
         redirect_to params[:client_id].present? ? url + "&clientId=#{params[:client_id]}" : url
-        new_stats(type)
       else
         render_login(type)
-        new_stats(type)
       end
+      new_stats(type)
     end
 
     def ssoe_slo_callback
@@ -134,14 +131,15 @@ module V1
       renderer = ActionController::Base.renderer
       renderer.controller.prepend_view_path(Rails.root.join('lib', 'saml', 'templates'))
       result = renderer.render template: 'sso_post_form',
-        locals: { url: login_url, params: post_params },
-        format: :html
-      render body: result, content_type: "text/html"
+                               locals: { url: login_url, params: post_params },
+                               format: :html
+      render body: result, content_type: 'text/html'
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity
     def login_params(type, previous_saml_uuid = nil)
       raise Common::Exceptions::RoutingError, type unless REDIRECT_URLS.include?(type)
+
       helper = url_service(previous_saml_uuid)
       case type
       when 'signup'
@@ -158,6 +156,7 @@ module V1
         helper.verify_url
       when 'custom'
         raise Common::Exceptions::ParameterMissing, 'authn' if params[:authn].blank?
+
         helper.custom_url params[:authn]
       end
     end

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 module SAML
-  # This class is responsible for providing the requests for the various
-  # SSO and SLO endpoints
-  # It provides a similar interface to URLService, but for most endpoints
-  # it returns an SSO URL and form request parameters for use in a SAML POST
-  # submission, instead of a self-contained redirect URL.
+  # This class is responsible for providing the requests for the various SSO and SLO endpoints.
+  # It provides a similar interface to {SAML::URLService}, but for most endpoints it returns an SSO URL and 
+  # form request parameters for use in a SAML POST submission, instead of a self-contained redirect URL.
+  #
+  # @see SAML::URLService
+  #
   class PostURLService < URLService
     # rubocop:disable Metrics/ParameterLists
     def initialize(saml_settings, session: nil, user: nil, params: {},

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -6,24 +6,8 @@ module SAML
   # It provides a similar interface to URLService, but for most endpoints
   # it returns an SSO URL and form request parameters for use in a SAML POST
   # submission, instead of a self-contained redirect URL.
-  class PostURLService
-    VIRTUAL_HOST_MAPPINGS = {
-      'https://api.vets.gov' => { base_redirect: 'https://www.vets.gov' },
-      'https://staging-api.vets.gov' => { base_redirect: 'https://staging.vets.gov' },
-      'https://dev-api.vets.gov' => { base_redirect: 'https://dev.vets.gov' },
-      'https://api.va.gov' => { base_redirect: 'https://www.va.gov' },
-      'https://staging-api.va.gov' => { base_redirect: 'https://staging.va.gov' },
-      'https://dev-api.va.gov' => { base_redirect: 'https://dev.va.gov' },
-      'http://localhost:3000' => { base_redirect: 'http://localhost:3001' },
-      'http://127.0.0.1:3000' => { base_redirect: 'http://127.0.0.1:3001' }
-    }.freeze
-
-    LOGIN_REDIRECT_PARTIAL = '/auth/login/callback'
-    LOGOUT_REDIRECT_PARTIAL = '/logout/'
-
-    attr_reader :saml_settings, :session, :user, :authn_context, :type, :query_params, :tracker
-
-    # rubocop:disable Metrics/ParameterLists
+  class PostURLService < URLService
+   # rubocop:disable Metrics/ParameterLists
     def initialize(saml_settings, session: nil, user: nil, params: {},
                    loa3_context: LOA::IDME_LOA3_VETS, previous_saml_uuid: nil)
       unless %w[new saml_callback saml_logout_callback ssoe_slo_callback].include?(params[:action])
@@ -49,11 +33,6 @@ module SAML
       Raven.user_context(session: session, user: user)
     end
     # rubocop:enable Metrics/ParameterLists
-
-    # REDIRECT_URLS
-    def base_redirect_url
-      VIRTUAL_HOST_MAPPINGS[current_host][:base_redirect]
-    end
 
     def should_uplevel?
       user.loa[:current] < user.loa[:highest]
@@ -88,69 +67,6 @@ module SAML
       "#{base_redirect_url}#{LOGOUT_REDIRECT_PARTIAL}"
     end
 
-    # SIGN ON URLS
-    def mhv_url
-      @type = 'mhv'
-      build_sso_url('myhealthevet')
-    end
-
-    def dslogon_url
-      @type = 'dslogon'
-      build_sso_url('dslogon')
-    end
-
-    def idme_url
-      @type = 'idme'
-      build_sso_url(LOA::IDME_LOA1_VETS)
-    end
-
-    def custom_url(authn)
-      @type = 'custom'
-      build_sso_url(authn)
-    end
-
-    def signup_url
-      @type = 'signup'
-      @query_params[:op] = 'signup'
-      build_sso_url(LOA::IDME_LOA1_VETS)
-    end
-
-    def verify_url
-      # For verification from a login callback, type should be the initial login policy.
-      # In that case, it will have been set to the type from RelayState.
-      @type ||= 'verify'
-
-      link_authn_context =
-        case authn_context
-        when LOA::IDME_LOA1_VETS, 'multifactor'
-          @loa3_context
-        when 'myhealthevet', 'myhealthevet_multifactor'
-          'myhealthevet_loa3'
-        when 'dslogon', 'dslogon_multifactor'
-          'dslogon_loa3'
-        when SAML::UserAttributes::SSOe::INBOUND_AUTHN_CONTEXT
-          "#{@user.identity.sign_in[:service_name]}_loa3"
-        end
-
-      build_sso_url(link_authn_context)
-    end
-
-    def mfa_url
-      @type = 'mfa'
-      link_authn_context =
-        case authn_context
-        when LOA::IDME_LOA1_VETS, LOA::IDME_LOA3_VETS, LOA::IDME_LOA3
-          'multifactor'
-        when 'myhealthevet', 'myhealthevet_loa3'
-          'myhealthevet_multifactor'
-        when 'dslogon', 'dslogon_loa3'
-          'dslogon_multifactor'
-        when SAML::UserAttributes::SSOe::INBOUND_AUTHN_CONTEXT
-          "#{@user.identity.sign_in[:service_name]}_multifactor"
-        end
-      build_sso_url(link_authn_context)
-    end
-
     # logout URL for SSOe
     def ssoe_slo_url
       Settings.saml_ssoe.logout_url
@@ -168,66 +84,6 @@ module SAML
       post_params = saml_auth_request.create_params(new_url_settings, 'RelayState' => relay_state_params)
       login_url = new_url_settings.idp_sso_target_url
       [login_url, post_params]
-    end
-
-    def relay_state_params
-      rs_params = {
-        originating_request_id: RequestStore.store['request_id'],
-        type: type
-      }
-      rs_params[:review_instance_slug] = Settings.review_instance_slug unless Settings.review_instance_slug.nil?
-      rs_params.to_json
-    end
-
-    def current_host
-      uri = URI.parse(saml_settings.assertion_consumer_service_url)
-      URI.join(uri, '/').to_s.chop
-    end
-
-    def url_settings
-      url_settings = saml_settings.dup
-      url_settings.name_identifier_value = session&.uuid
-      url_settings
-    end
-
-    def add_query(url, params)
-      if params.any?
-        uri = URI.parse(url)
-        uri.query = Rack::Utils.parse_nested_query(uri.query).merge(params).to_query
-        uri.to_s
-      else
-        url
-      end
-    end
-
-    def build_redirect(params)
-      default = Settings.ssoe.redirects[params[:application]]
-      return default unless default && params[:to]
-
-      prefix = default.delete_suffix('/')
-      suffix = params[:to].delete_prefix('/').gsub("\r\n", '')
-      [prefix, suffix].join('/')
-    end
-
-    # Initialize a new SAMLRequestTracker, if a valid previous SAML UUID is
-    # given, copy over the redirect and created_at timestamp.  This is useful
-    # for a user that has to go through the upleveling process.
-    def initialize_tracker(params, previous_saml_uuid: nil)
-      previous = previous_saml_uuid && SAMLRequestTracker.find(previous_saml_uuid)
-      redirect = previous&.payload_attr(:redirect) || build_redirect(params)
-      inbound = previous&.payload_attr(:inbound_ssoe) || params[:inbound]
-      type = previous&.payload_attr(:type) || params[:type]
-      # if created_at is set to nil (meaning no previous tracker to use), it
-      # will be initialized to the current time when it is saved
-      SAMLRequestTracker.new(
-        payload: { redirect: redirect, inbound_ssoe: inbound, type: type }.compact,
-        created_at: previous&.created_at
-      )
-    end
-
-    def save_saml_request_tracker(uuid)
-      @tracker.uuid = uuid
-      @tracker.save
     end
   end
 end

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -167,7 +167,7 @@ module SAML
       save_saml_request_tracker(saml_auth_request.uuid)
       post_params = saml_auth_request.create_params(new_url_settings, 'RelayState' => relay_state_params)
       login_url = new_url_settings.idp_sso_target_url
-      [post_params, login_url]
+      [login_url, post_params]
     end
 
     def relay_state_params

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -2,7 +2,7 @@
 
 module SAML
   # This class is responsible for providing the requests for the various SSO and SLO endpoints.
-  # It provides a similar interface to {SAML::URLService}, but for most endpoints it returns an SSO URL and 
+  # It provides a similar interface to {SAML::URLService}, but for most endpoints it returns an SSO URL and
   # form request parameters for use in a SAML POST submission, instead of a self-contained redirect URL.
   #
   # @see SAML::URLService

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+module SAML
+  # This class is responsible for providing the requests for the various 
+  # SSO and SLO endpoints
+  # It provides a similar interface to URLService, but for most endpoints
+  # it returns an SSO URL and form request parameters for use in a SAML POST
+  # submission, instead of a self-contained redirect URL.
+  class PostURLService
+    VIRTUAL_HOST_MAPPINGS = {
+      'https://api.vets.gov' => { base_redirect: 'https://www.vets.gov' },
+      'https://staging-api.vets.gov' => { base_redirect: 'https://staging.vets.gov' },
+      'https://dev-api.vets.gov' => { base_redirect: 'https://dev.vets.gov' },
+      'https://api.va.gov' => { base_redirect: 'https://www.va.gov' },
+      'https://staging-api.va.gov' => { base_redirect: 'https://staging.va.gov' },
+      'https://dev-api.va.gov' => { base_redirect: 'https://dev.va.gov' },
+      'http://localhost:3000' => { base_redirect: 'http://localhost:3001' },
+      'http://127.0.0.1:3000' => { base_redirect: 'http://127.0.0.1:3001' }
+    }.freeze
+
+    LOGIN_REDIRECT_PARTIAL = '/auth/login/callback'
+    LOGOUT_REDIRECT_PARTIAL = '/logout/'
+
+    attr_reader :saml_settings, :session, :user, :authn_context, :type, :query_params, :tracker
+
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(saml_settings, session: nil, user: nil, params: {},
+                   loa3_context: LOA::IDME_LOA3_VETS, previous_saml_uuid: nil)
+      unless %w[new saml_callback saml_logout_callback ssoe_slo_callback].include?(params[:action])
+        raise Common::Exceptions::RoutingError, params[:path]
+      end
+
+      if session.present?
+        @session = session
+        @user = user
+        @authn_context = user&.authn_context
+      end
+
+      @saml_settings = saml_settings
+      @loa3_context = loa3_context
+
+      if (params[:action] == 'saml_callback') && params[:RelayState].present?
+        @type = JSON.parse(params[:RelayState])['type']
+      end
+      @query_params = {}
+      @tracker = initialize_tracker(params, previous_saml_uuid: previous_saml_uuid)
+
+      Raven.extra_context(params: params)
+      Raven.user_context(session: session, user: user)
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    # REDIRECT_URLS
+    def base_redirect_url
+      VIRTUAL_HOST_MAPPINGS[current_host][:base_redirect]
+    end
+
+    def should_uplevel?
+      user.loa[:current] < user.loa[:highest]
+    end
+
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def login_redirect_url(auth: 'success', code: nil)
+      if auth == 'success'
+        # if the original auth request specified a redirect, use that
+        redirect_target = @tracker&.payload_attr(:redirect)
+        return redirect_target if redirect_target.present?
+      end
+
+      # if the original auth request specified inbound ssoe and authentication
+      # failed, set 'force-needed' so the FE can silently fail authentication and NOT
+      # show the user an error page
+      auth = 'force-needed' if (auth != 'success') && @tracker&.payload_attr(:inbound_ssoe)
+
+      @query_params[:type] = type if type
+      @query_params[:auth] = auth if auth != 'success'
+      @query_params[:code] = code if code
+
+      if Settings.saml.relay.present?
+        add_query(Settings.saml.relay, query_params)
+      else
+        add_query("#{base_redirect_url}#{LOGIN_REDIRECT_PARTIAL}", query_params)
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+    def logout_redirect_url
+      "#{base_redirect_url}#{LOGOUT_REDIRECT_PARTIAL}"
+    end
+
+    # SIGN ON URLS
+    def mhv_url
+      @type = 'mhv'
+      build_sso_url('myhealthevet')
+    end
+
+    def dslogon_url
+      @type = 'dslogon'
+      build_sso_url('dslogon')
+    end
+
+    def idme_url
+      @type = 'idme'
+      build_sso_url(LOA::IDME_LOA1_VETS)
+    end
+
+    def custom_url(authn)
+      @type = 'custom'
+      build_sso_url(authn)
+    end
+
+    def signup_url
+      @type = 'signup'
+      @query_params[:op] = 'signup'
+      build_sso_url(LOA::IDME_LOA1_VETS)
+    end
+
+    def verify_url
+      # For verification from a login callback, type should be the initial login policy.
+      # In that case, it will have been set to the type from RelayState.
+      @type ||= 'verify'
+
+      link_authn_context =
+        case authn_context
+        when LOA::IDME_LOA1_VETS, 'multifactor'
+          @loa3_context
+        when 'myhealthevet', 'myhealthevet_multifactor'
+          'myhealthevet_loa3'
+        when 'dslogon', 'dslogon_multifactor'
+          'dslogon_loa3'
+        when SAML::UserAttributes::SSOe::INBOUND_AUTHN_CONTEXT
+          "#{@user.identity.sign_in[:service_name]}_loa3"
+        end
+
+      build_sso_url(link_authn_context)
+    end
+
+    def mfa_url
+      @type = 'mfa'
+      link_authn_context =
+        case authn_context
+        when LOA::IDME_LOA1_VETS, LOA::IDME_LOA3_VETS, LOA::IDME_LOA3
+          'multifactor'
+        when 'myhealthevet', 'myhealthevet_loa3'
+          'myhealthevet_multifactor'
+        when 'dslogon', 'dslogon_loa3'
+          'dslogon_multifactor'
+        when SAML::UserAttributes::SSOe::INBOUND_AUTHN_CONTEXT
+          "#{@user.identity.sign_in[:service_name]}_multifactor"
+        end
+      build_sso_url(link_authn_context)
+    end
+
+    # SIGN OFF URLS
+    # This method is not used as SSOe does not support SAML SLO
+    def slo_url
+      @type = 'slo'
+      logout_request = OneLogin::RubySaml::Logoutrequest.new
+      # cache the request for session.token lookup when we receive the response
+      SingleLogoutRequest.create(uuid: logout_request.uuid, token: session.token)
+      Rails.logger.info "New SP SLO having logout_request '#{logout_request.uuid}' for userid '#{session.uuid}'"
+      logout_request.create(url_settings, RelayState: relay_state_params)
+    end
+
+    # logout URL for SSOe
+    def ssoe_slo_url
+      Settings.saml_ssoe.logout_url
+    end
+
+    private
+
+    # Builds the urls to trigger various SSO policies: mhv, dslogon, idme, mfa, or verify flows.
+    # link_authn_context is the new proposed authn_context
+    def build_sso_url(link_authn_context)
+      new_url_settings = url_settings
+      new_url_settings.authn_context = link_authn_context
+      saml_auth_request = OneLogin::RubySaml::Authrequest.new
+      save_saml_request_tracker(saml_auth_request.uuid)
+      post_params = saml_auth_request.create_params(new_url_settings, 'RelayState' => relay_state_params)
+      login_url = new_url_settings.idp_sso_target_url
+      [post_params, login_url]
+    end
+
+    def relay_state_params
+      rs_params = {
+        originating_request_id: RequestStore.store['request_id'],
+        type: type
+      }
+      rs_params[:review_instance_slug] = Settings.review_instance_slug unless Settings.review_instance_slug.nil?
+      rs_params.to_json
+    end
+
+    def current_host
+      uri = URI.parse(saml_settings.assertion_consumer_service_url)
+      URI.join(uri, '/').to_s.chop
+    end
+
+    def url_settings
+      url_settings = saml_settings.dup
+      url_settings.name_identifier_value = session&.uuid
+      url_settings
+    end
+
+    def add_query(url, params)
+      if params.any?
+        uri = URI.parse(url)
+        uri.query = Rack::Utils.parse_nested_query(uri.query).merge(params).to_query
+        uri.to_s
+      else
+        url
+      end
+    end
+
+    def build_redirect(params)
+      default = Settings.ssoe.redirects[params[:application]]
+      return default unless default && params[:to]
+
+      prefix = default.delete_suffix('/')
+      suffix = params[:to].delete_prefix('/').gsub("\r\n", '')
+      [prefix, suffix].join('/')
+    end
+
+    # Initialize a new SAMLRequestTracker, if a valid previous SAML UUID is
+    # given, copy over the redirect and created_at timestamp.  This is useful
+    # for a user that has to go through the upleveling process.
+    def initialize_tracker(params, previous_saml_uuid: nil)
+      previous = previous_saml_uuid && SAMLRequestTracker.find(previous_saml_uuid)
+      redirect = previous&.payload_attr(:redirect) || build_redirect(params)
+      inbound = previous&.payload_attr(:inbound_ssoe) || params[:inbound]
+      type = previous&.payload_attr(:type) || params[:type]
+      # if created_at is set to nil (meaning no previous tracker to use), it
+      # will be initialized to the current time when it is saved
+      SAMLRequestTracker.new(
+        payload: { redirect: redirect, inbound_ssoe: inbound, type: type }.compact,
+        created_at: previous&.created_at
+      )
+    end
+
+    def save_saml_request_tracker(uuid)
+      @tracker.uuid = uuid
+      @tracker.save
+    end
+  end
+end

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -7,7 +7,7 @@ module SAML
   # it returns an SSO URL and form request parameters for use in a SAML POST
   # submission, instead of a self-contained redirect URL.
   class PostURLService < URLService
-   # rubocop:disable Metrics/ParameterLists
+    # rubocop:disable Metrics/ParameterLists
     def initialize(saml_settings, session: nil, user: nil, params: {},
                    loa3_context: LOA::IDME_LOA3_VETS, previous_saml_uuid: nil)
       unless %w[new saml_callback saml_logout_callback ssoe_slo_callback].include?(params[:action])

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SAML
-  # This class is responsible for providing the requests for the various 
+  # This class is responsible for providing the requests for the various
   # SSO and SLO endpoints
   # It provides a similar interface to URLService, but for most endpoints
   # it returns an SSO URL and form request parameters for use in a SAML POST
@@ -149,17 +149,6 @@ module SAML
           "#{@user.identity.sign_in[:service_name]}_multifactor"
         end
       build_sso_url(link_authn_context)
-    end
-
-    # SIGN OFF URLS
-    # This method is not used as SSOe does not support SAML SLO
-    def slo_url
-      @type = 'slo'
-      logout_request = OneLogin::RubySaml::Logoutrequest.new
-      # cache the request for session.token lookup when we receive the response
-      SingleLogoutRequest.create(uuid: logout_request.uuid, token: session.token)
-      Rails.logger.info "New SP SLO having logout_request '#{logout_request.uuid}' for userid '#{session.uuid}'"
-      logout_request.create(url_settings, RelayState: relay_state_params)
     end
 
     # logout URL for SSOe

--- a/lib/saml/ssoe_settings_service.rb
+++ b/lib/saml/ssoe_settings_service.rb
@@ -25,6 +25,7 @@ module SAML
         settings.certificate_new = Settings.saml_ssoe.certificate_new
         settings.sp_entity_id = Settings.saml_ssoe.issuer
         settings.assertion_consumer_service_url = Settings.saml_ssoe.callback_url
+        settings.compress_request = false
 
         settings.security[:authn_requests_signed] = true
         settings.security[:logout_requests_signed] = true

--- a/lib/saml/templates/sso_post_form.html.erb
+++ b/lib/saml/templates/sso_post_form.html.erb
@@ -1,5 +1,3 @@
-<!doctype html>
-
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/lib/saml/templates/sso_post_form.html.erb
+++ b/lib/saml/templates/sso_post_form.html.erb
@@ -1,0 +1,36 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>VA.gov sign-in</title>
+
+
+</head>
+
+<body>
+  <noscript>
+    <p>Your browser does not support JavaScript. 
+    Please press the Continue button once to proceed with sign-in.
+    </p>
+  </noscript>
+
+  <%= form_tag url, authenticity_token: false, method: :post, id: "saml-form" do %>
+    <% params.each do |key, value| %>
+      <%= hidden_field_tag key, value %>
+    <% end %>
+    <noscript>
+      <div>
+        <input type=\”submit\” value=\”Continue\”/>
+      </div>
+    </noscript>
+  <% end %>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", function(event) {
+      document.getElementById("saml-form").submit();
+    });
+  </script>
+</body>
+</html>
+

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -3,9 +3,12 @@
 require 'rails_helper'
 require 'support/saml/response_builder'
 require 'support/url_service_helpers'
+require 'support/saml/form_validation_helpers'
 
 RSpec.describe V1::SessionsController, type: :controller do
   include SAML::ResponseBuilder
+  include SAML::ValidationHelpers
+  include RSpecHtmlMatchers
 
   let(:uuid) { SecureRandom.uuid }
   let(:token) { 'abracadabra-open-sesame' }
@@ -83,7 +86,7 @@ RSpec.describe V1::SessionsController, type: :controller do
       context 'routes not requiring auth' do
         %w[mhv dslogon idme].each do |type|
           context "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
-            it 'redirects' do
+            it 'presents login form' do
               expect(SAML::SSOeSettingsService)
                 .to receive(:saml_settings)
                 .with(force_authn: false)
@@ -96,11 +99,9 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .and not_trigger_statsd_increment(described_class::STATSD_SSO_NEW_INBOUND,
                                                   tags: ["context:#{type}", 'version:v1'])
 
-              expect(response).to have_http_status(:found)
-              expect(response.location)
-                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
-                .with_relay_state('originating_request_id' => nil, 'type' => type)
-                .with_params('clientId' => '123123')
+              expect(response).to have_http_status(:ok)
+              expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+                                    'originating_request_id' => nil, 'type' => type)
               expect(SAMLRequestTracker.keys.length).to eq(1)
               expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload).to eq({ type: type })
             end
@@ -116,11 +117,9 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .and trigger_statsd_increment(described_class::STATSD_SSO_NEW_FORCEAUTH,
                                               tags: ["context:#{type}", 'version:v1'], **once)
 
-              expect(response).to have_http_status(:found)
-              expect(response.location)
-                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
-                .with_relay_state('originating_request_id' => nil, 'type' => type)
-                .with_params('clientId' => '123123')
+              expect(response).to have_http_status(:ok)
+              expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+                                    'originating_request_id' => nil, 'type' => type)
               expect(SAMLRequestTracker.keys.length).to eq(1)
               expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload).to eq({ type: type })
             end
@@ -136,11 +135,9 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .and trigger_statsd_increment(described_class::STATSD_SSO_NEW_INBOUND,
                                               tags: ["context:#{type}", 'version:v1'], **once)
 
-              expect(response).to have_http_status(:found)
-              expect(response.location)
-                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
-                .with_relay_state('originating_request_id' => nil, 'type' => type)
-                .with_params('clientId' => '123123')
+              expect(response).to have_http_status(:ok)
+              expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+                                    'originating_request_id' => nil, 'type' => type)
               expect(SAMLRequestTracker.keys.length).to eq(1)
               expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload).to eq({ inbound_ssoe: 'true',
                                                                                           type: type })
@@ -151,11 +148,9 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                              tags: ["context:#{type}", 'version:v1'], **once)
 
-              expect(response).to have_http_status(:found)
-              expect(response.location)
-                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
-                .with_relay_state('originating_request_id' => nil, 'type' => type)
-                .with_params('clientId' => '123123')
+              expect(response).to have_http_status(:ok)
+              expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+                                    'originating_request_id' => nil, 'type' => type)
               expect(SAMLRequestTracker.keys.length).to eq(1)
               expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload)
                 .to eq({ redirect: 'https://ehrm-va-test.patientportal.us.healtheintent.com/', type: type })
@@ -169,11 +164,9 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                              tags: ["context:#{type}", 'version:v1'], **once)
 
-              expect(response).to have_http_status(:found)
-              expect(response.location)
-                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
-                .with_relay_state('originating_request_id' => nil, 'type' => type)
-                .with_params('clientId' => '123123')
+              expect(response).to have_http_status(:ok)
+              expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+                                    'originating_request_id' => nil, 'type' => type)
               expect(SAMLRequestTracker.keys.length).to eq(1)
               expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload)
                 .to eq({ redirect: 'https://ehrm-va-test.patientportal.us.healtheintent.com'\
@@ -189,11 +182,9 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                              tags: ["context:#{type}", 'version:v1'], **once)
 
-              expect(response).to have_http_status(:found)
-              expect(response.location)
-                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
-                .with_relay_state('originating_request_id' => nil, 'type' => type)
-                .with_params('clientId' => '123123')
+              expect(response).to have_http_status(:ok)
+              expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+                                    'originating_request_id' => nil, 'type' => type)
               expect(SAMLRequestTracker.keys.length).to eq(1)
               expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload)
                 .to eq({ redirect: 'https://ehrm-va-test.patientportal.us.healtheintent.com'\
@@ -208,11 +199,9 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                              tags: ["context:#{type}", 'version:v1'], **once)
 
-              expect(response).to have_http_status(:found)
-              expect(response.location)
-                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
-                .with_relay_state('originating_request_id' => nil, 'type' => type)
-                .with_params('clientId' => '123123')
+              expect(response).to have_http_status(:ok)
+              expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+                                    'originating_request_id' => nil, 'type' => type)
               expect(SAMLRequestTracker.keys.length).to eq(1)
               expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload)
                 .to eq({
@@ -226,11 +215,9 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                              tags: ["context:#{type}", 'version:v1'], **once)
 
-              expect(response).to have_http_status(:found)
-              expect(response.location)
-                .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
-                .with_relay_state('originating_request_id' => nil, 'type' => type)
-                .with_params('clientId' => '123123')
+              expect(response).to have_http_status(:ok)
+              expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+                                    'originating_request_id' => nil, 'type' => type)
               expect(SAMLRequestTracker.keys.length).to eq(1)
               expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload).to eq({ type: type })
             end
@@ -242,11 +229,9 @@ RSpec.describe V1::SessionsController, type: :controller do
             expect { get(:new, params: { type: :custom, authn: 'dslogon', client_id: '123123' }) }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                            tags: ['context:custom', 'version:v1'], **once)
-            expect(response).to have_http_status(:found)
-            expect(response.location)
-              .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
-              .with_relay_state('originating_request_id' => nil, 'type' => 'custom')
-              .with_params('clientId' => '123123')
+            expect(response).to have_http_status(:ok)
+            expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+                                  'originating_request_id' => nil, 'type' => 'custom')
           end
 
           it 'raises exception when missing authn parameter' do
@@ -271,11 +256,9 @@ RSpec.describe V1::SessionsController, type: :controller do
             expect { get(:new, params: { type: :signup, client_id: '123123' }) }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                            tags: ['context:signup', 'version:v1'], **once)
-            expect(response).to have_http_status(:found)
-            expect(response.location)
-              .to be_an_idme_saml_url('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login?SAMLRequest=')
-              .with_relay_state('originating_request_id' => nil, 'type' => 'signup')
-              .with_params('op' => 'signup', 'clientId' => '123123')
+            expect(response).to have_http_status(:ok)
+            expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+                                  'originating_request_id' => nil, 'type' => 'custom')
           end
         end
       end
@@ -380,8 +363,8 @@ RSpec.describe V1::SessionsController, type: :controller do
     end
 
     describe 'new' do
-      context 'all routes' do
-        %w[mhv dslogon idme mfa verify slo].each do |type|
+      context 'all login routes' do
+        %w[mhv dslogon idme mfa verify].each do |type|
           around do |example|
             Settings.sso.cookie_enabled = true
             example.run
@@ -389,13 +372,30 @@ RSpec.describe V1::SessionsController, type: :controller do
           end
 
           context "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
-            it 'redirects' do
+            it 'responds' do
               expect { get(:new, params: { type: type }) }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                              tags: ["context:#{type}", 'version:v1'], **once)
-              expect(response).to have_http_status(:found)
+              expect(response).to have_http_status(:ok)
               expect(cookies['vagov_session_dev']).not_to be_nil unless type.in?(%w[mhv dslogon idme slo])
             end
+          end
+        end
+      end
+
+      context 'slo routes' do
+        around do |example|
+          Settings.sso.cookie_enabled = true
+          example.run
+          Settings.sso.cookie_enabled = false
+        end
+
+        context "routes /sessions/slo/new to SessionsController#new with type: #slo" do
+          it 'redirects' do
+            expect { get(:new, params: { type: 'slo' }) }
+              .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
+                                             tags: ['context:slo', 'version:v1'], **once)
+            expect(response).to have_http_status(:found)
           end
         end
       end
@@ -583,13 +583,13 @@ RSpec.describe V1::SessionsController, type: :controller do
           )
         end
 
-        it 'redirects to idme for up-level' do
-          expect(post(:saml_callback)).to redirect_to(/pint.eauth.va.gov/)
+        it 'responds with form for idme for up-level' do
+          expect(post(:saml_callback)).to have_http_status(:ok)
         end
 
         it 'redirects to identity proof URL', :aggregate_failures do
           Timecop.freeze(Time.current)
-          expect_any_instance_of(SAML::URLService).to receive(:verify_url)
+          expect_any_instance_of(SAML::PostURLService).to receive(:verify_url)
           cookie_expiration_time = 30.minutes.from_now.iso8601(0)
 
           post :saml_callback

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe V1::SessionsController, type: :controller do
                                            tags: ['context:signup', 'version:v1'], **once)
             expect(response).to have_http_status(:ok)
             expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
-                                  'originating_request_id' => nil, 'type' => 'custom')
+                                  'originating_request_id' => nil, 'type' => 'signup')
           end
         end
       end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -8,7 +8,6 @@ require 'support/saml/form_validation_helpers'
 RSpec.describe V1::SessionsController, type: :controller do
   include SAML::ResponseBuilder
   include SAML::ValidationHelpers
-  include RSpecHtmlMatchers
 
   let(:uuid) { SecureRandom.uuid }
   let(:token) { 'abracadabra-open-sesame' }
@@ -390,11 +389,11 @@ RSpec.describe V1::SessionsController, type: :controller do
           Settings.sso.cookie_enabled = false
         end
 
-        context "routes /sessions/slo/new to SessionsController#new with type: #slo" do
+        context 'routes /sessions/slo/new to SessionsController#new with type: #slo' do
           it 'redirects' do
             expect { get(:new, params: { type: 'slo' }) }
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
-                                             tags: ['context:slo', 'version:v1'], **once)
+                                           tags: ['context:slo', 'version:v1'], **once)
             expect(response).to have_http_status(:found)
           end
         end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe V1::SessionsController, type: :controller do
             it 'presents login form' do
               expect(SAML::SSOeSettingsService)
                 .to receive(:saml_settings)
-                .with(force_authn: false)
+                .with(force_authn: true)
 
               expect { get(:new, params: { type: type, clientId: '123123' }) }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
@@ -126,7 +126,7 @@ RSpec.describe V1::SessionsController, type: :controller do
             it 'redirects for an inbound ssoe' do
               expect(SAML::SSOeSettingsService)
                 .to receive(:saml_settings)
-                .with(force_authn: false)
+                .with(force_authn: true)
 
               expect { get(:new, params: { type: type, clientId: '123123', inbound: true }) }
                 .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,

--- a/spec/lib/saml/post_url_service_spec.rb
+++ b/spec/lib/saml/post_url_service_spec.rb
@@ -1,0 +1,576 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'rails_helper'
+require 'saml/url_service'
+require 'support/url_service_helpers'
+require 'support/saml/form_validation_helpers'
+
+RSpec.describe SAML::PostURLService do
+  include SAML::ValidationHelpers
+
+  context 'using loa/3/vets context' do
+    subject do
+      described_class.new(saml_settings, session: session, user: user,
+                                         params: params, previous_saml_uuid: previous_saml_uuid)
+    end
+
+    let(:user) { build(:user) }
+    let(:session) { Session.create(uuid: user.uuid, token: 'abracadabra') }
+    let(:previous_saml_uuid) { nil }
+
+    around do |example|
+      User.create(user)
+      Timecop.freeze('2018-04-09T17:52:03Z')
+      RequestStore.store['request_id'] = '123'
+      example.run
+      Timecop.return
+    end
+
+    SAML::URLService::VIRTUAL_HOST_MAPPINGS.each do |vhost_url, values|
+      context "virtual host: #{vhost_url}" do
+        let(:saml_settings) do
+          build(:settings_no_context_v1, assertion_consumer_service_url: "#{vhost_url}/auth/saml/callback")
+        end
+
+        let(:params) { { action: 'new' } }
+
+        it 'has sign in url: mhv_url' do
+          url, params = subject.mhv_url
+          expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+          expect_saml_form_parameters(params,
+                                      'originating_request_id' => '123', 'type' => 'mhv')
+        end
+
+        it 'has sign in url: dslogon_url' do
+          url, params = subject.dslogon_url
+          expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+          expect_saml_form_parameters(params,
+                                      'originating_request_id' => '123', 'type' => 'dslogon')
+        end
+
+        it 'has sign in url: idme_url' do
+          url, params = subject.idme_url
+          expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+          expect_saml_form_parameters(params,
+                                      'originating_request_id' => '123', 'type' => 'idme')
+        end
+
+        it 'has sign up url: signup_url' do
+          url, params = subject.signup_url
+          expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+          expect_saml_form_parameters(params,
+                                      'originating_request_id' => '123', 'type' => 'signup')
+        end
+
+        context 'verify_url' do
+          it 'has sign in url: with (default authn_context)' do
+            expect(user.authn_context).to eq('http://idmanagement.gov/ns/assurance/loa/1/vets')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('http://idmanagement.gov/ns/assurance/loa/3/vets')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+
+          it 'has sign in url: with (multifactor authn_context)' do
+            allow(user).to receive(:authn_context).and_return('multifactor')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('http://idmanagement.gov/ns/assurance/loa/3/vets')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+
+          it 'has sign in url: with (myhealthevet authn_context)' do
+            allow(user).to receive(:authn_context).and_return('myhealthevet')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('myhealthevet_loa3')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+
+          it 'has sign in url: with (myhealthevet_multifactor authn_context)' do
+            allow(user).to receive(:authn_context).and_return('myhealthevet_multifactor')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('myhealthevet_loa3')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+
+          it 'has sign in url: with (dslogon authn_context)' do
+            allow(user).to receive(:authn_context).and_return('dslogon')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('dslogon_loa3')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+
+          it 'has sign in url: with (dslogon_multifactor authn_context)' do
+            allow(user).to receive(:authn_context).and_return('dslogon_multifactor')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('dslogon_loa3')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+        end
+
+        context 'mfa_url' do
+          it 'has mfa url: with (default authn_context)' do
+            expect(user.authn_context).to eq('http://idmanagement.gov/ns/assurance/loa/1/vets')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('multifactor')
+            url, params = subject.mfa_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'mfa')
+          end
+
+          it 'has mfa url: with (myhealthevet authn_context)' do
+            allow(user).to receive(:authn_context).and_return('myhealthevet')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('myhealthevet_multifactor')
+            url, params = subject.mfa_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'mfa')
+          end
+
+          it 'has mfa url: with (myhealthevet_loa3 authn_context)' do
+            allow(user).to receive(:authn_context).and_return('myhealthevet_loa3')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('myhealthevet_multifactor')
+            url, params = subject.mfa_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'mfa')
+          end
+
+          it 'has mfa url: with (dslogon authn_context)' do
+            allow(user).to receive(:authn_context).and_return('dslogon')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('dslogon_multifactor')
+            url, params = subject.mfa_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'mfa')
+          end
+
+          it 'has mfa url: with (dslogon_loa3 authn_context)' do
+            allow(user).to receive(:authn_context).and_return('dslogon_loa3')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('dslogon_multifactor')
+            url, params = subject.mfa_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'mfa')
+          end
+        end
+
+        context 'redirect urls' do
+          let(:params) { { action: 'saml_callback', RelayState: '{"type":"idme"}' } }
+
+          it 'has a base url' do
+            expect(subject.base_redirect_url).to eq(values[:base_redirect])
+          end
+
+          context 'with an user that needs to verify' do
+            it 'goes to verify URL before login redirect' do
+              expect(user.authn_context).to eq('http://idmanagement.gov/ns/assurance/loa/1/vets')
+              expect_any_instance_of(OneLogin::RubySaml::Settings)
+                .to receive(:authn_context=).with('http://idmanagement.gov/ns/assurance/loa/3/vets')
+              expect(subject.should_uplevel?).to be(true)
+              url, params = subject.verify_url
+              expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+              expect_saml_form_parameters(params,
+                                          'originating_request_id' => '123', 'type' => 'idme')
+            end
+          end
+
+          context 'with user that does not need to verify' do
+            let(:user) { build(:user, :loa3) }
+
+            it 'has a login redirect url with success' do
+              expect(subject.login_redirect_url)
+                .to eq(values[:base_redirect] + SAML::URLService::LOGIN_REDIRECT_PARTIAL + '?type=idme')
+            end
+
+            it 'has a login redirect url with fail' do
+              expect(subject.login_redirect_url(auth: 'fail', code: '001'))
+                .to eq(values[:base_redirect] +
+                       SAML::URLService::LOGIN_REDIRECT_PARTIAL +
+                       '?auth=fail&code=001&type=idme')
+            end
+          end
+
+          context 'for logout' do
+            let(:params) { { action: 'saml_logout_callback' } }
+
+            it 'has a logout redirect url' do
+              expect(subject.logout_redirect_url)
+                .to eq(values[:base_redirect] + SAML::URLService::LOGOUT_REDIRECT_PARTIAL)
+            end
+          end
+
+          context 'for a user with a custom redirect parameter' do
+            let(:user) { build(:user, :loa3) }
+            let(:previous_saml_uuid) do
+              SAMLRequestTracker.create(
+                uuid: SecureRandom.uuid,
+                payload: { redirect: 'https://custom.com/' }
+              ).uuid
+            end
+
+            it 'has a custom redirect url' do
+              expect(subject.login_redirect_url).to eq('https://custom.com/')
+            end
+          end
+
+          context 'for a user authenticating with inbound ssoe' do
+            let(:user) { build(:user, :loa3) }
+            let(:params) { { action: 'saml_callback', RelayState: '{"type":"idme"}', inbound: 'true' } }
+
+            it 'is successful' do
+              expect(subject.login_redirect_url)
+                .to eq(values[:base_redirect] + SAML::URLService::LOGIN_REDIRECT_PARTIAL + '?type=idme')
+            end
+
+            it 'is a failure' do
+              expect(subject.login_redirect_url(auth: 'fail', code: '001'))
+                .to eq(values[:base_redirect] +
+                       SAML::URLService::LOGIN_REDIRECT_PARTIAL +
+                       '?auth=force-needed&code=001&type=idme')
+            end
+          end
+        end
+
+        context 'instance created by invalid action' do
+          let(:params) { { action: 'saml_slo_callback' } }
+
+          it 'raises an exception' do
+            expect { subject }.to raise_error(Common::Exceptions::RoutingError)
+          end
+        end
+      end
+    end
+  end
+
+  context 'using loa/3 context' do
+    subject do
+      described_class.new(saml_settings, session: session, user: user,
+                                         params: params, loa3_context: LOA::IDME_LOA3)
+    end
+
+    let(:user) { build(:user) }
+    let(:session) { Session.create(uuid: user.uuid, token: 'abracadabra') }
+
+    around do |example|
+      User.create(user)
+      Timecop.freeze('2018-04-09T17:52:03Z')
+      RequestStore.store['request_id'] = '123'
+      example.run
+      Timecop.return
+    end
+
+    SAML::URLService::VIRTUAL_HOST_MAPPINGS.each do |vhost_url, values|
+      context "virtual host: #{vhost_url}" do
+        let(:saml_settings) do
+          build(:settings_no_context_v1, assertion_consumer_service_url: "#{vhost_url}/auth/saml/callback")
+        end
+
+        let(:params) { { action: 'new' } }
+
+        it 'has sign in url: mhv_url' do
+          url, params = subject.mhv_url
+          expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+          expect_saml_form_parameters(params,
+                                      'originating_request_id' => '123', 'type' => 'mhv')
+        end
+
+        it 'has sign in url: dslogon_url' do
+          url, params = subject.dslogon_url
+          expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+          expect_saml_form_parameters(params,
+                                      'originating_request_id' => '123', 'type' => 'dslogon')
+        end
+
+        it 'has sign in url: idme_url' do
+          url, params = subject.idme_url
+          expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+          expect_saml_form_parameters(params,
+                                      'originating_request_id' => '123', 'type' => 'idme')
+        end
+
+        it 'has sign in url: custom_url' do
+          allow(user).to receive(:authn_context).and_return('X')
+          expect_any_instance_of(OneLogin::RubySaml::Settings)
+            .to receive(:authn_context=).with('X')
+          url, params = subject.custom_url('X')
+          expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+          expect_saml_form_parameters(params,
+                                      'originating_request_id' => '123', 'type' => 'custom')
+        end
+
+        it 'has sign up url: signup_url' do
+          url, params = subject.signup_url
+          expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+          expect_saml_form_parameters(params,
+                                      'originating_request_id' => '123', 'type' => 'signup')
+        end
+
+        context 'verify_url' do
+          it 'has sign in url: with (default authn_context)' do
+            expect(user.authn_context).to eq('http://idmanagement.gov/ns/assurance/loa/1/vets')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('http://idmanagement.gov/ns/assurance/loa/3')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+
+          it 'has sign in url: with (multifactor authn_context)' do
+            allow(user).to receive(:authn_context).and_return('multifactor')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('http://idmanagement.gov/ns/assurance/loa/3')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+
+          it 'has sign in url: with (myhealthevet authn_context)' do
+            allow(user).to receive(:authn_context).and_return('myhealthevet')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('myhealthevet_loa3')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+
+          it 'has sign in url: with (myhealthevet_multifactor authn_context)' do
+            allow(user).to receive(:authn_context).and_return('myhealthevet_multifactor')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('myhealthevet_loa3')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+
+          it 'has sign in url: with (dslogon authn_context)' do
+            allow(user).to receive(:authn_context).and_return('dslogon')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('dslogon_loa3')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+
+          it 'has sign in url: with (dslogon_multifactor authn_context)' do
+            allow(user).to receive(:authn_context).and_return('dslogon_multifactor')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('dslogon_loa3')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+
+          it 'has sign in url: with (ssoe inbound authn_context)' do
+            allow(user).to receive(:authn_context).and_return('urn:oasis:names:tc:SAML:2.0:ac:classes:Password')
+            allow(user.identity).to receive(:sign_in).and_return({ service_name: 'dslogon' })
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('dslogon_loa3')
+            url, params = subject.verify_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'verify')
+          end
+        end
+
+        context 'mfa_url' do
+          it 'has mfa url: with (default authn_context)' do
+            expect(user.authn_context).to eq('http://idmanagement.gov/ns/assurance/loa/1/vets')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('multifactor')
+            url, params = subject.mfa_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'mfa')
+          end
+
+          it 'has mfa url: with (myhealthevet authn_context)' do
+            allow(user).to receive(:authn_context).and_return('myhealthevet')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('myhealthevet_multifactor')
+            url, params = subject.mfa_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'mfa')
+          end
+
+          it 'has mfa url: with (myhealthevet_loa3 authn_context)' do
+            allow(user).to receive(:authn_context).and_return('myhealthevet_loa3')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('myhealthevet_multifactor')
+            url, params = subject.mfa_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'mfa')
+          end
+
+          it 'has mfa url: with (dslogon authn_context)' do
+            allow(user).to receive(:authn_context).and_return('dslogon')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('dslogon_multifactor')
+            url, params = subject.mfa_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'mfa')
+          end
+
+          it 'has mfa url: with (dslogon_loa3 authn_context)' do
+            allow(user).to receive(:authn_context).and_return('dslogon_loa3')
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('dslogon_multifactor')
+            url, params = subject.mfa_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'mfa')
+          end
+
+          it 'has mfa url: with (ssoe inbound authn_context)' do
+            allow(user).to receive(:authn_context).and_return('urn:oasis:names:tc:SAML:2.0:ac:classes:Password')
+            allow(user.identity).to receive(:sign_in).and_return({ service_name: 'myhealthevet' })
+            expect_any_instance_of(OneLogin::RubySaml::Settings)
+              .to receive(:authn_context=).with('myhealthevet_multifactor')
+            url, params = subject.mfa_url
+            expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+            expect_saml_form_parameters(params,
+                                        'originating_request_id' => '123', 'type' => 'mfa')
+          end
+        end
+
+        context 'redirect urls' do
+          let(:params) { { action: 'saml_callback', RelayState: '{"type":"idme"}' } }
+
+          it 'has a base url' do
+            expect(subject.base_redirect_url).to eq(values[:base_redirect])
+          end
+
+          context 'with an user that needs to verify' do
+            it 'goes to verify URL before login redirect' do
+              expect(user.authn_context).to eq('http://idmanagement.gov/ns/assurance/loa/1/vets')
+              expect_any_instance_of(OneLogin::RubySaml::Settings)
+                .to receive(:authn_context=).with('http://idmanagement.gov/ns/assurance/loa/3')
+              expect(subject.should_uplevel?).to be(true)
+              url, params = subject.verify_url
+              expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+              expect_saml_form_parameters(params,
+                                          'originating_request_id' => '123', 'type' => 'idme')
+            end
+          end
+
+          context 'with user that does not need to verify' do
+            let(:user) { build(:user, :loa3) }
+
+            it 'has a login redirect url with success' do
+              expect(subject.login_redirect_url)
+                .to eq(values[:base_redirect] + SAML::URLService::LOGIN_REDIRECT_PARTIAL + '?type=idme')
+            end
+
+            it 'has a login redirect url with fail' do
+              expect(subject.login_redirect_url(auth: 'fail', code: '001'))
+                .to eq(values[:base_redirect] +
+                       SAML::URLService::LOGIN_REDIRECT_PARTIAL +
+                       '?auth=fail&code=001&type=idme')
+            end
+          end
+
+          context 'for logout' do
+            let(:params) { { action: 'saml_logout_callback' } }
+
+            it 'has a logout redirect url' do
+              expect(subject.logout_redirect_url)
+                .to eq(values[:base_redirect] + SAML::URLService::LOGOUT_REDIRECT_PARTIAL)
+            end
+          end
+        end
+
+        context 'instance created by invalid action' do
+          let(:params) { { action: 'saml_slo_callback' } }
+
+          it 'raises an exception' do
+            expect { subject }.to raise_error(Common::Exceptions::RoutingError)
+          end
+        end
+      end
+    end
+  end
+
+  context 'review instance' do
+    subject { described_class.new(saml_settings, session: session, user: user, params: params) }
+
+    let(:user) { build(:user) }
+    let(:session) { Session.create(uuid: user.uuid, token: 'abracadabra') }
+    let(:slug_id) { '617bed45ccb1fc2a87872b567c721009' }
+    let(:saml_settings) do
+      build(:settings_no_context_v1, assertion_consumer_service_url: 'https://staging-api.vets.gov/review_instance/saml/callback')
+    end
+
+    around do |example|
+      User.create(user)
+      Timecop.freeze('2018-04-09T17:52:03Z')
+      RequestStore.store['request_id'] = '123'
+      with_settings(Settings.saml, relay: "http://#{slug_id}.review.vetsgov-internal/auth/login/callback") do
+        with_settings(Settings, review_instance_slug: slug_id) do
+          example.run
+        end
+      end
+      Timecop.return
+    end
+
+    context 'new url' do
+      let(:params) { { action: 'new' } }
+
+      it 'has sign in url: mhv_url' do
+        url, params = subject.mhv_url
+        expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+        expect_saml_form_parameters(params,
+                                    'originating_request_id' => '123', 'type' => 'mhv',
+                                    'review_instance_slug' => slug_id)
+      end
+    end
+
+    context 'up-leveling' do
+      let(:params) do
+        { action: 'saml_callback', RelayState: "{\"type\":\"idme\",\"review_instance_slug:\":\"#{slug_id}\"}" }
+      end
+
+      it 'goes to verify URL before login redirect' do
+        expect(user.authn_context).to eq('http://idmanagement.gov/ns/assurance/loa/1/vets')
+        expect_any_instance_of(OneLogin::RubySaml::Settings)
+          .to receive(:authn_context=).with('http://idmanagement.gov/ns/assurance/loa/3/vets')
+        expect(subject.should_uplevel?).to be(true)
+        url, params = subject.verify_url
+        expect(url).to eq('https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login')
+        expect_saml_form_parameters(params,
+                                    'originating_request_id' => '123', 'type' => 'idme',
+                                    'review_instance_slug' => slug_id)
+      end
+    end
+  end
+end

--- a/spec/support/saml/form_validation_helpers.rb
+++ b/spec/support/saml/form_validation_helpers.rb
@@ -17,7 +17,7 @@ module SAML
 
     def expect_saml_form_parameters(params, expected_relay_state = nil)
       expect(params['SAMLRequest']).to be_truthy
-      expect(params['RelayState']).to eqexpected_relay_state.to_json if expected_relay_state.present?
+      expect(params['RelayState']).to eq(expected_relay_state.to_json) if expected_relay_state.present?
     end
   end
 end

--- a/spec/support/saml/form_validation_helpers.rb
+++ b/spec/support/saml/form_validation_helpers.rb
@@ -1,14 +1,23 @@
+# frozen_string_literal: true
+
 module SAML
   module ValidationHelpers
     extend ActiveSupport::Concern
 
     def expect_saml_post_form(body, expected_action, expected_relay_state = nil)
-      expect(body).to match(/form id=\"saml-form\"/)
-      expect(body).to match("action=\"#{expected_action}\"")
-      expect(body).to match(/input type=\"hidden\" name=\"SAMLRequest\"/)
+      doc = Nokogiri::HTML(body)
+      expect(doc.at_css('form').attributes['id'].value).to eq('saml-form')
+      expect(doc.at_css('form').attributes['action'].value).to eq(expected_action)
 
-      # TODO Add expects for relay state
-      
+      expect(doc.at_css('input[name=SAMLRequest]')).to be_truthy
+      if expected_relay_state.present?
+        expect(doc.at_css('input[name=RelayState]').attributes['value'].value).to eq(expected_relay_state.to_json)
+      end
+    end
+
+    def expect_saml_form_parameters(params, expected_relay_state = nil)
+      expect(params['SAMLRequest']).to be_truthy
+      expect(params['RelayState']).to eqexpected_relay_state.to_json if expected_relay_state.present?
     end
   end
 end

--- a/spec/support/saml/form_validation_helpers.rb
+++ b/spec/support/saml/form_validation_helpers.rb
@@ -1,0 +1,14 @@
+module SAML
+  module ValidationHelpers
+    extend ActiveSupport::Concern
+
+    def expect_saml_post_form(body, expected_action, expected_relay_state = nil)
+      expect(body).to match(/form id=\"saml-form\"/)
+      expect(body).to match("action=\"#{expected_action}\"")
+      expect(body).to match(/input type=\"hidden\" name=\"SAMLRequest\"/)
+
+      # TODO Add expects for relay state
+      
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Updates v1 session controller to use SAML POST Binding. This is done at request of IAM SSOe team who believes doing so is more in line with intent for their stack and will resolve some outstanding bugs. 

The hard-working "URLService" was unfortunately forked since now it needs to generate SAML POST request form parameters instead of a straight up URL. I think this can be brought back together by the consuming classes being aware of the need to render a form vs. a redirect depending on the scenario. 

Testing in local and dev shows no regression relative to using the SAML Redirect binding. Jury is still out on whether it resolves the suspected list of issues.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#10468

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
