### PR TITLE
fix typo in itf error message

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v0/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/intent_to_file_controller.rb
@@ -36,7 +36,7 @@ module ClaimsApi
               errors: [
                 {
                   status: 422,
-                  details: "#{form_type.titelize} claims are not currently supported, but will be in a future version"
+                  details: "#{form_type.titleize} claims are not currently supported, but will be in a future version"
                 }
               ]
             }

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
@@ -38,7 +38,7 @@ module ClaimsApi
               errors: [
                 {
                   status: 422,
-                  details: "#{form_type.titelize} claims are not currently supported, but will be in a future version"
+                  details: "#{form_type.titleize} claims are not currently supported, but will be in a future version"
                 }
               ]
             }


### PR DESCRIPTION
## Description of change
This PR fixes a typo in the claims ITF error response that causes a 500 error when type is not equal to compensation