### PR TITLE
Add Production URL to Appeals API v1 Server Block

### DIFF
--- a/modules/appeals_api/app/swagger/appeals_api/v1/swagger_root.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/swagger_root.rb
@@ -15,6 +15,11 @@ module AppealsApi::V1::SwaggerRoot
       variable(:version) { key :default, 'v1' }
     end
 
+    server description: 'VA.gov API production environment' do
+      key :url, 'https://api.va.gov/services/appeals/{version}/decision_reviews'
+      variable(:version) { key :default, 'v1' }
+    end
+
     hlr_create_schemas = AppealsApi::JsonSchemaToSwaggerConverter.new(
       read_json_schema['200996.json']
     ).to_swagger['components']['schemas']

--- a/modules/appeals_api/app/swagger/appeals_api/v1/swagger_root.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/swagger_root.rb
@@ -10,15 +10,13 @@ module AppealsApi::V1::SwaggerRoot
   swagger_root openapi: '3.0.0' do
     info title: 'Decision Reviews', version: '1.0.0', description: read_file_from_same_dir['api_description.md']
 
-    server description: 'VA.gov API sandbox environment' do
-      key :url, 'https://sandbox-api.va.gov/services/appeals/{version}/decision_reviews'
+    url = ->(prefix = '') { "https://#{prefix}api.va.gov/services/appeals/{version}/decision_reviews" }
+
+    server description: 'VA.gov API sandbox environment', url: url['sandbox-'] do
       variable(:version) { key :default, 'v1' }
     end
 
-    server description: 'VA.gov API production environment' do
-      key :url, 'https://api.va.gov/services/appeals/{version}/decision_reviews'
-      variable(:version) { key :default, 'v1' }
-    end
+    server description: 'VA.gov API production environment', url: url[] { variable(:version) { key :default, 'v1' } }
 
     hlr_create_schemas = AppealsApi::JsonSchemaToSwaggerConverter.new(
       read_json_schema['200996.json']

--- a/modules/appeals_api/spec/requests/v1/docs_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/docs_controller_spec.rb
@@ -13,6 +13,18 @@ describe AppealsApi::Docs::V1::DocsController, type: :request do
       expect(json['openapi']).to eq('3.0.0')
     end
 
+    context 'servers' do
+      let(:server_urls) { json['servers'].map { |server| server['url'] } }
+
+      it('lists the sandbox environment') do
+        expect(server_urls).to include('https://sandbox-api.va.gov/services/appeals/{version}/decision_reviews')
+      end
+
+      it('lists the production environment') do
+        expect(server_urls).to include('https://api.va.gov/services/appeals/{version}/decision_reviews')
+      end
+    end
+
     it('/higher_level_reviews supports POST') do
       expect(json['paths']['/higher_level_reviews']).to include('post')
     end


### PR DESCRIPTION
In preparation for production launch, add `api.va.gov` to Swagger documentation _server_ block.

resolves https://vajira.max.gov/browse/API-934