### PR TITLE
return a clear message when lighthouse API key is incorrect

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -1703,6 +1703,12 @@ en:
         code: DR_502
         detail: Received an an invalid response from the upstream server
         status: 502
+      DR_401:
+        <<: *defaults
+        title: Invalid API Key
+        code: DR_401
+        detail: Invalid api_key for the upstream server
+        status: 502
       DR_malformed_request:
         <<: *defaults
         title: Malformed Request

--- a/lib/decision_review/service.rb
+++ b/lib/decision_review/service.rb
@@ -120,6 +120,7 @@ module DecisionReview
       when Common::Client::Errors::ClientError
         save_error_details(error)
         raise Common::Exceptions::Forbidden if error.status == 403
+        raise raise_backend_exception('DR_401', self.class, error) if error.status == 401
 
         code = error.body['errors'].first.dig('code')
         raise_backend_exception("DR_#{code}", self.class, error)

--- a/spec/lib/decision_review/service_spec.rb
+++ b/spec/lib/decision_review/service_spec.rb
@@ -123,6 +123,20 @@ describe DecisionReview::Service do
       end
     end
 
+    context 'with a bad API key' do
+      it 'returns a 401 error' do
+        VCR.use_cassette('decision_review/401_intake_status', match_requests_on: %i[path query]) do
+          expect { subject.post_higher_level_reviews({}) }
+            .to raise_error do |e|
+            expect(e).to be_a(Common::Exceptions::BackendServiceException)
+            expect(e.status_code).to eq(502)
+            expect(e.errors.first[:detail]).to eq('Invalid api_key for the upstream server')
+            expect(e.errors.first[:code]).to eq('DR_401')
+          end
+        end
+      end
+    end
+
     context 'when service returns a 403' do
       it 'logs the error and raises an exception' do
         VCR.use_cassette('decision_review/403_intake_status') do

--- a/spec/support/vcr_cassettes/decision_review/401_intake_status.yml
+++ b/spec/support/vcr_cassettes/decision_review/401_intake_status.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox-api.va.gov/services/appeals/v1/decision_reviews/higher_level_reviews
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Apikey:
+      - "<MDOT_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Wed, 24 Jun 2020 01:02:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '48'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Set-Cookie:
+      - TS016f4012=01c8917e48d14ed3ed1201e2819cddb76c5255e8a0c6fc40859f802ea781a9b0ee3cd896dd6dbd52120e5909c19d11b85d246b1eff;
+        Max-Age=900; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"message":"Invalid authentication credentials"}'
+  recorded_at: Wed, 24 Jun 2020 01:02:51 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Description of change
when vets-api calls lighthouse with an invalid API key we should return a 502 & a reasonable message to vets-website.

before:
![Screen Shot 2020-06-23 at 2 01 59 PM](https://user-images.githubusercontent.com/19188/85488152-d10bef00-b59b-11ea-9dfa-3ee902424e34.png)
cc: @Mottie 