### PR TITLE
VAOS - set breakers threshold back to default (50)

### DIFF
--- a/modules/vaos/app/services/vaos/configuration.rb
+++ b/modules/vaos/app/services/vaos/configuration.rb
@@ -19,11 +19,6 @@ module VAOS
       @key ||= OpenSSL::PKey::RSA.new(File.read(Settings.va_mobile.key_path))
     end
 
-    # overriding the default error threshold from 50 to 90
-    def breakers_error_threshold
-      90
-    end
-
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
         conn.use :breakers


### PR DESCRIPTION
Description of change
Previously we were concerned about that the breakers threshold at 50% might cause similar looking endpoints to get grouped within the same threshold and bring down the application. That concern was not borne out. Now I'm concerned that too high a threshold might adversely affect stability of the platform with increase in traffic should there be an actual outage and breakers cannot do what it is intended to do.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10084

No additional testing planned, but we will continue to monitor Sentry and Grafana as we always do.
