### PR TITLE
adding security class to loaded swagger classes and set security blocks

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/docs/v0/api_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/docs/v0/api_controller.rb
@@ -18,6 +18,7 @@ module ClaimsApi
           ClaimsApi::V0::Form526ControllerSwagger,
           ClaimsApi::V0::Form0966ControllerSwagger,
           ClaimsApi::V0::Form2122ControllerSwagger,
+          ClaimsApi::V0::SecuritySchemeSwagger,
           ClaimsApi::V0::SwaggerRoot
         ].freeze
 

--- a/modules/claims_api/app/controllers/claims_api/docs/v1/api_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/docs/v1/api_controller.rb
@@ -18,6 +18,7 @@ module ClaimsApi
           ClaimsApi::V1::Form526ControllerSwagger,
           ClaimsApi::V1::Form0966ControllerSwagger,
           ClaimsApi::V1::Form2122ControllerSwagger,
+          ClaimsApi::V1::SecuritySchemeSwagger,
           ClaimsApi::V1::SwaggerRoot
         ].freeze
 

--- a/modules/claims_api/app/swagger/claims_api/v1/claims_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/claims_controller_swagger.rb
@@ -14,6 +14,10 @@ module ClaimsApi
             'Claims'
           ]
 
+          security do
+            key :bearer_token, []
+          end
+
           parameter do
             key :name, :id
             key :in, :path
@@ -112,6 +116,10 @@ module ClaimsApi
           key :tags, [
             'Claims'
           ]
+
+          security do
+            key :bearer_token, []
+          end
 
           parameter do
             key :name, 'X-VA-SSN'

--- a/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
@@ -20,6 +20,9 @@ module ClaimsApi
           key :tags, [
             'Intent to File'
           ]
+          security do
+            key :bearer_token, []
+          end
 
           response 200 do
             key :description, 'schema response'
@@ -58,14 +61,14 @@ module ClaimsApi
 
         operation :post do
           key :summary, 'Accepts 0966 Intent to File form submission'
-          key :description, 'Accepts JSON payload. Full URL, including\nquery parameters.'
+          key :description, 'Accepts JSON payload. Full URL, including query parameters.'
           key :operationId, 'post0966itf'
           key :tags, [
             'Intent to File'
           ]
 
           security do
-            key :apikey, []
+            key :bearer_token, []
           end
 
           parameter do
@@ -174,11 +177,14 @@ module ClaimsApi
       swagger_path '/forms/0966/active' do
         operation :get do
           key :summary, 'Returns last active 0966 Intent to File form submission'
-          key :description, 'Returns last active JSON payload. Full URL, including\nquery parameters.'
+          key :description, 'Returns last active JSON payload. Full URL, including query parameters.'
           key :operationId, 'active0966itf'
           key :tags, [
             'Intent to File'
           ]
+          security do
+            key :bearer_token, []
+          end
 
           parameter do
             key :name, 'X-VA-SSN'

--- a/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
@@ -18,6 +18,9 @@ module ClaimsApi
           key :tags, [
             'Power of Attorney'
           ]
+          security do
+            key :bearer_token, []
+          end
 
           response 200 do
             key :description, 'schema response'
@@ -63,7 +66,7 @@ module ClaimsApi
           ]
 
           security do
-            key :apikey, []
+            key :bearer_token, []
           end
 
           parameter do
@@ -163,6 +166,10 @@ module ClaimsApi
             'Power of Attorney'
           ]
 
+          security do
+            key :bearer_token, []
+          end
+
           parameter do
             key :name, :id
             key :in, :path
@@ -260,6 +267,10 @@ module ClaimsApi
             'Power of Attorney'
           ]
 
+          security do
+            key :bearer_token, []
+          end
+
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
@@ -343,6 +354,10 @@ module ClaimsApi
           key :tags, [
             'Power of Attorney'
           ]
+
+          security do
+            key :bearer_token, []
+          end
 
           parameter do
             key :name, 'X-VA-SSN'

--- a/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
@@ -19,6 +19,10 @@ module ClaimsApi
             'Disability'
           ]
 
+          security do
+            key :bearer_token, []
+          end
+
           response 200 do
             key :description, 'schema response'
             content 'application/json' do
@@ -71,7 +75,7 @@ module ClaimsApi
           ]
 
           security do
-            key :apikey, []
+            key :bearer_token, []
           end
 
           parameter do
@@ -179,6 +183,10 @@ module ClaimsApi
             'Disability'
           ]
 
+          security do
+            key :bearer_token, []
+          end
+
           parameter do
             key :name, :id
             key :in, :path
@@ -276,6 +284,10 @@ module ClaimsApi
           key :tags, [
             'Disability'
           ]
+
+          security do
+            key :bearer_token, []
+          end
 
           parameter do
             key :name, 'X-VA-SSN'
@@ -411,6 +423,10 @@ module ClaimsApi
           key :tags, [
             'Disability'
           ]
+
+          security do
+            key :bearer_token, []
+          end
 
           parameter do
             key :name, :id

--- a/modules/claims_api/app/swagger/claims_api/v1/security_scheme_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/security_scheme_swagger.rb
@@ -5,9 +5,11 @@ module ClaimsApi
     class SecuritySchemeSwagger
       include Swagger::Blocks
       swagger_component do
-        security_scheme :bearer do
+        security_scheme :bearer_token do
           key :type, :http
           key :name, :token
+          key :scheme, :bearer
+          key :bearerFormat, :JWT
         end
       end
     end

--- a/modules/claims_api/app/swagger/claims_api/v1/swagger_root.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/swagger_root.rb
@@ -19,6 +19,7 @@ module ClaimsApi
             key :name, 'Creative Commons'
           end
         end
+
         tag do
           key :name, 'Claims'
           key :description, 'Benefits Claims'


### PR DESCRIPTION
## Description of change
This PR fixes the swagger generation for curl generation on the Claims OAuth endpoints.