### PR TITLE
Add appeals metadata controller

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'appeals_api/health_checker'
+
+module AppealsApi
+  class MetadataController < ::ApplicationController
+    skip_before_action :verify_authenticity_token
+    skip_after_action :set_csrf_header
+    skip_before_action(:authenticate)
+
+    def healthcheck
+      if AppealsApi::HealthChecker.services_are_healthy?
+        render json: healthy_service_response
+      else
+        render json: unhealthy_service_response,
+               status: :service_unavailable
+      end
+    end
+
+    private
+
+    def healthy_service_response
+      {
+        data: {
+          id: 'appeals_healthcheck',
+          type: 'appeals_healthcheck',
+          attributes: {
+            healthy: true,
+            date: Time.zone.now.to_formatted_s(:iso8601)
+          }
+        }
+      }.to_json
+    end
+
+    def unhealthy_service_response
+      {
+        errors: [
+          {
+            title: 'AppealsAPI Unavailable',
+            detail: 'AppealsAPI is currently unavailable.',
+            code: '503',
+            status: '503'
+          }
+        ]
+      }.to_json
+    end
+  end
+end

--- a/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
@@ -20,10 +20,6 @@ module AppealsApi
         )
       end
 
-      def healthcheck
-        render json: Caseflow::Service.new.healthcheck.body
-      end
-
       private
 
       def log_request

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -3,9 +3,11 @@
 AppealsApi::Engine.routes.draw do
   match '/v0/*path', to: 'application#cors_preflight', via: [:options]
 
+  match '/v0/healthcheck', to: 'metadata#healthcheck', via: [:get]
+  match '/v1/healthcheck', to: 'metadata#healthcheck', via: [:get]
+
   namespace :v0, defaults: { format: 'json' } do
     resources :appeals, only: [:index]
-    get 'healthcheck', to: 'appeals#healthcheck'
   end
 
   namespace :v1, defaults: { format: 'json' } do

--- a/modules/appeals_api/lib/appeals_api/health_checker.rb
+++ b/modules/appeals_api/lib/appeals_api/health_checker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  class HealthChecker
+    def self.services_are_healthy?
+      response = Caseflow::Service.new.healthcheck
+      response.body['healthy'] == true
+    end
+  end
+end

--- a/modules/appeals_api/spec/requests/metadata_request_spec.rb
+++ b/modules/appeals_api/spec/requests/metadata_request_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'appeals_api/health_checker'
+
+RSpec.describe 'Appeals Metadata Endpoint', type: :request do
+  context 'healthchecks' do
+
+    context 'v0' do
+      it 'returns correct response and status when healthy' do
+        allow(AppealsApi::HealthChecker).to receive(:services_are_healthy?).and_return(true)
+        get '/services/appeals/v0/healthcheck'
+        parsed_response = JSON.parse(response.body)
+        expect(response.status).to eq(200)
+        expect(parsed_response['data']['attributes']['healthy']).to eq(true)
+      end
+
+      it 'returns correct status when evss is not healthy' do
+        allow(AppealsApi::HealthChecker).to receive(:services_are_healthy?).and_return(false)
+        get '/services/appeals/v0/healthcheck'
+        expect(response.status).to eq(503)
+      end
+    end
+
+    context 'v1' do
+      it 'returns correct response and status when healthy' do
+        allow(AppealsApi::HealthChecker).to receive(:services_are_healthy?).and_return(true)
+        get '/services/appeals/v1/healthcheck'
+        parsed_response = JSON.parse(response.body)
+        expect(response.status).to eq(200)
+        expect(parsed_response['data']['attributes']['healthy']).to eq(true)
+      end
+
+      it 'returns correct status when evss is not healthy' do
+        allow(AppealsApi::HealthChecker).to receive(:services_are_healthy?).and_return(false)
+        get '/services/appeals/v1/healthcheck'
+        expect(response.status).to eq(503)
+      end
+    end
+  end
+end

--- a/modules/appeals_api/spec/requests/metadata_request_spec.rb
+++ b/modules/appeals_api/spec/requests/metadata_request_spec.rb
@@ -5,7 +5,6 @@ require 'appeals_api/health_checker'
 
 RSpec.describe 'Appeals Metadata Endpoint', type: :request do
   context 'healthchecks' do
-
     context 'v0' do
       it 'returns correct response and status when healthy' do
         allow(AppealsApi::HealthChecker).to receive(:services_are_healthy?).and_return(true)


### PR DESCRIPTION
## Description of change
This PR adds the metadata controller to the appeals api. Currently the controller just runs the healthcheck for caseflow,  but its supported for v0 and v1 of the api.
