### PR TITLE
add rspec-retry, set retries=3 for uploads_request_spec, to unblock production deploys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,6 +135,7 @@ group :test do
   gem 'faker-medical'
   gem 'fakeredis'
   gem 'pdf-inspector'
+  gem 'rspec-retry'
   gem 'rspec_junit_formatter'
   gem 'rubocop-junit-formatter'
   gem 'shrine-memory'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -637,6 +637,8 @@ GEM
       rspec-expectations (~> 3.9)
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-support (3.9.3)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -895,6 +897,7 @@ DEPENDENCIES
   rgeo-geojson
   rspec-instrumentation-matcher
   rspec-rails
+  rspec-retry
   rspec_junit_formatter
   rubocop
   rubocop-junit-formatter

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -6,7 +6,7 @@ require_relative '../../support/vba_document_fixtures'
 require_dependency 'vba_documents/object_store'
 require_dependency 'vba_documents/multipart_parser'
 
-RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
+RSpec.describe 'VBA Document Uploads Endpoint', type: :request, retry: 3 do
   include VBADocuments::Fixtures
 
   describe '#create /v1/uploads' do
@@ -126,6 +126,7 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request do
         expect(response.status).to eq(404)
       end
     end
+
     it 'returns a 200 with content-type of zip' do
       objstore = instance_double(VBADocuments::ObjectStore)
       version = instance_double(Aws::S3::ObjectVersion)


### PR DESCRIPTION
##  Description of change

There is a flapping/blinky spec, which appears to be triggered by an encoding error in the Origami PDF library. We have yet to determine the root cause (it's a difficult one), and in the meantime, we want to unblock production deploys.

We (the BE tools team) identified two immediate ways to unblock deploys:
* Retry the failing spec
* Disable the failing spec

We have an [open PR](https://github.com/department-of-veterans-affairs/vets-api/pull/4453) for disabling the failing spec, but doing so means we lose test coverage for that API endpoint. I don't mean the coverage report, but the loss of actual coverage.

This PR is for the retry option. Introducing `rspec-retry` could, if never removed, theoretically lead to it being used more often, which is not ideal. The trade-off is that we get to retain spec coverage on the API while we investigate further.

## Original issue(s)
department-of-veterans-affairs/va.gov-team/issues/7305
