### PR TITLE
Temporarily disable flapping VAOS logging integration spec

### DIFF
--- a/modules/vaos/spec/services/middleware/vaos_logging_integration_spec.rb
+++ b/modules/vaos/spec/services/middleware/vaos_logging_integration_spec.rb
@@ -19,7 +19,7 @@ describe VAOS::Middleware::VaosLogging do
     let(:type) { 'va' }
 
     context 'with a succesful response' do
-      it 'increments statsd and logs additional details in a success line' do
+      xit 'increments statsd and logs additional details in a success line' do
         VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method uri]) do
           expect(Rails.logger).to receive(:info).with(
             '[StatsD] increment api.external_http_request.VAOS.success:1 '\


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Xs out the VAOS logging spec that is only failing on staging so that building is unblocked for other teams.

## Original issue(s)
N/A
