### PR TITLE
Appeals API v1 - Use Caseflow-style Field Names

### DIFF
--- a/modules/appeals_api/config/schemas/200996.json
+++ b/modules/appeals_api/config/schemas/200996.json
@@ -194,8 +194,8 @@
         "issue":                 { "$ref": "#/definitions/nonBlankStringMaxLength140" },
         "decisionDate":          { "$ref": "#/definitions/date" },
         "decisionIssueId":       { "type": "integer" },
-        "ratingIssueId":         { "type": "string" },
-        "ratingDecisionIssueId": { "type": "string" }
+        "ratingIssueReferenceId":    { "type": "string" },
+        "ratingDecisionReferenceId": { "type": "string" }
       },
       "additionalProperties": false,
       "required": [ "issue", "decisionDate" ]

--- a/modules/appeals_api/spec/fixtures/valid_200996.json
+++ b/modules/appeals_api/spec/fixtures/valid_200996.json
@@ -38,8 +38,8 @@
         "issue": "tinnitus",
         "decisionDate": "1900-01-01",
         "decisionIssueId": 1,
-        "ratingIssueId": "2",
-        "ratingDecisionIssueId": "3"
+        "ratingIssueReferenceId": "2",
+        "ratingDecisionReferenceId": "3"
       }
     },
     {
@@ -48,7 +48,7 @@
         "issue": "left knee",
         "decisionDate": "1900-01-02",
         "decisionIssueId": 4,
-        "ratingIssueId": "5"
+        "ratingIssueReferenceId": "5"
       }
     },
     {
@@ -56,8 +56,8 @@
       "attributes": {
         "issue": "right knee",
         "decisionDate": "1900-01-03",
-        "ratingIssueId": "6",
-        "ratingDecisionIssueId": "7"
+        "ratingIssueReferenceId": "6",
+        "ratingDecisionReferenceId": "7"
       }
     },
     {
@@ -66,7 +66,7 @@
         "issue": "PTSD",
         "decisionDate": "1900-01-04",
         "decisionIssueId": 8,
-        "ratingDecisionIssueId": "9"
+        "ratingDecisionReferenceId": "9"
       }
     },
     {

--- a/modules/appeals_api/spec/fixtures/valid_200996_extra.json
+++ b/modules/appeals_api/spec/fixtures/valid_200996_extra.json
@@ -38,8 +38,8 @@
           "issue": "tinnitus",
           "decisionDate": "1900-01-01",
           "decisionIssueId": 1,
-          "ratingIssueId": "2",
-          "ratingDecisionIssueId": "3"
+          "ratingIssueReferenceId": "2",
+          "ratingDecisionReferenceId": "3"
         }
       },
       {
@@ -48,7 +48,7 @@
           "issue": "left knee",
           "decisionDate": "1900-01-02",
           "decisionIssueId": 4,
-          "ratingIssueId": "5"
+          "ratingIssueReferenceId": "5"
         }
       },
       {
@@ -56,8 +56,8 @@
         "attributes": {
           "issue": "right knee",
           "decisionDate": "1900-01-03",
-          "ratingIssueId": "6",
-          "ratingDecisionIssueId": "7"
+          "ratingIssueReferenceId": "6",
+          "ratingDecisionReferenceId": "7"
         }
       },
       {
@@ -66,7 +66,7 @@
           "issue": "PTSD",
           "decisionDate": "1900-01-04",
           "decisionIssueId": 8,
-          "ratingDecisionIssueId": "9"
+          "ratingDecisionReferenceId": "9"
         }
       },
       {


### PR DESCRIPTION
As a developer, I want their to be as little translation layer between Caseflow and Vets-API, consequently, use Caseflow's field names verbatim (when possible).

Resolves https://vajira.max.gov/browse/API-1376