### PR TITLE
BDD: Default values isVaEmployee and standardClaim

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -45,7 +45,7 @@ module EVSS
       #
       def translate
         output_form['claimantCertification'] = true
-        output_form['standardClaim'] = input_form['standardClaim']
+        output_form['standardClaim'] = input_form['standardClaim'] || false
         output_form['autoCestPDFGenerationDisabled'] = input_form['autoCestPDFGenerationDisabled'] || false
         output_form['applicationExpirationDate'] = application_expiration_date
         output_form['overflowText'] = overflow_text
@@ -285,7 +285,7 @@ module EVSS
             'changeOfAddress' => translate_change_of_address(input_form['forwardingAddress']),
             'daytimePhone' => split_phone_number(input_form.dig('phoneAndEmail', 'primaryPhone')),
             'homelessness' => translate_homelessness,
-            'currentlyVAEmployee' => input_form['isVaEmployee']
+            'currentlyVAEmployee' => input_form['isVaEmployee'] || false
           }.compact
         }
       end

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -546,7 +546,8 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
             'type' => 'DOMESTIC',
             'zipFirstFive' => '12345',
             'zipLastFour' => '6789'
-          }
+          },
+          'currentlyVAEmployee' => false
         }
       end
     end
@@ -576,7 +577,8 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
             'type' => 'MILITARY',
             'zipFirstFive' => '12345',
             'zipLastFour' => '6789'
-          }
+          },
+          'currentlyVAEmployee' => false
         }
       end
     end
@@ -602,7 +604,8 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
             'country' => 'Germany',
             'type' => 'INTERNATIONAL',
             'internationalPostalCode' => '732'
-          }
+          },
+          'currentlyVAEmployee' => false
         }
       end
     end
@@ -643,7 +646,8 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
             'beginningDate' => '2018-02-01',
             'endingDate' => '2018-02-30',
             'addressChangeType' => 'TEMPORARY'
-          }
+          },
+          'currentlyVAEmployee' => false
         }
       end
     end

--- a/spec/support/disability_compensation_form/all_claims_fe_submission.json
+++ b/spec/support/disability_compensation_form/all_claims_fe_submission.json
@@ -114,7 +114,6 @@
         }
       ]
     },
-    "standardClaim": false,
     "isTerminallyIll": false,
     "vaTreatmentFacilities": [
       {


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

EVSS's xsd for the 526 claim form shows the fields isVaEmployee and standardClaim as optional/not required.  However, we noticed upon submission of BDD 526 claims, EVSS was returning errors telling us that both these fields are conditionally required under some circumstances for the BDD form.  To simplify this we're defaulting both values to `false`. 

## Original issue(s)
closes department-of-veterans-affairs/va.gov-team#10861

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
