### PR TITLE
ignore evss pciu errors during prefill

### DIFF
--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -286,7 +286,7 @@ class FormProfile
 
   def extract_pciu_data(user, method)
     user&.send(method)
-  rescue Common::Exceptions::Forbidden, Common::Exceptions::BackendServiceException
+  rescue Common::Exceptions::Forbidden, Common::Exceptions::BackendServiceException, EVSS::ErrorMiddleware::EVSSError
     ''
   end
 

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -743,6 +743,14 @@ RSpec.describe FormProfile, type: :model do
     end
   end
 
+  describe '#extract_pciu_data' do
+    it 'should rescue EVSS::ErrorMiddleware::EVSSError errors' do
+      expect(user).to receive(:pciu_primary_phone).and_raise(EVSS::ErrorMiddleware::EVSSError)
+
+      expect(form_profile.send(:extract_pciu_data, user, :pciu_primary_phone)).to eq('')
+    end
+  end
+
   describe '#prefill_form' do
     def can_prefill_emis(yes)
       expect(user).to receive(:authorize).at_least(:once).with(:emis, :access?).and_return(yes)

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -744,7 +744,7 @@ RSpec.describe FormProfile, type: :model do
   end
 
   describe '#extract_pciu_data' do
-    it 'should rescue EVSS::ErrorMiddleware::EVSSError errors' do
+    it 'rescues EVSS::ErrorMiddleware::EVSSError errors' do
       expect(user).to receive(:pciu_primary_phone).and_raise(EVSS::ErrorMiddleware::EVSSError)
 
       expect(form_profile.send(:extract_pciu_data, user, :pciu_primary_phone)).to eq('')


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
ignore evss pciu errors during prefill so that the rest of the prefill fields can be returned instead of returning a 500

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10798

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
tested with automated tests
<!-- Please describe testing done to verify the changes or any testing planned. -->
