### PR TITLE
Create MVI::Models::MviUserAttributes

### DIFF
--- a/lib/hca/user_attributes.rb
+++ b/lib/hca/user_attributes.rb
@@ -1,23 +1,12 @@
 # frozen_string_literal: true
 
-class HCA::UserAttributes
-  include ActiveModel::Validations
-  include Virtus.model(nullify_blank: true)
-
-  attribute :first_name, String
-  attribute :middle_name, String
-  attribute :last_name, String
-  attribute :birth_date, String
-  attribute :ssn, String
-
-  validates(:first_name, :last_name, :birth_date, :ssn, presence: true)
-
-  def ssn=(new_ssn)
-    super(new_ssn&.gsub(/\D/, ''))
-  end
-
+class HCA::UserAttributes < MVI::Models::MviUserAttributes
   def gender
     # MVI message_user_attributes expects a gender value but it's not asked on the HCA form
     nil
+  end
+
+  def to_h
+    super&.except(:gender)
   end
 end

--- a/lib/mvi/attr_service.rb
+++ b/lib/mvi/attr_service.rb
@@ -6,10 +6,12 @@ module MVI
 
     private
 
+    # @param user_attributes [MviUserAttributes]
     def create_profile_message(user_attributes)
       message_user_attributes(user_attributes)
     end
 
+    # @param user_attributes [MviUserAttributes]
     def measure_info(_user_attributes)
       Rails.logger.measure_info('Performed MVI Query') { yield }
     end

--- a/lib/mvi/models/mvi_user_attributes.rb
+++ b/lib/mvi/models/mvi_user_attributes.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module MVI
+  module Models
+    class MviUserAttributes
+      include ActiveModel::Validations
+      include Virtus.model(nullify_blank: true)
+
+      attribute :first_name, String
+      attribute :middle_name, String
+      attribute :last_name, String
+      attribute :birth_date, String
+      attribute :ssn, String
+      attribute :gender, String
+
+      validates :first_name, :last_name, :birth_date, :ssn, presence: true
+      validates :gender,
+                inclusion: { in: %w[M F] },
+                unless: proc { |model| model.gender.blank? }
+
+      def ssn=(new_ssn)
+        super(new_ssn&.gsub(/\D/, ''))
+      end
+    end
+  end
+end

--- a/spec/lib/mvi/attr_service_spec.rb
+++ b/spec/lib/mvi/attr_service_spec.rb
@@ -2,25 +2,30 @@
 
 require 'rails_helper'
 
+shared_examples_for 'MVI search with user attributes' do |user_attributes_class|
+  it "when using #{user_attributes_class.name}", run_at: 'Thu, 29 Aug 2019 17:45:03 GMT' do
+    allow(SecureRandom).to receive(:uuid).and_return('c3fa0769-70cb-419a-b3a6-d2563e7b8502')
+
+    VCR.use_cassette(
+      'mvi/find_candidate/find_profile_with_attributes',
+      VCR::MATCH_EVERYTHING
+    ) do
+      res = described_class.new.find_profile(
+        user_attributes_class.new(
+          first_name: 'WESLEY',
+          last_name: 'FORD',
+          birth_date: '1986-05-06',
+          ssn: '796043735'
+        )
+      )
+      expect(res.profile.icn).to eq('1012832025V743496')
+    end
+  end
+end
+
 describe MVI::AttrService do
   describe '#find_profile' do
-    it 'allows searching mvi with user attributes', run_at: 'Thu, 29 Aug 2019 17:45:03 GMT' do
-      allow(SecureRandom).to receive(:uuid).and_return('c3fa0769-70cb-419a-b3a6-d2563e7b8502')
-
-      VCR.use_cassette(
-        'mvi/find_candidate/find_profile_with_attributes',
-        VCR::MATCH_EVERYTHING
-      ) do
-        res = described_class.new.find_profile(
-          HCA::UserAttributes.new(
-            first_name: 'WESLEY',
-            last_name: 'FORD',
-            birth_date: '1986-05-06',
-            ssn: '796043735'
-          )
-        )
-        expect(res.profile.icn).to eq('1012832025V743496')
-      end
-    end
+    it_behaves_like 'MVI search with user attributes', MVI::Models::MviUserAttributes
+    it_behaves_like 'MVI search with user attributes', HCA::UserAttributes
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/9083
Context here: https://github.com/department-of-veterans-affairs/vets-api/pull/4064#discussion_r424115957

**Description**
Since there are now two places in the codebase where we do MPI Profile searches with only a user's attributes (vs a UserIdentity), we need to create a UserAttributes object in the MVI lib that other services can use for their search.

**Summary**
- [x] Move `HCA::UserAttributes` to MVI lib.
- [x] Update Form1010cg::Service to use `MviUserAttributes` instead of `UserIdentity`