### PR TITLE
Logs diagnostics about sessions without ID.me UUID

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -180,9 +180,10 @@ module V1
     # would be resolved by an account lookup, before we implement that
     def log_missing_uuid_info(exception)
       return if exception&.identifier.blank?
+
       accounts = Account.where(icn: exception.identifier)
-      Rails.logger.info("SSOe: Account UUID mapping NOT FOUND") if accounts.blank?
-      Rails.logger.info("SSOe: Account UUID mapping FOUND - #{accounts.size} entries") unless accounts.blank? 
+      Rails.logger.info('SSOe: Account UUID mapping NOT FOUND') if accounts.blank?
+      Rails.logger.info("SSOe: Account UUID mapping FOUND - #{accounts.size} entries") if accounts.present?
     end
 
     def new_stats(type)

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -57,6 +57,7 @@ module V1
       callback_stats(:success, saml_response)
     rescue SAML::SAMLError => e
       log_message_to_sentry(e.message, e.level, extra_context: e.context)
+      log_missing_uuid_info(e) if e.code == SAML::UserAttributeError::IDME_UUID_MISSING[:code]
       redirect_to url_service(saml_response&.in_response_to).login_redirect_url(auth: 'fail', code: e.code)
       callback_stats(:failure, saml_response, e.tag || e.code)
     rescue => e
@@ -173,6 +174,15 @@ module V1
         Rails.logger.info('SLO callback response could not resolve logout request for originating_request_id '\
           "'#{originating_request_id}'")
       end
+    end
+
+    # Diagnostic logging to determine what percentage of these issues
+    # would be resolved by an account lookup, before we implement that
+    def log_missing_uuid_info(exception)
+      return if exception&.identifier.blank?
+      accounts = Account.where(icn: exception.identifier)
+      Rails.logger.info("SSOe: Account UUID mapping NOT FOUND") if accounts.blank?
+      Rails.logger.info("SSOe: Account UUID mapping FOUND - #{accounts.size} entries") unless accounts.blank? 
     end
 
     def new_stats(type)

--- a/lib/saml/errors.rb
+++ b/lib/saml/errors.rb
@@ -19,11 +19,14 @@ module SAML
                           tag: :idme_uuid_missing,
                           message: 'User attributes is missing an ID.me UUID' }.freeze
 
-    def initialize(message:, code:, tag:)
+    attr_reader :identifier
+
+    def initialize(message:, code:, tag:, identifier: nil)
       @code = code
       @tag = tag
       @level = :warning
       @context = {}
+      @identifier = identifier
       super(message)
     end
   end

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -177,7 +177,9 @@ module SAML
 
       # Raise any fatal exceptions due to validation issues
       def validate!
-        raise SAML::UserAttributeError, SAML::UserAttributeError::IDME_UUID_MISSING.merge({identifier: mhv_icn})  unless idme_uuid
+        unless idme_uuid
+          raise SAML::UserAttributeError, SAML::UserAttributeError::IDME_UUID_MISSING.merge({ identifier: mhv_icn })
+        end
         raise SAML::UserAttributeError, SAML::UserAttributeError::MULTIPLE_MHV_IDS if mhv_id_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::MULTIPLE_EDIPIS if edipi_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::MHV_ICN_MISMATCH if mhv_icn_mismatch?

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -177,7 +177,7 @@ module SAML
 
       # Raise any fatal exceptions due to validation issues
       def validate!
-        raise SAML::UserAttributeError, SAML::UserAttributeError::IDME_UUID_MISSING unless idme_uuid
+        raise SAML::UserAttributeError, SAML::UserAttributeError::IDME_UUID_MISSING.merge({identifier: safe_attr})  unless idme_uuid
         raise SAML::UserAttributeError, SAML::UserAttributeError::MULTIPLE_MHV_IDS if mhv_id_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::MULTIPLE_EDIPIS if edipi_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::MHV_ICN_MISMATCH if mhv_icn_mismatch?

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -177,7 +177,7 @@ module SAML
 
       # Raise any fatal exceptions due to validation issues
       def validate!
-        raise SAML::UserAttributeError, SAML::UserAttributeError::IDME_UUID_MISSING.merge({identifier: safe_attr})  unless idme_uuid
+        raise SAML::UserAttributeError, SAML::UserAttributeError::IDME_UUID_MISSING.merge({identifier: mhv_icn})  unless idme_uuid
         raise SAML::UserAttributeError, SAML::UserAttributeError::MULTIPLE_MHV_IDS if mhv_id_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::MULTIPLE_EDIPIS if edipi_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::MHV_ICN_MISMATCH if mhv_icn_mismatch?

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -796,6 +796,7 @@ RSpec.describe SAML::User do
           expect { subject.validate! }.to raise_error { |error|
             expect(error).to be_a(SAML::UserAttributeError)
             expect(error.message).to eq('User attributes is missing an ID.me UUID')
+            expect(error.identifier).to eq('1012779219V964737')
           }
         end
       end


### PR DESCRIPTION
## Description of change
We want to consider consuming ID.me UUIDs from the accounts table but first are going to collect data about what percentage of inbound users this would help. 

## Original issue(s)


## Things to know about this PR
No PII concerns, data is logged to cloudwatch and contains no user-specific identifiers.
