### PR TITLE
Appeals API v1 - informalConferenceTimes bug

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -205,7 +205,7 @@ module AppealsApi
     end
 
     def informal_conference_times
-      data_attributes&.dig('informalConferenceTimes')
+      data_attributes&.dig('informalConferenceTimes') || []
     end
 
     def informal_conference_rep_name_and_phone_number

--- a/modules/appeals_api/spec/factories/higher_level_reviews.rb
+++ b/modules/appeals_api/spec/factories/higher_level_reviews.rb
@@ -26,4 +26,17 @@ FactoryBot.define do
       status { 'received' }
     end
   end
+
+  factory :minimal_higher_level_review, class: 'AppealsApi::HigherLevelReview' do
+    id { SecureRandom.uuid }
+    auth_headers do
+      JSON.parse File.read "#{::Rails.root}/modules/appeals_api/spec/fixtures/valid_200996_headers.json"
+    end
+    form_data do
+      JSON.parse File.read "#{::Rails.root}/modules/appeals_api/spec/fixtures/valid_200996_minimum.json"
+    end
+    trait :status_received do
+      status { 'received' }
+    end
+  end
 end

--- a/modules/appeals_api/spec/lib/higher_level_review_pdf_constructor_spec.rb
+++ b/modules/appeals_api/spec/lib/higher_level_review_pdf_constructor_spec.rb
@@ -17,6 +17,12 @@ describe AppealsApi::HigherLevelReviewPdfConstructor do
     expect(constructor.pdf_options).to eq(options)
   end
 
+  it 'still builds the pdf options' do
+    higher_level_review = create(:minimal_higher_level_review)
+    constructor = AppealsApi::HigherLevelReviewPdfConstructor.new(higher_level_review.id)
+    expect { constructor.pdf_options }.not_to raise_error
+  end
+
   private
 
   # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
The pdf constructor was expecting there to always be an array for informalConferenceTimes, but, if an informalConference wasn't requested, it returned nil.
Switched it to returing [] when nil.