### PR TITLE
Inject ID.me UUID from accounts table

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -178,6 +178,8 @@ module V1
 
     # Diagnostic logging to determine what percentage of these issues
     # would be resolved by an account lookup, before we implement that
+    # TODO: Remove this method after we're confident in the UUID injection
+    # performed in UserSessionForm
     def log_missing_uuid_info(exception)
       return if exception&.identifier.blank?
 

--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -16,19 +16,39 @@ class UserSessionForm
 
   def initialize(saml_response)
     @saml_uuid = saml_response.in_response_to
-    saml_attributes = SAML::User.new(saml_response)
-    saml_attributes.validate!
-    existing_user = User.find(saml_attributes.user_attributes.uuid)
-    @user_identity = UserIdentity.new(saml_attributes.to_hash)
+    saml_user = SAML::User.new(saml_response)
+    normalized_attributes = normalize_saml(saml_user)
+    existing_user = User.find(normalized_attributes[:uuid])
+    @user_identity = UserIdentity.new(normalized_attributes)
     @user = User.new(uuid: @user_identity.attributes[:uuid])
     @user.instance_variable_set(:@identity, @user_identity)
-    if saml_attributes.changing_multifactor?
+    if saml_user.changing_multifactor?
       @user.mhv_last_signed_in = existing_user.last_signed_in
       @user.last_signed_in = existing_user.last_signed_in
     else
       @user.last_signed_in = Time.current.utc
     end
     @session = Session.new(uuid: @user.uuid)
+  end
+
+  def normalize_saml(saml_user)
+    saml_user.validate!
+    saml_user.to_hash
+  rescue SAML::UserAttributeError => e
+    raise unless e.code == SAML::UserAttributeError::IDME_UUID_MISSING[:code]
+
+    idme_uuid = idme_uuid_from_account(e&.identifier)
+    raise if idme_uuid.blank?
+
+    saml_user.to_hash.merge({ uuid: idme_uuid,
+                              idme_uuid: idme_uuid })
+  end
+
+  def idme_uuid_from_account(identifier)
+    return if identifier.blank?
+
+    accounts = Account.where(icn: identifier)
+    accounts.size == 1 ? accounts&.first&.idme_uuid : nil
   end
 
   def valid?

--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -40,6 +40,7 @@ class UserSessionForm
     idme_uuid = idme_uuid_from_account(e&.identifier)
     raise if idme_uuid.blank?
 
+    Rails.logger.info('Account UUID injected into user SAML attributes')
     saml_user.to_hash.merge({ uuid: idme_uuid,
                               idme_uuid: idme_uuid })
   end

--- a/spec/models/user_session_form_spec.rb
+++ b/spec/models/user_session_form_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/saml/response_builder'
+
+RSpec.describe UserSessionForm, type: :model do
+  include SAML::ResponseBuilder
+
+  # subject { described_class.new(saml_response) }
+
+  let(:loa3_user) do
+    build(:user, :loa3, uuid: saml_attributes[:uuid],
+                        idme_uuid: saml_attributes[:uuid])
+  end
+  let(:saml_response) do
+    build_saml_response(
+      authn_context: 'myhealthevet',
+      level_of_assurance: '3',
+      attributes: saml_attributes,
+      existing_attributes: nil,
+      issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
+    )
+  end
+
+  context 'with ID.me UUID in SAML' do
+    let(:saml_attributes) do
+      build(:ssoe_idme_mhv_premium)
+    end
+
+    it 'instantiates cleanly' do
+      UserSessionForm.new(saml_response)
+    end
+  end
+
+  context 'with ID.me UUID not present in SAML' do
+    let(:saml_attributes) do
+      build(:ssoe_inbound_mhv_premium, va_eauth_gcIds: [''])
+    end
+
+    it 'raises a validation error' do
+      expect { UserSessionForm.new(saml_response) }.to raise_error { |error|
+        expect(error).to be_a(SAML::UserAttributeError)
+      }
+    end
+
+    it 'instantiates if a unique account mapping exists' do
+      create(:account, icn: saml_attributes[:va_eauth_icn])
+      UserSessionForm.new(saml_response)
+    end
+
+    it 'raises a validation error if multiple account mappings exist' do
+      create(:account, icn: saml_attributes[:va_eauth_icn])
+      create(:account, icn: saml_attributes[:va_eauth_icn])
+
+      expect { UserSessionForm.new(saml_response) }.to raise_error { |error|
+        expect(error).to be_a(SAML::UserAttributeError)
+      }
+    end
+  end
+end

--- a/spec/models/user_session_form_spec.rb
+++ b/spec/models/user_session_form_spec.rb
@@ -56,5 +56,13 @@ RSpec.describe UserSessionForm, type: :model do
         expect(error).to be_a(SAML::UserAttributeError)
       }
     end
+
+    it 'uses the injected identifier as the user key' do
+      account = create(:account, icn: saml_attributes[:va_eauth_icn])
+      subject = UserSessionForm.new(saml_response)
+      subject.persist
+      expect(User.find(account.idme_uuid)).to be_truthy
+      expect(UserIdentity.find(account.idme_uuid)).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
# Description of change
Detects a SAML payload that is missing an ID.me UUID, and attempts to look one up (based on the presented ICN) in the Accounts table. If a unique mapping is found, injects the idme_uuid into the User/UserIdentity before establishing a session.

There may be users who have ICNs that map to multiple ID.me UUIDs. For now, we are ignoring those until we can decide how to handle them correctly.

We found that ~80% of inbound SSOe sessions did not have an ID.me UUID present.
Of those, between 80-85% of a brief sample were present in the accounts table, and by doing this injection we let those users have auto-login without needing to re-authenticate.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/11096

## Things to know about this PR


## Feedback Requested
Should I remove the diagnostic logging from the sessions controller, and/or replace it with a log message indicating whether or not we were able to do this injection?