### PR TITLE
Revert "Update vets-json-schema"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,10 +57,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: ecae25f8c61c74a38b1be0c8def2d151a59764a3
+  revision: 9e21f294686847a9b2a389c0b29532a90f4531e2
   branch: master
   specs:
-    vets_json_schema (6.2.0)
+    vets_json_schema (6.1.1)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 


### PR DESCRIPTION
We need to quickly revert this before this change is deployed to production today.  I was under the impression that the FE is always sending us this field. Through staging testing we discovered that it is possible to not answer this question.  This schema mismatch will make some form526 submissions fail.

Reverts department-of-veterans-affairs/vets-api#4502