### PR TITLE
Allow Betamocks searches via ICN for Veteran Status in EMIS

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -334,10 +334,17 @@
   :endpoints:
   - :method: :post
     :path: "/VIERSService/eMIS/v1/VeteranStatusService"
-    :file_path: "emis/veteran_status"
+    :file_path: "emis/veteran_status/by_edipi"
     :cache_multiple_responses:
       :uid_location: body
-      :uid_locator: '<v13:edipiORicnValue>([V0-9]*)<\/v13:edipiORicnValue>'
+      :uid_locator: '<v13:edipiORicnValue>(\d+)<\/v13:edipiORicnValue>\s*<v13:inputType>EDIPI</v13:inputType>'
+
+  - :method: :post
+    :path: "/VIERSService/eMIS/v1/VeteranStatusService"
+    :file_path: "emis/veteran_status/by_icn"
+    :cache_multiple_responses:
+      :uid_location: body
+      :uid_locator: '<v13:edipiORicnValue>([V0-9]*)<\/v13:edipiORicnValue>\s*<v13:inputType>ICN</v13:inputType>'
 
   - :method: :post
     :path: "/VIERSService/eMIS/v1/MilitaryInformationService"

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -337,7 +337,7 @@
     :file_path: "emis/veteran_status"
     :cache_multiple_responses:
       :uid_location: body
-      :uid_locator: '<v13:edipiORicnValue>(\d+)<\/v13:edipiORicnValue>'
+      :uid_locator: '<v13:edipiORicnValue>([V0-9]*)<\/v13:edipiORicnValue>'
 
   - :method: :post
     :path: "/VIERSService/eMIS/v1/MilitaryInformationService"


### PR DESCRIPTION
**Relates vets-api-mockdata PR**: https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/145

**Description**
EMIS allows you to get a veteran's status by searching with either an EDIPI or ICN.

vets-api-mockdata only has a sample response for eMIS searches using EDIPI. I'd like to match a Betamocks response from a request searching via an ICN.

The current Betamocks config will filter the entire ICN out of the search resulting in a mockdata lookup of `../vets-api-mockdata/emis/veteran_status/.yml` vs `../vets-api-mockdata/emis/veteran_status/1012740600V714187.yml` (for an eMIS search of `icn: "1012740600V714187"`).

**Summary**
Update eMIS Betamocks config to support eMIS Veteran Status searchs with an ICN.
