### PR TITLE
base claims healthchecks on the mock flag

### DIFF
--- a/modules/claims_api/lib/claims_api/health_checker.rb
+++ b/modules/claims_api/lib/claims_api/health_checker.rb
@@ -10,11 +10,11 @@ module ClaimsApi
     end
 
     def self.evss_is_healthy?
-      EVSS::Service.service_is_up?
+      Settings.evss.mock_claims || EVSS::Service.service_is_up?
     end
 
     def self.mvi_is_healthy?
-      MVI::Service.service_is_up?
+      Settings.mvi.mock || MVI::Service.service_is_up?
     end
 
     def self.bgs_is_healthy?


### PR DESCRIPTION
## Description of change
This PR sets the claims healthchecks to be based on the mock flag for evss claims and for MVI
