### PR TITLE
Appeals API v1 - Bug Fix: Empty Central Mail Response Causing Exception to be Thrown

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -40,7 +40,7 @@ module AppealsApi
       private
 
       def parse_central_mail_response(response)
-        JSON.parse(response.body).map do |(hash)|
+        JSON.parse(response.body).flatten.map do |hash|
           Struct.new(:id, :status, :error_message).new(*hash.values_at('uuid', 'status', 'errorMessage'))
         end
       end

--- a/modules/appeals_api/spec/models/higher_level_review_spec.rb
+++ b/modules/appeals_api/spec/models/higher_level_review_spec.rb
@@ -7,11 +7,43 @@ describe AppealsApi::HigherLevelReview, type: :model do
   include FixtureHelpers
 
   let(:higher_level_review) { default_higher_level_review }
-  let(:default_higher_level_review) { create :higher_level_review }
+  let(:default_higher_level_review) { create :higher_level_review, :status_received }
   let(:auth_headers) { default_auth_headers }
   let(:default_auth_headers) { fixture_as_json 'valid_200996_headers.json' }
   let(:form_data) { default_form_data }
   let(:default_form_data) { fixture_as_json 'valid_200996.json' }
+
+  describe '.refresh_statuses_using_central_mail!' do
+    subject { described_class.refresh_statuses_using_central_mail!(higher_level_reviews) }
+
+    let(:higher_level_reviews) { AppealsApi::HigherLevelReview.all }
+    let(:central_mail) { instance_double('CentralMail::Service') }
+    let(:faraday_response) { instance_double('Faraday::Response') }
+
+    before do
+      allow(CentralMail::Service).to receive(:new).and_return central_mail
+      allow(central_mail).to receive(:status).and_return faraday_response
+      allow(faraday_response).to receive(:success?).and_return true
+    end
+
+    it 'updates with CentralMail status update' do
+      higher_level_review
+      returned_status = {
+        "uuid": higher_level_review.id,
+        "status": 'In Process',
+        "lastUpdated": Time.zone.yesterday.strftime('%F %T')
+      }
+      expect(faraday_response).to receive(:body).and_return [[returned_status]].to_json
+      subject
+      expect(higher_level_review.reload.status).to eq('processing')
+    end
+
+    it 'handles an empty CentralMail response' do
+      higher_level_review
+      expect(faraday_response).to receive(:body).and_return [[]].to_json
+      expect { subject }.not_to raise_error
+    end
+  end
 
   describe '#first_name' do
     subject { higher_level_review.first_name }

--- a/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
@@ -4,40 +4,27 @@ require 'rails_helper'
 
 describe AppealsApi::HigherLevelReviewUploadStatusUpdater, type: :job do
   let(:client_stub) { instance_double('CentralMail::Service') }
-  let(:upload1) { create(:higher_level_review, :status_received) }
-  let(:upload2) { create(:higher_level_review, :status_received) }
+  let(:upload) { create(:higher_level_review, :status_received) }
   let(:faraday_response) { instance_double('Faraday::Response') }
+  let(:in_process_element) do
+    [{ "uuid": 'ignored',
+       "status": 'In Process',
+       "errorMessage": '',
+       "lastUpdated": '2018-04-25 00:02:39' }]
+  end
 
   describe '#perform' do
     it 'updates the status of a HigherLevelReview' do
       expect(CentralMail::Service).to receive(:new) { client_stub }
       expect(client_stub).to receive(:status).and_return(faraday_response)
       expect(faraday_response).to receive(:success?).and_return(true)
-      returned_status = {
-        "uuid": upload1.id,
-        "status": 'In Process',
-        "errorMessage": '',
-        "lastUpdated": '2018-04-25 00:02:39'
-      }
-      expect(faraday_response).to receive(:body).at_least(:once).and_return([[returned_status]].to_json)
+      in_process_element[0]['uuid'] = upload.id
+      expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
 
       with_settings(Settings.modules_appeals_api, higher_level_review_updater_enabled: true) do
-        AppealsApi::HigherLevelReviewUploadStatusUpdater.new.perform([upload1])
-        upload1.reload
-        expect(upload1.status).to eq('processing')
-      end
-    end
-
-    it 'empty response is OK' do
-      expect(CentralMail::Service).to receive(:new) { client_stub }
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
-      expect(faraday_response).to receive(:body).at_least(:once).and_return([[]].to_json)
-
-      with_settings(Settings.modules_appeals_api, higher_level_review_updater_enabled: true) do
-        AppealsApi::HigherLevelReviewUploadStatusUpdater.new.perform([upload2])
-        upload2.reload
-        expect(upload2.status).to eq('received')
+        AppealsApi::HigherLevelReviewUploadStatusUpdater.new.perform([upload])
+        upload.reload
+        expect(upload.status).to eq('processing')
       end
     end
   end

--- a/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
@@ -4,27 +4,40 @@ require 'rails_helper'
 
 describe AppealsApi::HigherLevelReviewUploadStatusUpdater, type: :job do
   let(:client_stub) { instance_double('CentralMail::Service') }
-  let(:upload) { create(:higher_level_review, :status_received) }
+  let(:upload1) { create(:higher_level_review, :status_received) }
+  let(:upload2) { create(:higher_level_review, :status_received) }
   let(:faraday_response) { instance_double('Faraday::Response') }
-  let(:in_process_element) do
-    [{ "uuid": 'ignored',
-       "status": 'In Process',
-       "errorMessage": '',
-       "lastUpdated": '2018-04-25 00:02:39' }]
-  end
 
   describe '#perform' do
     it 'updates the status of a HigherLevelReview' do
       expect(CentralMail::Service).to receive(:new) { client_stub }
       expect(client_stub).to receive(:status).and_return(faraday_response)
       expect(faraday_response).to receive(:success?).and_return(true)
-      in_process_element[0]['uuid'] = upload.id
-      expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
+      returned_status = {
+        "uuid": upload1.id,
+        "status": 'In Process',
+        "errorMessage": '',
+        "lastUpdated": '2018-04-25 00:02:39'
+      }
+      expect(faraday_response).to receive(:body).at_least(:once).and_return([[returned_status]].to_json)
 
       with_settings(Settings.modules_appeals_api, higher_level_review_updater_enabled: true) do
-        AppealsApi::HigherLevelReviewUploadStatusUpdater.new.perform([upload])
-        upload.reload
-        expect(upload.status).to eq('processing')
+        AppealsApi::HigherLevelReviewUploadStatusUpdater.new.perform([upload1])
+        upload1.reload
+        expect(upload1.status).to eq('processing')
+      end
+    end
+
+    it 'empty response is OK' do
+      expect(CentralMail::Service).to receive(:new) { client_stub }
+      expect(client_stub).to receive(:status).and_return(faraday_response)
+      expect(faraday_response).to receive(:success?).and_return(true)
+      expect(faraday_response).to receive(:body).at_least(:once).and_return([[]].to_json)
+
+      with_settings(Settings.modules_appeals_api, higher_level_review_updater_enabled: true) do
+        AppealsApi::HigherLevelReviewUploadStatusUpdater.new.perform([upload2])
+        upload2.reload
+        expect(upload2.status).to eq('received')
       end
     end
   end


### PR DESCRIPTION
flatten the Central Mail response to end up with a one-dimensional array of hashes or empty array