### PR TITLE
BUGFIX: Pluralize the Eligibility Keys

### DIFF
--- a/lib/mdot/response.rb
+++ b/lib/mdot/response.rb
@@ -32,7 +32,7 @@ module MDOT
       eligibility = MDOT::Eligibility.new
 
       supplies.each do |supply|
-        group = supply.product_group.downcase.to_sym
+        group = supply.product_group.downcase.pluralize.to_sym
         eligibility.send("#{group}=", true) if eligibility.attributes.key?(group) && supply.available_for_reorder
       end
 


### PR DESCRIPTION
## Description of change
MDT Eligibility object is dependent upon pluralized keys. The latest iteration of the DLC API has keys that are singular, this fixes this by pluralizing them prior to determining eligibility.

## Original issue(s)
n/a

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
