### PR TITLE
Add option to run ClamAV from `make up`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,3 @@ dump.rdb
 /.project
 .generators
 .rakeTasks
-Procfile.local

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,4 @@ config/ca-trust
 dump.rdb
 /.project
 .generators
-.rakeTasks
+.rakeTasksProcfile.local

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,5 @@ config/ca-trust
 dump.rdb
 /.project
 .generators
-.rakeTasksProcfile.local
+.rakeTasks
+Procfile.local

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ else
     ENV_ARG	 := dev
 endif
 
+ifdef clam
+	FOREMAN_ARG := all=1
+else
+	FOREMAN_ARG := all=1,clamd=0,freshclam=0
+endif
+
 COMPOSE_DEV  := docker-compose
 COMPOSE_TEST := docker-compose -f docker-compose.test.yml
 BASH         := run --rm --service-ports vets-api bash
@@ -115,8 +121,4 @@ endif
 
 .PHONY: up
 up: db  ## Starts the server and associated services with docker-compose
-	@$(BASH_DEV) "rm -f tmp/pids/server.pid && foreman start -m all=1,clamd=0,freshclam=0"
-
-.PHONY: foreman
-foreman: db  ## Starts the server and associated services with docker-compose
-	@$(BASH_DEV) "rm -f tmp/pids/server.pid && foreman start --procfile=Procfile.local"
+	@$(BASH_DEV) "rm -f tmp/pids/server.pid && foreman start -m ${FOREMAN_ARG}"

--- a/Makefile
+++ b/Makefile
@@ -116,3 +116,7 @@ endif
 .PHONY: up
 up: db  ## Starts the server and associated services with docker-compose
 	@$(BASH_DEV) "rm -f tmp/pids/server.pid && foreman start -m all=1,clamd=0,freshclam=0"
+
+.PHONY: foreman
+up: db  ## Starts the server and associated services with docker-compose
+	@$(BASH_DEV) "rm -f tmp/pids/server.pid && foreman start --procfile=Procfile.local"

--- a/Makefile
+++ b/Makefile
@@ -118,5 +118,5 @@ up: db  ## Starts the server and associated services with docker-compose
 	@$(BASH_DEV) "rm -f tmp/pids/server.pid && foreman start -m all=1,clamd=0,freshclam=0"
 
 .PHONY: foreman
-up: db  ## Starts the server and associated services with docker-compose
+foreman: db  ## Starts the server and associated services with docker-compose
 	@$(BASH_DEV) "rm -f tmp/pids/server.pid && foreman start --procfile=Procfile.local"

--- a/Makefile
+++ b/Makefile
@@ -120,5 +120,5 @@ else
 endif
 
 .PHONY: up
-up: db  ## Starts the server and associated services with docker-compose
+up: db  ## Starts the server and associated services with docker-compose, use `clam=1 make up` to run ClamAV
 	@$(BASH_DEV) "rm -f tmp/pids/server.pid && foreman start -m ${FOREMAN_ARG}"


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Provide a way to run clamav in the Docker container with the Makefile.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11176

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
