### PR TITLE
don't reset session cookies for unauthenticated users

### DIFF
--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -26,7 +26,7 @@ module AuthenticationAndSSOConcerns
     load_user
 
     if @session_object.nil?
-      Rails.logger.info('SSO: INVALID SESSION', sso_logging_info)
+      Rails.logger.debug('SSO: INVALID SESSION', sso_logging_info)
       clear_session
       return false
     end
@@ -48,7 +48,7 @@ module AuthenticationAndSSOConcerns
 
   # Destroys the users session in 1) Redis and the MHV SSO Cookie
   def clear_session
-    Rails.logger.info('SSO: ApplicationController#clear_session', sso_logging_info)
+    Rails.logger.debug('SSO: ApplicationController#clear_session', sso_logging_info)
 
     cookies.delete(Settings.sso.cookie_name, domain: Settings.sso.cookie_domain)
     @session_object&.destroy

--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -2,6 +2,7 @@
 
 # This module only gets mixed in to one place, but is that cleanest way to organize everything in one place related
 # to this responsibility alone.
+# rubocop:disable Metrics/ModuleLength
 module AuthenticationAndSSOConcerns
   extend ActiveSupport::Concern
   include ActionController::Cookies
@@ -147,3 +148,4 @@ module AuthenticationAndSSOConcerns
     }
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -26,7 +26,7 @@ module AuthenticationAndSSOConcerns
 
     if @session_object.nil?
       Rails.logger.info('SSO: INVALID SESSION', sso_logging_info)
-      reset_session
+      clear_session
       return false
     end
 
@@ -45,15 +45,22 @@ module AuthenticationAndSSOConcerns
     @current_user = User.find(@session_object.uuid) if @session_object
   end
 
-  # Destroys the users session in 1) Redis, 1) the MHV SSO Cookie, 3) and the Session Cookie
-  def reset_session
-    Rails.logger.info('SSO: ApplicationController#reset_session', sso_logging_info)
+  # Destroys the users session in 1) Redis and the MHV SSO Cookie
+  def clear_session
+    Rails.logger.info('SSO: ApplicationController#clear_session', sso_logging_info)
 
     cookies.delete(Settings.sso.cookie_name, domain: Settings.sso.cookie_domain)
     @session_object&.destroy
     @current_user&.destroy
     @session_object = nil
     @current_user = nil
+  end
+
+  # Destroys the users session in 1) Redis, 2) the MHV SSO Cookie, 3) and the Session Cookie
+  def reset_session
+    Rails.logger.info('SSO: ApplicationController#reset_session', sso_logging_info)
+
+    clear_session
     super
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe ApplicationController, type: :controller do
         it 'renders json error' do
           get :test_authentication
           expect(controller.instance_variable_get(:@session_object)).to be_nil
-          expect(session).to_not be_empty
+          expect(session).not_to be_empty
           expect(response).to have_http_status(:unauthorized)
           expect(JSON.parse(response.body)['errors'].first)
             .to eq('title' => 'Not authorized', 'detail' => 'Not authorized', 'code' => '401', 'status' => '401')

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe ApplicationController, type: :controller do
         it 'renders json error' do
           get :test_authentication
           expect(controller.instance_variable_get(:@session_object)).to be_nil
-          expect(session).to be_empty
+          expect(session).to_not be_empty
           expect(response).to have_http_status(:unauthorized)
           expect(JSON.parse(response.body)['errors'].first)
             .to eq('title' => 'Not authorized', 'detail' => 'Not authorized', 'code' => '401', 'status' => '401')


### PR DESCRIPTION
If an unauthenticated user makes an API call to any controller that uses
the authentication and sso concern, the user's session cookie will
reset.  This is problematic as some forms can be submitted by
unauthenticated users, thus having their CSRF cookie reset early will
prevent the form submission from succeeding.
