### PR TITLE
Fetch a CARMA access token only once per user submission

### DIFF
--- a/lib/carma/README.md
+++ b/lib/carma/README.md
@@ -28,23 +28,24 @@ submission.metadata = {
   }
 }
 
-submission.submit!
+submission.submit!(CARMA::Client::Client.new)
 ```
 
 ### Submission with Attachments 
 ```
-claim       = SavedClaim::CaregiversAssistanceClaim.new
-submission  = CARMA::Models::Submission.from_claim(
-                claim,
-                {
-                  veteran: {
-                    icn: '1234',
-                    is_veteran: true
+carma_client  = CARMA::Client::Client.new
+claim         = SavedClaim::CaregiversAssistanceClaim.new
+submission    = CARMA::Models::Submission.from_claim(
+                  claim,
+                  {
+                    veteran: {
+                      icn: '1234',
+                      is_veteran: true
+                    }
                   }
-                }
-              )
+                )
 
-submission.submit!
+submission.submit!(carma_client)
 
 attachments = CARMA::Models::Attachments.new(
   submission.carma_case_id,
@@ -55,5 +56,5 @@ attachments = CARMA::Models::Attachments.new(
 attachments.add('10-10CG', 'tmp/pdfs/10-10CG-claim-guid.pdf')
 attachments.add('POA', 'tmp/pdfs/POA-claim-guid.pdf')
 
-attachments.submit!
+attachments.submit!(carma_client)
 ```

--- a/lib/carma/client/client.rb
+++ b/lib/carma/client/client.rb
@@ -5,8 +5,6 @@ require 'common/client/base'
 module CARMA
   module Client
     class Client < Salesforce::Service
-      include Singleton
-
       configuration CARMA::Client::Configuration
 
       STATSD_KEY_PREFIX = 'api.carma'
@@ -18,7 +16,7 @@ module CARMA
 
       def create_submission(payload)
         with_monitoring do
-          client.post(
+          restforce.post(
             '/services/apexrest/carma/v1/1010-cg-submissions',
             payload,
             'Content-Type': 'application/json',
@@ -42,7 +40,7 @@ module CARMA
 
       def upload_attachments(payload)
         with_monitoring do
-          client.post(
+          restforce.post(
             '/services/data/v47.0/composite/tree/ContentVersion',
             payload,
             'Content-Type': 'application/json'
@@ -65,7 +63,7 @@ module CARMA
 
       private
 
-      def client
+      def restforce
         @client ||= get_client
       end
     end

--- a/lib/carma/models/attachments.rb
+++ b/lib/carma/models/attachments.rb
@@ -43,13 +43,13 @@ module CARMA
         }
       end
 
-      def submit!
+      def submit!(external_client = nil)
         return response if response
 
         @response = if Flipper.enabled?(:stub_carma_responses)
-                      client.upload_attachments_stub(to_request_payload)
+                      (external_client || client).upload_attachments_stub(to_request_payload)
                     else
-                      client.upload_attachments(to_request_payload)
+                      (external_client || client).upload_attachments(to_request_payload)
                     end
 
         @has_errors = @response['hasErrors']
@@ -75,7 +75,7 @@ module CARMA
       private
 
       def client
-        CARMA::Client::Client.instance
+        CARMA::Client::Client.new
       end
     end
   end

--- a/lib/carma/models/attachments.rb
+++ b/lib/carma/models/attachments.rb
@@ -43,13 +43,13 @@ module CARMA
         }
       end
 
-      def submit!(external_client = nil)
+      def submit!(client)
         return response if response
 
         @response = if Flipper.enabled?(:stub_carma_responses)
-                      (external_client || client).upload_attachments_stub(to_request_payload)
+                      client.upload_attachments_stub(to_request_payload)
                     else
-                      (external_client || client).upload_attachments(to_request_payload)
+                      client.upload_attachments(to_request_payload)
                     end
 
         @has_errors = @response['hasErrors']
@@ -70,12 +70,6 @@ module CARMA
           has_errors: has_errors,
           data: all.map(&:to_hash)
         }
-      end
-
-      private
-
-      def client
-        CARMA::Client::Client.new
       end
     end
   end

--- a/lib/carma/models/submission.rb
+++ b/lib/carma/models/submission.rb
@@ -42,13 +42,13 @@ module CARMA
         self.metadata = args[:metadata] || {}
       end
 
-      def submit!(external_client = nil)
+      def submit!(client)
         raise 'This submission has already been submitted to CARMA' if submitted?
 
         response =  if Flipper.enabled?(:stub_carma_responses)
-                      (external_client || client).create_submission_stub(to_request_payload)
+                      client.create_submission_stub(to_request_payload)
                     else
-                      (external_client || client).create_submission(to_request_payload)
+                      client.create_submission(to_request_payload)
                     end
 
         @carma_case_id = response['data']['carmacase']['id']
@@ -63,12 +63,6 @@ module CARMA
 
       def metadata=(metadata_hash)
         @metadata = Metadata.new(metadata_hash)
-      end
-
-      private
-
-      def client
-        CARMA::Client::Client.new
       end
     end
   end

--- a/lib/carma/models/submission.rb
+++ b/lib/carma/models/submission.rb
@@ -42,13 +42,13 @@ module CARMA
         self.metadata = args[:metadata] || {}
       end
 
-      def submit!
+      def submit!(external_client = nil)
         raise 'This submission has already been submitted to CARMA' if submitted?
 
         response =  if Flipper.enabled?(:stub_carma_responses)
-                      client.create_submission_stub(to_request_payload)
+                      (external_client || client).create_submission_stub(to_request_payload)
                     else
-                      client.create_submission(to_request_payload)
+                      (external_client || client).create_submission(to_request_payload)
                     end
 
         @carma_case_id = response['data']['carmacase']['id']
@@ -68,7 +68,7 @@ module CARMA
       private
 
       def client
-        CARMA::Client::Client.instance
+        CARMA::Client::Client.new
       end
     end
   end

--- a/spec/lib/carma/client/client_spec.rb
+++ b/spec/lib/carma/client/client_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CARMA::Client::Client, type: :model do
       restforce_client  = double
       response_double   = double
 
-      expect(described_class.instance).to receive(:client).and_return(restforce_client)
+      expect(subject).to receive(:get_client).and_return(restforce_client)
       expect(restforce_client).to receive(:post).with(
         '/services/apexrest/carma/v1/1010-cg-submissions',
         payload,
@@ -31,7 +31,7 @@ RSpec.describe CARMA::Client::Client, type: :model do
 
       expect(response_double).to receive(:body).and_return(:response_token)
 
-      response = described_class.instance.create_submission(payload)
+      response = subject.create_submission(payload)
       expect(response).to eq(:response_token)
     end
   end
@@ -40,8 +40,8 @@ RSpec.describe CARMA::Client::Client, type: :model do
     timestamp = DateTime.parse('2020-03-09T06:48:59-04:00')
 
     it 'returns a hard coded response', run_at: timestamp.iso8601 do
-      expect(described_class.instance).not_to receive(:client)
-      response = described_class.instance.create_submission_stub(nil)
+      expect(subject).not_to receive(:get_client)
+      response = subject.create_submission_stub(nil)
 
       expect(response['message']).to eq('Application Received')
       expect(response['data']).to be_present
@@ -57,7 +57,7 @@ RSpec.describe CARMA::Client::Client, type: :model do
       restforce_client  = double
       response_double   = double
 
-      expect(described_class.instance).to receive(:client).and_return(restforce_client)
+      expect(subject).to receive(:get_client).and_return(restforce_client)
 
       expect(restforce_client).to receive(:post).with(
         '/services/data/v47.0/composite/tree/ContentVersion',
@@ -69,15 +69,15 @@ RSpec.describe CARMA::Client::Client, type: :model do
 
       expect(response_double).to receive(:body).and_return(:response_token)
 
-      response = described_class.instance.upload_attachments(payload)
+      response = subject.upload_attachments(payload)
       expect(response).to eq(:response_token)
     end
   end
 
   describe '#upload_attachments_stub' do
     it 'returns a hard coded response' do
-      expect(described_class.instance).not_to receive(:client)
-      response = described_class.instance.upload_attachments_stub(nil)
+      expect(subject).not_to receive(:get_client)
+      response = subject.upload_attachments_stub(nil)
 
       expect(response).to eq(
         {

--- a/spec/lib/carma/models/attachments_spec.rb
+++ b/spec/lib/carma/models/attachments_spec.rb
@@ -118,14 +118,15 @@ RSpec.describe CARMA::Models::Attachments, type: :model do
             ]
           }
 
-          expect(CARMA::Client::Client.instance).not_to receive(:upload_attachments)
-          expect(CARMA::Client::Client.instance).to receive(:upload_attachments_stub).with(
+          carma_client = double
+          expect(carma_client).not_to receive(:upload_attachments)
+          expect(carma_client).to receive(:upload_attachments_stub).with(
             expected_request_payload
           ).and_return(
             expected_response
           )
 
-          subject.submit!
+          subject.submit!(carma_client)
 
           expect(subject.response).to eq(expected_response)
           expect(subject.has_errors).to eq(false)
@@ -169,14 +170,15 @@ RSpec.describe CARMA::Models::Attachments, type: :model do
               ]
             }
 
-            expect(CARMA::Client::Client.instance).not_to receive(:upload_attachments)
-            expect(CARMA::Client::Client.instance).to receive(:upload_attachments_stub).with(
+            carma_client = double
+            expect(carma_client).not_to receive(:upload_attachments)
+            expect(carma_client).to receive(:upload_attachments_stub).with(
               expected_request_payload
             ).and_return(
               expected_response
             )
 
-            5.times { subject.submit! }
+            5.times { subject.submit!(carma_client) }
 
             expect(subject.response).to eq(expected_response)
             expect(subject.has_errors).to eq(false)
@@ -222,14 +224,15 @@ RSpec.describe CARMA::Models::Attachments, type: :model do
             ]
           }
 
-          expect(CARMA::Client::Client.instance).not_to receive(:upload_attachments_stub)
-          expect(CARMA::Client::Client.instance).to receive(:upload_attachments).with(
+          carma_client = double
+          expect(carma_client).not_to receive(:upload_attachments_stub)
+          expect(carma_client).to receive(:upload_attachments).with(
             expected_request_payload
           ).and_return(
             expected_response
           )
 
-          subject.submit!
+          subject.submit!(carma_client)
 
           expect(subject.response).to eq(expected_response)
           expect(subject.has_errors).to eq(false)
@@ -273,14 +276,15 @@ RSpec.describe CARMA::Models::Attachments, type: :model do
               ]
             }
 
-            expect(CARMA::Client::Client.instance).not_to receive(:upload_attachments_stub)
-            expect(CARMA::Client::Client.instance).to receive(:upload_attachments).with(
+            carma_client = double
+            expect(carma_client).not_to receive(:upload_attachments_stub)
+            expect(carma_client).to receive(:upload_attachments).with(
               expected_request_payload
             ).and_return(
               expected_response
             )
 
-            5.times { subject.submit! }
+            5.times { subject.submit!(carma_client) }
 
             expect(subject.response).to eq(expected_response)
             expect(subject.has_errors).to eq(false)

--- a/spec/lib/carma/models/submission_spec.rb
+++ b/spec/lib/carma/models/submission_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe CARMA::Models::Submission, type: :model do
         submission.submitted_at = DateTime.now.iso8601
         submission.carma_case_id = 'aB935000000A9GoCAK'
 
-        expect { submission.submit! }.to raise_error('This submission has already been submitted to CARMA')
+        expect { submission.submit!(double) }.to raise_error('This submission has already been submitted to CARMA')
       end
     end
 
@@ -342,17 +342,18 @@ RSpec.describe CARMA::Models::Submission, type: :model do
 
         expect(Flipper).to receive(:enabled?).with(:stub_carma_responses).and_return(false)
 
-        expect(CARMA::Client::Client.instance).not_to receive(:create_submission_stub)
+        carma_client = double
+        expect(carma_client).not_to receive(:create_submission_stub)
 
         expect(submission.carma_case_id).to eq(nil)
         expect(submission.submitted_at).to eq(nil)
         expect(submission.submitted?).to eq(false)
 
-        expect(CARMA::Client::Client.instance).to receive(:create_submission).and_return(
+        expect(carma_client).to receive(:create_submission).and_return(
           expected_response
         )
 
-        submission.submit!
+        submission.submit!(carma_client)
 
         expect(submission.carma_case_id).to eq(expected_response['data']['carmacase']['id'])
         expect(submission.submitted_at).to eq(expected_response['data']['carmacase']['createdAt'])
@@ -375,8 +376,9 @@ RSpec.describe CARMA::Models::Submission, type: :model do
 
         expect(submission).to receive(:to_request_payload).and_return(:REQUEST_PAYLOAD)
 
-        expect(CARMA::Client::Client.instance).not_to receive(:create_submission)
-        expect(CARMA::Client::Client.instance).to receive(
+        carma_client = double
+        expect(carma_client).not_to receive(:create_submission)
+        expect(carma_client).to receive(
           :create_submission_stub
         ).with(
           :REQUEST_PAYLOAD
@@ -388,7 +390,7 @@ RSpec.describe CARMA::Models::Submission, type: :model do
         expect(submission.submitted_at).to eq(nil)
         expect(submission.submitted?).to eq(false)
 
-        submission.submit!
+        submission.submit!(carma_client)
 
         expect(submission.carma_case_id).to eq(expected_response['data']['carmacase']['id'])
         expect(submission.submitted_at).to eq(expected_response['data']['carmacase']['createdAt'])

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -496,6 +496,9 @@ RSpec.describe Form1010cg::Service do
         )
       )
 
+      emis_service = double
+      expect(EMIS::VeteranStatusService).to receive(:new).with(no_args).and_return(emis_service)
+
       # Only two calls should be made to eMIS for the six calls of :is_veteran below
       2.times do |index|
         expected_form_subject = index.zero? ? 'veteran' : 'primaryCaregiver'
@@ -503,7 +506,6 @@ RSpec.describe Form1010cg::Service do
 
         expect(subject).to receive(:icn_for).with(expected_form_subject).and_return(expected_icn)
 
-        emis_service = double
         emis_response_title38_value = index.zero? ? 'V1' : 'V4'
         emis_response = double(
           error?: false,
@@ -514,7 +516,6 @@ RSpec.describe Form1010cg::Service do
           ]
         )
 
-        expect(EMIS::VeteranStatusService).to receive(:new).with(no_args).and_return(emis_service)
         expect(emis_service).to receive(:get_veteran_status).with(
           icn: expected_icn
         ).and_return(


### PR DESCRIPTION
Fixes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/6686

## Description
Update CARMA to get an access token once per submission "session" (submitting data and attachment of a single claim).

## Considerations
Rather than waiting for a 401 from CARMA to get a new access token, I decided to just get a new access token every time a user submits a claim. This results in one request to get a token, second request to submit raw data, third request to send an attachment.

## Summary
- Convert `CARMA::Client::Client` back to a regular object (revert singleton changes)
- Use a single instance of `CARMA::Client::Client` for the CARMA submission and attachments
- List all dependent services for `Form1010cg::Service` in private methods for clarity
