### PR TITLE
added my email to settings.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -468,6 +468,7 @@ flipper:
     - hughes_dustin@bah.com
     - jbalboni@gmail.com
     - jeff@adhocteam.us
+    - jesse.cohn@adhocteam.us
     - johnny@oddball.io
     - johnpaul.ashenfelter@oddball.io
     - kabrown@thoughtworks.com


### PR DESCRIPTION
## Description of change
This PR is to get my email added to the flipper list in settings.yml so that I can turn on flipper toggles in staging and test our flipper implimentation.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/11265

## Things to know about this PR
There is an addition to the settings.yml file

