### PR TITLE
Removing middle name from 526 alternateNames schema

### DIFF
--- a/modules/claims_api/config/schemas/526.json
+++ b/modules/claims_api/config/schemas/526.json
@@ -473,7 +473,6 @@
             "type": "object",
             "required": [
               "firstName",
-              "middleName",
               "lastName"
             ],
             "properties": {


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Removing unnecessary required field in schema, Mark Greenburge was able to show this validation on va.gov https://github.com/department-of-veterans-affairs/vets-website/blob/7e40a773626d8f0f58742fed6c90f9586707db6c/src/applications/disability-benefits/all-claims/pages/alternateNames.js I think this is a good enough argument then to change it on our end, I reached out to EVSS folks who were not responding but if it were required then every non filled in submission from VA.gov would automatically fail, good enough for me