### PR TITLE
Add additional info field to request mapping

### DIFF
--- a/modules/vaos/app/controllers/vaos/v0/appointment_requests_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v0/appointment_requests_controller.rb
@@ -16,7 +16,7 @@ module VAOS
         :provider_id, :provider_name, :second_request, :second_request_submitted, :requested_phone_call,
         :type_of_care_id, :additional_information, :address, :city, :state, :zip_code, :distance_willing_to_travel,
         :new_message, :office_hours, :preferred_city, :preferred_state, :preferred_zip_code, :provider_option,
-        :preferred_language, :reason_for_visit, :service,
+        :preferred_language, :reason_for_visit, :additional_information, :service,
         best_timeto_call: [],
         appointment_request_detail_code: [], preferred_providers: [
           :id, :first_name, :last_name, :practice_name, :provider_street, :provider_city, :provider_state,

--- a/modules/vaos/app/models/vaos/appointment_request_form.rb
+++ b/modules/vaos/app/models/vaos/appointment_request_form.rb
@@ -17,6 +17,7 @@ module VAOS
     attribute :appointment_type, String
     attribute :visit_type, String
     attribute :reason_for_visit, String
+    attribute :additional_information, String
     attribute :text_messaging_allowed, Boolean
     attribute :phone_number, String
     attribute :purpose_of_visit, String

--- a/modules/vaos/app/serializers/vaos/v0/appointment_requests_serializer.rb
+++ b/modules/vaos/app/serializers/vaos/v0/appointment_requests_serializer.rb
@@ -38,6 +38,7 @@ module VAOS
                  :appointment_type,
                  :visit_type,
                  :reason_for_visit,
+                 :additional_information,
                  :email,
                  :text_messaging_allowed,
                  :phone_number,

--- a/modules/vaos/spec/models/cc_appointment_request_form_spec.rb
+++ b/modules/vaos/spec/models/cc_appointment_request_form_spec.rb
@@ -12,6 +12,7 @@ describe VAOS::CCAppointmentRequestForm, type: :model do
   it 'responds to the correct attributes' do
     expect(subject.attributes.keys)
       .to contain_exactly(
+        :additional_information,
         :appointment_request_detail_code,
         :appointment_request_id,
         :appointment_type,

--- a/spec/support/schemas/vaos/appointment_request.json
+++ b/spec/support/schemas/vaos/appointment_request.json
@@ -20,6 +20,7 @@
         "appointment_type": { "type": "string" },
         "visit_type": { "type": "string" },
         "reason_for_visit": { "type": ["string", null] },
+        "additional_information": { "type": ["string", null] },
         "facility": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This adds the additional information field to the vets-api request form, so that we can see that field on the FE.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11002
