### PR TITLE
Claims API - Remove Unused Method from BaseDisabilityCompensationController

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
@@ -62,17 +62,5 @@ module ClaimsApi
         StatsD.increment STATSD_VALIDATION_FAIL_TYPE_KEY, tags: ["key: #{key}"]
       end
     end
-
-    def service(auth_headers)
-      if Settings.claims_api.disability_claims_mock_override && !auth_headers['Mock-Override']
-        ClaimsApi::DisabilityCompensation::MockOverrideService.new(
-          auth_headers
-        )
-      else
-        EVSS::DisabilityCompensationForm::ServiceAllClaim.new(
-          auth_headers
-        )
-      end
-    end
   end
 end


### PR DESCRIPTION
the `service` method in app/controllers/claims_api/base_disability_compensation_controller.rb is not being used, as far as I can tell (checked parents and children)