### PR TITLE
update and set default faraday adapter when in prod settings

### DIFF
--- a/modules/va_forms/app/workers/va_forms/form_reloader.rb
+++ b/modules/va_forms/app/workers/va_forms/form_reloader.rb
@@ -61,12 +61,12 @@ module VaForms
     end
 
     def build_and_save_form(form)
-      va_form = VaForms::Form.find_or_initialize_by form_name: form['fieldVaFormName']
+      va_form = VaForms::Form.find_or_initialize_by form_name: form['fieldVaFormNumber']
       current_sha256 = va_form.sha256
       url = form['fieldVaFormUrl']['uri']
       va_form_url = url.starts_with?('http') ? url.gsub('http:', 'https:') : expand_va_url(url)
       va_form.url = Addressable::URI.parse(va_form_url).normalize.to_s
-      va_form.title = form['fieldVaFormNumber']
+      va_form.title = form['fieldVaFormName']
       issued_string = form.dig('fieldVaFormIssueDate', 'value')
       va_form.first_issued_on = parse_date(issued_string) if issued_string.present?
       revision_string = form.dig('fieldVaFormRevisionDate', 'value')

--- a/modules/va_forms/app/workers/va_forms/form_reloader.rb
+++ b/modules/va_forms/app/workers/va_forms/form_reloader.rb
@@ -34,8 +34,12 @@ module VaForms
       @connection ||= Faraday.new(Settings.va_forms.drupal_url, faraday_options) do |faraday|
         faraday.request :url_encoded
         faraday.use basic_auth_class, Settings.va_forms.drupal_username, Settings.va_forms.drupal_password
-        faraday.adapter :net_http_socks unless Rails.env.production?
+        faraday.adapter faraday_adapter
       end
+    end
+
+    def faraday_adapter
+      Rails.env.production? ? Faraday.default_adapter : :net_http_socks
     end
 
     def faraday_options


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR fixes an issue in the VA Forms loader where the faraday adapter is not set when in prod.
