### PR TITLE
mc - add email to settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -484,6 +484,7 @@ flipper:
     - marisa.hoenig@thoughtworks.com
     - mark.greenburg@adhocteam.us
     - mdewey@governmentcio.com
+    - micah@adhocteam.us
     - n.ratana@gmail.com
     - narin@adhocteam.us
     - osanchez@governmentcio.com


### PR DESCRIPTION
## Description of change
This pull request adds the email micah@adhocteam.us to settings.yml, so I can manage feature toggles in flipper for my team. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/11265

## Things to know about this PR
n/a
