### PR TITLE
fix login status failure stats

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -103,7 +103,7 @@ module V1
       begin
         user_session_form = UserSessionForm.new(saml_response)
         raise_saml_error(user_session_form) unless user_session_form.valid?
-      rescue SAML::SAMLError => e
+      rescue SAML::UserAttributeError => e
         login_stats(:failure, saml_response, e)
         raise
       end

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -57,7 +57,6 @@ module V1
       callback_stats(:success, saml_response)
     rescue SAML::SAMLError => e
       log_message_to_sentry(e.message, e.level, extra_context: e.context)
-      log_missing_uuid_info(e) if e.code == SAML::UserAttributeError::IDME_UUID_MISSING[:code]
       redirect_to url_service(saml_response&.in_response_to).login_redirect_url(auth: 'fail', code: e.code)
       callback_stats(:failure, saml_response, e.tag || e.code)
     rescue => e
@@ -101,10 +100,12 @@ module V1
     end
 
     def user_login(saml_response)
-      user_session_form = UserSessionForm.new(saml_response)
-      unless user_session_form.valid?
-        login_stats(:failure, saml_response, user_session_form)
-        raise_saml_error(user_session_form)
+      begin
+        user_session_form = UserSessionForm.new(saml_response)
+        raise_saml_error(user_session_form) unless user_session_form.valid?
+      rescue SAML::SAMLError => e
+        login_stats(:failure, saml_response, e)
+        raise
       end
 
       @current_user, @session_object = user_session_form.persist
@@ -115,7 +116,7 @@ module V1
         render_login('verify', user_session_form.saml_uuid)
       else
         redirect_to helper.login_redirect_url
-        login_stats(:success, saml_response, user_session_form)
+        login_stats(:success, saml_response)
       end
     end
 
@@ -190,25 +191,13 @@ module V1
       end
     end
 
-    # Diagnostic logging to determine what percentage of these issues
-    # would be resolved by an account lookup, before we implement that
-    # TODO: Remove this method after we're confident in the UUID injection
-    # performed in UserSessionForm
-    def log_missing_uuid_info(exception)
-      return if exception&.identifier.blank?
-
-      accounts = Account.where(icn: exception.identifier)
-      Rails.logger.info('SSOe: Account UUID mapping NOT FOUND') if accounts.blank?
-      Rails.logger.info("SSOe: Account UUID mapping FOUND - #{accounts.size} entries") if accounts.present?
-    end
-
     def new_stats(type)
       tags = ["context:#{type}", VERSION_TAG]
       StatsD.increment(STATSD_SSO_NEW_KEY, tags: tags)
     end
 
-    def login_stats(status, _saml_response, user_session_form)
-      tracker = url_service(user_session_form&.saml_uuid).tracker
+    def login_stats(status, saml_response, error = nil)
+      tracker = url_service(saml_response&.in_response_to).tracker
       type = tracker.payload_attr(:type)
       tags = ["context:#{type}", VERSION_TAG]
       case status
@@ -219,7 +208,7 @@ module V1
         StatsD.increment(STATSD_LOGIN_STATUS_SUCCESS, tags: tags)
         StatsD.measure(STATSD_LOGIN_LATENCY, tracker.age, tags: tags)
       when :failure
-        StatsD.increment(STATSD_LOGIN_STATUS_FAILURE, tags: tags)
+        StatsD.increment(STATSD_LOGIN_STATUS_FAILURE, tags: tags << "error:#{error.code}")
       end
     end
 

--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -35,7 +35,7 @@ class UserSessionForm
     saml_user.validate!
     saml_user.to_hash
   rescue SAML::UserAttributeError => e
-    raise unless e.code == SAML::UserAttributeError::IDME_UUID_MISSING[:code]
+    raise unless e.code == SAML::UserAttributeError::ERRORS[:idme_uuid_missing][:code]
 
     idme_uuid = idme_uuid_from_account(e&.identifier)
     raise if idme_uuid.blank?

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'saml/errors'
 
 host = Settings.statsd.host
@@ -12,8 +13,8 @@ StatsD.backend = if host.present? && port.present?
 
 # Initialize session controller metric counters at 0
 LOGIN_ERRORS = SAML::Responses::Base::ERRORS.values +
-                UserSessionForm::ERRORS.values +
-                SAML::UserAttributeError::ERRORS.values
+               UserSessionForm::ERRORS.values +
+               SAML::UserAttributeError::ERRORS.values
 %w[v0 v1].each do |v|
   StatsD.increment(V1::SessionsController::STATSD_SSO_CALLBACK_TOTAL_KEY, 0,
                    tags: ["version:#{v}"])

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -10,6 +10,9 @@ StatsD.backend = if host.present? && port.present?
                  end
 
 # Initialize session controller metric counters at 0
+LOGIN_ERRORS = SAML::Responses::Base::ERRORS.values +
+                UserSessionForm::ERRORS.values +
+                SAML::UserAttributeError::ERRORS.values
 %w[v0 v1].each do |v|
   StatsD.increment(V1::SessionsController::STATSD_SSO_CALLBACK_TOTAL_KEY, 0,
                    tags: ["version:#{v}"])
@@ -20,8 +23,11 @@ StatsD.backend = if host.present? && port.present?
                      tags: ["version:#{v}", "context:#{t}"])
     StatsD.increment(V1::SessionsController::STATSD_LOGIN_STATUS_SUCCESS, 0,
                      tags: ["version:#{v}", "context:#{t}"])
-    StatsD.increment(V1::SessionsController::STATSD_LOGIN_STATUS_FAILURE, 0,
-                     tags: ["version:#{v}", "context:#{t}"])
+
+    LOGIN_ERRORS.each do |err|
+      StatsD.increment(V1::SessionsController::STATSD_LOGIN_STATUS_FAILURE, 0,
+                       tags: ["version:#{v}", "context:#{t}", "error:#{err[:code]}"])
+    end
   end
   %w[success failure].each do |s|
     (SAML::User::AUTHN_CONTEXTS.keys + [SAML::User::UNKNOWN_AUTHN_CONTEXT]).each do |ctx|
@@ -35,9 +41,9 @@ StatsD.backend = if host.present? && port.present?
     StatsD.increment(V1::SessionsController::STATSD_SSO_SAMLREQUEST_KEY, 0,
                      tags: ["version:#{v}", "context:#{ctx}"])
   end
-  SAML::Responses::Base::ERRORS.merge(UserSessionForm::ERRORS).each_value do |known_error|
+  LOGIN_ERRORS.each do |err|
     StatsD.increment(V1::SessionsController::STATSD_SSO_CALLBACK_FAILED_KEY, 0,
-                     tags: ["version:#{v}", "error:#{known_error[:tag]}"])
+                     tags: ["version:#{v}", "error:#{err[:tag]}"])
   end
 end
 

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'saml/errors'
 
 host = Settings.statsd.host
 port = Settings.statsd.port

--- a/lib/saml/errors.rb
+++ b/lib/saml/errors.rb
@@ -8,18 +8,18 @@ module SAML
   class UserAttributeError < SAMLError
     ERRORS = {
       multiple_mhv_ids: { code: '101',
-                           tag: :multiple_mhv_ids,
-                           message: 'User attributes contain multiple distinct MHV ID values' }.freeze,
+                          tag: :multiple_mhv_ids,
+                          message: 'User attributes contain multiple distinct MHV ID values' }.freeze,
       multiple_edipis: { code: '102',
-                          tag: :multiple_edipis,
-                          message: 'User attributes contain multiple distinct EDIPI values' }.freeze,
+                         tag: :multiple_edipis,
+                         message: 'User attributes contain multiple distinct EDIPI values' }.freeze,
       mhv_icn_mismatch: { code: '103',
-                           tag: :mhv_icn_mismatch,
-                           message: 'MHV credential ICN does not match MPI record' }.freeze,
-      idme_uuid_missing:  { code: '104',
-                            tag: :idme_uuid_missing,
-                            message: 'User attributes is missing an ID.me UUID' }.freeze,
-    }
+                          tag: :mhv_icn_mismatch,
+                          message: 'MHV credential ICN does not match MPI record' }.freeze,
+      idme_uuid_missing: { code: '104',
+                           tag: :idme_uuid_missing,
+                           message: 'User attributes is missing an ID.me UUID' }.freeze
+    }.freeze
 
     attr_reader :identifier
 

--- a/lib/saml/errors.rb
+++ b/lib/saml/errors.rb
@@ -6,18 +6,20 @@ module SAML
   end
 
   class UserAttributeError < SAMLError
-    MULTIPLE_MHV_IDS = { code: '101',
-                         tag: :multiple_mhv_ids,
-                         message: 'User attributes contain multiple distinct MHV ID values' }.freeze
-    MULTIPLE_EDIPIS = { code: '102',
-                        tag: :multiple_edipis,
-                        message: 'User attributes contain multiple distinct EDIPI values' }.freeze
-    MHV_ICN_MISMATCH = { code: '103',
-                         tag: :mhv_icn_mismatch,
-                         message: 'MHV credential ICN does not match MPI record' }.freeze
-    IDME_UUID_MISSING = { code: '104',
-                          tag: :idme_uuid_missing,
-                          message: 'User attributes is missing an ID.me UUID' }.freeze
+    ERRORS = {
+      multiple_mhv_ids: { code: '101',
+                           tag: :multiple_mhv_ids,
+                           message: 'User attributes contain multiple distinct MHV ID values' }.freeze,
+      multiple_edipis: { code: '102',
+                          tag: :multiple_edipis,
+                          message: 'User attributes contain multiple distinct EDIPI values' }.freeze,
+      mhv_icn_mismatch: { code: '103',
+                           tag: :mhv_icn_mismatch,
+                           message: 'MHV credential ICN does not match MPI record' }.freeze,
+      idme_uuid_missing:  { code: '104',
+                            tag: :idme_uuid_missing,
+                            message: 'User attributes is missing an ID.me UUID' }.freeze,
+    }
 
     attr_reader :identifier
 

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -178,11 +178,11 @@ module SAML
       # Raise any fatal exceptions due to validation issues
       def validate!
         unless idme_uuid
-          raise SAML::UserAttributeError, SAML::UserAttributeError::IDME_UUID_MISSING.merge({ identifier: mhv_icn })
+          raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:idme_uuid_missing].merge({ identifier: mhv_icn })
         end
-        raise SAML::UserAttributeError, SAML::UserAttributeError::MULTIPLE_MHV_IDS if mhv_id_mismatch?
-        raise SAML::UserAttributeError, SAML::UserAttributeError::MULTIPLE_EDIPIS if edipi_mismatch?
-        raise SAML::UserAttributeError, SAML::UserAttributeError::MHV_ICN_MISMATCH if mhv_icn_mismatch?
+        raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_mhv_ids] if mhv_id_mismatch?
+        raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_edipis] if edipi_mismatch?
+        raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:mhv_icn_mismatch] if mhv_icn_mismatch?
       end
 
       private

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -178,7 +178,8 @@ module SAML
       # Raise any fatal exceptions due to validation issues
       def validate!
         unless idme_uuid
-          raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:idme_uuid_missing].merge({ identifier: mhv_icn })
+          data = SAML::UserAttributeError::ERRORS[:idme_uuid_missing].merge({ identifier: mhv_icn })
+          raise SAML::UserAttributeError, data
         end
         raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_mhv_ids] if mhv_id_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_edipis] if edipi_mismatch?

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe V1::SessionsController, type: :controller do
       level_of_assurance: ['3'],
       attributes: build(:ssoe_idme_loa1, va_eauth_ial: 3),
       in_response_to: login_uuid,
-      issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
+      issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
     )
   end
 
@@ -329,7 +329,7 @@ RSpec.describe V1::SessionsController, type: :controller do
             level_of_assurance: ['3'],
             attributes: invalid_attributes,
             in_response_to: login_uuid,
-            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
+            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
           )
         end
 
@@ -347,7 +347,8 @@ RSpec.describe V1::SessionsController, type: :controller do
           )
           expect(controller).to receive(:log_message_to_sentry)
           expect { post(:saml_callback) }
-            .to trigger_statsd_increment(described_class::STATSD_LOGIN_STATUS_FAILURE, tags: ['context:mhv', 'version:v1', 'error:101'])
+            .to trigger_statsd_increment(described_class::STATSD_LOGIN_STATUS_FAILURE,
+                                         tags: ['context:mhv', 'version:v1', 'error:101'])
 
           expect(response).to have_http_status(:found)
           expect(cookies['vagov_session_dev']).to be_nil

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe V1::SessionsController, type: :controller do
       authn_context: authn_context,
       level_of_assurance: ['3'],
       attributes: build(:ssoe_idme_loa1, va_eauth_ial: 3),
-      in_response_to: login_uuid
+      in_response_to: login_uuid,
+      issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
     )
   end
 
@@ -327,13 +328,27 @@ RSpec.describe V1::SessionsController, type: :controller do
             authn_context: authn_context,
             level_of_assurance: ['3'],
             attributes: invalid_attributes,
-            in_response_to: login_uuid
+            in_response_to: login_uuid,
+            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
           )
         end
 
         it 'redirects to an auth failure page' do
           expect(controller).to receive(:log_message_to_sentry)
-          expect(post(:saml_callback)).to redirect_to('http://127.0.0.1:3001/auth/login/callback?auth=fail&code=004')
+          expect(post(:saml_callback)).to redirect_to('http://127.0.0.1:3001/auth/login/callback?auth=fail&code=101')
+          expect(response).to have_http_status(:found)
+          expect(cookies['vagov_session_dev']).to be_nil
+        end
+
+        it 'logs a status failure stat' do
+          SAMLRequestTracker.create(
+            uuid: login_uuid,
+            payload: { type: 'mhv' }
+          )
+          expect(controller).to receive(:log_message_to_sentry)
+          expect { post(:saml_callback) }
+            .to trigger_statsd_increment(described_class::STATSD_LOGIN_STATUS_FAILURE, tags: ['context:mhv', 'version:v1', 'error:101'])
+
           expect(response).to have_http_status(:found)
           expect(cookies['vagov_session_dev']).to be_nil
         end


### PR DESCRIPTION
After reviewing the `user_login` function in the `V1::SessionController` it was noted that the `UserAttributeErrors` are raised when we initialize the `UserSessionForm`, not when we invoke the `valid?` method.  Thus any of these validation errors immediately bubble up to the `saml_callback` method and don't log `login_stats`.  Adding a begin/rescue block around this code will allow us to issue the login stats before moving back to the `saml_callback` method.

Additionally changes were made the tags associated to `api.auth.login.failure` so we can also track the error issued when a failure happens.

fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/11595
