### PR TITLE
Add 686c-674 failure mailer

### DIFF
--- a/app/mailers/dependents_application_failure_mailer.rb
+++ b/app/mailers/dependents_application_failure_mailer.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class DependentsApplicationFailureMailer < TransactionalEmailMailer
-  TEMPLATE = 'hca_submission_failure'
-
   def build(user_hash)
     @user_hash = user_hash
     template = File.read('app/mailers/views/dependents_application_failure.erb')

--- a/app/mailers/dependents_application_failure_mailer.rb
+++ b/app/mailers/dependents_application_failure_mailer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class DependentsApplicationFailureMailer < TransactionalEmailMailer
+  TEMPLATE = 'hca_submission_failure'
+
+  def build(user_hash)
+    @user_hash = user_hash
+    template = File.read('app/mailers/views/dependents_application_failure.erb')
+
+    mail(
+      to: @user_hash['email'],
+      subject: "We can't process your dependents application",
+      body: ERB.new(template).result(binding)
+    )
+  end
+end

--- a/app/mailers/dependents_application_failure_mailer.rb
+++ b/app/mailers/dependents_application_failure_mailer.rb
@@ -2,11 +2,10 @@
 
 class DependentsApplicationFailureMailer < ApplicationMailer
   def build(user_hash)
-    @user_hash = user_hash
     template = File.read('app/mailers/views/dependents_application_failure.erb')
 
     mail(
-      to: @user_hash['email'],
+      to: user_hash['email'],
       subject: "We can't process your dependents application",
       body: ERB.new(template).result(binding)
     )

--- a/app/mailers/dependents_application_failure_mailer.rb
+++ b/app/mailers/dependents_application_failure_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DependentsApplicationFailureMailer < TransactionalEmailMailer
+class DependentsApplicationFailureMailer < ApplicationMailer
   def build(user_hash)
     @user_hash = user_hash
     template = File.read('app/mailers/views/dependents_application_failure.erb')

--- a/app/mailers/views/dependents_application_failure.erb
+++ b/app/mailers/views/dependents_application_failure.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
+  </head>
+  <body>
+    <p>Hello <%= @user_hash['first_name'] %> <%= @user_hash['last_name'] %></p>
+    <p>You recently submitted an application to add or remove dependents from your VA benefits (VA Form 28-686c/674) on
+      VA.gov. We’re sorry. Your application didn’t go through because of a technical problem on our end. You'll need to go
+      back and apply again: https://va.gov/view-change-dependents/add-remove-form-686c/.</p>
+    <p>Because of the issue, we won't be able to retrieve your application. If you have general questions about adding or
+      removing dependents, you can call our toll-free hotline at 800-827-1000. We’re here Monday through Friday, 8:00 am to
+      9:00 pm ET.</p>
+    <p><i>Note: This is an automated message sent from an unmonitored email account.</i></p>
+  </body>
+</html>

--- a/app/mailers/views/dependents_application_failure.erb
+++ b/app/mailers/views/dependents_application_failure.erb
@@ -4,7 +4,7 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
   </head>
   <body>
-    <p>Hello <%= @user_hash['first_name'] %> <%= @user_hash['last_name'] %></p>
+    <p>Hello <%= user_hash['first_name'] %> <%= user_hash['last_name'] %></p>
     <p>You recently submitted an application to add or remove dependents from your VA benefits (VA Form 28-686c/674) on
       VA.gov. We’re sorry. Your application didn’t go through because of a technical problem on our end. You'll need to go
       back and apply again: https://va.gov/view-change-dependents/add-remove-form-686c/.</p>

--- a/app/services/bgs/people_service.rb
+++ b/app/services/bgs/people_service.rb
@@ -29,7 +29,7 @@ module BGS
         {
           icn: @current_user.icn
         },
-        { team: 'eBenefits' }
+        { team: 'vfs-ebenefits' }
       )
 
       PersonalInformationLog.create(

--- a/spec/mailers/dependents_application_failure_mailer_spec.rb
+++ b/spec/mailers/dependents_application_failure_mailer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DependentsApplicationFailureMailer, type: [:mailer] do
+  let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
+  let(:user_hash) do
+    {
+      'participant_id' => user_object.participant_id,
+      'ssn' => user_object.ssn,
+      'first_name' => user_object.first_name,
+      'last_name' => user_object.last_name,
+      'email' => user_object.email,
+      'external_key' => user_object.common_name || user_object.email,
+      'icn' => user_object.icn
+    }
+  end
+
+  describe '#build' do
+    it 'includes all info' do
+      mailer = described_class.build(user_hash).deliver_now
+
+      expect(mailer.subject).to eq("We can't process your dependents application")
+      expect(mailer.to).to eq([user_object.email])
+      expect(mailer.body.raw_source).to include(
+        "Hello #{user_object.first_name} #{user_object.last_name}",
+        'You recently submitted an application to add or remove dependents from your VA benefits (VA Form 28-686c/674)'
+      )
+    end
+  end
+end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR adds a mailer and testing to verify all dynamic data is sent through.

The email will get fired if a user's 686c-674 submission fails. [Code for the 686c-674 form is moving through PR](https://github.com/department-of-veterans-affairs/vets-api/pull/4546) and being developed currently.

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11339

## Things to know about this PR

* Are there additions to a `settings.yml` file? Do they vary by environment?
    * Mailer should already be configured for each env
* Is there a feature flag? What is it?
    * Not on this code particularly but the FE will use Flipper
* Is there some Sentry logging that was added? What alerts are relevant?
    * There are sentry alerts in other code associated with this process that will fire, they have tags for our team
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
    * N/A
* Are there Swagger docs that were updated?
    * N/A
* Is there any PII concerns or questions?
    * No concerns

<!-- Please describe testing done to verify the changes or any testing planned. -->
