### PR TITLE
adding transactionid to sign_in property in user serializer

### DIFF
--- a/app/swagger/swagger/schemas/user_internal_services.rb
+++ b/app/swagger/swagger/schemas/user_internal_services.rb
@@ -66,6 +66,13 @@ module Swagger
                          enum: %w[Basic Premium 1 2 3],
                          example: 'Basic',
                          description: 'myhealthevet account_types: Basic, Premium. dslogon account account_types: 1-3'
+                property :ssoe,
+                         type: :boolean,
+                         description: 'true if the user was authenticated using SSOe'
+                property :transactionid,
+                         type: :string,
+                         example: 'E35imPCwyUBl/Eo4AhlCJfioOcQEWDdyjFXUJRBky1k=',
+                         description: 'a unique id representing the authentication transaction with SSOe'
               end
               property :verified, type: :boolean, example: true
               property :loa, type: :object do

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -162,13 +162,17 @@ module SAML
         { current: loa_current, highest: [loa_current, loa_highest].max }
       end
 
+      def transactionid
+        safe_attr('va_eauth_transactionid')
+      end
+
       def sign_in
         sign_in = if @authn_context == INBOUND_AUTHN_CONTEXT
                     { service_name: csid == 'mhv' ? 'myhealthevet' : csid }
                   else
                     SAML::User::AUTHN_CONTEXTS.fetch(@authn_context).fetch(:sign_in)
                   end
-        sign_in.merge(account_type: account_type, ssoe: true)
+        sign_in.merge(account_type: account_type, ssoe: true, transactionid: transactionid)
       end
 
       def to_hash

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe SAML::User do
           idme_uuid: '54e78de6140d473f87960f211be49c08',
           multifactor: false,
           loa: { current: 1, highest: 1 },
-          sign_in: { 
-            service_name: 'idme', 
+          sign_in: {
+            service_name: 'idme',
             account_type: 'N/A',
             ssoe: true,
             transactionid: 'abcd1234xyz'
@@ -146,7 +146,7 @@ RSpec.describe SAML::User do
           idme_uuid: '54e78de6140d473f87960f211be49c08',
           multifactor: true,
           loa: { current: 1, highest: 3 },
-          sign_in: { 
+          sign_in: {
             service_name: 'idme',
             account_type: 'N/A',
             ssoe: true,
@@ -660,7 +660,7 @@ RSpec.describe SAML::User do
           email: 'kam+tristanmhv@adhocteam.us',
           idme_uuid: '0e1bb5723d7c4f0686f46ca4505642ad',
           loa: { current: 1, highest: 3 },
-          sign_in: { 
+          sign_in: {
             service_name: 'dslogon',
             account_type: '1',
             ssoe: true
@@ -696,7 +696,7 @@ RSpec.describe SAML::User do
           email: 'iam.tester@example.com',
           idme_uuid: '363761e8857642f7b77ef7d99200e711',
           loa: { current: 3, highest: 3 },
-          sign_in: { 
+          sign_in: {
             service_name: 'dslogon',
             account_type: '2',
             ssoe: true,
@@ -822,7 +822,7 @@ RSpec.describe SAML::User do
           email: nil,
           idme_uuid: nil,
           loa: { current: 3, highest: 3 },
-          sign_in: { 
+          sign_in: {
             service_name: 'dslogon',
             account_type: 'N/A',
             ssoe: true,

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -107,7 +107,12 @@ RSpec.describe SAML::User do
           idme_uuid: '54e78de6140d473f87960f211be49c08',
           multifactor: false,
           loa: { current: 1, highest: 1 },
-          sign_in: { service_name: 'idme', account_type: 'N/A', ssoe: true },
+          sign_in: { 
+            service_name: 'idme', 
+            account_type: 'N/A',
+            ssoe: true,
+            transactionid: 'abcd1234xyz'
+          },
           sec_id: nil,
           authenticated_by_ssoe: true,
           common_name: nil
@@ -141,7 +146,12 @@ RSpec.describe SAML::User do
           idme_uuid: '54e78de6140d473f87960f211be49c08',
           multifactor: true,
           loa: { current: 1, highest: 3 },
-          sign_in: { service_name: 'idme', account_type: 'N/A', ssoe: true },
+          sign_in: { 
+            service_name: 'idme',
+            account_type: 'N/A',
+            ssoe: true,
+            transactionid: 'abcd1234xyz'
+          },
           sec_id: nil,
           authenticated_by_ssoe: true,
           common_name: nil
@@ -176,7 +186,7 @@ RSpec.describe SAML::User do
           idme_uuid: '54e78de6140d473f87960f211be49c08',
           multifactor: true,
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'idme', account_type: 'N/A', ssoe: true },
+          sign_in: { service_name: 'idme', account_type: 'N/A', ssoe: true, transactionid: 'abcd1234xyz' },
           sec_id: '1008830476',
           authenticated_by_ssoe: true,
           common_name: 'vets.gov.user+262@example.com'
@@ -212,7 +222,7 @@ RSpec.describe SAML::User do
           email: 'alexmac_0@example.com',
           idme_uuid: '881571066e5741439652bc80759dd88c',
           loa: { current: 1, highest: 3 },
-          sign_in: { service_name: 'myhealthevet', account_type: 'Advanced', ssoe: true },
+          sign_in: { service_name: 'myhealthevet', account_type: 'Advanced', ssoe: true, transactionid: 'abcd1234xyz' },
           sec_id: nil,
           multifactor: multifactor,
           authenticated_by_ssoe: true,
@@ -251,7 +261,7 @@ RSpec.describe SAML::User do
           email: 'alexmac_0@example.com',
           idme_uuid: '881571066e5741439652bc80759dd88c',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'myhealthevet', account_type: 'Advanced', ssoe: true },
+          sign_in: { service_name: 'myhealthevet', account_type: 'Advanced', ssoe: true, transactionid: 'abcd1234xyz' },
           sec_id: '1013183292',
           multifactor: multifactor,
           authenticated_by_ssoe: true,
@@ -285,7 +295,12 @@ RSpec.describe SAML::User do
           email: 'pv+mhvtestb@example.com',
           idme_uuid: '72782a87a807407f83e8a052d804d7f7',
           loa: { current: 1, highest: 1 },
-          sign_in: { service_name: 'myhealthevet', account_type: 'Basic', ssoe: true },
+          sign_in: {
+            service_name: 'myhealthevet',
+            account_type: 'Basic',
+            ssoe: true,
+            transactionid: 'abcd1234xyz'
+          },
           sec_id: nil,
           multifactor: true,
           authenticated_by_ssoe: true,
@@ -322,7 +337,12 @@ RSpec.describe SAML::User do
           email: 'k+tristanmhv@example.com',
           idme_uuid: '0e1bb5723d7c4f0686f46ca4505642ad',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'myhealthevet', account_type: 'Premium', ssoe: true },
+          sign_in: {
+            service_name: 'myhealthevet',
+            account_type: 'Premium',
+            ssoe: true,
+            transactionid: 'VDeAfteF14dJV9gke1tQ4rBX2UntryiGMkD5anKJiHQ='
+          },
           sec_id: '1012853550',
           multifactor: multifactor,
           authenticated_by_ssoe: true,
@@ -360,7 +380,12 @@ RSpec.describe SAML::User do
           email: 'k+tristanmhv@example.com',
           idme_uuid: nil,
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'myhealthevet', account_type: 'Premium', ssoe: true },
+          sign_in: {
+            service_name: 'myhealthevet',
+            account_type: 'Premium',
+            ssoe: true,
+            transactionid: 'VDeAfteF14dJV9gke1tQ4rBX2UntryiGMkD5anKJiHQ='
+          },
           sec_id: '1012853550',
           multifactor: multifactor,
           authenticated_by_ssoe: true,
@@ -635,7 +660,11 @@ RSpec.describe SAML::User do
           email: 'kam+tristanmhv@adhocteam.us',
           idme_uuid: '0e1bb5723d7c4f0686f46ca4505642ad',
           loa: { current: 1, highest: 3 },
-          sign_in: { service_name: 'dslogon', account_type: '1', ssoe: true },
+          sign_in: { 
+            service_name: 'dslogon',
+            account_type: '1',
+            ssoe: true
+          },
           sec_id: nil,
           multifactor: multifactor,
           authenticated_by_ssoe: true
@@ -667,7 +696,12 @@ RSpec.describe SAML::User do
           email: 'iam.tester@example.com',
           idme_uuid: '363761e8857642f7b77ef7d99200e711',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'dslogon', account_type: '2', ssoe: true },
+          sign_in: { 
+            service_name: 'dslogon',
+            account_type: '2',
+            ssoe: true,
+            transactionid: '3oiTInhBKGiA/FbtYGVloGdOqUtvKCw4rcuchfwPNAo='
+          },
           sec_id: '1013173963',
           multifactor: false,
           authenticated_by_ssoe: true,
@@ -705,7 +739,12 @@ RSpec.describe SAML::User do
           email: 'Test0206@gmail.com',
           idme_uuid: '1655c16aa0784dbe973814c95bd69177',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'dslogon', account_type: '2', ssoe: true },
+          sign_in: {
+            service_name: 'dslogon',
+            account_type: '2',
+            ssoe: true,
+            transactionid: 'abcd1234xyz'
+          },
           sec_id: '0000028007',
           multifactor: multifactor,
           authenticated_by_ssoe: true,
@@ -742,7 +781,12 @@ RSpec.describe SAML::User do
           email: 'Test0206@gmail.com',
           idme_uuid: '1655c16aa0784dbe973814c95bd69177',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'dslogon', account_type: '2', ssoe: true },
+          sign_in: {
+            service_name: 'dslogon',
+            account_type: '2',
+            ssoe: true,
+            transactionid: 'abcd1234xyz'
+          },
           sec_id: '0000028007',
           multifactor: multifactor,
           authenticated_by_ssoe: true,
@@ -778,7 +822,12 @@ RSpec.describe SAML::User do
           email: nil,
           idme_uuid: nil,
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'dslogon', account_type: 'N/A', ssoe: true },
+          sign_in: { 
+            service_name: 'dslogon',
+            account_type: 'N/A',
+            ssoe: true,
+            transactionid: 'yGXMk81W0r3aArfVXHdZuCl5utlNQ1adITH8QHsLlB0'
+          },
           sec_id: '1012779219',
           multifactor: multifactor,
           authenticated_by_ssoe: true,
@@ -829,7 +878,12 @@ RSpec.describe SAML::User do
           email: nil,
           idme_uuid: '53f065475a794e14a32d707bfd9b215f',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'myhealthevet', account_type: 'N/A', ssoe: true },
+          sign_in: {
+            service_name: 'myhealthevet',
+            account_type: 'N/A',
+            ssoe: true,
+            transactionid: '6e/7qHvlmQR0NPaplboby1mJJlKDKz2UEXk9Ul9e5tU='
+          },
           sec_id: '1013062086',
           multifactor: multifactor,
           authenticated_by_ssoe: true,
@@ -865,7 +919,12 @@ RSpec.describe SAML::User do
           email: 'vets.gov.user+262@gmail.com',
           idme_uuid: '54e78de6140d473f87960f211be49c08',
           loa: { current: 3, highest: 3 },
-          sign_in: { service_name: 'idme', account_type: 'N/A', ssoe: true },
+          sign_in: {
+            service_name: 'idme',
+            account_type: 'N/A',
+            ssoe: true,
+            transactionid: 'HZmR3a1TZAnLNzLfliYLFXO6Xu1cUEA1p18v2B3bekI='
+          },
           sec_id: '1012827134',
           multifactor: multifactor,
           authenticated_by_ssoe: true,


### PR DESCRIPTION
this will only be available for users that authenticated via SSOe and is
needed to address a vulnerability with two users using the same
computer.

refs https://github.com/department-of-veterans-affairs/va.gov-team/issues/10303