### PR TITLE
using a browser safe ready function to post the saml request

### DIFF
--- a/lib/saml/templates/sso_post_form.html.erb
+++ b/lib/saml/templates/sso_post_form.html.erb
@@ -25,9 +25,9 @@
   <% end %>
 
   <script>
-    document.addEventListener("DOMContentLoaded", function(event) {
+    (function() {
       document.getElementById("saml-form").submit();
-    });
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
some versions of IE 11 don't work with addEventListner.  Using a
function closure at the end of the page should work for all browsers

fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/11596
