### PR TITLE
Add backend review group to vaos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,5 @@
 *       @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 
 # Experiment for isolating VFS teams
-modules/vaos/                        @department-of-veterans-affairs/vfs-vaos
-spec/support/*/vaos/                 @department-of-veterans-affairs/vfs-vaos
+modules/vaos/                        @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/backend-review-group
+spec/support/*/vaos/                 @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/backend-review-group


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Add @department-of-veterans-affairs/backend-review-group back to VAOS modules as a (co) CODEOWNER to facilitate bug fixes and systemic changes that aren't directly necessary for VAOS team to review. This restores our original capabilities while retaining the new capability of VAOS to review their own code without VSP review.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11618

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
