### PR TITLE
address request spec supports camel-inflected requests

### DIFF
--- a/spec/request/address_request_spec.rb
+++ b/spec/request/address_request_spec.rb
@@ -181,6 +181,13 @@ RSpec.describe 'address', type: :request do
             expect(response).to match_response_schema('states')
           end
         end
+        it 'matches the states schema with camel-inflection' do
+          VCR.use_cassette('evss/pciu_address/states') do
+            get '/v0/address/states', headers: camel_header
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('states')
+          end
+        end
       end
     end
 
@@ -235,6 +242,13 @@ RSpec.describe 'address', type: :request do
             get '/v0/address/states'
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('states')
+          end
+        end
+        it 'matches the states schema with camel-inflection' do
+          VCR.use_cassette('evss/reference_data/states') do
+            get '/v0/address/states', headers: camel_header
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('states')
           end
         end
       end

--- a/spec/request/address_request_spec.rb
+++ b/spec/request/address_request_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe 'address', type: :request do
   after(:all) { Settings.evss.reference_data_service.enabled = @cached_enabled_val }
 
   let(:headers) { { 'Content-Type' => 'application/json', 'Accept' => 'application/json' } }
+  let(:camel_header) { { 'X-Key-Inflection' => 'camel' } }
+  let(:headers_with_camel) { headers.merge(camel_header) }
   let(:current_user) { create(:evss_user) }
 
   before do
@@ -32,7 +34,7 @@ RSpec.describe 'address', type: :request do
         end
         it 'matches the address schema when camel-inflected' do
           VCR.use_cassette('evss/pciu_address/address') do
-            get '/v0/address', headers: { 'X-Key-Inflection' => 'camel' }
+            get '/v0/address', headers: camel_header
             expect(response).to have_http_status(:ok)
             expect(response).to match_camelized_response_schema('address_response')
           end
@@ -40,23 +42,37 @@ RSpec.describe 'address', type: :request do
       end
 
       context 'with a domestic address' do
+        # domestic and international addresses are manually edited as EVSS CI only includes one military response
         it 'matches the address schema' do
-          # domestic and international addresses are manually edited as EVSS CI only includes one military response
           VCR.use_cassette('evss/pciu_address/address_domestic') do
             get '/v0/address'
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('address_response')
           end
         end
+        it 'matches the address schema when camel-inflected' do
+          VCR.use_cassette('evss/pciu_address/address_domestic') do
+            get '/v0/address', headers: camel_header
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('address_response')
+          end
+        end
       end
 
       context 'with an international address' do
+        # domestic and international addresses are manually edited as EVSS CI only includes one military response
         it 'matches the address schema' do
-          # domestic and international addresses are manually edited as EVSS CI only includes one military response
           VCR.use_cassette('evss/pciu_address/address_international') do
             get '/v0/address'
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('address_response')
+          end
+        end
+        it 'matches the address schema when camel-inflected' do
+          VCR.use_cassette('evss/pciu_address/address_international') do
+            get '/v0/address', headers: camel_header
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('address_response')
           end
         end
       end
@@ -81,6 +97,13 @@ RSpec.describe 'address', type: :request do
             put '/v0/address', params: domestic_address.to_json, headers: headers
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('address_response')
+          end
+        end
+        it 'matches the address schema when camel-infelcted' do
+          VCR.use_cassette('evss/pciu_address/address_update') do
+            put '/v0/address', params: domestic_address.to_json, headers: headers_with_camel
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('address_response')
           end
         end
       end

--- a/spec/request/address_request_spec.rb
+++ b/spec/request/address_request_spec.rb
@@ -193,6 +193,13 @@ RSpec.describe 'address', type: :request do
             expect(response).to match_response_schema('countries')
           end
         end
+        it 'matches the countries schema when camel-inflected' do
+          VCR.use_cassette('evss/pciu_address/countries') do
+            get '/v0/address/countries', headers: camel_header
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('countries')
+          end
+        end
       end
     end
   end
@@ -209,6 +216,13 @@ RSpec.describe 'address', type: :request do
             get '/v0/address/countries'
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('countries')
+          end
+        end
+        it 'matches the countries schema when camel-inflected' do
+          VCR.use_cassette('evss/reference_data/countries') do
+            get '/v0/address/countries', headers: camel_header
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('countries')
           end
         end
       end

--- a/spec/request/address_request_spec.rb
+++ b/spec/request/address_request_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe 'address', type: :request do
             expect(response).to match_response_schema('address_response')
           end
         end
+        it 'matches the address schema when camel-inflected' do
+          VCR.use_cassette('evss/pciu_address/address') do
+            get '/v0/address', headers: { 'X-Key-Inflection' => 'camel' }
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('address_response')
+          end
+        end
       end
 
       context 'with a domestic address' do

--- a/spec/request/address_request_spec.rb
+++ b/spec/request/address_request_spec.rb
@@ -85,6 +85,13 @@ RSpec.describe 'address', type: :request do
             expect(response).to match_response_schema('errors')
           end
         end
+        it 'matches the errors schema with camel-inflection' do
+          VCR.use_cassette('evss/pciu_address/address_500') do
+            get '/v0/address', headers: camel_header
+            expect(response).to have_http_status(:bad_gateway)
+            expect(response).to match_camelized_response_schema('errors')
+          end
+        end
       end
     end
 
@@ -118,6 +125,13 @@ RSpec.describe 'address', type: :request do
             expect(response).to match_response_schema('errors')
           end
         end
+        it 'matches the errors schema when camel-inflected' do
+          VCR.use_cassette('evss/pciu_address/address_500') do
+            put '/v0/address', params: domestic_address.to_json, headers: headers_with_camel
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to match_camelized_response_schema('errors')
+          end
+        end
       end
 
       context 'with an address field that is too long' do
@@ -131,6 +145,13 @@ RSpec.describe 'address', type: :request do
             expect(response).to match_response_schema('errors')
           end
         end
+        it 'matches the errors schema when camel-inflected' do
+          VCR.use_cassette('evss/pciu_address/address_update_invalid_format') do
+            put '/v0/address', params: domestic_address.to_json, headers: headers_with_camel
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to match_camelized_response_schema('errors')
+          end
+        end
       end
 
       context 'with a 500 response' do
@@ -139,6 +160,13 @@ RSpec.describe 'address', type: :request do
             get '/v0/address'
             expect(response).to have_http_status(:bad_gateway)
             expect(response).to match_response_schema('errors')
+          end
+        end
+        it 'matches the errors schema when camel-inflected' do
+          VCR.use_cassette('evss/pciu_address/address_500') do
+            get '/v0/address', headers: camel_header
+            expect(response).to have_http_status(:bad_gateway)
+            expect(response).to match_camelized_response_schema('errors')
           end
         end
       end

--- a/spec/support/schemas_camelized/address_domestic.json
+++ b/spec/support/schemas_camelized/address_domestic.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "required": [
+    "addressOne",
+    "type",
+    "city",
+    "stateCode",
+    "zipCode"
+  ],
+  "properties": {
+    "addressEffectiveDate": {
+      "type": "string"
+    },
+    "addressOne": {
+      "type": "string"
+    },
+    "addressThree": {
+      "type": "string"
+    },
+    "addressTwo": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "city": {
+      "type": "string"
+    },
+    "countryName": {
+      "type": "string"
+    },
+    "stateCode": {
+      "type": "string"
+    },
+    "zipCode": {
+      "type": "string"
+    },
+    "zipSuffix": {
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/address_international.json
+++ b/spec/support/schemas_camelized/address_international.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "required": [
+    "addressOne",
+    "type",
+    "city",
+    "countryName"
+  ],
+  "properties": {
+    "addressEffectiveDate": {
+      "type": "string"
+    },
+    "addressOne": {
+      "type": "string"
+    },
+    "addressThree": {
+      "type": "string"
+    },
+    "addressTwo": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "city": {
+      "type": "string"
+    },
+    "countryName": {
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/address_military.json
+++ b/spec/support/schemas_camelized/address_military.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "required": [
+    "addressOne",
+    "type",
+    "zipCode",
+    "militaryPostOfficeTypeCode",
+    "militaryStateCode"
+  ],
+  "properties": {
+    "addressEffectiveDate": {
+      "type": "string"
+    },
+    "addressOne": {
+      "type": "string"
+    },
+    "addressThree": {
+      "type": "string"
+    },
+    "addressTwo": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "militaryPostOfficeTypeCode": {
+      "type": "string"
+    },
+    "militaryStateCode": {
+      "type": "string"
+    },
+    "zipCode": {
+      "type": "string"
+    },
+    "zipSuffix": {
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/address_response.json
+++ b/spec/support/schemas_camelized/address_response.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "address": {
+              "oneOf": [
+                {
+                  "$ref": "address_domestic.json"
+                },
+                {
+                  "$ref": "address_international.json"
+                },
+                {
+                  "$ref": "address_military.json"
+                }
+              ]
+            },
+            "controlInformation": {
+              "$ref": "control_information.json"
+            }
+          },
+          "required": [
+            "address",
+            "controlInformation"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "attributes",
+        "id",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "data"
+  ],
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/control_information.json
+++ b/spec/support/schemas_camelized/control_information.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "canUpdate": {
+      "type": "boolean"
+    },
+    "corpAvailIndicator": {
+      "type": "boolean"
+    },
+    "corpRecFoundIndicator": {
+      "type": "boolean"
+    },
+    "hasNoBdnPaymentsIndicator": {
+      "type": "boolean"
+    },
+    "isCompetentIndicator": {
+      "type": "boolean"
+    },
+    "indentityIndicator": {
+      "type": "boolean"
+    },
+    "indexIndicator": {
+      "type": "boolean"
+    },
+    "noFiduciaryAssignedIndicator": {
+      "type": "boolean"
+    },
+    "notDeceasedIndicator": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "canUpdate"
+  ],
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/countries.json
+++ b/spec/support/schemas_camelized/countries.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "countries": {
+              "description": "Array of countries",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/errors.json
+++ b/spec/support/schemas_camelized/errors.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "errors": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "source": {
+            "type": [
+              "string",
+              "object"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "source",
+          "code",
+          "detail",
+          "title"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "errors"
+  ],
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/states.json
+++ b/spec/support/schemas_camelized/states.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "states": {
+              "description": "Array of states",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## Description of change
Introduces camel-inflected schemas for the specs used by address_request_spec.  This ensures we support `X-Key-Inflection` requests.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11585
