### PR TITLE
11585 add camel inflected schemas for intent to file

### DIFF
--- a/spec/request/intent_to_files_request_spec.rb
+++ b/spec/request/intent_to_files_request_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe 'Intent to file', type: :request do
           expect(response).to match_response_schema('evss_errors', strict: false)
         end
       end
+      it 'returns a not authorized response with camel-inflection' do
+        VCR.use_cassette('evss/intent_to_file/intent_to_file_403') do
+          get '/v0/intent_to_file', headers: camel_inflection_header
+          expect(response).to have_http_status(:forbidden)
+          expect(response).to match_camelized_response_schema('evss_errors', strict: false)
+        end
+      end
     end
 
     context 'with a 400 invalid intent type' do
@@ -45,6 +52,13 @@ RSpec.describe 'Intent to file', type: :request do
           get '/v0/intent_to_file'
           expect(response).to have_http_status(:bad_request)
           expect(response).to match_response_schema('evss_errors')
+        end
+      end
+      it 'returns a bad gateway response when camel-inflected' do
+        VCR.use_cassette('evss/intent_to_file/intent_to_file_intent_type_invalid') do
+          get '/v0/intent_to_file', headers: camel_inflection_header
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_camelized_response_schema('evss_errors')
         end
       end
     end
@@ -76,6 +90,13 @@ RSpec.describe 'Intent to file', type: :request do
           expect(response).to match_response_schema('evss_errors', strict: false)
         end
       end
+      it 'returns a not authorized response when camel-inflected' do
+        VCR.use_cassette('evss/intent_to_file/active_compensation_403') do
+          get '/v0/intent_to_file/compensation/active', headers: camel_inflection_header
+          expect(response).to have_http_status(:forbidden)
+          expect(response).to match_camelized_response_schema('evss_errors', strict: false)
+        end
+      end
     end
 
     context 'with a 502 partner service invalid' do
@@ -84,6 +105,13 @@ RSpec.describe 'Intent to file', type: :request do
           get '/v0/intent_to_file/compensation/active'
           expect(response).to have_http_status(:bad_gateway)
           expect(response).to match_response_schema('evss_errors')
+        end
+      end
+      it 'returns a bad gateway response when camel-inlfected' do
+        VCR.use_cassette('evss/intent_to_file/active_compensation_partner_service_invalid') do
+          get '/v0/intent_to_file/compensation/active', headers: camel_inflection_header
+          expect(response).to have_http_status(:bad_gateway)
+          expect(response).to match_camelized_response_schema('evss_errors')
         end
       end
     end
@@ -115,6 +143,13 @@ RSpec.describe 'Intent to file', type: :request do
           expect(response).to match_response_schema('evss_errors', strict: false)
         end
       end
+      it 'returns a not authorized response when camel-inflected' do
+        VCR.use_cassette('evss/intent_to_file/create_compensation_403') do
+          post '/v0/intent_to_file/compensation', headers: camel_inflection_header
+          expect(response).to have_http_status(:forbidden)
+          expect(response).to match_camelized_response_schema('evss_errors', strict: false)
+        end
+      end
     end
 
     context 'with a 502 partner service error' do
@@ -125,6 +160,13 @@ RSpec.describe 'Intent to file', type: :request do
           expect(response).to match_response_schema('evss_errors')
         end
       end
+      it 'returns a bad gateway response with camel-inflection' do
+        VCR.use_cassette('evss/intent_to_file/create_compensation_partner_service_error') do
+          post '/v0/intent_to_file/compensation', headers: camel_inflection_header
+          expect(response).to have_http_status(:bad_gateway)
+          expect(response).to match_camelized_response_schema('evss_errors')
+        end
+      end
     end
 
     context 'with a 400 intent type invalid' do
@@ -133,6 +175,13 @@ RSpec.describe 'Intent to file', type: :request do
           post '/v0/intent_to_file/compensation'
           expect(response).to have_http_status(:bad_request)
           expect(response).to match_response_schema('evss_errors')
+        end
+      end
+      it 'returns a bad gateway response with camel-inflection' do
+        VCR.use_cassette('evss/intent_to_file/create_compensation_type_error') do
+          post '/v0/intent_to_file/compensation', headers: camel_inflection_header
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_camelized_response_schema('evss_errors')
         end
       end
     end

--- a/spec/request/intent_to_files_request_spec.rb
+++ b/spec/request/intent_to_files_request_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Intent to file', type: :request do
     sign_in
   end
 
+  let(:camel_inflection_header) { { 'X-Key-Inflection' => 'camel' } }
+
   describe 'GET /v0/intent_to_file' do
     context 'with a valid evss response' do
       it 'matches the intent to files schema' do
@@ -16,6 +18,13 @@ RSpec.describe 'Intent to file', type: :request do
           get '/v0/intent_to_file'
           expect(response).to have_http_status(:ok)
           expect(response).to match_response_schema('intent_to_files')
+        end
+      end
+      it 'matches the intent to files schema when camel-inflected' do
+        VCR.use_cassette('evss/intent_to_file/intent_to_file') do
+          get '/v0/intent_to_file', headers: camel_inflection_header
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_camelized_response_schema('intent_to_files')
         end
       end
     end
@@ -50,6 +59,13 @@ RSpec.describe 'Intent to file', type: :request do
           expect(response).to match_response_schema('intent_to_file')
         end
       end
+      it 'matches the intent to file schema with camel-inflection' do
+        VCR.use_cassette('evss/intent_to_file/active_compensation') do
+          get '/v0/intent_to_file/compensation/active', headers: camel_inflection_header
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_camelized_response_schema('intent_to_file')
+        end
+      end
     end
 
     context 'with a 403 response' do
@@ -80,6 +96,13 @@ RSpec.describe 'Intent to file', type: :request do
           post '/v0/intent_to_file/compensation'
           expect(response).to have_http_status(:ok)
           expect(response).to match_response_schema('intent_to_file')
+        end
+      end
+      it 'matches the intent to file schema when camel-inflected' do
+        VCR.use_cassette('evss/intent_to_file/create_compensation') do
+          post '/v0/intent_to_file/compensation', headers: camel_inflection_header
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_camelized_response_schema('intent_to_file')
         end
       end
     end

--- a/spec/support/schemas_camelized/evss_errors.json
+++ b/spec/support/schemas_camelized/evss_errors.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "id": "http://example.com/example.json",
+  "properties": {
+    "errors": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "meta": {
+            "properties": {
+              "messages": {
+                "items": {
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "severity": {
+                      "type": "string"
+                    },
+                    "text": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "text",
+                    "severity",
+                    "key"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "messages"
+            ],
+            "type": "object"
+          },
+          "source": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "code",
+          "title",
+          "detail"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "errors"
+  ],
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/intent_to_file.json
+++ b/spec/support/schemas_camelized/intent_to_file.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "data": {
+      "intentToFile": "intent_to_file_base.json"
+    }
+  }
+}

--- a/spec/support/schemas_camelized/intent_to_file_base.json
+++ b/spec/support/schemas_camelized/intent_to_file_base.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "required": [
+    "status"
+  ],
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "creationDate": {
+      "type": "string"
+    },
+    "expirationDate": {
+      "type": "string"
+    },
+    "participantId": {
+      "type": "integer"
+    },
+    "source": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/intent_to_files.json
+++ b/spec/support/schemas_camelized/intent_to_files.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "intentToFile": {
+              "description": "Array of ITFs the user has been assigned",
+              "items": {
+                "$ref": "intent_to_file_base.json"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "required": [
+            "intentToFile"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## Description of change
Introduces camel-inflected schemas for the specs used by intent_to_files_request_spec. This ensures we support X-Key-Inflection requests.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11585
