### PR TITLE
11585 add camel inflected schemas to user preferences

### DIFF
--- a/spec/request/user_preferences_request_spec.rb
+++ b/spec/request/user_preferences_request_spec.rb
@@ -253,6 +253,20 @@ describe 'user_preferences', type: :request do
         expect(error_details_for(response, key: 'status')).to eq '422'
         expect(error_details_for(response, key: 'detail')).to include 'ActiveRecord::RecordNotDestroyed'
       end
+
+      it 'returns a 422 unprocessable with camel-inflection', :aggregate_failures do
+        allow(UserPreference).to receive(:for_preference_and_account).and_raise(
+          ActiveRecord::RecordNotDestroyed.new('Cannot destroy this record')
+        )
+
+        delete '/v0/user/preferences/notifications/delete_all', headers: headers.merge(inflection_header)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_camelized_response_schema('errors')
+        expect(error_details_for(response, key: 'title')).to eq 'Unprocessable Entity'
+        expect(error_details_for(response, key: 'status')).to eq '422'
+        expect(error_details_for(response, key: 'detail')).to include 'ActiveRecord::RecordNotDestroyed'
+      end
     end
   end
 

--- a/spec/request/user_preferences_request_spec.rb
+++ b/spec/request/user_preferences_request_spec.rb
@@ -14,6 +14,9 @@ describe 'user_preferences', type: :request do
       'Accept' => 'application/json'
     }
   end
+  let(:inflection_header) do
+    { 'X-Key-Inflection' => 'camel' }
+  end
   let(:preference_1) { create :preference }
   let(:preference_2) { create :preference }
   let(:choice_1) { create :preference_choice, preference: preference_1 }
@@ -53,6 +56,13 @@ describe 'user_preferences', type: :request do
       expect(response).to match_response_schema('user_preferences')
     end
 
+    it 'returns the expected shape of attributes with camel-inflection', :aggregate_failures do
+      post '/v0/user/preferences', params: request_body.to_json, headers: headers.merge(inflection_header)
+
+      expect(response).to have_http_status(:ok)
+      expect(response).to match_camelized_response_schema('user_preferences')
+    end
+
     context 'current user does not have an Account record' do
       let(:user) { build(:user, :loa3) }
 
@@ -68,6 +78,14 @@ describe 'user_preferences', type: :request do
         expect(user.account).to be_present
         expect(response).to have_http_status(:ok)
         expect(response).to match_response_schema('user_preferences')
+      end
+
+      it 'creates an Account record for the current user with camel-inflection', :aggregate_failures do
+        post '/v0/user/preferences', params: request_body.to_json, headers: headers.merge(inflection_header)
+
+        expect(user.account).to be_present
+        expect(response).to have_http_status(:ok)
+        expect(response).to match_camelized_response_schema('user_preferences')
       end
     end
 
@@ -252,6 +270,13 @@ describe 'user_preferences', type: :request do
 
       expect(response).to be_ok
       expect(response).to match_response_schema('user_preferences')
+    end
+
+    it 'returns an index of all of the user\'s preferences' do
+      get '/v0/user/preferences', headers: headers.merge(inflection_header)
+
+      expect(response).to be_ok
+      expect(response).to match_camelized_response_schema('user_preferences')
     end
   end
 end

--- a/spec/request/user_preferences_request_spec.rb
+++ b/spec/request/user_preferences_request_spec.rb
@@ -219,6 +219,14 @@ describe 'user_preferences', type: :request do
         expect(response).to match_response_schema('delete_all_user_preferences')
         expect(UserPreference.where(account_id: user.account.id).count).to eq 0
       end
+
+      it 'deletes all of a User\'s UserPreferences with camel-inflection', :aggregate_failures do
+        delete '/v0/user/preferences/notifications/delete_all', headers: headers.merge(inflection_header)
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to match_camelized_response_schema('delete_all_user_preferences')
+        expect(UserPreference.where(account_id: user.account.id).count).to eq 0
+      end
     end
 
     context 'when given a nonexistent code' do
@@ -272,7 +280,7 @@ describe 'user_preferences', type: :request do
       expect(response).to match_response_schema('user_preferences')
     end
 
-    it 'returns an index of all of the user\'s preferences' do
+    it 'returns an index of all of the user\'s preferences with camel-inflection' do
       get '/v0/user/preferences', headers: headers.merge(inflection_header)
 
       expect(response).to be_ok

--- a/spec/support/schemas_camelized/delete_all_user_preferences.json
+++ b/spec/support/schemas_camelized/delete_all_user_preferences.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "preferenceCode": {
+              "description": "String representing the Preference code",
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "userPreferences": {
+              "description": "Array of Preference and PreferenceChoice pairings",
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "userPreferences": {
+                    "description": "Array of PreferenceChoice codes the user selected",
+                    "items": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/errors.json
+++ b/spec/support/schemas_camelized/errors.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "errors": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "source": {
+            "type": [
+              "string",
+              "object"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "source",
+          "code",
+          "detail",
+          "title"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "errors"
+  ],
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/user_preferences.json
+++ b/spec/support/schemas_camelized/user_preferences.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "userPreferences": {
+              "description": "Array of Preference and PreferenceChoice pairings",
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "userPreferences": {
+                    "description": "Array of PreferenceChoice codes the user selected",
+                    "items": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
#4538  Description of change
Introduces camel-inflected schemas for the specs used by `user_preferences_request_spec.rb`. This ensures we support X-Key-Inflection requests.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11585
