### PR TITLE
Add Backend Exception Handling for Debts

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -384,6 +384,11 @@ en:
         code: 'CASEFLOWSTATUS502'
         detail: 'Received an invalid response from the upstream server'
         status: 502
+      DEBTS400:
+        <<: *external_defaults
+        title: 'Bad Request'
+        code: 'DEBTS400'
+        detail: 'Received a bad request response from the upstream server'
       GI404:
         <<: *external_defaults
         title: 'Record not found'

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -389,6 +389,7 @@ en:
         title: 'Bad Request'
         code: 'DEBTS400'
         detail: 'Received a bad request response from the upstream server'
+        status: 400
       GI404:
         <<: *external_defaults
         title: 'Record not found'

--- a/lib/debts/configuration.rb
+++ b/lib/debts/configuration.rb
@@ -19,7 +19,7 @@ module Debts
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |f|
-        f.use     :breakers
+        f.use :breakers
         f.use Faraday::Response::RaiseError
         f.request :json
         f.response :betamocks if Settings.debts.mock

--- a/lib/debts/configuration.rb
+++ b/lib/debts/configuration.rb
@@ -20,6 +20,7 @@ module Debts
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |f|
         f.use     :breakers
+        f.use Faraday::Response::RaiseError
         f.request :json
         f.response :betamocks if Settings.debts.mock
         f.response :json

--- a/lib/debts/get_letters_response.rb
+++ b/lib/debts/get_letters_response.rb
@@ -15,7 +15,7 @@ module Debts
 
     def validate_response_against_schema(response)
       schema_path = Rails.root.join('lib', 'debts', 'schemas', "debts.json").to_s
-      JSON::Validator.validate!(schema_path, response.body, strict: false)
+      JSON::Validator.validate!(schema_path, response, strict: false)
     end
   end
 end

--- a/lib/debts/get_letters_response.rb
+++ b/lib/debts/get_letters_response.rb
@@ -3,7 +3,6 @@
 module Debts
   class GetLettersResponse
     def initialize(res)
-      # modify response here
       @res = res
     end
 

--- a/lib/debts/get_letters_response.rb
+++ b/lib/debts/get_letters_response.rb
@@ -14,7 +14,7 @@ module Debts
     private
 
     def validate_response_against_schema(response)
-      schema_path = Rails.root.join('lib', 'debts', 'schemas', "debts.json").to_s
+      schema_path = Rails.root.join('lib', 'debts', 'schemas', 'debts.json').to_s
       JSON::Validator.validate!(schema_path, response, strict: false)
     end
   end

--- a/lib/debts/get_letters_response.rb
+++ b/lib/debts/get_letters_response.rb
@@ -3,11 +3,19 @@
 module Debts
   class GetLettersResponse
     def initialize(res)
+      validate_response_against_schema(res)
       @res = res
     end
 
     def to_json(*_args)
       @res.to_json
+    end
+
+    private
+
+    def validate_response_against_schema(response)
+      schema_path = Rails.root.join('lib', 'debts', 'schemas', "debts.json").to_s
+      JSON::Validator.validate!(schema_path, response.body, strict: false)
     end
   end
 end

--- a/lib/debts/schemas/debts.json
+++ b/lib/debts/schemas/debts.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "",
+  "type": "array",
+  "properties": {
+    "items": {
+      "type": "object",
+      "properties": {
+        "fileNumber": {
+          "type": "string"
+        },
+        "payeeNumber": {
+          "type": "string"
+        },
+        "personEntitled": {
+          "type": "string"
+        },
+        "deductionCode": {
+          "type": "string"
+        },
+        "benefitType": {
+          "type": "string"
+        },
+        "amountOverpaid": {
+          "type": "number"
+        },
+        "amountWithheld": {
+          "type": "number"
+        },
+        "originalAR": {
+          "type": "number"
+        },
+        "currentAR": {
+          "type": "number"
+        },
+        "debtHistory": {
+          "type": "array",
+          "items": {
+            "date": {
+              "type": "string"
+            },
+            "letterCode": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/debts/service.rb
+++ b/lib/debts/service.rb
@@ -2,6 +2,8 @@
 
 module Debts
   class Service < Common::Client::Base
+    include Common::Client::Concerns::Monitoring
+
     configuration Debts::Configuration
 
     def get_letters(body)

--- a/lib/debts/service.rb
+++ b/lib/debts/service.rb
@@ -39,10 +39,10 @@ module Debts
       save_error_details(error)
 
       raise_backend_exception(
-          "DEBTS#{error&.status}", 
-          self.class, 
-          error
-        )
+        "DEBTS#{error&.status}", 
+        self.class, 
+        error
+      )
     end
   end
 end

--- a/lib/debts/service.rb
+++ b/lib/debts/service.rb
@@ -5,7 +5,44 @@ module Debts
     configuration Debts::Configuration
 
     def get_letters(body)
-      GetLettersResponse.new(perform(:post, 'letterdetails/get', body).body)
+      with_monitoring do
+        GetLettersResponse.new(perform(:post, 'letterdetails/get', body).body)
+      end
+    rescue => e
+      handle_error(e)
+    end
+
+    private
+
+    def save_error_details(error)
+      Raven.tags_context(
+        external_service: self.class.to_s.underscore
+      )
+
+      Raven.extra_context(
+        url: config.base_path,
+        message: error.message,
+        body: error.body
+      )
+    end
+
+    def handle_error(error)
+      case error
+      when Common::Client::Errors::ClientError
+        handle_client_error(error)
+      else
+        raise error
+      end
+    end
+
+    def handle_client_error(status)
+      save_error_details(error)
+
+      raise_backend_exception(
+          "DEBTS#{error&.status}", 
+          self.class, 
+          error
+        )
     end
   end
 end

--- a/lib/debts/service.rb
+++ b/lib/debts/service.rb
@@ -9,7 +9,7 @@ module Debts
     STATSD_KEY_PREFIX = 'api.debts'
 
     def get_letters(body)
-      with_monitoring do
+      with_monitoring(2) do
         GetLettersResponse.new(perform(:post, 'letterdetails/get', body).body)
       end
     rescue => e

--- a/lib/debts/service.rb
+++ b/lib/debts/service.rb
@@ -35,7 +35,7 @@ module Debts
       end
     end
 
-    def handle_client_error(status)
+    def handle_client_error(error)
       save_error_details(error)
 
       raise_backend_exception(

--- a/lib/debts/service.rb
+++ b/lib/debts/service.rb
@@ -9,14 +9,20 @@ module Debts
     STATSD_KEY_PREFIX = 'api.debts'
 
     def get_letters(body)
-      with_monitoring(2) do
+      with_monitoring_and_error_handling do
         GetLettersResponse.new(perform(:post, 'letterdetails/get', body).body)
+      end
+    end
+
+    private
+
+    def with_monitoring_and_error_handling
+      with_monitoring(2) do
+        yield
       end
     rescue => e
       handle_error(e)
     end
-
-    private
 
     def save_error_details(error)
       Raven.tags_context(

--- a/lib/debts/service.rb
+++ b/lib/debts/service.rb
@@ -6,6 +6,8 @@ module Debts
 
     configuration Debts::Configuration
 
+    STATSD_KEY_PREFIX = 'api.debts'
+
     def get_letters(body)
       with_monitoring do
         GetLettersResponse.new(perform(:post, 'letterdetails/get', body).body)

--- a/lib/debts/service.rb
+++ b/lib/debts/service.rb
@@ -39,8 +39,8 @@ module Debts
       save_error_details(error)
 
       raise_backend_exception(
-        "DEBTS#{error&.status}", 
-        self.class, 
+        "DEBTS#{error&.status}",
+        self.class,
         error
       )
     end

--- a/spec/lib/debts/service_spec.rb
+++ b/spec/lib/debts/service_spec.rb
@@ -30,8 +30,11 @@ RSpec.describe Debts::Service do
           expect(StatsD).to receive(:increment).once.with(
             'api.debts.get_letters.total'
           )
-          res = described_class.new.get_letters(fileNumber: '')
-          expect(JSON.parse(res.to_json)['errors']['code']).to eq('DEBTS400')
+          expect { described_class.new.get_letters(fileNumber: '') }.to raise_error(
+            Common::Exceptions::BackendServiceException
+          ) do |e|
+            expect(e.message).to match(/DEBTS400/)
+          end
         end
       end
     end

--- a/spec/lib/debts/service_spec.rb
+++ b/spec/lib/debts/service_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe Debts::Service do
           'debts/get_letters',
           VCR::MATCH_EVERYTHING
         ) do
+          expect(StatsD).to receive(:increment).once.with(
+            'api.debts.get_letters.total'
+          )
           res = described_class.new.get_letters(fileNumber: '000000009')
           expect(JSON.parse(res.to_json)[0]['fileNumber']).to eq('000000009')
         end
@@ -23,9 +26,7 @@ RSpec.describe Debts::Service do
           VCR::MATCH_EVERYTHING
         ) do
           expect(StatsD).to receive(:increment).once.with(
-            'api.debts.get_letters.fail', tags: [
-              'error:Common::Client::Errors::ClientError', 'status:400'
-            ]
+            'api.debts.get_letters.total'
           )
           res = described_class.new.get_letters(fileNumber: '')
           expect(JSON.parse(res.to_json)['message']).to eq('Bad request')

--- a/spec/lib/debts/service_spec.rb
+++ b/spec/lib/debts/service_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe Debts::Service do
           'debts/get_letters_empty_ssn',
           VCR::MATCH_EVERYTHING
         ) do
+          expect(StatsD).to receive(:increment).once.with(
+            'api.debts.get_letters.fail', tags: [
+              'error:Common::Client::Errors::ClientError', 'status:400'
+            ]
+          )
           res = described_class.new.get_letters(fileNumber: '')
           expect(JSON.parse(res.to_json)['message']).to eq('Bad request')
         end

--- a/spec/lib/debts/service_spec.rb
+++ b/spec/lib/debts/service_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe Debts::Service do
           expect(StatsD).to receive(:increment).once.with(
             'api.debts.get_letters.total'
           )
+          expect(Raven).to receive(:tags_context).once.with(external_service: described_class.to_s.underscore)
+          expect(Raven).to receive(:extra_context).once.with(
+            url: "#{Settings.debts.url}/api/v1/debtletter/",
+            message: 'the server responded with status 400',
+            body: { 'message' => 'Bad request' }
+          )
           expect { described_class.new.get_letters(fileNumber: '') }.to raise_error(
             Common::Exceptions::BackendServiceException
           ) do |e|

--- a/spec/lib/debts/service_spec.rb
+++ b/spec/lib/debts/service_spec.rb
@@ -10,9 +10,6 @@ RSpec.describe Debts::Service do
           'debts/get_letters',
           VCR::MATCH_EVERYTHING
         ) do
-          expect(StatsD).to receive(:increment).once.with(
-            'api.debts.get_letters.total'
-          )
           res = described_class.new.get_letters(fileNumber: '000000009')
           expect(JSON.parse(res.to_json)[0]['fileNumber']).to eq('000000009')
         end
@@ -26,10 +23,15 @@ RSpec.describe Debts::Service do
           VCR::MATCH_EVERYTHING
         ) do
           expect(StatsD).to receive(:increment).once.with(
+            'api.debts.get_letters.fail', tags: [
+              'error:Common::Client::Errors::ClientError', 'status:400'
+            ]
+          )
+          expect(StatsD).to receive(:increment).once.with(
             'api.debts.get_letters.total'
           )
           res = described_class.new.get_letters(fileNumber: '')
-          expect(JSON.parse(res.to_json)['message']).to eq('Bad request')
+          expect(JSON.parse(res.to_json)['errors']['code']).to eq('DEBTS400')
         end
       end
     end


### PR DESCRIPTION
## Description of change
* Adds exception handling to the Debts service. 
* Adds a 400 Bad Request exception for debts within the exceptions yml file.
* Adds JSON schema validation for Debts responses.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/11791

## Things to know about this PR
Tested and verified locally.
