### PR TITLE
exclude .csv files from danger bot

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,6 +1,6 @@
 # Warn if a pull request is too big
 MAX_PR_SIZE = 250
-EXCLUSIONS = ['Gemfile.lock', '.json', 'spec/fixtures/', '.txt', 'spec/support/vcr_cassettes/', 'app/swagger']
+EXCLUSIONS = ['Gemfile.lock', '.json', 'spec/fixtures/', '.txt', 'spec/support/vcr_cassettes/', 'app/swagger', '.csv']
 
 # takes form {"some/file.rb"=>{:insertions=>4, :deletions=>1}}
 changed_files = git.diff.stats[:files]


### PR DESCRIPTION
### The Problem
I came across a PR where large changes were made to a `.csv` file that triggered the dangerbot warning. We should not be counting changes to `.csv` files.

## Description of change
Updated the Dangerbot exclusions list to include `.csv` files.

## Original issue(s)
None.

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
