### PR TITLE
When submitting to Central Mail, add `Appeals-HLR-` prefix to consumer name

### DIFF
--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -31,7 +31,7 @@ module AppealsApi
         'veteranLastName' => higher_level_review.last_name,
         'fileNumber' => higher_level_review.file_number.presence || higher_level_review.ssn,
         'zipCode' => higher_level_review.zip_code_5,
-        'source' => higher_level_review.consumer_name || 'lighthouse-hlr',
+        'source' => "Appeals-HLR-#{higher_level_review.consumer_name}",
         'uuid' => higher_level_review.id,
         'hashV' => Digest::SHA256.file(pdf_path).hexdigest,
         'numberAttachments' => 0,


### PR DESCRIPTION
As Central Mail, I want to know where a HLR Submission came from. Currently, the `source` is whatever the Lighthouse user's consumer name is. Add `Appeals-HLR-` as a prefix so that Central Mail can quickly tell what API submitted the form.

resolves https://vajira.max.gov/browse/API-1661
