### PR TITLE
Fixing an implementation error around PPMS::Specialty

### DIFF
--- a/app/models/ppms/specialty.rb
+++ b/app/models/ppms/specialty.rb
@@ -3,10 +3,11 @@
 require 'common/models/base'
 
 class PPMS::Specialty < Common::Base
-  attribute :specialty_code, String
-  attribute :grouping, String
   attribute :classification, String
+  attribute :grouping, String
+  attribute :name, String
   attribute :specialization, String
+  attribute :specialty_code, String
   attribute :specialty_description, String
 
   def initialize(attr)

--- a/app/serializers/ppms/specialty_serializer.rb
+++ b/app/serializers/ppms/specialty_serializer.rb
@@ -7,6 +7,7 @@ class PPMS::SpecialtySerializer
 
   attributes :classification,
              :grouping,
+             :name,
              :specialization,
              :specialty_code,
              :specialty_description

--- a/lib/lighthouse/facilities/configuration.rb
+++ b/lib/lighthouse/facilities/configuration.rb
@@ -24,6 +24,10 @@ module Lighthouse
           conn.use :breakers
           conn.use :instrumentation, name: 'lighthouse.facilities.request.faraday'
 
+          # Uncomment this if you want curl command equivalent or response output to log
+          # conn.request(:curl, ::Logger.new(STDOUT), :warn) unless Rails.env.production?
+          # conn.response(:logger, ::Logger.new(STDOUT), bodies: true) unless Rails.env.production?
+
           conn.response :raise_error, error_prefix: service_name
           conn.response :lighthouse_facilities_errors
 

--- a/spec/request/v1/facilities/ccp_request_spec.rb
+++ b/spec/request/v1/facilities/ccp_request_spec.rb
@@ -449,6 +449,7 @@ RSpec.describe 'Community Care Providers', type: :request, team: :facilities do
               'attributes' => {
                 'classification' => 'Podiatrist',
                 'grouping' => 'Podiatric Medicine & Surgery Service Providers',
+                'name' => 'Podiatrist',
                 'specialization' => nil,
                 'specialty_code' => '213E00000X',
                 'specialty_description' => 'A podiatrist is a person qualified by a Doctor of Podiatric Medicine ' \
@@ -523,6 +524,7 @@ RSpec.describe 'Community Care Providers', type: :request, team: :facilities do
               'attributes' => {
                 'classification' => 'Podiatrist',
                 'grouping' => 'Podiatric Medicine & Surgery Service Providers',
+                'name' => 'Podiatrist',
                 'specialization' => nil,
                 'specialty_code' => '213E00000X',
                 'specialty_description' => 'A podiatrist is a person qualified by a Doctor of Podiatric Medicine ' \
@@ -920,6 +922,7 @@ RSpec.describe 'Community Care Providers', type: :request, team: :facilities do
             'attributes' => {
               'classification' => 'Podiatrist',
               'grouping' => 'Podiatric Medicine & Surgery Service Providers',
+              'name' => 'Podiatrist',
               'specialization' => nil,
               'specialty_code' => '213E00000X',
               'specialty_description' => 'A podiatrist is a person qualified by a Doctor of Podiatric Medicine ' \
@@ -941,13 +944,14 @@ RSpec.describe 'Community Care Providers', type: :request, team: :facilities do
 
       bod = JSON.parse(response.body)
 
-      expect(bod['data'][0..1]).to include(
-        {
+      expect(bod['data'][0..1]).to match(
+        [{
           'id' => '101Y00000X',
           'type' => 'specialty',
           'attributes' => {
             'classification' => 'Counselor',
             'grouping' => 'Behavioral Health & Social Service Providers',
+            'name' => 'Counselor',
             'specialization' => nil,
             'specialty_code' => '101Y00000X',
             'specialty_description' => 'A provider who is trained and educated in the performance of behavior ' \
@@ -957,17 +961,18 @@ RSpec.describe 'Community Care Providers', type: :request, team: :facilities do
          'or certification.'
           }
         },
-        {
-          'id' => '101YA0400X',
-          'type' => 'specialty',
-          'attributes' => {
-            'classification' => 'Counselor',
-            'grouping' => 'Behavioral Health & Social Service Providers',
-            'specialization' => 'Addiction (Substance Use Disorder)',
-            'specialty_code' => '101YA0400X',
-            'specialty_description' => 'Definition to come...'
-          }
-        }
+         {
+           'id' => '101YA0400X',
+           'type' => 'specialty',
+           'attributes' => {
+             'classification' => 'Counselor',
+             'grouping' => 'Behavioral Health & Social Service Providers',
+             'name' => 'Counselor - Addiction (Substance Use Disorder)',
+             'specialization' => 'Addiction (Substance Use Disorder)',
+             'specialty_code' => '101YA0400X',
+             'specialty_description' => 'Definition to come...'
+           }
+         }]
       )
     end
   end


### PR DESCRIPTION
when promoting it to a first-class object I forgot the `name` attribute

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Adding a missing attribute to the `PPMS::Specialty` object and serializer

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11987

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
