### PR TITLE
Claims API - Handle Streams That Don't Respond to Path (VbmsUploadJob)

### DIFF
--- a/modules/claims_api/app/workers/claims_api/vbms_upload_job.rb
+++ b/modules/claims_api/app/workers/claims_api/vbms_upload_job.rb
@@ -25,6 +25,7 @@ module ClaimsApi
       return uploader.file.file unless Settings.evss.s3.uploads_enabled
 
       stream = URI.parse(uploader.file.url).open
+      # stream could be a Tempfile or a StringIO https://stackoverflow.com/a/23666898
       stream.try(:path) || stream_to_temp_file(stream).path
     end
 

--- a/modules/claims_api/app/workers/claims_api/vbms_upload_job.rb
+++ b/modules/claims_api/app/workers/claims_api/vbms_upload_job.rb
@@ -21,27 +21,22 @@ module ClaimsApi
       rescue_file_not_found(power_of_attorney)
     end
 
-    private
-
     def fetch_file_path(uploader)
       return uploader.file.file unless Settings.evss.s3.uploads_enabled
 
       stream = URI.parse(uploader.file.url).open
-
-      stream.try(:path) || stream_to_temp_file(stream).then do |temp_file|
-        stream.close
-        temp_file.path
-      end
+      stream.try(:path) || stream_to_temp_file(stream).path
     end
 
-    def stream_to_temp_file(stream)
-      Tempfile.new.tap do |file|
-        file.binmode
-        file.write stream.read
-      end
+    def stream_to_temp_file(stream, close_stream: true)
+      file = Tempfile.new
+      file.binmode
+      file.write stream.read
+      file
     ensure
       file.flush
       file.close
+      stream.close if close_stream
     end
   end
 end

--- a/modules/claims_api/app/workers/claims_api/vbms_upload_job.rb
+++ b/modules/claims_api/app/workers/claims_api/vbms_upload_job.rb
@@ -21,6 +21,8 @@ module ClaimsApi
       rescue_file_not_found(power_of_attorney)
     end
 
+    private
+
     def fetch_file_path(uploader)
       return uploader.file.file unless Settings.evss.s3.uploads_enabled
 


### PR DESCRIPTION
resolves https://vajira.max.gov/browse/API-1834

Turns out that OpenURI will sometimes return a `Tempfile` and sometimes a `StringIO`:

>The root of this problem is that if you use open(url) on a file smaller than 10kb it will convert it into a string IO object auto-magically instead of using a Tempfile. The StringIO object as everyone has pointed out does not have the path method defined on it.

https://stackoverflow.com/a/23666898

_As a dev, when using VbmsUploadJob, I want s3 urls to always open as Tempfiles, and not sometimes as StringIO's (causing an exception to be thrown because StringIO's don't respond to `:path`)._

My solution is an amalgamation of:
https://stackoverflow.com/a/22937649
https://stackoverflow.com/a/31527533