### PR TITLE
dangerbot to fail large PRs

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,6 +1,9 @@
 # Warn if a pull request is too big
-MAX_PR_SIZE = 250
-EXCLUSIONS = ['Gemfile.lock', '.json', 'spec/fixtures/', '.txt', 'spec/support/vcr_cassettes/', 'app/swagger', '.csv']
+PR_SIZE = {
+  RECOMMENDED_MAXIMUM: 250,
+  ABSOLUTE_MAXIMUM:    1000,
+}
+EXCLUSIONS = ['Gemfile.lock', '.json', 'spec/fixtures/', '.txt', 'spec/support/vcr_cassettes/', 'app/swagger']
 
 # takes form {"some/file.rb"=>{:insertions=>4, :deletions=>1}}
 changed_files = git.diff.stats[:files]
@@ -9,10 +12,8 @@ excluded_changed_files = changed_files.select { |key| EXCLUSIONS.any? { |exclusi
 filtered_changed_files = changed_files.reject { |key| EXCLUSIONS.any? { |exclusion| key.include?(exclusion) } }
 lines_of_code = filtered_changed_files.sum { |_file, changes| (changes[:insertions] + changes[:deletions]) }
 
-if lines_of_code > MAX_PR_SIZE
-  msg = <<~HTML
-    You changed `#{lines_of_code}` LoC. This exceeds our desired maximum of `#{MAX_PR_SIZE}`.
-
+if lines_of_code > PR_SIZE[:RECOMMENDED_MAXIMUM]
+  file_summary = <<~HTML
     <details><summary>File Summary</summary>
 
     #### Included Files
@@ -33,11 +34,17 @@ if lines_of_code > MAX_PR_SIZE
     ```
 
     </details>
-
-    Big PRs are difficult to review and often become stale. Consider breaking this PR up into smaller ones.
-
   HTML
-  warn(msg)
+
+  footer = 'Big PRs are difficult to review, often become stale, and cause delays.'
+
+  if lines_of_code > PR_SIZE[:ABSOLUTE_MAXIMUM]
+    msg = "This PR changes `#{lines_of_code}` LoC. In order to ensure each PR receives the proper attention it deserves, those exceeding `#{PR_SIZE[:ABSOLUTE_MAXIMUM]}` will not be reviewed, nor will they be allowed to merge. Please break this PR up into smaller ones. If you have reason to believe that this PR should be granted an exception, please see the [Code Review Guidelines FAQ](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md#faq).\n"
+    fail(msg + file_summary + footer) 
+  else
+    msg = "This PR changes `#{lines_of_code}` LoC. In order to ensure each PR receives the proper attention it deserves, we recommend not exceeding `#{PR_SIZE[:RECOMMENDED_MAXIMUM]}`. Expect some delays getting reviews.\n"
+    warn(msg + file_summary + footer)
+  end
 end
 
 # Warn when a PR includes a simultaneous DB migration and application code changes
@@ -73,4 +80,3 @@ if !db_files.empty? && !app_files.empty?
 
   fail(msg)
 end
-


### PR DESCRIPTION
## Description of change
- Update the ruby danger-bot to ❌ `fail` ❌  PR's exceeding 1000 lines of code
- Updates wording for when these failures occur

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/11630

## Things to know about this PR
This has been tested over in this separate Draft PR where the message can be seen: https://github.com/department-of-veterans-affairs/vets-api/pull/4596
