### PR TITLE
update danger and include patched kramdown

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
-    danger (8.0.2)
+    danger (8.0.4)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -448,7 +448,7 @@ GEM
     jsonapi-parser (0.1.1.beta3)
     jsonapi-renderer (0.1.1.beta1)
     jwt (2.2.1)
-    kramdown (2.2.1)
+    kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)


### PR DESCRIPTION
## Description of change
`danger` gem has a dependency on `kramdown` which has a vulnerability.  updated danger to get latest kramdown.
`danger`'s changes are merely cosmetic https://github.com/danger/danger/blob/master/CHANGELOG.md#803---804
## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-api/network/alert/Gemfile.lock/kramdown/open