### PR TITLE
[686] Change User hash to User object

### DIFF
--- a/app/models/bgs_dependents/veteran.rb
+++ b/app/models/bgs_dependents/veteran.rb
@@ -7,7 +7,6 @@ module BGSDependents
     attribute :first_name, String
     attribute :middle_name, String
     attribute :last_name, String
-    attribute :external_key, String
     attribute :icn, String
 
     def initialize(proc_id, user)
@@ -58,14 +57,12 @@ module BGSDependents
     private
 
     def user_veteran_attributes
-      external_key = @user.common_name || @user.email
       {
         participant_id: @user.participant_id,
         ssn: @user.ssn,
         first_name: @user.first_name,
         middle_name: @user.middle_name,
         last_name: @user.last_name,
-        external_key: external_key,
         icn: @user.icn
       }
     end

--- a/app/models/bgs_dependents/veteran.rb
+++ b/app/models/bgs_dependents/veteran.rb
@@ -12,11 +12,13 @@ module BGSDependents
 
     def initialize(proc_id, user)
       @proc_id = proc_id
-      self.attributes = user
+      @user = user
+      self.attributes = user_veteran_attributes
     end
 
     def formatted_params(payload)
       dependents_application = payload['dependents_application']
+
       vet_info = [
         *payload['veteran_information'],
         ['first', first_name],
@@ -54,6 +56,19 @@ module BGSDependents
     end
 
     private
+
+    def user_veteran_attributes
+      external_key = @user.common_name || @user.email
+      {
+        participant_id: @user.participant_id,
+        ssn: @user.ssn,
+        first_name: @user.first_name,
+        middle_name: @user.middle_name,
+        last_name: @user.last_name,
+        external_key: external_key,
+        icn: @user.icn
+      }
+    end
 
     def marital_status(dependents_application)
       spouse_lives_with_vet = dependents_application.dig('does_live_with_spouse', 'spouse_does_live_with_veteran')

--- a/lib/bgs/form686c.rb
+++ b/lib/bgs/form686c.rb
@@ -3,7 +3,7 @@
 module BGS
   class Form686c
     def initialize(user)
-      @user = user.with_indifferent_access
+      @user = user
     end
 
     def submit(payload)

--- a/lib/bgs/service.rb
+++ b/lib/bgs/service.rb
@@ -128,12 +128,6 @@ module BGS
       notify_of_service_exception(e, __method__)
     end
 
-    def get_va_file_number
-      person = service.people.find_person_by_ptcpnt_id(@user[:participant_id])
-
-      person[:file_nbr]
-    end
-
     def insert_benefit_claim(benefit_claim_params)
       service.claims.insert_benefit_claim(benefit_claim_params)
     end
@@ -159,7 +153,9 @@ module BGS
     private
 
     def service
-      @service ||= BGS::Services.new(external_uid: @user[:icn], external_key: @user[:external_key])
+      external_key = @user.common_name || @user.email
+
+      @service ||= BGS::Services.new(external_uid: @user[:icn], external_key: external_key)
     end
   end
 end

--- a/lib/bgs/vnp_veteran.rb
+++ b/lib/bgs/vnp_veteran.rb
@@ -12,7 +12,7 @@ module BGS
     def create
       participant = bgs_service.create_participant(@proc_id, nil)
       claim_type_end_product = bgs_service.find_benefit_claim_type_increment
-      va_file_number = bgs_service.get_va_file_number
+      va_file_number = @payload['veteran_information']['va_file_number']
       person_params = veteran.create_person_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
       address_params = veteran.create_address_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
       address = bgs_service.create_address(address_params)

--- a/spec/factories/686c/form_686c_674.rb
+++ b/spec/factories/686c/form_686c_674.rb
@@ -16,6 +16,15 @@ FactoryBot.define do
         'spouse_was_married_before' => true,
         'student_did_attend_school_last_term' => true,
         'veteran_was_married_before' => true,
+        'veteran_information' => {
+          'birth_date' => '1809-02-12',
+          'full_name' => {
+            'first' => 'WESLEY',
+            'last' => 'FORD',
+            'middle' => nil
+          }, 'ssn' => '796043735',
+          'va_file_number' => '796043735'
+        },
         'dependents_application' => {
           'student_does_have_networth' => true,
           'student_networth_information' => {

--- a/spec/lib/bgs/benefit_claim_spec.rb
+++ b/spec/lib/bgs/benefit_claim_spec.rb
@@ -4,26 +4,16 @@ require 'rails_helper'
 
 RSpec.describe BGS::BenefitClaim do
   let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
-  let(:user_hash) do
-    {
-      participant_id: user_object.participant_id,
-      ssn: user_object.ssn,
-      first_name: user_object.first_name,
-      last_name: user_object.last_name,
-      external_key: user_object.common_name || user_object.email,
-      icn: user_object.icn
-    }
-  end
   let(:proc_id) { '3828033' }
   let(:participant_id) { '146189' }
   let(:vet_hash) do
     {
-      file_number: user_hash[:ssn],
-      vnp_participant_id: user_hash[:participant_id],
-      ssn_number: user_hash[:ssn],
+      file_number: user_object.ssn,
+      vnp_participant_id: user_object.participant_id,
+      ssn_number: user_object.ssn,
       benefit_claim_type_end_product: '133',
-      first_name: user_hash[:first_name],
-      last_name: user_hash[:last_name],
+      first_name: user_object.first_name,
+      last_name: user_object.last_name,
       vnp_participant_address_id: '113372',
       phone_number: '5555555555',
       address_line_one: '123 Mainstreet',
@@ -41,7 +31,7 @@ RSpec.describe BGS::BenefitClaim do
         benefit_claim = BGS::BenefitClaim.new(
           vnp_benefit_claim: { vnp_benefit_claim_type_code: '130DPNEBNADJ' },
           veteran: vet_hash,
-          user: user_hash,
+          user: user_object,
           proc_id: proc_id
         ).create
 
@@ -82,7 +72,7 @@ RSpec.describe BGS::BenefitClaim do
         BGS::BenefitClaim.new(
           vnp_benefit_claim: { vnp_benefit_claim_type_code: '130DPNEBNADJ' },
           veteran: vet_hash,
-          user: user_hash,
+          user: user_object,
           proc_id: proc_id
         ).create
       end
@@ -90,7 +80,7 @@ RSpec.describe BGS::BenefitClaim do
 
     context 'error' do
       it 'handles error' do
-        user_hash[:file_number] = nil
+        vet_hash[:file_number] = nil
 
         VCR.use_cassette('bgs/benefit_claim/create/error') do
           expect_any_instance_of(BGS::BenefitClaim).to receive(:handle_error).with(
@@ -100,21 +90,21 @@ RSpec.describe BGS::BenefitClaim do
           BGS::BenefitClaim.new(
             vnp_benefit_claim: { vnp_benefit_claim_type_code: '130DPNEBNADJ' },
             veteran: vet_hash,
-            user: user_hash,
+            user: user_object,
             proc_id: proc_id
           ).create
         end
       end
 
       it 'handles updates proc to manual' do
-        user_hash[:file_number] = nil
+        vet_hash[:file_number] = nil
 
         VCR.use_cassette('bgs/benefit_claim/create/error') do
           expect do
             BGS::BenefitClaim.new(
               vnp_benefit_claim: { vnp_benefit_claim_type_code: '130DPNEBNADJ' },
               veteran: vet_hash,
-              user: user_hash,
+              user: user_object,
               proc_id: proc_id
             ).create
           end.to raise_error(BGS::ServiceException)

--- a/spec/lib/bgs/dependents_spec.rb
+++ b/spec/lib/bgs/dependents_spec.rb
@@ -4,16 +4,6 @@ require 'rails_helper'
 
 RSpec.describe BGS::Dependents do
   let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
-  let(:user_hash) do
-    {
-      participant_id: user_object.participant_id,
-      ssn: user_object.ssn,
-      first_name: user_object.first_name,
-      last_name: user_object.last_name,
-      external_key: user_object.common_name || user_object.email,
-      icn: user_object.icn
-    }
-  end
   let(:proc_id) { '3828033' }
   let(:all_flows_payload) { FactoryBot.build(:form_686c_674) }
 
@@ -26,7 +16,7 @@ RSpec.describe BGS::Dependents do
           dependents = BGS::Dependents.new(
             proc_id: proc_id,
             payload: all_flows_payload,
-            user: user_hash
+            user: user_object
           ).create
 
           expect(dependents).to include(
@@ -66,7 +56,7 @@ RSpec.describe BGS::Dependents do
           dependents = BGS::Dependents.new(
             proc_id: proc_id,
             payload: adopted_payload,
-            user: user_hash
+            user: user_object
           ).create
 
           expect(dependents).to include(
@@ -86,7 +76,7 @@ RSpec.describe BGS::Dependents do
           dependents = BGS::Dependents.new(
             proc_id: proc_id,
             payload: all_flows_payload,
-            user: user_hash
+            user: user_object
           ).create
 
           expect(dependents).to include(
@@ -106,7 +96,7 @@ RSpec.describe BGS::Dependents do
           dependents = BGS::Dependents.new(
             proc_id: proc_id,
             payload: all_flows_payload,
-            user: user_hash
+            user: user_object
           ).create
 
           # TODO: this expectation will change when we get the new data keys from the FE
@@ -127,7 +117,7 @@ RSpec.describe BGS::Dependents do
           dependents = BGS::Dependents.new(
             proc_id: proc_id,
             payload: all_flows_payload,
-            user: user_hash
+            user: user_object
           ).create
 
           expect(dependents).to include(
@@ -147,7 +137,7 @@ RSpec.describe BGS::Dependents do
           dependents = BGS::Dependents.new(
             proc_id: proc_id,
             payload: all_flows_payload,
-            user: user_hash
+            user: user_object
           ).create
 
           expect(dependents).to include(
@@ -168,7 +158,7 @@ RSpec.describe BGS::Dependents do
           dependents = BGS::Dependents.new(
             proc_id: proc_id,
             payload: all_flows_payload,
-            user: user_hash
+            user: user_object
           ).create
 
           expect(dependents).to include(
@@ -189,7 +179,7 @@ RSpec.describe BGS::Dependents do
           dependents = BGS::Dependents.new(
             proc_id: proc_id,
             payload: all_flows_payload,
-            user: user_hash
+            user: user_object
           ).create
 
           expect(dependents).to include(

--- a/spec/lib/bgs/form686c_spec.rb
+++ b/spec/lib/bgs/form686c_spec.rb
@@ -3,22 +3,12 @@
 require 'rails_helper'
 RSpec.describe BGS::Form686c do
   let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
-  let(:user_hash) do
-    {
-      participant_id: user_object.participant_id,
-      ssn: user_object.ssn,
-      first_name: user_object.first_name,
-      last_name: user_object.last_name,
-      external_key: user_object.common_name || user_object.email,
-      icn: user_object.icn
-    }
-  end
   let(:all_flows_payload) { FactoryBot.build(:form_686c_674) }
 
   # @TODO: may want to return something else
   it 'returns a hash with proc information' do
     VCR.use_cassette('bgs/form686c/submit') do
-      modify_dependents = BGS::Form686c.new(user_hash).submit(all_flows_payload)
+      modify_dependents = BGS::Form686c.new(user_object).submit(all_flows_payload)
 
       expect(modify_dependents).to include(
         :jrn_dt,
@@ -43,7 +33,7 @@ RSpec.describe BGS::Form686c do
       expect_any_instance_of(BGS::BenefitClaim).to receive(:create).and_call_original
       expect_any_instance_of(BGS::VnpBenefitClaim).to receive(:update).and_call_original
 
-      BGS::Form686c.new(user_hash).submit(all_flows_payload)
+      BGS::Form686c.new(user_object).submit(all_flows_payload)
     end
   end
 end

--- a/spec/lib/bgs/marriages_spec.rb
+++ b/spec/lib/bgs/marriages_spec.rb
@@ -4,16 +4,6 @@ require 'rails_helper'
 
 RSpec.describe BGS::Marriages do
   let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
-  let(:user_hash) do
-    {
-      participant_id: user_object.participant_id,
-      ssn: user_object.ssn,
-      first_name: user_object.first_name,
-      last_name: user_object.last_name,
-      external_key: user_object.common_name || user_object.email,
-      icn: user_object.icn
-    }
-  end
   let(:proc_id) { '3828033' }
   let(:all_flows_payload) { FactoryBot.build(:form_686c_674) }
   let(:spouse_payload) { FactoryBot.build(:spouse) }
@@ -25,7 +15,7 @@ RSpec.describe BGS::Marriages do
           dependents = BGS::Marriages.new(
             proc_id: proc_id,
             payload: spouse_payload,
-            user: user_hash
+            user: user_object
           ).create
 
           expect(dependents).to include(
@@ -46,7 +36,7 @@ RSpec.describe BGS::Marriages do
           dependents = BGS::Marriages.new(
             proc_id: proc_id,
             payload: all_flows_payload,
-            user: user_hash
+            user: user_object
           ).create
 
           expect(dependents).to include(
@@ -88,7 +78,7 @@ RSpec.describe BGS::Marriages do
           BGS::Marriages.new(
             proc_id: proc_id,
             payload: spouse_payload,
-            user: user_hash
+            user: user_object
           ).create
         end
       end

--- a/spec/lib/bgs/service_spec.rb
+++ b/spec/lib/bgs/service_spec.rb
@@ -4,17 +4,7 @@ require 'rails_helper'
 
 RSpec.describe BGS::Service do
   let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
-  let(:user_hash) do
-    {
-      participant_id: user_object.participant_id,
-      ssn: user_object.ssn,
-      first_name: user_object.first_name,
-      last_name: user_object.last_name,
-      external_key: user_object.common_name || user_object.email,
-      icn: user_object.icn
-    }
-  end
-  let(:bgs_service) { BGS::Service.new(user_hash) }
+  let(:bgs_service) { BGS::Service.new(user_object) }
   let(:proc_id) { '3829671' }
   let(:participant_id) { '149456' }
 

--- a/spec/lib/bgs/student_school_spec.rb
+++ b/spec/lib/bgs/student_school_spec.rb
@@ -4,16 +4,6 @@ require 'rails_helper'
 
 RSpec.describe BGS::StudentSchool do
   let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
-  let(:user_hash) do
-    {
-      participant_id: user_object.participant_id,
-      ssn: user_object.ssn,
-      first_name: user_object.first_name,
-      last_name: user_object.last_name,
-      external_key: user_object.common_name || user_object.email,
-      icn: user_object.icn
-    }
-  end
   let(:proc_id) { '3829729' }
   let(:vnp_participant_id) { '149471' }
   let(:all_flows_payload) { FactoryBot.build(:form_686c_674) }
@@ -67,7 +57,7 @@ RSpec.describe BGS::StudentSchool do
           proc_id: proc_id,
           vnp_participant_id: vnp_participant_id,
           payload: all_flows_payload,
-          user: user_hash
+          user: user_object
         ).create
       end
     end

--- a/spec/lib/bgs/vnp_benefit_claim_spec.rb
+++ b/spec/lib/bgs/vnp_benefit_claim_spec.rb
@@ -4,16 +4,6 @@ require 'rails_helper'
 
 RSpec.describe BGS::VnpBenefitClaim do
   let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
-  let(:user_hash) do
-    {
-      participant_id: user_object.participant_id,
-      ssn: user_object.ssn,
-      first_name: user_object.first_name,
-      last_name: user_object.last_name,
-      external_key: user_object.common_name || user_object.email,
-      icn: user_object.icn
-    }
-  end
   let(:proc_id) { '3828033' }
   let(:participant_id) { '146189' }
   let(:veteran_hash) do
@@ -49,7 +39,7 @@ RSpec.describe BGS::VnpBenefitClaim do
         vnp_benefit_claim = BGS::VnpBenefitClaim.new(
           proc_id: proc_id,
           veteran: veteran_hash,
-          user: user_hash
+          user: user_object
         ).create
 
         expect(vnp_benefit_claim).to include(
@@ -80,7 +70,7 @@ RSpec.describe BGS::VnpBenefitClaim do
         BGS::VnpBenefitClaim.new(
           proc_id: proc_id,
           veteran: veteran_hash,
-          user: user_hash
+          user: user_object
         ).create
       end
     end
@@ -92,7 +82,7 @@ RSpec.describe BGS::VnpBenefitClaim do
         existing_record = BGS::VnpBenefitClaim.new(
           proc_id: proc_id,
           veteran: veteran_hash,
-          user: user_hash
+          user: user_object
         ).update(benefit_claim, vnp_benefit_claim)
 
         expect(existing_record).to include(
@@ -122,7 +112,7 @@ RSpec.describe BGS::VnpBenefitClaim do
         BGS::VnpBenefitClaim.new(
           proc_id: proc_id,
           veteran: veteran_hash,
-          user: user_hash
+          user: user_object
         ).update(benefit_claim, vnp_benefit_claim)
       end
     end

--- a/spec/lib/bgs/vnp_relationships_spec.rb
+++ b/spec/lib/bgs/vnp_relationships_spec.rb
@@ -4,16 +4,6 @@ require 'rails_helper'
 
 RSpec.describe BGS::VnpRelationships do
   let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
-  let(:user_hash) do
-    {
-      participant_id: user_object.participant_id,
-      ssn: user_object.ssn,
-      first_name: user_object.first_name,
-      last_name: user_object.last_name,
-      external_key: user_object.common_name || user_object.email,
-      icn: user_object.icn
-    }
-  end
   let(:proc_id) { '3828033' }
   let(:participant_id) { '146189' }
   let(:veteran_hash) { { vnp_participant_id: '146189' } }
@@ -41,7 +31,7 @@ RSpec.describe BGS::VnpRelationships do
           dependent_array = [child]
 
           dependents = BGS::VnpRelationships.new(
-            proc_id: proc_id, veteran: veteran_hash, dependents: dependent_array, user: user_hash
+            proc_id: proc_id, veteran: veteran_hash, dependents: dependent_array, user: user_object
           ).create_all
 
           expect(dependents.first).to include(
@@ -109,7 +99,7 @@ RSpec.describe BGS::VnpRelationships do
             proc_id: proc_id,
             veteran: veteran_hash,
             dependents: dependent_array,
-            user: user_hash
+            user: user_object
           ).create_all
           expect(dependents.first).to include(
             participant_relationship_type_name: 'Spouse',
@@ -143,7 +133,7 @@ RSpec.describe BGS::VnpRelationships do
             proc_id: proc_id,
             veteran: veteran_hash,
             dependents: dependent_array,
-            user: user_hash
+            user: user_object
           ).create_all
           expect(dependents.first).to include(
             participant_relationship_type_name: 'Spouse',
@@ -177,7 +167,7 @@ RSpec.describe BGS::VnpRelationships do
           dependents = BGS::VnpRelationships.new(proc_id: proc_id,
                                                  veteran: veteran_hash,
                                                  dependents: dependent_array,
-                                                 user: user_hash).create_all
+                                                 user: user_object).create_all
           expect(dependents.first).to include(
             participant_relationship_type_name: 'Spouse',
             family_relationship_type_name: 'Spouse',

--- a/spec/lib/bgs/vnp_veteran_spec.rb
+++ b/spec/lib/bgs/vnp_veteran_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe BGS::VnpVeteran do
         middle_nm: nil,
         last_nm: 'FORD',
         suffix_nm: nil,
-        brthdy_dt: '1809-02-12T00:00:00-05:00',
         birth_state_cd: nil,
         birth_city_nm: nil,
         file_nbr: '796043735',

--- a/spec/lib/bgs/vnp_veteran_spec.rb
+++ b/spec/lib/bgs/vnp_veteran_spec.rb
@@ -3,16 +3,6 @@
 require 'rails_helper'
 RSpec.describe BGS::VnpVeteran do
   let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
-  let(:user_hash) do
-    {
-      participant_id: user_object.participant_id,
-      ssn: user_object.ssn,
-      first_name: user_object.first_name,
-      last_name: user_object.last_name,
-      external_key: user_object.common_name || user_object.email,
-      icn: user_object.icn
-    }
-  end
   let(:all_flows_payload) { FactoryBot.build(:form_686c_674) }
   let(:formatted_payload) do
     {
@@ -42,7 +32,7 @@ RSpec.describe BGS::VnpVeteran do
     context 'married veteran' do
       it 'returns a VnpPersonAddressPhone object' do
         VCR.use_cassette('bgs/vnp_veteran/create') do
-          vnp_veteran = BGS::VnpVeteran.new(proc_id: '3828241', payload: all_flows_payload, user: user_hash).create
+          vnp_veteran = BGS::VnpVeteran.new(proc_id: '3828241', payload: all_flows_payload, user: user_object).create
 
           expect(vnp_veteran).to eq(
             vnp_participant_id: '149500',
@@ -72,11 +62,11 @@ RSpec.describe BGS::VnpVeteran do
         middle_nm: nil,
         last_nm: 'FORD',
         suffix_nm: nil,
-        brthdy_dt: nil,
+        brthdy_dt: '1809-02-12T00:00:00-05:00',
         birth_state_cd: nil,
         birth_city_nm: nil,
-        file_nbr: nil,
-        ssn_nbr: nil,
+        file_nbr: '796043735',
+        ssn_nbr: '796043735',
         death_dt: nil,
         ever_maried_ind: nil,
         vet_ind: 'Y',
@@ -102,18 +92,18 @@ RSpec.describe BGS::VnpVeteran do
       }
       VCR.use_cassette('bgs/vnp_veteran/create') do
         expect_any_instance_of(BGS::Service).to receive(:create_person)
-          .with(vet_person_hash)
+          .with(a_hash_including(vet_person_hash))
           .and_call_original
 
         expect_any_instance_of(BGS::Service).to receive(:create_phone)
-          .with(anything, anything, formatted_payload)
+          .with(anything, anything, a_hash_including(formatted_payload))
           .and_call_original
 
         expect_any_instance_of(BGS::Service).to receive(:create_address)
           .with(a_hash_including(expected_address))
           .and_call_original
 
-        BGS::VnpVeteran.new(proc_id: '12345', payload: all_flows_payload, user: user_hash).create
+        BGS::VnpVeteran.new(proc_id: '12345', payload: all_flows_payload, user: user_object).create
       end
     end
   end

--- a/spec/models/bgs_dependents/veteran_spec.rb
+++ b/spec/models/bgs_dependents/veteran_spec.rb
@@ -14,16 +14,7 @@ RSpec.describe BGSDependents::Veteran do
       file_number: '1234'
     }
   end
-  let(:user) do
-    {
-      participant_id: '600061742',
-      ssn: '796043735',
-      first_name: 'WESLEY',
-      last_name: 'FORD',
-      external_key: 'abraham.lincoln@vets.gov',
-      icn: '14512449011616630'
-    }
-  end
+  let(:user) { FactoryBot.create(:evss_user, :loa3) }
   let(:vet) { described_class.new('12345', user) }
   let(:formatted_params_result) do
     {


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This is an adjustment to support a passing in a user object in instead of a hash for the 686c form.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11260
