### PR TITLE
11585 add camel inflected schemas to disability compensation form

### DIFF
--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Disability compensation form', type: :request do
 
   let(:user) { build(:disabilities_compensation_user) }
   let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+  let(:headers_with_camel) { headers.merge('X-Key-Inflection' => 'camel') }
 
   before do
     sign_in_as(user)
@@ -19,6 +20,13 @@ RSpec.describe 'Disability compensation form', type: :request do
           get '/v0/disability_compensation_form/rated_disabilities', params: nil, headers: headers
           expect(response).to have_http_status(:ok)
           expect(response).to match_response_schema('rated_disabilities')
+        end
+      end
+      it 'matches the rated disabilities schema when camel-inflected' do
+        VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
+          get '/v0/disability_compensation_form/rated_disabilities', params: nil, headers: headers_with_camel
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_camelized_response_schema('rated_disabilities')
         end
       end
     end

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -117,7 +117,10 @@ RSpec.describe 'Disability compensation form', type: :request do
     end
 
     it 'returns matching conditions with camel-inflection', :aggregate_failures do
-      get '/v0/disability_compensation_form/suggested_conditions?name_part=art', params: nil, headers: headers_with_camel
+      get '/v0/disability_compensation_form/suggested_conditions?name_part=art',
+          params: nil,
+          headers: headers_with_camel
+
       expect(response).to have_http_status(:ok)
       expect(response).to match_camelized_response_schema('suggested_conditions')
       expect(conditions.count).to eq 3

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -165,6 +165,12 @@ RSpec.describe 'Disability compensation form', type: :request do
           expect(response).to match_response_schema('submit_disability_form')
         end
 
+        it 'matches the rated disabilites schema with camel-inflection' do
+          post '/v0/disability_compensation_form/submit_all_claim', params: all_claims_form, headers: headers_with_camel
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_camelized_response_schema('submit_disability_form')
+        end
+
         it 'starts the submit job' do
           expect(EVSS::DisabilityCompensationForm::SubmitForm526AllClaim).to receive(:perform_async).once
           post '/v0/disability_compensation_form/submit_all_claim', params: all_claims_form, headers: headers
@@ -178,6 +184,12 @@ RSpec.describe 'Disability compensation form', type: :request do
           post '/v0/disability_compensation_form/submit_all_claim', params: bdd_form, headers: headers
           expect(response).to have_http_status(:ok)
           expect(response).to match_response_schema('submit_disability_form')
+        end
+
+        it 'matches the rated disabilites schema with camel-inflection' do
+          post '/v0/disability_compensation_form/submit_all_claim', params: bdd_form, headers: headers_with_camel
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_camelized_response_schema('submit_disability_form')
         end
       end
     end

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe 'Disability compensation form', type: :request do
           expect(response).to match_response_schema('evss_errors', strict: false)
         end
       end
+      it 'returns a bad gateway response with camel-inflection' do
+        VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_500') do
+          get '/v0/disability_compensation_form/rated_disabilities', params: nil, headers: headers_with_camel
+          expect(response).to have_http_status(:bad_gateway)
+          expect(response).to match_camelized_response_schema('evss_errors', strict: false)
+        end
+      end
     end
 
     context 'with a 401 response' do

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe 'Disability compensation form', type: :request do
           expect(response).to match_response_schema('evss_errors', strict: false)
         end
       end
+      it 'returns a bad gateway response with camel-inflection' do
+        VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_401') do
+          get '/v0/disability_compensation_form/submit_all_claim', params: nil, headers: headers_with_camel
+          expect(response).to have_http_status(:not_found)
+          expect(response).to match_camelized_response_schema('evss_errors', strict: false)
+        end
+      end
     end
 
     context 'with a 403 unauthorized response' do
@@ -66,6 +73,13 @@ RSpec.describe 'Disability compensation form', type: :request do
           expect(response).to match_response_schema('evss_errors', strict: false)
         end
       end
+      it 'returns a not authorized response with camel-inflection' do
+        VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_403') do
+          get '/v0/disability_compensation_form/rated_disabilities', params: nil, headers: headers_with_camel
+          expect(response).to have_http_status(:forbidden)
+          expect(response).to match_camelized_response_schema('evss_errors', strict: false)
+        end
+      end
     end
 
     context 'with a generic 400 response' do
@@ -74,6 +88,13 @@ RSpec.describe 'Disability compensation form', type: :request do
           get '/v0/disability_compensation_form/rated_disabilities', params: nil, headers: headers
           expect(response).to have_http_status(:bad_request)
           expect(response).to match_response_schema('evss_errors', strict: false)
+        end
+      end
+      it 'returns a bad request response with camel-inflection' do
+        VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_400') do
+          get '/v0/disability_compensation_form/rated_disabilities', params: nil, headers: headers_with_camel
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_camelized_response_schema('evss_errors', strict: false)
         end
       end
     end

--- a/spec/request/disability_compensation_form_request_spec.rb
+++ b/spec/request/disability_compensation_form_request_spec.rb
@@ -116,6 +116,13 @@ RSpec.describe 'Disability compensation form', type: :request do
       expect(conditions.count).to eq 3
     end
 
+    it 'returns matching conditions with camel-inflection', :aggregate_failures do
+      get '/v0/disability_compensation_form/suggested_conditions?name_part=art', params: nil, headers: headers_with_camel
+      expect(response).to have_http_status(:ok)
+      expect(response).to match_camelized_response_schema('suggested_conditions')
+      expect(conditions.count).to eq 3
+    end
+
     it 'returns an empty array when no conditions match', :aggregate_failures do
       get '/v0/disability_compensation_form/suggested_conditions?name_part=xyz', params: nil, headers: headers
       expect(response).to have_http_status(:ok)

--- a/spec/support/schemas/rated_disability_base.json
+++ b/spec/support/schemas/rated_disability_base.json
@@ -3,7 +3,7 @@
   "required": [
     "decision_code",
     "decision_text",
-		"diagnostic_code",
+    "diagnostic_code",
     "name",
     "effective_date",
     "rated_disability_id",

--- a/spec/support/schemas_camelized/rated_disabilities.json
+++ b/spec/support/schemas_camelized/rated_disabilities.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "ratedDisabilities": {
+              "description": "Array of previously rated disabilities",
+              "items": {
+                "$ref": "rated_disability_base.json"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "required": [
+            "ratedDisabilities"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/rated_disability_base.json
+++ b/spec/support/schemas_camelized/rated_disability_base.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "required": [
+    "decisionCode",
+    "decisionText",
+    "diagnosticCode",
+    "name",
+    "effectiveDate",
+    "ratedDisabilityId",
+    "ratingDecisionId",
+    "ratingPercentage",
+    "relatedDisabilityDate",
+    "specialIssues"
+  ],
+  "properties": {
+    "decisionCode": {
+      "type": "string"
+    },
+    "decisionText": {
+      "type": "string"
+    },
+    "diagnosticCode": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "effectiveDate": {
+      "type": "datetime"
+    },
+    "ratedDisabilityId": {
+      "type": "string"
+    },
+    "ratingDecisionId": {
+      "type": "string"
+    },
+    "ratingPercentage": {
+      "type": "integer"
+    },
+    "relatedDisabilityDate": {
+      "type": "datetime"
+    },
+    "specialIssues": {
+      "type": "array"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/submit_disability_form.json
+++ b/spec/support/schemas_camelized/submit_disability_form.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "jobId": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "required": [
+            "jobId"
+          ]
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/suggested_conditions.json
+++ b/spec/support/schemas_camelized/suggested_conditions.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "properties": {
+              "code": {
+                "type": "integer"
+              },
+              "medicalTerm": {
+                "type": "string"
+              },
+              "layTerm": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        }
+      }
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## Description of change
Adding camelCase version of tests and schema for the disability compensation form request spec.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11585