### PR TITLE
11585 schema camelizer supports nested directories

### DIFF
--- a/lib/tasks/support/schema_camelizer.rb
+++ b/lib/tasks/support/schema_camelizer.rb
@@ -42,6 +42,7 @@ class SchemaCamelizer
   end
 
   # Getter for path to which new camel schema will be saved
+  # defaults to changing `path/to/schemas` to `path/to/schemas_camelized`
   #
   # @return [string] the path for saving the camel schema
   def camel_path
@@ -54,7 +55,7 @@ class SchemaCamelizer
   #
   # @return [array] files created
   def save!
-    raise 'expected to move from a schemas directory to a schemas_camelized directory!' if original_path == camel_path
+    raise "expected `#camel_path` (#{camel_path}) to be different from the given path" if original_path == camel_path
 
     File.open(camel_path, 'w') do |file|
       file.write(JSON.pretty_generate(camel_schema))

--- a/lib/tasks/support/schema_camelizer.rb
+++ b/lib/tasks/support/schema_camelizer.rb
@@ -57,6 +57,9 @@ class SchemaCamelizer
   def save!
     raise "expected `#camel_path` (#{camel_path}) to be different from the given path" if original_path == camel_path
 
+    camel_path_directories = camel_path.gsub(%r{[^\/]*$}, '')
+    FileUtils.mkdir_p(camel_path_directories)
+
     File.open(camel_path, 'w') do |file|
       file.write(JSON.pretty_generate(camel_schema))
       file.write("\n")

--- a/spec/lib/tasks/support/schema_camelizer_spec.rb
+++ b/spec/lib/tasks/support/schema_camelizer_spec.rb
@@ -146,7 +146,8 @@ describe SchemaCamelizer do
       File.open(schema_file_in_weird_location, 'w') { |file| file.write(JSON.pretty_generate(schema)) }
 
       subject = SchemaCamelizer.new(schema_file_in_weird_location)
-      exception_text = 'expected to move from a schemas directory to a schemas_camelized directory!'
+      exception_text = 'expected `#camel_path` (tmp/camel_schema_tests/bad_location.json) ' \
+                       'to be different from the given path'
       expect { subject.save! }.to raise_error(exception_text)
     end
   end

--- a/spec/lib/tasks/support/schema_camelizer_spec.rb
+++ b/spec/lib/tasks/support/schema_camelizer_spec.rb
@@ -136,6 +136,7 @@ describe SchemaCamelizer do
     it 'writes files to the disk' do
       subject = SchemaCamelizer.new(snake_key_file)
       result = subject.save!
+      expect(result.count).to be > 0
       result.each do |filename|
         expect(File.exist?(filename)).to be true
       end
@@ -149,6 +150,14 @@ describe SchemaCamelizer do
       exception_text = 'expected `#camel_path` (tmp/camel_schema_tests/bad_location.json) ' \
                        'to be different from the given path'
       expect { subject.save! }.to raise_error(exception_text)
+    end
+    it 'creates directories for camel_path output' do
+      subject = SchemaCamelizer.new(snake_key_file, "#{TEST_DIRECTORY}/new_directory/snake_in_camel.json")
+      result = subject.save!
+      expect(result.count).to be > 0
+      result.each do |filename|
+        expect(File.exist?(filename)).to be true
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
Some of the tests that use schema matchers refer to schemas in a directory nested under `spec/support/schemas` and this change is so the `SchemaCamelizer` supports those schema files.
Also cleaned up the error message around saving when the output path is not different.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11585