### PR TITLE
11585 add camel inflected schemas to full name and health records

### DIFF
--- a/spec/request/full_name_request_spec.rb
+++ b/spec/request/full_name_request_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe 'full_name', type: :request do
         expect(response).to have_http_status(:ok)
         expect(response).to match_response_schema('full_name_response')
       end
+
+      it 'matches the full name schema when camel-inflected' do
+        get '/v0/profile/full_name', headers: { 'X-Key-Inflection' => 'camel' }
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to match_camelized_response_schema('full_name_response')
+      end
     end
   end
 end

--- a/spec/request/health_records_request_spec.rb
+++ b/spec/request/health_records_request_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe 'health records', type: :request do
     }
   end
 
+  let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }
+
   context 'forbidden user' do
     let(:current_user) { build(:user) }
 
@@ -52,6 +54,16 @@ RSpec.describe 'health records', type: :request do
     expect(response).to match_response_schema('extract_statuses')
   end
 
+  it 'responds to GET #refresh when camel-inflected' do
+    VCR.use_cassette('bb_client/gets_a_list_of_extract_statuses') do
+      get '/v0/health_records/refresh', headers: inflection_header
+    end
+
+    expect(response).to be_successful
+    expect(response.body).to be_a(String)
+    expect(response).to match_camelized_response_schema('extract_statuses')
+  end
+
   it 'responds to GET #eligible_data_classes' do
     VCR.use_cassette('bb_client/gets_a_list_of_eligible_data_classes') do
       get '/v0/health_records/eligible_data_classes'
@@ -60,6 +72,16 @@ RSpec.describe 'health records', type: :request do
     expect(response).to be_successful
     expect(response.body).to be_a(String)
     expect(response).to match_response_schema('eligible_data_classes')
+  end
+
+  it 'responds to GET #eligible_data_classes when camel-inflected' do
+    VCR.use_cassette('bb_client/gets_a_list_of_eligible_data_classes') do
+      get '/v0/health_records/eligible_data_classes', headers: inflection_header
+    end
+
+    expect(response).to be_successful
+    expect(response.body).to be_a(String)
+    expect(response).to match_camelized_response_schema('eligible_data_classes')
   end
 
   it 'responds to POST #create to generate a new report' do

--- a/spec/support/schemas_camelized/eligible_data_classes.json
+++ b/spec/support/schemas_camelized/eligible_data_classes.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data",
+    "meta"
+  ],
+  "properties": {
+    "data": {
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "eligible_data_classes"
+          ]
+        },
+        "attributes": {
+          "type": "object",
+          "required": [
+            "dataClasses"
+          ],
+          "properties": {
+            "dataClasses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": [
+        "updatedAt",
+        "failedStationList"
+      ],
+      "properties": {
+        "updatedAt": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "failedStationList": {
+          "type": [
+            "string",
+            null
+          ]
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/extract_statuses.json
+++ b/spec/support/schemas_camelized/extract_statuses.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data",
+    "meta"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "extract_statuses"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "extractType",
+              "lastUpdated",
+              "status",
+              "createdOn",
+              "stationNumber"
+            ],
+            "properties": {
+              "extractType": {
+                "type": "string"
+              },
+              "lastUpdated": {
+                "type": [
+                  "string",
+                  null
+                ]
+              },
+              "status": {
+                "type": [
+                  "string",
+                  null
+                ]
+              },
+              "createdOn": {
+                "type": [
+                  "integer",
+                  null
+                ]
+              },
+              "stationNumber": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": [
+        "updatedAt",
+        "failedStationList"
+      ],
+      "properties": {
+        "updatedAt": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "failedStationList": {
+          "type": [
+            "string",
+            null
+          ]
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/full_name_response.json
+++ b/spec/support/schemas_camelized/full_name_response.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "properties": {
+        "attributes": {
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "middle": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "suffix": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## Description of change
CamelCase schema tests for two different specs, `/v0/health_records` and `/v0/profile/full_name`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11585
