### PR TITLE
Add failure mailer for 686 form submission

### DIFF
--- a/app/mailers/dependents_application_failure_mailer.rb
+++ b/app/mailers/dependents_application_failure_mailer.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class DependentsApplicationFailureMailer < ApplicationMailer
-  def build(user_hash)
+  def build(user)
     template = File.read('app/mailers/views/dependents_application_failure.erb')
 
     mail(
-      to: user_hash['email'],
+      to: user.email,
       subject: "We can't process your dependents application",
       body: ERB.new(template).result(binding)
     )

--- a/app/mailers/dependents_application_failure_mailer.rb
+++ b/app/mailers/dependents_application_failure_mailer.rb
@@ -6,7 +6,7 @@ class DependentsApplicationFailureMailer < ApplicationMailer
 
     mail(
       to: user.email,
-      subject: "We can't process your dependents application",
+      subject: t( 'dependency_claim_failuer_mailer.subject' ),
       body: ERB.new(template).result(binding)
     )
   end

--- a/app/mailers/dependents_application_failure_mailer.rb
+++ b/app/mailers/dependents_application_failure_mailer.rb
@@ -6,7 +6,7 @@ class DependentsApplicationFailureMailer < ApplicationMailer
 
     mail(
       to: user.email,
-      subject: t( 'dependency_claim_failuer_mailer.subject' ),
+      subject: t('dependency_claim_failuer_mailer.subject'),
       body: ERB.new(template).result(binding)
     )
   end

--- a/app/mailers/views/dependents_application_failure.erb
+++ b/app/mailers/views/dependents_application_failure.erb
@@ -5,12 +5,6 @@
   </head>
   <body>
     <p>Dear <%= user.first_name %> <%= user.last_name %></p>
-    <p>We're sorry. Something went wrong when we tried to submit your application to add or remove a dependent on your VA benefits (VA Forms 21-686c and 21-674).</p>
-    <p>Your online application didn’t go through because of a technical problem and we aren’t able to access your application. We're sorry for the extra work, but you’ll need to go back and apply again at https://www.va.gov/view-change-dependents/add-remove-form-686c/.</p>
-    <p>If you have general questions about adding or removing a dependent, you can call Veteran Benefits Assistance at 800-827-1000. We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.</p>
-    <p>Thank you for your service,</p>
-    <p>VA.gov</p>
-
-    <p><i>Note: This is an automated message sent from an unmonitored email account.</i></p>
+    <%= t( 'dependency_claim_failuer_mailer.body_html' ) %>
   </body>
 </html>

--- a/app/mailers/views/dependents_application_failure.erb
+++ b/app/mailers/views/dependents_application_failure.erb
@@ -4,13 +4,13 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
   </head>
   <body>
-    <p>Hello <%= user_hash['first_name'] %> <%= user_hash['last_name'] %></p>
-    <p>You recently submitted an application to add or remove dependents from your VA benefits (VA Form 28-686c/674) on
-      VA.gov. We’re sorry. Your application didn’t go through because of a technical problem on our end. You'll need to go
-      back and apply again: https://va.gov/view-change-dependents/add-remove-form-686c/.</p>
-    <p>Because of the issue, we won't be able to retrieve your application. If you have general questions about adding or
-      removing dependents, you can call our toll-free hotline at 800-827-1000. We’re here Monday through Friday, 8:00 am to
-      9:00 pm ET.</p>
+    <p>Dear <%= user.first_name %> <%= user.last_name %></p>
+    <p>We're sorry. Something went wrong when we tried to submit your application to add or remove a dependent on your VA benefits (VA Forms 21-686c and 21-674).</p>
+    <p>Your online application didn’t go through because of a technical problem and we aren’t able to access your application. We're sorry for the extra work, but you’ll need to go back and apply again at https://www.va.gov/view-change-dependents/add-remove-form-686c/.</p>
+    <p>If you have general questions about adding or removing a dependent, you can call Veteran Benefits Assistance at 800-827-1000. We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.</p>
+    <p>Thank you for your service,</p>
+    <p>VA.gov</p>
+
     <p><i>Note: This is an automated message sent from an unmonitored email account.</i></p>
   </body>
 </html>

--- a/app/workers/bgs/submit_form686c_job.rb
+++ b/app/workers/bgs/submit_form686c_job.rb
@@ -18,6 +18,8 @@ module BGS
       claim.add_veteran_info(vet_info)
 
       BGS::Form686c.new(user).submit(claim.parsed_form)
+    rescue
+      DependentsApplicationFailureMailer.build(user).deliver_now if user.present?
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,12 @@ en:
       invalid: PDF is not able to be opened. Try re-saving or re-uploading it.
     text:
       not_ascii: Cannot read file encoding. Text files must be ASCII encoded.
+  dependency_claim_failuer_mailer:
+    subject: We can't process your dependents application
+    body_html: >
+      <p>We're sorry. Something went wrong when we tried to submit your application to add or remove a dependent on your VA benefits (VA Forms 21-686c and 21-674).</p>
+      <p>Your online application didn’t go through because of a technical problem and we aren’t able to access your application. We're sorry for the extra work, but you’ll need to go back and apply again at https://www.va.gov/view-change-dependents/add-remove-form-686c/.</p>
+      <p>If you have general questions about adding or removing a dependent, you can call Veteran Benefits Assistance at 800-827-1000. We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.</p>
+      <p>Thank you for your service,</p>
+      <p>VA.gov</p>
+      <p><i>Note: This is an automated message sent from an unmonitored email account.</i></p>

--- a/spec/jobs/bgs/submit_form686c_job_spec.rb
+++ b/spec/jobs/bgs/submit_form686c_job_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BGS::SubmitForm686cJob, type: :job do
   context 'error' do
     it 'calls #submit for 686c submission' do
       client_stub = instance_double('BGS::Form686c')
-      mailer_double = instance_double('DependentsApplicationFailureMailer')
+      mailer_double = double('Mail::Message')
       allow(BGS::Form686c).to receive(:new).with(an_instance_of(User)) { client_stub }
       expect(client_stub).to receive(:submit).and_raise(StandardError)
 

--- a/spec/jobs/bgs/submit_form686c_job_spec.rb
+++ b/spec/jobs/bgs/submit_form686c_job_spec.rb
@@ -26,4 +26,18 @@ RSpec.describe BGS::SubmitForm686cJob, type: :job do
 
     described_class.new.perform(user.uuid, dependency_claim.id, vet_info)
   end
+
+  context 'error' do
+    it 'calls #submit for 686c submission' do
+      client_stub = instance_double('BGS::Form686c')
+      mailer_double = instance_double('DependentsApplicationFailureMailer')
+      allow(BGS::Form686c).to receive(:new).with(an_instance_of(User)) { client_stub }
+      expect(client_stub).to receive(:submit).and_raise(StandardError)
+
+      allow(mailer_double).to receive(:deliver_now)
+      expect(DependentsApplicationFailureMailer).to receive(:build).with(an_instance_of(User)) { mailer_double }
+
+      described_class.new.perform(user.uuid, dependency_claim.id, vet_info)
+    end
+  end
 end

--- a/spec/mailers/dependents_application_failure_mailer_spec.rb
+++ b/spec/mailers/dependents_application_failure_mailer_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-include ActionView::Helpers::TranslationHelper
 
 RSpec.describe DependentsApplicationFailureMailer, type: [:mailer] do
+  include ActionView::Helpers::TranslationHelper
   let(:user) { FactoryBot.create(:evss_user, :loa3) }
 
   describe '#build' do
     it 'includes all info' do
       mailer = described_class.build(user).deliver_now
 
-      expect(mailer.subject).to eq( t( 'dependency_claim_failuer_mailer.subject' ) )
+      expect(mailer.subject).to eq(t('dependency_claim_failuer_mailer.subject'))
       expect(mailer.to).to eq([user.email])
       expect(mailer.body.raw_source).to include(
         "Dear #{user.first_name} #{user.last_name}",

--- a/spec/mailers/dependents_application_failure_mailer_spec.rb
+++ b/spec/mailers/dependents_application_failure_mailer_spec.rb
@@ -3,28 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe DependentsApplicationFailureMailer, type: [:mailer] do
-  let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
-  let(:user_hash) do
-    {
-      'participant_id' => user_object.participant_id,
-      'ssn' => user_object.ssn,
-      'first_name' => user_object.first_name,
-      'last_name' => user_object.last_name,
-      'email' => user_object.email,
-      'external_key' => user_object.common_name || user_object.email,
-      'icn' => user_object.icn
-    }
-  end
+  let(:user) { FactoryBot.create(:evss_user, :loa3) }
 
   describe '#build' do
     it 'includes all info' do
-      mailer = described_class.build(user_hash).deliver_now
+      mailer = described_class.build(user).deliver_now
 
       expect(mailer.subject).to eq("We can't process your dependents application")
-      expect(mailer.to).to eq([user_object.email])
+      expect(mailer.to).to eq([user.email])
       expect(mailer.body.raw_source).to include(
-        "Hello #{user_object.first_name} #{user_object.last_name}",
-        'You recently submitted an application to add or remove dependents from your VA benefits (VA Form 28-686c/674)'
+        "Dear #{user.first_name} #{user.last_name}",
+        "We're sorry. Something went wrong when we tried to submit your application to add or remove a dependent"
       )
     end
   end

--- a/spec/mailers/dependents_application_failure_mailer_spec.rb
+++ b/spec/mailers/dependents_application_failure_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+include ActionView::Helpers::TranslationHelper
 
 RSpec.describe DependentsApplicationFailureMailer, type: [:mailer] do
   let(:user) { FactoryBot.create(:evss_user, :loa3) }
@@ -9,7 +10,7 @@ RSpec.describe DependentsApplicationFailureMailer, type: [:mailer] do
     it 'includes all info' do
       mailer = described_class.build(user).deliver_now
 
-      expect(mailer.subject).to eq("We can't process your dependents application")
+      expect(mailer.subject).to eq( t( 'dependency_claim_failuer_mailer.subject' ) )
       expect(mailer.to).to eq([user.email])
       expect(mailer.body.raw_source).to include(
         "Dear #{user.first_name} #{user.last_name}",


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
The 686 form runs many calls to BGS in order to complete its objective of adding dependents to a veteran's benefits. We would like to inform the Veteran that their submission failed. We run retries in almost every call. We then raise an exception if all retries are exhausted.

The goal of this PR is to capture exceptions that have occured during the submission process (in the /lib/bgs directory) and fire a mailer informing the veteran that they need to either revisit the form or get in touch w/ someone at the VA to resolve their issue.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12265

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
