### PR TITLE
use the camelCase schemas for v0/profile/primary_phone

### DIFF
--- a/spec/request/primary_phone_request_spec.rb
+++ b/spec/request/primary_phone_request_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'primary phone', type: :request do
   include SchemaMatchers
 
   let(:headers) { { 'Content-Type' => 'application/json', 'Accept' => 'application/json' } }
+  let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }
+  let(:headers_with_camel) { headers.merge(inflection_header) }
 
   before { sign_in }
 
@@ -19,6 +21,15 @@ RSpec.describe 'primary phone', type: :request do
           expect(response).to match_response_schema('phone_number_response')
         end
       end
+
+      it 'matches the primary phone schema when camel-inflected', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/primary_phone') do
+          get '/v0/profile/primary_phone', headers: inflection_header
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_camelized_response_schema('phone_number_response')
+        end
+      end
     end
 
     context 'with a 400 response' do
@@ -28,6 +39,15 @@ RSpec.describe 'primary phone', type: :request do
 
           expect(response).to have_http_status(:bad_request)
           expect(response).to match_response_schema('errors')
+        end
+      end
+
+      it 'matches the errors schema when camel-inflected', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/primary_phone_status_400') do
+          get '/v0/profile/primary_phone', headers: inflection_header
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_camelized_response_schema('errors')
         end
       end
     end
@@ -51,6 +71,15 @@ RSpec.describe 'primary phone', type: :request do
           expect(response).to match_response_schema('errors')
         end
       end
+
+      it 'matches the errors schema when camel-inflected', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/primary_phone_status_500') do
+          get '/v0/profile/primary_phone', headers: inflection_header
+
+          expect(response).to have_http_status(:bad_gateway)
+          expect(response).to match_camelized_response_schema('errors')
+        end
+      end
     end
   end
 
@@ -66,6 +95,15 @@ RSpec.describe 'primary phone', type: :request do
           expect(response).to match_response_schema('phone_number_response')
         end
       end
+
+      it 'matches the primary phone schema when camel-inflected', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/post_primary_phone') do
+          post('/v0/profile/primary_phone', params: phone.to_json, headers: headers_with_camel)
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to match_camelized_response_schema('phone_number_response')
+        end
+      end
     end
 
     context 'with a missing phone number' do
@@ -76,6 +114,16 @@ RSpec.describe 'primary phone', type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to match_response_schema('errors')
+        expect(errors_for(response)).to include "number - can't be blank", 'number - Only numbers are permitted.'
+      end
+
+      it 'matches the errors schema when camel-inflected', :aggregate_failures do
+        phone = build :phone_number, :nil_effective_date, number: ''
+
+        post('/v0/profile/primary_phone', params: phone.to_json, headers: headers_with_camel)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_camelized_response_schema('errors')
         expect(errors_for(response)).to include "number - can't be blank", 'number - Only numbers are permitted.'
       end
     end
@@ -90,6 +138,16 @@ RSpec.describe 'primary phone', type: :request do
         expect(response).to match_response_schema('errors')
         expect(errors_for(response)).to include 'number - Only numbers are permitted.'
       end
+
+      it 'matches the errors schema with camel-inflection', :aggregate_failures do
+        phone = build :phone_number, :nil_effective_date, number: '123-456-7890'
+
+        post('/v0/profile/primary_phone', params: phone.to_json, headers: headers_with_camel)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to match_camelized_response_schema('errors')
+        expect(errors_for(response)).to include 'number - Only numbers are permitted.'
+      end
     end
 
     context 'with a 400 response' do
@@ -99,6 +157,15 @@ RSpec.describe 'primary phone', type: :request do
 
           expect(response).to have_http_status(:bad_request)
           expect(response).to match_response_schema('errors')
+        end
+      end
+
+      it 'matches the errors schema when camel-inflected', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/post_primary_phone_status_400') do
+          post('/v0/profile/primary_phone', params: phone.to_json, headers: headers_with_camel)
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response).to match_camelized_response_schema('errors')
         end
       end
     end
@@ -120,6 +187,15 @@ RSpec.describe 'primary phone', type: :request do
 
           expect(response).to have_http_status(:bad_gateway)
           expect(response).to match_response_schema('errors')
+        end
+      end
+
+      it 'matches the errors schema when camel-inflected', :aggregate_failures do
+        VCR.use_cassette('evss/pciu/post_primary_phone_status_500') do
+          post('/v0/profile/primary_phone', params: phone.to_json, headers: headers_with_camel)
+
+          expect(response).to have_http_status(:bad_gateway)
+          expect(response).to match_camelized_response_schema('errors')
         end
       end
     end


### PR DESCRIPTION
## Description of change
camelCase schemas used in tests for primary phone

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11585

## Things to know about this PR
this spec used already camelCase'd schemas
