### PR TITLE
add more graceful handling of 526 error

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
@@ -73,7 +73,7 @@ module ClaimsApi
 
     def unprocessable_response
       {
-        errors: [{detail: 'An unknown error occurred. Please retry the request'}]
+        errors: [{ detail: 'An unknown error occurred. Please retry the request' }]
       }.to_json
     end
   end

--- a/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
@@ -73,15 +73,7 @@ module ClaimsApi
 
     def unprocessable_response
       {
-        data: {
-          type: 'claims_api_526_upload_error',
-          errors: [{
-            title: 'ClaimsAPI upload error',
-            detail: 'An unknown error occurred. Please retry the request',
-            code: '422',
-            status: '422'
-          }]
-        }
+        errors: [{detail: 'An unknown error occurred. Please retry the request'}]
       }.to_json
     end
   end

--- a/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
@@ -13,6 +13,8 @@ module ClaimsApi
       ClaimsApi::ClaimUploader.perform_async(pending_claim.id)
 
       render json: pending_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
+    rescue
+      render json: unprocessable_response, status: :unprocessable_entity
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -67,6 +69,20 @@ module ClaimsApi
         key = error['key']&.gsub(/\[(.*?)\]/, '')
         StatsD.increment STATSD_VALIDATION_FAIL_TYPE_KEY, tags: ["key: #{key}"]
       end
+    end
+
+    def unprocessable_response
+      {
+        data: {
+          type: 'claims_api_526_upload_error',
+          errors: [{
+            title: 'ClaimsAPI upload error',
+            detail: 'An unknown error occurred. Please retry the request',
+            code: '422',
+            status: '422'
+          }]
+        }
+      }.to_json
     end
   end
 end

--- a/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
@@ -213,6 +213,12 @@ RSpec.describe 'Disability Claims ', type: :request do
       expect(auto_claim.file_data).to be_truthy
     end
 
+    it 'responds with a 422 when unknown error' do
+      expect(ClaimsApi::ClaimUploader).to receive(:perform_async).and_raise(Common::Exceptions::UnprocessableEntity)
+      put "/services/claims/v0/forms/526/#{auto_claim.id}", params: binary_params, headers: headers
+      expect(response.status).to eq(422)
+    end
+
     it 'upload 526 base64 form through PUT' do
       allow_any_instance_of(ClaimsApi::SupportingDocumentUploader).to receive(:store!)
       put "/services/claims/v0/forms/526/#{auto_claim.id}", params: base64_params, headers: headers


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR makes a more graceful handling of unknown issues during the claims api 526 upload endpoint
