### PR TITLE
11585 add camel inflected schemas to preneeds

### DIFF
--- a/spec/request/preneeds/attachment_types_request_spec.rb
+++ b/spec/request/preneeds/attachment_types_request_spec.rb
@@ -14,4 +14,14 @@ RSpec.describe 'Preneeds Attachment Types Integration', type: :request do
     expect(response.body).to be_a(String)
     expect(response).to match_response_schema('preneeds/attachment_types')
   end
+
+  it 'responds to GET #index when camel-inlfected' do
+    VCR.use_cassette('preneeds/attachment_types/gets_a_list_of_attachment_types') do
+      get '/v0/preneeds/attachment_types/', headers: { 'X-Key-Inflection' => 'camel' }
+    end
+
+    expect(response).to be_successful
+    expect(response.body).to be_a(String)
+    expect(response).to match_camelized_response_schema('preneeds/attachment_types')
+  end
 end

--- a/spec/request/preneeds/branches_of_service_request_spec.rb
+++ b/spec/request/preneeds/branches_of_service_request_spec.rb
@@ -14,4 +14,14 @@ RSpec.describe 'Branches of Service Integration', type: :request do
     expect(response.body).to be_a(String)
     expect(response).to match_response_schema('preneeds/branches_of_service')
   end
+
+  it 'responds to GET #index when camel-inflected' do
+    VCR.use_cassette('preneeds/branches_of_service/gets_a_list_of_service_branches') do
+      get '/v0/preneeds/branches_of_service/', headers: { 'X-Key-Inflection' => 'camel' }
+    end
+
+    expect(response).to be_successful
+    expect(response.body).to be_a(String)
+    expect(response).to match_camelized_response_schema('preneeds/branches_of_service')
+  end
 end

--- a/spec/request/preneeds/burial_forms_request_spec.rb
+++ b/spec/request/preneeds/burial_forms_request_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe 'Preneeds Burial Form Integration', type: :request do
     { application: attributes_for(:burial_form) }
   end
 
-  def post_burial_forms
-    post '/v0/preneeds/burial_forms', params: params.to_json, headers: { 'CONTENT_TYPE' => 'application/json' }
+  def post_burial_forms(additional_headers = {})
+    post '/v0/preneeds/burial_forms',
+         params: params.to_json,
+         headers: { 'CONTENT_TYPE' => 'application/json' }.merge(additional_headers)
   end
 
   context 'with valid input' do
@@ -22,6 +24,16 @@ RSpec.describe 'Preneeds Burial Form Integration', type: :request do
       expect(response).to be_successful
       expect(response.body).to be_a(String)
       expect(response).to match_response_schema('preneeds/receive_applications')
+    end
+
+    it 'responds to POST #create when camel-inflected' do
+      VCR.use_cassette('preneeds/burial_forms/creates_a_pre_need_burial_form') do
+        post_burial_forms({ 'X-Key-Inflection' => 'camel' })
+      end
+
+      expect(response).to be_successful
+      expect(response.body).to be_a(String)
+      expect(response).to match_camelized_response_schema('preneeds/receive_applications')
     end
   end
 

--- a/spec/request/preneeds/cemeteries_request_spec.rb
+++ b/spec/request/preneeds/cemeteries_request_spec.rb
@@ -14,4 +14,14 @@ RSpec.describe 'Cemeteries Integration', type: :request do
     expect(response.body).to be_a(String)
     expect(response).to match_response_schema('preneeds/cemeteries')
   end
+
+  it 'responds to GET #index when camel-inflected' do
+    VCR.use_cassette('preneeds/cemeteries/gets_a_list_of_cemeteries') do
+      get '/v0/preneeds/cemeteries/', headers: { 'X-Key-Inflection' => 'camel' }
+    end
+
+    expect(response).to be_successful
+    expect(response.body).to be_a(String)
+    expect(response).to match_camelized_response_schema('preneeds/cemeteries')
+  end
 end

--- a/spec/request/preneeds/discharge_types_request_spec.rb
+++ b/spec/request/preneeds/discharge_types_request_spec.rb
@@ -14,4 +14,14 @@ RSpec.describe 'Discharge Types Integration', type: :request do
     expect(response.body).to be_a(String)
     expect(response).to match_response_schema('preneeds/discharge_types')
   end
+
+  it 'responds to GET #index when camel-inflected' do
+    VCR.use_cassette('preneeds/discharge_types/gets_a_list_of_discharge_types') do
+      get '/v0/preneeds/discharge_types/', headers: { 'X-Key-Inflection' => 'camel' }
+    end
+
+    expect(response).to be_successful
+    expect(response.body).to be_a(String)
+    expect(response).to match_camelized_response_schema('preneeds/discharge_types')
+  end
 end

--- a/spec/request/preneeds/military_ranks_request_spec.rb
+++ b/spec/request/preneeds/military_ranks_request_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe 'Military Ranks Integration', type: :request do
       expect(response.body).to be_a(String)
       expect(response).to match_response_schema('preneeds/military_ranks')
     end
+
+    it 'responds to GET #index when camel-inflected' do
+      VCR.use_cassette('preneeds/military_ranks/gets_a_list_of_military_ranks') do
+        get '/v0/preneeds/military_ranks', params: params, headers: { 'X-Key-Inflection' => 'camel' }
+      end
+
+      expect(response).to be_successful
+      expect(response.body).to be_a(String)
+      expect(response).to match_camelized_response_schema('preneeds/military_ranks')
+    end
   end
 
   context 'with missing parameters' do

--- a/spec/request/preneeds/states_request_spec.rb
+++ b/spec/request/preneeds/states_request_spec.rb
@@ -14,4 +14,14 @@ RSpec.describe 'Preneeds States Integration', type: :request do
     expect(response.body).to be_a(String)
     expect(response).to match_response_schema('preneeds/states')
   end
+
+  it 'responds to GET #index when camel-inflected' do
+    VCR.use_cassette('preneeds/states/gets_a_list_of_states') do
+      get '/v0/preneeds/states/', headers: { 'X-Key-Inflection' => 'camel' }
+    end
+
+    expect(response).to be_successful
+    expect(response.body).to be_a(String)
+    expect(response).to match_camelized_response_schema('preneeds/states')
+  end
 end

--- a/spec/support/schemas_camelized/preneeds/attachment_types.json
+++ b/spec/support/schemas_camelized/preneeds/attachment_types.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "preneeds_attachment_types"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "attachmentTypeId",
+              "description"
+            ],
+            "properties": {
+              "attachmentTypeId": {
+                "type": "integer"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/preneeds/branches_of_service.json
+++ b/spec/support/schemas_camelized/preneeds/branches_of_service.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "preneeds_branches_of_services"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "branchesOfServiceId",
+              "beginDate",
+              "code",
+              "endDate",
+              "flatFullDescr",
+              "fullDescr",
+              "shortDescr",
+              "stateRequired",
+              "uprightFullDescr"
+            ],
+            "properties": {
+              "branchesOfServiceId": {
+                "type": "string"
+              },
+              "beginDate": {
+                "type": "string"
+              },
+              "code": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "flatFullDescr": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "fullDescr": {
+                "type": "string"
+              },
+              "shortDescr": {
+                "type": "string"
+              },
+              "stateRequired": {
+                "type": "string"
+              },
+              "uprightFullDescr": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/preneeds/cemeteries.json
+++ b/spec/support/schemas_camelized/preneeds/cemeteries.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "preneeds_cemeteries"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "cemeteryId",
+              "name",
+              "cemeteryType",
+              "num"
+            ],
+            "properties": {
+              "cemeteryId": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "cemeteryType": {
+                "type": "string"
+              },
+              "num": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/preneeds/discharge_types.json
+++ b/spec/support/schemas_camelized/preneeds/discharge_types.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "preneeds_discharge_types"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "dischargeTypeId",
+              "description"
+            ],
+            "properties": {
+              "dischargeTypeId": {
+                "type": "integer"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/preneeds/military_ranks.json
+++ b/spec/support/schemas_camelized/preneeds/military_ranks.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "preneeds_military_ranks"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "branchOfServiceCd",
+              "militaryRankDetail"
+            ],
+            "properties": {
+              "branchOfServiceCd": {
+                "type": "string"
+              },
+              "activatedOneDate": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "activatedTwoDate": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "activatedThreeDate": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "deactivatedOneDate": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "deactivatedTwoDate": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "deactivatedThreeDate": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "militaryRankDetail": {
+                "type": "object",
+                "required": [
+                  "branchOfServiceCode",
+                  "rankCode",
+                  "rankDescr"
+                ],
+                "properties": {
+                  "branchOfServiceCode": {
+                    "type": "string"
+                  },
+                  "rankCode": {
+                    "type": "string"
+                  },
+                  "rankDescr": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/preneeds/receive_applications.json
+++ b/spec/support/schemas_camelized/preneeds/receive_applications.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "preneeds_receive_applications"
+          ]
+        },
+        "attributes": {
+          "type": "object",
+          "required": [
+            "receiveApplicationId",
+            "trackingNumber",
+            "returnCode",
+            "applicationUuid",
+            "returnDescription",
+            "submittedAt"
+          ],
+          "properties": {
+            "submittedAt": {
+              "type": "string"
+            },
+            "receiveApplicationId": {
+              "type": "string"
+            },
+            "trackingNumber": {
+              "type": "string"
+            },
+            "returnCode": {
+              "type": "integer"
+            },
+            "applicationUuid": {
+              "type": "string"
+            },
+            "returnDescription": {
+              "type": "return_description"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/preneeds/states.json
+++ b/spec/support/schemas_camelized/preneeds/states.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "preneeds_states"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "preneedsStateId",
+              "code",
+              "firstFiveZip",
+              "lastFiveZip",
+              "lowerIndicator",
+              "name"
+            ],
+            "properties": {
+              "preneedsStateId": {
+                "type": "string"
+              },
+              "code": {
+                "type": "string"
+              },
+              "firstFiveZip": {
+                "type": "string"
+              },
+              "lastFiveZip": {
+                "type": "string"
+              },
+              "lowerIndicator": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description of change
Adding camelCase schemas for all the /v0/preneeds tests:
camelCase schema test for /v0/preneeds/attachment_types
camelCase schema test for /v0/preneeds/branches_of_service
camelCase schema test for /v0/preneeds/burial_forms
camelCase schema test for /v0/preneeds/cemeteries
camelCase schema test for /v0/preneeds/discharge_types
camelCase schema test for /v0/preneeds/military_ranks
camelCase schema test for /v0/preneeds/states

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11585
