### PR TITLE
Covid research

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'websocket-extensions', '>= 0.1.5'
 # Modules
 gem 'appeals_api', path: 'modules/appeals_api'
 gem 'claims_api', path: 'modules/claims_api'
+gem 'covid_research', path: 'modules/covid_research'
 gem 'openid_auth', path: 'modules/openid_auth'
 gem 'va_facilities', path: 'modules/va_facilities'
 gem 'va_forms', path: 'modules/va_forms'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,13 @@ PATH
     claims_api (0.0.1)
 
 PATH
+  remote: modules/covid_research
+  specs:
+    covid_research (0.1.0)
+      rails (~> 6.0.3, >= 6.0.3.2)
+      sidekiq
+
+PATH
   remote: modules/openid_auth
   specs:
     openid_auth (0.0.1)
@@ -859,6 +866,7 @@ DEPENDENCIES
   combine_pdf
   config
   connect_vbms!
+  covid_research!
   danger
   database_cleaner
   date_validator

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -320,6 +320,7 @@ Rails.application.routes.draw do
   end
 
   mount VAOS::Engine, at: '/vaos'
+  mount CovidResearch::Engine, at: '/covid-research'
 
   if Rails.env.development? || Settings.sidekiq_admin_panel
     require 'sidekiq/web'

--- a/modules/covid_research/Gemfile
+++ b/modules/covid_research/Gemfile
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+# Declare your gem's dependencies in covid_research.gemspec.
+# Bundler will treat runtime dependencies like base dependencies, and
+# development dependencies will be added by default to the :development group.
+gemspec
+
+# Declare any dependencies that are still in development here instead of in
+# your gemspec. These might include edge Rails or gems from your path or
+# Git. Remember to move these dependencies to your gemspec before releasing
+# your gem to rubygems.org.
+
+# To use a debugger
+# gem 'byebug', group: [:development, :test]

--- a/modules/covid_research/app/controllers/covid_research/application_controller.rb
+++ b/modules/covid_research/app/controllers/covid_research/application_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CovidResearch
+  class ApplicationController < ActionController::API
+    # protect_from_forgery with: :exception
+  end
+end

--- a/modules/covid_research/app/controllers/covid_research/base_controller.rb
+++ b/modules/covid_research/app/controllers/covid_research/base_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Bypass authentication
+require_dependency 'covid_research/application_controller'
+
+module CovidResearch
+  class BaseController < ApplicationController
+    include Common::Client::Concerns::Monitoring
+    include SentryLogging
+
+    STATSD_KEY_PREFIX = 'api.covid_research'
+
+    private
+
+    def payload
+      JSON.parse(request.body.string) # Ditch :format, :controller and friends
+    end
+  end
+end

--- a/modules/covid_research/app/controllers/covid_research/volunteer/submissions_controller.rb
+++ b/modules/covid_research/app/controllers/covid_research/volunteer/submissions_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Bypass auth requirements
+require_dependency 'covid_research/base_controller'
+
+module CovidResearch
+  module Volunteer
+    class SubmissionsController < BaseController
+      STATSD_KEY_PREFIX = STATSD_KEY_PREFIX + '.volunteer'
+
+      def create
+        with_monitoring do
+          form_service = FormService.new
+
+          if form_service.valid?(payload)
+            render json: { status: 'accepted' }, status: :accepted
+          else
+            StatsD.increment(STATSD_KEY_PREFIX + '.create.fail')
+
+            error = {
+              errors: form_service.submission_errors(payload)
+            }
+            render json: error, status: 422
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/covid_research/app/jobs/covid_research/application_job.rb
+++ b/modules/covid_research/app/jobs/covid_research/application_job.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module CovidResearch
+  class ApplicationJob < ActiveJob::Base
+  end
+end

--- a/modules/covid_research/app/mailers/covid_research/application_mailer.rb
+++ b/modules/covid_research/app/mailers/covid_research/application_mailer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module CovidResearch
+  class ApplicationMailer < ActionMailer::Base
+    default from: 'from@example.com'
+    layout 'mailer'
+  end
+end

--- a/modules/covid_research/app/models/covid_research/application_record.rb
+++ b/modules/covid_research/app/models/covid_research/application_record.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CovidResearch
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/modules/covid_research/app/services/covid_research/volunteer/form_service.rb
+++ b/modules/covid_research/app/services/covid_research/volunteer/form_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'json_schemer'
+require 'vets_json_schema'
+
+module CovidResearch
+  module Volunteer
+    class FormService
+      SCHEMA = 'COVID-VACCINE-TRIAL'
+      delegate :valid?, to: :schema
+
+      def valid!(json)
+        raise SchemaValidationError, submission_errors(json) unless valid?(json)
+
+        valid?(json)
+      end
+
+      def submission_errors(json)
+        schema.validate(json).map do |e|
+          if e['data_pointer'].blank?
+            {
+              detail: e['details']
+            }
+          else
+            {
+              source: {
+                pointer: e['data_pointer']
+              }
+            }
+          end
+        end
+      end
+
+      private
+
+      def schema
+        @schema ||= JSONSchemer.schema(schema_data)
+      end
+
+      def schema_data
+        VetsJsonSchema::SCHEMAS[SCHEMA]
+      end
+
+      class SchemaValidationError < StandardError
+        attr_reader :errors
+
+        def initialize(errors)
+          @errors = errors
+        end
+      end
+    end
+  end
+end

--- a/modules/covid_research/bin/rails
+++ b/modules/covid_research/bin/rails
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/covid_research/engine', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails'
+# Pick the frameworks you want:
+require 'active_model/railtie'
+require 'active_job/railtie'
+require 'active_record/railtie'
+require 'active_storage/engine'
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
+require 'action_view/railtie'
+require 'action_cable/engine'
+require 'sprockets/railtie'
+# require 'rails/test_unit/railtie'
+require 'rails/engine/commands'

--- a/modules/covid_research/config/routes.rb
+++ b/modules/covid_research/config/routes.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 CovidResearch::Engine.routes.draw do
+  namespace :volunteer, defaults: { format: :json } do
+    post 'create', to: 'submissions#create'
+  end
 end

--- a/modules/covid_research/config/routes.rb
+++ b/modules/covid_research/config/routes.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+CovidResearch::Engine.routes.draw do
+end

--- a/modules/covid_research/covid_research.gemspec
+++ b/modules/covid_research/covid_research.gemspec
@@ -1,0 +1,25 @@
+$:.push File.expand_path('lib', __dir__)
+
+# Maintain your gem's version:
+require 'covid_research/version'
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |spec|
+  spec.name        = 'covid_research'
+  spec.version     = CovidResearch::VERSION
+  spec.authors     = ['LeakyBucket']
+  spec.email       = ['Lawrence.Holcomb@va.gov']
+  spec.homepage    = 'https://api.va.gov'
+  spec.summary     = 'CovidResearch API'
+  spec.description = 'This exists to support the intake of COVID Research volunteers'
+  spec.license     = 'MIT'
+
+  spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
+  spec.test_files = Dir['spec/**/*']
+
+  spec.add_dependency 'rails', '~> 6.0.3', '>= 6.0.3.2'
+  spec.add_dependency 'sidekiq'
+
+  spec.add_development_dependency 'pg'
+  spec.add_development_dependency 'rspec-rails'
+end

--- a/modules/covid_research/lib/covid_research.rb
+++ b/modules/covid_research/lib/covid_research.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'covid_research/engine'
+
+module CovidResearch
+  # Your code goes here...
+end

--- a/modules/covid_research/lib/covid_research/engine.rb
+++ b/modules/covid_research/lib/covid_research/engine.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module CovidResearch
+  class Engine < ::Rails::Engine
+    isolate_namespace CovidResearch
+    config.generators.api_only = true
+  end
+end

--- a/modules/covid_research/lib/covid_research/version.rb
+++ b/modules/covid_research/lib/covid_research/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module CovidResearch
+  VERSION = '0.1.0'
+end

--- a/modules/covid_research/lib/tasks/covid_research_tasks.rake
+++ b/modules/covid_research/lib/tasks/covid_research_tasks.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# desc "Explaining what the task does"
+# task :covid_research do
+#   # Task goes here
+# end

--- a/modules/covid_research/spec/covid_research_spec_helper.rb
+++ b/modules/covid_research/spec/covid_research_spec_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CovidResearchSpecHelper
+  def read_fixture(file_name)
+    path = File.expand_path('fixtures/files', __dir__)
+
+    File.read(File.join(path, file_name))
+  end
+end

--- a/modules/covid_research/spec/fixtures/files/no-name-submission.json
+++ b/modules/covid_research/spec/fixtures/files/no-name-submission.json
@@ -1,0 +1,65 @@
+{
+  "residentsInHome": "THREE_FIVE",
+  "healthHistory": {
+    "ALLERGY_VACCINE": false,
+    "AUTOIMMUNE_DISEASE": false,
+    "CANCER": true,
+    "DIABETES": true,
+    "HEART_DISEASE": true,
+    "HIGH_BLOOD_PRESSURE": false,
+    "IMMUNOCOMPROMISED": false,
+    "KIDNEY_LIVER_DISEASE": true,
+    "LUNG_DISEASE": false,
+    "STROKE": false,
+    "ANOTHER_SERIOUS_CHRONIC_ILLNESS": false
+  },
+  "diagnosed": true,
+  "closeContactPositive": "NO",
+  "hospitalized": false,
+  "smokeOrVape": false,
+  "employmentStatus": {
+    "EMPLOYED_HOME": true,
+    "EMPLOYED_OUTSIDE_OF_HOME": false,
+    "FRONTLINE_WORKER": true,
+    "FURLOUGHED_UNEMPLOYED": false,
+    "RETIRED": true,
+    "STUDENT": true,
+    "NONE_OF_ABOVE": false
+  },
+  "transportation": {
+    "CAR": true,
+    "FREQUENT_AIR_TRAVEL": false,
+    "PUBLIC_TRANSPORT": true,
+    "WALK_BIKE": false,
+    "WORK_FROM_HOME": true,
+    "NONE_OF_ABOVE": false
+  },
+  "closeContact": "ZERO",
+  "zipCode": "52787",
+  "height": {
+    "heightFeet": "SEVEN",
+    "heightInches": "SEVEN"
+  },
+  "weight": "ABCDEFGHIJKLMNOP",
+  "gender": {
+    "FEMALE": true,
+    "MALE": false,
+    "TRANSGENDER_FEMALE": false,
+    "TRANSGENDER_MALE": false,
+    "GENDER_VARIANT": false,
+    "SELF_IDENTIFY": false,
+    "PREFER_NO_ANSWER": true
+  },
+  "raceEthnicityOrigin": {
+    "AMERICAN_INDIAN_ALASKA_NATIVE": false,
+    "ASIAN": true,
+    "BLACK_AFRICAN_AMERICAN": true,
+    "HISPANIC_LATINO_SPANISH_ORIGIN": false,
+    "HAWAIIAN_PACIFIC_ISLANDER": false,
+    "WHITE": false,
+    "OTHER_RACE_ETHNICITY": false,
+    "PREFER_NO_ANSWER": false
+  },
+  "email": "test@example.com",
+  "date": "1980-11-19"
+}

--- a/modules/covid_research/spec/fixtures/files/valid-submission.json
+++ b/modules/covid_research/spec/fixtures/files/valid-submission.json
@@ -1,0 +1,32 @@
+{
+	"diagnosed": false,
+	"closeContactPositive": "NO",
+	"hospitalized": false,
+	"smokeOrVape": false,
+	"healthHistory": {
+		"ANOTHER_SERIOUS_CHRONIC_ILLNESS": true
+	},
+	"employmentStatus": {
+		"STUDENT": true
+	},
+	"transportation": {
+		"WALK_BIKE": true
+	},
+	"residentsInHome": "ONE_TWO",
+	"closeContact": "ONE_TEN",
+	"veteranFullName": {
+		"first": "sven",
+		"last": "Tester"
+	},
+	"email": "test@test.com",
+	"phone": "5554447788",
+	"zipCode": "33755",
+	"veteranDateOfBirth": "1970-10-07",
+	"weight": "150",
+	"gender": {
+		"MALE": true
+	},
+	"raceEthnicityOrigin": {
+		"WHITE": true
+	}
+}

--- a/modules/covid_research/spec/requests/volunteer_request_spec.rb
+++ b/modules/covid_research/spec/requests/volunteer_request_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../covid_research_spec_helper.rb'
+
+RSpec.configure do |c|
+  c.include CovidResearchSpecHelper
+end
+
+RSpec.describe 'covid research volunteer submissions', type: :request do
+  describe 'POST /covid-research/volunteer/create' do
+    let(:valid)   { read_fixture('valid-submission.json') }
+    let(:invalid) { read_fixture('no-name-submission.json') }
+
+    it 'validates the payload' do
+      expect_any_instance_of(CovidResearch::Volunteer::FormService).to receive(:valid?)
+
+      post '/covid-research/volunteer/create', params: valid
+    end
+
+    context 'metrics' do
+      it 'records a metric for each call' do
+        expect { post '/covid-research/volunteer/create', params: valid }.to trigger_statsd_increment(
+          'api.covid_research.volunteer.create.total', times: 1, value: 1
+        )
+      end
+
+      it 'records a metric on failure' do
+        expect { post '/covid-research/volunteer/create', params: invalid }.to trigger_statsd_increment(
+          'api.covid_research.volunteer.create.fail', times: 1, value: 1
+        )
+      end
+    end
+
+    context 'with a valid payload' do
+      it 'returns a 202' do
+        post '/covid-research/volunteer/create', params: valid
+
+        expect(response).to have_http_status(:accepted)
+      end
+    end
+
+    context 'with an invalid payload' do
+      it 'returns a description of the errors' do
+        post '/covid-research/volunteer/create', params: invalid
+
+        expect(JSON.parse(response.body)).to have_key('errors')
+      end
+
+      it 'returns a 422 status' do
+        post '/covid-research/volunteer/create', params: invalid
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/modules/covid_research/spec/services/volunteer/form_service_spec.rb
+++ b/modules/covid_research/spec/services/volunteer/form_service_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative '../../../app/services/covid_research/volunteer/form_service.rb'
+require_relative '../../covid_research_spec_helper.rb'
+
+RSpec.configure do |c|
+  c.include CovidResearchSpecHelper
+end
+
+RSpec.describe CovidResearch::Volunteer::FormService do
+  let(:valid)   { JSON.parse(read_fixture('valid-submission.json')) }
+  let(:invalid) { JSON.parse(read_fixture('no-name-submission.json')) }
+
+  context 'JSON Schema validation' do
+    describe '#valid?' do
+      it 'returns true if the JSON is valid' do
+        expect(subject.valid?(valid)).to be(true)
+      end
+
+      it 'returns false if the JSON is invalid' do
+        expect(subject.valid?(invalid)).to be(false)
+      end
+    end
+
+    describe '#valid!' do
+      it 'returns true if the JSON is valid' do
+        expect { subject.valid!(valid) }.not_to raise_exception
+        expect(subject.valid!(valid)).to be(true)
+      end
+
+      it 'raises an exception if the JSON is invalid' do
+        expect { subject.valid!(invalid) }.to raise_exception(described_class::SchemaValidationError)
+      end
+    end
+
+    describe '#submission_errors' do
+      it 'returns a list of error objects if the JSON is invalid' do
+        expect(subject.submission_errors(invalid)).not_to be_empty
+      end
+
+      it 'returns an empty list if they JSON is valid' do
+        expect(subject.submission_errors(valid)).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This change introduces a new module for the handling of COVID Research related data and business logic.  This initial PR adds a controller for receiving form submissions and logic to validate those against a `vets_json_schema` definition.

There are two significant bodies of logic here: the controller, and a small service class.  The controller has a single action, `create`, which accepts a `POST` with the `JSON` payload for a form submission.  The service currently validates the payload against the schema in `vets_json_schema`.  The controller then returns an _unprocessable_ or _accepted_ response.

It is worth noting that authentication is not required or desired for this specific form.  It is desired that the volunteer process be open to anyone.

The first iteration is only intended to return a success message if the form is valid and errors otherwise.  The next iterations will include data delivery (to `genISIS`) as well as an email notification of receipt.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12096

## Things to know about this PR
There are some basic Prometheus metrics being collected with this PR.  Total submissions and validation failures currently, this is expected to expand with the introduction of the back-end integration.

Is there anything special I need to do to strip PII from the logs (in the JSON body)?
