### PR TITLE
11585 add camel inflected schemas to claims api

### DIFF
--- a/modules/claims_api/spec/requests/v1/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/claims_request_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'EVSS Claims management', type: :request do
       'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00'
     }
   end
+  let(:camel_inflection_header) { { 'X-Key-Inflection' => 'camel' } }
+  let(:request_headers_camel) { request_headers.merge(camel_inflection_header) }
   let(:scopes) { %w[claim.read] }
 
   before do
@@ -31,6 +33,16 @@ RSpec.describe 'EVSS Claims management', type: :request do
         end
       end
     end
+
+    it 'lists all Claims when camel-inflection', run_at: 'Tue, 12 Dec 2017 03:09:06 GMT' do
+      with_okta_user(scopes) do |auth_header|
+        VCR.use_cassette('evss/claims/claims') do
+          get '/services/claims/v1/claims', params: nil, headers: request_headers_camel.merge(auth_header)
+          expect(response).to match_camelized_response_schema('claims_api/claims')
+        end
+      end
+    end
+
     context 'with errors' do
       it 'renders an empty array' do
         with_okta_user(scopes) do |auth_header|
@@ -53,6 +65,15 @@ RSpec.describe 'EVSS Claims management', type: :request do
       end
     end
 
+    it 'shows a single Claim when camel-inflected', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+      with_okta_user(scopes) do |auth_header|
+        VCR.use_cassette('evss/claims/claim') do
+          get '/services/claims/v1/claims/600118851', params: nil, headers: request_headers_camel.merge(auth_header)
+          expect(response).to match_camelized_response_schema('claims_api/claim')
+        end
+      end
+    end
+
     it 'shows a single Claim through auto established claims', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
       with_okta_user(scopes) do |auth_header|
         create(:auto_established_claim,
@@ -65,6 +86,23 @@ RSpec.describe 'EVSS Claims management', type: :request do
             params: nil, headers: request_headers.merge(auth_header)
           )
           expect(response).to match_response_schema('claims_api/claim')
+        end
+      end
+    end
+
+    it 'shows a single Claim through auto established claims when camel-inflected',
+       run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+      with_okta_user(scopes) do |auth_header|
+        create(:auto_established_claim,
+               auth_headers: { some: 'data' },
+               evss_id: 600_118_851,
+               id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
+        VCR.use_cassette('evss/claims/claim') do
+          get(
+            '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
+            params: nil, headers: request_headers_camel.merge(auth_header)
+          )
+          expect(response).to match_camelized_response_schema('claims_api/claim')
         end
       end
     end
@@ -145,7 +183,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
   end
 
   context 'with oauth user and no headers' do
-    it 'lists all Claims ', run_at: 'Tue, 12 Dec 2017 03:09:06 GMT' do
+    it 'lists all Claims', run_at: 'Tue, 12 Dec 2017 03:09:06 GMT' do
       with_okta_user(scopes) do |auth_header|
         verifier_stub = instance_double('EVSS::PowerOfAttorneyVerifier')
         allow(EVSS::PowerOfAttorneyVerifier).to receive(:new) { verifier_stub }
@@ -153,6 +191,18 @@ RSpec.describe 'EVSS Claims management', type: :request do
         VCR.use_cassette('evss/claims/claims') do
           get '/services/claims/v1/claims', params: nil, headers: auth_header
           expect(response).to match_response_schema('claims_api/claims')
+        end
+      end
+    end
+
+    it 'lists all Claims when camel-inflected', run_at: 'Tue, 12 Dec 2017 03:09:06 GMT' do
+      with_okta_user(scopes) do |auth_header|
+        verifier_stub = instance_double('EVSS::PowerOfAttorneyVerifier')
+        allow(EVSS::PowerOfAttorneyVerifier).to receive(:new) { verifier_stub }
+        allow(verifier_stub).to receive(:verify)
+        VCR.use_cassette('evss/claims/claims') do
+          get '/services/claims/v1/claims', params: nil, headers: auth_header.merge(camel_inflection_header)
+          expect(response).to match_camelized_response_schema('claims_api/claims')
         end
       end
     end

--- a/spec/support/schemas_camelized/claims_api/claim.json
+++ b/spec/support/schemas_camelized/claims_api/claim.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "claims_api_claim"
+          ]
+        },
+        "attributes": {
+          "type": "object",
+          "required": [
+            "evssId",
+            "dateFiled",
+            "minEstDate",
+            "maxEstDate",
+            "open",
+            "waiverSubmitted",
+            "requestedDecision",
+            "contentionList",
+            "eventsTimeline",
+            "vaRepresentative",
+            "documentsNeeded",
+            "developmentLetterSent",
+            "decisionLetterSent",
+            "status",
+            "claimType",
+            "claimType"
+          ],
+          "properties": {
+            "evssId": {
+              "type": "integer"
+            },
+            "dateFiled": {
+              "type": "string"
+            },
+            "contentionList": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "eventsTimeline": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "minEstDate": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "maxEstDate": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "open": {
+              "type": "boolean"
+            },
+            "vaRepresentative": {
+              "type": "string"
+            },
+            "waiverSubmitted": {
+              "type": "boolean"
+            },
+            "requestedDecision": {
+              "type": "boolean"
+            },
+            "documentsNeeded": {
+              "type": "boolean"
+            },
+            "developmentLetterSent": {
+              "type": "boolean"
+            },
+            "decisionLetterSent": {
+              "type": "boolean"
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "claimType": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supportingDocuments": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/claims_api/claims.json
+++ b/spec/support/schemas_camelized/claims_api/claims.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "evss_claims"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "evssId",
+              "dateFiled",
+              "minEstDate",
+              "maxEstDate",
+              "open",
+              "waiverSubmitted",
+              "requestedDecision",
+              "documentsNeeded",
+              "developmentLetterSent",
+              "decisionLetterSent",
+              "status",
+              "claimType"
+            ],
+            "properties": {
+              "evssId": {
+                "type": "integer"
+              },
+              "dateFiled": {
+                "type": "string"
+              },
+              "minEstDate": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "maxEstDate": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "open": {
+                "type": "boolean"
+              },
+              "waiverSubmitted": {
+                "type": "boolean"
+              },
+              "requestedDecision": {
+                "type": "boolean"
+              },
+              "documentsNeeded": {
+                "type": "boolean"
+              },
+              "developmentLetterSent": {
+                "type": "boolean"
+              },
+              "decisionLetterSent": {
+                "type": "boolean"
+              },
+              "status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "claimType": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description of change
adding camelCase versions of schemas to support responses when camel-inflection headers used

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11585