### PR TITLE
11585 add camel inflected schemas to veteran verification

### DIFF
--- a/modules/veteran_verification/spec/requests/disability_rating_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/disability_rating_request_spec.rb
@@ -42,6 +42,20 @@ RSpec.describe 'Disability Rating API endpoint', type: :request do
         end
       end
     end
+
+    it 'returns all the current user disability ratings and ' \
+       'overall service connected combined degree when camel-inflected' do
+      with_okta_configured do
+        VCR.use_cassette('bgs/rating_web_service/rating_data') do
+          get '/services/veteran_verification/v0/disability_rating',
+              params: nil,
+              headers: auth_header.merge('X-Key-Inflection' => 'camel')
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('disability_rating_response')
+        end
+      end
+    end
   end
 
   context 'with request for a jws' do

--- a/modules/veteran_verification/spec/requests/keys_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/keys_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Keys endpoint', type: :request do
   end
 
   it 'returns an array of keys when camel-inflected' do
-    get '/services/veteran_verification/v0/keys'
+    get '/services/veteran_verification/v0/keys', headers: { 'X-Key-Inflection' => 'camel' }
 
     expect(response).to have_http_status(:ok)
     expect(response).to match_camelized_response_schema('veteran_verification/keys')

--- a/modules/veteran_verification/spec/requests/keys_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/keys_request_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe 'Keys endpoint', type: :request do
     expect(response).to match_response_schema('veteran_verification/keys')
   end
 
+  it 'returns an array of keys when camel-inflected' do
+    get '/services/veteran_verification/v0/keys'
+
+    expect(response).to have_http_status(:ok)
+    expect(response).to match_camelized_response_schema('veteran_verification/keys')
+  end
+
   it 'the pem field is a valid base64url encoded public key' do
     get '/services/veteran_verification/v0/keys'
 

--- a/modules/veteran_verification/spec/requests/service_history_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/service_history_request_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Service History API endpoint', type: :request, skip_emis: true d
   include SchemaMatchers
 
   let(:scopes) { %w[profile email openid service_history.read] }
+  let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }
 
   def headers(auth)
     auth.merge('Accept' => 'application/json')
@@ -81,6 +82,17 @@ RSpec.describe 'Service History API endpoint', type: :request, skip_emis: true d
 
       expect(response).to have_http_status(:bad_gateway)
       expect(response).to match_response_schema('errors')
+    end
+
+    it 'matches the errors camel-inflected schema', :aggregate_failures do
+      with_okta_user(scopes) do |auth_header|
+        get '/services/veteran_verification/v0/service_history',
+            params: nil,
+            headers: headers(auth_header.merge(inflection_header))
+      end
+
+      expect(response).to have_http_status(:bad_gateway)
+      expect(response).to match_camelized_response_schema('errors')
     end
   end
 end

--- a/modules/veteran_verification/spec/requests/service_history_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/service_history_request_spec.rb
@@ -26,6 +26,21 @@ RSpec.describe 'Service History API endpoint', type: :request, skip_emis: true d
       end
     end
 
+    it 'returns the current users service history with one episode when camel-inflected' do
+      with_okta_user(scopes) do |auth_header|
+        VCR.use_cassette('emis/get_deployment_v2/valid') do
+          VCR.use_cassette('emis/get_military_service_episodes_v2/valid') do
+            get '/services/veteran_verification/v0/service_history',
+                params: nil,
+                headers: headers(auth_header.merge(inflection_header))
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to be_a(String)
+            expect(response).to match_camelized_response_schema('service_and_deployment_history_response')
+          end
+        end
+      end
+    end
+
     it 'returns the current users service history with multiple episodes' do
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('emis/get_deployment_v2/valid') do
@@ -35,6 +50,22 @@ RSpec.describe 'Service History API endpoint', type: :request, skip_emis: true d
             expect(response.body).to be_a(String)
             expect(JSON.parse(response.body)['data'].length).to eq(2)
             expect(response).to match_response_schema('service_and_deployment_history_response')
+          end
+        end
+      end
+    end
+
+    it 'returns the current users service history with multiple episodes when camel-inflected' do
+      with_okta_user(scopes) do |auth_header|
+        VCR.use_cassette('emis/get_deployment_v2/valid') do
+          VCR.use_cassette('emis/get_military_service_episodes_v2/valid_multiple_episodes') do
+            get '/services/veteran_verification/v0/service_history',
+                params: nil,
+                headers: headers(auth_header.merge(inflection_header))
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to be_a(String)
+            expect(JSON.parse(response.body)['data'].length).to eq(2)
+            expect(response).to match_camelized_response_schema('service_and_deployment_history_response')
           end
         end
       end

--- a/modules/veteran_verification/spec/requests/veteran_status_request_spec.rb
+++ b/modules/veteran_verification/spec/requests/veteran_status_request_spec.rb
@@ -45,5 +45,17 @@ RSpec.describe 'Veteran Status API endpoint', type: :request, skip_emis: true do
         expect(JSON.parse(response.body)['errors'].first['code']).to eq 'EMIS_STATUS502'
       end
     end
+
+    it 'matches the errors camel-inflected schema', :aggregate_failures do
+      with_okta_user(scopes) do |auth_header|
+        get '/services/veteran_verification/v0/status',
+            params: nil,
+            headers: auth_header.merge('X-Key-Inflection' => 'camel')
+
+        expect(response).to have_http_status(:bad_gateway)
+        expect(response).to match_camelized_response_schema('errors')
+        expect(JSON.parse(response.body)['errors'].first['code']).to eq 'EMIS_STATUS502'
+      end
+    end
   end
 end

--- a/spec/support/schemas_camelized/disability_rating_response.json
+++ b/spec/support/schemas_camelized/disability_rating_response.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "combinedDisabilityRating": {
+              "type": "integer"
+            },
+            "combinedEffectiveDate": {
+              "type": "string"
+            },
+            "individualRatings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "decision": {
+                    "type": "string"
+                  },
+                  "ratingPercentage": {
+                    "type": "integer"
+                  },
+                  "effectiveDate": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/service_and_deployment_history_response.json
+++ b/spec/support/schemas_camelized/service_and_deployment_history_response.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "data": {
+      "items": {
+        "properties": {
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "firstName": {
+                "type": "string"
+              },
+              "lastName": {
+                "type": "string"
+              },
+              "branchOfService": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "payGrade": {
+                "type": "string"
+              },
+              "separationReason": {
+                "type": "string"
+              },
+              "dischargeStatus": {
+                "type": "string"
+              },
+              "deployments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "startDate": {
+                      "type": "string"
+                    },
+                    "endDate": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    }
+  }
+}

--- a/spec/support/schemas_camelized/veteran_verification/keys.json
+++ b/spec/support/schemas_camelized/veteran_verification/keys.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+  },
+  "properties": {
+    "keys": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "kty": {
+            "type": "string"
+          },
+          "alg": {
+            "type": "string"
+          },
+          "kid": {
+            "type": "string"
+          },
+          "pem": {
+            "type": "string"
+          },
+          "e": {
+            "type": "string"
+          },
+          "n": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description of change
uses camelCase versions of schema files for testing the veteran_verification endpoints

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11585