### PR TITLE
capture failed login stats when saml response is invalid

### DIFF
--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -741,8 +741,11 @@ RSpec.describe V1::SessionsController, type: :controller do
       end
 
       context 'when saml response contains multiple errors (known or otherwise)' do
-        let (:multi_error_uuid) { '2222' }
-        before { allow(SAML::Responses::Login).to receive(:new).and_return(saml_response_multi_error(multi_error_uuid)) }
+        let(:multi_error_uuid) { '2222' }
+
+        before do
+          allow(SAML::Responses::Login).to receive(:new).and_return(saml_response_multi_error(multi_error_uuid))
+        end
 
         it 'logs a generic error' do
           expect(controller).to receive(:log_message_to_sentry)
@@ -766,17 +769,19 @@ RSpec.describe V1::SessionsController, type: :controller do
         end
 
         it 'increments the failed and total statsd counters' do
-            SAMLRequestTracker.create(
-              uuid: multi_error_uuid,
-              payload: { type: 'idme' }
-            )
+          SAMLRequestTracker.create(
+            uuid: multi_error_uuid,
+            payload: { type: 'idme' }
+          )
           callback_tags = ['status:failure', 'context:unknown', 'version:v1']
           callback_failed_tags = ['error:clicked_deny', 'version:v1']
           login_failed_tags = ['context:idme', 'version:v1', 'error:001']
 
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
-            .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_FAILED_KEY, tags: callback_failed_tags, **once)
+            .and trigger_statsd_increment(
+              described_class::STATSD_SSO_CALLBACK_FAILED_KEY, tags: callback_failed_tags, **once
+            )
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)
             .and trigger_statsd_increment(described_class::STATSD_LOGIN_STATUS_FAILURE, tags: login_failed_tags)
         end

--- a/spec/support/saml/response_builder.rb
+++ b/spec/support/saml/response_builder.rb
@@ -128,10 +128,10 @@ module SAML
       )
     end
 
-    def saml_response_multi_error
+    def saml_response_multi_error(in_response_to = nil)
       build_invalid_saml_response(
         status_message: 'Subject did not consent to attribute release',
-        in_response_to: uuid,
+        in_response_to: in_response_to || uuid,
         decrypted_document: document_partial,
         errors: ['Subject did not consent to attribute release', 'Other random error']
       )


### PR DESCRIPTION
Previously, the `login_stats(:failed...` call was only happening from the `user_login` function, this if an error was raised on line 57 when the SAML response was invalid, no login stats would be captured.

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/12484
