### PR TITLE
Added stem sco email feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -221,4 +221,9 @@ features:
   show_healthcare_experience_questionnaire:
     actor_type: cookie_id
     description: >
-      Enables showing the pre-appointment questionnaire feature. 
+      Enables showing the pre-appointment questionnaire feature.
+  stem_sco_email:
+    actor_type: user
+    description: >
+      Temporarily change the behavior of the 10203 form for MVP production launch. Disable EVSS entitlement request and alter SCO email process.
+

--- a/config/features.yml
+++ b/config/features.yml
@@ -225,5 +225,5 @@ features:
   stem_sco_email:
     actor_type: user
     description: >
-      Temporarily change the behavior of the 10203 form for MVP production launch. Disable EVSS entitlement request and alter SCO email process.
+      Enable/disable SCO email per environment
 


### PR DESCRIPTION
## Description
As a developer, I need a way to toggle when the SCO email is sent from the staging environment so that SCOs are not being sent test data unnecessarily.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/12467

frontend pr: https://github.com/department-of-veterans-affairs/vets-website/pull/13883
## Testing done
local testing 

## Screenshots
![Screen Shot 2020-08-17 at 9 05 33 AM](https://user-images.githubusercontent.com/50601724/90399672-575b2380-e069-11ea-9096-b21a2b41a6e9.png)


## Acceptance criteria
- [x] The STEM SCO Email feature flag is created and available in all environments.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs