### PR TITLE
11585 add camel inflected schemas to vaos

### DIFF
--- a/modules/vaos/spec/request/appointment_requests_request_spec.rb
+++ b/modules/vaos/spec/request/appointment_requests_request_spec.rb
@@ -86,6 +86,15 @@ RSpec.describe 'vaos appointment requests', type: :request do
           expect(response).to match_response_schema('vaos/appointment_requests')
         end
       end
+
+      it 'has access and returns va appointments when camel-inflected' do
+        VCR.use_cassette('vaos/appointment_requests/get_requests_with_params', match_requests_on: %i[method uri]) do
+          get '/vaos/v0/appointment_requests', params: params, headers: { 'X-Key-Inflection' => 'camel' }
+          expect(response).to have_http_status(:success)
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('vaos/appointment_requests')
+        end
+      end
     end
   end
 

--- a/modules/vaos/spec/request/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/appointments_request_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
   end
 
+  let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }
+
   context 'loa1 user' do
     let(:current_user) { build(:user, :loa1) }
 
@@ -142,12 +144,31 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
       end
 
+      it 'has access and returns va appointments when camel-inflected' do
+        VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method uri]) do
+          get '/vaos/v0/appointments', params: params, headers: inflection_header
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('vaos/va_appointments', { strict: false })
+        end
+      end
+
       it 'has access and returns cc appointments' do
         VCR.use_cassette('vaos/appointments/get_cc_appointments', match_requests_on: %i[method uri]) do
           get '/vaos/v0/appointments', params: params.merge(type: 'cc')
           expect(response).to have_http_status(:success)
           expect(response.body).to be_a(String)
           expect(response).to match_response_schema('vaos/cc_appointments')
+        end
+      end
+
+      it 'has access and returns cc appointments when camel-inflected' do
+        VCR.use_cassette('vaos/appointments/get_cc_appointments', match_requests_on: %i[method uri]) do
+          get '/vaos/v0/appointments', params: params.merge(type: 'cc'), headers: inflection_header
+          expect(response).to have_http_status(:success)
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('vaos/cc_appointments')
         end
       end
 
@@ -170,6 +191,25 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
             expect(response).to match_response_schema('vaos/va_appointments')
           end
         end
+
+        it 'returns an empty list when camel-inflected' do
+          VCR.use_cassette('vaos/appointments/get_appointments_empty', match_requests_on: %i[method uri]) do
+            get '/vaos/v0/appointments', params: params, headers: inflection_header
+            expect(response).to have_http_status(:success)
+            expect(JSON.parse(response.body)).to eq(
+              'data' => [],
+              'meta' => {
+                'pagination' => {
+                  'currentPage' => 0,
+                  'perPage' => 0,
+                  'totalEntries' => 0,
+                  'totalPages' => 0
+                }
+              }
+            )
+            expect(response).to match_camelized_response_schema('vaos/va_appointments')
+          end
+        end
       end
 
       context 'with a response that includes blank providers' do
@@ -178,6 +218,14 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
             get '/vaos/v0/appointments', params: params
             expect(response).to have_http_status(:success)
             expect(response).to match_response_schema('vaos/va_appointments', { strict: false })
+          end
+        end
+
+        it 'parses the data and does not throw an undefined method error when camel-inflected' do
+          VCR.use_cassette('vaos/appointments/get_appointments_map_error', match_requests_on: %i[method uri]) do
+            get '/vaos/v0/appointments', params: params, headers: inflection_header
+            expect(response).to have_http_status(:success)
+            expect(response).to match_camelized_response_schema('vaos/va_appointments', { strict: false })
           end
         end
       end

--- a/modules/vaos/spec/request/cc_supported_sites_request_spec.rb
+++ b/modules/vaos/spec/request/cc_supported_sites_request_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe 'supported_sites', type: :request do
           expect(response).to match_response_schema('vaos/cc_supported_sites')
         end
       end
+
+      it 'returns a 200 with the correct schema when camel-inflected' do
+        VCR.use_cassette('vaos/cc_supported_sites/get_one_site', match_requests_on: %i[method uri]) do
+          get '/vaos/v0/community_care/supported_sites',
+              params: { site_codes: [983, 984] },
+              headers: { 'X-Key-Inflection' => 'camel' }
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('vaos/cc_supported_sites')
+        end
+      end
     end
 
     context 'with a invalid GET supported_sites request' do

--- a/modules/vaos/spec/request/facilities_request_spec.rb
+++ b/modules/vaos/spec/request/facilities_request_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'facilities', type: :request do
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
   end
 
+  let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }
+
   describe '/vaos/v0/facilities' do
     context 'with a loa1 user' do
       let(:user) { FactoryBot.create(:user, :loa1) }
@@ -35,6 +37,15 @@ RSpec.describe 'facilities', type: :request do
             expect(response).to match_response_schema('vaos/facilities')
           end
         end
+
+        it 'returns a 200 with the correct camel-inflected schema' do
+          VCR.use_cassette('vaos/systems/get_facilities', match_requests_on: %i[method uri]) do
+            get '/vaos/v0/facilities', params: { facility_codes: 688 }, headers: inflection_header
+
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('vaos/facilities')
+          end
+        end
       end
 
       context 'with a multiple valid facility codes' do
@@ -44,6 +55,15 @@ RSpec.describe 'facilities', type: :request do
 
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('vaos/facilities')
+          end
+        end
+
+        it 'returns a 200 with the correct camel-inflected schema' do
+          VCR.use_cassette('vaos/systems/get_facilities_multiple') do
+            get '/vaos/v0/facilities', params: { facility_codes: [983, 984] }, headers: inflection_header
+
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('vaos/facilities')
           end
         end
       end
@@ -85,6 +105,17 @@ RSpec.describe 'facilities', type: :request do
 
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('vaos/facility_clinics')
+          end
+        end
+
+        it 'returns a 200 with the correct camel-inflected schema' do
+          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method uri]) do
+            get '/vaos/v0/facilities/983/clinics',
+                params: { type_of_care_id: '323', system_id: '983' },
+                headers: inflection_header
+
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('vaos/facility_clinics')
           end
         end
       end
@@ -137,6 +168,15 @@ RSpec.describe 'facilities', type: :request do
             expect(response).to match_response_schema('vaos/facility_cancel_reasons')
           end
         end
+
+        it 'returns a 200 with the correct camel-inflected schema' do
+          VCR.use_cassette('vaos/systems/get_cancel_reasons', match_requests_on: %i[method uri]) do
+            get '/vaos/v0/facilities/984/cancel_reasons', headers: inflection_header
+
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('vaos/facility_cancel_reasons')
+          end
+        end
       end
     end
   end
@@ -179,6 +219,21 @@ RSpec.describe 'facilities', type: :request do
 
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('vaos/facility_available_appointments')
+          end
+        end
+
+        it 'returns a 200 with the correct camel-inflected schema' do
+          VCR.use_cassette('vaos/systems/get_facility_available_appointments', match_requests_on: %i[method uri]) do
+            get "/vaos/v0/facilities/#{facility_id}/available_appointments",
+                params: {
+                  start_date: start_date,
+                  end_date: end_date,
+                  clinic_ids: clinic_ids
+                },
+                headers: inflection_header
+
+            expect(response).to have_http_status(:ok)
+            expect(response).to match_camelized_response_schema('vaos/facility_available_appointments')
           end
         end
       end
@@ -278,6 +333,16 @@ RSpec.describe 'facilities', type: :request do
           expect(response).to match_response_schema('vaos/facility_limits')
         end
       end
+
+      it 'returns a 200 with the correct camel-inflected schema' do
+        VCR.use_cassette('vaos/systems/get_facility_limits', match_requests_on: %i[method uri]) do
+          get '/vaos/v0/facilities/688/limits', params: { type_of_care_id: '323' }, headers: inflection_header
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('vaos/facility_limits')
+        end
+      end
     end
 
     context 'when type_of_care_id is missing' do
@@ -304,6 +369,18 @@ RSpec.describe 'facilities', type: :request do
           expect(response).to have_http_status(:ok)
           expect(response.body).to be_a(String)
           expect(response).to match_response_schema('vaos/facility_visits')
+        end
+      end
+
+      it 'returns a 200 with the correct camel-inflected schema' do
+        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method uri]) do
+          get '/vaos/v0/facilities/688/visits/direct',
+              params: { system_id: '688', type_of_care_id: '323' },
+              headers: inflection_header
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('vaos/facility_visits')
         end
       end
     end

--- a/modules/vaos/spec/request/messages_request_spec.rb
+++ b/modules/vaos/spec/request/messages_request_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe 'vaos appointment request messages', type: :request do
           expect(response).to match_response_schema('vaos/messages')
         end
       end
+
+      it 'has access and returns messages when camel-inflected', :skip_mvi do
+        VCR.use_cassette('vaos/messages/get_messages', match_requests_on: %i[method uri]) do
+          get "/vaos/v0/appointment_requests/#{request_id}/messages", headers: { 'X-Key-Inflection' => 'camel' }
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('vaos/messages')
+        end
+      end
     end
   end
 

--- a/modules/vaos/spec/request/preferences_request_spec.rb
+++ b/modules/vaos/spec/request/preferences_request_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'preferences', type: :request do
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
   end
 
+  let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }
+
   context 'with a loa1 user' do
     let(:user) { FactoryBot.create(:user, :loa1) }
 
@@ -35,6 +37,16 @@ RSpec.describe 'preferences', type: :request do
           expect(response).to match_response_schema('vaos/preferences')
         end
       end
+
+      it 'returns a 200 with the correct schema when camel-inflected' do
+        VCR.use_cassette('vaos/preferences/get_preferences', match_requests_on: %i[method uri]) do
+          get '/vaos/v0/preferences', headers: inflection_header
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('vaos/preferences')
+        end
+      end
     end
 
     context 'with a valid PUT preferences request', :skip_mvi do
@@ -56,6 +68,16 @@ RSpec.describe 'preferences', type: :request do
           expect(response).to have_http_status(:ok)
           expect(response.body).to be_a(String)
           expect(response).to match_response_schema('vaos/preferences')
+        end
+      end
+
+      it 'returns a 200 with correct camel-inflected schema' do
+        VCR.use_cassette('vaos/preferences/put_preferences', match_requests_on: %i[method uri]) do
+          put '/vaos/v0/preferences', params: request_body, headers: inflection_header
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('vaos/preferences')
         end
       end
     end

--- a/modules/vaos/spec/request/request_eligibility_criteria_request_spec.rb
+++ b/modules/vaos/spec/request/request_eligibility_criteria_request_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'request eligibility criteria', type: :request do
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
   end
 
+  let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }
+
   context 'with a loa1 user' do
     let(:user) { FactoryBot.create(:user, :loa1) }
 
@@ -35,6 +37,15 @@ RSpec.describe 'request eligibility criteria', type: :request do
           expect(response).to match_response_schema('vaos/request_eligibility_criteria', { strict: false })
         end
       end
+
+      it 'returns a 200 with the correct camel-inflected schema' do
+        VCR.use_cassette('vaos/systems/get_request_eligibility_criteria', match_requests_on: %i[method uri]) do
+          get '/vaos/v0/request_eligibility_criteria', headers: inflection_header
+          expect(response).to have_http_status(:ok)
+          expect(size).to eq(1269)
+          expect(response).to match_camelized_response_schema('vaos/request_eligibility_criteria', { strict: false })
+        end
+      end
     end
 
     context 'with one id' do
@@ -44,6 +55,15 @@ RSpec.describe 'request eligibility criteria', type: :request do
           expect(response).to have_http_status(:ok)
           expect(size).to eq(1)
           expect(response).to match_response_schema('vaos/request_eligibility_criteria', { strict: false })
+        end
+      end
+
+      it 'returns a 200 with the correct camel-inflected schema' do
+        VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_id', match_requests_on: %i[method uri]) do
+          get '/vaos/v0/request_eligibility_criteria', params: { site_codes: '688' }, headers: inflection_header
+          expect(response).to have_http_status(:ok)
+          expect(size).to eq(1)
+          expect(response).to match_camelized_response_schema('vaos/request_eligibility_criteria', { strict: false })
         end
       end
     end
@@ -58,6 +78,16 @@ RSpec.describe 'request eligibility criteria', type: :request do
           expect(response).to match_response_schema('vaos/request_eligibility_criteria', { strict: false })
         end
       end
+
+      it 'returns a 200 with the correct camel-inflected schema' do
+        VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_site_codes',
+                         match_requests_on: %i[method uri]) do
+          get '/vaos/v0/request_eligibility_criteria', params: { site_codes: %w[442 534] }, headers: inflection_header
+          expect(response).to have_http_status(:ok)
+          expect(size).to eq(2)
+          expect(response).to match_camelized_response_schema('vaos/request_eligibility_criteria', { strict: false })
+        end
+      end
     end
 
     context 'with multiple parent_sites' do
@@ -68,6 +98,19 @@ RSpec.describe 'request eligibility criteria', type: :request do
           expect(response).to have_http_status(:ok)
           expect(size).to eq(5)
           expect(response).to match_response_schema('vaos/request_eligibility_criteria', { strict: false })
+        end
+      end
+
+      it 'returns a 200 with the correct camel-inflected schema' do
+        VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_parent_sites',
+                         match_requests_on: %i[method uri]) do
+          get '/vaos/v0/request_eligibility_criteria',\
+              params: { parent_sites: %w[983 984] },
+              headers: inflection_header
+
+          expect(response).to have_http_status(:ok)
+          expect(size).to eq(5)
+          expect(response).to match_camelized_response_schema('vaos/request_eligibility_criteria', { strict: false })
         end
       end
     end

--- a/spec/support/schemas_camelized/vaos/appointment_request.json
+++ b/spec/support/schemas_camelized/vaos/appointment_request.json
@@ -1,0 +1,284 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "lastUpdatedAt": {
+          "type": "null"
+        },
+        "appointmentDate": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "appointmentTime": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "optionDate1": {
+          "type": "string"
+        },
+        "optionTime1": {
+          "type": "string"
+        },
+        "optionDate2": {
+          "type": "string"
+        },
+        "optionTime2": {
+          "type": "string"
+        },
+        "optionDate3": {
+          "type": "string"
+        },
+        "optionTime3": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "appointmentType": {
+          "type": "string"
+        },
+        "visitType": {
+          "type": "string"
+        },
+        "reasonForVisit": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "additionalInformation": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "facility": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "facilityCode": {
+              "type": "string"
+            },
+            "type": {
+              "type": [
+                "string",
+                null
+              ]
+            },
+            "address": {
+              "type": [
+                "string",
+                null
+              ]
+            },
+            "state": {
+              "type": "string"
+            },
+            "city": {
+              "type": "string"
+            },
+            "parentSiteCode": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "facilityCode",
+            "state",
+            "city",
+            "parentSiteCode"
+          ]
+        },
+        "email": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "textMessagingAllowed": {
+          "type": "boolean"
+        },
+        "phoneNumber": {
+          "type": "string"
+        },
+        "purposeOfVisit": {
+          "type": "string"
+        },
+        "providerId": {
+          "type": "string"
+        },
+        "secondRequest": {
+          "type": "boolean"
+        },
+        "secondRequestSubmitted": {
+          "type": "boolean"
+        },
+        "patient": {
+          "type": "object",
+          "properties": {
+            "inpatient": {
+              "type": "boolean"
+            },
+            "textMessagingAllowed": {
+              "type": "boolean",
+              "required": false
+            }
+          },
+          "required": [
+            "inpatient",
+            "textMessagingAllowed"
+          ]
+        },
+        "bestTimetoCall": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "appointmentRequestDetailCode": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "appointmentRequestDetailCodeId": {
+                  "type": "string"
+                },
+                "createdDate": {
+                  "type": "string"
+                },
+                "detailCode": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "providerMessage": {
+                      "type": "string"
+                    },
+                    "veteranMessage": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "code",
+                    "providerMessage",
+                    "veteranMessage"
+                  ]
+                }
+              },
+              "required": [
+                "appointmentRequestDetailCodeId",
+                "createdDate",
+                "detailCode"
+              ]
+            }
+          ]
+        },
+        "hasVeteranNewMessage": {
+          "type": "boolean"
+        },
+        "hasProviderNewMessage": {
+          "type": "boolean"
+        },
+        "providerSeenAppointmentRequest": {
+          "type": "boolean"
+        },
+        "requestedPhoneCall": {
+          "type": "boolean"
+        },
+        "bookedApptDateTime": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "typeOfCareId": {
+          "type": "string"
+        },
+        "friendlyLocationName": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "ccAppointmentRequest": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "cc_appointment_request.json"
+            }
+          ]
+        },
+        "date": {
+          "type": "string"
+        },
+        "assigningAuthority": {
+          "type": "string"
+        },
+        "createdDate": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "lastUpdatedAt",
+        "appointmentDate",
+        "appointmentTime",
+        "optionDate1",
+        "optionTime1",
+        "optionDate2",
+        "optionTime2",
+        "optionDate3",
+        "optionTime3",
+        "status",
+        "appointmentType",
+        "visitType",
+        "facility",
+        "email",
+        "textMessagingAllowed",
+        "phoneNumber",
+        "purposeOfVisit",
+        "providerId",
+        "secondRequest",
+        "secondRequestSubmitted",
+        "patient",
+        "bestTimetoCall",
+        "appointmentRequestDetailCode",
+        "hasVeteranNewMessage",
+        "hasProviderNewMessage",
+        "providerSeenAppointmentRequest",
+        "requestedPhoneCall",
+        "bookedApptDateTime",
+        "typeOfCareId",
+        "friendlyLocationName",
+        "date",
+        "assigningAuthority",
+        "createdDate"
+      ]
+    }
+  },
+  "required": [
+    "id",
+    "type",
+    "attributes"
+  ]
+}

--- a/spec/support/schemas_camelized/vaos/appointment_requests.json
+++ b/spec/support/schemas_camelized/vaos/appointment_requests.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data",
+    "meta"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "appointment_request.json"
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": [
+        "pagination"
+      ],
+      "properties": {
+        "pagination": {
+          "type": "object",
+          "required": [
+            "currentPage",
+            "perPage",
+            "totalPages",
+            "totalEntries"
+          ],
+          "properties": {
+            "currentPage": {
+              "type": "integer"
+            },
+            "perPage": {
+              "type": "integer"
+            },
+            "totalPages": {
+              "type": "integer"
+            },
+            "totalEntries": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/appointment_time_slot.json
+++ b/spec/support/schemas_camelized/vaos/appointment_time_slot.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "required": [
+    "startDateTime",
+    "endDateTime",
+    "bookingStatus",
+    "remainingAllowedOverBookings",
+    "availability"
+  ],
+  "properties": {
+    "startDateTime": {
+      "type": "string",
+      "format": "date"
+    },
+    "endDateTime": {
+      "type": "string",
+      "format": "date"
+    },
+    "bookingStatus": {
+      "type": "string"
+    },
+    "remainingAllowedOverBookings": {
+      "type": "string"
+    },
+    "availability": {
+      "type": "boolean"
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/schemas_camelized/vaos/cc_appointment.json
+++ b/spec/support/schemas_camelized/vaos/cc_appointment.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "id",
+    "type",
+    "attributes"
+  ],
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "type": {
+      "enum": [
+        "cc_appointments"
+      ]
+    },
+    "attributes": {
+      "type": "object",
+      "required": [
+        "appointmentRequestId",
+        "distanceEligibleConfirmed",
+        "name",
+        "providerPractice",
+        "providerPhone",
+        "address",
+        "instructionsToVeteran",
+        "appointmentTime",
+        "timeZone"
+      ],
+      "properties": {
+        "appointmentRequestId": {
+          "type": "string"
+        },
+        "distanceEligibleConfirmed": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "object",
+          "required": [
+            "firstName",
+            "lastName"
+          ],
+          "properties": {
+            "firstName": {
+              "type": "string"
+            },
+            "lastName": {
+              "type": "string"
+            }
+          }
+        },
+        "providerPractice": {
+          "type": "string"
+        },
+        "providerPhone": {
+          "type": "string"
+        },
+        "address": {
+          "type": "object",
+          "required": [
+            "street",
+            "city",
+            "state",
+            "zipCode"
+          ],
+          "properties": {
+            "street": {
+              "type": "string"
+            },
+            "city": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string"
+            },
+            "zipCode": {
+              "type": "string"
+            }
+          }
+        },
+        "instructionsToVeteran": {
+          "type": "string"
+        },
+        "appointmentTime": {
+          "type": "string"
+        },
+        "timeZone": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/cc_appointment_request.json
+++ b/spec/support/schemas_camelized/vaos/cc_appointment_request.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "dataIdentifier",
+    "hasVeteranNewMessage",
+    "preferredState",
+    "preferredCity",
+    "preferredLanguage",
+    "preferredZipCode",
+    "distanceWillingToTravel",
+    "distanceEligible",
+    "officeHours",
+    "preferredProviders"
+  ],
+  "properties": {
+    "dataIdentifier": {
+      "type": "object"
+    },
+    "hasVeteranNewMessage": {
+      "type": "boolean"
+    },
+    "preferredState": {
+      "type": "string"
+    },
+    "preferredCity": {
+      "type": "string"
+    },
+    "preferredZipCode": {
+      "type": "string"
+    },
+    "preferredLanguage": {
+      "type": "string"
+    },
+    "distanceWillingToTravel": {
+      "type": "integer"
+    },
+    "distanceEligible": {
+      "type": "boolean"
+    },
+    "officeHours": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "preferredProviders": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "firstName",
+          "lastName",
+          "practiceName",
+          "address",
+          "preferredOrder",
+          "objectType",
+          "link"
+        ],
+        "properties": {
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "practiceName": {
+            "type": "string"
+          },
+          "address": {
+            "type": "object"
+          },
+          "preferredOrder": {
+            "type": "integer"
+          },
+          "objectType": {
+            "type": "string"
+          },
+          "link": {
+            "type": "array"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/cc_appointments.json
+++ b/spec/support/schemas_camelized/vaos/cc_appointments.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data",
+    "meta"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "cc_appointment.json"
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": [
+        "pagination"
+      ],
+      "properties": {
+        "pagination": {
+          "type": "object",
+          "required": [
+            "currentPage",
+            "perPage",
+            "totalPages",
+            "totalEntries"
+          ],
+          "properties": {
+            "currentPage": {
+              "type": "integer"
+            },
+            "perPage": {
+              "type": "integer"
+            },
+            "totalPages": {
+              "type": "integer"
+            },
+            "totalEntries": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/cc_supported_sites.json
+++ b/spec/support/schemas_camelized/vaos/cc_supported_sites.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "timezone": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "timezone"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ]
+      }
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/spec/support/schemas_camelized/vaos/facilities.json
+++ b/spec/support/schemas_camelized/vaos/facilities.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "institutionCode",
+              "city",
+              "stateAbbrev",
+              "authoritativeName",
+              "rootStationCode",
+              "adminParent",
+              "parentStationCode"
+            ],
+            "properties": {
+              "institutionCode": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "stateAbbrev": {
+                "type": "string"
+              },
+              "authoritativeName": {
+                "type": "string"
+              },
+              "rootStationCode": {
+                "type": "string"
+              },
+              "adminParent": {
+                "type": "boolean"
+              },
+              "parentStationCode": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/facility_available_appointments.json
+++ b/spec/support/schemas_camelized/vaos/facility_available_appointments.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "clinicId",
+              "clinicName",
+              "appointmentLength",
+              "clinicDisplayStartTime",
+              "displayIncrements",
+              "stopCode",
+              "askForCheckIn",
+              "maxOverbooksPerDay",
+              "hasUserAccessToClinic",
+              "primaryStopCode",
+              "secondaryStopCode",
+              "listSize",
+              "empty",
+              "appointmentTimeSlot"
+            ],
+            "properties": {
+              "clinicId": {
+                "type": "string"
+              },
+              "clinicName": {
+                "type": "string"
+              },
+              "appointmentLength": {
+                "type": "integer"
+              },
+              "clinicDisplayStartTime": {
+                "type": "string"
+              },
+              "displayIncrements": {
+                "type": "string"
+              },
+              "stopCode": {
+                "type": "string"
+              },
+              "askForCheckIn": {
+                "type": "boolean"
+              },
+              "maxOverbooksPerDay": {
+                "type": "integer"
+              },
+              "hasUserAccessToClinic": {
+                "type": "boolean"
+              },
+              "primaryStopCode": {
+                "type": "string"
+              },
+              "secondaryStopCode": {
+                "type": "string"
+              },
+              "listSize": {
+                "type": "integer"
+              },
+              "empty": {
+                "type": "boolean"
+              },
+              "appointmentTimeSlot": {
+                "type": "array",
+                "items": {
+                  "$ref": "appointment_time_slot.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/facility_cancel_reasons.json
+++ b/spec/support/schemas_camelized/vaos/facility_cancel_reasons.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "number",
+              "text",
+              "type",
+              "inactive"
+            ],
+            "properties": {
+              "number": {
+                "type": "string"
+              },
+              "text": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "inactive": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/facility_clinics.json
+++ b/spec/support/schemas_camelized/vaos/facility_clinics.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "siteCode",
+              "clinicId",
+              "clinicName",
+              "clinicFriendlyLocationName",
+              "primaryStopCode",
+              "secondaryStopCode",
+              "directSchedulingFlag",
+              "displayToPatientFlag",
+              "institutionName",
+              "institutionCode",
+              "objectType"
+            ],
+            "properties": {
+              "siteCode": {
+                "type": "string"
+              },
+              "clinicId": {
+                "type": "string"
+              },
+              "clinicName": {
+                "type": "string"
+              },
+              "clinicFriendlyLocationName": {
+                "type": "string"
+              },
+              "primaryStopCode": {
+                "type": "string"
+              },
+              "secondaryStopCode": {
+                "type": "string"
+              },
+              "directSchedulingFlag": {
+                "type": "string"
+              },
+              "displayToPatientFlag": {
+                "type": "string"
+              },
+              "institutionName": {
+                "type": "string"
+              },
+              "institutionCode": {
+                "type": "string"
+              },
+              "objectType": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/facility_limits.json
+++ b/spec/support/schemas_camelized/vaos/facility_limits.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "required": [
+            "numberOfRequests",
+            "requestLimit"
+          ],
+          "properties": {
+            "numberOfRequests": {
+              "type": "integer"
+            },
+            "requestLimit": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/facility_visits.json
+++ b/spec/support/schemas_camelized/vaos/facility_visits.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "required": [
+            "hasVisitedInPastMonths",
+            "durationInMonths"
+          ],
+          "properties": {
+            "hasVisitedInPastMonths": {
+              "type": "boolean"
+            },
+            "durationInMonths": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/message.json
+++ b/spec/support/schemas_camelized/vaos/message.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "messageText": {
+          "type": "string"
+        },
+        "messageDateTime": {
+          "type": "string"
+        },
+        "appointmentRequestId": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "messageText",
+        "messageDateTime",
+        "appointmentRequestId",
+        "date"
+      ]
+    }
+  },
+  "required": [
+    "id",
+    "type",
+    "attributes"
+  ]
+}

--- a/spec/support/schemas_camelized/vaos/messages.json
+++ b/spec/support/schemas_camelized/vaos/messages.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "$ref": "message.json"
+      }
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/spec/support/schemas_camelized/vaos/patient.json
+++ b/spec/support/schemas_camelized/vaos/patient.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "type": "string"
+        },
+        "middleInitial": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      }
+    },
+    "contactInformation": {
+      "type": "object",
+      "properties": {
+        "mobile": {
+          "type": "string"
+        },
+        "preferredEmail": {
+          "type": "string"
+        },
+        "timeZone": {
+          "type": "string"
+        }
+      }
+    },
+    "location": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "facility": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "siteCode": {
+              "type": "string"
+            },
+            "timeZone": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "patientAppointment": {
+      "type": "boolean"
+    },
+    "virtualMeetingRoom": {
+      "type": "object",
+      "properties": {
+        "conference": {
+          "type": "string"
+        },
+        "pin": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/preferences.json
+++ b/spec/support/schemas_camelized/vaos/preferences.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "required": [
+            "notificationFrequency",
+            "emailAllowed",
+            "emailAddress",
+            "textMsgAllowed"
+          ],
+          "properties": {
+            "notificationFrequency": {
+              "type": "string"
+            },
+            "emailAllowed": {
+              "type": "boolean"
+            },
+            "emailAddress": {
+              "type": "string"
+            },
+            "textMsgAllowed": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/provider.json
+++ b/spec/support/schemas_camelized/vaos/provider.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "type": "string"
+        },
+        "middleInitial": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      }
+    },
+    "contactInformation": {
+      "type": "object",
+      "properties": {
+        "mobile": {
+          "type": "string"
+        },
+        "preferredEmail": {
+          "type": "string"
+        },
+        "timeZone": {
+          "type": "string"
+        }
+      }
+    },
+    "location": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "facility": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "siteCode": {
+              "type": "string"
+            },
+            "timeZone": {
+              "type": "string"
+            }
+          }
+        },
+        "clinic": {
+          "type": "object",
+          "properties": {
+            "ien": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "virtualMeetingRoom": {
+      "type": "object",
+      "properties": {
+        "conference": {
+          "type": "string"
+        },
+        "pin": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/request_eligibility_criteria.json
+++ b/spec/support/schemas_camelized/vaos/request_eligibility_criteria.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "requestSettings",
+              "customRequestSettings"
+            ],
+            "properties": {
+              "requestSettings": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "typeOfCare",
+                    "stopCodes",
+                    "submittedRequestLimit",
+                    "enterpriseSubmittedRequestLimit"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "typeOfCare": {
+                      "type": "string"
+                    },
+                    "patientHistoryRequired": {
+                      "type": "string"
+                    },
+                    "patientHistoryDuration": {
+                      "type": "integer"
+                    },
+                    "stopCodes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "primary"
+                        ],
+                        "properties": {
+                          "primary": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "submittedRequestLimit": {
+                      "type": "integer"
+                    },
+                    "enterpriseSubmittedRequestLimit": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "customRequestSettings": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "typeOfCare",
+                    "submittedRequestLimit",
+                    "enterpriseSubmittedRequestLimit",
+                    "supported",
+                    "schedulingDays"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "typeOfCare": {
+                      "type": "string"
+                    },
+                    "submittedRequestLimit": {
+                      "type": "integer"
+                    },
+                    "enterpriseSubmittedRequestLimit": {
+                      "type": "integer"
+                    },
+                    "supported": {
+                      "type": "boolean"
+                    },
+                    "schedulingDays": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "day",
+                          "canSchedule"
+                        ],
+                        "properties": {
+                          "day": {
+                            "type": "string"
+                          },
+                          "canSchedule": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/system_facilities.json
+++ b/spec/support/schemas_camelized/vaos/system_facilities.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "institutionCode",
+              "city",
+              "stateAbbrev",
+              "authoritativeName",
+              "rootStationCode",
+              "adminParent",
+              "parentStationCode",
+              "requestSupported",
+              "directSchedulingSupported",
+              "expressTimes",
+              "institutionTimezone"
+            ],
+            "properties": {
+              "institutionCode": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "stateAbbrev": {
+                "type": "string"
+              },
+              "authoritativeName": {
+                "type": "string"
+              },
+              "rootStationCode": {
+                "type": "string"
+              },
+              "adminParent": {
+                "type": "boolean"
+              },
+              "parentStationCode": {
+                "type": "string"
+              },
+              "requestSupported": {
+                "type": "boolean"
+              },
+              "directSchedulingSupported": {
+                "type": "boolean"
+              },
+              "expressTimes": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "start",
+                      "end",
+                      "timezone",
+                      "offsetUtc"
+                    ],
+                    "properties": {
+                      "start": {
+                        "type": "string"
+                      },
+                      "end": {
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "type": "string"
+                      },
+                      "offsetUtc": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              },
+              "institutionTimezone": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/system_institutions.json
+++ b/spec/support/schemas_camelized/vaos/system_institutions.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "locationIen",
+              "institutionSid",
+              "institutionIen",
+              "institutionName",
+              "institutionCode"
+            ],
+            "properties": {
+              "locationIen": {
+                "type": "string"
+              },
+              "institutionSid": {
+                "type": "integer"
+              },
+              "institutionIen": {
+                "type": "string"
+              },
+              "institutionName": {
+                "type": "string"
+              },
+              "institutionCode": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/system_pact.json
+++ b/spec/support/schemas_camelized/vaos/system_pact.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "facilityId",
+              "possiblePrimary",
+              "providerPosition",
+              "providerSid",
+              "staffName",
+              "teamName",
+              "teamPurpose",
+              "teamSid",
+              "title"
+            ],
+            "properties": {
+              "facilityId": {
+                "type": "string"
+              },
+              "possiblePrimary": {
+                "type": "string"
+              },
+              "providerPosition": {
+                "type": "string"
+              },
+              "providerSid": {
+                "type": "string"
+              },
+              "staffName": {
+                "type": "string"
+              },
+              "teamName": {
+                "type": "string"
+              },
+              "teamPurpose": {
+                "type": "string"
+              },
+              "teamSid": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/systems.json
+++ b/spec/support/schemas_camelized/vaos/systems.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "uniqueId",
+              "assigningAuthority",
+              "assigningCode",
+              "idStatus"
+            ],
+            "properties": {
+              "uniqueId": {
+                "type": "string"
+              },
+              "assigningAuthority": {
+                "type": {
+                  "enum": [
+                    "ICN",
+                    "EDIPI",
+                    "UNKNOWN"
+                  ]
+                }
+              },
+              "assigningCode": {
+                "type": "string"
+              },
+              "idStatus": {
+                "type": {
+                  "enum": [
+                    "ACTIVE",
+                    "PERMANENT"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/va_appointment.json
+++ b/spec/support/schemas_camelized/vaos/va_appointment.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "id",
+    "type",
+    "attributes"
+  ],
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "va_appointments"
+      ]
+    },
+    "attributes": {
+      "type": "object",
+      "properties": {
+        "startDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "sta6aid": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "clinicId": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "clinicFriendlyName": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "facilityId": {
+          "type": [
+            "string",
+            null
+          ]
+        },
+        "communityCare": {
+          "type": [
+            "boolean",
+            null
+          ]
+        },
+        "vdsAppointments": {
+          "type": "array",
+          "optional": true,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "appointmentLength": {
+                "type": [
+                  "string",
+                  null
+                ]
+              },
+              "appointmentTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "clinic": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "askForCheckIn",
+                  "facilityCode"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "askForCheckIn": {
+                    "type": "boolean"
+                  },
+                  "facilityCode": {
+                    "type": "string"
+                  }
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "currentStatus": {
+                "type": "string"
+              },
+              "bookingNote": {
+                "type": [
+                  "string",
+                  null
+                ]
+              }
+            }
+          }
+        },
+        "vvsAppointments": {
+          "type": "array",
+          "optional": true,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "appointmentKind": {
+                "type": "string"
+              },
+              "schedulingRequestType": {
+                "type": "string"
+              },
+              "instruction": {
+                "type": "string"
+              },
+              "invities": {
+                "type": "array"
+              },
+              "sourceSystem": {
+                "type": "string"
+              },
+              "dateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "desiredDate": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "duration": {
+                "type": "integer"
+              },
+              "status": {
+                "type": "object",
+                "required": [
+                  "description",
+                  "code"
+                ],
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "code": {
+                    "type": "string"
+                  }
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "bookingNotes": {
+                "type": "string"
+              },
+              "instructionsOther": {
+                "type": "boolean"
+              },
+              "patients": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "$ref": "patient.json"
+                }
+              },
+              "providers": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "$ref": "provider.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas_camelized/vaos/va_appointments.json
+++ b/spec/support/schemas_camelized/vaos/va_appointments.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "data",
+    "meta"
+  ],
+  "properties": {
+    "data": {
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "va_appointment.json"
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": [
+        "pagination"
+      ],
+      "properties": {
+        "pagination": {
+          "type": "object",
+          "required": [
+            "currentPage",
+            "perPage",
+            "totalPages",
+            "totalEntries"
+          ],
+          "properties": {
+            "currentPage": {
+              "type": "integer"
+            },
+            "perPage": {
+              "type": "integer"
+            },
+            "totalPages": {
+              "type": "integer"
+            },
+            "totalEntries": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description of change
This adds camelCase schema tests for endpoints in the vaos module.
 
## Original issue(s)
department-of-veterans-affairs/va.gov-team#11585

## Things to know about this PR
vets-api uses the gem `olive_branch` to support the `X-Key-Inflection` header and return json in camelCase.  Issue #11585 is about finding all the places we use `match_response_schema` and create a parallel test that uses the new `match_camelized_response_schema` matcher to test this header is properly supported for any requests.