### PR TITLE
[Development] Add 526 intro wizard feature

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -221,4 +221,8 @@ features:
   show_healthcare_experience_questionnaire:
     actor_type: cookie_id
     description: >
-      Enables showing the pre-appointment questionnaire feature. 
+      Enables showing the pre-appointment questionnaire feature.
+  show_526_wizard:
+    acto_type: user
+    description: >
+      This determines when the wizard should show up on the form 526 intro page


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

We're adding form 526 wizard to the introduction page.

This PR adds `show_526_wizard` feature flag to set the visibility of this change.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10966

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
