### PR TITLE
removed route_st_louis_rpo_to_buffalo_rpo feature flag

### DIFF
--- a/app/workers/education_form/education_facility.rb
+++ b/app/workers/education_form/education_facility.rb
@@ -90,21 +90,10 @@ module EducationForm
 
     def self.check_area(address)
       area = address&.state
-      if Flipper.enabled?(:route_st_louis_rpo_to_buffalo_rpo)
-        if WESTERN.any? { |state| state == area }
-          :western
-        else
-          :eastern
-        end
+      if WESTERN.any? { |state| state == area }
+        :western
       else
-        case area
-        when *CENTRAL
-          :central
-        when *WESTERN
-          :western
-        else
-          :eastern
-        end
+        :eastern
       end
     end
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -166,10 +166,6 @@ features:
     actor_type: user
     description: >
       Comparison Tool Search Enhancements to improve usability
-  route_st_louis_rpo_to_buffalo_rpo:
-    actor_type: user
-    description: >
-      All submission data that was previously routed to St Louis RPO is routed to the Buffalo RPO
   form996_higher_level_review:
     actor_type: user
     description: >


### PR DESCRIPTION
## Description
As a developer, I need to remove the feature flag for the RPO routing updates because it will not be disabled going forward.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/10816
frontend pr: https://github.com/department-of-veterans-affairs/vets-website/pull/13889

## Testing done
Local Testing 

## Screenshots
After applying to a school in Illinois, application gets routed to Buffalo

![Screen Shot 2020-08-17 at 12 38 27 PM](https://user-images.githubusercontent.com/50601724/90420913-a06da080-e086-11ea-9766-d4275256f013.png)


## Acceptance criteria
- [x] The feature flag 'route_st_louis_rpo_to_buffalo_rpo' is not displayed here: https://[environment]-api.va.gov/flipper/features.
- [x] The routing updates made as part of the following stories is still behaving as expected:
a. #10581

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
