### PR TITLE
10976 use hca as acronym

### DIFF
--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -133,7 +133,7 @@ module V0
       Swagger::Requests::Gibct::InstitutionPrograms,
       Swagger::Requests::Gibct::YellowRibbonPrograms,
       Swagger::Requests::HealthCareApplications,
-      Swagger::Requests::HcaAttachments,
+      Swagger::Requests::HCAAttachments,
       Swagger::Requests::InProgressForms,
       Swagger::Requests::IntentToFile,
       Swagger::Requests::Letters,

--- a/app/controllers/v0/hca_attachments_controller.rb
+++ b/app/controllers/v0/hca_attachments_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module V0
-  class HcaAttachmentsController < ApplicationController
+  class HCAAttachmentsController < ApplicationController
     include FormAttachmentCreate
 
-    FORM_ATTACHMENT_MODEL = HcaAttachment
+    FORM_ATTACHMENT_MODEL = HCAAttachment
   end
 end

--- a/app/models/hca_attachment.rb
+++ b/app/models/hca_attachment.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class HcaAttachment < FormAttachment
-  ATTACHMENT_UPLOADER_CLASS = HcaAttachmentUploader
+class HCAAttachment < FormAttachment
+  ATTACHMENT_UPLOADER_CLASS = HCAAttachmentUploader
 end

--- a/app/serializers/hca_attachment_serializer.rb
+++ b/app/serializers/hca_attachment_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class HcaAttachmentSerializer < ActiveModel::Serializer
+class HCAAttachmentSerializer < ActiveModel::Serializer
   attribute :guid
 end

--- a/app/swagger/swagger/requests/hca_attachments.rb
+++ b/app/swagger/swagger/requests/hca_attachments.rb
@@ -2,7 +2,7 @@
 
 module Swagger
   module Requests
-    class HcaAttachments
+    class HCAAttachments
       include Swagger::Blocks
 
       swagger_path '/v0/hca_attachments' do

--- a/app/uploaders/hca_attachment_uploader.rb
+++ b/app/uploaders/hca_attachment_uploader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class HcaAttachmentUploader < CarrierWave::Uploader::Base
+class HCAAttachmentUploader < CarrierWave::Uploader::Base
   include ValidateFileSize
   include SetAwsConfig
   include UploaderVirusScan

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -12,6 +12,7 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'EVSS'
   inflect.acronym 'GIDS'
   inflect.acronym 'GI'
+  inflect.acronym 'HCA'
   inflect.acronym 'IHub'
   inflect.acronym 'MDOT'
   inflect.acronym 'MHV' # My HealtheVet

--- a/lib/hca/enrollment_system.rb
+++ b/lib/hca/enrollment_system.rb
@@ -727,7 +727,7 @@ module HCA
       request = build_form_for_user(current_user)
 
       veteran['attachments']&.each do |attachment|
-        hca_attachment = HcaAttachment.find_by(guid: attachment['confirmationCode'])
+        hca_attachment = HCAAttachment.find_by(guid: attachment['confirmationCode'])
         request['va:form']['va:attachments'] ||= []
         request['va:form']['va:attachments'] << add_attachment(hca_attachment.get_file, attachment['dd214'])
       end

--- a/spec/controllers/v0/hca_attachments_controller_spec.rb
+++ b/spec/controllers/v0/hca_attachments_controller_spec.rb
@@ -2,14 +2,14 @@
 
 require 'rails_helper'
 
-RSpec.describe V0::HcaAttachmentsController, type: :controller do
+RSpec.describe V0::HCAAttachmentsController, type: :controller do
   describe '#create' do
     it 'uploads an hca attachment' do
       post(:create, params: { hca_attachment: {
              file_data: fixture_file_upload('pdf_fill/extras.pdf')
            } })
-      expect(JSON.parse(response.body)['data']['attributes']['guid']).to eq HcaAttachment.last.guid
-      expect(FormAttachment.last).to be_a(HcaAttachment)
+      expect(JSON.parse(response.body)['data']['attributes']['guid']).to eq HCAAttachment.last.guid
+      expect(FormAttachment.last).to be_a(HCAAttachment)
     end
 
     it 'validates input parameters' do
@@ -26,7 +26,7 @@ RSpec.describe V0::HcaAttachmentsController, type: :controller do
              file_data: file_data
            } })
 
-      uploaded_file_path =  HcaAttachment.last.get_file.file
+      uploaded_file_path =  HCAAttachment.last.get_file.file
       file_1 = File.open(uploaded_file_path).read
       file_2 = File.open(file_data).read
 


### PR DESCRIPTION
## Description of change
`HCA` is used throughout the app as an acronym.  To support upcoming zeitwerk changes, the inflection to support it as an acronym was added.  Additionally, there were some variations of `HcaAttachment` that were updated to `HCAAttachment`.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#10976
