### PR TITLE
use upstream pact-ruby instead of fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ group :test do
   gem 'apivore', git: 'https://github.com/department-of-veterans-affairs/apivore', branch: 'master'
   gem 'awrence'
   gem 'fakeredis'
-  gem 'pact', git: 'https://github.com/f1337/pact-ruby', branch: 'f1337/bump-thor-dependency', require: false
+  gem 'pact', require: false
   gem 'pact-mock_service', require: false
   gem 'pdf-inspector'
   gem 'rspec-retry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,20 +64,6 @@ GIT
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 
-GIT
-  remote: https://github.com/f1337/pact-ruby
-  revision: a01e136f246d64117a24635a98b3c40e9d1b070a
-  branch: f1337/bump-thor-dependency
-  specs:
-    pact (1.51.0)
-      pact-mock_service (~> 3.0, >= 3.3.1)
-      pact-support (~> 1.9)
-      rack-test (>= 0.6.3, < 2.0.0)
-      rspec (~> 3.0)
-      term-ansicolor (~> 1.0)
-      thor (>= 0.20, < 2.0)
-      webrick (~> 1.3)
-
 PATH
   remote: modules/appeals_api
   specs:
@@ -532,6 +518,14 @@ GEM
       childprocess (>= 0.6.3, < 4)
       iniparse (~> 1.4)
     ox (2.13.2)
+    pact (1.51.1)
+      pact-mock_service (~> 3.0, >= 3.3.1)
+      pact-support (~> 1.9)
+      rack-test (>= 0.6.3, < 2.0.0)
+      rspec (~> 3.0)
+      term-ansicolor (~> 1.0)
+      thor (>= 0.20, < 2.0)
+      webrick (~> 1.3)
     pact-mock_service (3.6.2)
       filelock (~> 1.1)
       find_a_port (~> 1.0.1)
@@ -915,7 +909,7 @@ DEPENDENCIES
   origami
   overcommit
   ox
-  pact!
+  pact
   pact-mock_service
   paper_trail
   pdf-forms


### PR DESCRIPTION
The [upstream PR](https://github.com/pact-foundation/pact-ruby/pull/218) merged, so we no longer need the fork. 👯 