### PR TITLE
[Flipper] Add three new admins based on Cerner rollout

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -463,6 +463,7 @@ flipper:
     - anna@adhoc.team
     - bconley@governmentcio.com
     - bill.ryan@adhocteam.us
+    - cory.trimm@va.gov
     - dan.hinze@adhocteam.us
     - delli-gatti_michael@bah.com
     - devinmccurdy@gmail.com
@@ -479,6 +480,7 @@ flipper:
     - kabrown@thoughtworks.com
     - kam@adhocteam.us
     - keifer@oddball.io
+    - kadams@governmentcio.com
     - kenneth.gary@va.gov
     - kenneth.santiago2010@gmail.com
     - kmircovich@governmentcio.com
@@ -492,6 +494,7 @@ flipper:
     - michael.fleet@oddball.io
     - n.ratana@gmail.com
     - narin@adhocteam.us
+    - nick.sullivan@adhocteam.us
     - osanchez@governmentcio.com
     - patrick.bateman@va.gov
     - patrick@adhocteam.us


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

Cerner integration is beginning today and so we have shipped several products hooked up to Flipper flags. Search `cerner` on the list of feature flags to see which ones. We're adding a few users to the list of Flipper admins so that we can control the Flipper state ourselves.

## Original issue(s)
- https://dsva.slack.com/archives/C52CL1PKQ/p1597934941010800

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
