### PR TITLE
use transactional fixtures for pact rspec config

### DIFF
--- a/spec/factories/in_progress_forms/hca_forms.rb
+++ b/spec/factories/in_progress_forms/hca_forms.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :hca_in_progress_form do
+  factory :hca_in_progress_form, class: InProgressForm do
     user_uuid { SecureRandom.uuid }
     form_id { '1010cg' }
     metadata do

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -36,6 +36,8 @@ Pact.configure do |config|
 end
 
 RSpec.configure do |config|
+  config.use_transactional_fixtures = true
+
   config.before do |example|
     stub_mvi unless example.metadata[:skip_mvi]
     stub_emis unless example.metadata[:skip_emis]


### PR DESCRIPTION
## Description of change
This rspec config change was overlooked when implementing the pact helper. config.use_transactional_fixtures needs to be set to true in order to start each example with a clean database. Without wrapping in a transaction to rollback the data, the pact test gives misleading passing status based on pre existing data left hanging around.

Additionally, the class name for the HCA form factory needs to be defined. Pacts will pass once the frontend pushes pact updates to the broker.


## Testing
- [x] Specs pass