### PR TITLE
Remove unnecessary upsert gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,6 @@ gem 'staccato'
 gem 'statsd-instrument', '~> 2.6.0' # versions beyond 2.6 deprecate config and change logging messages
 gem 'swagger-blocks'
 gem 'typhoeus'
-gem 'upsert'
 gem 'utf8-cleaner'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -789,7 +789,6 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
-    upsert (2.9.10)
     uri_template (0.7.0)
     utf8-cleaner (0.2.5)
       activesupport
@@ -965,7 +964,6 @@ DEPENDENCIES
   timecop
   typhoeus
   tzinfo-data
-  upsert
   utf8-cleaner
   va_facilities!
   va_forms!

--- a/app/models/form526_job_status.rb
+++ b/app/models/form526_job_status.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'upsert/active_record_upsert'
-
 class Form526JobStatus < ApplicationRecord
   belongs_to :form526_submission
 

--- a/app/workers/evss/disability_compensation_form/job_status.rb
+++ b/app/workers/evss/disability_compensation_form/job_status.rb
@@ -29,7 +29,7 @@ module EVSS
             error_message: error_message,
             updated_at: Time.now.utc
           }
-          Form526JobStatus.upsert({ job_id: jid }, values)
+          Form526JobStatus.upsert(values, unique_by: :job_id)
 
           Rails.logger.error(
             'Form526 Exhausted', submission_id: submission_id, job_id: jid, error_message: error_message
@@ -109,7 +109,7 @@ module EVSS
         }
         values[:error_class] = error.class if error
         values[:error_message] = error_message(error) if error
-        Form526JobStatus.upsert({ job_id: jid }, values)
+        Form526JobStatus.upsert(values, unique_by: :job_id)
       end
 
       def error_message(error)

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
             status: Form526JobStatus::STATUS[:try],
             updated_at: Time.now.utc
           }
-          Form526JobStatus.upsert({ job_id: jid }, values)
+          Form526JobStatus.upsert(values, unique_by: :job_id)
 
           described_class.drain
           expect(Form526JobStatus.last.status).to eq 'success'

--- a/spec/models/form526_job_status_spec.rb
+++ b/spec/models/form526_job_status_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Form526JobStatus do
 
     it 'creates a record' do
       expect do
-        Form526JobStatus.upsert({ job_id: jid }, values)
+        Form526JobStatus.upsert(values, unique_by: :job_id)
       end.to change(Form526JobStatus, :count).by(1)
     end
   end


### PR DESCRIPTION
## Description of change
Upsert was added to vets-api in https://github.com/department-of-veterans-affairs/vets-api/pull/2418 before rails added upsert https://github.com/rails/rails/pull/35077 

Upsert was only used in Form526JobStatus