### PR TITLE
Covid research/form delivery

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -574,3 +574,10 @@ va_forms:
   drupal_username: ~
   drupal_password: ~
   drupal_url: http://internal-dsva-vagov-dev-cms-812329399.us-gov-west-1.elb.amazonaws.com
+
+# Settings for connecting to genISIS, this is the storage system for the COVID Research initiative
+genisis:
+  base_url: https://vaausapprne60.aac.dva.va.gov
+  service_path: /COVID19Service
+  user: TestUser
+  pass: bogus

--- a/modules/covid_research/app/services/covid_research/volunteer/genisis_service.rb
+++ b/modules/covid_research/app/services/covid_research/volunteer/genisis_service.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Base URL: https://vaausapprne60.aac.dva.va.gov/COVID19Service
+# Endpoint: formdata
+# Method: POST
+
+# Username: COVTestUser
+# Password: VAcovid-19test!
+
+module CovidResearch
+  module Volunteer
+    class GenisisService < Common::Client::Base
+      include Common::Client::Concerns::Monitoring
+      include SentryLogging
+
+      STATSD_KEY_PREFIX = 'api.covid-research.volunteer'
+
+      attr_reader :delivery_response, :serializer, :submission
+
+      def initialize(form_data, ser = :default)
+        @serializer = ser == :default ? GenisisSerializer.new : ser
+        @submission = form_data
+        @delivery_respone = :unattempted
+      end
+
+      def deliver_form
+        with_monitoring do
+          @delivery_response = post(payload)
+
+          unless @delivery_response.success?
+            StatsD.increment(STATSD_KEY_PREFIX + '.deliver_form.fail')
+          end
+        end
+      end
+
+      def payload
+        serializer.serialize(submission)
+      end
+
+      private
+
+      def post(params)
+        conn.post("#{Settings.genisis.service_path}/formdata", params)
+      end
+
+      def headers
+        {
+          'Content-Type' => 'application/json'
+        }
+      end
+
+      def conn
+        c = Faraday.new(url: Settings.genisis.base_url)
+        c.basic_auth(Settings.genisis.user, Settings.genisis.pass)
+
+        c
+      end
+    end
+  end
+end

--- a/modules/covid_research/app/services/covid_research/volunteer/genisis_service.rb
+++ b/modules/covid_research/app/services/covid_research/volunteer/genisis_service.rb
@@ -27,9 +27,7 @@ module CovidResearch
         with_monitoring do
           @delivery_response = post(payload)
 
-          unless @delivery_response.success?
-            StatsD.increment(STATSD_KEY_PREFIX + '.deliver_form.fail')
-          end
+          StatsD.increment(STATSD_KEY_PREFIX + '.deliver_form.fail') unless @delivery_response.success?
         end
       end
 

--- a/modules/covid_research/app/workers/covid_research/volunteer/genisis_delivery_job.rb
+++ b/modules/covid_research/app/workers/covid_research/volunteer/genisis_delivery_job.rb
@@ -23,9 +23,7 @@ module CovidResearch
       end
 
       def handle_response(response)
-        unless response.success?
-          raise GenisisDeliveryFailure.new response.body, response.status
-        end
+        raise GenisisDeliveryFailure.new(response.body, response.status) unless response.success?
       end
 
       private

--- a/modules/covid_research/app/workers/covid_research/volunteer/genisis_delivery_job.rb
+++ b/modules/covid_research/app/workers/covid_research/volunteer/genisis_delivery_job.rb
@@ -24,14 +24,14 @@ module CovidResearch
 
       def handle_response(response)
         unless response.success?
-          raise GenisisDeliveryFailure response.body, response.status
+          raise GenisisDeliveryFailure.new response.body, response.status
         end
       end
 
       private
 
       def set_submission(submission)
-        @submitter ||= service.new(JSON.parse(submission.form_data))
+        @submitter ||= service.new(JSON.parse(submission))
       end
     end
 

--- a/modules/covid_research/spec/covid_research_spec_helper.rb
+++ b/modules/covid_research/spec/covid_research_spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'webmock/rspec'
+
 module CovidResearchSpecHelper
   def read_fixture(file_name)
     path = File.expand_path('fixtures/files', __dir__)

--- a/modules/covid_research/spec/services/covid_research/volunteer/genisis_service_spec.rb
+++ b/modules/covid_research/spec/services/covid_research/volunteer/genisis_service_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../../app/services/covid_research/volunteer/genisis_service.rb'
+require_relative '../../../covid_research_spec_helper.rb'
+
+RSpec.configure do |c|
+  c.include CovidResearchSpecHelper
+end
+
+RSpec.describe CovidResearch::Volunteer::GenisisService do
+  let(:subject)    { described_class.new(form_data, serializer) }
+  let(:serializer) { double('serializer', serialize: 'form') }
+  let(:form_data)  { 'form_data' }
+
+  describe 'prep' do
+    it 'serializes the data to build the genISIS payload' do
+      expect(serializer).to receive(:serialize).with(form_data)
+
+      subject.payload
+    end
+  end
+
+  describe 'delivery' do
+    it 'stores the delivery response' do
+      stub_request(:post, "#{Settings.genisis.base_url}#{Settings.genisis.service_path}/formdata")
+        .to_return(status: 200, body: '{}')
+
+      subject.deliver_form
+      expect(subject.delivery_response).not_to eq(:unattempted)
+    end
+
+    it 'increments the form delivery statsd counter' do
+      stub_request(:post, "#{Settings.genisis.base_url}#{Settings.genisis.service_path}/formdata")
+        .to_return(status: 200, body: '{}')
+
+      expect { subject.deliver_form }.to trigger_statsd_increment('api.covid-research.volunteer.deliver_form.total', times: 1, value: 1)
+    end
+
+    it 'increments the failed delivery counter if there is an error' do
+      stub_request(:post, "#{Settings.genisis.base_url}#{Settings.genisis.service_path}/formdata")
+        .to_return(status: 500)
+
+      expect { subject.deliver_form }.to trigger_statsd_increment('api.covid-research.volunteer.deliver_form.fail', times: 1, value: 1)
+    end
+  end
+end

--- a/modules/covid_research/spec/services/covid_research/volunteer/genisis_service_spec.rb
+++ b/modules/covid_research/spec/services/covid_research/volunteer/genisis_service_spec.rb
@@ -34,14 +34,18 @@ RSpec.describe CovidResearch::Volunteer::GenisisService do
       stub_request(:post, "#{Settings.genisis.base_url}#{Settings.genisis.service_path}/formdata")
         .to_return(status: 200, body: '{}')
 
-      expect { subject.deliver_form }.to trigger_statsd_increment('api.covid-research.volunteer.deliver_form.total', times: 1, value: 1)
+      expect { subject.deliver_form }.to trigger_statsd_increment(
+        'api.covid-research.volunteer.deliver_form.total', times: 1, value: 1
+      )
     end
 
     it 'increments the failed delivery counter if there is an error' do
       stub_request(:post, "#{Settings.genisis.base_url}#{Settings.genisis.service_path}/formdata")
         .to_return(status: 500)
 
-      expect { subject.deliver_form }.to trigger_statsd_increment('api.covid-research.volunteer.deliver_form.fail', times: 1, value: 1)
+      expect { subject.deliver_form }.to trigger_statsd_increment(
+        'api.covid-research.volunteer.deliver_form.fail', times: 1, value: 1
+      )
     end
   end
 end

--- a/modules/covid_research/spec/workers/covid_research/volunteer/genisis_delivery_job_spec.rb
+++ b/modules/covid_research/spec/workers/covid_research/volunteer/genisis_delivery_job_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../../app/workers/covid_research/volunteer/genisis_delivery_job.rb'
+require_relative '../../../../lib/redis_format.rb'
+require_relative '../../../covid_research_spec_helper.rb'
+
+RSpec.configure do |c|
+  c.include CovidResearchSpecHelper
+end
+
+RSpec.describe CovidResearch::Volunteer::GenisisDeliveryJob do
+  subject               { described_class.new }
+
+  let(:fmt_double)      { double('RedisFormat Instance', from_redis: submission) }
+  let(:form_data)       { read_fixture('encrypted-form.json') }
+  let(:response_double) { double('response') }
+  let(:service_double)  { double('Service Instance', deliver_form: true) }
+  let(:submission)      { read_fixture('valid-submission.json') }
+
+  before do
+    allow(CovidResearch::RedisFormat).to receive(:new).and_return(fmt_double)
+    allow(CovidResearch::Volunteer::GenisisService).to receive(:new).and_return(service_double)
+  end
+
+  describe '#perform' do
+    before do
+      allow(service_double).to receive(:delivery_response).and_return(response_double)
+      allow(response_double).to receive(:success?).and_return(true)
+    end
+
+    it 'converts the raw data to the internal RedisFormat' do
+      expect(fmt_double).to receive(:from_redis).with(form_data)
+
+      subject.perform(form_data)
+    end
+
+    it 'delivers the form' do
+      expect(service_double).to receive(:deliver_form)
+
+      subject.perform(form_data)
+    end
+
+    describe 'response handling' do
+      it 'does not raise an exception if the response is a success' do
+        expect { subject.perform(form_data) }.not_to raise_error
+      end
+
+      it 'raises GenisisDeliveryFailure if there is an error' do
+        allow(response_double).to receive(:success?).and_return(false)
+        allow(response_double).to receive(:body).and_return('Internal Server Error')
+        allow(response_double).to receive(:status).and_return(500)
+
+        expect { subject.perform(form_data) }.to raise_error(CovidResearch::Volunteer::GenisisDeliveryFailure)
+      end
+    end
+  end
+end


### PR DESCRIPTION

## Description of change
This PR adds logic responsible for the delivery of a submitted Volunteer form to the `genISIS` backend.  

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12096

## Things to know about this PR
This PR does include new values for `settings.yml`, they are all name spaced under `genisis`.  Currently the settings are in place for dev and staging.  They will not be added for production until the implementation has been tested.  The next PR will introduce a flipper along with logic which actually makes this code live.  Currently the controller does nothing with a valid submission other than return a small static JSON body.

There are unit tests for all the new code.  The integration can't currently be tested outside the VA network and the code is not yet passing the data all the way through.
