### PR TITLE
Covid research/genisis flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -15,6 +15,10 @@ features:
       of manual screening with a VHA employee.
       This toggle is owned by Patrick B. and the rest of the CTO Health Products
       team.
+  covid_volunteer_delivery:
+    actor_type: cookie_id
+    description: >
+      Toggles whether COVID Research volunteer submissions will be delivered to genISIS
   dashboard_show_covid19_alert:
     actor_type: user
     description: >

--- a/modules/covid_research/app/services/covid_research/volunteer/genisis_service.rb
+++ b/modules/covid_research/app/services/covid_research/volunteer/genisis_service.rb
@@ -32,7 +32,7 @@ module CovidResearch
       end
 
       def payload
-        serializer.serialize(submission)
+        serializer.serialize(JSON.parse(submission))
       end
 
       private

--- a/modules/covid_research/app/workers/covid_research/volunteer/genisis_delivery_job.rb
+++ b/modules/covid_research/app/workers/covid_research/volunteer/genisis_delivery_job.rb
@@ -29,7 +29,7 @@ module CovidResearch
       private
 
       def set_submission(submission)
-        @submitter ||= service.new(JSON.parse(submission))
+        @submitter ||= service.new(submission)
       end
     end
 

--- a/modules/covid_research/lib/covid_research.rb
+++ b/modules/covid_research/lib/covid_research.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'covid_research/engine'
+require 'redis_format'
 
 module CovidResearch
   # Your code goes here...

--- a/modules/covid_research/spec/covid_research_spec_helper.rb
+++ b/modules/covid_research/spec/covid_research_spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'webmock/rspec'
+require 'statsd-instrument'
+require 'statsd/instrument/matchers'
 
 module CovidResearchSpecHelper
   def read_fixture(file_name)

--- a/modules/covid_research/spec/services/covid_research/volunteer/form_service_spec.rb
+++ b/modules/covid_research/spec/services/covid_research/volunteer/form_service_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../../../app/services/covid_research/volunteer/form_service.rb'
-require_relative '../../covid_research_spec_helper.rb'
+require_relative '../../../../app/services/covid_research/volunteer/form_service.rb'
+require_relative '../../../covid_research_spec_helper.rb'
+require_relative '../../../../lib/redis_format.rb' # No Rails helper no auto-load
 
 RSpec.configure do |c|
   c.include CovidResearchSpecHelper
@@ -40,6 +41,36 @@ RSpec.describe CovidResearch::Volunteer::FormService do
 
       it 'returns an empty list if they JSON is valid' do
         expect(subject.submission_errors(valid)).to be_empty
+      end
+    end
+  end
+
+  context 'genISIS delivery' do
+    describe '#queue_delivery' do
+      let(:subject)       { described_class.new(worker_double) }
+      let(:worker_double) { double('worker', perform_async: true) }
+      let(:redis_format)  { 'redis' }
+      let(:encrypted)     { 'encrypted' } # For sanity, it doesn't really matter
+
+      let(:submission) do
+        { 'submission' => 'data' }
+      end
+
+      before do
+        allow_any_instance_of(CovidResearch::RedisFormat).to receive(:to_json).and_return(encrypted)
+      end
+
+      it 'converts the submission to the RedisFormat' do
+        expect_any_instance_of(CovidResearch::RedisFormat).to receive(:form_data=)
+
+        subject.queue_delivery(submission)
+      end
+
+      it 'schedules the submission for delivery to genISIS' do
+        allow_any_instance_of(CovidResearch::RedisFormat).to receive(:form_data=).and_return(submission)
+        expect(worker_double).to receive(:perform_async).with(encrypted)
+
+        subject.queue_delivery(submission)
       end
     end
   end

--- a/modules/covid_research/spec/services/covid_research/volunteer/genisis_service_spec.rb
+++ b/modules/covid_research/spec/services/covid_research/volunteer/genisis_service_spec.rb
@@ -6,16 +6,17 @@ require_relative '../../../covid_research_spec_helper.rb'
 
 RSpec.configure do |c|
   c.include CovidResearchSpecHelper
+  c.include StatsD::Instrument::Matchers
 end
 
 RSpec.describe CovidResearch::Volunteer::GenisisService do
   let(:subject)    { described_class.new(form_data, serializer) }
   let(:serializer) { double('serializer', serialize: 'form') }
-  let(:form_data)  { 'form_data' }
+  let(:form_data)  { '{"form_data":"content"}' }
 
   describe 'prep' do
     it 'serializes the data to build the genISIS payload' do
-      expect(serializer).to receive(:serialize).with(form_data)
+      expect(serializer).to receive(:serialize).with(JSON.parse(form_data))
 
       subject.payload
     end


### PR DESCRIPTION
## Description of change
This PR cleans up the "full" flow for volunteer form delivery to `genISIS` as well as adding a feature flag to control how/where that flow actually executes.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12096

## Things to know about this PR
This one is pretty straight forward.  The only "feature"/behavior it adds is the flag for the `genISIS` delivery.  It also has some corrections encountered while testing that flow.

I did not see anything in the documentation about defaulting a Flipper to off.  Is that something that happens for production by default?

Once these changes are merged my intent is to test actual form delivery to `genISIS` in development.  Once we confirm that that is working we will work with the `genISIS` team to setup a production instance of their application, add that configuration to `vets-api` (in the prod settings) then test after the next deploy.
