### PR TITLE
Education spool file region cleanup

### DIFF
--- a/app/workers/education_form/education_facility.rb
+++ b/app/workers/education_form/education_facility.rb
@@ -5,18 +5,15 @@ module EducationForm
     # sourced from http://www.vba.va.gov/pubs/forms/VBA-22-1990-ARE.pdf
 
     EASTERN = %w[
-      CT DE DC ME MD MA NC NH NJ NY PA RI VT VA
-      VI AA
+      CO CT DE DC IA IL IN KS KY MA ME MI MD MN MO MT NC ND NE
+      NH NJ NY OH PA RI SD TN VT VA WV WI WY VI AA
     ].freeze
 
-    # We need to keep SOUTHERN because existing records will have
+    # We need to keep SOUTHERN and CENTRAL because existing records will have
     # this as a region, and we need to continue to show the counts
     # in the YTD reports.
     SOUTHERN = %w[].freeze
-
-    CENTRAL = %w[
-      CO IA IL IN KS KY MI MN MO MT NE ND OH SD TN WV WI WY
-    ].freeze
+    CENTRAL = %w[].freeze
 
     WESTERN = %w[
       AK AL AR AZ CA FL GA HI ID LA MS NM NV OK OR SC TX UT WA


### PR DESCRIPTION
## Description of change
Moved states from `CENTRAL` to `EASTERN` because all submissions are now routed to only the Buffalo or Muskogee region.  Updated the comment to make clear that the empty list is required for historical reporting purposes.

This change doesn't modify any functionality but should make it clearer that there are only two possible regions for submissions.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12818

## Things to know about this PR
- Tested locally and QA reviewed