### PR TITLE
10185 add missing requires to rake tasks

### DIFF
--- a/rakelib/load_test.rake
+++ b/rakelib/load_test.rake
@@ -20,6 +20,7 @@ namespace :load_test do
   desc 'Load test the HCA Enrollment & Eligibility API'
   task :hca_ee, [:icn] => [:environment] do |_, args|
     require './rakelib/support/vic_load_test'
+    require 'hca/enrollment_eligibility/service'
 
     LoadTest.measure_elapsed do
       10.times do

--- a/rakelib/mvi.rake
+++ b/rakelib/mvi.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'csv'
+require 'mvi/models/mvi_profile'
 require 'mvi/responses/id_parser'
 
 namespace :mvi do

--- a/rakelib/vet360.rake
+++ b/rakelib/vet360.rake
@@ -2,6 +2,8 @@
 
 require 'vet360/contact_information/service'
 require 'vet360/exceptions/builder'
+require 'vet360/models/email'
+require 'vet360/models/telephone'
 require 'vet360/person/service'
 
 namespace :vet360 do


### PR DESCRIPTION
## Description of change
Checked rake tasks for missing `requires` commands, these are the ones I found

## Original issue(s)
department-of-veterans-affairs/va.gov-team#10185