### PR TITLE
Lighthouse APIs - use property detail instead of details

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/concerns/document_validations.rb
+++ b/modules/claims_api/app/controllers/claims_api/concerns/document_validations.rb
@@ -39,7 +39,7 @@ module ClaimsApi
         {
           status: 422,
           source: document.original_filename,
-          details: "#{document.original_filename} exceeds the maximum page dimensions of 11 in x 11 in"
+          detail: "#{document.original_filename} exceeds the maximum page dimensions of 11 in x 11 in"
         }
       end
 
@@ -47,7 +47,7 @@ module ClaimsApi
         {
           status: 422,
           source: document.original_filename,
-          details: "#{document.original_filename} must be in PDF format"
+          detail: "#{document.original_filename} must be in PDF format"
         }
       end
     end

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -64,7 +64,7 @@ module ClaimsApi
               errors: [
                 {
                   status: 422,
-                  details: 'Veteran has no claims, autoCestPDFGenerationDisabled requires true for Initial Claim'
+                  detail: 'Veteran has no claims, autoCestPDFGenerationDisabled requires true for Initial Claim'
                 }
               ]
             }
@@ -77,7 +77,7 @@ module ClaimsApi
 
           unless @claim
             render(
-              json: { errors: [{ status: 404, details: "Claim not found: #{params[:id]}" }] },
+              json: { errors: [{ status: 404, detail: "Claim not found: #{params[:id]}" }] },
               status: :not_found
             )
           end

--- a/modules/claims_api/app/swagger/claims_api/common/error_model_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/common/error_model_swagger.rb
@@ -9,7 +9,7 @@ module ClaimsApi
         schema :ErrorModel do
           key :description, 'Errors with some details for the given request'
 
-          key :required, %i[status details]
+          key :required, %i[status detail]
           property :status do
             key :type, :integer
             key :format, :int32
@@ -23,7 +23,7 @@ module ClaimsApi
             key :description, 'a JSON Pointer to the offending attribute in the payload'
           end
 
-          property :details do
+          property :detail do
             key :type, :string
             key :example, 'burial is not currently supported, but will be in a future version'
             key :description, 'A more detailed message about why an error occured'

--- a/modules/vba_documents/app/swagger/vba_documents/v1/error_model_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v1/error_model_swagger.rb
@@ -9,7 +9,7 @@ module VbaDocuments
         schema :ErrorModel do
           key :description, 'Errors with some details for the given request'
 
-          key :required, %i[status details]
+          key :required, %i[status detail]
           property :status do
             key :type, :integer
             key :format, :int32
@@ -17,7 +17,7 @@ module VbaDocuments
             key :description, 'Standard HTTP Status returned with Error'
           end
 
-          property :details do
+          property :detail do
             key :type, :string
             key :example, 'DOC104 - Upload rejected by downstream system.'
             key :description, 'A more detailed message about why an error occured'


### PR DESCRIPTION
noticed this typo.
JSON:API errors can have property `detail` not `details`
https://jsonapi.org/format/#errors