### PR TITLE
Fixing the intent to file /active because BGS can return a single or …

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v0/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/intent_to_file_controller.rb
@@ -23,15 +23,16 @@ module ClaimsApi
             target_veteran.participant_id,
             ClaimsApi::IntentToFile::ITF_TYPES[active_param]
           )
-          if bgs_response.present?
+          if bgs_response.is_a?(Array)
             bgs_active = bgs_response.detect do |itf|
-              itf.present? && itf[:itf_status_type_cd] == 'Active' && itf[:exprtn_dt].to_datetime > Time.zone.now
+              active?(itf)
             end
-            if bgs_active.present?
-              render json: bgs_active, serializer: ClaimsApi::IntentToFileSerializer
-            else
-              render json: itf_not_found, status: :not_found
-            end
+          elsif active?(bgs_response)
+            bgs_active = bgs_response
+          end
+
+          if bgs_active.present?
+            render json: bgs_active, serializer: ClaimsApi::IntentToFileSerializer
           else
             render json: itf_not_found, status: :not_found
           end
@@ -42,6 +43,10 @@ module ClaimsApi
         end
 
         private
+
+        def active?(itf)
+          itf.present? && itf[:itf_status_type_cd] == 'Active' && itf[:exprtn_dt].to_datetime > Time.zone.now
+        end
 
         def active_param
           params.require(:type)

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
@@ -24,15 +24,16 @@ module ClaimsApi
             target_veteran.participant_id,
             ClaimsApi::IntentToFile::ITF_TYPES[active_param]
           )
-          if bgs_response.present?
+          if bgs_response.is_a?(Array)
             bgs_active = bgs_response.detect do |itf|
-              itf.present? && itf[:itf_status_type_cd] == 'Active' && itf[:exprtn_dt].to_datetime > Time.zone.now
+              active?(itf)
             end
-            if bgs_active.present?
-              render json: bgs_active, serializer: ClaimsApi::IntentToFileSerializer
-            else
-              render json: itf_not_found, status: :not_found
-            end
+          elsif active?(bgs_response)
+            bgs_active = bgs_response
+          end
+
+          if bgs_active.present?
+            render json: bgs_active, serializer: ClaimsApi::IntentToFileSerializer
           else
             render json: itf_not_found, status: :not_found
           end
@@ -43,6 +44,10 @@ module ClaimsApi
         end
 
         private
+
+        def active?(itf)
+          itf.present? && itf[:itf_status_type_cd] == 'Active' && itf[:exprtn_dt].to_datetime > Time.zone.now
+        end
 
         def active_param
           params.require(:type)


### PR DESCRIPTION
…array of objects

## Description of change
During my sandbox/production testing of ITF I ran into a bug that we couldn't account for in our refactor and testing.

http://sentry.vfs.va.gov/vets-gov/platform-api-sandbox/issues/190291/?referrer=slack

## Original issue(s)
https://vajira.max.gov/browse/API-2160

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
