### PR TITLE
Added user to feature flags for added email access

### DIFF
--- a/app/models/form_profiles/va10203.rb
+++ b/app/models/form_profiles/va10203.rb
@@ -27,7 +27,7 @@ class FormProfiles::VA10203 < FormProfile
   def prefill(user)
     authorized = user.authorize :evss, :access?
 
-    if Flipper.enabled?(:stem_sco_email) && authorized
+    if Flipper.enabled?(:stem_sco_email, user) && authorized
       gi_bill_status = get_gi_bill_status(user)
       @remaining_entitlement = initialize_entitlement_information(gi_bill_status)
       @school_information = initialize_school_information(gi_bill_status)

--- a/app/models/saved_claim/education_benefits/va10203.rb
+++ b/app/models/saved_claim/education_benefits/va10203.rb
@@ -9,7 +9,7 @@ class SavedClaim::EducationBenefits::VA10203 < SavedClaim::EducationBenefits
 
     StemApplicantConfirmationMailer.build(self, nil).deliver_now
 
-    if Flipper.enabled?(:stem_sco_email) && user.present?
+    if Flipper.enabled?(:stem_sco_email, user) && user.present?
       authorized = user.authorize(:evss, :access?)
 
       EducationForm::SendSCOEmail.perform_async(user.uuid, id) if authorized

--- a/spec/jobs/education_form/create_daily_fiscal_year_to_date_report_spec.rb
+++ b/spec/jobs/education_form/create_daily_fiscal_year_to_date_report_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe EducationForm::CreateDailyFiscalYearToDateReport, type: :aws_help
   let(:date) { Time.zone.today - 1.day }
 
   before do
-    Flipper.enable('edu_benefits_stem_scholarship')
     allow_any_instance_of(EducationBenefitsClaim).to receive(:create_education_benefits_submission)
   end
 

--- a/spec/jobs/education_form/create_daily_year_to_date_report_spec.rb
+++ b/spec/jobs/education_form/create_daily_year_to_date_report_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe EducationForm::CreateDailyYearToDateReport, type: :aws_helpers do
   let(:date) { Time.zone.today - 1.day }
 
   before do
-    Flipper.enable('edu_benefits_stem_scholarship')
     allow_any_instance_of(EducationBenefitsClaim).to receive(:create_education_benefits_submission)
   end
 

--- a/spec/models/saved_claim/education_benefits/va10203_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va10203_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
     context 'authorized' do
       before do
-        allow(Flipper).to receive(:enabled?).with(:stem_sco_email).and_return(true)
+        allow(Flipper).to receive(:enabled?).with(:stem_sco_email, user).and_return(true)
         expect(FeatureFlipper).to receive(:send_email?).once.and_return(true)
         expect(user).to receive(:authorize).with(:evss, :access?).and_return(true).at_least(:once)
         expect(user.authorize(:evss, :access?)).to eq(true)
@@ -67,7 +67,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
     context 'stem_sco_email flipped off' do
       before do
-        allow(Flipper).to receive(:enabled?).with(:stem_sco_email).and_return(false)
+        allow(Flipper).to receive(:enabled?).with(:stem_sco_email, user).and_return(false)
         expect(FeatureFlipper).to receive(:send_email?).once.and_return(true)
         mail = double('mail')
         allow(mail).to receive(:deliver_now)
@@ -90,7 +90,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
     context 'unauthorized' do
       before do
-        allow(Flipper).to receive(:enabled?).with(:stem_sco_email).and_return(true)
+        allow(Flipper).to receive(:enabled?).with(:stem_sco_email, user).and_return(true)
         expect(FeatureFlipper).to receive(:send_email?).once.and_return(true)
         expect(user).to receive(:authorize).with(:evss, :access?).and_return(false).at_least(:once)
         expect(user.authorize(:evss, :access?)).to eq(false)

--- a/spec/models/saved_claim/education_benefits/va10203_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va10203_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
     context 'Not logged in' do
       before do
-        allow(Flipper).to receive(:enabled?).with(:stem_sco_email).and_return(true)
+        allow(Flipper).to receive(:enabled?).with(:stem_sco_email, nil).and_return(true)
         expect(FeatureFlipper).to receive(:send_email?).once.and_return(true)
         mail = double('mail')
         allow(mail).to receive(:deliver_now)
@@ -75,8 +75,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
       end
 
       it 'does not call SendSCOEmail' do
-        unauthorized_evss_user = build(:unauthorized_evss_user, :loa3)
-        expect { instance.after_submit(unauthorized_evss_user) }
+        expect { instance.after_submit(user) }
           .to change(EducationForm::SendSCOEmail.jobs, :size).by(0)
       end
 
@@ -100,8 +99,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
       end
 
       it 'does not call SendSCOEmail' do
-        unauthorized_evss_user = build(:unauthorized_evss_user, :loa3)
-        expect { instance.after_submit(unauthorized_evss_user) }
+        expect { instance.after_submit(user) }
           .to change(EducationForm::SendSCOEmail.jobs, :size).by(0)
       end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
As a developer, I need to modify feature flags to verify user has authorization to access the feature flag.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/12944

## Acceptance Criteria
- [x] stem sco email had the ability to add email verified users

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
