### PR TITLE
Add additional Flipper admins for Profile 2.0 UAT

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -507,12 +507,16 @@ flipper:
     - ryan.thurlwell@va.gov
     - saman.moshafi@thoughtworks.com
     - samara.strauss@va.gov
+    - shallie@governmentcio.com
     - shawkey_daniel@bah.com
     - sonntag_adam@bah.com
     - travis.hilton@oddball.io
     - zurbergram@gmail.com
     - tony.williams@va.gov
     - jennie.mcgibney@va.gov
+    - callen@governmentcio.com # Remove after Profile 2.0 UAT
+    - matt.shea@adhocteam.us # Remove after Profile 2.0 UAT
+    - tressa.furner@adhocteam.us # Remove after Profile 2.0 UAT
 
 bgs:
   application: ~


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
In preparation for Profile 2.0 we need to give Flipper access to a few members of our team so that we are able to add users on the fly during a UAT session.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/12878

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->