### PR TITLE
Configure Pact Broker Auth Credentials for Pact

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -59,7 +59,7 @@ Pact.service_provider 'VA.gov API' do
   # end
 
   honours_pacts_from_pact_broker do
-    pact_broker_base_url 'https://vagov-pact-broker.herokuapp.com'
+    pact_broker_base_url 'https://vagov-pact-broker.herokuapp.com', {username: ENV["PACT_BROKER_BASIC_AUTH_USERNAME"], password: ENV[PACT_BROKER_BASIC_AUTH_PASSWORD]}
   end
 
   app_version git_sha

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -59,8 +59,11 @@ Pact.service_provider 'VA.gov API' do
   # end
 
   honours_pacts_from_pact_broker do
-    pact_broker_base_url 'https://vagov-pact-broker.herokuapp.com', 
-      { username: ENV['PACT_BROKER_BASIC_AUTH_USERNAME'], password: ENV['PACT_BROKER_BASIC_AUTH_PASSWORD'] }
+    pact_broker_base_url 'https://vagov-pact-broker.herokuapp.com',
+    { 
+      username: ENV['PACT_BROKER_BASIC_AUTH_USERNAME'], 
+      password: ENV['PACT_BROKER_BASIC_AUTH_PASSWORD'] 
+    }
   end
 
   app_version git_sha

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -59,7 +59,7 @@ Pact.service_provider 'VA.gov API' do
   # end
 
   honours_pacts_from_pact_broker do
-    pact_broker_base_url 'https://vagov-pact-broker.herokuapp.com', {username: ENV["PACT_BROKER_BASIC_AUTH_USERNAME"], password: ENV[PACT_BROKER_BASIC_AUTH_PASSWORD]}
+    pact_broker_base_url 'https://vagov-pact-broker.herokuapp.com', {username: ENV["PACT_BROKER_BASIC_AUTH_USERNAME"], password: ENV["PACT_BROKER_BASIC_AUTH_PASSWORD"]}
   end
 
   app_version git_sha

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -59,12 +59,10 @@ Pact.service_provider 'VA.gov API' do
   # end
 
   honours_pacts_from_pact_broker do
-    pact_broker_base_url 'https://vagov-pact-broker.herokuapp.com', {username: ENV["PACT_BROKER_BASIC_AUTH_USERNAME"], password: ENV["PACT_BROKER_BASIC_AUTH_PASSWORD"]}
+    pact_broker_base_url 'https://vagov-pact-broker.herokuapp.com', { username: ENV['PACT_BROKER_BASIC_AUTH_USERNAME'], password: ENV['PACT_BROKER_BASIC_AUTH_PASSWORD'] }
   end
 
   app_version git_sha
   app_version_tags git_branch
-  if ENV['CIRCLE_JOB']
-    publish_verification_results publish_flag
-  end
+  publish_verification_results publish_flag if ENV['CIRCLE_JOB']
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -64,5 +64,7 @@ Pact.service_provider 'VA.gov API' do
 
   app_version git_sha
   app_version_tags git_branch
-  publish_verification_results publish_flag
+  if ENV['CIRCLE_JOB']
+    publish_verification_results publish_flag
+  end
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -59,7 +59,8 @@ Pact.service_provider 'VA.gov API' do
   # end
 
   honours_pacts_from_pact_broker do
-    pact_broker_base_url 'https://vagov-pact-broker.herokuapp.com', { username: ENV['PACT_BROKER_BASIC_AUTH_USERNAME'], password: ENV['PACT_BROKER_BASIC_AUTH_PASSWORD'] }
+    pact_broker_base_url 'https://vagov-pact-broker.herokuapp.com', 
+      { username: ENV['PACT_BROKER_BASIC_AUTH_USERNAME'], password: ENV['PACT_BROKER_BASIC_AUTH_PASSWORD'] }
   end
 
   app_version git_sha

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -60,10 +60,10 @@ Pact.service_provider 'VA.gov API' do
 
   honours_pacts_from_pact_broker do
     pact_broker_base_url 'https://vagov-pact-broker.herokuapp.com',
-    { 
-      username: ENV['PACT_BROKER_BASIC_AUTH_USERNAME'], 
-      password: ENV['PACT_BROKER_BASIC_AUTH_PASSWORD'] 
-    }
+                         {
+                           username: ENV['PACT_BROKER_BASIC_AUTH_USERNAME'],
+                           password: ENV['PACT_BROKER_BASIC_AUTH_PASSWORD']
+                         }
   end
 
   app_version git_sha


### PR DESCRIPTION
## Description of change
Basic auth is now implemented for the pact broker. In order to successfully publish verification results in CI, the username and password need to be passed in. PACT_BROKER_BASIC_AUTH_USERNAME and PACT_BROKER_BASIC_AUTH_PASSWORD are implemented as ENV variables in the CircleCI vets-api project settings.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#10224

## Testing
- [x] The pact verification webhook can properly be invoked from the broker with the new credentials
- [x] The Circle verification and builds workflows pass and are able to push results to the broker

