### PR TITLE
Add support for controller in external requests

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -165,7 +165,6 @@ end
 StatsD.increment('shared.sidekiq.default.Facilities_InitializingErrorMetric.error', 0)
 
 ActiveSupport::Notifications.subscribe('facilities.ppms.request.faraday') do |_, start_time, end_time, _, payload|
-  duration = end_time - start_time
   measurement = case payload[:url].path
                 when /ProviderLocator/
                   'facilities.ppms.provider_locator'
@@ -182,4 +181,14 @@ ActiveSupport::Notifications.subscribe('lighthouse.facilities.request.faraday') 
   duration = end_time - start_time
 
   StatsD.measure('facilities.lighthouse', duration, tags: ['facilities.lighthouse'])
+end
+
+require 'active_support/notifications'
+
+ActiveSupport::Notifications.subscribe('request.faraday') do |name, start_time, end_time, _, env|
+  url = env[:url]
+  duration = end_time - start_time
+  http_method = env[:method].to_s.upcase
+  StatsD.measure('api.external.request.duration', duration, tags: ["host:#{url.host}"])
+  StatsD.increment('api.external.request.total', tags: ["host:#{url.host}"])
 end


### PR DESCRIPTION
## Description of change
This PR adds support for calling controller labels in breakers metrics exports using the `Kernel#caller` method

Also automates instrumentation of all Faraday requests using `:instrumentation` middleware.

No tests yet, it's pretty bad and needs some adjusting.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15482

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
