### PR TITLE
Fix time-dependent test

### DIFF
--- a/spec/models/saved_claim/disability_compensation/form526_all_claim_bdd_spec.rb
+++ b/spec/models/saved_claim/disability_compensation/form526_all_claim_bdd_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe SavedClaim::DisabilityCompensation::Form526AllClaim do
 
   before do
     create(:in_progress_form, form_id: FormProfiles::VA526ezbdd::FORM_ID, user_uuid: user.uuid)
+    Timecop.freeze(Date.new(2020, 8, 1))
   end
+
+  after { Timecop.return }
 
   describe '#to_submission_data' do
     context 'without a 4142 submission' do


### PR DESCRIPTION

## Description of change
I wrote a time dependent test.
spec/models/saved_claim/disability_compensation/form526_all_claim_bdd_spec.rb:23 will fail if it's not more than 90 days before Dec 1, 2020

http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-api/detail/PR-4827/2/pipeline
