### PR TITLE
validate_virus_free should require common/virus_scan

### DIFF
--- a/lib/shrine/plugins/validate_virus_free.rb
+++ b/lib/shrine/plugins/validate_virus_free.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'common/virus_scan'
+
 class Shrine
   module Plugins
     module ValidateVirusFree


### PR DESCRIPTION
Two sentry errors due to this issue:
http://sentry.vfs.va.gov/vets-gov/platform-api-production/issues/197997
http://sentry.vfs.va.gov/vets-gov/platform-api-production/issues/197996