### PR TITLE
statsd metrics with tags not matching those initialized restart the StatsD agent

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -206,7 +206,7 @@ module V0
                          tags: ['status:failure',
                                 "context:#{saml_response.authn_context}",
                                 VERSION_TAG])
-        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [failure_tag, VERSION_TAG])
+        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: ["error:#{failure_tag}", VERSION_TAG])
       when :failed_unknown
         StatsD.increment(STATSD_SSO_CALLBACK_KEY,
                          tags: ['status:failure', 'context:unknown', VERSION_TAG])

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -206,7 +206,7 @@ module V0
                          tags: ['status:failure',
                                 "context:#{saml_response.authn_context}",
                                 VERSION_TAG])
-        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: ["error:#{failure_tag}", VERSION_TAG])
+        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [failure_tag, VERSION_TAG])
       when :failed_unknown
         StatsD.increment(STATSD_SSO_CALLBACK_KEY,
                          tags: ['status:failure', 'context:unknown', VERSION_TAG])

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -34,7 +34,8 @@ module V0
 
       StatsD.increment(STATSD_SSO_NEW_KEY, tags: ["context:#{type}", VERSION_TAG])
       Rails.logger.info("SSO_NEW_KEY, tags: #{["context:#{type}", VERSION_TAG]}")
-      url = url_service.send("#{type}_url")
+      helper = url_service
+      url = helper.send("#{type}_url")
       if type == 'slo'
         Rails.logger.info('SSO: LOGOUT', sso_logging_info)
         reset_session
@@ -42,7 +43,7 @@ module V0
       # clientId must be added at the end or the URL will be invalid for users using various "Do not track"
       # extensions with their browser.
       redirect_to params[:client_id].present? ? url + "&clientId=#{params[:client_id]}" : url
-      saml_request_stats(url_service.tracker)
+      saml_request_stats(helper.tracker)
     end
 
     def saml_logout_callback

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -20,7 +20,6 @@ module V0
     STATSD_LOGIN_NEW_USER_KEY = 'api.auth.new_user'
     STATSD_LOGIN_STATUS_SUCCESS = 'api.auth.login.success'
     STATSD_LOGIN_STATUS_FAILURE = 'api.auth.login.failure'
-    STATSD_LOGIN_SHARED_COOKIE = 'api.auth.sso_shared_cookie'
     STATSD_LOGIN_LATENCY = 'api.auth.latency'
 
     VERSION_TAG = 'version:v0'
@@ -175,7 +174,6 @@ module V0
       type = tracker.payload_attr(:type)
       tags = ["context:#{type}", VERSION_TAG]
       StatsD.increment(STATSD_LOGIN_NEW_USER_KEY, tags: [VERSION_TAG]) if type == 'signup'
-      StatsD.increment(STATSD_LOGIN_SHARED_COOKIE, tags: tags) if cookies.key?(Settings.sso.cookie_name)
       StatsD.increment(STATSD_LOGIN_STATUS_SUCCESS, tags: tags)
       Rails.logger.info("LOGIN_STATUS_SUCCESS, tags: #{tags}")
       StatsD.measure(STATSD_LOGIN_LATENCY, tracker.age, tags: tags)

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -22,7 +22,6 @@ module V1
     STATSD_LOGIN_NEW_USER_KEY = 'api.auth.new_user'
     STATSD_LOGIN_STATUS_SUCCESS = 'api.auth.login.success'
     STATSD_LOGIN_STATUS_FAILURE = 'api.auth.login.failure'
-    STATSD_LOGIN_SHARED_COOKIE = 'api.auth.sso_shared_cookie'
     STATSD_LOGIN_LATENCY = 'api.auth.latency'
     VERSION_TAG = 'version:v1'
 
@@ -213,7 +212,6 @@ module V1
       case status
       when :success
         StatsD.increment(STATSD_LOGIN_NEW_USER_KEY, tags: [VERSION_TAG]) if type == 'signup'
-        StatsD.increment(STATSD_LOGIN_SHARED_COOKIE, tags: tags)
         StatsD.increment(STATSD_LOGIN_STATUS_SUCCESS, tags: tags)
         Rails.logger.info("LOGIN_STATUS_SUCCESS, tags: #{tags}")
         StatsD.measure(STATSD_LOGIN_LATENCY, tracker.age, tags: tags)

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -234,7 +234,7 @@ module V1
                          tags: ['status:failure',
                                 "context:#{saml_response&.authn_context}",
                                 VERSION_TAG])
-        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [failure_tag, VERSION_TAG])
+        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: ["error:#{failure_tag}", VERSION_TAG])
       when :failed_unknown
         StatsD.increment(STATSD_SSO_CALLBACK_KEY,
                          tags: ['status:failure', 'context:unknown', VERSION_TAG])

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -230,11 +230,12 @@ module V1
                                 "context:#{saml_response&.authn_context}",
                                 VERSION_TAG])
       when :failure
+        tag = failure_tag.to_s.starts_with?('error:') ? failure_tag : "error:#{failure_tag}"
         StatsD.increment(STATSD_SSO_CALLBACK_KEY,
                          tags: ['status:failure',
                                 "context:#{saml_response&.authn_context}",
                                 VERSION_TAG])
-        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: ["error:#{failure_tag}", VERSION_TAG])
+        StatsD.increment(STATSD_SSO_CALLBACK_FAILED_KEY, tags: [tag, VERSION_TAG])
       when :failed_unknown
         StatsD.increment(STATSD_SSO_CALLBACK_KEY,
                          tags: ['status:failure', 'context:unknown', VERSION_TAG])
@@ -250,7 +251,7 @@ module V1
       log_message_to_sentry(exc.message, level, extra_context: context)
       redirect_to url_service(response&.in_response_to).login_redirect_url(auth: 'fail', code: code) unless performed?
       login_stats(:failure, response, exc) unless response.nil?
-      callback_stats(status, response, tag || code)
+      callback_stats(status, response, tag)
       PersonalInformationLog.create(
         error_class: exc,
         data: {

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -46,8 +46,6 @@ LOGIN_ERRORS = SAML::Responses::Base::ERRORS.values +
     (SAML::User::AUTHN_CONTEXTS.keys + [SAML::User::UNKNOWN_AUTHN_CONTEXT]).each do |ctx|
       StatsD.increment(V1::SessionsController::STATSD_SSO_CALLBACK_KEY, 0,
                        tags: ["version:#{v}", "status:#{s}", "context:#{ctx}"])
-      StatsD.increment(V1::SessionsController::STATSD_LOGIN_SHARED_COOKIE, 0,
-                       tags: ["version:#{v}", "context:#{ctx}"])
     end
   end
   (SAML::User::AUTHN_CONTEXTS.keys + [SAML::User::UNKNOWN_AUTHN_CONTEXT]).each do |ctx|

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -404,8 +404,6 @@ RSpec.describe V0::SessionsController, type: :controller do
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY,
                                          tags: ['status:success', 'context:multifactor', 'version:v0'], **once)
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)
-            .and trigger_statsd_increment(described_class::STATSD_LOGIN_SHARED_COOKIE,
-                                          tags: ['context:mfa', 'version:v0'], **once)
 
           expect(cookies['vagov_session_dev']).not_to be_nil
           expect(JSON.parse(decrypter.decrypt(cookies['vagov_session_dev'])))
@@ -650,9 +648,6 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)
-            .and trigger_statsd_increment(described_class::STATSD_LOGIN_SHARED_COOKIE,
-                                          tags: ['context:mhv', 'version:v0'],
-                                          **once)
           expect(response.location).to start_with('http://127.0.0.1:3001/auth/login/callback')
           expect(cookies['vagov_session_dev']).not_to be_nil
           MVI::Configuration.instance.breakers_service.end_forced_outage!

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe V0::SessionsController, type: :controller do
             .to receive(:warn).with(/#{SAML::Responses::Login::ERRORS[:auth_too_late][:short_message]}/)
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_FAILED_KEY,
-                                          tags: ['error:auth_too_late', 'version:v0'], **once)
+                                         tags: ['error:auth_too_late', 'version:v0'], **once)
           expect(response).to have_http_status(:found)
           expect(response.location).to eq('http://127.0.0.1:3001/auth/login/callback?auth=fail&code=005')
           expect(cookies['vagov_session_dev']).to be_nil

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -495,9 +495,6 @@ RSpec.describe V1::SessionsController, type: :controller do
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)
-            .and trigger_statsd_increment(described_class::STATSD_LOGIN_SHARED_COOKIE,
-                                          tags: ['context:verify', 'version:v1'],
-                                          **once)
 
           expect(response.location).to start_with('http://127.0.0.1:3001/auth/login/callback')
 
@@ -549,8 +546,6 @@ RSpec.describe V1::SessionsController, type: :controller do
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY,
                                          tags: ['status:success', 'context:multifactor', 'version:v1'], **once)
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)
-            .and trigger_statsd_increment(described_class::STATSD_LOGIN_SHARED_COOKIE,
-                                          tags: ['context:mfa', 'version:v1'], **once)
 
           expect(cookies['vagov_session_dev']).not_to be_nil
           expect(JSON.parse(decrypter.decrypt(cookies['vagov_session_dev'])))
@@ -814,9 +809,6 @@ RSpec.describe V1::SessionsController, type: :controller do
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)
-            .and trigger_statsd_increment(described_class::STATSD_LOGIN_SHARED_COOKIE,
-                                          tags: ['context:mhv', 'version:v1'],
-                                          **once)
           expect(response.location).to start_with('http://127.0.0.1:3001/auth/login/callback')
           expect(cookies['vagov_session_dev']).not_to be_nil
           MVI::Configuration.instance.breakers_service.end_forced_outage!

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -353,6 +353,8 @@ RSpec.describe V1::SessionsController, type: :controller do
                                                 'version:v1'])
             .and trigger_statsd_increment(described_class::STATSD_LOGIN_STATUS_FAILURE,
                                           tags: ['context:idme', 'version:v1', 'error:101'])
+            .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_FAILED_KEY,
+                                          tags: ['error:multiple_mhv_ids', 'version:v1'])
 
           expect(response).to have_http_status(:found)
           expect(cookies['vagov_session_dev']).to be_nil


### PR DESCRIPTION
If we increment a metric using tags that are different from the values used during initialization, the [statsd exporter raises an exception and triggers a restart](https://console.amazonaws-us-gov.com/cloudwatch/home?region=us-gov-west-1#logEventViewer:group=dsva-vagov-prod/var/log/prometheus/statsd_exporter.log;stream=deployment-vagov-prod-vets-api-server-20200903-190131-10.247.33.111;filter=restart;start=2020-09-02T19:54:38Z).  This will through off any prometheus queries that are attempting to calculate the rate of change over time, if triggered often.

[Slack thread that identified the issue](https://dsva.slack.com/archives/C30LCU8S3/p1599164567086300)

This PR addresses 3 problematic statsd metrics issues in the session controllers:
- `STATSD_SSO_CALLBACK_FAILED_KEY`: UserAttributeErrors raises would send the symbol code in, and thus needs to be prefixed with "error:"
- `STATSD_LOGIN_SHARED_COOKIE`: removing entirely because the tags didn't line up and its not being used for any queries
- `STATSD_SSO_SAMLREQUEST_KEY`: context was always being set to `nil` because it was referencing a different instance of `url_service`