### PR TITLE
Require EVSS and MVI in Claims and Appeals APIs

### DIFF
--- a/lib/shrine/plugins/validate_virus_free.rb
+++ b/lib/shrine/plugins/validate_virus_free.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'common/virus_scan'
+
 class Shrine
   module Plugins
     module ValidateVirusFree

--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json_marshal/marshaller'
+require 'central_mail/service'
 
 module AppealsApi
   class HigherLevelReview < ApplicationRecord

--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -4,6 +4,7 @@ require 'sidekiq'
 require 'appeals_api/higher_level_review_pdf_constructor'
 require 'appeals_api/upload_error'
 require 'central_mail/utilities'
+require 'central_mail/service'
 require 'pdf_info'
 
 module AppealsApi

--- a/modules/appeals_api/lib/appeals_api/health_checker.rb
+++ b/modules/appeals_api/lib/appeals_api/health_checker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'caseflow/service'
+
 module AppealsApi
   class HealthChecker
     def self.services_are_healthy?

--- a/modules/appeals_api/spec/controllers/v1/contestable_issues_controller_spec.rb
+++ b/modules/appeals_api/spec/controllers/v1/contestable_issues_controller_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
+require 'caseflow/service'
 
 describe AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesController do
   describe '#get_contestable_issues_from_caseflow' do

--- a/modules/appeals_api/spec/models/higher_level_review_spec.rb
+++ b/modules/appeals_api/spec/models/higher_level_review_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'central_mail/service'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::HigherLevelReview, type: :model do

--- a/modules/appeals_api/spec/requests/appeals_request_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_request_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'evss/auth_headers'
+require 'evss/power_of_attorney_verifier'
 
 RSpec.describe 'Claim Appeals API endpoint', type: :request do
   include SchemaMatchers

--- a/modules/appeals_api/spec/requests/v1/contestable_issues_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/contestable_issues_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'caseflow/service'
 
 describe AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesController, type: :request do
   let(:get_issues) do

--- a/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'sidekiq/testing'
+require 'central_mail/service'
 
 Sidekiq::Testing.fake!
 

--- a/modules/appeals_api/spec/workers/higher_level_review_upload_status_batch_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_upload_status_batch_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'central_mail/service'
 
 describe AppealsApi::HigherLevelReviewUploadStatusBatch, type: :job do
   let(:client_stub) { instance_double('CentralMail::Service') }

--- a/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'central_mail/service'
 
 describe AppealsApi::HigherLevelReviewUploadStatusUpdater, type: :job do
   let(:client_stub) { instance_double('CentralMail::Service') }

--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -4,7 +4,7 @@ require_dependency 'claims_api/concerns/mvi_verification'
 require_dependency 'claims_api/concerns/header_validation'
 require_dependency 'claims_api/unsynchronized_evss_claims_service'
 require_dependency 'claims_api/concerns/json_format_validation'
-require 'evss/error_middleware/evss_error'
+require 'evss/error_middleware'
 require 'evss/power_of_attorney_verifier'
 
 module ClaimsApi

--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -4,6 +4,8 @@ require_dependency 'claims_api/concerns/mvi_verification'
 require_dependency 'claims_api/concerns/header_validation'
 require_dependency 'claims_api/unsynchronized_evss_claims_service'
 require_dependency 'claims_api/concerns/json_format_validation'
+require 'evss/error_middleware/evss_error'
+require 'evss/power_of_attorney_verifier'
 
 module ClaimsApi
   class ApplicationController < ::OpenidApplicationController

--- a/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'evss/disability_compensation_form/service'
+require 'evss/disability_compensation_form/service_exception'
+require 'evss/error_middleware/evss_error'
+
 module ClaimsApi
   class BaseDisabilityCompensationController < ClaimsApi::BaseFormController
     STATSD_VALIDATION_FAIL_KEY = 'api.claims_api.526.validation_fail'

--- a/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
@@ -2,7 +2,7 @@
 
 require 'evss/disability_compensation_form/service'
 require 'evss/disability_compensation_form/service_exception'
-require 'evss/error_middleware/evss_error'
+require 'evss/error_middleware'
 
 module ClaimsApi
   class BaseDisabilityCompensationController < ClaimsApi::BaseFormController

--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -2,6 +2,8 @@
 
 require 'json_schema/json_api_missing_attribute'
 require 'claims_api/form_schemas'
+require 'evss/disability_compensation_auth_headers'
+require 'evss/auth_headers'
 
 module ClaimsApi
   class BaseFormController < ClaimsApi::ApplicationController

--- a/modules/claims_api/app/controllers/claims_api/concerns/poa_verification.rb
+++ b/modules/claims_api/app/controllers/claims_api/concerns/poa_verification.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'evss/power_of_attorney_verifier'
+
 module ClaimsApi
   module PoaVerification
     extend ActiveSupport::Concern

--- a/modules/claims_api/app/controllers/claims_api/v0/claims_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/claims_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency 'claims_api/application_controller'
-require 'evss/error_middleware/evss_error'
+require 'evss/error_middleware'
 
 module ClaimsApi
   module V0

--- a/modules/claims_api/app/controllers/claims_api/v0/claims_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/claims_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency 'claims_api/application_controller'
+require 'evss/error_middleware/evss_error'
 
 module ClaimsApi
   module V0

--- a/modules/claims_api/app/controllers/claims_api/v1/claims_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/claims_controller.rb
@@ -2,7 +2,7 @@
 
 require_dependency 'claims_api/application_controller'
 require_dependency 'claims_api/concerns/poa_verification'
-require 'evss/error_middleware/evss_error'
+require 'evss/error_middleware'
 
 module ClaimsApi
   module V1

--- a/modules/claims_api/app/controllers/claims_api/v1/claims_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/claims_controller.rb
@@ -2,6 +2,7 @@
 
 require_dependency 'claims_api/application_controller'
 require_dependency 'claims_api/concerns/poa_verification'
+require 'evss/error_middleware/evss_error'
 
 module ClaimsApi
   module V1

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -2,6 +2,8 @@
 
 require_dependency 'claims_api/concerns/poa_verification'
 require_dependency 'claims_api/concerns/document_validations'
+require 'evss/power_of_attorney_verifier'
+
 
 module ClaimsApi
   module V1

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -4,7 +4,6 @@ require_dependency 'claims_api/concerns/poa_verification'
 require_dependency 'claims_api/concerns/document_validations'
 require 'evss/power_of_attorney_verifier'
 
-
 module ClaimsApi
   module V1
     module Forms

--- a/modules/claims_api/app/services/claims_api/unsynchronized_evss_claims_service.rb
+++ b/modules/claims_api/app/services/claims_api/unsynchronized_evss_claims_service.rb
@@ -3,7 +3,7 @@
 require 'evss/claims_service'
 require 'evss/documents_service'
 require 'evss/auth_headers'
-require 'evss/error_middleware/evss_error'
+require 'evss/error_middleware'
 
 module ClaimsApi
   class UnsynchronizedEVSSClaimService

--- a/modules/claims_api/app/services/claims_api/unsynchronized_evss_claims_service.rb
+++ b/modules/claims_api/app/services/claims_api/unsynchronized_evss_claims_service.rb
@@ -3,6 +3,7 @@
 require 'evss/claims_service'
 require 'evss/documents_service'
 require 'evss/auth_headers'
+require 'evss/error_middleware/evss_error'
 
 module ClaimsApi
   class UnsynchronizedEVSSClaimService

--- a/modules/claims_api/app/workers/claims_api/claim_establisher.rb
+++ b/modules/claims_api/app/workers/claims_api/claim_establisher.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'sidekiq'
+require 'evss/disability_compensation_form/service_exception'
+require 'evss/disability_compensation_form/service'
 
 module ClaimsApi
   class ClaimEstablisher

--- a/modules/claims_api/app/workers/claims_api/claim_uploader.rb
+++ b/modules/claims_api/app/workers/claims_api/claim_uploader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'sidekiq'
+require 'evss/documents_service'
 
 module ClaimsApi
   class ClaimUploader

--- a/modules/claims_api/lib/claims_api/health_checker.rb
+++ b/modules/claims_api/lib/claims_api/health_checker.rb
@@ -2,6 +2,7 @@
 
 require 'bgs/service'
 require 'mvi/service'
+require 'evss/service'
 
 module ClaimsApi
   class HealthChecker

--- a/modules/claims_api/lib/claims_api/health_checker.rb
+++ b/modules/claims_api/lib/claims_api/health_checker.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'bgs/service'
+require 'mvi/service'
+
 module ClaimsApi
   class HealthChecker
     BGS_WSDL = "#{Settings.bgs.url}/VetRecordServiceBean/VetRecordWebService?WSDL"

--- a/modules/claims_api/spec/lib/health_checker_spec.rb
+++ b/modules/claims_api/spec/lib/health_checker_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'claims_api/health_checker'
+require 'mvi/service'
 
 describe ClaimsApi::HealthChecker do
   describe 'something' do

--- a/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'evss/disability_compensation_auth_headers'
+require 'evss/disability_compensation_form/configuration'
+require 'evss/disability_compensation_form/service'
 
 RSpec.describe 'Disability Claims ', type: :request do
   let(:headers) do

--- a/modules/claims_api/spec/requests/v1/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/claims_request_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 require 'evss/request_decision'
+require 'evss/power_of_attorney_verifier'
 
 RSpec.describe 'EVSS Claims management', type: :request do
   include SchemaMatchers

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'evss/disability_compensation_auth_headers'
+require 'evss/disability_compensation_form/configuration'
+require 'evss/disability_compensation_form/service'
 
 RSpec.describe 'Disability Claims ', type: :request do
   let(:headers) do

--- a/modules/claims_api/spec/unsynchronized_evss_claims_service_spec.rb
+++ b/modules/claims_api/spec/unsynchronized_evss_claims_service_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 require 'claims_api/unsynchronized_evss_claims_service'
 require 'evss/vso_search/service' # required to stub before initializing Veteran
+require 'evss/auth_headers'
 
 RSpec.describe ClaimsApi::UnsynchronizedEVSSClaimService, type: :model do
   let(:user) { FactoryBot.create(:user, :loa3) }

--- a/modules/claims_api/spec/workers/claim_establisher_spec.rb
+++ b/modules/claims_api/spec/workers/claim_establisher_spec.rb
@@ -2,6 +2,10 @@
 
 require 'rails_helper'
 require 'sidekiq/testing'
+require 'evss/disability_compensation_auth_headers'
+require 'evss/auth_headers'
+require 'evss/disability_compensation_form/service'
+require 'evss/disability_compensation_form/service_exception'
 Sidekiq::Testing.fake!
 
 RSpec.describe ClaimsApi::ClaimEstablisher, type: :job do

--- a/modules/claims_api/spec/workers/claim_uploader_spec.rb
+++ b/modules/claims_api/spec/workers/claim_uploader_spec.rb
@@ -2,6 +2,9 @@
 
 require 'rails_helper'
 require 'sidekiq/testing'
+require 'evss/disability_compensation_auth_headers'
+require 'evss/auth_headers'
+require 'evss/documents_service'
 Sidekiq::Testing.fake!
 
 RSpec.describe ClaimsApi::ClaimUploader, type: :job do

--- a/modules/claims_api/spec/workers/poa_updater_spec.rb
+++ b/modules/claims_api/spec/workers/poa_updater_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 require 'sidekiq/testing'
 require 'bgs'
+require 'evss/disability_compensation_auth_headers'
+require 'evss/auth_headers'
 
 Sidekiq::Testing.fake!
 

--- a/modules/claims_api/spec/workers/vbms_upload_job_spec.rb
+++ b/modules/claims_api/spec/workers/vbms_upload_job_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 require 'sidekiq/testing'
 require 'claims_api/vbms_uploader'
 require_relative '../support/fake_vbms'
+require 'evss/disability_compensation_auth_headers'
+require 'evss/auth_headers'
 
 Sidekiq::Testing.fake!
 

--- a/modules/vba_documents/app/controllers/vba_documents/metadata_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/metadata_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'central_mail/service'
+
 module VBADocuments
   class MetadataController < ::ApplicationController
     skip_before_action :verify_authenticity_token

--- a/modules/vba_documents/app/models/vba_documents/upload_submission.rb
+++ b/modules/vba_documents/app/models/vba_documents/upload_submission.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency 'vba_documents/upload_error'
+require 'central_mail/service'
 
 module VBADocuments
   class UploadSubmission < ApplicationRecord

--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -3,6 +3,7 @@
 require_dependency 'vba_documents/multipart_parser'
 require_dependency 'vba_documents/payload_manager'
 require 'central_mail/utilities'
+require 'central_mail/service'
 require 'pdf_info'
 require 'sidekiq'
 require 'vba_documents/object_store'

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 require_relative '../support/vba_document_fixtures'
 require 'vba_documents/object_store'
 require 'vba_documents/upload_processor'
+require 'central_mail/service'
 
 RSpec.describe VBADocuments::UploadProcessor, type: :job do
   include VBADocuments::Fixtures

--- a/modules/vba_documents/spec/jobs/upload_status_batch_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_status_batch_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'central_mail/service'
 
 RSpec.describe VBADocuments::UploadStatusBatch, type: :job do
   let(:client_stub) { instance_double('CentralMail::Service') }

--- a/modules/vba_documents/spec/jobs/upload_status_updater_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_status_updater_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'central_mail/service'
 
 RSpec.describe VBADocuments::UploadStatusUpdater, type: :job do
   let(:client_stub) { instance_double('CentralMail::Service') }

--- a/modules/vba_documents/spec/models/upload_submission_spec.rb
+++ b/modules/vba_documents/spec/models/upload_submission_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'central_mail/service'
 
 describe VBADocuments::UploadSubmission, type: :model do
   let(:upload_pending) { FactoryBot.create(:upload_submission) }

--- a/modules/vba_documents/spec/request/metadata_request_spec.rb
+++ b/modules/vba_documents/spec/request/metadata_request_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'central_mail/service'
 
 RSpec.describe 'VBA Documents Metadata Endpoint', type: :request do
   describe '#get /metadata' do

--- a/modules/vba_documents/spec/request/v0/reports_request_spec.rb
+++ b/modules/vba_documents/spec/request/v0/reports_request_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'central_mail/service'
 
 RSpec.describe 'VBA Document Uploads Report Endpoint', type: :request do
   describe '#create /v0/uploads/report' do


### PR DESCRIPTION
necessary after https://github.com/department-of-veterans-affairs/vets-api/pull/4787

related PRs
https://github.com/department-of-veterans-affairs/vets-api/pull/4841
https://github.com/department-of-veterans-affairs/vets-api/pull/4840