### PR TITLE
log more info when MVI add_person fails

### DIFF
--- a/lib/mvi/responses/add_parser.rb
+++ b/lib/mvi/responses/add_parser.rb
@@ -26,6 +26,15 @@ module MVI
       def initialize(response)
         @original_body = locate_element(response.body, BODY_XPATH)
         @code = locate_element(@original_body, CODE_XPATH)
+
+        if failed_or_invalid?
+          PersonalInformationLog.create(
+            error_class: 'MVI::Errors',
+            data: {
+              payload: response.body
+            }
+          )
+        end
       end
 
       # MVI returns failed or invalid codes if the request is malformed or MVI throws an internal error.

--- a/spec/lib/mvi/responses/add_parser_spec.rb
+++ b/spec/lib/mvi/responses/add_parser_spec.rb
@@ -62,6 +62,7 @@ describe MVI::Responses::AddParser do
       it 'returns true' do
         allow(faraday_response).to receive(:body) { body }
         expect(parser).to be_failed_or_invalid
+        expect(PersonalInformationLog.last.error_class).to eq 'MVI::Errors'
       end
     end
   end


### PR DESCRIPTION
## Description of change
We are seeing a high rate of error for MVI add person calls and I hope that logging the response will provide more info.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12376


## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
