### PR TITLE
add a rake task to retry form526 evss uploads

### DIFF
--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -214,4 +214,17 @@ namespace :form526 do
       puts "\n\n"
     end
   end
+
+  # EVSS has asked us to re-upload files that were corrupted upstream
+  desc 'Resubmit uploads to EVSS for submitted claims given an array of saved_claim_ids'
+  task retry_corrupted_uploads: :environment do |_, args|
+    raise 'No saved_claim_ids provided' unless args.extras.count.positive?
+
+    form_submissions = Form526Submission.where(saved_claim_id: args.extras)
+    form_submissions.each do |form_submission|
+      form_submission.send(:submit_uploads)
+      puts "reuploaded files for saved_claim_id #{form_submission.saved_claim_id}"
+    end
+    puts "reuploaded files for #{form_submissions.count} submissions"
+  end
 end


### PR DESCRIPTION
## Description of change

EVSS has an issue where files were being corrupted and asked us to re upload files associated with some form526 claim submissions 
## Original issue(s)
department-of-veterans-affairs/va.gov-team#12915

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
