### PR TITLE
EVSSClaim detele unused code

### DIFF
--- a/app/workers/evss/document_upload.rb
+++ b/app/workers/evss/document_upload.rb
@@ -13,13 +13,3 @@ class EVSS::DocumentUpload
     uploader.remove!
   end
 end
-
-# Allows gracefully migrating tasks in queue
-# TODO(knkski): Remove after migration
-class EVSSClaim::DocumentUpload
-  include Sidekiq::Worker
-
-  def perform(auth_headers, user_uuid, document_hash)
-    EVSS::DocumentUpload.perform_async(auth_headers, user_uuid, document_hash)
-  end
-end

--- a/spec/jobs/evss/document_upload_spec.rb
+++ b/spec/jobs/evss/document_upload_spec.rb
@@ -32,12 +32,3 @@ RSpec.describe EVSS::DocumentUpload, type: :job do
     described_class.new.perform(auth_headers, user.uuid, document_data.to_serializable_hash)
   end
 end
-
-RSpec.describe EVSSClaim::DocumentUpload, type: :job do
-  it 're-queues the job into the new namespace' do
-    expect { described_class.new.perform(nil, nil, nil) }
-      .to change { EVSS::DocumentUpload.jobs.size }
-      .from(0)
-      .to(1)
-  end
-end


### PR DESCRIPTION
## Description of change
Delete unused code.  

I verified that this job is not run in Graana

It was transition code added in https://github.com/department-of-veterans-affairs/vets-api/commit/71792cb767f0ab939b26f80515ba36d9e3dd18cf

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

