### PR TITLE
fix typo of ubuntu in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For frontend, see [vets-website](https://github.com/department-of-veterans-affai
 
 Developers who work with vets-api daily tend to prefer the native setup because they don't have to deal with the abstraction of docker-compose while those who would to spend less time on getting started prefer the docker setup. Docker is also useful when it's necessary to have a setup as close to production as possible.
 
-- [native setup instructions](docs/setup/native.md) (OSX/Ubunty)
+- [native setup instructions](docs/setup/native.md) (OSX/Ubuntu)
 - [docker setup instructions](docs/setup/docker.md)
 
 1. Setup key & cert for localhost authentication to ID.me:


### PR DESCRIPTION
based on this PR https://github.com/department-of-veterans-affairs/vets-api/pull/4868 because it can't be merged from a fork because pipeline didn't run