### PR TITLE
Add index to `accounts` table on `icn` field

### DIFF
--- a/db/migrate/20200911143406_add_index_to_accounts.rb
+++ b/db/migrate/20200911143406_add_index_to_accounts.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexToAccounts < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :accounts, :icn, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -153,25 +153,6 @@ ActiveRecord::Schema.define(version: 2020_09_11_143406) do
     t.uuid "auto_established_claim_id"
   end
 
-  create_table "disability_compensation_job_statuses", id: :serial, force: :cascade do |t|
-    t.integer "disability_compensation_submission_id", null: false
-    t.string "job_id", null: false
-    t.string "job_class", null: false
-    t.string "status", null: false
-    t.string "error_message"
-    t.datetime "updated_at", null: false
-    t.index ["disability_compensation_submission_id"], name: "index_disability_compensation_job_statuses_on_dsc_id"
-    t.index ["job_id"], name: "index_disability_compensation_job_statuses_on_job_id", unique: true
-  end
-
-  create_table "disability_compensation_submissions", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "disability_compensation_id"
-    t.integer "va526ez_submit_transaction_id"
-    t.boolean "complete", default: false
-  end
-
   create_table "disability_contentions", id: :serial, force: :cascade do |t|
     t.integer "code", null: false
     t.string "medical_term", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_17_140442) do
+ActiveRecord::Schema.define(version: 2020_09_11_143406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2020_08_17_140442) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "sec_id"
+    t.index ["icn"], name: "index_accounts_on_icn"
     t.index ["idme_uuid"], name: "index_accounts_on_idme_uuid", unique: true
     t.index ["sec_id"], name: "index_accounts_on_sec_id"
     t.index ["uuid"], name: "index_accounts_on_uuid", unique: true
@@ -150,6 +151,25 @@ ActiveRecord::Schema.define(version: 2020_08_17_140442) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "auto_established_claim_id"
+  end
+
+  create_table "disability_compensation_job_statuses", id: :serial, force: :cascade do |t|
+    t.integer "disability_compensation_submission_id", null: false
+    t.string "job_id", null: false
+    t.string "job_class", null: false
+    t.string "status", null: false
+    t.string "error_message"
+    t.datetime "updated_at", null: false
+    t.index ["disability_compensation_submission_id"], name: "index_disability_compensation_job_statuses_on_dsc_id"
+    t.index ["job_id"], name: "index_disability_compensation_job_statuses_on_job_id", unique: true
+  end
+
+  create_table "disability_compensation_submissions", id: :serial, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "disability_compensation_id"
+    t.integer "va526ez_submit_transaction_id"
+    t.boolean "complete", default: false
   end
 
   create_table "disability_contentions", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Description of change
The `accounts` table can be queried on the `icn` field as part of the SAML login callback.
This field is not indexed, resulting in slow query times.

This PR adds an index to `accounts` table on `icn` field

## Original issue(s)
department-of-veterans-affairs/va.gov-team#13442

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
