### PR TITLE
Add stem_document_type feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -261,4 +261,4 @@ features:
   stem_document_type:
     actor_type: user
     description: >
-      This will allow spool files generated for the 10203 form to use the correct form id
+      Set 10203 spool file document type

--- a/config/features.yml
+++ b/config/features.yml
@@ -258,3 +258,7 @@ features:
     actor_type: user
     description: >
       API endpoints consumed by the VA Mobile App (iOS/Android)
+  stem_document_type:
+    actor_type: user
+    description: >
+      This will allow spool files generated for the 10203 form to use the correct form id


### PR DESCRIPTION
## Description of change
Added the `stem_document_type` feature flag.  This will be used to determine the form ID used for 10203 spool files.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12799

## Things to know about this PR
- Tested locally and QA reviewed
- Related PR using feature flag: https://github.com/department-of-veterans-affairs/vets-api/pull/4884