### PR TITLE
[API-1793] Create an PoA /validate end point

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v0/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/power_of_attorney_controller.rb
@@ -13,7 +13,7 @@ module ClaimsApi
         FORM_NUMBER = '2122'
 
         skip_before_action(:authenticate)
-        before_action :validate_json_schema, only: %i[submit_form_2122]
+        before_action :validate_json_schema, only: %i[submit_form_2122 validate]
         before_action :validate_documents_content_type, only: %i[upload]
         before_action :validate_documents_page_size, only: %i[upload]
 
@@ -62,6 +62,10 @@ module ClaimsApi
           render json: power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
         end
 
+        def validate
+          render json: validation_success
+        end
+
         private
 
         def header_md5
@@ -76,6 +80,17 @@ module ClaimsApi
             name: request.headers['X-Consumer-Username'],
             icn: Settings.bgs.external_uid,
             email: Settings.bgs.external_key
+          }
+        end
+
+        def validation_success
+          {
+            data: {
+              type: 'powerOfAttorneyValidation',
+              attributes: {
+                status: 'valid'
+              }
+            }
           }
         end
       end

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -11,7 +11,7 @@ module ClaimsApi
         include ClaimsApi::DocumentValidations
 
         before_action { permit_scopes %w[claim.write] }
-        before_action :validate_json_schema, only: %i[submit_form_2122]
+        before_action :validate_json_schema, only: %i[submit_form_2122 validate]
         before_action :validate_documents_content_type, only: %i[upload]
         before_action :validate_documents_page_size, only: %i[upload]
         before_action :find_poa_by_id, only: %i[upload status]
@@ -73,6 +73,10 @@ module ClaimsApi
           end
         end
 
+        def validate
+          render json: validation_success
+        end
+
         private
 
         def current_poa
@@ -106,6 +110,17 @@ module ClaimsApi
 
         def render_poa_not_found
           render json: { errors: [{ status: 404, detail: 'POA not found' }] }, status: :not_found
+        end
+
+        def validation_success
+          {
+            data: {
+              type: 'powerOfAttorneyValidation',
+              attributes: {
+                status: 'valid'
+              }
+            }
+          }
         end
       end
     end

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -478,6 +478,122 @@ module ClaimsApi
           end
         end
       end
+
+      swagger_path '/forms/2122/validate' do
+        operation :post do
+          key :summary, ' 2122 Power of Attorney form submission dry run'
+          key :description, 'Accepts JSON payload.'
+          key :operationId, 'validate2122poa'
+          key :tags, [
+              'Power of Attorney'
+          ]
+
+          security do
+            key :bearer_token, []
+          end
+
+          parameter do
+            key :name, 'X-VA-SSN'
+            key :in, :header
+            key :description, 'SSN of Veteran to fetch'
+            key :required, false
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'X-VA-First-Name'
+            key :in, :header
+            key :description, 'First Name of Veteran to fetch'
+            key :required, false
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'X-VA-Last-Name'
+            key :in, :header
+            key :description, 'Last Name of Veteran to fetch'
+            key :required, false
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'X-VA-Birth-Date'
+            key :in, :header
+            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :required, false
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'X-VA-EDIPI'
+            key :in, :header
+            key :description, 'EDIPI Number of Veteran to fetch'
+            key :required, false
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'X-VA-User'
+            key :in, :header
+            key :description, 'VA username of the person making the request'
+            key :required, false
+            key :type, :string
+          end
+
+          request_body do
+            key :description, 'JSON API Payload of Veteran requesting POA change'
+            key :required, true
+            content 'application/json' do
+              schema do
+                key :'$ref', :Form2122Input
+              end
+            end
+          end
+
+          response 200 do
+            key :description, 'Valid'
+            content 'application/json' do
+              key(
+                  :examples,
+                  {
+                      default: {
+                          value: {
+                              data: { type: 'powerOfAttorneyValidation', attributes: { status: 'valid' } }
+                          }
+                      }
+                  }
+              )
+              schema do
+                key :type, :object
+                property :data do
+                  key :type, :object
+                  property :type, type: :string
+                  property :attributes do
+                    key :type, :object
+                    property :status, type: :string
+                  end
+                end
+              end
+            end
+          end
+
+          response 422 do
+            key :description, 'Invalid Payload'
+            content 'application/json' do
+              schema do
+                key :type, :object
+                key :required, [:errors]
+                property :errors do
+                  key :type, :array
+                  items do
+                    key :'$ref', :ErrorModel
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -485,7 +485,7 @@ module ClaimsApi
           key :description, 'Accepts JSON payload.'
           key :operationId, 'validate2122poa'
           key :tags, [
-              'Power of Attorney'
+            'Power of Attorney'
           ]
 
           security do
@@ -554,14 +554,14 @@ module ClaimsApi
             key :description, 'Valid'
             content 'application/json' do
               key(
-                  :examples,
-                  {
-                      default: {
-                          value: {
-                              data: { type: 'powerOfAttorneyValidation', attributes: { status: 'valid' } }
-                          }
-                      }
+                :examples,
+                {
+                  default: {
+                    value: {
+                      data: { type: 'powerOfAttorneyValidation', attributes: { status: 'valid' } }
+                    }
                   }
+                }
               )
               schema do
                 key :type, :object

--- a/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
@@ -477,7 +477,7 @@ module ClaimsApi
           key :description, 'Accepts JSON payload.'
           key :operationId, 'validate2122poa'
           key :tags, [
-              'Power of Attorney'
+            'Power of Attorney'
           ]
 
           security do
@@ -546,14 +546,14 @@ module ClaimsApi
             key :description, 'Valid'
             content 'application/json' do
               key(
-                  :examples,
-                  {
-                      default: {
-                          value: {
-                              data: { type: 'powerOfAttorneyValidation', attributes: { status: 'valid' } }
-                          }
-                      }
+                :examples,
+                {
+                  default: {
+                    value: {
+                      data: { type: 'powerOfAttorneyValidation', attributes: { status: 'valid' } }
+                    }
                   }
+                }
               )
               schema do
                 key :type, :object

--- a/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
@@ -470,6 +470,122 @@ module ClaimsApi
           end
         end
       end
+
+      swagger_path '/forms/2122/validate' do
+        operation :post do
+          key :summary, ' 2122 Power of Attorney form submission dry run'
+          key :description, 'Accepts JSON payload.'
+          key :operationId, 'validate2122poa'
+          key :tags, [
+              'Power of Attorney'
+          ]
+
+          security do
+            key :bearer_token, []
+          end
+
+          parameter do
+            key :name, 'X-VA-SSN'
+            key :in, :header
+            key :description, 'SSN of Veteran to fetch'
+            key :required, false
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'X-VA-First-Name'
+            key :in, :header
+            key :description, 'First Name of Veteran to fetch'
+            key :required, false
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'X-VA-Last-Name'
+            key :in, :header
+            key :description, 'Last Name of Veteran to fetch'
+            key :required, false
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'X-VA-Birth-Date'
+            key :in, :header
+            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :required, false
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'X-VA-EDIPI'
+            key :in, :header
+            key :description, 'EDIPI Number of Veteran to fetch'
+            key :required, false
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'X-VA-User'
+            key :in, :header
+            key :description, 'VA username of the person making the request'
+            key :required, false
+            key :type, :string
+          end
+
+          request_body do
+            key :description, 'JSON API Payload of Veteran requesting POA change'
+            key :required, true
+            content 'application/json' do
+              schema do
+                key :'$ref', :Form2122Input
+              end
+            end
+          end
+
+          response 200 do
+            key :description, 'Valid'
+            content 'application/json' do
+              key(
+                  :examples,
+                  {
+                      default: {
+                          value: {
+                              data: { type: 'powerOfAttorneyValidation', attributes: { status: 'valid' } }
+                          }
+                      }
+                  }
+              )
+              schema do
+                key :type, :object
+                property :data do
+                  key :type, :object
+                  property :type, type: :string
+                  property :attributes do
+                    key :type, :object
+                    property :status, type: :string
+                  end
+                end
+              end
+            end
+          end
+
+          response 422 do
+            key :description, 'Invalid Payload'
+            content 'application/json' do
+              schema do
+                key :type, :object
+                key :required, [:errors]
+                property :errors do
+                  key :type, :array
+                  items do
+                    key :'$ref', :ErrorModel
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/modules/claims_api/config/routes.rb
+++ b/modules/claims_api/config/routes.rb
@@ -51,6 +51,7 @@ ClaimsApi::Engine.routes.draw do
       get '2122/active', to: 'power_of_attorney#active'
       put '2122/:id', to: 'power_of_attorney#upload'
       get '2122/:id', to: 'power_of_attorney#status'
+      post '2122/validate', to: 'power_of_attorney#validate'
     end
   end
 

--- a/modules/claims_api/config/routes.rb
+++ b/modules/claims_api/config/routes.rb
@@ -27,6 +27,7 @@ ClaimsApi::Engine.routes.draw do
       get '2122/active', to: 'power_of_attorney#active'
       put '2122/:id', to: 'power_of_attorney#upload'
       get '2122/:id', to: 'power_of_attorney#status'
+      post '2122/validate', to: 'power_of_attorney#validate'
     end
   end
 

--- a/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
@@ -110,5 +110,26 @@ RSpec.describe 'Power of Attorney ', type: :request do
         expect(power_of_attorney.status).to eq('submitted')
       end
     end
+
+    describe '#validate' do
+      it 'returns a response when valid' do
+        post "#{path}/validate", params: data, headers: headers
+        parsed = JSON.parse(response.body)
+        expect(parsed['data']['attributes']['status']).to eq('valid')
+        expect(parsed['data']['type']).to eq('powerOfAttorneyValidation')
+      end
+
+      it 'returns a response when invalid' do
+        post "#{path}/validate", params: { data: { attributes: nil } }.to_json, headers: headers
+        parsed = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed['errors']).not_to be_empty
+      end
+
+      it 'responds properly when JSON parse error' do
+        post "#{path}/validate", params: 'hello', headers: headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 end

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -135,5 +135,32 @@ RSpec.describe 'Power of Attorney ', type: :request do
         end
       end
     end
+
+    describe '#validate' do
+      it 'returns a response when valid' do
+        with_okta_user(scopes) do |auth_header|
+          post "#{path}/validate", params: data, headers: headers.merge(auth_header)
+          parsed = JSON.parse(response.body)
+          expect(parsed['data']['attributes']['status']).to eq('valid')
+          expect(parsed['data']['type']).to eq('powerOfAttorneyValidation')
+        end
+      end
+
+      it 'returns a response when invalid' do
+        with_okta_user(scopes) do |auth_header|
+          post "#{path}/validate", params: { data: { attributes: nil } }.to_json, headers: headers.merge(auth_header)
+          parsed = JSON.parse(response.body)
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(parsed['errors']).not_to be_empty
+        end
+      end
+
+      it 'responds properly when JSON parse error' do
+        with_okta_user(scopes) do |auth_header|
+          post "#{path}/validate", params: 'hello', headers: headers.merge(auth_header)
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION

## Description of change
This adds the validate endpoint for v0 and v1 for form 21-22 (PowerOfAttorneyController). 

## Original issue(s)
[Create an PoA /validate end point](https://vajira.max.gov/browse/API-1793)

## Things to know about this PR
Swagger docs were updated for v0 and v1 validate endpoints.
Tests were added for v0 and v1 request specs for the validate endpoint. 
