### PR TITLE
Bump gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/bgs-ext.git
-  revision: 64537e01a2eef2299bf851d1fb0051eb285bea3c
+  revision: f8e5d69ed0cb1791bc41e5b6e55b22134c39fad4
   specs:
     bgs_ext (0.14.6)
       httpclient


### PR DESCRIPTION
## Description of change
This is a gem version bump to support getting mock data from the BGS-Ext gem so that our FE team can continue with their feature. Here is the associated approved gem PR: https://github.com/department-of-veterans-affairs/bgs-ext/pull/34

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
