### PR TITLE
SSOe SAML Tracker event changes

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -69,7 +69,7 @@ module V1
     end
 
     def tracker
-      id = pparams[:id]
+      id = params[:id]
       type = params[:type]
       authn = params[:authn]
       values = { 'id' => id, 'type' => type, 'authn' => authn }

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -69,7 +69,7 @@ module V1
     end
 
     def tracker
-      id = params[:id]
+      id = pparams[:id]
       type = params[:type]
       authn = params[:authn]
       values = { 'id' => id, 'type' => type, 'authn' => authn }
@@ -149,7 +149,7 @@ module V1
                                locals: {
                                  url: login_url,
                                  params: post_params,
-                                 saml_uuid: helper.tracker.uuid,
+                                 id: helper.tracker.uuid,
                                  authn: helper.tracker.payload_attr(:authn_context),
                                  type: helper.tracker.payload_attr(:type)
                                },

--- a/lib/saml/templates/sso_post_form.html.erb
+++ b/lib/saml/templates/sso_post_form.html.erb
@@ -26,15 +26,14 @@
 
   <script>
     (function() {
-      var form = document.getElementById("saml-form");
       var req = new XMLHttpRequest();
-      var qs = "saml_uuid=" + encodeURIComponent("<%= saml_uuid %>") +
+      var qs = "id=" + encodeURIComponent("<%= id %>") +
                 "&authn=" + encodeURIComponent("<%= authn %>") +
                 "&type=" + encodeURIComponent("<%= type %>");
       var url = location.origin + "/v1/sessions/tracker?" + qs;
       req.open("GET", url);
       req.send();
-      form.submit();
+      document.getElementById("saml-form").submit();
     })();
   </script>
 </body>

--- a/lib/saml/templates/sso_post_form.html.erb
+++ b/lib/saml/templates/sso_post_form.html.erb
@@ -32,8 +32,12 @@
                 "&type=" + encodeURIComponent("<%= type %>");
       var url = location.origin + "/v1/sessions/tracker?" + qs;
       req.open("GET", url);
+      req.onreadystatechange = function (evt) {
+        if (req.readyState == 2) {
+          document.getElementById("saml-form").submit();
+        }
+      };
       req.send();
-      document.getElementById("saml-form").submit();
     })();
   </script>
 </body>

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe V1::SessionsController, type: :controller do
       it 'logs a SAML stat with valid params' do
         allow(Rails.logger).to receive(:info)
         expect(Rails.logger)
-          .to receive(:info).with('SSOe: SAML Tracker => {"id"=>"1", "type"=>"mhv", "authn"=>"myhealthevet"}') 
+          .to receive(:info).with('SSOe: SAML Tracker => {"id"=>"1", "type"=>"mhv", "authn"=>"myhealthevet"}')
         expect { get(:tracker, params: { id: 1, type: 'mhv', authn: 'myhealthevet' }) }
           .to trigger_statsd_increment(described_class::STATSD_SSO_SAMLTRACKER_KEY,
                                        tags: ['type:mhv',

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -379,7 +379,10 @@ RSpec.describe V1::SessionsController, type: :controller do
       end
 
       it 'logs a SAML stat with valid params' do
-        expect { get(:tracker, params: { type: 'mhv', authn: 'myhealthevet' }) }
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger)
+          .to receive(:info).with('SSOe: SAML Tracker => {"id"=>"1", "type"=>"mhv", "authn"=>"myhealthevet"}') 
+        expect { get(:tracker, params: { id: 1, type: 'mhv', authn: 'myhealthevet' }) }
           .to trigger_statsd_increment(described_class::STATSD_SSO_SAMLTRACKER_KEY,
                                        tags: ['type:mhv',
                                               'context:myhealthevet',


### PR DESCRIPTION
The SSOe SAML Tracker was added to give more clarity on how successful the SAML Post binding form is in submitting, however the numbers reported back are extremely low, and in some cases even lower than our SAML Response rates.  I believe the issue is that the XHR request is in some cases being canceled because the form submission is happening too quickly.  This PR addresses that, by only submitting the form once we receive acknowledgment from the XHR request that it has been received.

This will add a small delay to the user's experience, but should give us accurate metrics whether the SAML Post form JS block is loading properly.

This PR also fixes a param naming issue which is causing all the application logs to show up with SAML ids of `nil`.

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/13409
