### PR TITLE
[API-1188] Create daily sidekiq job to find, catch and rerun "uploaded" statuses for when SNS fails

### DIFF
--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -131,7 +131,7 @@ VBADocuments::ReportUnsuccessfulSubmissions:
   description: "Weekly report of unsuccessful submissions"
 
 VBADocuments::RunUnsuccessfulSubmissions:
-  cron: "0 0 * * MON-FRI America/New_York"
+  cron: "0 0 23 * * America/New_York"
   class: VBADocuments::RunUnsuccessfulSubmissions
   description: "Run VBADocuments::UploadProcessor for submissions that are stuck in uploaded status"
 

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -130,6 +130,11 @@ VBADocuments::ReportUnsuccessfulSubmissions:
   class: VBADocuments::ReportUnsuccessfulSubmissions
   description: "Weekly report of unsuccessful submissions"
 
+VBADocuments::RunUnsuccessfulSubmissions:
+  cron: "0 0 * * MON-FRI America/New_York"
+  class: VBADocuments::RunUnsuccessfulSubmissions
+  description: "Run VBADocuments::UploadProcessor for submissions that are stuck in uploaded status"
+
 AppealsApi::HigherLevelReviewUploadStatusBatch:
   every: "60m"
   class: AppealsApi::HigherLevelReviewUploadStatusBatch

--- a/modules/vba_documents/app/workers/vba_documents/run_unsuccessful_submissions.rb
+++ b/modules/vba_documents/app/workers/vba_documents/run_unsuccessful_submissions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+
+module VBADocuments
+  class RunUnsuccessfulSubmissions
+    include Sidekiq::Worker
+
+    def perform
+      guids = VBADocuments::UploadSubmission.where(status: 'uploaded').pluck(:guid)
+      guids.each { |guid| VBADocuments::UploadProcessor.perform_async(guid) }
+    end
+  end
+end

--- a/modules/vba_documents/spec/jobs/run_unsuccessful_submissions_spec.rb
+++ b/modules/vba_documents/spec/jobs/run_unsuccessful_submissions_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VBADocuments::RunUnsuccessfulSubmissions, type: :job do
+  let(:uploaded_submission) { create(:upload_submission, :status_uploaded) }
+  let(:pending_submission) { create(:upload_submission) }
+
+  let(:subject) { described_class }
+
+  describe '#perform' do
+    it 'runs the UploadProcessor for the uploaded UploadSubmission' do
+      expect(VBADocuments::UploadProcessor).to receive(:perform_async).with(uploaded_submission.guid).once
+      expect(VBADocuments::UploadProcessor).not_to receive(:perform_async).with(pending_submission.guid)
+      subject.new.perform
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Setup a daily sidekiq job to find `UploadSubmissions` that are stuck in the `uploaded` status when SNS fails for some reason. The job runs the `UploadProcessor` worker.

## Original issue(s)
[Create daily sidekiq job to find, catch and rerun "uploaded" statuses for when SNS fails](https://vajira.max.gov/browse/API-1188)

## Things to know about this PR

