### PR TITLE
[API-2253] Add new team member emails to UnsuccessfulReportMailer

### DIFF
--- a/modules/vba_documents/app/mailers/vba_documents/unsuccessful_report_mailer.rb
+++ b/modules/vba_documents/app/mailers/vba_documents/unsuccessful_report_mailer.rb
@@ -11,6 +11,9 @@ module VBADocuments
       emily@oddball.io
       valerie.hase@va.gov
       mark.greenburg@adhocteam.us
+      premal.shah@va.gov
+      dan.hinze@adhocteam.us
+      emily.goodrich@oddball.io
     ].freeze
 
     def build(consumer_totals, stuck_submissions, unsuccessful_submissions, date_from, date_to)

--- a/modules/vba_documents/spec/mailers/unsuccessful_report_mailer_spec.rb
+++ b/modules/vba_documents/spec/mailers/unsuccessful_report_mailer_spec.rb
@@ -52,6 +52,9 @@ RSpec.describe VBADocuments::UnsuccessfulReportMailer, type: [:mailer] do
           emily@oddball.io
           valerie.hase@va.gov
           mark.greenburg@adhocteam.us
+          premal.shah@va.gov
+          dan.hinze@adhocteam.us
+          emily.goodrich@oddball.io
         ]
       )
     end


### PR DESCRIPTION
## Description of change
This PR adds new team member emails to the UnsuccessfulReportMailer 

## Original issue(s)
[Add new team member emails to UnsuccessfulReportMailer](https://vajira.max.gov/browse/API-2253)

## Things to know about this PR