### PR TITLE
Don't auto-disable `ssoe` feature toggles in `development`

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -47,10 +47,6 @@ FLIPPER_FEATURE_CONFIG['features'].each_key do |feature|
     # default features to enabled for development and test only
     Flipper.enable(feature) if Rails.env.development? || Rails.env.test?
   end
-  # TODO
-  # The following line disables SSOe login for `development` environtments, including review instances.
-  # Line is to be removed after SSOe is working locally and in review instances.
-  Flipper.disable(feature) if (Rails.env.development? || Rails.env.test?) && feature.match?(/ssoe/)
 rescue
   # make sure we can still run rake tasks before table has been created
   nil


### PR DESCRIPTION
## Description of change
Remove code that disables `ssoe` feature toggles in `development` environments.
SSOe is now functional in `development` environments (local, review instances)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#13449

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
