### PR TITLE
Added school ratings feature flag to the backend

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -170,6 +170,10 @@ features:
     actor_type: user
     description: >
       Comparison Tool Search Enhancements to improve usability
+  gibct_school_ratings:
+    actor_type: user
+    description: >
+      Show/Hide the school ratings section of the Comparison Tool School Profile Page.    
   form996_higher_level_review:
     actor_type: user
     description: >


### PR DESCRIPTION
## Description
As a developer, I need to create a feature flag for the school ratings UI functionality so that it is not displayed in production as development is completed.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13359

front end pr: https://github.com/department-of-veterans-affairs/vets-website/pull/14233

## Testing done
local testing

## Screenshots


## Acceptance criteria
- [x] The Feature Flag gibct_school_ratings is available to be used for the ratings enhancements.
- [x] The Feature Flag description is: "Show/Hide the school ratings section of the Comparison Tool School Profile Page"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
