### PR TITLE
[13357] Debt letter filename fix

### DIFF
--- a/app/controllers/v0/debt_letters_controller.rb
+++ b/app/controllers/v0/debt_letters_controller.rb
@@ -10,7 +10,7 @@ module V0
       send_data(
         service.get_letter(params[:id]),
         type: 'application/pdf',
-        filename: 'letter.pdf'
+        filename: service.file_name(params[:id])
       )
     end
 

--- a/lib/debts/letter_downloader.rb
+++ b/lib/debts/letter_downloader.rb
@@ -29,6 +29,15 @@ module Debts
       ).content
     end
 
+    def file_name(document_id)
+      document = @client.send_request(
+        VBMS::Requests::FindDocumentVersionReference.new(@service.file_number)
+      ).detect do |doc|
+        doc.document_id == document_id
+      end
+      "#{document.type_description} #{document.upload_date.to_formatted_s(:long)}"
+    end
+
     def list_letters
       debts_records = @client.send_request(
         VBMS::Requests::FindDocumentVersionReference.new(@service.file_number)

--- a/lib/debts/letter_downloader.rb
+++ b/lib/debts/letter_downloader.rb
@@ -30,18 +30,15 @@ module Debts
     end
 
     def file_name(document_id)
-      document = @client.send_request(
-        VBMS::Requests::FindDocumentVersionReference.new(@service.file_number)
-      ).detect do |doc|
+      document = vbms_documents.detect do |doc|
         doc.document_id == document_id
       end
+
       "#{document.type_description} #{document.upload_date.to_formatted_s(:long)}"
     end
 
     def list_letters
-      debts_records = @client.send_request(
-        VBMS::Requests::FindDocumentVersionReference.new(@service.file_number)
-      ).find_all do |record|
+      debts_records = vbms_documents.find_all do |record|
         DEBTS_DOCUMENT_TYPES.include?(record.doc_type)
       end
 
@@ -53,6 +50,12 @@ module Debts
     end
 
     private
+
+    def vbms_documents
+      @client.send_request(
+        VBMS::Requests::FindDocumentVersionReference.new(@service.file_number)
+      )
+    end
 
     def debts_service
       Debts::Service.new(@user)

--- a/lib/debts/letter_downloader.rb
+++ b/lib/debts/letter_downloader.rb
@@ -30,6 +30,8 @@ module Debts
     end
 
     def file_name(document_id)
+      verify_letter_in_folder(document_id)
+
       document = vbms_documents.detect { |doc| doc.document_id == document_id }
       "#{document.type_description} #{document.upload_date.to_formatted_s(:long)}"
     end

--- a/lib/debts/letter_downloader.rb
+++ b/lib/debts/letter_downloader.rb
@@ -30,10 +30,7 @@ module Debts
     end
 
     def file_name(document_id)
-      document = vbms_documents.detect do |doc|
-        doc.document_id == document_id
-      end
-
+      document = vbms_documents.detect { |doc| doc.document_id == document_id }
       "#{document.type_description} #{document.upload_date.to_formatted_s(:long)}"
     end
 

--- a/spec/lib/debts/letter_downloader_spec.rb
+++ b/spec/lib/debts/letter_downloader_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Debts::LetterDownloader do
 
   describe '#get_letter' do
     context 'with a document in the users folder' do
-
       let(:content) { File.read('spec/fixtures/pdf_fill/extras.pdf') }
 
       before do

--- a/spec/lib/debts/letter_downloader_spec.rb
+++ b/spec/lib/debts/letter_downloader_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Debts::LetterDownloader do
   def stub_vbms_client_request(request_name, args, return_val)
     request_double = double
     return_val.map { |letter| letter.upload_date = Date.parse(letter.upload_date) }
-    expect("VBMS::Requests::#{request_name}".constantize).to receive(:new).twice.with(args).and_return(request_double)
+    expect("VBMS::Requests::#{request_name}".constantize).to receive(:new).at_most(:twice).with(args).and_return(request_double)
 
     expect(vbms_client).to receive(:send_request).with(
       request_double

--- a/spec/lib/debts/letter_downloader_spec.rb
+++ b/spec/lib/debts/letter_downloader_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Debts::LetterDownloader do
 
       it 'downloads a debt letter' do
         use_person_and_letter_cassettes do
-          expect(subject.get_letter(document_id)).to eq(content)
+          expect(subject.get_letter(good_document_id)).to eq(content)
         end
       end
     end

--- a/spec/lib/debts/letter_downloader_spec.rb
+++ b/spec/lib/debts/letter_downloader_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe Debts::LetterDownloader do
   def stub_vbms_client_request(request_name, args, return_val)
     request_double = double
     return_val.map { |letter| letter.upload_date = Date.parse(letter.upload_date) }
-    expect("VBMS::Requests::#{request_name}".constantize).to receive(:new).at_most(:twice).with(args).and_return(request_double)
+    expect(
+      "VBMS::Requests::#{request_name}".constantize
+    ).to receive(:new).at_most(:twice).with(args).and_return(request_double)
 
     expect(vbms_client).to receive(:send_request).with(
       request_double

--- a/spec/lib/debts/letter_downloader_spec.rb
+++ b/spec/lib/debts/letter_downloader_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Debts::LetterDownloader do
   def stub_vbms_client_request(request_name, args, return_val)
     request_double = double
     return_val.map { |letter| letter.upload_date = Date.parse(letter.upload_date) }
-    expect("VBMS::Requests::#{request_name}".constantize).to receive(:new).with(args).and_return(request_double)
+    expect("VBMS::Requests::#{request_name}".constantize).to receive(:new).twice.with(args).and_return(request_double)
 
     expect(vbms_client).to receive(:send_request).with(
       request_double

--- a/spec/lib/debts/letter_downloader_spec.rb
+++ b/spec/lib/debts/letter_downloader_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Debts::LetterDownloader do
       "VBMS::Requests::#{request_name}".constantize
     ).to receive(:new).at_most(:twice).with(args).and_return(request_double)
 
-    expect(vbms_client).to receive(:send_request).with(
+    expect(vbms_client).to receive(:send_request).at_most(:twice).with(
       request_double
     ).and_return(
       return_val

--- a/spec/lib/debts/letter_downloader_spec.rb
+++ b/spec/lib/debts/letter_downloader_spec.rb
@@ -10,9 +10,12 @@ RSpec.describe Debts::LetterDownloader do
   let(:file_number) { '796043735' }
   let(:user) { build(:user, :loa3, ssn: file_number) }
   let(:vbms_client) { FakeVbms.new }
+  let(:good_document_id) { '{93631483-E9F9-44AA-BB55-3552376400D8}' }
+  let(:bad_document_id) { '{abc}' }
 
   def stub_vbms_client_request(request_name, args, return_val)
     request_double = double
+    return_val.map { |letter| letter.upload_date = Date.parse(letter.upload_date) }
     expect("VBMS::Requests::#{request_name}".constantize).to receive(:new).with(args).and_return(request_double)
 
     expect(vbms_client).to receive(:send_request).with(
@@ -46,15 +49,15 @@ RSpec.describe Debts::LetterDownloader do
 
   describe '#get_letter' do
     context 'with a document in the users folder' do
-      let(:document_id) { '{93631483-E9F9-44AA-BB55-3552376400D8}' }
+      
       let(:content) { File.read('spec/fixtures/pdf_fill/extras.pdf') }
 
       before do
         stub_vbms_client_request(
           'GetDocumentContent',
-          document_id,
+          good_document_id,
           OpenStruct.new(
-            document_id: document_id,
+            document_id: good_document_id,
             content: content
           )
         )
@@ -68,11 +71,9 @@ RSpec.describe Debts::LetterDownloader do
     end
 
     context 'with a document not in the users folder' do
-      let(:document_id) { '{abc}' }
-
       it 'raises an unauthorized error' do
         use_person_and_letter_cassettes do
-          expect { subject.get_letter(document_id) }.to raise_error(Common::Exceptions::Unauthorized)
+          expect { subject.get_letter(bad_document_id) }.to raise_error(Common::Exceptions::Unauthorized)
         end
       end
     end
@@ -84,6 +85,26 @@ RSpec.describe Debts::LetterDownloader do
         expect(subject.list_letters.to_json).to eq(
           get_fixture('vbms/list_letters').to_json
         )
+      end
+    end
+  end
+
+  describe '#file_name' do
+    context 'with a proper document id' do
+      it 'returns a filename' do
+        use_person_and_letter_cassettes do
+          expect(subject.file_name(good_document_id)).to eq(
+            "DMC - Debt Increase Letter June 03, 2020"
+          )
+        end
+      end
+    end
+
+    context 'without a proper document id' do
+      it 'raises an unauthorized error' do
+        use_person_and_letter_cassettes do
+          expect { subject.file_name(bad_document_id) }.to raise_error(Common::Exceptions::Unauthorized)
+        end
       end
     end
   end

--- a/spec/lib/debts/letter_downloader_spec.rb
+++ b/spec/lib/debts/letter_downloader_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Debts::LetterDownloader do
 
   describe '#get_letter' do
     context 'with a document in the users folder' do
-      
+
       let(:content) { File.read('spec/fixtures/pdf_fill/extras.pdf') }
 
       before do
@@ -94,7 +94,7 @@ RSpec.describe Debts::LetterDownloader do
       it 'returns a filename' do
         use_person_and_letter_cassettes do
           expect(subject.file_name(good_document_id)).to eq(
-            "DMC - Debt Increase Letter June 03, 2020"
+            'DMC - Debt Increase Letter June 03, 2020'
           )
         end
       end

--- a/spec/support/stub_debt_letters.rb
+++ b/spec/support/stub_debt_letters.rb
@@ -15,6 +15,7 @@ def stub_debt_letters(method)
 
     before do
       expect(letter_downloader).to receive(:get_letter).with(document_id).and_return(content)
+      expect(letter_downloader).to receive(:file_name).with(document_id).and_return('filename.pdf')
     end
   else
     let(:list_letters_res) { get_fixture('vbms/list_letters') }

--- a/spec/support/stub_debt_letters.rb
+++ b/spec/support/stub_debt_letters.rb
@@ -17,12 +17,20 @@ def stub_debt_letters(method)
       expect(letter_downloader).to receive(:get_letter).with(document_id).and_return(content)
       expect(letter_downloader).to receive(:file_name).with(document_id).and_return('filename.pdf')
     end
-  else
+  elsif method == :index
     let(:list_letters_res) { get_fixture('vbms/list_letters') }
 
     before do
       expect(letter_downloader).to receive(:list_letters).and_return(
         list_letters_res
+      )
+    end
+  else
+    let(:list_letters_res) { get_fixture('vbms/list_letters') }
+
+    before do
+      expect(letter_downloader).to receive(:vbms_documents).and_return(
+
       )
     end
   end

--- a/spec/support/stub_debt_letters.rb
+++ b/spec/support/stub_debt_letters.rb
@@ -17,20 +17,12 @@ def stub_debt_letters(method)
       expect(letter_downloader).to receive(:get_letter).with(document_id).and_return(content)
       expect(letter_downloader).to receive(:file_name).with(document_id).and_return('filename.pdf')
     end
-  elsif method == :index
+  else
     let(:list_letters_res) { get_fixture('vbms/list_letters') }
 
     before do
       expect(letter_downloader).to receive(:list_letters).and_return(
         list_letters_res
-      )
-    end
-  else
-    let(:list_letters_res) { get_fixture('vbms/list_letters') }
-
-    before do
-      expect(letter_downloader).to receive(:vbms_documents).and_return(
-
       )
     end
   end


### PR DESCRIPTION
##  Description of change
This changes the filename of the debt letters that can be downloaded by the veteran from `letter.pdf` to a more user friendly filename, which is the concatenation of the document's type description along with the date.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/13357

## Things to know about this PR
Tested and verified locally.
