### PR TITLE
Update SCO email links

### DIFF
--- a/app/mailers/views/school_certifying_officials.html.erb
+++ b/app/mailers/views/school_certifying_officials.html.erb
@@ -69,7 +69,7 @@
       Respondent Burden: 15 minutes<br>
       OMB Control Number: 2900-0878<br>
       OMB Expiration Date: 6/30/2023<br>
-      <a href="https://va.gov/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203/introduction#privacy_policy/?utm_source=confirmation_email&utm_medium=email&utm_campaign=privacy_policy">Privacy Act Statement (available online)</a><br>
+      <a href="https://www.va.gov/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203/introduction#privacy_policy/?utm_source=confirmation_email&utm_medium=email&utm_campaign=privacy_policy">Privacy Act Statement (available online)</a><br>
       cc: <%= @applicant.email %>
     </p>
   </body>

--- a/app/mailers/views/school_certifying_officials.html.erb
+++ b/app/mailers/views/school_certifying_officials.html.erb
@@ -27,7 +27,7 @@
       <ul>
         <li>
           Is the student pursuing a bachelor's degree in an approved STEM program?
-          (<a href="https://benefits.va.gov/gibill/docs/fgib/STEM_Program_List.pdf">Programs approved for the Rogers STEM Scholarship</a>)
+          (<a href="https://benefits.va.gov/gibill/docs/fgib/STEM_Program_List.pdf?utm_source=confirmation_email&utm_medium=email&utm_campaign=stem_approved_programs">Programs approved for the Rogers STEM Scholarship</a>)
         </li>
         <li>Name of STEM program student is enrolled in:</li>
         <li>6-digit CIP Code for the program:</li>
@@ -43,7 +43,7 @@
       <ul>
         <li>
           Has the student earned a bachelor's degree in an approved STEM program?
-          (<a href="https://benefits.va.gov/gibill/docs/fgib/STEM_Program_List.pdf">Programs approved for the Rogers STEM Scholarship</a>)
+          (<a href="https://benefits.va.gov/gibill/docs/fgib/STEM_Program_List.pdf?utm_source=confirmation_email&utm_medium=email&utm_campaign=stem_approved_programs">Programs approved for the Rogers STEM Scholarship</a>)
         </li>
         <li>Name of STEM program of degree conferred:</li>
         <li>6-digit CIP Code of degree conferred:</li>
@@ -69,7 +69,7 @@
       Respondent Burden: 15 minutes<br>
       OMB Control Number: 2900-0878<br>
       OMB Expiration Date: 6/30/2023<br>
-      <a href="https://www.va.gov/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203/introduction#omb-info-container">Privacy Act Statement (available online)</a><br>
+      <a href="https://va.gov/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203/introduction#privacy_policy/?utm_source=confirmation_email&utm_medium=email&utm_campaign=privacy_policy">Privacy Act Statement (available online)</a><br>
       cc: <%= @applicant.email %>
     </p>
   </body>


### PR DESCRIPTION
## Description of change
Added ga tracking to links in SCO email

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12359

## Things to know about this PR
- SCO emails are behind the `stem_sco_email` feature flag
