### PR TITLE
Load user from redits and pass to flipper to enable UAT for specific …

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -129,7 +129,8 @@ class Form526Submission < ApplicationRecord
   def workflow_complete_handler(_status, options)
     submission = Form526Submission.find(options['submission_id'])
     if submission.form526_job_statuses.all?(&:success?)
-      submission.send_form526_confirmation_email(options['full_name']) if Flipper.enabled?(:form526_confirmation_email)
+      user = User.find(user_uuid)
+      submission.send_form526_confirmation_email(options['full_name']) if Flipper.enabled?(:form526_confirmation_email, user)
       submission.workflow_complete = true
       submission.save
     end

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -129,7 +129,8 @@ class Form526Submission < ApplicationRecord
   def workflow_complete_handler(_status, options)
     submission = Form526Submission.find(options['submission_id'])
     if submission.form526_job_statuses.all?(&:success?)
-      user = User.find(user_uuid)
+      user = User.find(submission.user_uuid)
+      Rails.logger.info('User info', user_uuid: submission.user_uuid, user: user.to_yaml)
       if Flipper.enabled?(:form526_confirmation_email, user)
         submission.send_form526_confirmation_email(options['full_name'])
       end

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -130,7 +130,6 @@ class Form526Submission < ApplicationRecord
     submission = Form526Submission.find(options['submission_id'])
     if submission.form526_job_statuses.all?(&:success?)
       user = User.find(submission.user_uuid)
-      Rails.logger.info('User info', user_uuid: submission.user_uuid, user: user.to_yaml)
       if Flipper.enabled?(:form526_confirmation_email, user)
         submission.send_form526_confirmation_email(options['full_name'])
       end

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -130,7 +130,9 @@ class Form526Submission < ApplicationRecord
     submission = Form526Submission.find(options['submission_id'])
     if submission.form526_job_statuses.all?(&:success?)
       user = User.find(user_uuid)
-      submission.send_form526_confirmation_email(options['full_name']) if Flipper.enabled?(:form526_confirmation_email, user)
+      if Flipper.enabled?(:form526_confirmation_email, user)
+        submission.send_form526_confirmation_email(options['full_name'])
+      end
       submission.workflow_complete = true
       submission.save
     end


### PR DESCRIPTION
Configure form526_confirmation_email feature toggle in vets-api so that it can be used for UAT
[department-of-veterans-affairs/notification-api#175]

Co-authored-by: Phil Herber <pherbert@thoughtworks.com>

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Load user from Redis and pass it to flipper, so that we can turn the toggle for specific users.
Since it's a background task it can happen that user session will not be present in Redis - in that case we will pass nil to flipper (as actor) and feature toggle will remain disabled.

## Original issue(s)
department-of-veterans-affairs/notification-api#175

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
