### PR TITLE
EVSS 500 error catch and fix

### DIFF
--- a/modules/claims_api/spec/workers/claim_establisher_spec.rb
+++ b/modules/claims_api/spec/workers/claim_establisher_spec.rb
@@ -47,16 +47,27 @@ RSpec.describe ClaimsApi::ClaimEstablisher, type: :job do
     expect(claim.status).to eq(ClaimsApi::AutoEstablishedClaim::ESTABLISHED)
   end
 
-  it 'sets the status of the claim to an error if it raises an error on EVSS' do
+  it 'sets the status of the claim to an error if it raises an EVSS::DisabilityCompensationForm::Service error' do
     body = { 'messages' => [{ 'key' => 'serviceError', 'severity' => 'FATAL', 'text' => 'Not established.' }] }
     allow_any_instance_of(EVSS::DisabilityCompensationForm::Service).to(
       receive(:submit_form526).and_raise(EVSS::DisabilityCompensationForm::ServiceException.new(body))
     )
-    expect { subject.new.perform(claim.id) }.to raise_error(EVSS::DisabilityCompensationForm::ServiceException)
-
+    subject.new.perform(claim.id)
     claim.reload
     expect(claim.evss_id).to be_nil
     expect(claim.evss_response).to eq(body['messages'])
+    expect(claim.status).to eq(ClaimsApi::AutoEstablishedClaim::ERRORED)
+  end
+
+  it 'sets the status of the claim to an error if it raises an Common::Exceptions::BackendServiceException error' do
+    body = [{ 'key' => 400, 'severity' => 'FATAL', 'text' => nil }]
+    allow_any_instance_of(EVSS::DisabilityCompensationForm::Service).to(
+      receive(:submit_form526).and_raise(Common::Exceptions::BackendServiceException.new)
+    )
+    subject.new.perform(claim.id)
+    claim.reload
+    expect(claim.evss_id).to be_nil
+    expect(claim.evss_response).to eq(body)
     expect(claim.status).to eq(ClaimsApi::AutoEstablishedClaim::ERRORED)
   end
 end


### PR DESCRIPTION
## Description of change
GDIT asked us to look up some ID's in Staging for test Claims V0 Submissions and found that the upstream 500 errors weren't being relayed downstream.

## Original issue(s)
https://vajira.max.gov/browse/API-2387

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
