### PR TITLE
Add missing requires to routing_error

### DIFF
--- a/lib/common/exceptions/routing_error.rb
+++ b/lib/common/exceptions/routing_error.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'common/exceptions/base_error'
+
 module Common
   module Exceptions
     # Routing Error - if route is invalid


### PR DESCRIPTION
found a spot with a missing `require`, will support https://github.com/department-of-veterans-affairs/vets-api/pull/4897