### PR TITLE
Add facility_locator_predictive_location_search feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -40,9 +40,9 @@ features:
   facility_locator_ppms_forced_unique_id:
     actor_type: user
     description: Use an hexdigest for the ID on PPMS Place of Service Calls
-  facility_locator_fe_use_v1:
+  facility_locator_predictive_location_search:
     actor_type: user
-    description: Have the front end use the V1 api
+    description: Use predictive location search in the Facility Locator UI
   facilities_ppms_suppress_community_care:
     actor_type: user
     description: Hide ppms community care searches


### PR DESCRIPTION
Add facility_locator_predictive_location_search feature flag.

This will be used to toggle predictive location search in the Facility Locator.

Also, delete facility_locator_fe_use_v1 (unused)

Issue:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/12722
https://github.com/department-of-veterans-affairs/vets-website/pull/14187


