### PR TITLE
Update string to match contract in broker

### DIFF
--- a/spec/service_consumers/provider_states_for/search.rb
+++ b/spec/service_consumers/provider_states_for/search.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Pact.provider_states_for 'Search' do
-  provider_state 'multiple matching results exist' do
+  provider_state 'at least one matching result exists' do
     set_up do
       VCR.insert_cassette('search/success_utf8')
     end


### PR DESCRIPTION
## Description of change
Frontend Tools pushed a change to the pact search contract and renamed the interaction string. The string defined in the provider state MUST be an exact match to what's defined as the interaction in the contract. Otherwise, [verification fails](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/vets-api/5769/workflows/63cff8fe-0093-45c0-b40c-6294a24c406f/jobs/8866). Pact verification will fail until this is merged

[Search Contract](https://vagov-pact-broker.herokuapp.com/pacts/provider/VA.gov%20API/consumer/Search/latest)
