### PR TITLE
[13658] Fix MDT birthdate formatting issue

### DIFF
--- a/lib/mdot/client.rb
+++ b/lib/mdot/client.rb
@@ -74,9 +74,13 @@ module MDOT
         VA_VETERAN_MIDDLE_NAME: @user.middle_name,
         VA_VETERAN_LAST_NAME: @user.last_name,
         VA_VETERAN_ID: @user.ssn.last(4),
-        VA_VETERAN_BIRTH_DATE: @user.birth_date,
+        VA_VETERAN_BIRTH_DATE: format_birthdate(@user.birth_date),
         VA_ICN: @user.icn
       }
+    end
+
+    def format_birthdate(date)
+      Date.parse(date).strftime('%Y-%m-%d')
     end
 
     def submission_headers

--- a/spec/lib/mdot/client_spec.rb
+++ b/spec/lib/mdot/client_spec.rb
@@ -12,7 +12,7 @@ describe MDOT::Client, type: :mdot_helpers do
       first_name: 'Greg',
       last_name: 'Anderson',
       middle_name: 'A',
-      birth_date: '1991-04-05',
+      birth_date: '19910405',
       ssn: '000550237'
     }
   end
@@ -22,7 +22,11 @@ describe MDOT::Client, type: :mdot_helpers do
   describe '#get_supplies' do
     context 'with a valid supplies response' do
       it 'returns an array of supplies' do
-        VCR.use_cassette('mdot/get_supplies_200') do
+        VCR.use_cassette(
+          'mdot/get_supplies_200',
+          match_requests_on: %i[method uri headers],
+          erb: { icn: user.icn }
+        ) do
           response = subject.get_supplies
           expect(response).to be_ok
           expect(response).to be_an MDOT::Response

--- a/spec/support/vcr_cassettes/mdot/get_supplies_200.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_200.yml
@@ -15,6 +15,8 @@ http_interactions:
       - Vets.gov Agent
       Va-Veteran-First-Name:
       - Greg
+      Va-Veteran-Middle-Name:
+      - A
       Va-Veteran-Last-Name:
       - Anderson
       Va-Veteran-Id:
@@ -22,7 +24,7 @@ http_interactions:
       Va-Veteran-Birth-Date:
       - '1991-04-05'
       Va-Icn:
-      - 11263043841512898
+      - '<%= icn %>'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:


### PR DESCRIPTION
## Description of change 
Birthdates that do not have hyphens between the month & year and day & month will not pass validation when they are submitted to DLC's API. In order to ensure that this format is always followed, I've added a method that will parse whatever date is gathered from the `@current_user`'s `birth_date` instance variable and format it appropriately so that it will be accepted by DLC's API.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/13658

## Things to know about this PR
tested and verified locally
