### PR TITLE
renaming the ssoe tracker url to trace

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,8 @@ Rails.application.routes.draw do
       to: 'v1/sessions#new',
       constraints: ->(request) { V1::SessionsController::REDIRECT_URLS.include?(request.path_parameters[:type]) }
   get '/v1/sessions/ssoe_logout', to: 'v1/sessions#ssoe_slo_callback'
-  get '/v1/sessions/tracker', to: 'v1/sessions#tracker'
+  # don't use the word "tracker" in the url, as some ad blockers will prevent the call
+  get '/v1/sessions/trace', to: 'v1/sessions#tracker'
 
   namespace :v0, defaults: { format: 'json' } do
     resources :appointments, only: :index

--- a/lib/saml/templates/sso_post_form.html.erb
+++ b/lib/saml/templates/sso_post_form.html.erb
@@ -30,7 +30,7 @@
       var qs = "id=" + encodeURIComponent("<%= id %>") +
                 "&authn=" + encodeURIComponent("<%= authn %>") +
                 "&type=" + encodeURIComponent("<%= type %>");
-      var url = location.origin + "/v1/sessions/tracker?" + qs;
+      var url = location.origin + "/v1/sessions/trace?" + qs;
       req.open("GET", url);
       req.onreadystatechange = function (evt) {
         if (req.readyState == 2) {


### PR DESCRIPTION
Renaming the `/v1/sessions/tracker` URL to `/v1/sessions/trace`.  Some browser ad blocker extensions (ie AdblockPlus) prevent XHR requests to urls with the word "track" in it.

I manually tested this locally with the following AdblockPlus settings enabled.  With the former URL, the form submission was blocked, however when using the `/v1/sessions/trace` URL, the POST SAML binding form was successfully submitted.
<img width="742" alt="Screen Shot 2020-09-17 at 08 54 36" src="https://user-images.githubusercontent.com/170002/93496007-94fad880-f8c3-11ea-90d4-c44a1f4f3ef5.png">

refs https://github.com/department-of-veterans-affairs/vets-api/pull/4806#issuecomment-694289957
