### PR TITLE
Add specialIssues to 526 form schema

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/forms/form_526_response_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_526_response_swagger.rb
@@ -432,7 +432,7 @@ module ClaimsApi
                     items do
                       key :type, :string
                       key :example, 'ALS'
-                      key :enum, %w(ALS HEPC POW PTSD/1 PTSD/2 PTSD/3 PTSD/4 MST)
+                      key :enum, %w[ALS HEPC POW PTSD/1 PTSD/2 PTSD/3 PTSD/4 MST]
                     end
                   end
 
@@ -473,7 +473,7 @@ module ClaimsApi
                         items do
                           key :type, :string
                           key :example, 'ALS'
-                          key :enum, %w(ALS HEPC POW PTSD/1 PTSD/2 PTSD/3 PTSD/4 MST)
+                          key :enum, %w[ALS HEPC POW PTSD/1 PTSD/2 PTSD/3 PTSD/4 MST]
                         end
                       end
                     end

--- a/modules/claims_api/app/swagger/claims_api/forms/form_526_response_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_526_response_swagger.rb
@@ -425,6 +425,17 @@ module ClaimsApi
                     key :example, 'PTSD (post traumatic stress disorder)'
                   end
 
+                  property :specialIssues do
+                    key :type, :array
+                    key :description, 'The special issues related to the disability'
+
+                    items do
+                      key :type, :string
+                      key :example, 'ALS'
+                      key :enum, %w(ALS HEPC POW PTSD/1 PTSD/2 PTSD/3 PTSD/4 MST)
+                    end
+                  end
+
                   property :secondaryDisabilities do
                     key :type, :array
                     key :description, 'Identifies the Secondary Service Disability information of the Veteran'
@@ -453,6 +464,17 @@ module ClaimsApi
                         key :type, :string
                         key :description, 'How the veteran got the disability.'
                         key :example, 'Caused by a service-connected disability\\nLengthy description'
+                      end
+
+                      property :specialIssues do
+                        key :type, :array
+                        key :description, 'The special issues related to the disability'
+
+                        items do
+                          key :type, :string
+                          key :example, 'ALS'
+                          key :enum, %w(ALS HEPC POW PTSD/1 PTSD/2 PTSD/3 PTSD/4 MST)
+                        end
                       end
                     end
                   end

--- a/modules/claims_api/config/schemas/526.json
+++ b/modules/claims_api/config/schemas/526.json
@@ -20,6 +20,13 @@
     "date": {
       "type": "string",
       "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$"
+    },
+    "specialIssues": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["ALS", "HEPC", "POW", "PTSD/1", "PTSD/2", "PTSD/3", "PTSD/4", "MST"]
+      }
     }
   },
   "properties": {
@@ -510,6 +517,9 @@
           "name"
         ],
         "properties": {
+          "specialIssues": {
+            "$ref": "#/definitions/specialIssues"
+          },
           "ratedDisabilityId": {
             "type": "string"
           },
@@ -542,6 +552,9 @@
                 },
                 "serviceRelevance": {
                   "type": "string"
+                },
+                "specialIssues": {
+                  "$ref": "#/definitions/specialIssues"
                 }
               }
             }

--- a/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe 'Disability Claims ', type: :request do
           it 'returns a successful status' do
             VCR.use_cassette('evss/claims/claims') do
               params = json_data
-              params['data']['attributes']['disabilities'][0]['specialIssues'] = %w(ALS HEPC)
+              params['data']['attributes']['disabilities'][0]['specialIssues'] = %w[ALS HEPC]
               post path, params: params.to_json, headers: headers
               expect(response.status).to eq(200)
             end

--- a/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
@@ -121,6 +121,29 @@ RSpec.describe 'Disability Claims ', type: :request do
         expect(JSON.parse(response.body)['errors'].size).to eq(2)
       end
 
+      describe 'disabilities specialIssues' do
+        context 'when an incorrect type is passed for specialIssues' do
+          it 'returns errors explaining the failure' do
+            params = json_data
+            params['data']['attributes']['disabilities'][0]['specialIssues'] = ['invalidType']
+            post path, params: params.to_json, headers: headers
+            expect(response.status).to eq(422)
+            expect(JSON.parse(response.body)['errors'].size).to eq(1)
+          end
+        end
+
+        context 'when correct types are passed for specialIssues' do
+          it 'returns a successful status' do
+            VCR.use_cassette('evss/claims/claims') do
+              params = json_data
+              params['data']['attributes']['disabilities'][0]['specialIssues'] = %w(ALS HEPC)
+              post path, params: params.to_json, headers: headers
+              expect(response.status).to eq(200)
+            end
+          end
+        end
+      end
+
       it 'requires international postal code when address type is international' do
         params = json_data
         mailing_address = params['data']['attributes']['veteran']['currentMailingAddress']

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe 'Disability Claims ', type: :request do
             VCR.use_cassette('evss/claims/claims') do
               with_okta_user(scopes) do |auth_header|
                 params = json_data
-                params['data']['attributes']['disabilities'][0]['specialIssues'] = %w(ALS HEPC)
+                params['data']['attributes']['disabilities'][0]['specialIssues'] = %w[ALS HEPC]
                 post path, params: params.to_json, headers: headers.merge(auth_header)
                 expect(response.status).to eq(200)
               end

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -146,6 +146,33 @@ RSpec.describe 'Disability Claims ', type: :request do
         end
       end
 
+      describe 'disabilities specialIssues' do
+        context 'when an incorrect type is passed for specialIssues' do
+          it 'returns errors explaining the failure' do
+            with_okta_user(scopes) do |auth_header|
+              params = json_data
+              params['data']['attributes']['disabilities'][0]['specialIssues'] = ['invalidType']
+              post path, params: params.to_json, headers: headers.merge(auth_header)
+              expect(response.status).to eq(422)
+              expect(JSON.parse(response.body)['errors'].size).to eq(1)
+            end
+          end
+        end
+
+        context 'when correct types are passed for specialIssues' do
+          it 'returns a successful status' do
+            VCR.use_cassette('evss/claims/claims') do
+              with_okta_user(scopes) do |auth_header|
+                params = json_data
+                params['data']['attributes']['disabilities'][0]['specialIssues'] = %w(ALS HEPC)
+                post path, params: params.to_json, headers: headers.merge(auth_header)
+                expect(response.status).to eq(200)
+              end
+            end
+          end
+        end
+      end
+
       it 'requires international postal code when address type is international' do
         with_okta_user(scopes) do |auth_header|
           params = json_data


### PR DESCRIPTION
## Description of change
Add `specialIssues` to form 526 schema. 

## Original issue(s)
[Add specialIssues to the Claims API 526 Schema](https://vajira.max.gov/browse/API-1480)

