### PR TITLE
remove obsolete feature toggles

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -41,13 +41,18 @@ FLIPPER_ACTOR_STRING = 'cookie_id'
 
 Flipper::UI.configuration.feature_creation_enabled = false
 # Make sure that each feature we reference in code is present in the UI, as long as we have a Database already
-FLIPPER_FEATURE_CONFIG['features'].each do |feature, feature_config|
-  unless Flipper.exist?(feature)
-    Flipper.add(feature)
+begin
+  FLIPPER_FEATURE_CONFIG['features'].each do |feature, feature_config|
+    unless Flipper.exist?(feature)
+      Flipper.add(feature)
 
-    # default features to enabled for test and those explicitly set for development
-    Flipper.enable(feature) if Rails.env.test? || (Rails.env.development? && feature_config['enable_in_development'])
+      # default features to enabled for test and those explicitly set for development
+      Flipper.enable(feature) if Rails.env.test? || (Rails.env.development? && feature_config['enable_in_development'])
+    end
   end
+  # remove features from UI that have been removed from code
+  removed_features = (Flipper.features.collect(&:name) - FLIPPER_FEATURE_CONFIG['features'].keys)
+  removed_features.each { |feature_name| Flipper.remove(feature_name) }
 rescue
   # make sure we can still run rake tasks before table has been created
   nil


### PR DESCRIPTION
## Description of change
when a dev deletes a feature toggle in the code it should go away in the UI as well.  

For example in staging there's both ` show_526_wizard` and `show526_wizard`, due to a renaming.

for @Mottie 