### PR TITLE
placing ssoe transaction in session object

### DIFF
--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -70,7 +70,7 @@ module AuthenticationAndSSOConcerns
     # TODO: This logic needs updating to let us log out either/or
     # SSOe session or MHV-SSO session but for  now  the next line lets
     # us avoid terminating  the session due to not setting it  previously
-    return false if @current_user&.authenticated_by_ssoe
+    return false if @session_object&.authenticated_by_ssoe
     return false unless Settings.sso.cookie_enabled && Settings.sso.cookie_signout_enabled
 
     cookies[Settings.sso.cookie_name].blank? && request.host.match(Settings.sso.cookie_domain)
@@ -97,7 +97,7 @@ module AuthenticationAndSSOConcerns
                   @session_object.present? &&
                   # if the user logged in via SSOe, there is no benefit from
                   # creating a MHV SSO shared cookie
-                  !@current_user&.authenticated_by_ssoe
+                  !@session_object&.authenticated_by_ssoe
 
     Rails.logger.info('SSO: ApplicationController#set_sso_cookie!', sso_logging_info)
 

--- a/app/controllers/v0/users_controller.rb
+++ b/app/controllers/v0/users_controller.rb
@@ -3,7 +3,7 @@
 module V0
   class UsersController < ApplicationController
     def show
-      pre_serialized_profile = Users::Profile.new(current_user).pre_serialize
+      pre_serialized_profile = Users::Profile.new(current_user, @session_object).pre_serialize
 
       render(
         json: pre_serialized_profile,

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -41,7 +41,7 @@ class Session < Common::RedisStore
   end
 
   def authenticated_by_ssoe
-    !@ssoe_transactionid.nil?
+    @ssoe_transactionid.present?
   end
 
   private

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -40,6 +40,8 @@ class Session < Common::RedisStore
     Time.current.utc + ttl
   end
 
+  def authenticated_by_ssoe
+    @ssoe_transaction != nil
   private
 
   def secure_random_token(length = DEFAULT_TOKEN_LENGTH)

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -41,7 +41,9 @@ class Session < Common::RedisStore
   end
 
   def authenticated_by_ssoe
-    @ssoe_transaction != nil
+    !@ssoe_transaction.nil?
+  end
+
   private
 
   def secure_random_token(length = DEFAULT_TOKEN_LENGTH)

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -41,7 +41,7 @@ class Session < Common::RedisStore
   end
 
   def authenticated_by_ssoe
-    !@ssoe_transaction.nil?
+    !@ssoe_transactionid.nil?
   end
 
   private

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -16,6 +16,7 @@ class Session < Common::RedisStore
   attribute :token
   attribute :uuid
   attribute :created_at
+  attribute :ssoe_transaction
 
   validates :token, presence: true
   validates :uuid, presence: true

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -16,7 +16,7 @@ class Session < Common::RedisStore
   attribute :token
   attribute :uuid
   attribute :created_at
-  attribute :ssoe_transaction
+  attribute :ssoe_transactionid
 
   validates :token, presence: true
   validates :uuid, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,7 +126,6 @@ class User < Common::RedisStore
   delegate :mhv_icn, to: :identity, allow_nil: true
   delegate :idme_uuid, to: :identity, allow_nil: true
   delegate :dslogon_edipi, to: :identity, allow_nil: true
-  delegate :authenticated_by_ssoe, to: :identity, allow_nil: true
   delegate :common_name, to: :identity, allow_nil: true
 
   # mvi attributes

--- a/app/models/user_identity.rb
+++ b/app/models/user_identity.rb
@@ -32,7 +32,6 @@ class UserIdentity < Common::RedisStore
   attribute :mhv_account_type # this is only available for MHV sign-in users
   attribute :dslogon_edipi # this is only available for dslogon users
   attribute :sign_in, Hash # original sign_in (see sso_service#mergable_identity_attributes)
-  attribute :authenticated_by_ssoe, Boolean
 
   validates :uuid, presence: true
   validates :loa, presence: true

--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -40,7 +40,8 @@ class UserSessionForm
     else
       @user.last_signed_in = Time.current.utc
     end
-    @session = Session.new(uuid: @user.uuid, ssoe_transaction: normalized_attributes[:transactionid])
+    transactionid = saml_user.user_attributes.transactionid
+    @session = Session.new(uuid: @user.uuid, ssoe_transaction: transactionid)
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -40,7 +40,7 @@ class UserSessionForm
     else
       @user.last_signed_in = Time.current.utc
     end
-    @session = Session.new(uuid: @user.uuid)
+    @session = Session.new(uuid: @user.uuid, ssoe_transaction: normalized_attributes[:transactionid])
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -42,7 +42,7 @@ class UserSessionForm
     end
     @session = Session.new(
       uuid: @user.uuid,
-      ssoe_transaction: saml_user.user_attributes.try(:transactionid)
+      ssoe_transactionid: saml_user.user_attributes.try(:transactionid)
     )
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -40,8 +40,10 @@ class UserSessionForm
     else
       @user.last_signed_in = Time.current.utc
     end
-    transactionid = saml_user.user_attributes.transactionid
-    @session = Session.new(uuid: @user.uuid, ssoe_transaction: transactionid)
+    @session = Session.new(
+      uuid: @user.uuid,
+      ssoe_transaction: saml_user.user_attributes.try(:transactionid)
+    )
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -7,7 +7,8 @@ class UserSerializer < ActiveModel::Serializer
   include Common::Client::Concerns::ServiceStatus
 
   attributes :services, :account, :profile, :va_profile, :veteran_status,
-             :in_progress_forms, :prefills_available, :vet360_contact_information
+             :in_progress_forms, :prefills_available, :vet360_contact_information,
+             :session
 
   def id
     nil
@@ -21,4 +22,5 @@ class UserSerializer < ActiveModel::Serializer
   delegate :in_progress_forms, to: :object
   delegate :prefills_available, to: :object
   delegate :services, to: :object
+  delegate :session, to: :object
 end

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -12,8 +12,9 @@ module Users
 
     attr_reader :user, :scaffold
 
-    def initialize(user)
+    def initialize(user, session)
       @user = validate!(user)
+      @session = session
       @scaffold = Users::Scaffold.new([], HTTP_OK)
     end
 
@@ -52,6 +53,7 @@ module Users
       scaffold.in_progress_forms = in_progress_forms
       scaffold.prefills_available = prefills_available
       scaffold.services = services
+      scaffold.session = session_data
     end
 
     def account
@@ -164,6 +166,13 @@ module Users
       {
         facility_id: facility_id,
         is_cerner: cerner_facility_ids.include?(facility_id)
+      }
+    end
+
+    def session_data
+      {
+        ssoe: @session[:ssoe_transaction] ? true : false,
+        transactionid: @session[:ssoe_transaction]
       }
     end
   end

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -12,9 +12,9 @@ module Users
 
     attr_reader :user, :scaffold
 
-    def initialize(user, session)
+    def initialize(user, session = nil)
       @user = validate!(user)
-      @session = session
+      @session = session || {}
       @scaffold = Users::Scaffold.new([], HTTP_OK)
     end
 
@@ -171,8 +171,8 @@ module Users
 
     def session_data
       {
-        ssoe: @session[:ssoe_transaction] ? true : false,
-        transactionid: @session[:ssoe_transaction]
+        ssoe: @session[:ssoe_transactionid] ? true : false,
+        transactionid: @session[:ssoe_transactionid]
       }
     end
   end

--- a/app/services/users/scaffold.rb
+++ b/app/services/users/scaffold.rb
@@ -9,7 +9,7 @@ module Users
   #
   # rubocop:disable Style/StructInheritance
   class Scaffold < Struct.new(:errors, :status, :services, :account, :profile, :va_profile, :veteran_status,
-                              :in_progress_forms, :prefills_available, :vet360_contact_information)
+                              :in_progress_forms, :prefills_available, :vet360_contact_information, :session)
   end
   # rubocop:enable Style/StructInheritance
 end

--- a/app/swagger/swagger/schemas/user_internal_services.rb
+++ b/app/swagger/swagger/schemas/user_internal_services.rb
@@ -97,7 +97,7 @@ module Swagger
             end
             property :session, type: :object do
               property :ssoe, type: :boolean
-              property :transactionid, type: :string
+              property :transactionid, type: %i[string null]
             end
           end
         end

--- a/app/swagger/swagger/schemas/user_internal_services.rb
+++ b/app/swagger/swagger/schemas/user_internal_services.rb
@@ -95,6 +95,10 @@ module Swagger
                 key :type, :string
               end
             end
+            property :session, type: :object do
+              property :ssoe, type: :boolean
+              property :transactionid, type: :string
+            end
           end
         end
       end

--- a/lib/saml/user.rb
+++ b/lib/saml/user.rb
@@ -60,7 +60,7 @@ module SAML
     private
 
     def serializable_attributes
-      %i[authn_context authenticated_by_ssoe]
+      %i[authn_context]
     end
 
     def log_warnings_to_sentry

--- a/lib/saml/user_attributes/base.rb
+++ b/lib/saml/user_attributes/base.rb
@@ -60,10 +60,6 @@ module SAML
         { service_name: 'unknown', account_type: 'N/A' }
       end
 
-      def transactionid
-        nil
-      end
-
       def to_hash
         serializable_attributes.index_with { |k| send(k) }
       end

--- a/lib/saml/user_attributes/base.rb
+++ b/lib/saml/user_attributes/base.rb
@@ -3,7 +3,7 @@
 module SAML
   module UserAttributes
     class Base
-      REQUIRED_ATTRIBUTES = %i[email uuid idme_uuid sec_id loa sign_in multifactor transactionid].freeze
+      REQUIRED_ATTRIBUTES = %i[email uuid idme_uuid sec_id loa sign_in multifactor].freeze
 
       attr_reader :attributes, :authn_context, :warnings
 

--- a/lib/saml/user_attributes/base.rb
+++ b/lib/saml/user_attributes/base.rb
@@ -3,7 +3,7 @@
 module SAML
   module UserAttributes
     class Base
-      REQUIRED_ATTRIBUTES = %i[email uuid idme_uuid sec_id loa sign_in multifactor].freeze
+      REQUIRED_ATTRIBUTES = %i[email uuid idme_uuid sec_id loa sign_in multifactor transactionid].freeze
 
       attr_reader :attributes, :authn_context, :warnings
 
@@ -58,6 +58,10 @@ module SAML
                                   .merge(account_type: account_type)
       rescue
         { service_name: 'unknown', account_type: 'N/A' }
+      end
+
+      def transactionid
+        nil
       end
 
       def to_hash

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -172,7 +172,6 @@ module SAML
                   else
                     SAML::User::AUTHN_CONTEXTS.fetch(@authn_context).fetch(:sign_in)
                   end
-        # TODO: remove ssoe and transactionid ....
         sign_in.merge(account_type: account_type, ssoe: true, transactionid: transactionid)
       end
 

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -9,7 +9,7 @@ module SAML
       include SentryLogging
       SERIALIZABLE_ATTRIBUTES = %i[email first_name middle_name last_name common_name zip gender ssn birth_date
                                    uuid idme_uuid sec_id mhv_icn mhv_correlation_id mhv_account_type
-                                   dslogon_edipi loa sign_in multifactor transactionid].freeze
+                                   dslogon_edipi loa sign_in multifactor].freeze
       IDME_GCID_REGEX = /^(?<idme>\w+)\^PN\^200VIDM\^USDVA\^A$/.freeze
       INBOUND_AUTHN_CONTEXT = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password'
 

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -9,7 +9,7 @@ module SAML
       include SentryLogging
       SERIALIZABLE_ATTRIBUTES = %i[email first_name middle_name last_name common_name zip gender ssn birth_date
                                    uuid idme_uuid sec_id mhv_icn mhv_correlation_id mhv_account_type
-                                   dslogon_edipi loa sign_in multifactor].freeze
+                                   dslogon_edipi loa sign_in multifactor transactionid].freeze
       IDME_GCID_REGEX = /^(?<idme>\w+)\^PN\^200VIDM\^USDVA\^A$/.freeze
       INBOUND_AUTHN_CONTEXT = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password'
 
@@ -172,6 +172,7 @@ module SAML
                   else
                     SAML::User::AUTHN_CONTEXTS.fetch(@authn_context).fetch(:sign_in)
                   end
+        # TODO: remove ssoe and transactionid ....
         sign_in.merge(account_type: account_type, ssoe: true, transactionid: transactionid)
       end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -24,7 +24,6 @@ FactoryBot.define do
       va_patient { nil }
       search_token { nil }
       icn_with_aaid { nil }
-      authenticated_by_ssoe { false }
       common_name { nil }
 
       sign_in do

--- a/spec/lib/saml/dslogon_user_spec.rb
+++ b/spec/lib/saml/dslogon_user_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe SAML::User do
           loa: { current: 1, highest: 3 },
           sign_in: { service_name: 'dslogon', account_type: '1' },
           sec_id: nil,
-          authn_context: 'dslogon',
-          authenticated_by_ssoe: false
+          authn_context: 'dslogon'
         )
       end
 
@@ -75,8 +74,7 @@ RSpec.describe SAML::User do
             ssn: nil,
             multifactor: true,
             authn_context: 'dslogon_multifactor',
-            dslogon_edipi: '1606997570',
-            authenticated_by_ssoe: false
+            dslogon_edipi: '1606997570'
           )
         end
 
@@ -107,8 +105,7 @@ RSpec.describe SAML::User do
             sign_in: { service_name: 'dslogon', account_type: '1' },
             sec_id: nil,
             multifactor: true,
-            authn_context: 'dslogon_loa3',
-            authenticated_by_ssoe: false
+            authn_context: 'dslogon_loa3'
           )
         end
 
@@ -138,8 +135,7 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'dslogon', account_type: '2' },
           sec_id: nil,
           multifactor: false,
-          authn_context: 'dslogon',
-          authenticated_by_ssoe: false
+          authn_context: 'dslogon'
         )
       end
 
@@ -168,8 +164,7 @@ RSpec.describe SAML::User do
             ssn: '111223333',
             multifactor: true,
             authn_context: 'dslogon_multifactor',
-            dslogon_edipi: '1606997570',
-            authenticated_by_ssoe: false
+            dslogon_edipi: '1606997570'
           )
         end
 

--- a/spec/lib/saml/idme_user_spec.rb
+++ b/spec/lib/saml/idme_user_spec.rb
@@ -78,8 +78,7 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: nil,
           multifactor: false,
-          authn_context: LOA::IDME_LOA1_VETS,
-          authenticated_by_ssoe: false
+          authn_context: LOA::IDME_LOA1_VETS
         )
       end
 
@@ -108,8 +107,7 @@ RSpec.describe SAML::User do
             ssn: nil,
             zip: nil,
             multifactor: true,
-            authn_context: 'multifactor',
-            authenticated_by_ssoe: false
+            authn_context: 'multifactor'
           )
         end
 
@@ -143,8 +141,7 @@ RSpec.describe SAML::User do
               ssn: nil,
               zip: nil,
               multifactor: true,
-              authn_context: 'multifactor',
-              authenticated_by_ssoe: false
+              authn_context: 'multifactor'
             )
           end
         end
@@ -171,8 +168,7 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: nil,
           multifactor: false,
-          authn_context: LOA::IDME_LOA1_VETS,
-          authenticated_by_ssoe: false
+          authn_context: LOA::IDME_LOA1_VETS
         )
       end
 
@@ -200,8 +196,7 @@ RSpec.describe SAML::User do
             ssn: nil,
             zip: nil,
             multifactor: true,
-            authn_context: 'multifactor',
-            authenticated_by_ssoe: false
+            authn_context: 'multifactor'
           )
         end
 
@@ -232,8 +227,7 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: nil,
           multifactor: true,
-          authn_context: LOA::IDME_LOA3_VETS,
-          authenticated_by_ssoe: false
+          authn_context: LOA::IDME_LOA3_VETS
         )
       end
 

--- a/spec/lib/saml/mhv_user_spec.rb
+++ b/spec/lib/saml/mhv_user_spec.rb
@@ -39,8 +39,7 @@ RSpec.describe SAML::User do
           mhv_icn: '',
           multifactor: false,
           sec_id: nil,
-          authn_context: 'myhealthevet',
-          authenticated_by_ssoe: false
+          authn_context: 'myhealthevet'
         )
       end
 
@@ -67,8 +66,7 @@ RSpec.describe SAML::User do
             mhv_account_type: 'Basic',
             mhv_correlation_id: '12345748',
             mhv_icn: '',
-            sign_in: { service_name: 'myhealthevet', account_type: 'Basic' },
-            authenticated_by_ssoe: false
+            sign_in: { service_name: 'myhealthevet', account_type: 'Basic' }
           )
         end
 
@@ -101,8 +99,7 @@ RSpec.describe SAML::User do
             loa: { current: 3, highest: 3 },
             sign_in: { service_name: 'myhealthevet', account_type: 'Advanced' },
             multifactor: true,
-            authn_context: 'myhealthevet_loa3',
-            authenticated_by_ssoe: false
+            authn_context: 'myhealthevet_loa3'
           )
         end
 
@@ -127,8 +124,7 @@ RSpec.describe SAML::User do
           mhv_correlation_id: '12345748',
           mhv_icn: '1012853550V207686',
           multifactor: false,
-          authn_context: 'myhealthevet',
-          authenticated_by_ssoe: false
+          authn_context: 'myhealthevet'
         )
       end
 
@@ -157,8 +153,7 @@ RSpec.describe SAML::User do
             sec_id: nil,
             mhv_account_type: 'Premium',
             mhv_correlation_id: '12345748',
-            mhv_icn: '1012853550V207686',
-            authenticated_by_ssoe: false
+            mhv_icn: '1012853550V207686'
           )
         end
 

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe SAML::User do
             transactionid: 'abcd1234xyz'
           },
           sec_id: nil,
-          authenticated_by_ssoe: true,
           common_name: nil
         )
       end
@@ -153,7 +152,6 @@ RSpec.describe SAML::User do
             transactionid: 'abcd1234xyz'
           },
           sec_id: nil,
-          authenticated_by_ssoe: true,
           common_name: nil
         )
       end
@@ -188,7 +186,6 @@ RSpec.describe SAML::User do
           loa: { current: 3, highest: 3 },
           sign_in: { service_name: 'idme', account_type: 'N/A', ssoe: true, transactionid: 'abcd1234xyz' },
           sec_id: '1008830476',
-          authenticated_by_ssoe: true,
           common_name: 'vets.gov.user+262@example.com'
         )
       end
@@ -225,7 +222,6 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'myhealthevet', account_type: 'Advanced', ssoe: true, transactionid: 'abcd1234xyz' },
           sec_id: nil,
           multifactor: multifactor,
-          authenticated_by_ssoe: true,
           common_name: nil
         )
       end
@@ -264,7 +260,6 @@ RSpec.describe SAML::User do
           sign_in: { service_name: 'myhealthevet', account_type: 'Advanced', ssoe: true, transactionid: 'abcd1234xyz' },
           sec_id: '1013183292',
           multifactor: multifactor,
-          authenticated_by_ssoe: true,
           common_name: 'alexmac_0@example.com'
         )
       end
@@ -303,7 +298,6 @@ RSpec.describe SAML::User do
           },
           sec_id: nil,
           multifactor: true,
-          authenticated_by_ssoe: true,
           common_name: nil
         )
       end
@@ -345,7 +339,6 @@ RSpec.describe SAML::User do
           },
           sec_id: '1012853550',
           multifactor: multifactor,
-          authenticated_by_ssoe: true,
           common_name: 'k+tristan@example.com'
         )
       end
@@ -388,7 +381,6 @@ RSpec.describe SAML::User do
           },
           sec_id: '1012853550',
           multifactor: multifactor,
-          authenticated_by_ssoe: true,
           common_name: 'k+tristan@example.com'
         )
       end
@@ -666,8 +658,7 @@ RSpec.describe SAML::User do
             ssoe: true
           },
           sec_id: nil,
-          multifactor: multifactor,
-          authenticated_by_ssoe: true
+          multifactor: multifactor
         )
       end
     end
@@ -704,7 +695,6 @@ RSpec.describe SAML::User do
           },
           sec_id: '1013173963',
           multifactor: false,
-          authenticated_by_ssoe: true,
           common_name: 'iam.tester@example.com'
         )
       end
@@ -747,7 +737,6 @@ RSpec.describe SAML::User do
           },
           sec_id: '0000028007',
           multifactor: multifactor,
-          authenticated_by_ssoe: true,
           common_name: 'dslogon10923109@gmail.com'
         )
       end
@@ -789,7 +778,6 @@ RSpec.describe SAML::User do
           },
           sec_id: '0000028007',
           multifactor: multifactor,
-          authenticated_by_ssoe: true,
           common_name: 'dslogon10923109@gmail.com'
         )
       end
@@ -830,7 +818,6 @@ RSpec.describe SAML::User do
           },
           sec_id: '1012779219',
           multifactor: multifactor,
-          authenticated_by_ssoe: true,
           common_name: 'SOFIA MCKIBBENS'
         )
       end
@@ -886,7 +873,6 @@ RSpec.describe SAML::User do
           },
           sec_id: '1013062086',
           multifactor: multifactor,
-          authenticated_by_ssoe: true,
           common_name: 'mhvzack@mhv.va.gov'
         )
       end
@@ -927,7 +913,6 @@ RSpec.describe SAML::User do
           },
           sec_id: '1012827134',
           multifactor: multifactor,
-          authenticated_by_ssoe: true,
           common_name: 'vets.gov.user+262@gmail.com'
         )
       end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -154,5 +154,17 @@ RSpec.describe Session, type: :model do
         expect(described_class.find(subject.token)).to be_nil
       end
     end
+
+    context 'authenticated_by_ssoe' do
+      let(:transaction_session) { described_class.new({ uuid: 'a', ssoe_transaction: 'b' }) }
+
+      it 'is false when no transaction attribute is provided' do
+        expect(subject.authenticated_by_ssoe).to be_falsey
+      end
+
+      it 'is true when a transaction attribute is provided' do
+        expect(transaction_session.authenticated_by_ssoe).to be_truthy
+      end
+    end
   end
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Session, type: :model do
     end
 
     context 'authenticated_by_ssoe' do
-      let(:transaction_session) { described_class.new({ uuid: 'a', ssoe_transaction: 'b' }) }
+      let(:transaction_session) { described_class.new({ uuid: 'a', ssoe_transactionid: 'b' }) }
 
       it 'is false when no transaction attribute is provided' do
         expect(subject.authenticated_by_ssoe).to be_falsey

--- a/spec/models/user_session_form_spec.rb
+++ b/spec/models/user_session_form_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe UserSessionForm, type: :model do
     it 'instantiates cleanly' do
       UserSessionForm.new(saml_response)
     end
+
+    it 'instantiates with a Session SSOe transactionid' do
+      form = UserSessionForm.new(saml_response)
+      expect(form.session[:ssoe_transactionid])
+        .to eq(saml_attributes['va_eauth_transactionid'])
+    end
   end
 
   context 'with ID.me UUID not present in SAML' do

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -48,4 +48,8 @@ RSpec.describe UserSerializer, type: :serializer do
   it 'returns serialized #vet360_contact_information data' do
     expect(attributes.dig('vet360_contact_information')).to be_present
   end
+
+  it 'returns serialized #session data' do
+    expect(attributes.dig('session')).to be_present
+  end
 end

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -424,5 +424,19 @@ RSpec.describe Users::Profile do
         expect(subject.services).to include 'facilities', 'hca', 'edu-benefits'
       end
     end
+
+    context '#session_data' do
+      let(:scaffold_with_ssoe) { Users::Profile.new(user, { ssoe_transactionid: 'a' }).pre_serialize }
+
+      it 'no session object indicates no SSOe authentication' do
+        expect(subject.session)
+          .to eq({ ssoe: false, transactionid: nil })
+      end
+
+      it 'with a transaction in the Session shows a SSOe authentication' do
+        expect(scaffold_with_ssoe.session)
+          .to eq({ ssoe: true, transactionid: 'a' })
+      end
+    end
   end
 end

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -1,6 +1,4 @@
 {
-  "$schema" : "http://json-schema.org/draft-04/schema#",
-  "type": "object",
   "required": ["data", "meta"],
   "properties": {
     "data": {
@@ -24,6 +22,14 @@
               }
             },
             "prefills_available": { "type": [ "array", null ] },
+            "session": {
+              "type": "object",
+              "required": ["ssoe", "transactionid"],
+              "properties": {
+                "ssoe": { "type": "boolean"},
+                "transactionid": { "type": [ "string", null ] }
+              }
+            },
             "services": { "type": [ "array", null ] },
             "account": {
               "type": "object",

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -1,4 +1,6 @@
 {
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "type": "object",
   "required": ["data", "meta"],
   "properties": {
     "data": {

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -25,6 +25,14 @@
               }
             },
             "prefills_available": { "type": [ "array", null ] },
+            "session": {
+              "type": "object",
+              "required": ["ssoe", "transactionid"],
+              "properties": {
+                "ssoe": { "type": "boolean"},
+                "transactionid": { "type": [ "string", null ] }
+              }
+            },
             "services": { "type": [ "array", null ] },
             "account": {
               "type": "object",

--- a/spec/support/schemas_camelized/user_loa1.json
+++ b/spec/support/schemas_camelized/user_loa1.json
@@ -48,6 +48,14 @@
                 null
               ]
             },
+            "session": {
+              "type": "object",
+              "required": ["ssoe", "transactionid"],
+              "properties": {
+                "ssoe": { "type": "boolean"},
+                "transactionid": { "type": [ "string", null ] }
+              }
+            },
             "services": {
               "type": [
                 "array",

--- a/spec/support/schemas_camelized/user_loa3.json
+++ b/spec/support/schemas_camelized/user_loa3.json
@@ -54,6 +54,14 @@
                 null
               ]
             },
+            "session": {
+              "type": "object",
+              "required": ["ssoe", "transactionid"],
+              "properties": {
+                "ssoe": { "type": "boolean"},
+                "transactionid": { "type": [ "string", null ] }
+              }
+            },
             "services": {
               "type": [
                 "array",

--- a/spec/support/vcr_cassettes/complex_interaction/internal_interactions.yml
+++ b/spec/support/vcr_cassettes/complex_interaction/internal_interactions.yml
@@ -264,7 +264,7 @@ http_interactions:
       - '591'
     body:
       encoding: UTF-8
-      string: '{"data":{"id":"","type":"users","attributes":{"services":["facilities","hca","edu-benefits","user-profile","form-save-in-progress","form-prefill"],"profile":{"email":"vets.gov.user+0@gmail.com","first_name":"HECTOR","middle_name":null,"last_name":"ALLEN","birth_date":null,"gender":null,"zip":null,"last_signed_in":"2017-08-29T03:32:30.000Z","loa":{"current":1,"highest":3}},"va_profile":{"status":"NOT_AUTHORIZED"},"veteran_status":{"status":"SERVER_ERROR"},"in_progress_forms":[],"prefills_available":["1010ez","21P-527EZ","21P-530"]}}}'
+      string: '{"data":{"id":"","type":"users","attributes":{"services":["facilities","hca","edu-benefits","user-profile","form-save-in-progress","form-prefill"],"profile":{"email":"vets.gov.user+0@gmail.com","first_name":"HECTOR","middle_name":null,"last_name":"ALLEN","birth_date":null,"gender":null,"zip":null,"last_signed_in":"2017-08-29T03:32:30.000Z","loa":{"current":1,"highest":3}},"va_profile":{"status":"NOT_AUTHORIZED"},"veteran_status":{"status":"SERVER_ERROR"},"in_progress_forms":[],"prefills_available":["1010ez","21P-527EZ","21P-530"],"sessions":{"ssoe":false,"transactionid":null}}}}'
     http_version:
   recorded_at: Tue, 29 Aug 2017 03:32:30 GMT
 - request:

--- a/spec/support/vcr_cassettes/complex_interaction/internal_interactions.yml
+++ b/spec/support/vcr_cassettes/complex_interaction/internal_interactions.yml
@@ -264,7 +264,7 @@ http_interactions:
       - '591'
     body:
       encoding: UTF-8
-      string: '{"data":{"id":"","type":"users","attributes":{"services":["facilities","hca","edu-benefits","user-profile","form-save-in-progress","form-prefill"],"profile":{"email":"vets.gov.user+0@gmail.com","first_name":"HECTOR","middle_name":null,"last_name":"ALLEN","birth_date":null,"gender":null,"zip":null,"last_signed_in":"2017-08-29T03:32:30.000Z","loa":{"current":1,"highest":3}},"va_profile":{"status":"NOT_AUTHORIZED"},"veteran_status":{"status":"SERVER_ERROR"},"in_progress_forms":[],"prefills_available":["1010ez","21P-527EZ","21P-530"],"sessions":{"ssoe":false,"transactionid":null}}}}'
+      string: '{"data":{"id":"","type":"users","attributes":{"services":["facilities","hca","edu-benefits","user-profile","form-save-in-progress","form-prefill"],"profile":{"email":"vets.gov.user+0@gmail.com","first_name":"HECTOR","middle_name":null,"last_name":"ALLEN","birth_date":null,"gender":null,"zip":null,"last_signed_in":"2017-08-29T03:32:30.000Z","loa":{"current":1,"highest":3}},"va_profile":{"status":"NOT_AUTHORIZED"},"veteran_status":{"status":"SERVER_ERROR"},"in_progress_forms":[],"prefills_available":["1010ez","21P-527EZ","21P-530"],"session":{"ssoe":false,"transactionid":null}}}}'
     http_version:
   recorded_at: Tue, 29 Aug 2017 03:32:30 GMT
 - request:


### PR DESCRIPTION
Copying the SSOe transaction id value from UserIdentity to the Session object and also serializing that info into the UserProfile.

refs https://github.com/department-of-veterans-affairs/va.gov-team/issues/13726

### testing
I ran the following manual test locally to verify that the change will work
1. In Firefox, I opened a tab with https://localhost:3000/v1/sessions/idme/new and completed the authentication process with testing user 262
1. In Firefox, I opened a tab with https://localhost:3000/v0/user and verified that both the transactionid in profile.sign_in and session matched
1. In Chrome, I opened a tab with https://localhost:3000/v1/sessions/idme/new and completed the authentication process with testing user 262
1. In Chrome, I opened a tab with https://localhost:3000/v0/user and verified that both the transactionid in profile.sign_in and session matched
1. In Firefox, I REFRESHED the tab with https://localhost:3000/v0/user and verified that the transactionid in profile.sign_in was DIFFERENT from the transactionid in session (the former matched that in step 4, and the latter mathced the one in step 2)