### PR TITLE
increment statsd on success of form526 confirmation email job

### DIFF
--- a/app/workers/form526_confirmation_email_job.rb
+++ b/app/workers/form526_confirmation_email_job.rb
@@ -9,6 +9,7 @@ class Form526ConfirmationEmailJob
   sidekiq_options expires_in: 1.day
 
   STATSD_ERROR_NAME = 'worker.form526_confirmation_email.error'
+  STATSD_SUCCESS_NAME = 'worker.form526_confirmation_email.success'
 
   def perform(personalization_parameters)
     @notify_client ||= VaNotify::Service.new
@@ -21,8 +22,10 @@ class Form526ConfirmationEmailJob
         'full_name' => personalization_parameters['full_name']
       }
     )
-  rescue => e
-    handle_errors(e)
+    StatsD.increment(STATSD_SUCCESS_NAME)
+    
+    rescue => e
+      handle_errors(e)
   end
 
   def handle_errors(ex)

--- a/app/workers/form526_confirmation_email_job.rb
+++ b/app/workers/form526_confirmation_email_job.rb
@@ -23,9 +23,8 @@ class Form526ConfirmationEmailJob
       }
     )
     StatsD.increment(STATSD_SUCCESS_NAME)
-    
-    rescue => e
-      handle_errors(e)
+  rescue => e
+    handle_errors(e)
   end
 
   def handle_errors(ex)


### PR DESCRIPTION
## Description of change
This is a small addition to the Form526ConfirmationEmailJob, which is to increment statsd on success. We've previously only incremented on failure.

## Original issue(s)
department-of-veterans-affairs/notification-api#137

## Things to know about this PR
Increment statsd on success for Form526ConfirmationEmailJob

<!-- Please describe testing done to verify the changes or any testing planned. -->
