### PR TITLE
added questionnaire to enabled by default

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -238,6 +238,7 @@ features:
       Enables inquiry form for users to submit questions, suggestions, and complaints.
   show_healthcare_experience_questionnaire:
     actor_type: cookie_id
+    enable_in_development: true
     description: >
       Enables showing the pre-appointment questionnaire feature.
   stem_sco_email:


### PR DESCRIPTION
## Description of change
Since the update for the feature flags, our feature was not enabled for development. We needed to have the `show_healthcare_experience_questionnaire` flag to be enabled in development.  


