### PR TITLE
multi-key saml support when decrypting authn responses

### DIFF
--- a/config/initializers/saml.rb
+++ b/config/initializers/saml.rb
@@ -6,8 +6,13 @@ def new_saml_cert_exists?
   !Settings.saml.cert_new_path.nil? && File.file?(File.expand_path(Settings.saml.cert_new_path))
 end
 
+def new_saml_key_exists?
+  !Settings.saml.key_new_path.nil? && File.file?(File.expand_path(Settings.saml.key_new_path))
+end
+
 Settings.saml.certificate = File.read(File.expand_path(Settings.saml.cert_path))
 Settings.saml.key = File.read(File.expand_path(Settings.saml.key_path))
+Settings.saml.key_new = new_saml_key_exists? ? File.read(File.expand_path(Settings.saml.key_new_path)) : nil
 Settings.saml.certificate_new = new_saml_cert_exists? ? File.read(File.expand_path(Settings.saml.cert_new_path)) : nil
 
 def saml_ssoe_cert_exists?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,7 @@ saml:
   cert_path: config/certs/vetsgov-localhost.crt
   cert_new_path: config/certs/vetsgov-localhost_new.crt
   key_path: config/certs/vetsgov-localhost.key
+  key_new_path: ~
   issuer: saml-rp.vetsgov.localhost
   callback_url: http://localhost:3000/auth/saml/callback
   metadata_url: https://api.idmelabs.com/saml/metadata/provider

--- a/lib/saml/responses/login.rb
+++ b/lib/saml/responses/login.rb
@@ -10,11 +10,13 @@ module SAML
       def initialize(saml_response, options = {})
         super(saml_response, options)
       rescue OpenSSL::PKey::RSAError => e # "padding check failed." when decrypt fails
+        # :nocov: Temporary code only required during key rollovers using a new private key
         raise e unless Settings.saml.key_new
 
         duped_options = options.dup
         duped_options[:settings].private_key = Settings.saml.key_new
         super(saml_response, duped_options)
+        # :nocov:
       end
 
       def errors_message

--- a/lib/saml/responses/login.rb
+++ b/lib/saml/responses/login.rb
@@ -7,16 +7,14 @@ module SAML
     class Login < OneLogin::RubySaml::Response
       include SAML::Responses::Base
 
-      def initialize(saml_response, options={})
-        begin
-          super(saml_response, options)
-        rescue OpenSSL::PKey::RSAError => e
-          raise e unless Settings.saml.key_new
+      def initialize(saml_response, options = {})
+        super(saml_response, options)
+      rescue OpenSSL::PKey::RSAError => e # "padding check failed." when decrypt fails
+        raise e unless Settings.saml.key_new
 
-          duped_options = options.dup
-          duped_options[:settings].private_key = Settings.saml.key_new
-          super(saml_response, duped_options)
-        end
+        duped_options = options.dup
+        duped_options[:settings].private_key = Settings.saml.key_new
+        super(saml_response, duped_options)
       end
 
       def errors_message

--- a/lib/saml/responses/login.rb
+++ b/lib/saml/responses/login.rb
@@ -7,6 +7,18 @@ module SAML
     class Login < OneLogin::RubySaml::Response
       include SAML::Responses::Base
 
+      def initialize(saml_response, options={})
+        begin
+          super(saml_response, options)
+        rescue OpenSSL::PKey::RSAError => e
+          raise e unless Settings.saml.key_new
+
+          duped_options = options.dup
+          duped_options[:settings].private_key = Settings.saml.key_new
+          super(saml_response, duped_options)
+        end
+      end
+
       def errors_message
         @errors_message ||= if errors.any?
                               message = 'Login Failed! '


### PR DESCRIPTION
## Description of change
Adds support for a concurrent 2nd saml key for ID.me auth. 

## Why?
Our existing certificate is expiring soon, and our private key has not changed for a while, and our existing certificate still has "vetsgov" references in it... so we generated a brand new keypair. We don't want to incur any login downtime, so this PR makes `vets-api` support both keys for login. Once ID.me makes the new certificate "active", we can remove this logic and just use the new key + cert.

## Extra Context
`ruby-saml` has support for multiple certificates ([and it's what we used last time we rolled over](https://github.com/department-of-veterans-affairs/vets-api/pull/1431)), but that support requires both old and new cert to cryptographically chain back to the same private key. In our case, we have a _new_ private key.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
