### PR TITLE
14053 consolidate google analytics keys

### DIFF
--- a/app/mailers/transactional_email_mailer.rb
+++ b/app/mailers/transactional_email_mailer.rb
@@ -3,7 +3,7 @@
 class TransactionalEmailMailer < ApplicationMailer
   def build(email, google_analytics_client_id, opt = {})
     @google_analytics_client_id = google_analytics_client_id
-    @google_analytics_tracking_id = Settings.google_analytics_tracking_id
+    @google_analytics_tracking_id = Settings.google_analytics.tracking_id
 
     template = File.read("app/mailers/views/#{self.class::TEMPLATE}.html.erb")
 

--- a/app/workers/transactional_email_analytics_job.rb
+++ b/app/workers/transactional_email_analytics_job.rb
@@ -12,13 +12,13 @@ class TransactionalEmailAnalyticsJob
         detail: 'It should be configured in settings.yml'
       )
     end
-    if Settings.google_analytics_tracking_id.blank?
+    if Settings.google_analytics.tracking_id.blank?
       raise Common::Exceptions::ParameterMissing.new(
         'Google Analytics tracking ID',
         detail: 'It should be configured in settings.yml'
       )
     end
-    @tracker = Staccato.tracker(Settings.google_analytics_tracking_id)
+    @tracker = Staccato.tracker(Settings.google_analytics.tracking_id)
     @time_range_start = 1445.minutes.ago
     @time_range_end = 5.minutes.ago
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -455,8 +455,6 @@ betamocks:
   cache_dir: /cache
   services_config: config/betamocks/services_config.yml
 
-google_analytics_tracking_id: ~
-
 # Settings for search
 search:
   access_key: SEARCH_GOV_ACCESS_KEY
@@ -575,6 +573,7 @@ github_stats:
 
 google_analytics:
   url: 'https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4473'
+  tracking_id: ~
 
 # Settings for the coronavirus chatbot tokens
 coronavirus_chatbot:

--- a/spec/jobs/transactional_email_analytics_job_spec.rb
+++ b/spec/jobs/transactional_email_analytics_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TransactionalEmailAnalyticsJob, type: :job do
 
   before do
     Settings.govdelivery.token = 'asdf'
-    Settings.google_analytics_tracking_id = 'UA-XXXXXXXXX-1'
+    Settings.google_analytics.tracking_id = 'UA-XXXXXXXXX-1'
   end
 
   describe '#perform', run_at: '2018-05-30 18:18:56' do
@@ -22,7 +22,7 @@ RSpec.describe TransactionalEmailAnalyticsJob, type: :job do
 
     context 'Google Analytics tracking ID is missing from settings' do
       it 'raises an error' do
-        Settings.google_analytics_tracking_id = nil
+        Settings.google_analytics.tracking_id = nil
         expect { subject.perform }.to raise_error(Common::Exceptions::ParameterMissing)
       end
     end


### PR DESCRIPTION
Recently another `google_analytics` key was introduced to `settings.yml`.  This PR is to put them in the same namespace together


## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/14053
https://github.com/department-of-veterans-affairs/va.gov-team/issues/14017


corresponding PR for devops https://github.com/department-of-veterans-affairs/devops/pull/7657