### PR TITLE
added stem text FF to backend

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -285,3 +285,8 @@ features:
     actor_type: user
     description: >
       Set 10203 spool file document type
+  stem_text_message_question:
+    actor_type: user
+    description: >
+      Add text message opt-in question to 10203 Personal Information chapter and layout changes     
+


### PR DESCRIPTION
## Description
As a developer, I need a way to toggle when the new text message option question is displayed within the 10203 form, so that it can be delivered when EDU is ready to accept the data.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13826

front end pr: https://github.com/department-of-veterans-affairs/vets-website/pull/14380
## Testing done

local testing
## Screenshots


## Acceptance criteria
- [x] The Feature Flag stem_text_message_question is available to be used for the text message enhancements.
- [x] The Feature Flag description is: "Add text message opt-in question to 10203 Personal Information chapter and layout changes"
- [x] The text message feature flag is created and available in all environments.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
