### PR TITLE
Fixing bad documentation for valid_pdf

### DIFF
--- a/modules/va_forms/app/serializers/va_forms/form_detail_serializer.rb
+++ b/modules/va_forms/app/serializers/va_forms/form_detail_serializer.rb
@@ -6,7 +6,7 @@ module VaForms
 
     attributes :form_name, :url, :title, :first_issued_on,
                :last_revision_on, :pages, :sha256, :valid_pdf,
-               :form_usage, :form_tool_intro, :form_tool_url,
+               :form_usage, :form_tool_intro, :form_tool_url, :form_details_url,
                :form_type, :language, :deleted_at, :related_forms,
                :benefit_categories, :versions
 

--- a/modules/va_forms/app/serializers/va_forms/form_detail_serializer.rb
+++ b/modules/va_forms/app/serializers/va_forms/form_detail_serializer.rb
@@ -6,12 +6,17 @@ module VaForms
 
     attributes :form_name, :url, :title, :first_issued_on,
                :last_revision_on, :pages, :sha256, :valid_pdf,
-               :form_usage, :form_tool_intro, :form_tool_url, :form_details_url,
+               :form_usage, :form_tool_intro, :form_tool_url,
                :form_type, :language, :deleted_at, :related_forms,
                :benefit_categories, :versions
 
     def id
       object.form_name
+    end
+
+    # TODO: Need to remove and add back to attributes when ready for production
+    def form_details_url
+      nil
     end
 
     def versions

--- a/modules/va_forms/app/serializers/va_forms/form_list_serializer.rb
+++ b/modules/va_forms/app/serializers/va_forms/form_list_serializer.rb
@@ -12,5 +12,10 @@ module VaForms
     def id
       object.form_name
     end
+
+    # TODO: Need to remove and add back to attributes when ready for production
+    def form_details_url
+      nil
+    end
   end
 end

--- a/modules/va_forms/app/swagger/va_forms/forms/form_swagger.rb
+++ b/modules/va_forms/app/swagger/va_forms/forms/form_swagger.rb
@@ -60,7 +60,7 @@ module VaForms
             property :valid_pdf do
               key :description, I18n.t('va_forms.field_descriptions.valid_pdf')
               key :type, :boolean
-              key :example, 3
+              key :example, true
             end
 
             property :sha256 do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Documentation error is showing the valid_pdf as being an integer instead of it's stated boolean in the example. They also needed us to remove the forms_details_url for now until they are ready for production.

## Original issue(s)
https://vajira.max.gov/browse/API-2585
https://vajira.max.gov/browse/API-2654

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
