### PR TITLE
notification-api#77 handling more error types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,6 @@ PATH
 
 GEM
   remote: https://rubygems.org/
-  remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.0.3)
     aasm (5.0.6)
@@ -351,7 +350,6 @@ GEM
     e2mmap (0.1.0)
     ecma-re-validator (0.2.0)
       regexp_parser (~> 1.2)
-    einhorn (0.7.4)
     encryptor (3.0.0)
     equalizer (0.0.11)
     erubi (1.9.0)
@@ -738,13 +736,6 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 4.2)
-    sidekiq-ent (1.8.1)
-      einhorn (= 0.7.4)
-      sidekiq (>= 5.2.3)
-      sidekiq-pro (>= 4.0.4)
-    sidekiq-pro (5.0.0)
-      concurrent-ruby (>= 1.0.5)
-      sidekiq (>= 5.2.7)
     sidekiq-scheduler (3.0.1)
       e2mmap
       redis (>= 3, < 5)
@@ -815,7 +806,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.6.0)
+    webrick (1.6.1)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -958,8 +949,6 @@ DEPENDENCIES
   shrine
   shrine-memory
   sidekiq (~> 5.0)
-  sidekiq-ent!
-  sidekiq-pro!
   sidekiq-scheduler (~> 3.0)
   simplecov (< 0.18)
   spring

--- a/app/workers/form526_confirmation_email_job.rb
+++ b/app/workers/form526_confirmation_email_job.rb
@@ -31,7 +31,7 @@ class Form526ConfirmationEmailJob
     log_exception_to_sentry(ex)
     StatsD.increment(STATSD_ERROR_NAME)
 
-    raise ex if !ex.class.method_defined? 'status_code'
+    raise ex unless ex.class.method_defined? 'status_code'
     raise ex if ex.status_code.between?(500, 599)
   end
 end

--- a/app/workers/form526_confirmation_email_job.rb
+++ b/app/workers/form526_confirmation_email_job.rb
@@ -31,6 +31,7 @@ class Form526ConfirmationEmailJob
     log_exception_to_sentry(ex)
     StatsD.increment(STATSD_ERROR_NAME)
 
+    raise ex if !ex.class.method_defined? 'status_code'
     raise ex if ex.status_code.between?(500, 599)
   end
 end


### PR DESCRIPTION

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
in sending notifications make sure the handle_error method handles all exceptions. For example of the notification client fails to instantiate an exception with no status_code is raised.

## Original issue(s)
department-of-veterans-affairs/notification-api#77

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment? No
* Is there a feature flag? What is it? No
* Is there some Sentry logging that was added? What alerts are relevant? No, the sentry log is already configured
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do? No
* Are there Swagger docs that were updated? No
* Is there any PII concerns or questions? No
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Added one unit test so if NoArgument error is raised the expected behavior is observed