### PR TITLE
enable SSOe in development by default

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -139,6 +139,7 @@ features:
       Enables global downtime notification- do not use in production
   ssoe:
     actor_type: cookie_id
+    enable_in_development: true
     description: >
       Enables ssoe, as opposed to saml authentication wrapped by id.me
   edu_benefits_stem_scholarship:
@@ -169,6 +170,7 @@ features:
       Enable eBenefits links to be proxied through eauth.va.gov, this allows users with SSOe sessions to stay logged in.
   ssoe_inbound:
     actor_type: cookie_id
+    enable_in_development: true
     description: >
       Enables automatic establishment/disconnection of vets-api session based on a user's SSOe session status
   allow_online_10_10cg_submissions:


### PR DESCRIPTION
## Description of change
### PREVIOUSLY:
SSOe wasn’t working locally.  Because of that we had a line in an initializer to ensure that SSOe login was disabled for localhost.

### NOW:
SSOe is working locally.  I removed the line from the initializer that ensured SSOe login was disabled.  However, previously disabled SSOe flags remain disabled until manually enabled.

Since then, the new `enable_in_development` flag was added to `features.yml`.  

SSOe is the path forward and we will eventually remove the “old” login flow altogether.

Therefore, I'm setting `enable_in_development` to `true` for the SSOe toggles so that engineers will use SSOe locally by default. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14179

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
