### PR TITLE
upgrade Webrick to 1.6.1 to resolve CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -815,7 +815,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.6.0)
+    webrick (1.6.1)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
## Description of change
```
[2020-09-29T17:10:27.152Z] running bundle-audit to check for insecure dependencies...
[2020-09-29T17:10:27.715Z] Updating ruby-advisory-db ...
[2020-09-29T17:10:27.715Z] Cloning into '/srv/vets-api/.local/share/ruby-advisory-db'...
[2020-09-29T17:10:28.277Z] Updated ruby-advisory-db
[2020-09-29T17:10:28.277Z] ruby-advisory-db: 469 advisories
[2020-09-29T17:10:28.839Z] Name: webrick
[2020-09-29T17:10:28.839Z] Version: 1.6.0
[2020-09-29T17:10:28.839Z] Advisory: CVE-2020-25613
[2020-09-29T17:10:28.839Z] Criticality: Unknown
[2020-09-29T17:10:28.839Z] URL: https://www.ruby-lang.org/en/news/2020/09/29/http-request-smuggling-cve-2020-25613/
[2020-09-29T17:10:28.839Z] Title: Potential HTTP Request Smuggling Vulnerability in WEBrick
[2020-09-29T17:10:28.839Z] Solution: upgrade to >= 1.6.1
```

[Info about the CVE](https://www.ruby-lang.org/en/news/2020/09/29/http-request-smuggling-cve-2020-25613/)

We do not use Webrick in production


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR

