### PR TITLE
Adding a timeout rescue with a status refresh check

### DIFF
--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -36,6 +36,8 @@ module VBADocuments
         response = submit(metadata, parts)
         process_response(response)
         log_submission(@upload, metadata)
+      rescue Faraday::TimeoutError
+        VBADocuments::UploadSubmission.refresh_statuses!([@upload])
       rescue VBADocuments::UploadError => e
         retry_errors(e, @upload)
       ensure

--- a/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_processor.rb
@@ -36,7 +36,7 @@ module VBADocuments
         response = submit(metadata, parts)
         process_response(response)
         log_submission(@upload, metadata)
-      rescue Faraday::TimeoutError
+      rescue Common::Exceptions::GatewayTimeout, Faraday::TimeoutError
         VBADocuments::UploadSubmission.refresh_statuses!([@upload])
       rescue VBADocuments::UploadError => e
         retry_errors(e, @upload)

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -377,7 +377,15 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       end
     end
 
-    it 'checks for updated status for timeout error' do
+    it 'checks for updated status for Gateway timeout error' do
+      allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
+      allow(CentralMail::Service).to receive(:new) { client_stub }
+      expect(client_stub).to receive(:upload)
+        .and_raise(Common::Exceptions::GatewayTimeout.new)
+      expect { described_class.new.perform(upload.guid) }.not_to raise_error(Common::Exceptions::GatewayTimeout)
+    end
+
+    it 'checks for updated status for Faraday timeout error' do
       allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
       allow(CentralMail::Service).to receive(:new) { client_stub }
       expect(client_stub).to receive(:upload)

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -383,6 +383,8 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       expect(client_stub).to receive(:upload)
         .and_raise(Common::Exceptions::GatewayTimeout.new)
       expect { described_class.new.perform(upload.guid) }.not_to raise_error(Common::Exceptions::GatewayTimeout)
+      upload.reload
+      expect(upload.status).to eq('recieved')
     end
 
     it 'checks for updated status for Faraday timeout error' do
@@ -391,6 +393,8 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       expect(client_stub).to receive(:upload)
         .and_raise(Faraday::TimeoutError.new)
       expect { described_class.new.perform(upload.guid) }.not_to raise_error(Faraday::TimeoutError)
+      upload.reload
+      expect(upload.status).to eq('recieved')
     end
   end
 end

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
         .and_raise(Common::Exceptions::GatewayTimeout.new)
       expect { described_class.new.perform(upload.guid) }.not_to raise_error(Common::Exceptions::GatewayTimeout)
       upload.reload
-      expect(upload.status).to eq('recieved')
+      expect(upload.status).to eq('uploaded')
     end
 
     it 'checks for updated status for Faraday timeout error' do
@@ -394,7 +394,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
         .and_raise(Faraday::TimeoutError.new)
       expect { described_class.new.perform(upload.guid) }.not_to raise_error(Faraday::TimeoutError)
       upload.reload
-      expect(upload.status).to eq('recieved')
+      expect(upload.status).to eq('uploaded')
     end
   end
 end

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -377,14 +377,12 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       end
     end
 
-    it 'does not set error status for retriable timeout error' do
+    it 'checks for updated status for timeout error' do
       allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
       allow(CentralMail::Service).to receive(:new) { client_stub }
       expect(client_stub).to receive(:upload)
         .and_raise(Faraday::TimeoutError.new)
-      expect { described_class.new.perform(upload.guid) }.to raise_error(Faraday::TimeoutError)
-      updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
-      expect(updated.status).to eq('uploaded')
+      expect { described_class.new.perform(upload.guid) }.not_to raise_error(Faraday::TimeoutError)
     end
   end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Checking status refreshing if Faraday::TimeoutError persists...

## Original issue(s)
https://vajira.max.gov/browse/API-2488

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
