### PR TITLE
[API 687] Update the documentation for original appeals status endpoint

### DIFF
--- a/modules/appeals_api/app/swagger/v0/appeals.yml
+++ b/modules/appeals_api/app/swagger/v0/appeals.yml
@@ -74,7 +74,7 @@ paths:
                   - data
                 properties:
                   data:
-                    $ref: "#/components/schemas/Appeal"
+                    $ref: "#/components/schemas/Appeals"
         '400':
           description: Missing SSN header
         '401':
@@ -92,6 +92,10 @@ components:
       name: apikey
       in: query
   schemas:
+    Appeals:
+      type: array
+      items:
+        $ref: '#components/schemas/Appeal'
     Appeal:
       type: object
       properties:


### PR DESCRIPTION
## Description of change
This PR updates the documentation to display an array instead of an object for the data field in the appeals status API. 

## Original issue(s)
[Update the documentation for original appeals status endpoint](https://vajira.max.gov/browse/API-687)
