### PR TITLE
add_parser has too much code copy-pasted

### DIFF
--- a/lib/mvi/responses/add_parser.rb
+++ b/lib/mvi/responses/add_parser.rb
@@ -1,23 +1,17 @@
 # frozen_string_literal: true
 
 require 'sentry_logging'
+require_relative 'parser_base'
 
 module MVI
   module Responses
     # Parses a MVI response and returns a MviProfile
-    class AddParser
+    class AddParser < ParserBase
       include SentryLogging
 
       ACKNOWLEDGEMENT_DETAIL_CODE_XPATH = 'acknowledgement/acknowledgementDetail/code'
       BODY_XPATH = 'env:Envelope/env:Body/idm:MCCI_IN000002UV01'
       CODE_XPATH = 'acknowledgement/typeCode/@code'
-
-      # MVI response code options.
-      EXTERNAL_RESPONSE_CODES = {
-        success: 'AA',
-        failure: 'AR',
-        invalid_request: 'AE'
-      }.freeze
 
       # Creates a new parser instance.
       #
@@ -35,27 +29,6 @@ module MVI
             }
           )
         end
-      end
-
-      # MVI returns failed or invalid codes if the request is malformed or MVI throws an internal error.
-      #
-      # @return [Boolean] has failed or invalid code?
-      def failed_or_invalid?
-        invalid_request? || failed_request?
-      end
-
-      # MVI returns failed if MVI throws an internal error.
-      #
-      # @return [Boolean] has failed
-      def failed_request?
-        EXTERNAL_RESPONSE_CODES[:failure] == @code
-      end
-
-      # MVI returns invalid request if request is malformed.
-      #
-      # @return [Boolean] has invalid request
-      def invalid_request?
-        EXTERNAL_RESPONSE_CODES[:invalid_request] == @code
       end
 
       # Parse the response.
@@ -76,31 +49,15 @@ module MVI
         attributes.each do |attribute|
           case attribute[:code]
           when /BRLS/
-            codes[:birls_id] = sanitize_ids(attribute[:code])
+            codes[:birls_id] = sanitize_birls_id(attribute[:code])
           when /CORP/
-            codes[:participant_id] = sanitize_ids(attribute[:code])
+            codes[:participant_id] = sanitize_participant_id(attribute[:code])
           else
             codes[:other].append(attribute)
           end
         end
         codes.delete(:other) if codes[:other].empty?
         codes
-      end
-
-      def sanitize_ids(raw_id)
-        return if raw_id.nil?
-
-        raw_id.match(/^\d+/)&.to_s
-      end
-
-      def locate_element(el, path)
-        locate_elements(el, path)&.first
-      end
-
-      def locate_elements(el, path)
-        return nil unless el
-
-        el.locate(path)
       end
     end
   end

--- a/lib/mvi/responses/parser_base.rb
+++ b/lib/mvi/responses/parser_base.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class ParserBase
+  # MVI response code options.
+  EXTERNAL_RESPONSE_CODES = {
+    success: 'AA',
+    failure: 'AR',
+    invalid_request: 'AE'
+  }.freeze
+
+  # MVI returns failed or invalid codes if the request is malformed or MVI throws an internal error.
+  #
+  # @return [Boolean] has failed or invalid code?
+  def failed_or_invalid?
+    invalid_request? || failed_request?
+  end
+
+  # MVI returns failed if MVI throws an internal error.
+  #
+  # @return [Boolean] has failed
+  def failed_request?
+    EXTERNAL_RESPONSE_CODES[:failure] == @code
+  end
+
+  # MVI returns invalid request if request is malformed.
+  #
+  # @return [Boolean] has invalid request
+  def invalid_request?
+    EXTERNAL_RESPONSE_CODES[:invalid_request] == @code
+  end
+
+  def sanitize_edipi(edipi)
+    return if edipi.nil?
+
+    # Get rid of invalid values like 'UNK'
+    sanitized_result = edipi.match(/\d{10}/)&.to_s
+    Rails.logger.info "Edipi sanitized was: '#{edipi}' now: '#{sanitized_result}'." unless sanitized_result == edipi
+    sanitized_result
+  end
+
+  def sanitize_participant_id(participant_id)
+    return if participant_id.nil?
+
+    # Get rid of non-digit characters like 'UNK'/'ASKU'
+    sanitized_result = participant_id.match(/\d+/)&.to_s
+    if sanitized_result != participant_id
+      Rails.logger.info "Participant id sanitized, was: '#{participant_id}' now: '#{sanitized_result}'."
+    end
+    sanitized_result
+  end
+
+  def sanitize_birls_id(birls_id)
+    return if birls_id.nil?
+
+    # Get rid of non-digit characters like 'UNK'/'ASKU'
+    sanitized_result = birls_id.match(/\d+/)&.to_s
+    if sanitized_result != birls_id
+      Rails.logger.info "Birls id sanitized, was: '#{birls_id}' now: '#{sanitized_result}'."
+    end
+    sanitized_result
+  end
+
+  def locate_element(el, path)
+    locate_elements(el, path)&.first
+  end
+
+  def locate_elements(el, path)
+    return nil unless el
+
+    el.locate(path)
+  end
+end

--- a/lib/mvi/responses/parser_base.rb
+++ b/lib/mvi/responses/parser_base.rb
@@ -1,72 +1,76 @@
 # frozen_string_literal: true
 
-class ParserBase
-  # MVI response code options.
-  EXTERNAL_RESPONSE_CODES = {
-    success: 'AA',
-    failure: 'AR',
-    invalid_request: 'AE'
-  }.freeze
+module MVI
+  module Responses
+    class ParserBase
+      # MVI response code options.
+      EXTERNAL_RESPONSE_CODES = {
+        success: 'AA',
+        failure: 'AR',
+        invalid_request: 'AE'
+      }.freeze
 
-  # MVI returns failed or invalid codes if the request is malformed or MVI throws an internal error.
-  #
-  # @return [Boolean] has failed or invalid code?
-  def failed_or_invalid?
-    invalid_request? || failed_request?
-  end
+      # MVI returns failed or invalid codes if the request is malformed or MVI throws an internal error.
+      #
+      # @return [Boolean] has failed or invalid code?
+      def failed_or_invalid?
+        invalid_request? || failed_request?
+      end
 
-  # MVI returns failed if MVI throws an internal error.
-  #
-  # @return [Boolean] has failed
-  def failed_request?
-    EXTERNAL_RESPONSE_CODES[:failure] == @code
-  end
+      # MVI returns failed if MVI throws an internal error.
+      #
+      # @return [Boolean] has failed
+      def failed_request?
+        EXTERNAL_RESPONSE_CODES[:failure] == @code
+      end
 
-  # MVI returns invalid request if request is malformed.
-  #
-  # @return [Boolean] has invalid request
-  def invalid_request?
-    EXTERNAL_RESPONSE_CODES[:invalid_request] == @code
-  end
+      # MVI returns invalid request if request is malformed.
+      #
+      # @return [Boolean] has invalid request
+      def invalid_request?
+        EXTERNAL_RESPONSE_CODES[:invalid_request] == @code
+      end
 
-  def sanitize_edipi(edipi)
-    return if edipi.nil?
+      def sanitize_edipi(edipi)
+        return if edipi.nil?
 
-    # Get rid of invalid values like 'UNK'
-    sanitized_result = edipi.match(/\d{10}/)&.to_s
-    Rails.logger.info "Edipi sanitized was: '#{edipi}' now: '#{sanitized_result}'." unless sanitized_result == edipi
-    sanitized_result
-  end
+        # Get rid of invalid values like 'UNK'
+        sanitized_result = edipi.match(/\d{10}/)&.to_s
+        Rails.logger.info "Edipi sanitized was: '#{edipi}' now: '#{sanitized_result}'." unless sanitized_result == edipi
+        sanitized_result
+      end
 
-  def sanitize_participant_id(participant_id)
-    return if participant_id.nil?
+      def sanitize_participant_id(participant_id)
+        return if participant_id.nil?
 
-    # Get rid of non-digit characters like 'UNK'/'ASKU'
-    sanitized_result = participant_id.match(/\d+/)&.to_s
-    if sanitized_result != participant_id
-      Rails.logger.info "Participant id sanitized, was: '#{participant_id}' now: '#{sanitized_result}'."
+        # Get rid of non-digit characters like 'UNK'/'ASKU'
+        sanitized_result = participant_id.match(/\d+/)&.to_s
+        if sanitized_result != participant_id
+          Rails.logger.info "Participant id sanitized, was: '#{participant_id}' now: '#{sanitized_result}'."
+        end
+        sanitized_result
+      end
+
+      def sanitize_birls_id(birls_id)
+        return if birls_id.nil?
+
+        # Get rid of non-digit characters like 'UNK'/'ASKU'
+        sanitized_result = birls_id.match(/\d+/)&.to_s
+        if sanitized_result != birls_id
+          Rails.logger.info "Birls id sanitized, was: '#{birls_id}' now: '#{sanitized_result}'."
+        end
+        sanitized_result
+      end
+
+      def locate_element(el, path)
+        locate_elements(el, path)&.first
+      end
+
+      def locate_elements(el, path)
+        return nil unless el
+
+        el.locate(path)
+      end
     end
-    sanitized_result
-  end
-
-  def sanitize_birls_id(birls_id)
-    return if birls_id.nil?
-
-    # Get rid of non-digit characters like 'UNK'/'ASKU'
-    sanitized_result = birls_id.match(/\d+/)&.to_s
-    if sanitized_result != birls_id
-      Rails.logger.info "Birls id sanitized, was: '#{birls_id}' now: '#{sanitized_result}'."
-    end
-    sanitized_result
-  end
-
-  def locate_element(el, path)
-    locate_elements(el, path)&.first
-  end
-
-  def locate_elements(el, path)
-    return nil unless el
-
-    el.locate(path)
   end
 end

--- a/lib/mvi/responses/profile_parser.rb
+++ b/lib/mvi/responses/profile_parser.rb
@@ -3,11 +3,12 @@
 require 'sentry_logging'
 require_relative 'id_parser'
 require_relative 'historical_icn_parser'
+require_relative 'parser_base'
 
 module MVI
   module Responses
     # Parses a MVI response and returns a MviProfile
-    class ProfileParser
+    class ProfileParser < ParserBase
       include SentryLogging
 
       BODY_XPATH = 'env:Envelope/env:Body/idm:PRPA_IN201306UV02'
@@ -29,13 +30,6 @@ module MVI
       ACKNOWLEDGEMENT_DETAIL_XPATH = 'acknowledgement/acknowledgementDetail/text'
       MULTIPLE_MATCHES_FOUND = 'Multiple Matches Found'
 
-      # MVI response code options.
-      EXTERNAL_RESPONSE_CODES = {
-        success: 'AA',
-        failure: 'AR',
-        invalid_request: 'AE'
-      }.freeze
-
       # Creates a new parser instance.
       #
       # @param response [struct Faraday::Env] the Faraday response
@@ -43,27 +37,6 @@ module MVI
       def initialize(response)
         @original_body = locate_element(response.body, BODY_XPATH)
         @code = locate_element(@original_body, CODE_XPATH)
-      end
-
-      # MVI returns failed or invalid codes if the request is malformed or MVI throws an internal error.
-      #
-      # @return [Boolean] has failed or invalid code?
-      def failed_or_invalid?
-        invalid_request? || failed_request?
-      end
-
-      # MVI returns failed if MVI throws an internal error.
-      #
-      # @return [Boolean] has failed
-      def failed_request?
-        EXTERNAL_RESPONSE_CODES[:failure] == @code
-      end
-
-      # MVI returns invalid request if request is malformed.
-      #
-      # @return [Boolean] has invalid request
-      def invalid_request?
-        EXTERNAL_RESPONSE_CODES[:invalid_request] == @code
       end
 
       # MVI returns multiple match warnings if a query returns more than one match.
@@ -154,37 +127,6 @@ module MVI
         locate_element(patient, NAME_XPATH)
       end
 
-      def sanitize_edipi(edipi)
-        return if edipi.nil?
-
-        # Get rid of invalid values like 'UNK'
-        sanitized_result = edipi.match(/\d{10}/)&.to_s
-        Rails.logger.info "Edipi sanitized was: '#{edipi}' now: '#{sanitized_result}'." unless sanitized_result == edipi
-        sanitized_result
-      end
-
-      def sanitize_participant_id(participant_id)
-        return if participant_id.nil?
-
-        # Get rid of non-digit characters like 'UNK'/'ASKU'
-        sanitized_result = participant_id.match(/\d+/)&.to_s
-        if sanitized_result != participant_id
-          Rails.logger.info "Participant id sanitized, was: '#{participant_id}' now: '#{sanitized_result}'."
-        end
-        sanitized_result
-      end
-
-      def sanitize_birls_id(birls_id)
-        return if birls_id.nil?
-
-        # Get rid of non-digit characters like 'UNK'/'ASKU'
-        sanitized_result = birls_id.match(/\d+/)&.to_s
-        if sanitized_result != birls_id
-          Rails.logger.info "Birls id sanitized, was: '#{birls_id}' now: '#{sanitized_result}'."
-        end
-        sanitized_result
-      end
-
       # name can be a hash or an array of hashes with extra unneeded details
       # given may be an array if it includes middle name
       def parse_name(name)
@@ -232,12 +174,6 @@ module MVI
           node = oi.nodes.select { |n| n.attributes[:root] == SSN_ROOT_ID }
           return node.first unless node.empty?
         end
-      end
-
-      def locate_element(el, path)
-        return nil unless el
-
-        el.locate(path)&.first
       end
     end
   end


### PR DESCRIPTION
## Description of change
The MVI find profile response parser and the mvi add profile response parser shared a significant amount of code overlap.  

It looks like code was copy-pasted from `profile_parser` to `add-parser` [here](https://github.com/department-of-veterans-affairs/vets-api/pull/3632/files#diff-622e8b48f34f2d83fb6089237648d2ffR1
).

This PR cleans that up as a precursor to department-of-veterans-affairs/va.gov-team#11353 

Surely there's more to be done in reducing redundancy and increasing consistency, but this is a first step.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11353

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
