### PR TITLE
Revert "multi-key saml support when decrypting authn responses (#4965)"

### DIFF
--- a/config/initializers/saml.rb
+++ b/config/initializers/saml.rb
@@ -6,13 +6,8 @@ def new_saml_cert_exists?
   !Settings.saml.cert_new_path.nil? && File.file?(File.expand_path(Settings.saml.cert_new_path))
 end
 
-def new_saml_key_exists?
-  !Settings.saml.key_new_path.nil? && File.file?(File.expand_path(Settings.saml.key_new_path))
-end
-
 Settings.saml.certificate = File.read(File.expand_path(Settings.saml.cert_path))
 Settings.saml.key = File.read(File.expand_path(Settings.saml.key_path))
-Settings.saml.key_new = new_saml_key_exists? ? File.read(File.expand_path(Settings.saml.key_new_path)) : nil
 Settings.saml.certificate_new = new_saml_cert_exists? ? File.read(File.expand_path(Settings.saml.cert_new_path)) : nil
 
 def saml_ssoe_cert_exists?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,7 +12,6 @@ saml:
   cert_path: config/certs/vetsgov-localhost.crt
   cert_new_path: config/certs/vetsgov-localhost_new.crt
   key_path: config/certs/vetsgov-localhost.key
-  key_new_path: ~
   issuer: saml-rp.vetsgov.localhost
   callback_url: http://localhost:3000/auth/saml/callback
   metadata_url: https://api.idmelabs.com/saml/metadata/provider

--- a/lib/saml/responses/login.rb
+++ b/lib/saml/responses/login.rb
@@ -7,18 +7,6 @@ module SAML
     class Login < OneLogin::RubySaml::Response
       include SAML::Responses::Base
 
-      def initialize(saml_response, options = {})
-        super(saml_response, options)
-      rescue OpenSSL::PKey::RSAError => e # "padding check failed." when decrypt fails
-        # :nocov: Temporary code only required during key rollovers using a new private key
-        raise e unless Settings.saml.key_new
-
-        duped_options = options.dup
-        duped_options[:settings].private_key = Settings.saml.key_new
-        super(saml_response, duped_options)
-        # :nocov:
-      end
-
       def errors_message
         @errors_message ||= if errors.any?
                               message = 'Login Failed! '


### PR DESCRIPTION
This reverts commit 34fbd2a75e499b8babe43ce55201b8a6ad66499b.

## Description of change
We introduced temporary code to support multiple ID.me SAML keys to decrypt auth responses ([link to PR](https://github.com/department-of-veterans-affairs/vets-api/pull/4965)). ID.me has now "activated" the new certificate and our key rollover phase is complete. We no longer need this code.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/14221

## Things to know about this PR
The settings.yml files have been updated to exclusively use the new key & new cert and do not need this code anymore:
- dev https://github.com/department-of-veterans-affairs/devops/pull/7689
- staging https://github.com/department-of-veterans-affairs/devops/pull/7696
- prod https://github.com/department-of-veterans-affairs/devops/pull/7691
