### PR TITLE
Update Letter Types

### DIFF
--- a/lib/evss/letters/letter.rb
+++ b/lib/evss/letters/letter.rb
@@ -16,14 +16,15 @@ module EVSS
     #
     class Letter < Common::Base
       LETTER_TYPES = %w[
+        benefit_summary
+        benefit_summary_dependent
+        benefit_verification
+        civil_service
         commissary
         proof_of_service
+        service_verification
         medicare_partd
         minimum_essential_coverage
-        service_verification
-        civil_service
-        benefit_summary
-        benefit_verification
         certificate_of_eligibility
       ].freeze
 

--- a/lib/evss/letters/letter.rb
+++ b/lib/evss/letters/letter.rb
@@ -15,17 +15,18 @@ module EVSS
     #   @return [String] The letter type (must be one of LETTER_TYPES)
     #
     class Letter < Common::Base
+      # if you update LETTER_TYPES, update vets-website src/applications/letters/utils/constants.js
       LETTER_TYPES = %w[
         benefit_summary
         benefit_summary_dependent
         benefit_verification
+        certificate_of_eligibility
         civil_service
         commissary
-        proof_of_service
-        service_verification
         medicare_partd
         minimum_essential_coverage
-        certificate_of_eligibility
+        proof_of_service
+        service_verification
       ].freeze
 
       attribute :name, String

--- a/lib/evss/letters/letter.rb
+++ b/lib/evss/letters/letter.rb
@@ -15,7 +15,7 @@ module EVSS
     #   @return [String] The letter type (must be one of LETTER_TYPES)
     #
     class Letter < Common::Base
-      # if you update LETTER_TYPES, update vets-website src/applications/letters/utils/constants.js
+      # if you update LETTER_TYPES, update LETTER_TYPES in vets-website src/applications/letters/utils/constants.js
       LETTER_TYPES = %w[
         benefit_summary
         benefit_summary_dependent

--- a/spec/lib/evss/letters/download_service_spec.rb
+++ b/spec/lib/evss/letters/download_service_spec.rb
@@ -9,12 +9,17 @@ describe EVSS::Letters::DownloadService do
     subject { described_class.new(user) }
 
     let(:user) { build(:user, :loa3) }
+    let(:letter_type) { 'commissary' }
 
     describe '#download_by_type' do
+      it 'letter type is valid' do
+        expect(EVSS::Letters::Letter::LETTER_TYPES).to include letter_type
+      end
+
       context 'without options' do
         it 'downloads a pdf' do
           VCR.use_cassette('evss/letters/download') do
-            response = subject.download_letter(EVSS::Letters::Letter::LETTER_TYPES.first)
+            response = subject.download_letter(letter_type)
             expect(response).to include('%PDF-1.4')
           end
         end
@@ -22,7 +27,7 @@ describe EVSS::Letters::DownloadService do
         it 'increments downloads total' do
           VCR.use_cassette('evss/letters/download') do
             expect do
-              subject.download_letter(EVSS::Letters::Letter::LETTER_TYPES.first)
+              subject.download_letter(letter_type)
             end.to trigger_statsd_increment('api.evss.download_letter.total')
           end
         end
@@ -38,7 +43,7 @@ describe EVSS::Letters::DownloadService do
             )
             expect(StatsD).to receive(:increment).once.with('api.evss.download_letter.total')
             expect do
-              subject.download_letter(EVSS::Letters::Letter::LETTER_TYPES.first)
+              subject.download_letter(letter_type)
             end.to raise_error(Common::Exceptions::GatewayTimeout)
           end
         end
@@ -49,7 +54,7 @@ describe EVSS::Letters::DownloadService do
               receive(:download_letter).and_raise(Common::Exceptions::BackendServiceException)
             )
             expect do
-              subject.download_letter(EVSS::Letters::Letter::LETTER_TYPES.first)
+              subject.download_letter(letter_type)
             end.to raise_error(Common::Exceptions::BackendServiceException)
           end
         end
@@ -75,7 +80,7 @@ describe EVSS::Letters::DownloadService do
         it 'downloads a pdf' do
           VCR.use_cassette('evss/letters/download_options') do
             response = subject.download_letter(
-              EVSS::Letters::Letter::LETTER_TYPES.first,
+              letter_type,
               options
             )
             expect(response).to include('%PDF-1.4')
@@ -86,7 +91,7 @@ describe EVSS::Letters::DownloadService do
           VCR.use_cassette('evss/letters/download_options') do
             expect do
               subject.download_letter(
-                EVSS::Letters::Letter::LETTER_TYPES.first,
+                letter_type,
                 options
               )
             end.to trigger_statsd_increment('api.evss.download_letter.total')


### PR DESCRIPTION
Does:
* Adds missing letter type `benefit_summary_dependent`
* Alphabetizes list

Notes:
[error example in sentry](http://sentry.vfs.va.gov/vets-gov/platform-api-production/issues/155640/?query=is%3Aunresolved%20invalid%20letter%20type) (see ADDITIONAL DATA / message)

More complete list found at https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/veteran-military-records/documents-and-letters/letters-api-docs-fe-notes.md

Related PR https://github.com/department-of-veterans-affairs/vets-website/pull/14446
