### PR TITLE
updated logging to use the request instead of the response

### DIFF
--- a/modules/vaos/app/services/vaos/jwt_wrapper.rb
+++ b/modules/vaos/app/services/vaos/jwt_wrapper.rb
@@ -14,7 +14,7 @@ module VAOS
     end
 
     def token
-      JWT.encode(payload, Configuration.instance.rsa_key, 'RS512')
+      @token ||= JWT.encode(payload, Configuration.instance.rsa_key, 'RS512')
     end
 
     private


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This issue is looking to enhance our ability to coordinate with VAMF when tracking down issues a user may encounter when interacting with VAOS. Prior to this change the code was logging the JTI present on the response object.  This was problematic if a response wasn't present due to a down-stream error.  In this case, we would lose the ability to identify a user to VAMF because we wouldn't have a JTI.  The solution was to record the JTI present in the request body/header (as opposed to the response) so in the case of a down-stream error, we would be able to access the JTI associated with the request which could then be presented to VAMF to facilitate identifying the error.

The `token` variable was also memoized in the jwt_wrapper as an optimization.

Also, we noticed that we’re using two different variations of the header name `X-Vamf-Jwt` and `X-VAMF-JWT`.  We will fix this as part of a future PR and tag the ticket number that will address that in the comment.


## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/6837

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Unit tests were updated to reflect this change