### PR TITLE
Add DEPCHG to update calls

### DIFF
--- a/lib/bgs/children.rb
+++ b/lib/bgs/children.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'service'
+
 module BGS
   class Children
     def initialize(proc_id:, payload:, user:)

--- a/lib/bgs/form686c.rb
+++ b/lib/bgs/form686c.rb
@@ -8,6 +8,7 @@ require_relative 'student_school'
 require_relative 'vnp_benefit_claim'
 require_relative 'vnp_relationships'
 require_relative 'vnp_veteran'
+require_relative 'children'
 
 module BGS
   class Form686c

--- a/lib/bgs/service.rb
+++ b/lib/bgs/service.rb
@@ -30,7 +30,7 @@ module BGS
 
     def create_proc_form(vnp_proc_id)
       # Temporary log proc_id to sentry
-      log_message_to_sentry(vnp_proc_id, :warn, '' ,{ team: 'vfs-ebenefits' })
+      log_message_to_sentry(vnp_proc_id, :warn, '', { team: 'vfs-ebenefits' })
       with_multiple_attempts_enabled do
         service.vnp_proc_form.vnp_proc_form_create(
           { vnp_proc_id: vnp_proc_id, form_type_cd: '21-686c' }.merge(bgs_auth)

--- a/lib/bgs/service.rb
+++ b/lib/bgs/service.rb
@@ -29,6 +29,8 @@ module BGS
     end
 
     def create_proc_form(vnp_proc_id)
+      # Temporary log proc_id to sentry
+      log_message_to_sentry(vnp_proc_id, :warn, '' ,{ team: 'vfs-ebenefits' })
       with_multiple_attempts_enabled do
         service.vnp_proc_form.vnp_proc_form_create(
           { vnp_proc_id: vnp_proc_id, form_type_cd: '21-686c' }.merge(bgs_auth)
@@ -41,6 +43,7 @@ module BGS
         service.vnp_proc_v2.vnp_proc_update(
           {
             vnp_proc_id: proc_id,
+            vnp_proc_type_cd: 'DEPCHG',
             vnp_proc_state_type_cd: 'Ready',
             creatd_dt: Time.current.iso8601,
             last_modifd_dt: Time.current.iso8601,
@@ -136,7 +139,7 @@ module BGS
 
     def update_manual_proc(proc_id)
       service.vnp_proc_v2.vnp_proc_update(
-        { vnp_proc_id: proc_id, vnp_proc_state_type_cd: 'Manual' }.merge(bgs_auth)
+        { vnp_proc_id: proc_id, vnp_proc_state_type_cd: 'Manual', vnp_proc_type_cd: 'DEPCHG' }.merge(bgs_auth)
       )
     rescue => e
       notify_of_service_exception(e, __method__)

--- a/lib/bgs/service.rb
+++ b/lib/bgs/service.rb
@@ -5,6 +5,7 @@ require_relative 'exceptions/bgs_errors'
 module BGS
   class Service
     include BGS::Exceptions::BGSErrors
+    include SentryLogging
     # Journal Status Type Code
     # The alphabetic character representing the last action taken on the record
     # (I = Input, U = Update, D = Delete)


### PR DESCRIPTION
## Description of change
During testing with BGS, we found we need to send the `vnPProcTypeCd` in update calls in order for that attribute to persist in their system and create a valid claim.

We also would like to capture the procId associated with the claim submission to help them debug their systems.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
* Are there additions to a `settings.yml` file? Do they vary by environment?
  * No additional changes
* Is there a feature flag? What is it?
  * This feature is flagged, it is not available to the public
* Is there some Sentry logging that was added? What alerts are relevant?
  * We added a message log to get the procId which is a unique "procedure ID" for the submission
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
  * No additional changes
* Are there Swagger docs that were updated?
  * No additional changes
* Is there any PII concerns or questions?
  * No concerns

-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
