### PR TITLE
Allow configurable Caseflow timeout

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -327,6 +327,7 @@ caseflow:
   mock: true
   app_token: PUBLICDEMO123
   host: https://dsva-appeals-certification-dev-1895622301.us-gov-west-1.elb.amazonaws.com
+  timeout: 20
 
 vic:
   url: https://some.fakesite.com

--- a/lib/caseflow/configuration.rb
+++ b/lib/caseflow/configuration.rb
@@ -10,6 +10,7 @@ module Caseflow
   # sets the base path, a default timeout, and a service name for breakers and metrics.
   #
   class Configuration < Common::Client::Configuration::REST
+    self.read_timeout = Settings.caseflow.timeout || 20
     ##
     # @return [String] The auth token for the caseflow service.
     #

--- a/spec/lib/caseflow/configuration_spec.rb
+++ b/spec/lib/caseflow/configuration_spec.rb
@@ -19,7 +19,7 @@ describe Caseflow::Configuration do
   describe '.read_timeout' do
     context 'when Settings.mvi.timeout is set' do
       it 'uses the setting' do
-        expect(Caseflow::Configuration.instance.read_timeout).to eq(30)
+        expect(Caseflow::Configuration.instance.read_timeout).to eq(20)
       end
     end
   end

--- a/spec/lib/caseflow/configuration_spec.rb
+++ b/spec/lib/caseflow/configuration_spec.rb
@@ -16,6 +16,14 @@ describe Caseflow::Configuration do
     end
   end
 
+  describe '.read_timeout' do
+    context 'when Settings.mvi.timeout is set' do
+      it 'uses the setting' do
+        expect(Caseflow::Configuration.instance.read_timeout).to eq(30)
+      end
+    end
+  end
+
   describe '#mock_enabled?' do
     context 'when Settings.caseflow.mock is true' do
       before { Settings.caseflow.mock = 'true' }


### PR DESCRIPTION
## Description of change
Make the timeout for the caseflow/appeals endpoint configurable and possibly increase it more in staging

## Original issue(s)
department-of-veterans-affairs/va.gov-team#13547

## Things to know about this PR


<!-- Please describe testing done to verify the changes or any testing planned. -->
