### PR TITLE
Fix: 10-10CG PDF not found when attempting to delete it after submission

### DIFF
--- a/app/services/form1010cg/service.rb
+++ b/app/services/form1010cg/service.rb
@@ -64,7 +64,7 @@ module Form1010cg
     # Will generate a PDF version of the submission and attach it to the CARMA Case.
     #
     # @return [Boolean]
-    def submit_attachment # rubocop:disable Metrics/MethodLength
+    def submit_attachment # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity
       raise 'requires a processed submission'     if  submission&.carma_case_id.blank?
       raise 'submission already has attachments'  if  submission.attachments.any?
 
@@ -96,11 +96,13 @@ module Form1010cg
         #
         # If we made it this far, there is a submission that exists in CARMA.
         # So the user should get a sucessful response, whether attachments reach CARMA or not.
-        File.delete(file_path)
+        File.delete(file_path) if File.exist?(file_path)
         return false
       end
 
-      File.delete(file_path)
+      # In some cases the file will not exist here even though it's generated above.
+      # Check to see the file exists before attempting to delete it, in order to avoid raising an error.
+      File.delete(file_path) if File.exist?(file_path)
       true
     end
 

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -721,6 +721,7 @@ RSpec.describe Form1010cg::Service do
       expect(carma_attachment).to receive(:to_hash).and_return(:attachments_as_hash)
       expect(submission).to receive(:attachments=).with(:attachments_as_hash)
 
+      expect(File).to receive(:exist?).with(file_path).and_return(true)
       expect(File).to receive(:delete).with(file_path)
 
       expect(subject.submit_attachment).to eq(true)
@@ -757,6 +758,7 @@ RSpec.describe Form1010cg::Service do
 
       expect(CARMA::Models::Attachments).to receive(:new).and_raise('failure')
 
+      expect(File).to receive(:exist?).with(file_path).and_return(true)
       expect(File).to receive(:delete).with(file_path)
 
       expect(subject.submit_attachment).to eq(false)
@@ -787,12 +789,13 @@ RSpec.describe Form1010cg::Service do
 
       expect(carma_attachment).to receive(:add).with(document_type, file_path).and_raise('failure')
 
+      expect(File).to receive(:exist?).with(file_path).and_return(true)
       expect(File).to receive(:delete).with(file_path)
 
       expect(subject.submit_attachment).to eq(false)
     end
 
-    it 'returns false submission fails' do
+    it 'returns false when submission fails' do
       document_type     = '10-10CG'
       file_path         = 'tmp/my_file.pdf'
       carma_attachment  = double
@@ -818,7 +821,40 @@ RSpec.describe Form1010cg::Service do
       expect(carma_attachment).to receive(:add).with(document_type, file_path).and_return(carma_attachment)
       expect(carma_attachment).to receive(:submit!).and_raise('bad request')
 
+      expect(File).to receive(:exist?).with(file_path).and_return(true)
       expect(File).to receive(:delete).with(file_path)
+
+      expect(subject.submit_attachment).to eq(false)
+    end
+
+    it 'returns false when file is deleted from another source' do
+      document_type     = '10-10CG'
+      file_path         = 'tmp/my_file.pdf'
+      carma_attachment  = double
+      claim             = build(:caregivers_assistance_claim)
+
+      submission = Form1010cg::Submission.new(
+        carma_case_id: 'aB9350000000TjICAU',
+        submitted_at: '2020-06-26 13:30:59'
+      )
+
+      subject = described_class.new(claim, submission)
+
+      expect(subject.claim).to receive(:to_pdf).and_return(file_path)
+
+      expect(CARMA::Models::Attachments).to receive(:new).with(
+        submission.carma_case_id,
+        claim.veteran_data['fullName']['first'],
+        claim.veteran_data['fullName']['last']
+      ).and_return(
+        carma_attachment
+      )
+
+      expect(carma_attachment).to receive(:add).with(document_type, file_path).and_return(carma_attachment)
+      expect(carma_attachment).to receive(:submit!).and_raise('bad request')
+
+      expect(File).to receive(:exist?).with(file_path).and_return(false)
+      expect(File).not_to receive(:delete).with(file_path)
 
       expect(subject.submit_attachment).to eq(false)
     end


### PR DESCRIPTION
Fixes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14273

**Description**:
When a user submits a 10-10CG, we generate a PDF of their submission and send it to CARMA as an attachment to the Case. There were, as of this time, two production submissions where the data and the attachment made it successfully to CARMA, but the user received a 500 error because we called `File.delete` on a file or directory that apparently didn't exist after it was sent to CARMA.

We are still not sure why the file cannot be found when it was generated just a few lines of code above where we try to delete it, but this fix will prevent any additional users from being told their submission failed when it actually didn't.

**Sentry**:
http://sentry.vfs.va.gov/vets-gov/platform-api-production/issues/221016/events/b8710ff80f0a4553bf655093d2d3a471/
