### PR TITLE
fix time-dependent spec

### DIFF
--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -39,7 +39,10 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
     context 'kitchen sink BDD' do
       before do
         create(:in_progress_form, form_id: FormProfiles::VA526ez::FORM_ID, user_uuid: user.uuid)
+        Timecop.freeze(Date.new(2020, 8, 1))
       end
+
+      after { Timecop.return }
 
       let(:form_content) do
         JSON.parse(File.read('spec/support/disability_compensation_form/bdd_large_fe_submission.json'))


### PR DESCRIPTION
## Description of change
freeze time on BDD spec. BDD has a 3-month eligibility window. 
