### PR TITLE
only initialize Setnry if its defined

### DIFF
--- a/lib/saml/templates/sso_post_form.html.erb
+++ b/lib/saml/templates/sso_post_form.html.erb
@@ -29,7 +29,7 @@
 
   <script>
     (function() {
-      if ("<%= sentrydsn %>") {
+      if (typeof(Sentry) != 'undefined' && "<%= sentrydsn %>") {
         Sentry.init({
           dsn: "<%= sentrydsn %>",
           integrations: [new Sentry.Integrations.BrowserTracing()],


### PR DESCRIPTION
some ad blockers are preventing the bundle from being loaded via the
sentry dsn, in that case we need to check that the Sentry variable is
defined or else the call to `Sentry.init` will result in an error and
prevent the user from submitting.

### testing
I manually tested this locally running AdblockPlus in Chrome.  With all the settings enabled, `/v1/sessions/idme/new` raised an error and the submission halted, however after introducing this change the submission went forward.