### PR TITLE
no zero padding for the hour

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -143,7 +143,7 @@ class Form526Submission < ApplicationRecord
     personalization_parameters = {
       'email' => email_address,
       'submitted_claim_id' => submitted_claim_id,
-      'date_submitted' => created_at.strftime('%B %-d, %Y %l:%M %P %Z').sub(/(\d{4})( +)(.*)([ap])m/, '\1 \3\4.m.'),
+      'date_submitted' => created_at.strftime('%B %-d, %Y %l:%M %P %Z').sub(/(\d{4})( +)(\d.*)([ap])m/, '\1 \3\4.m.'),
       'full_name' => full_name
     }
     Form526ConfirmationEmailJob.perform_async(personalization_parameters)

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -143,7 +143,7 @@ class Form526Submission < ApplicationRecord
     personalization_parameters = {
       'email' => email_address,
       'submitted_claim_id' => submitted_claim_id,
-      'date_submitted' => created_at.strftime('%B %-d, %Y %l:%M %P %Z').sub(/(\d{4})( +)(\d.*)([ap])m/, '\1 \3\4.m.'),
+      'date_submitted' => created_at.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.'),
       'full_name' => full_name
     }
     Form526ConfirmationEmailJob.perform_async(personalization_parameters)

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -143,7 +143,7 @@ class Form526Submission < ApplicationRecord
     personalization_parameters = {
       'email' => email_address,
       'submitted_claim_id' => submitted_claim_id,
-      'date_submitted' => created_at.strftime('%B %-d, %Y %l:%M %P %Z').sub(/([ap])m/, '\1.m.'),
+      'date_submitted' => created_at.strftime('%B %-d, %Y %l:%M %P %Z').sub(/(\d{4})( +)(.*)([ap])m/, '\1 \3\4.m.'),
       'full_name' => full_name
     }
     Form526ConfirmationEmailJob.perform_async(personalization_parameters)

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -143,7 +143,7 @@ class Form526Submission < ApplicationRecord
     personalization_parameters = {
       'email' => email_address,
       'submitted_claim_id' => submitted_claim_id,
-      'date_submitted' => created_at.strftime('%B %-d, %Y %I:%M %P %Z').sub(/([ap])m/, '\1.m.'),
+      'date_submitted' => created_at.strftime('%B %-d, %Y %l:%M %P %Z').sub(/([ap])m/, '\1.m.'),
       'full_name' => full_name
     }
     Form526ConfirmationEmailJob.perform_async(personalization_parameters)

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe Form526Submission do
           expect(args[0]['full_name']).to eql('some name')
           expect(args[0]['submitted_claim_id']).to be(123_654_879)
           expect(args[0]['email']).to eql('test@email.com')
-          expect(args[0]['date_submitted']).to eql('July 20, 2012 02:15 p.m. UTC')
+          expect(args[0]['date_submitted']).to eql('July 20, 2012  2:15 p.m. UTC')
         end
 
         options = {
@@ -250,7 +250,7 @@ RSpec.describe Form526Submission do
           expect(args[0]['full_name']).to eql('some name')
           expect(args[0]['submitted_claim_id']).to be(123_654_879)
           expect(args[0]['email']).to eql('test@email.com')
-          expect(args[0]['date_submitted']).to eql('July 20, 2012 08:07 a.m. UTC')
+          expect(args[0]['date_submitted']).to eql('July 20, 2012  8:07 a.m. UTC')
         end
 
         options = {

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -225,7 +225,32 @@ RSpec.describe Form526Submission do
           expect(args[0]['full_name']).to eql('some name')
           expect(args[0]['submitted_claim_id']).to be(123_654_879)
           expect(args[0]['email']).to eql('test@email.com')
-          expect(args[0]['date_submitted']).to eql('July 20, 2012  2:15 p.m. UTC')
+          expect(args[0]['date_submitted']).to eql('July 20, 2012 2:15 p.m. UTC')
+        end
+
+        options = {
+          'submission_id' => subject.id,
+          'full_name' => 'some name'
+        }
+        subject.workflow_complete_handler(nil, options)
+      end
+    end
+
+    context 'with multiple successful jobs and email and submitted time in PM with two digit hour' do
+      subject { create(:form526_submission, :with_multiple_succesful_jobs, submitted_claim_id: 123_654_879) }
+
+      before { Timecop.freeze(Time.zone.parse('2012-07-20 11:12:00 UTC')) }
+
+      after { Timecop.return }
+
+      it 'calls confirmation email job with correct personalization' do
+        Flipper.enable(:form526_confirmation_email)
+
+        allow(Form526ConfirmationEmailJob).to receive(:perform_async) do |*args|
+          expect(args[0]['full_name']).to eql('some name')
+          expect(args[0]['submitted_claim_id']).to be(123_654_879)
+          expect(args[0]['email']).to eql('test@email.com')
+          expect(args[0]['date_submitted']).to eql('July 20, 2012 11:12 a.m. UTC')
         end
 
         options = {
@@ -250,7 +275,7 @@ RSpec.describe Form526Submission do
           expect(args[0]['full_name']).to eql('some name')
           expect(args[0]['submitted_claim_id']).to be(123_654_879)
           expect(args[0]['email']).to eql('test@email.com')
-          expect(args[0]['date_submitted']).to eql('July 20, 2012  8:07 a.m. UTC')
+          expect(args[0]['date_submitted']).to eql('July 20, 2012 8:07 a.m. UTC')
         end
 
         options = {


### PR DESCRIPTION
[notification-api#189]

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
hour should not have a zero pad if it is one digit, e.g. ' 3' rather than '03'

## Original issue(s)
department-of-veterans-affairs/notification-api#189

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment? No
* Is there a feature flag? What is it? No
* Is there some Sentry logging that was added? What alerts are relevant? No
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do? No
* Are there Swagger docs that were updated? No
* Is there any PII concerns or questions? No
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
