### PR TITLE
Adjusted form profile mappings and spec

### DIFF
--- a/config/form_profile_mappings/28-8832.yml
+++ b/config/form_profile_mappings/28-8832.yml
@@ -1,1 +1,7 @@
-claimantAddress: [contact_information, address]
+claimantAddress:
+  countryName: [contact_information, address, country]
+  addressLine1: [contact_information, address, street]
+  addressLine2: [contact_information, address, street2]
+  city: [contact_information, address, city]
+  stateCode: [contact_information, address, state]
+  zipCode: [contact_information, address, postal_code]

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -695,12 +695,12 @@ RSpec.describe FormProfile, type: :model do
   let(:v28_8832_expected) do
     {
       'claimantAddress' => {
-        'street' => street_check[:street],
-        'street2' => street_check[:street2],
+        'addressLine1' => street_check[:street],
+        'addressLine2' => street_check[:street2],
         'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => 'USA',
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'stateCode' => user.va_profile[:address][:state],
+        'countryName' => 'USA',
+        'zipCode' => user.va_profile[:address][:postal_code][0..4]
       }
     }
   end


### PR DESCRIPTION
## Description of change
When we originally set up prefill for this form we did not map the prefill data to the correct fields in the form schema. This PR is to adjust both the way the prefill data is mapped and the spec that accompanies the prefill

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/12669
