### PR TITLE
Updates to `rake form526:errors`

### DIFF
--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -73,15 +73,15 @@ namespace :form526 do
     end
   end
 
-  desc 'Get an error report within a given date period. [<start date: yyyy-mm-dd>,<end date: yyyy-mm-dd>]'
-  task :errors, %i[start_date end_date] => [:environment] do |_, args|
+  desc 'Get an error report within a given date period. [<start date: yyyy-mm-dd>,<end date: yyyy-mm-dd>,<flag>]'
+  task :errors, %i[start_date end_date flag] => [:environment] do |_, args|
     def print_row(sub_id, p_id, created_at, is_bdd, job_class)
       printf "%-15s %-16s  %-25s %-10s %-20s\n", sub_id, p_id, created_at, is_bdd, job_class
       # rubocop:enable Style/FormatStringToken
     end
 
     def print_errors(errors)
-      errors.each do |k, v|
+      errors.sort_by { |_message, hash| -hash[:submission_ids].length }.each do |(k, v)|
         puts k
         puts '*****************'
         puts "Unique Participant ID count: #{v[:participant_ids].count}"
@@ -146,6 +146,11 @@ namespace :form526 do
           errors[message][:participant_ids].add(submission.auth_headers['va_eauth_pid'])
         end
       end
+    end
+
+    if args[:flag]&.downcase&.include?('j')
+      puts errors.to_json
+      next
     end
 
     puts '------------------------------------------------------------'


### PR DESCRIPTION
1. sort results of rake form526:errors by number of errors descending
2. take in extra arg that can force json output