### PR TITLE
add basic questionnaire responses endpoint

### DIFF
--- a/modules/health_quest/app/controllers/health_quest/v0/pgd_questionnaire_responses_controller.rb
+++ b/modules/health_quest/app/controllers/health_quest/v0/pgd_questionnaire_responses_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module V0
+    class PgdQuestionnaireResponsesController < HealthQuest::V0::BaseController
+      def show
+        head :ok
+      end
+    end
+  end
+end

--- a/modules/health_quest/config/routes.rb
+++ b/modules/health_quest/config/routes.rb
@@ -4,5 +4,6 @@ HealthQuest::Engine.routes.draw do
   namespace :v0, defaults: { format: :json } do
     resources :appointments, only: %i[index show]
     resources :pgd_questionnaires, only: %i[show]
+    resources :pgd_questionnaire_responses, only: %i[show]
   end
 end

--- a/modules/health_quest/spec/request/pgd_questionnaire_responses_request_spec.rb
+++ b/modules/health_quest/spec/request/pgd_questionnaire_responses_request_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'health_quest questionnaire_responses', type: :request do
+  let(:access_denied_message) { 'You do not have access to the health quest service' }
+  let(:questionnaire_responses_id) { '32' }
+
+  before do
+    sign_in_as(current_user)
+  end
+
+  describe 'GET questionnaire responses' do
+    context 'loa1 user' do
+      let(:current_user) { build(:user, :loa1) }
+
+      it 'has forbidden status' do
+        get "/health_quest/v0/pgd_questionnaire_responses/#{questionnaire_responses_id}"
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'has access denied message' do
+        get "/health_quest/v0/pgd_questionnaire_responses/#{questionnaire_responses_id}"
+
+        expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
+      end
+    end
+
+    context 'health quest user' do
+      let(:current_user) { build(:user, :health_quest) }
+
+      it 'has success status' do
+        get "/health_quest/v0/pgd_questionnaire_responses/#{questionnaire_responses_id}"
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

- Adding a basic endpoint that will be responsible for fetching questionnaire responses data.
- This endpoint currently only returns a 200 status.
- The route is: `GET /v0/pgd_questionnaire_responses/:id`
- This is a placeholder route. It will return questionnaire responses data in the nearby future.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

Zenhub link: https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13599

<!-- Please describe testing done to verify the changes or any testing planned. -->

- Basic rspec tests have been written to test the endpoint.
- Swagger docs will be added separately for this endpoint.