### PR TITLE
convert Breakers `duration` value to ms before sending via StatsD

### DIFF
--- a/lib/breakers/statsd_plugin.rb
+++ b/lib/breakers/statsd_plugin.rb
@@ -28,7 +28,7 @@ module Breakers
       metric_base = "api.external_http_request.#{service.name}."
       StatsD.increment(metric_base + status, 1, tags: tags)
       if response_env && response_env[:duration]
-        StatsD.measure(metric_base + 'time', response_env[:duration], tags: tags)
+        StatsD.measure(metric_base + 'time', response_env[:duration] * 1000, tags: tags)
       end
     end
 


### PR DESCRIPTION
## Description of change
convert Breakers `duration` value to ms before sending via StatsD

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
