### PR TITLE
[API 2880] NOD contestable issues endpoint (vets-api)

### DIFF
--- a/lib/caseflow/service.rb
+++ b/lib/caseflow/service.rb
@@ -44,13 +44,14 @@ module Caseflow
     # Returns contestable issues for a veteran.
     #
     # @param headers [Hash] Headers to include.
+    # @param appeal_type [String] The type of appeal (appeals (nod), higher_level_reviews, etc)
     # @return [Hash] Response object.
     #
-    def get_contestable_issues(headers:, benefit_type:)
+    def get_contestable_issues(headers:, benefit_type:, appeal_type:)
       with_monitoring do
         authorized_perform(
           :get,
-          "#{CASEFLOW_V3_API_PATH}higher_level_reviews/contestable_issues/#{benefit_type}",
+          "#{CASEFLOW_V3_API_PATH}#{appeal_type}/contestable_issues/#{benefit_type}",
           {},
           headers
         )

--- a/lib/caseflow/service.rb
+++ b/lib/caseflow/service.rb
@@ -44,14 +44,14 @@ module Caseflow
     # Returns contestable issues for a veteran.
     #
     # @param headers [Hash] Headers to include.
-    # @param appeal_type [String] The type of appeal (appeals (nod), higher_level_reviews, etc)
+    # @param decision_review_type [String] The type of decision review (appeals (nod), higher_level_reviews, etc)
     # @return [Hash] Response object.
     #
-    def get_contestable_issues(headers:, benefit_type:, appeal_type:)
+    def get_contestable_issues(headers:, benefit_type:, decision_review_type:)
       with_monitoring do
         authorized_perform(
           :get,
-          "#{CASEFLOW_V3_API_PATH}#{appeal_type}/contestable_issues/#{benefit_type}",
+          "#{CASEFLOW_V3_API_PATH}#{decision_review_type}/contestable_issues/#{benefit_type}",
           {},
           headers
         )

--- a/modules/appeals_api/app/controllers/appeals_api/docs/v1/docs_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/docs/v1/docs_controller.rb
@@ -5,6 +5,7 @@ class AppealsApi::Docs::V1::DocsController < ApplicationController
 
   SWAGGERED_CLASSES = [
     AppealsApi::V1::HigherLevelReviewsControllerSwagger,
+    AppealsApi::V1::NoticeOfDisagreementsControllerSwagger,
     AppealsApi::V1::SwaggerRoot
   ].freeze
 

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/base_contestable_issues_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/base_contestable_issues_controller.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'caseflow/service'
+require 'common/exceptions'
+
+class AppealsApi::V1::DecisionReviews::BaseContestableIssuesController < AppealsApi::ApplicationController
+  skip_before_action(:authenticate)
+
+  EXPECTED_HEADERS = %w[X-VA-SSN X-VA-Receipt-Date].freeze
+
+  UNUSABLE_RESPONSE_ERROR = {
+    errors: [
+      {
+        title: 'Bad Gateway',
+        code: 'bad_gateway',
+        detail: 'Received an unusable response from Caseflow.',
+        status: 502
+      }
+    ]
+  }.freeze
+
+  def index
+    get_contestable_issues_from_caseflow
+    if caseflow_response_has_a_body_and_a_status?
+      render_response(caseflow_response)
+    else
+      render_unusable_response_error
+    end
+  end
+
+  private
+
+  attr_reader :caseflow_response, :backend_service_exception
+
+  def get_contestable_issues_from_caseflow
+    @caseflow_response = Caseflow::Service.new.get_contestable_issues headers: headers,
+                                                                      benefit_type: benefit_type,
+                                                                      appeal_type: appeal_type
+  rescue Common::Exceptions::BackendServiceException => @backend_service_exception # rubocop:disable Naming/RescuedExceptionsVariableName
+    raise unless caseflow_returned_a_4xx?
+
+    @caseflow_response = caseflow_response_from_backend_service_exception
+  end
+
+  def benefit_type
+    params[:benefit_type]
+  end
+
+  ##
+  # Returns the type of appeal, used when retrieving contestable issues from Caseflow
+  #
+  # @return [String] The appeal type (appeals (nod), higher_level_reviews, etc)
+  #
+  def appeal_type
+    raise NotImplementedError, 'Subclass of ContestableIssuesBaseController must implement appeal_type method'
+  end
+
+  def headers
+    EXPECTED_HEADERS.reduce({}) do |hash, key|
+      hash.merge(key => request.headers[key])
+    end
+  end
+
+  def caseflow_response_has_a_body_and_a_status?
+    caseflow_response.try(:status) && caseflow_response.try(:body).is_a?(Hash)
+  end
+
+  def caseflow_returned_a_4xx?
+    status = Integer backend_service_exception.original_status
+    status >= 400 && status < 500
+  end
+
+  def caseflow_response_from_backend_service_exception
+    Struct.new(:status, :body).new(
+      backend_service_exception.original_status,
+      backend_service_exception.original_body
+    )
+  end
+
+  def render_unusable_response_error
+    render json: UNUSABLE_RESPONSE_ERROR, status: UNUSABLE_RESPONSE_ERROR[:errors].first[:status]
+  end
+end

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/base_contestable_issues_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/base_contestable_issues_controller.rb
@@ -35,7 +35,7 @@ class AppealsApi::V1::DecisionReviews::BaseContestableIssuesController < Appeals
   def get_contestable_issues_from_caseflow
     @caseflow_response = Caseflow::Service.new.get_contestable_issues headers: headers,
                                                                       benefit_type: benefit_type,
-                                                                      appeal_type: appeal_type
+                                                                      decision_review_type: decision_review_type
   rescue Common::Exceptions::BackendServiceException => @backend_service_exception # rubocop:disable Naming/RescuedExceptionsVariableName
     raise unless caseflow_returned_a_4xx?
 
@@ -51,8 +51,8 @@ class AppealsApi::V1::DecisionReviews::BaseContestableIssuesController < Appeals
   #
   # @return [String] The appeal type (appeals (nod), higher_level_reviews, etc)
   #
-  def appeal_type
-    raise NotImplementedError, 'Subclass of ContestableIssuesBaseController must implement appeal_type method'
+  def decision_review_type
+    raise NotImplementedError, 'Subclass of BaseContestableIssuesController must implement decision_review_type method'
   end
 
   def headers

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/base_contestable_issues_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/base_contestable_issues_controller.rb
@@ -43,7 +43,7 @@ class AppealsApi::V1::DecisionReviews::BaseContestableIssuesController < Appeals
   end
 
   def benefit_type
-    params[:benefit_type]
+    params[:benefit_type] || '' # Notice of Disagreements does not use benefit type
   end
 
   ##

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews/contestable_issues_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews/contestable_issues_controller.rb
@@ -3,7 +3,7 @@
 class AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesController < AppealsApi::V1::DecisionReviews::BaseContestableIssuesController # rubocop:disable Layout/LineLength
   private
 
-  def appeal_type
+  def decision_review_type
     'higher_level_reviews'
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews/contestable_issues_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews/contestable_issues_controller.rb
@@ -1,72 +1,9 @@
 # frozen_string_literal: true
 
-require 'caseflow/service'
-require 'common/exceptions'
-
-class AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesController < AppealsApi::ApplicationController # rubocop:disable Layout/LineLength
-  skip_before_action(:authenticate)
-
-  EXPECTED_HEADERS = %w[X-VA-SSN X-VA-Receipt-Date].freeze
-
-  UNUSABLE_RESPONSE_ERROR = {
-    errors: [
-      {
-        title: 'Bad Gateway',
-        code: 'bad_gateway',
-        detail: 'Received an unusable response from Caseflow.',
-        status: 502
-      }
-    ]
-  }.freeze
-
-  def index
-    get_contestable_issues_from_caseflow
-    if caseflow_response_has_a_body_and_a_status?
-      render_response(caseflow_response)
-    else
-      render_unusable_response_error
-    end
-  end
-
+class AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesController < AppealsApi::V1::DecisionReviews::BaseContestableIssuesController # rubocop:disable Layout/LineLength
   private
 
-  attr_reader :caseflow_response, :backend_service_exception
-
-  def get_contestable_issues_from_caseflow
-    @caseflow_response = Caseflow::Service.new.get_contestable_issues headers: headers, benefit_type: benefit_type
-  rescue Common::Exceptions::BackendServiceException => @backend_service_exception # rubocop:disable Naming/RescuedExceptionsVariableName
-    raise unless caseflow_returned_a_4xx?
-
-    @caseflow_response = caseflow_response_from_backend_service_exception
-  end
-
-  def benefit_type
-    params[:benefit_type]
-  end
-
-  def headers
-    EXPECTED_HEADERS.reduce({}) do |hash, key|
-      hash.merge(key => request.headers[key])
-    end
-  end
-
-  def caseflow_response_has_a_body_and_a_status?
-    caseflow_response.try(:status) && caseflow_response.try(:body).is_a?(Hash)
-  end
-
-  def caseflow_returned_a_4xx?
-    status = Integer backend_service_exception.original_status
-    status >= 400 && status < 500
-  end
-
-  def caseflow_response_from_backend_service_exception
-    Struct.new(:status, :body).new(
-      backend_service_exception.original_status,
-      backend_service_exception.original_body
-    )
-  end
-
-  def render_unusable_response_error
-    render json: UNUSABLE_RESPONSE_ERROR, status: UNUSABLE_RESPONSE_ERROR[:errors].first[:status]
+  def appeal_type
+    'higher_level_reviews'
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/contestable_issues_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/contestable_issues_controller.rb
@@ -3,7 +3,7 @@
 class AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::ContestableIssuesController < AppealsApi::V1::DecisionReviews::BaseContestableIssuesController # rubocop:disable Layout/LineLength
   private
 
-  def appeal_type
+  def decision_review_type
     'appeals' # notice of disagreement is `appeals` inside of Caseflow
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/contestable_issues_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/contestable_issues_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::ContestableIssuesController < AppealsApi::V1::DecisionReviews::BaseContestableIssuesController # rubocop:disable Layout/LineLength
+  private
+
+  def appeal_type
+    'appeals' # notice of disagreement is `appeals` inside of Caseflow
+  end
+end

--- a/modules/appeals_api/app/swagger/appeals_api/v1/higher_level_reviews_controller_swagger.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/higher_level_reviews_controller_swagger.rb
@@ -135,6 +135,7 @@ class AppealsApi::V1::HigherLevelReviewsControllerSwagger
     end
   end
 
+  # rubocop:disable Metrics/BlockLength
   swagger_path '/higher_level_reviews/contestable_issues/{benefit_type}' do
     operation :get, tags: HLR_TAG do
       key :operationId, 'getContestableIssues'
@@ -154,10 +155,21 @@ class AppealsApi::V1::HigherLevelReviewsControllerSwagger
       parameter name: 'benefit_type', 'in': 'path', required: true, description: 'benefit type' do
         schema '$ref': 'hlrCreateBenefitType'
       end
-      key :responses, read_json_from_same_dir['responses_contestable_issues.json']
+
+      responses = read_json_from_same_dir['responses_contestable_issues.json']
+      responses['422']['content']['application/vnd.api+json']['examples']['invalid benefit_type'] = {
+        "value": {
+          "errors": [{ "status": 422, "code": 'invalid_benefit_type', "title": 'Invalid Benefit Type',
+                       "detail": 'Benefit type nil is invalid. Must be one of: ["compensation", "pension",' \
+              '"fiduciary", "insurance", "education", "voc_rehab", "loan_guaranty", "vha", "nca"]' }]
+        }
+      }
+      key :responses, responses
+
       security do
         key :apikey, []
       end
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/modules/appeals_api/app/swagger/appeals_api/v1/notice_of_disagreements_controller_swagger.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/notice_of_disagreements_controller_swagger.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class AppealsApi::V1::NoticeOfDisagreementsControllerSwagger
+  include Swagger::Blocks
+
+  NOD_TAG = ['Notice of Disagreements'].freeze
+
+  read_file = ->(path) { File.read(AppealsApi::Engine.root.join(*path)) }
+  read_json = ->(path) { JSON.parse(read_file.call(path)) }
+  read_json_from_same_dir = ->(filename) { read_json.call(['app', 'swagger', 'appeals_api', 'v1', filename]) }
+
+  swagger_path '/notice_of_disagreements/contestable_issues/{benefit_type}' do
+    operation :get, tags: NOD_TAG do
+      key :operationId, 'getNODContestableIssues'
+      key :summary, 'Returns all contestable issues for a specific veteran.'
+      desc = 'Returns all issues a Veteran could contest in a Notice of Disagreement as of the `receiptDate` ' \
+        'and bound by `benefitType`. Associate these results when creating new Decision Reviews.'
+      key :description, desc
+      parameter name: 'X-VA-SSN', 'in': 'header', required: true, description: 'veteran\'s ssn' do
+        schema '$ref': 'X-VA-SSN'
+      end
+      parameter name: 'X-VA-Receipt-Date', 'in': 'header', required: true do
+        desc = '(yyyy-mm-dd) In order to determine contestability of issues, ' \
+          'the receipt date of a hypothetical Decision Review must be specified.'
+        key :description, desc
+        schema type: :string, 'format': :date
+      end
+      parameter name: 'benefit_type', 'in': 'path', required: true, description: 'benefit type' do
+        schema '$ref': 'hlrCreateBenefitType'
+      end
+      key :responses, read_json_from_same_dir['responses_contestable_issues.json']
+      security do
+        key :apikey, []
+      end
+    end
+  end
+end

--- a/modules/appeals_api/app/swagger/appeals_api/v1/notice_of_disagreements_controller_swagger.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/notice_of_disagreements_controller_swagger.rb
@@ -9,12 +9,12 @@ class AppealsApi::V1::NoticeOfDisagreementsControllerSwagger
   read_json = ->(path) { JSON.parse(read_file.call(path)) }
   read_json_from_same_dir = ->(filename) { read_json.call(['app', 'swagger', 'appeals_api', 'v1', filename]) }
 
-  swagger_path '/notice_of_disagreements/contestable_issues/{benefit_type}' do
+  swagger_path '/notice_of_disagreements/contestable_issues' do
     operation :get, tags: NOD_TAG do
       key :operationId, 'getNODContestableIssues'
       key :summary, 'Returns all contestable issues for a specific veteran.'
       desc = 'Returns all issues a Veteran could contest in a Notice of Disagreement as of the `receiptDate` ' \
-        'and bound by `benefitType`. Associate these results when creating new Decision Reviews.'
+        'Associate these results when creating new Decision Reviews.'
       key :description, desc
       parameter name: 'X-VA-SSN', 'in': 'header', required: true, description: 'veteran\'s ssn' do
         schema '$ref': 'X-VA-SSN'
@@ -24,9 +24,6 @@ class AppealsApi::V1::NoticeOfDisagreementsControllerSwagger
           'the receipt date of a hypothetical Decision Review must be specified.'
         key :description, desc
         schema type: :string, 'format': :date
-      end
-      parameter name: 'benefit_type', 'in': 'path', required: true, description: 'benefit type' do
-        schema '$ref': 'hlrCreateBenefitType'
       end
       key :responses, read_json_from_same_dir['responses_contestable_issues.json']
       security do

--- a/modules/appeals_api/app/swagger/appeals_api/v1/responses_contestable_issues.json
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/responses_contestable_issues.json
@@ -100,9 +100,6 @@
           "unparsable date": {
             "value": {
               "errors": [{ "status": 422, "code": "invalid_receipt_date", "title": "Invalid Receipt Date", "detail": "\"Widdershins\" is not a valid date." }]}},
-          "invalid benefit_type": {
-            "value": {
-              "errors": [{ "status": 422, "code": "invalid_benefit_type", "title": "Invalid Benefit Type", "detail": "Benefit type nil is invalid. Must be one of: [\"compensation\", \"pension\", \"fiduciary\", \"insurance\", \"education\", \"voc_rehab\", \"loan_guaranty\", \"vha\", \"nca\"]" }]}},
           "invalid veteran ssn": {
             "value": {
               "errors": [{ "status": 422, "code": "invalid_veteran_ssn", "title": "Invalid Veteran SSN", "detail": "SSN regex: /^\\d{9}$/)." }]}}}}}},

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -20,6 +20,9 @@ AppealsApi::Engine.routes.draw do
           post 'validate', to: 'higher_level_reviews#validate'
         end
       end
+      namespace :notice_of_disagreements do
+        get 'contestable_issues(/:benefit_type)', to: 'contestable_issues#index'
+      end
     end
   end
   namespace :docs do

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -21,7 +21,7 @@ AppealsApi::Engine.routes.draw do
         end
       end
       namespace :notice_of_disagreements do
-        get 'contestable_issues(/:benefit_type)', to: 'contestable_issues#index'
+        get 'contestable_issues', to: 'contestable_issues#index'
       end
     end
   end

--- a/modules/appeals_api/spec/requests/v1/contestable_issues_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/contestable_issues_controller_spec.rb
@@ -1,64 +1,8 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../../support/shared_examples_contestable_issues'
 
 describe AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesController, type: :request do
-  let(:get_issues) do
-    get(
-      '/services/appeals/v1/decision_reviews/higher_level_reviews/contestable_issues/compensation',
-      headers: {
-        'X-VA-SSN' => '872958715',
-        'X-VA-Receipt-Date' => '2019-12-01'
-      }
-    )
-  end
-
-  describe '#index' do
-    it 'GETs contestable_issues from Caseflow successfully' do
-      VCR.use_cassette('caseflow/higher_level_reviews/contestable_issues') do
-        get_issues
-        expect(response).to have_http_status(:ok)
-        json = JSON.parse(response.body)
-        expect(json['data']).not_to be nil
-      end
-    end
-
-    context 'unusable response' do
-      before do
-        allow_any_instance_of(Caseflow::Service).to(
-          receive(:get_contestable_issues).and_return(
-            Struct.new(:status, :body).new(
-              200,
-              '<html>Some html!</html>'
-            )
-          )
-        )
-      end
-
-      it 'returns a 502 when Caseflow returns an unusable response' do
-        get_issues
-        expect(response).to have_http_status(:bad_gateway)
-        expect(JSON.parse(response.body)['errors']).to be_an Array
-      end
-    end
-
-    context 'Caseflow 4XX response' do
-      let(:status) { 400 }
-      let(:body) { { hello: 'world' }.as_json }
-
-      before do
-        allow_any_instance_of(Caseflow::Service).to(
-          receive(:get_contestable_issues).and_return(
-            Struct.new(:status, :body).new(status, body)
-          )
-        )
-      end
-
-      it 'lets 4XX responses passthrough' do
-        get_issues
-        expect(response.status).to be status
-        expect(JSON.parse(response.body)).to eq body
-      end
-    end
-  end
+  include_examples 'contestable issues index requests', appeal_type: 'higher_level_reviews'
 end

--- a/modules/appeals_api/spec/requests/v1/higher_level_reviews/contestable_issues_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/higher_level_reviews/contestable_issues_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../../support/shared_examples_contestable_issues'
+require_relative '../../../support/shared_examples_contestable_issues'
 
 describe AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesController, type: :request do
   include_examples 'contestable issues index requests', appeal_type: 'higher_level_reviews'

--- a/modules/appeals_api/spec/requests/v1/higher_level_reviews/contestable_issues_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/higher_level_reviews/contestable_issues_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../../../support/shared_examples_contestable_issues'
+require_relative AppealsApi::Engine.root.join('spec', 'support', 'shared_examples_contestable_issues.rb')
 
 describe AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesController, type: :request do
   include_examples 'contestable issues index requests',

--- a/modules/appeals_api/spec/requests/v1/higher_level_reviews/contestable_issues_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/higher_level_reviews/contestable_issues_controller_spec.rb
@@ -4,5 +4,7 @@ require 'rails_helper'
 require_relative '../../../support/shared_examples_contestable_issues'
 
 describe AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesController, type: :request do
-  include_examples 'contestable issues index requests', appeal_type: 'higher_level_reviews'
+  include_examples 'contestable issues index requests',
+                   appeal_type: 'higher_level_reviews',
+                   benefit_type: 'compensation'
 end

--- a/modules/appeals_api/spec/requests/v1/higher_level_reviews/contestable_issues_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/higher_level_reviews/contestable_issues_controller_spec.rb
@@ -5,6 +5,6 @@ require_relative AppealsApi::Engine.root.join('spec', 'support', 'shared_example
 
 describe AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesController, type: :request do
   include_examples 'contestable issues index requests',
-                   appeal_type: 'higher_level_reviews',
+                   decision_review_type: 'higher_level_reviews',
                    benefit_type: 'compensation'
 end

--- a/modules/appeals_api/spec/requests/v1/notifce_of_disagreements/contestable_issues_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notifce_of_disagreements/contestable_issues_controller_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples_contestable_issues'
+
+describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::ContestableIssuesController, type: :request do
+  include_examples 'contestable issues index requests', appeal_type: 'notice_of_disagreements'
+end

--- a/modules/appeals_api/spec/requests/v1/notifce_of_disagreements/contestable_issues_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notifce_of_disagreements/contestable_issues_controller_spec.rb
@@ -4,5 +4,7 @@ require 'rails_helper'
 require_relative '../../../support/shared_examples_contestable_issues'
 
 describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::ContestableIssuesController, type: :request do
-  include_examples 'contestable issues index requests', appeal_type: 'notice_of_disagreements'
+  include_examples 'contestable issues index requests',
+                   appeal_type: 'notice_of_disagreements',
+                   benefit_type: ''
 end

--- a/modules/appeals_api/spec/requests/v1/notifce_of_disagreements/contestable_issues_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notifce_of_disagreements/contestable_issues_controller_spec.rb
@@ -5,6 +5,6 @@ require_relative AppealsApi::Engine.root.join('spec', 'support', 'shared_example
 
 describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::ContestableIssuesController, type: :request do
   include_examples 'contestable issues index requests',
-                   appeal_type: 'notice_of_disagreements',
+                   decision_review_type: 'notice_of_disagreements',
                    benefit_type: ''
 end

--- a/modules/appeals_api/spec/requests/v1/notifce_of_disagreements/contestable_issues_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notifce_of_disagreements/contestable_issues_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../../../support/shared_examples_contestable_issues'
+require_relative AppealsApi::Engine.root.join('spec', 'support', 'shared_examples_contestable_issues.rb')
 
 describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::ContestableIssuesController, type: :request do
   include_examples 'contestable issues index requests',

--- a/modules/appeals_api/spec/support/shared_examples_contestable_issues.rb
+++ b/modules/appeals_api/spec/support/shared_examples_contestable_issues.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'contestable issues index requests' do |options|
+  let(:get_issues) do
+    get(
+      "/services/appeals/v1/decision_reviews/#{options[:appeal_type]}/contestable_issues/compensation",
+      headers: {
+        'X-VA-SSN' => '872958715',
+        'X-VA-Receipt-Date' => '2019-12-01'
+      }
+    )
+  end
+
+  describe '#index' do
+    it 'GETs contestable_issues from Caseflow successfully' do
+      VCR.use_cassette("caseflow/#{options[:appeal_type]}/contestable_issues") do
+        get_issues
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json['data']).not_to be nil
+      end
+    end
+
+    context 'unusable response' do
+      before do
+        allow_any_instance_of(Caseflow::Service).to(
+          receive(:get_contestable_issues).and_return(
+            Struct.new(:status, :body).new(
+              200,
+              '<html>Some html!</html>'
+            )
+          )
+        )
+      end
+
+      it 'returns a 502 when Caseflow returns an unusable response' do
+        get_issues
+        expect(response).to have_http_status(:bad_gateway)
+        expect(JSON.parse(response.body)['errors']).to be_an Array
+      end
+    end
+
+    context 'Caseflow 4XX response' do
+      let(:status) { 400 }
+      let(:body) { { hello: 'world' }.as_json }
+
+      before do
+        allow_any_instance_of(Caseflow::Service).to(
+          receive(:get_contestable_issues).and_return(
+            Struct.new(:status, :body).new(status, body)
+          )
+        )
+      end
+
+      it 'lets 4XX responses passthrough' do
+        get_issues
+        expect(response.status).to be status
+        expect(JSON.parse(response.body)).to eq body
+      end
+    end
+  end
+end

--- a/modules/appeals_api/spec/support/shared_examples_contestable_issues.rb
+++ b/modules/appeals_api/spec/support/shared_examples_contestable_issues.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples 'contestable issues index requests' do |options|
   let(:get_issues) do
     get(
-      "/services/appeals/v1/decision_reviews/#{options[:appeal_type]}/contestable_issues/compensation",
+      "/services/appeals/v1/decision_reviews/#{options[:appeal_type]}/contestable_issues/#{options[:benefit_type]}",
       headers: {
         'X-VA-SSN' => '872958715',
         'X-VA-Receipt-Date' => '2019-12-01'

--- a/modules/appeals_api/spec/support/shared_examples_contestable_issues.rb
+++ b/modules/appeals_api/spec/support/shared_examples_contestable_issues.rb
@@ -3,7 +3,8 @@
 RSpec.shared_examples 'contestable issues index requests' do |options|
   let(:get_issues) do
     get(
-      "/services/appeals/v1/decision_reviews/#{options[:appeal_type]}/contestable_issues/#{options[:benefit_type]}",
+      "/services/appeals/v1/decision_reviews/#{options[:decision_review_type]}/" \
+      "contestable_issues/#{options[:benefit_type]}",
       headers: {
         'X-VA-SSN' => '872958715',
         'X-VA-Receipt-Date' => '2019-12-01'
@@ -13,7 +14,7 @@ RSpec.shared_examples 'contestable issues index requests' do |options|
 
   describe '#index' do
     it 'GETs contestable_issues from Caseflow successfully' do
-      VCR.use_cassette("caseflow/#{options[:appeal_type]}/contestable_issues") do
+      VCR.use_cassette("caseflow/#{options[:decision_review_type]}/contestable_issues") do
         get_issues
         expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)

--- a/spec/support/vcr_cassettes/caseflow/notice_of_disagreements/contestable_issues.yml
+++ b/spec/support/vcr_cassettes/caseflow/notice_of_disagreements/contestable_issues.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://dsva-appeals-certification-dev-1895622301.us-gov-west-1.elb.amazonaws.com/api/v3/decision_reviews/appeals/contestable_issues/compensation
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - Token token=PUBLICDEMO123
+      X-VA-SSN:
+      - '872958715'
+      X-VA-Receipt-Date:
+      - '2019-12-01'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"d6bf72b7b802348bbd01a2bd9a2129c8"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Meta-Request-Version:
+      - 0.7.2
+      X-Request-Id:
+      - da12dfa2-d2ae-405f-a015-2aedfc7266c7
+      X-Runtime:
+      - '0.495623'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"type":"contestableIssue","attributes":{"ratingIssueReferenceId":"826209597423","ratingIssueProfileDate":"2019-02-22","ratingIssueDiagnosticCode":null,"description":"Left
+        knee","isRating":true,"latestIssuesInChain":[{"id":null,"approxDecisionDate":"2019-02-26"}],"decisionIssueId":null,"ratingDecisionReferenceId":null,"approxDecisionDate":"2019-02-26","rampClaimId":null,"titleOfActiveReview":null,"sourceReviewType":null,"timely":true}},{"type":"contestableIssue","attributes":{"ratingIssueReferenceId":"826209920000","ratingIssueProfileDate":"2019-02-22","ratingIssueDiagnosticCode":null,"description":"Right
+        knee","isRating":true,"latestIssuesInChain":[{"id":null,"approxDecisionDate":"2019-02-26"}],"decisionIssueId":null,"ratingDecisionReferenceId":null,"approxDecisionDate":"2019-02-26","rampClaimId":null,"titleOfActiveReview":null,"sourceReviewType":null,"timely":true}},{"type":"contestableIssue","attributes":{"ratingIssueReferenceId":"826209441170","ratingIssueProfileDate":"2019-02-22","ratingIssueDiagnosticCode":null,"description":"PTSD","isRating":true,"latestIssuesInChain":[{"id":null,"approxDecisionDate":"2019-02-26"}],"decisionIssueId":null,"ratingDecisionReferenceId":null,"approxDecisionDate":"2019-02-26","rampClaimId":null,"titleOfActiveReview":null,"sourceReviewType":null,"timely":true}},{"type":"contestableIssue","attributes":{"ratingIssueReferenceId":"in-active-review-ref-id","ratingIssueProfileDate":"2019-02-22","ratingIssueDiagnosticCode":null,"description":"This
+        rating is in active review","isRating":true,"latestIssuesInChain":[{"id":null,"approxDecisionDate":"2019-02-26"}],"decisionIssueId":null,"ratingDecisionReferenceId":null,"approxDecisionDate":"2019-02-26","rampClaimId":null,"titleOfActiveReview":null,"sourceReviewType":null,"timely":true}},{"type":"contestableIssue","attributes":{"ratingIssueReferenceId":"826209942179","ratingIssueProfileDate":"2019-02-22","ratingIssueDiagnosticCode":null,"description":"I
+        am on a completed Higher Level Review","isRating":true,"latestIssuesInChain":[{"id":null,"approxDecisionDate":"2019-02-26"}],"decisionIssueId":null,"ratingDecisionReferenceId":null,"approxDecisionDate":"2019-02-26","rampClaimId":null,"titleOfActiveReview":null,"sourceReviewType":"HigherLevelReview","timely":true}},{"type":"contestableIssue","attributes":{"ratingIssueReferenceId":"before_ama_ref_id","ratingIssueProfileDate":"2019-02-09","ratingIssueDiagnosticCode":null,"description":"Issue
+        before AMA not from a RAMP Review","isRating":true,"latestIssuesInChain":[{"id":null,"approxDecisionDate":"2019-02-14"}],"decisionIssueId":null,"ratingDecisionReferenceId":null,"approxDecisionDate":"2019-02-14","rampClaimId":null,"titleOfActiveReview":null,"sourceReviewType":null,"timely":true}},{"type":"contestableIssue","attributes":{"ratingIssueReferenceId":"ramp_reference_id","ratingIssueProfileDate":"2019-02-09","ratingIssueDiagnosticCode":null,"description":"Issue
+        before AMA from a RAMP Review","isRating":true,"latestIssuesInChain":[{"id":null,"approxDecisionDate":"2019-02-14"}],"decisionIssueId":null,"ratingDecisionReferenceId":null,"approxDecisionDate":"2019-02-14","rampClaimId":null,"titleOfActiveReview":null,"sourceReviewType":null,"timely":true}},{"type":"contestableIssue","attributes":{"ratingIssueReferenceId":"826209918301","ratingIssueProfileDate":"2018-12-12","ratingIssueDiagnosticCode":null,"description":"Old
+        injury","isRating":true,"latestIssuesInChain":[{"id":null,"approxDecisionDate":"2018-12-17"}],"decisionIssueId":null,"ratingDecisionReferenceId":null,"approxDecisionDate":"2018-12-17","rampClaimId":null,"titleOfActiveReview":null,"sourceReviewType":null,"timely":true}},{"type":"contestableIssue","attributes":{"ratingIssueReferenceId":"before_test_ama_ref_id","ratingIssueProfileDate":"2017-10-12","ratingIssueDiagnosticCode":null,"description":"Issue
+        before test AMA not from a RAMP Review","isRating":true,"latestIssuesInChain":[{"id":null,"approxDecisionDate":"2017-10-17"}],"decisionIssueId":null,"ratingDecisionReferenceId":null,"approxDecisionDate":"2017-10-17","rampClaimId":null,"titleOfActiveReview":null,"sourceReviewType":null,"timely":false}},{"type":"contestableIssue","attributes":{"ratingIssueReferenceId":"ramp_reference_id","ratingIssueProfileDate":"2017-10-12","ratingIssueDiagnosticCode":null,"description":"Issue
+        before test AMA from a RAMP Review","isRating":true,"latestIssuesInChain":[{"id":null,"approxDecisionDate":"2017-10-17"}],"decisionIssueId":null,"ratingDecisionReferenceId":null,"approxDecisionDate":"2017-10-17","rampClaimId":null,"titleOfActiveReview":null,"sourceReviewType":null,"timely":false}}]}'
+    http_version: 
+  recorded_at: Fri, 17 Jan 2020 16:09:22 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/vcr_cassettes/caseflow/notice_of_disagreements/contestable_issues.yml
+++ b/spec/support/vcr_cassettes/caseflow/notice_of_disagreements/contestable_issues.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dsva-appeals-certification-dev-1895622301.us-gov-west-1.elb.amazonaws.com/api/v3/decision_reviews/appeals/contestable_issues/compensation
+    uri: https://dsva-appeals-certification-dev-1895622301.us-gov-west-1.elb.amazonaws.com/api/v3/decision_reviews/appeals/contestable_issues/
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
## Description of change
This PR:
 - Refactors HigherLevelReviews/ContestableIssuesController to use a common base class `BaseContestableIssuesController` 
- Implements `NoticeOfDisagreements/ContestableIssuesController` which inherits from base class
- Updates specs using shared examples
- Updates documentation for `NoticeOfDisagreements/ContestableIssuesController`

## Original issue(s)
[NOD contestable issues endpoint (vets-api)](https://vajira.max.gov/browse/API-2880)

