### PR TITLE
Add documentation and specs for Claim Status Tool file uploads

### DIFF
--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -81,6 +81,10 @@ module V0
         key :description, 'In-progress form operations'
       end
       tag do
+        key :name, 'claim_status_tool'
+        key :description, 'Claim Status Tool'
+      end
+      tag do
         key :name, 'site'
         key :description, 'Site service availability and feedback'
       end
@@ -121,6 +125,7 @@ module V0
       Swagger::Requests::BackendStatuses,
       Swagger::Requests::BB::HealthRecords,
       Swagger::Requests::BurialClaims,
+      Swagger::Requests::ClaimStatus,
       Swagger::Requests::DebtLetters,
       Swagger::Requests::DependentsApplications,
       Swagger::Requests::DisabilityCompensationForm,

--- a/app/controllers/v0/documents_controller.rb
+++ b/app/controllers/v0/documents_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Upload documents associated with a claim in the Claim Status Tool, to be sent to EVSS in a Job
 module V0
   class DocumentsController < ApplicationController
     before_action { authorize :evss, :access? }

--- a/app/services/evss_claim_service.rb
+++ b/app/services/evss_claim_service.rb
@@ -48,6 +48,10 @@ class EVSSClaimService
     # the uploader sanitizes the filename before storing, so set our doc to match
     evss_claim_document.file_name = uploader.final_filename
     EVSS::DocumentUpload.perform_async(auth_headers, @user.uuid, evss_claim_document.to_serializable_hash)
+  rescue CarrierWave::IntegrityError => e
+    log_exception_to_sentry(e, nil, nil, 'warn')
+    raise Common::Exceptions::UnprocessableEntity.new(detail: e.message,
+                                                      source: 'EVSSClaimService.upload_document')
   end
 
   private

--- a/app/swagger/swagger/requests/claim_status.rb
+++ b/app/swagger/swagger/requests/claim_status.rb
@@ -53,8 +53,8 @@ module Swagger
         end
         property :document_type do
           key :type, :string
-          # key :example, 'L023',
-          # key :enum, EVSSClaimDocument::DOCUMENT_TYPES.keys
+          key :example, 'L023'
+          key :enum, EVSSClaimDocument::DOCUMENT_TYPES.keys
         end
       end
     end

--- a/app/swagger/swagger/requests/claim_status.rb
+++ b/app/swagger/swagger/requests/claim_status.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Requests
+    class ClaimStatus
+      include Swagger::Blocks
+
+      swagger_path '/v0/evss_claims/{evss_claim_id}/documents' do
+        operation :post do
+          extend Swagger::Responses::UnprocessableEntityError
+          key :description, 'upload a document associated with a claim'
+          key :operationId, 'postDocument'
+          key :tags, %w[claim_status_tool]
+
+          parameter :authorization
+
+          parameter do
+            key :name, :cst_file_upload
+            key :in, :body
+            key :description, ''
+            key :required, true
+            schema do
+              key :'$ref', :ClaimDocumentInput
+            end
+          end
+
+          parameter do
+            key :name, :evss_claim_id
+            key :description, ''
+            key :in, :path
+            key :required, true
+            key :type, :string
+          end
+
+          response 202 do
+            key :description, 'Response is Accepted'
+            schema do
+              key :required, %i[job_id]
+              property :job_id, type: :string, example: ''
+            end
+          end
+        end
+      end
+
+      swagger_schema :ClaimDocumentInput do
+        key :required, [:file]
+
+        property :file do
+          key :type, :string
+        end
+        property :tracked_item_id do
+          key :type, :string
+        end
+        property :document_type do
+          key :type, :string
+          # key :example, 'L023',
+          # key :enum, EVSSClaimDocument::DOCUMENT_TYPES.keys
+        end
+      end
+    end
+  end
+end

--- a/spec/request/documents_spec.rb
+++ b/spec/request/documents_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Documents management', type: :request do
   end
 
   context 'with unaccepted file_type' do
-    let(:file) { fixture_file_upload('files/invalid_idme_cert.crt', 'application/pdf') }
+    let(:file) { fixture_file_upload('files/invalid_idme_cert.crt', 'application/x-x509-ca-cert') }
 
     it 'rejects files with invalid document_types' do
       params = { file: file, tracked_item_id: tracked_item_id, document_type: document_type }

--- a/spec/request/documents_spec.rb
+++ b/spec/request/documents_spec.rb
@@ -78,6 +78,19 @@ RSpec.describe 'Documents management', type: :request do
     end
   end
 
+  context 'with no body' do
+    let(:file) { fixture_file_upload('/files/empty_file.txt', 'text/plain') }
+
+    it 'rejects a text file with no body' do
+      params = { file: file, tracked_item_id: tracked_item_id, document_type: document_type }
+      post '/v0/evss_claims/189625/documents', params: params
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)['errors'].first['detail']).to eq(
+        I18n.t('errors.messages.min_size_error', min_size: '1 Byte')
+      )
+    end
+  end
+
   context 'with an emoji in text' do
     let(:tempfile) do
       f = Tempfile.new(['test', '.txt'])

--- a/spec/request/documents_spec.rb
+++ b/spec/request/documents_spec.rb
@@ -3,12 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Documents management', type: :request do
-  let(:file) do
-    fixture_file_upload(
-      "#{::Rails.root}/spec/fixtures/files/doctors-note.pdf",
-      'application/pdf'
-    )
-  end
+  let(:file) { fixture_file_upload('/files/doctors-note.pdf', 'application/pdf') }
   let(:tracked_item_id) { 33 }
   let(:document_type) { 'L023' }
   let!(:claim) do
@@ -45,13 +40,19 @@ RSpec.describe 'Documents management', type: :request do
     expect(args['tracked_item_id']).to be_nil
   end
 
-  context 'with locked PDF' do
-    let(:locked_file) do
-      fixture_file_upload(
-        "#{::Rails.root}/spec/fixtures/files/locked-pdf.pdf",
-        'application/pdf'
-      )
+  context 'with unaccepted file_type' do
+    let(:file) { fixture_file_upload('files/invalid_idme_cert.crt', 'application/pdf') }
+
+    it 'rejects files with invalid document_types' do
+      params = { file: file, tracked_item_id: tracked_item_id, document_type: document_type }
+      post '/v0/evss_claims/189625/documents', params: params
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)['errors'].first['title']).to eq('Unprocessable Entity')
     end
+  end
+
+  context 'with locked PDF' do
+    let(:locked_file) { fixture_file_upload('files/locked-pdf.pdf', 'application/pdf') }
 
     it 'rejects locked PDFs' do
       params = { file: locked_file, tracked_item_id: tracked_item_id, document_type: document_type }

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -2790,6 +2790,35 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
         expect(subject).to validate(:get, '/v0/profile/payment_history', 200, headers)
       end
     end
+
+    describe 'claim status tool' do
+      let!(:claim) do
+        FactoryBot.create(:evss_claim, id: 1, evss_id: 189_625,
+                                       user_uuid: mhv_user.uuid, data: {})
+      end
+
+      it 'uploads a document to support a claim' do
+        expect(subject).to validate(
+          :post,
+          '/v0/evss_claims/{evss_claim_id}/documents',
+          202,
+          headers.merge('_data' => { file: fixture_file_upload('/files/doctors-note.pdf', 'application/pdf'),
+                                     tracked_item_id: 33,
+                                     document_type: 'L023' }, 'evss_claim_id' => 189_625)
+        )
+      end
+      it 'rejects a malformed document' do
+        expect(subject).to validate(
+          :post,
+          '/v0/evss_claims/{evss_claim_id}/documents',
+          422,
+          headers.merge('_data' => { file: fixture_file_upload('spec/fixtures/files/malformed-pdf.pdf',
+                                                               'application/pdf'),
+                                     tracked_item_id: 33,
+                                     document_type: 'L023' }, 'evss_claim_id' => 189_625)
+        )
+      end
+    end
   end
 
   context 'and' do


### PR DESCRIPTION
## Description of change
Before we start allowing password-protected pdf's (#5072) I want to make sure our file upload code is well-tested and documented.  

This adds swagger docs and rescues an exception that would've raised 500's

in #5070 I'm taking a look at the text of the error messages.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14002

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
