### PR TITLE
update `breakers` gem to version 0.4.0.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
     benchmark-ips (2.8.2)
     bindex (0.8.1)
     brakeman (4.9.0)
-    breakers (0.3.0)
+    breakers (0.4.0)
       faraday (>= 0.7.4, < 0.18)
       multi_json (~> 1.0)
     builder (3.2.4)


### PR DESCRIPTION
## Description of change
update `breakers` gem to version 0.4.0.
This version reports "duration" metrics in milliseconds instead of seconds

The StatsD Exporter now expects time measurements in milliseconds, hence this change.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
