### PR TITLE
Add Identifier for BGS Mock Services

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,9 +34,9 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/bgs-ext.git
-  revision: 40d00689d0845c2eb72819f3c0df04869564c980
+  revision: c7883a1a05b5812e0fdfb5c07aef868713a7b4a4
   specs:
-    bgs_ext (0.14.9)
+    bgs_ext (0.15.0)
       httpclient
       nokogiri (>= 1.8.5)
       savon (~> 2.12)

--- a/app/services/bgs/people_service.rb
+++ b/app/services/bgs/people_service.rb
@@ -5,7 +5,6 @@ module BGS
     class VaFileNumberNotFound < StandardError; end
 
     def find_person_by_participant_id
-      # adding ssn for bgs mock data
       response = @service.people.find_person_by_ptcpnt_id(@user.participant_id, @user.ssn)
 
       raise VaFileNumberNotFound if response.nil?

--- a/app/services/bgs/people_service.rb
+++ b/app/services/bgs/people_service.rb
@@ -5,7 +5,7 @@ module BGS
     class VaFileNumberNotFound < StandardError; end
 
     def find_person_by_participant_id
-      response = @service.people.find_person_by_ptcpnt_id(@user.participant_id)
+      response = @service.people.find_person_by_ptcpnt_id(@user.participant_id, @user.ssn)
 
       raise VaFileNumberNotFound if response.nil?
 

--- a/app/services/bgs/people_service.rb
+++ b/app/services/bgs/people_service.rb
@@ -5,6 +5,7 @@ module BGS
     class VaFileNumberNotFound < StandardError; end
 
     def find_person_by_participant_id
+      # adding ssn for bgs mock data
       response = @service.people.find_person_by_ptcpnt_id(@user.participant_id, @user.ssn)
 
       raise VaFileNumberNotFound if response.nil?


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
While implementing mock data for the View Payments functionality, it was discovered that one of the calls being used was not currently set up to use mock data services.  This PR updates that call to pass the identifier as a param to the BGS gem so that other developers can test the View Payments functionality without being connected to BGS.

This PR also bumps the bgs_ext gem version to match the latest in master for that repo.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14595

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is a very minor PR so no additional logging or settings have been changed.  

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] Local Testing