### PR TITLE
clear saved "in progress" Preneeds Burial forms

### DIFF
--- a/app/controllers/v0/preneeds/burial_forms_controller.rb
+++ b/app/controllers/v0/preneeds/burial_forms_controller.rb
@@ -19,6 +19,7 @@ module V0
           return_code: resource.return_code
         )
 
+        clear_saved_form(FORM)
         render json: resource, serializer: ReceiveApplicationSerializer
       end
 


### PR DESCRIPTION

## Description of change
clear saved "in progress" form upon successful submission of Preneeds Burial form.

I just happened to notice in the controller that "in progress" forms were not deleted after submission.
I tested on staging that this is an issue:
- logged in
- completed a Preneeds Burial form
- logged out
- logged back in as same user
- visited the Preneeds Burial form page where my previous submission was still available for me to "continue" 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
