### PR TITLE
[Development] Add PDF password feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -288,9 +288,14 @@ features:
     actor_type: user
     enable_in_development: true
     description: >
-      Add text message opt-in question to 10203 Personal Information chapter and layout changes     
+      Add text message opt-in question to 10203 Personal Information chapter and layout changes
   form_1995_edu_updates:
     actor_type: user
     enable_in_development: true
     description: >
       Form updates to bring EDU forms in compliance with latest DEPO patterns and practices
+  request_locked_pdf_password:
+    actor_type: user
+    enable_in_development: true
+    description: >
+      Ask for a password when an encrypted PDF is detected before uploading


### PR DESCRIPTION
## Description of change

In anticipation of asking the user for a password after attempting to upload an encrypted PDF, this feature flag is being added to allow thorough testing.

## Original issue(s)
- All forms: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14011
- Claim status tool: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14723
- API: https://github.com/department-of-veterans-affairs/vets-api/pull/5072

## Things to know about this PR

Adding a `request_locked_pdf_password` feature flag
