### PR TITLE
add inflection for MPI

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -18,7 +18,7 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'IHub'
   inflect.acronym 'MDOT'
   inflect.acronym 'MHV' # My HealtheVet
-  inflect.acronym 'MPI'
+  inflect.acronym 'MPI' # Master Persons Index (formerly MVI for Veteran instead of Persons)
   inflect.acronym 'NCA' # National Cemetery Administration
   inflect.acronym 'OAuth'
   inflect.acronym 'PagerDuty'

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -18,6 +18,7 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'IHub'
   inflect.acronym 'MDOT'
   inflect.acronym 'MHV' # My HealtheVet
+  inflect.acronym 'MPI'
   inflect.acronym 'NCA' # National Cemetery Administration
   inflect.acronym 'OAuth'
   inflect.acronym 'PagerDuty'


### PR DESCRIPTION
MVI's use as an acronym that's not inflected is blocking enabling zeitwerk.  The plan is to move to using 'MPI' to reflect the real name, so the inflection will be added for that and then the MVI classes will be changed and be supported by the new inflection of MPI.  There are already starting to be places that refer to MPI, so this will help keep people on the right path.