### PR TITLE
14770 rename MviPolicy

### DIFF
--- a/app/controllers/v0/mvi_users_controller.rb
+++ b/app/controllers/v0/mvi_users_controller.rb
@@ -2,7 +2,7 @@
 
 module V0
   class MviUsersController < ApplicationController
-    before_action { authorize :mvi, :access_add_person? }
+    before_action { authorize :mpi, :access_add_person? }
 
     def submit
       # Caller must be using proxy add in order to complete Intent to File or Disability Compensation forms

--- a/app/controllers/v0/profile/personal_informations_controller.rb
+++ b/app/controllers/v0/profile/personal_informations_controller.rb
@@ -3,7 +3,7 @@
 module V0
   module Profile
     class PersonalInformationsController < ApplicationController
-      before_action { authorize :mvi, :queryable? }
+      before_action { authorize :mpi, :queryable? }
 
       # Fetches the personal information for the current user.
       # Namely their gender and birth date.

--- a/app/policies/mpi_policy.rb
+++ b/app/policies/mpi_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-MviPolicy = Struct.new(:user, :mvi) do
+MPIPolicy = Struct.new(:user, :mvi) do
   def access_add_person?
     user.edipi.present? && user.ssn.present? && (user.birls_id.blank? || user.participant_id.blank?)
   end

--- a/app/services/users/services.rb
+++ b/app/services/users/services.rb
@@ -24,7 +24,7 @@ module Users
       @list << BackendServices::MHV_AC if user.authorize :mhv_account_creation, :access?
       @list << BackendServices::EVSS_CLAIMS if user.authorize :evss, :access?
       @list << BackendServices::FORM526 if user.authorize :evss, :access_form526?
-      @list << BackendServices::ADD_PERSON if user.authorize :mvi, :access_add_person?
+      @list << BackendServices::ADD_PERSON if user.authorize :mpi, :access_add_person?
       @list << BackendServices::USER_PROFILE if user.can_access_user_profile?
       @list << BackendServices::APPEALS_STATUS if user.authorize :appeals, :access?
       @list << BackendServices::ID_CARD if user.can_access_id_card?

--- a/spec/policies/mpi_policy_spec.rb
+++ b/spec/policies/mpi_policy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe MviPolicy do
+describe MPIPolicy do
   subject { described_class }
 
   permissions :queryable? do


### PR DESCRIPTION
# Description of change
app/policies/mvi_policy.rb defines MviPolicy and should become app/policies/mpi_policy.rb and use the inflection to be MPIPolicy. MPIPolicy is derived from the notion of policy classes from the pundit gem. The authorize before_action in the  mvi_users_controller automatically infers that mpi will have a matching MPIPolicy class. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14705

## Things to know about this PR
- [x] Green Test Suite
