### PR TITLE
Modify how is_cerner is derived

### DIFF
--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -163,10 +163,7 @@ module Users
 
     def facility(facility_id)
       cerner_facility_ids = user.va_profile.cerner_facility_ids || []
-
-      is_cerner = cerner_facility_ids.include?(facility_id)
-      is_cerner = true if facility_id == '668' && Flipper.enabled?(:cerner_override_668)
-      is_cerner = true if facility_id == '757' && Flipper.enabled?(:cerner_override_757)
+      is_cerner = cerner_facility_ids.include?(facility_id) || Flipper.enabled?("cerner_override_#{facility_id}")
 
       {
         facility_id: facility_id,

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -163,9 +163,10 @@ module Users
 
     def facility(facility_id)
       cerner_facility_ids = user.va_profile.cerner_facility_ids || []
+      is_cerner = cerner_facility_ids.include?(facility_id) || Settings.cerner.facility_ids.include?(facility_id)
       {
         facility_id: facility_id,
-        is_cerner: cerner_facility_ids.include?(facility_id)
+        is_cerner: is_cerner
       }
     end
 

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -163,7 +163,11 @@ module Users
 
     def facility(facility_id)
       cerner_facility_ids = user.va_profile.cerner_facility_ids || []
-      is_cerner = cerner_facility_ids.include?(facility_id) || Settings.cerner.facility_ids.include?(facility_id)
+
+      is_cerner = cerner_facility_ids.include?(facility_id)
+      is_cerner = true if facility_id == '668' && Flipper.enabled?(:cerner_override_668)
+      is_cerner = true if facility_id == '757' && Flipper.enabled?(:cerner_override_757)
+
       {
         facility_id: facility_id,
         is_cerner: is_cerner

--- a/config/features.yml
+++ b/config/features.yml
@@ -244,26 +244,18 @@ features:
     actor_type: user
     description: >
       This determines when the wizard should show up on the form 526 intro page
-  show_new_get_medical_records_page:
+  cerner_override_668:
     actor_type: user
     description: >
-      This will show the non-Cerner-user and Cerner-user content for the page /health-care/get-medical-records/
-  show_new_refill_track_prescriptions_page:
+      This will show the Cerner facility 668 as `isCerner`.
+  cerner_override_757:
     actor_type: user
     description: >
-      This will show the non-Cerner-user and Cerner-user content for the page /health-care/refill-track-prescriptions/
+      This will show the Cerner facility 757 as `isCerner`.
   show_new_schedule_view_appointments_page:
     actor_type: user
     description: >
       This will show the non-Cerner-user and Cerner-user content for the page /health-care/schedule-view-va-appointments/
-  show_new_secure_messaging_page:
-    actor_type: user
-    description: >
-      This will show the non-Cerner-user and Cerner-user content for the page /health-care/secure-messaging/
-  show_new_view_test_lab_results_page:
-    actor_type: user
-    description: >
-      This will show the non-Cerner-user and Cerner-user content for the page /health-care/view-test-and-lab-results/
   gibct_benefit_filter_enhancement:
     actor_type: user
     description: >

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -614,3 +614,9 @@ genisis:
   service_path: /COVID19Service
   user: TestUser
   pass: bogus
+
+# Settings for live Cerner facilities
+cerner:
+  facility_ids:
+    - 757
+    - 668

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -614,9 +614,3 @@ genisis:
   service_path: /COVID19Service
   user: TestUser
   pass: bogus
-
-# Settings for live Cerner facilities
-cerner:
-  facility_ids:
-    - 757
-    - 668


### PR DESCRIPTION
## Description of change
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/14203

This PR changes how `is_cerner` is derived so that it's not only dependent on MVI but also on Flipper feature toggles for exceptions (e.g. Chalmers should be `is_cerner: true`).

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/14203

## Things to know about this PR
* Are there additions to a `settings.yml` file? Do they vary by environment?
No.

* Is there a feature flag? What is it?

**Yes, several feature flags have been modified.**

I removed the following feature toggles since they are not used:

```
show_new_get_medical_records_page
show_new_refill_track_prescriptions_page
show_new_secure_messaging_page
show_new_view_test_lab_results_page
```

We currently still use `show_new_schedule_view_appointments_page`, but I'll send up a follow-up PR post-Cerner launch to remove that too.

I added the following feature toggles:

```
cerner_override_668
cerner_override_757
```

These are used to force `is_cerner` to true for these 2 facilities.

* Is there some Sentry logging that was added? What alerts are relevant?
No.

* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
No.

* Are there Swagger docs that were updated?
No.

* Is there any PII concerns or questions?
No.
