### PR TITLE
Remove no-longer-used emails from settings.yml flipper admin list

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -491,8 +491,6 @@ flipper:
     - jbalboni@gmail.com
     - jeff@adhocteam.us
     - jesse.cohn@adhocteam.us
-    - johnny@oddball.io
-    - johnpaul.ashenfelter@oddball.io
     - kabrown@thoughtworks.com
     - kam@adhocteam.us
     - keifer@oddball.io


### PR DESCRIPTION
## Description of change
Remove no-longer-used emails from settings.yml flipper admin list.
These users no longer work on this project.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
