### PR TITLE
moving the Sentry init code outside of the IIFE

### DIFF
--- a/lib/saml/templates/sso_post_form.html.erb
+++ b/lib/saml/templates/sso_post_form.html.erb
@@ -28,15 +28,15 @@
   <% end %>
 
   <script>
+    if (typeof(Sentry) != 'undefined' && "<%= sentrydsn %>") {
+      Sentry.init({
+        dsn: "<%= sentrydsn %>",
+        integrations: [new Sentry.Integrations.BrowserTracing()],
+      });
+      /* extra tag so we can easily search for any errors in Sentry */
+      Sentry.setTag("page", "SSOe-Post-Binding-Form");
+    }
     (function() {
-      if (typeof(Sentry) != 'undefined' && "<%= sentrydsn %>") {
-        Sentry.init({
-          dsn: "<%= sentrydsn %>",
-          integrations: [new Sentry.Integrations.BrowserTracing()],
-        });
-        /* extra tag so we can easily search for any errors in Sentry */
-        Sentry.setTag("page", "SSOe-Post-Binding-Form");
-      }
       var req = new XMLHttpRequest();
       var qs = "id=" + encodeURIComponent("<%= id %>") +
                 "&authn=" + encodeURIComponent("<%= authn %>") +


### PR DESCRIPTION
we are still seeing a ~2% in the number of browsers that submit the SSOe
post binding SAML form (when comparing saml requests created to those
that are traced).  the initial hope was that Sentry would capture any of
these errors, however if the errors are related to the IIFE, then the
Sentry initialization code will never be executed.

here we are moving that initialization code outside of the IIFE, in hopes
that we will capture any errors in Sentry if the IIFE fails to load in
browsers.
