### PR TITLE
Remove edu_benefits_stem_scholarship feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -142,11 +142,6 @@ features:
     enable_in_development: true
     description: >
       Enables ssoe, as opposed to saml authentication wrapped by id.me
-  edu_benefits_stem_scholarship:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables STEM scholarship functionality
   form526_original_claims:
     actor_type: user
     description: >


### PR DESCRIPTION
## Description of change
Removed the `edu_benefits_stem_scholarship` flag.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#13850

## Things to know about this PR
- Tested locally and QA reviewed
- vets-api PR to remove usage: https://github.com/department-of-veterans-affairs/vets-website/pull/14619