### PR TITLE
Raise on missing tranlsations in test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,5 +50,5 @@ Rails.application.configure do
     config.log_level = :fatal
   end
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
## Description of change
In rails test mode, raise if we call a missing translation key
