### PR TITLE
remove stem_document_type feature flag

### DIFF
--- a/app/workers/education_form/forms/va10203.rb
+++ b/app/workers/education_form/forms/va10203.rb
@@ -3,8 +3,6 @@
 module EducationForm::Forms
   class VA10203 < Base
     def header_form_type
-      return 'STEM1995' unless Flipper.enabled?(:stem_document_type)
-
       'V10203'
     end
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -280,11 +280,6 @@ features:
     actor_type: user
     description: >
       This will toggle between an eBenefits link and a VA.gov link for the VR&E chapter 36 form
-  stem_document_type:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Set 10203 spool file document type
   stem_text_message_question:
     actor_type: user
     enable_in_development: true

--- a/spec/support/spool_helpers.rb
+++ b/spec/support/spool_helpers.rb
@@ -4,7 +4,6 @@ module SpoolHelpers
   extend ActiveSupport::Concern
 
   module ClassMethods
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def test_spool_file(form_type, test_name)
       describe "#{form_type} #{test_name} spool test" do
         subject do
@@ -34,6 +33,5 @@ module SpoolHelpers
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
   end
 end

--- a/spec/support/spool_helpers.rb
+++ b/spec/support/spool_helpers.rb
@@ -20,7 +20,6 @@ module SpoolHelpers
         end
 
         before do
-          allow(Flipper).to receive(:enabled?).with(:stem_document_type).and_return(true)
           allow(Flipper).to receive(:enabled?).with(:stem_text_message_question).and_return(true)
           allow(education_benefits_claim).to receive(:id).and_return(1)
           education_benefits_claim.instance_variable_set(:@application, nil)

--- a/spec/support/spool_helpers.rb
+++ b/spec/support/spool_helpers.rb
@@ -4,6 +4,7 @@ module SpoolHelpers
   extend ActiveSupport::Concern
 
   module ClassMethods
+    # rubocop:disable Metrics/MethodLength
     def test_spool_file(form_type, test_name)
       describe "#{form_type} #{test_name} spool test" do
         subject do
@@ -33,5 +34,6 @@ module SpoolHelpers
         end
       end
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Remove the stem_document_type feature flag. 


## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13439

## Things to know about this PR
All 10203 submissions should be displayed in the spool file are V10203 document type. 

<!-- Please describe testing done to verify the changes or any testing planned. -->
