### PR TITLE
Add a betamocks route for Appeals NOD

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -472,7 +472,7 @@
       :uid_locator: X-VA-SSN
   - :method: :get
     :path: "/api/v3/decision_reviews/appeals/contestable_issues"
-    :file_path: "modules_appeals_api/decision_reviews/contestable_issues"
+    :file_path: "modules_appeals_api/notice_of_disagreements/contestable_issues"
     :cache_multiple_responses:
       :uid_location: header
       :uid_locator: X-VA-SSN

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -471,6 +471,12 @@
       :uid_location: header
       :uid_locator: X-VA-SSN
   - :method: :get
+    :path: "/api/v3/decision_reviews/appeals/contestable_issues"
+    :file_path: "modules_appeals_api/decision_reviews/contestable_issues"
+    :cache_multiple_responses:
+      :uid_location: header
+      :uid_locator: X-VA-SSN
+  - :method: :get
     :path: "/health-check"
     :file_path: "appeals/health-check"
 


### PR DESCRIPTION
This PR adds a betamocks path for hitting the NOD endpoint on caseflow so we can record and use the new responses.
