### PR TITLE
Update EVSS file upload retry

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/workers/evss/disability_compensation_form/submit_uploads.rb
@@ -3,11 +3,11 @@
 module EVSS
   module DisabilityCompensationForm
     class SubmitUploads < Job
-      RETRY = 10
       FORM_TYPE = '21-526EZ'
       STATSD_KEY_PREFIX = 'worker.evss.submit_form526_upload'
 
-      sidekiq_options retry: RETRY
+      # retry for one day
+      sidekiq_options retry: 14
 
       # Recursively submits a file in a new instance of this job for each upload in the uploads list
       #

--- a/app/workers/evss/document_upload.rb
+++ b/app/workers/evss/document_upload.rb
@@ -3,6 +3,9 @@
 class EVSS::DocumentUpload
   include Sidekiq::Worker
 
+  # retry for one day
+  sidekiq_options retry: 14
+
   def perform(auth_headers, user_uuid, document_hash)
     document = EVSSClaimDocument.new document_hash
     client = EVSS::DocumentsService.new(auth_headers)


### PR DESCRIPTION
## Description of change
app/workers/evss/disability_compensation_form/submit_uploads.rb
and app/workers/evss/document_upload.rb call the same EVSS endpoint.  We should retry the jobs in case of EVSS/partner downtime.  

The jobs were retrying fo4 4h or 21 days.  I've updated them both to be ~1d which is the likely max downtime. 