### PR TITLE
[department-of-veterans-affairs/orchid#139] Adding admin user email for access to flipper feature toggles on staging

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -532,6 +532,7 @@ flipper:
     - zurbergram@gmail.com
     - tony.williams@va.gov
     - jennie.mcgibney@va.gov
+    - adewitt@thoughtworks.com
     - callen@governmentcio.com # Remove after Profile 2.0 UAT
     - matt.shea@adhocteam.us # Remove after Profile 2.0 UAT
     - tressa.furner@adhocteam.us # Remove after Profile 2.0 UAT


### PR DESCRIPTION
Adding admin user email for access to flipper feature toggles on staging

Co-authored-by: Steven Garcia <sgarcia@thoughtworks.com>

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
We added an additional email to `settings.yml` config in order to have access to the staging flipper feature toggles. This is necessary to turn on and off our `get_help_ask_form` toggle.  

## Original issue(s)
[department-of-veterans-affairs/orchid#139]

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment? Yes. The addition does not vary by environment.
* Is there a feature flag? What is it? No
* Is there some Sentry logging that was added? What alerts are relevant? No
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do? No
* Are there Swagger docs that were updated? No
* Is there any PII concerns or questions? No
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
