### PR TITLE
configure betamocks for appointment service

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -551,3 +551,11 @@
       :cache_multiple_responses:
         :uid_location: body
         :uid_locator: 'email_address":"(.*?)"'
+
+#MAP_APPOINTMENT_SERVICE
+- :name: "MAP_APPOINTMENT_SERVICE"
+  :base_uri: <%= "#{URI(Settings.hqva_mobile.url).host}" %>
+  :endpoints:
+  - :method: :get
+    :path: "/appointments/v1/patients/*/appointments/*"
+    :file_path: "hqva_mobile/appointments/default"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -554,7 +554,7 @@ va_mobile:
 
 hqva_mobile:
   url: "https://veteran.apps.va.gov"
-  mock: false
+  mock: true
   key_path: /fake/client/key/path
   timeout: 15
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- We are mocking out the response from the staging MAP Appointment Service when the vets-api Health Quest module queries the service for an appointment by a given ID.
- The appropriate modifications have been made to the `config/settings.yml`: Setting `mock` to true for the `hqva_mobile` app.
- Added a new config in `config/betamocks/services_config.yml` for the MAP Appointment Service
- Mock data will be added to the `vets-api-mockdata` repository.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14991

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- Route(example: `'/health_quest/v0/appointments/132'` on the vets-api) will be tested on the staging environment in order to verify that it's pulling mock data from the vets-api-mockdata repository