### PR TITLE
API-1544: Report All Upstream Status Dependencies in our Healthchecks - Benefits Intake API

### DIFF
--- a/lib/central_mail/service.rb
+++ b/lib/central_mail/service.rb
@@ -59,8 +59,10 @@ module CentralMail
     def self.current_breaker_outage?
       last_cm_outage = Breakers::Outage.find_latest(service: CentralMail::Configuration.instance.breakers_service)
       if last_cm_outage.present? && last_cm_outage.end_time.blank?
-        CentralMail::Service.new.status('').try(:status) != 200
+        return CentralMail::Service.new.status('').try(:status) != 200
       end
+
+      false
     end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
@@ -71,10 +71,10 @@ module AppealsApi
       healthy = health_checker.healthy_service?(service_name)
 
       {
-        description: service_name.capitalize,
+        description: service_name.titleize,
         status: healthy ? 'UP' : 'DOWN',
         details: {
-          name: service_name.capitalize,
+          name: service_name.titleize,
           statusCode: healthy ? 200 : 503,
           status: healthy ? 'OK' : 'Unavailable',
           time: time

--- a/modules/vba_documents/config/routes.rb
+++ b/modules/vba_documents/config/routes.rb
@@ -4,6 +4,8 @@ VBADocuments::Engine.routes.draw do
   match '/metadata', to: 'metadata#index', via: [:get]
   match '/v0/healthcheck', to: 'metadata#healthcheck', via: [:get]
   match '/v1/healthcheck', to: 'metadata#healthcheck', via: [:get]
+  match '/v0/upstream_healthcheck', to: 'metadata#upstream_healthcheck', via: [:get]
+  match '/v1/upstream_healthcheck', to: 'metadata#upstream_healthcheck', via: [:get]
   match '/v0/*path', to: 'application#cors_preflight', via: [:options]
   match '/v1/*path', to: 'application#cors_preflight', via: [:options]
 

--- a/modules/vba_documents/lib/vba_documents/health_checker.rb
+++ b/modules/vba_documents/lib/vba_documents/health_checker.rb
@@ -28,7 +28,7 @@ module VBADocuments
     def central_mail_is_healthy?
       return @central_mail_healthy unless @central_mail_healthy.nil?
 
-      @caseflow_healthy = CentralMail::Service.current_breaker_outage?
+      @central_mail_healthy = !CentralMail::Service.current_breaker_outage?
     end
   end
 end

--- a/modules/vba_documents/lib/vba_documents/health_checker.rb
+++ b/modules/vba_documents/lib/vba_documents/health_checker.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'central_mail/service'
+
+module VBADocuments
+  class HealthChecker
+    SERVICES = %w[central_mail].freeze
+
+    def initialize
+      @central_mail_healthy = nil
+    end
+
+    def services_are_healthy?
+      central_mail_is_healthy?
+    end
+
+    def healthy_service?(service)
+      case service
+      when /central_mail/i
+        central_mail_is_healthy?
+      else
+        raise "VBADocuments::HealthChecker doesn't recognize #{service}"
+      end
+    end
+
+    private
+
+    def central_mail_is_healthy?
+      return @central_mail_healthy unless @central_mail_healthy.nil?
+
+      @caseflow_healthy = CentralMail::Service.current_breaker_outage?
+    end
+  end
+end

--- a/modules/vba_documents/spec/request/metadata_request_spec.rb
+++ b/modules/vba_documents/spec/request/metadata_request_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'VBA Documents Metadata Endpoint', type: :request do
 
     context 'v0' do
       it 'returns correct response and status when healthy' do
-        expect(CentralMail::Service).to receive(:current_breaker_outage?).at_least(:once).and_return(true)
+        allow(Breakers::Outage).to receive(:find_latest).and_return(nil)
         get '/services/vba_documents/v0/upstream_healthcheck'
         expect(response).to have_http_status(:ok)
 
@@ -70,7 +70,8 @@ RSpec.describe 'VBA Documents Metadata Endpoint', type: :request do
       end
 
       it 'returns correct status when central_mail is not healthy' do
-        expect(CentralMail::Service).to receive(:current_breaker_outage?).at_least(:once).and_return(false)
+        allow(Breakers::Outage).to receive(:find_latest).and_return(OpenStruct.new(start_time: Time.zone.now))
+        allow_any_instance_of(CentralMail::Service).to receive(:status).and_return(OpenStruct.new(status: 503))
         get '/services/vba_documents/v0/upstream_healthcheck'
         expect(response).to have_http_status(:service_unavailable)
 
@@ -94,7 +95,7 @@ RSpec.describe 'VBA Documents Metadata Endpoint', type: :request do
 
       context 'v1' do
         it 'returns correct response and status when healthy' do
-          expect(CentralMail::Service).to receive(:current_breaker_outage?).at_least(:once).and_return(true)
+          allow(Breakers::Outage).to receive(:find_latest).and_return(nil)
           get '/services/vba_documents/v1/upstream_healthcheck'
           expect(response).to have_http_status(:ok)
 
@@ -117,7 +118,8 @@ RSpec.describe 'VBA Documents Metadata Endpoint', type: :request do
         end
 
         it 'returns correct status when central_mail is not healthy' do
-          expect(CentralMail::Service).to receive(:current_breaker_outage?).at_least(:once).and_return(false)
+          allow(Breakers::Outage).to receive(:find_latest).and_return(OpenStruct.new(start_time: Time.zone.now))
+          allow_any_instance_of(CentralMail::Service).to receive(:status).and_return(OpenStruct.new(status: 503))
           get '/services/vba_documents/v1/upstream_healthcheck'
           expect(response).to have_http_status(:service_unavailable)
 

--- a/modules/vba_documents/spec/request/metadata_request_spec.rb
+++ b/modules/vba_documents/spec/request/metadata_request_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'vba_documents/health_checker'
 
 RSpec.describe 'VBA Documents Metadata Endpoint', type: :request do
   describe '#get /metadata' do
@@ -10,34 +11,165 @@ RSpec.describe 'VBA Documents Metadata Endpoint', type: :request do
     end
   end
 
-  context 'healthchecks' do
-    context 'V0' do
-      it 'returns correct response and status when healthy' do
-        get '/services/vba_documents/v0/healthcheck'
-        parsed_response = JSON.parse(response.body)
-        expect(response.status).to eq(200)
-        expect(parsed_response['data']['attributes']['healthy']).to eq(true)
-      end
+  # context 'healthchecks' do
+  #   context 'V0' do
+  #     it 'returns correct response and status when healthy' do
+  #       get '/services/vba_documents/v0/healthcheck'
+  #       parsed_response = JSON.parse(response.body)
+  #       expect(response.status).to eq(200)
+  #       expect(parsed_response['data']['attributes']['healthy']).to eq(true)
+  #     end
+  #
+  #     it 'returns correct status when not healthy' do
+  #       allow(CentralMail::Service).to receive(:current_breaker_outage?).and_return(true)
+  #       get '/services/vba_documents/v0/healthcheck'
+  #       expect(response.status).to eq(503)
+  #     end
+  #   end
+  #
+  #   context 'V1' do
+  #     it 'returns correct response and status when healthy' do
+  #       get '/services/vba_documents/v1/healthcheck'
+  #       parsed_response = JSON.parse(response.body)
+  #       expect(response.status).to eq(200)
+  #       expect(parsed_response['data']['attributes']['healthy']).to eq(true)
+  #     end
+  #
+  #     it 'returns correct status when not healthy' do
+  #       allow(CentralMail::Service).to receive(:current_breaker_outage?).and_return(true)
+  #       get '/services/vba_documents/v1/healthcheck'
+  #       expect(response.status).to eq(503)
+  #     end
+  #   end
+  # end
 
-      it 'returns correct status when not healthy' do
-        allow(CentralMail::Service).to receive(:current_breaker_outage?).and_return(true)
+  describe '#healthcheck' do
+    context 'v0' do
+      it 'returns a successful health check' do
         get '/services/vba_documents/v0/healthcheck'
-        expect(response.status).to eq(503)
+
+        parsed_response = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['description']).to eq('VBA Documents API health check')
+        expect(parsed_response['status']).to eq('UP')
+        expect(parsed_response['time']).not_to be_nil
       end
     end
 
-    context 'V1' do
-      it 'returns correct response and status when healthy' do
+    context 'v1' do
+      it 'returns a successful health check' do
         get '/services/vba_documents/v1/healthcheck'
+
         parsed_response = JSON.parse(response.body)
-        expect(response.status).to eq(200)
-        expect(parsed_response['data']['attributes']['healthy']).to eq(true)
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['description']).to eq('VBA Documents API health check')
+        expect(parsed_response['status']).to eq('UP')
+        expect(parsed_response['time']).not_to be_nil
+      end
+    end
+  end
+
+  describe '#upstream_healthcheck' do
+    before do
+      time = Time.utc(2020, 9, 21, 0, 0, 0)
+      Timecop.freeze(time)
+    end
+
+    after { Timecop.return }
+
+    context 'v0' do
+      it 'returns correct response and status when healthy' do
+        expect(CentralMail::Service).to receive(:current_breaker_outage?).at_least(:once).and_return(true)
+        get '/services/vba_documents/v0/upstream_healthcheck'
+        expect(response).to have_http_status(:ok)
+
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['description']).to eq('VBA Documents API upstream health check')
+        expect(parsed_response['status']).to eq('UP')
+        expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+
+        details = parsed_response['details']
+        expect(details['name']).to eq('All upstream services')
+
+        upstream_service = details['upstreamServices'].first
+        expect(details['upstreamServices'].size).to eq(1)
+        expect(upstream_service['description']).to eq('Central Mail')
+        expect(upstream_service['status']).to eq('UP')
+        expect(upstream_service['details']['name']).to eq('Central Mail')
+        expect(upstream_service['details']['statusCode']).to eq(200)
+        expect(upstream_service['details']['status']).to eq('OK')
+        expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
       end
 
-      it 'returns correct status when not healthy' do
-        allow(CentralMail::Service).to receive(:current_breaker_outage?).and_return(true)
-        get '/services/vba_documents/v1/healthcheck'
-        expect(response.status).to eq(503)
+      it 'returns correct status when central_mail is not healthy' do
+        expect(CentralMail::Service).to receive(:current_breaker_outage?).at_least(:once).and_return(false)
+        get '/services/vba_documents/v0/upstream_healthcheck'
+        expect(response).to have_http_status(:service_unavailable)
+
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['description']).to eq('VBA Documents API upstream health check')
+        expect(parsed_response['status']).to eq('DOWN')
+        expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+
+        details = parsed_response['details']
+        expect(details['name']).to eq('All upstream services')
+
+        upstream_service = details['upstreamServices'].first
+        expect(details['upstreamServices'].size).to eq(1)
+        expect(upstream_service['description']).to eq('Central Mail')
+        expect(upstream_service['status']).to eq('DOWN')
+        expect(upstream_service['details']['name']).to eq('Central Mail')
+        expect(upstream_service['details']['statusCode']).to eq(503)
+        expect(upstream_service['details']['status']).to eq('Unavailable')
+        expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
+      end
+
+      context 'v1' do
+        it 'returns correct response and status when healthy' do
+          expect(CentralMail::Service).to receive(:current_breaker_outage?).at_least(:once).and_return(true)
+          get '/services/vba_documents/v1/upstream_healthcheck'
+          expect(response).to have_http_status(:ok)
+
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['description']).to eq('VBA Documents API upstream health check')
+          expect(parsed_response['status']).to eq('UP')
+          expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+
+          details = parsed_response['details']
+          expect(details['name']).to eq('All upstream services')
+
+          upstream_service = details['upstreamServices'].first
+          expect(details['upstreamServices'].size).to eq(1)
+          expect(upstream_service['description']).to eq('Central Mail')
+          expect(upstream_service['status']).to eq('UP')
+          expect(upstream_service['details']['name']).to eq('Central Mail')
+          expect(upstream_service['details']['statusCode']).to eq(200)
+          expect(upstream_service['details']['status']).to eq('OK')
+          expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
+        end
+
+        it 'returns correct status when central_mail is not healthy' do
+          expect(CentralMail::Service).to receive(:current_breaker_outage?).at_least(:once).and_return(false)
+          get '/services/vba_documents/v1/upstream_healthcheck'
+          expect(response).to have_http_status(:service_unavailable)
+
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['description']).to eq('VBA Documents API upstream health check')
+          expect(parsed_response['status']).to eq('DOWN')
+          expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+
+          details = parsed_response['details']
+          expect(details['name']).to eq('All upstream services')
+
+          upstream_service = details['upstreamServices'].first
+          expect(details['upstreamServices'].size).to eq(1)
+          expect(upstream_service['description']).to eq('Central Mail')
+          expect(upstream_service['status']).to eq('DOWN')
+          expect(upstream_service['details']['name']).to eq('Central Mail')
+          expect(upstream_service['details']['statusCode']).to eq(503)
+          expect(upstream_service['details']['status']).to eq('Unavailable')
+          expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
+        end
       end
     end
   end

--- a/modules/vba_documents/spec/request/metadata_request_spec.rb
+++ b/modules/vba_documents/spec/request/metadata_request_spec.rb
@@ -11,38 +11,6 @@ RSpec.describe 'VBA Documents Metadata Endpoint', type: :request do
     end
   end
 
-  # context 'healthchecks' do
-  #   context 'V0' do
-  #     it 'returns correct response and status when healthy' do
-  #       get '/services/vba_documents/v0/healthcheck'
-  #       parsed_response = JSON.parse(response.body)
-  #       expect(response.status).to eq(200)
-  #       expect(parsed_response['data']['attributes']['healthy']).to eq(true)
-  #     end
-  #
-  #     it 'returns correct status when not healthy' do
-  #       allow(CentralMail::Service).to receive(:current_breaker_outage?).and_return(true)
-  #       get '/services/vba_documents/v0/healthcheck'
-  #       expect(response.status).to eq(503)
-  #     end
-  #   end
-  #
-  #   context 'V1' do
-  #     it 'returns correct response and status when healthy' do
-  #       get '/services/vba_documents/v1/healthcheck'
-  #       parsed_response = JSON.parse(response.body)
-  #       expect(response.status).to eq(200)
-  #       expect(parsed_response['data']['attributes']['healthy']).to eq(true)
-  #     end
-  #
-  #     it 'returns correct status when not healthy' do
-  #       allow(CentralMail::Service).to receive(:current_breaker_outage?).and_return(true)
-  #       get '/services/vba_documents/v1/healthcheck'
-  #       expect(response.status).to eq(503)
-  #     end
-  #   end
-  # end
-
   describe '#healthcheck' do
     context 'v0' do
       it 'returns a successful health check' do


### PR DESCRIPTION
## Description of change
Brings current vba_documents healthcheck inline with current healthcheck standards and ensures consumers of this API know the status of its various dependencies as well as this specific service health.

## Original issue(s)
https://vajira.max.gov/browse/API-1544

## Things to know about this PR
This does change the functionality of the existing healthcheck endpoint. Previously it would present as down if any of this service's dependencies were down. That endpoint will still present up even if one of the downstream dependencies is down. This change includes a new endpoint, "upstream_healthcheck," which will present as down if any upstream dependencies are down and includes additional information about those dependencies.

Interacted with endpoints locally.
Updated specs to resolve existing tests and include new tests for the new endpoint.
