### PR TITLE
Revert extra CSRF token Rails logging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,9 +46,7 @@ class ApplicationController < ActionController::API
   attr_reader :current_user
 
   def set_csrf_header
-    token = form_authenticity_token
-    response.set_header('X-CSRF-Token', token)
-    Rails.logger.info('CSRF response token', csrf_token: token)
+    response.set_header('X-CSRF-Token', form_authenticity_token)
   end
 
   def saml_settings(options = {})


### PR DESCRIPTION
## Description of change
This reverts the logging introduced in #4148

## Original issue(s)
#4148

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
