### PR TITLE
Delegate code ownership to the mobile API team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,5 @@ spec/support/*/vaos/                 @department-of-veterans-affairs/vfs-vaos @d
 lib/bgs @department-of-veterans-affairs/vfs-ebenefits @department-of-veterans-affairs/backend-review-group
 spec/bgs @department-of-veterans-affairs/vfs-ebenefits @department-of-veterans-affairs/backend-review-group
 
-modules/mobile/                      @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/backend-review-group
-spec/support/*/mobile/               @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/backend-review-group
+modules/mobile/                      @department-of-veterans-affairs/mobile-api-team
+spec/support/*/mobile/               @department-of-veterans-affairs/mobile-api-team


### PR DESCRIPTION
## Description of change
Delegates code ownership of the /mobile module to the [mobile API team](https://github.com/orgs/department-of-veterans-affairs/teams/mobile-api-team), thus no longer requiring the backend-review-group to approve PRs within this dir. **This will allow our team to move faster when working on non-shared code.** This is a continuation of #5010 which added the mobile api team but did not make them the exclusive codeowners of /mobile.

