### PR TITLE
adding key and cert to hqva_mobile

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -555,7 +555,8 @@ va_mobile:
 hqva_mobile:
   url: "https://veteran.apps.va.gov"
   mock: true
-  key_path: /fake/client/key/path
+  cert_path: config/certs/vetsgov-localhost.crt
+  key_path: config/certs/vetsgov-localhost.key
   timeout: 15
 
 lighthouse:


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Added cert and key access to config/settings.yml for the `hqva_mobile` section

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14991

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14991

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
When querying mock appointment data, the vets-api is returning an error message because the proper key/cert info is not set under the `hqva_mobile` section in the config/settings.yml file. An example of a failing URI would be `localhost:3000/health_quest/v0/appointments/123123` This PR adds a cert/key to the settings, resolving the current problem.

Mock appointment data will be returned from all environments until the backend API for returning live appointment data is configured.

<!-- Please describe testing done to verify the changes or any testing planned. -->
This will be tested/verified by the FE team when the code is merged back into master.