### PR TITLE
Update lookup_veteran_from_mvi to mpi

### DIFF
--- a/app/workers/structured_data/process_data_job.rb
+++ b/app/workers/structured_data/process_data_job.rb
@@ -19,7 +19,7 @@ module StructuredData
         @claim = SavedClaim.find(saved_claim_id)
 
         relationship_type = @claim.parsed_form['relationship']&.fetch('type', nil)
-        veteran = BipClaims::Service.new.lookup_veteran_from_mvi(@claim)
+        veteran = BipClaims::Service.new.lookup_veteran_from_mpi(@claim)
       ensure
         @claim.process_attachments! # upload claim and attachments to Central Mail
 

--- a/lib/bip_claims/service.rb
+++ b/lib/bip_claims/service.rb
@@ -33,7 +33,7 @@ module BipClaims
       )
     end
 
-    def lookup_veteran_from_mvi(claim)
+    def lookup_veteran_from_mpi(claim)
       veteran = MVI::AttrService.new.find_profile(veteran_attributes(claim))
       if veteran.profile&.participant_id
         StatsD.increment("#{STATSD_KEY_PREFIX}.mvi_lookup_hit")

--- a/spec/jobs/structured_data/process_data_job_spec.rb
+++ b/spec/jobs/structured_data/process_data_job_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe StructuredData::ProcessDataJob, uploader_helpers: true do
 
     before do
       allow(BipClaims::Service).to receive(:new).and_return(bip_claims)
-      allow(bip_claims).to receive(:lookup_veteran_from_mvi).and_return(
+      allow(bip_claims).to receive(:lookup_veteran_from_mpi).and_return(
         OpenStruct.new(participant_id: 123)
       )
     end
 
     it 'attempts Veteran MVI lookup' do
-      expect(bip_claims).to receive(:lookup_veteran_from_mvi).with(claim).and_return(
+      expect(bip_claims).to receive(:lookup_veteran_from_mpi).with(claim).and_return(
         OpenStruct.new(participant_id: 123)
       )
       job.perform(claim.id)

--- a/spec/lib/bip_claims/service_spec.rb
+++ b/spec/lib/bip_claims/service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe BipClaims::Service do
       )
       expect(mvi_service).to receive(:find_profile)
 
-      service.lookup_veteran_from_mvi(claim)
+      service.lookup_veteran_from_mpi(claim)
     end
   end
 end


### PR DESCRIPTION
## Description of change
Renames lookup_veteran_from_mvi to lookup_veteran_from_mpi in lib/bip_claims/service.rb as part of the renaming efforts for the Master Person Index.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14787

## Testing 
- [x] Passing test suite locally 
