### PR TITLE
Remove HTTPI logs from CI output to make easier to read output

### DIFF
--- a/config/initializers/httpi.rb
+++ b/config/initializers/httpi.rb
@@ -2,3 +2,4 @@
 
 # since the httpclient gem uses its own certificate store, force HTTPI to use :net_http
 HTTPI.adapter = :net_http
+HTTPI.log = false


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
When I was working on another ticket, I was getting errors in my tests. When I went to Jenkins I saw a bunch of logs that were being output because of the HTTPI library. Those logs were not producing any value, rather making it harder to read and scroll through. This PR turns those logs off.

```bash
[2020-10-23T15:43:43.875Z] D, [2020-10-23T15:43:43.644290 #25] DEBUG -- : HTTPI /peer POST request to internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com (net_http)
[2020-10-23T15:43:43.875Z] .D, [2020-10-23T15:43:43.737761 #25] DEBUG -- : HTTPI /peer GET request to internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com (net_http)
[2020-10-23T15:43:43.875Z] D, [2020-10-23T15:43:43.745324 #25] DEBUG -- : HTTPI /peer POST request to internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com (net_http)
```