### PR TITLE
Catch nil birth dates in the mobile user serializer

### DIFF
--- a/modules/mobile/app/serializers/mobile/v0/user_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/user_serializer.rb
@@ -51,7 +51,7 @@ module Mobile
           middle_name: user.middle_name,
           last_name: user.last_name,
           email: user.email,
-          birth_date: Date.parse(user.birth_date).iso8601,
+          birth_date: user.birth_date.nil? ? nil : Date.parse(user.birth_date).iso8601,
           gender: user.gender,
           residential_address: filter_keys(user.vet360_contact_info&.residential_address, ADDRESS_KEYS),
           mailing_address: filter_keys(user.vet360_contact_info&.mailing_address, ADDRESS_KEYS),

--- a/modules/mobile/spec/request/user_request_spec.rb
+++ b/modules/mobile/spec/request/user_request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'user', type: :request do
     context 'with no upstream errors' do
       before { get '/mobile/v0/user', headers: iam_headers }
 
-      let(:attributes) { JSON.parse(response.body).dig('data', 'attributes') }
+      let(:attributes) { response.parsed_body.dig('data', 'attributes') }
 
       it 'returns an ok response' do
         expect(response).to have_http_status(:ok)
@@ -34,6 +34,12 @@ RSpec.describe 'user', type: :request do
       it 'includes the users email' do
         expect(attributes['profile']).to include(
           'email' => 'va.api.user+idme.008@gmail.com'
+        )
+      end
+
+      it 'includes the users birth date' do
+        expect(attributes['profile']).to include(
+          'birthDate' => '1970-08-12'
         )
       end
 
@@ -138,6 +144,20 @@ RSpec.describe 'user', type: :request do
             userProfileUpdate
           ]
         )
+      end
+
+      context 'when user object birth_date is nil' do
+        before do
+          allow_any_instance_of(IAMUserIdentity).to receive(:birth_date).and_return(nil)
+          get '/mobile/v0/user', headers: iam_headers
+        end
+
+        it 'returns a nil birthdate' do
+          expect(response).to have_http_status(:ok)
+          expect(attributes['profile']).to include(
+            'birthDate' => nil
+          )
+        end
       end
 
       context 'with a user who does not have access to evss' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Some test users have nil birth dates in their provider traits. Since MPI dev is mocked out with staging data looking them up by the IAM dev ICN doesn't return a result and the birth date remains nil and throws an error.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15292

## Things to know about this PR
testing done: local integration tests
testing planned: dev/staging integration tests
