### PR TITLE
Form526 exhausted metric

### DIFF
--- a/app/workers/evss/disability_compensation_form/job_status.rb
+++ b/app/workers/evss/disability_compensation_form/job_status.rb
@@ -14,7 +14,7 @@ module EVSS
         #
         # @param msg [Hash] The message payload from Sidekiq
         #
-        def job_exhausted(msg)
+        def job_exhausted(msg, statsd_key_prefix)
           values = {
             form526_submission_id: msg['args'].first,
             job_id: msg['jid'],
@@ -32,7 +32,7 @@ module EVSS
                                  error_class: msg['error_class'],
                                  error_message: msg['error_message']
           )
-          Metrics.new(STATSD_KEY_PREFIX).increment_exhausted
+          Metrics.new(statsd_key_prefix).increment_exhausted
         rescue => e
           Rails.logger.error('error tracking job exhausted', error: e, class: msg['class'].demodulize)
         end

--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -16,7 +16,7 @@ module EVSS
       # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
       # :nocov:
       sidekiq_retries_exhausted do |msg, _ex|
-        job_exhausted(msg)
+        job_exhausted(msg, STATSD_KEY_PREFIX)
       end
       # :nocov:
 

--- a/spec/jobs/evss/disability_compensation_form/job_status_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/job_status_spec.rb
@@ -17,7 +17,8 @@ describe EVSS::DisabilityCompensationForm::JobStatus do
     end
 
     it 'tracks an exhausted job' do
-      dummy_class.job_exhausted(msg)
+      expect_any_instance_of(EVSS::DisabilityCompensationForm::Metrics).to receive(:increment_exhausted)
+      dummy_class.job_exhausted(msg, 'stats_key')
       job_status = Form526JobStatus.last
       expect(job_status.status).to eq 'exhausted'
       expect(job_status.job_class).to eq 'SubmitForm526AllClaim'


### PR DESCRIPTION
## Description of change
in the logs we saw 
`{"host":"05086feeefd7","application":"vets-api-worker","timestamp":"2020-01-16T13:14:54.841379Z","level":"error","level_index":4,"pid":10,"thread":"47034767190920","file":"/srv/vets-api/src/app/workers/evss/disability_compensation_form/job_status.rb","line":39,"name":"Rails","message":"error tracking job exhausted","payload":{"error":"uninitialized constant EVSS::DisabilityCompensationForm::JobStatus::STATSD_KEY_PREFIX","class":"Class"}}`

and no exhausted metrics [this graph](http://grafana.vfs.va.gov/d/000000066/evss-526-submissions?viewPanel=8&orgId=1)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15307

