### PR TITLE
Update serializer type to use new mpi acronym

### DIFF
--- a/modules/openid_auth/app/serializers/openid_auth/mpi_lookup_serializer.rb
+++ b/modules/openid_auth/app/serializers/openid_auth/mpi_lookup_serializer.rb
@@ -2,7 +2,7 @@
 
 module OpenidAuth
   class MPILookupSerializer < ActiveModel::Serializer
-    type 'user-mvi-icn'
+    type 'user-mpi-icn'
 
     def id
       object.profile.icn


### PR DESCRIPTION
## Description of change
OpenidAuth::MPILookupSerializer (formerly OpenidAuth::MviLookupSerializer) uses the type 'user-mvi-icn'. This PR is renaming the type to 'user-mpi-icn' and doesn't have any downstream effects.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14794

## Testing
- [x] Test suite passing locally
