### PR TITLE
API-2936: autoCestPDFGenerationDisabled is not in 526 POST dev portal docs

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/forms/form_526_example.json
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_526_example.json
@@ -31,6 +31,7 @@
       }
     ],
     "standardClaim": false,
+    "autoCestPDFGenerationDisabled": false,
     "applicationExpirationDate": "2015-08-28T19:53:45+00:00",
     "serviceInformation": {
       "servicePeriods": [
@@ -41,7 +42,7 @@
         },
         {
           "activeDutyEndDate": "1999-01-01",
-          "serviceBranch": "Air Force Reserve",
+          "serviceBranch": "Air Force Reserves",
           "activeDutyBeginDate": "1990-04-05"
         }
       ]


### PR DESCRIPTION
## Description of change
Fixes auto-generated curl for 526 POST on https://developer.va.gov/explore/benefits/docs/claims?version=current

## Original issue(s)
https://vajira.max.gov/browse/API-2936

## Things to know about this PR
This will require deployment of swagger docs to developer.va.gov 

Tested creating a 526 claim locally.
