### PR TITLE
Update rakefile to use MPIData

### DIFF
--- a/rakelib/mvi.rake
+++ b/rakelib/mvi.rake
@@ -67,8 +67,8 @@ middle_name="W" last_name="Smith" birth_date="1945-01-25" gender="M" ssn="555443
             # Not persisting any users, user_identities, or caching MVI by doing it this way.
             user = User.new(uuid: user_identity.uuid)
             user.instance_variable_set(:@identity, user_identity)
-            mvi = Mvi.for_user(user)
-            response = mvi.send(:mvi_service).find_profile(user_identity)
+            mpi = MPIData.for_user(user)
+            response = mpi.send(:mpi_service).find_profile(user_identity)
 
             appended_headers.each do |column_name|
               case column_name


### PR DESCRIPTION
##  Description of change
This updates an mvi rakefile task to use the new MPIData model instead of the former. 


