### PR TITLE
[15381] Fix returnUrl for Financial Status Report form

### DIFF
--- a/app/models/form_profiles/va5655.rb
+++ b/app/models/form_profiles/va5655.rb
@@ -5,7 +5,7 @@ class FormProfiles::VA5655 < FormProfile
     {
       version: 0,
       prefill: true,
-      returnUrl: '/5655/applicant/information'
+      returnUrl: '/veteran-information'
     }
   end
 end


### PR DESCRIPTION
## Description of change
Fixes the `returnUrl` so end user can progress through the FSR form.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15381
