### PR TITLE
[department-of-veterans-affairs/orchid#139] Adding admin user emails for access to flipper feature toggles on staging

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -531,6 +531,11 @@ flipper:
     - tony.williams@va.gov
     - jennie.mcgibney@va.gov
     - adewitt@thoughtworks.com
+    - shefai.nayak@thoughtworks.com
+    - jacob.gacek@thoughtworks.com
+    - paul.phillips@thoughtworks.com
+    - marknunemaker@thoughtworks.com
+    - hshin@thoughtworks.com
     - callen@governmentcio.com # Remove after Profile 2.0 UAT
     - matt.shea@adhocteam.us # Remove after Profile 2.0 UAT
     - tressa.furner@adhocteam.us # Remove after Profile 2.0 UAT


### PR DESCRIPTION


<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
We are adding additional developer emails in order to have access to enable and disable our feature toggle `get_help_ask_form`

## Original issue(s)
department-of-veterans-affairs/orchid#139

## Things to know about this PR
* Are there additions to a `settings.yml` file? Do they vary by environment? Yes for admin access to feature toggles
* Is there a feature flag? What is it? Yes, `get_help_ask_form` 
* Is there some Sentry logging that was added? What alerts are relevant? No
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do? No
* Are there Swagger docs that were updated? No
* Is there any PII concerns or questions? No


<!-- Please describe testing done to verify the changes or any testing planned. -->
