### PR TITLE
Removes Sentry tracing from SAML POST binding form

### DIFF
--- a/lib/saml/templates/sso_post_form.html.erb
+++ b/lib/saml/templates/sso_post_form.html.erb
@@ -2,11 +2,6 @@
 <head>
   <meta charset="utf-8">
   <title>VA.gov sign-in</title>
-  <script
-    src="https://browser.sentry-cdn.com/5.24.2/bundle.tracing.min.js"
-    integrity="sha384-Epltozh7S1cJM2hcIRDJBbqiiVpZsNlFCciHxKIAfKN8mSTa+gMivtz7glp/30Mz"
-    crossorigin="anonymous"
-    ></script>
 </head>
 
 <body>
@@ -28,14 +23,6 @@
   <% end %>
 
   <script>
-    if (typeof(Sentry) != 'undefined' && "<%= sentrydsn %>") {
-      Sentry.init({
-        dsn: "<%= sentrydsn %>",
-        integrations: [new Sentry.Integrations.BrowserTracing()],
-      });
-      /* extra tag so we can easily search for any errors in Sentry */
-      Sentry.setTag("page", "SSOe-Post-Binding-Form");
-    }
     (function() {
       var req = new XMLHttpRequest();
       var qs = "id=" + encodeURIComponent("<%= id %>") +


### PR DESCRIPTION
Sentry bundle is causing JS execution issues on IE in compatibility
mode. This removes the Sentry tracing (which is not providing any useful
hits) while we investigate further.

