### PR TITLE
Suggestion for Creates provider state for contact us pact

### DIFF
--- a/spec/service_consumers/provider_states_for/contact_us.rb
+++ b/spec/service_consumers/provider_states_for/contact_us.rb
@@ -2,10 +2,6 @@
 
 Pact.provider_states_for 'Contact Us' do
   provider_state 'minimum required data' do
-    set_up do
-    end
-
-    tear_down do
-    end
+    no_op # nothing to setup or tear down
   end
 end


### PR DESCRIPTION
After approving this PR https://github.com/department-of-veterans-affairs/vets-api/pull/5173, I learned there's a cleaner way to do no provider states.
@jgacek we'll close this if you don't need it, but I just wished I had offered this to you yesterday when I was reviewing it but didn't learn until it was too late.
https://docs.pact.io/implementation_guides/ruby/provider_states/#ruby