### PR TITLE
[15526] Add filenumber/ssn to 5655 form prefill

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,10 +57,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 009e0f2249c6400296713ddb0d0339317517f725
+  revision: 1a499b7154f60c7d1acc86d34e395b5db6deed82
   branch: master
   specs:
-    vets_json_schema (17.3.0)
+    vets_json_schema (17.3.1)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,10 +57,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: cbb673d117186c9ccb94aad7df849618b238d82d
+  revision: 009e0f2249c6400296713ddb0d0339317517f725
   branch: master
   specs:
-    vets_json_schema (17.2.0)
+    vets_json_schema (17.3.0)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 1a499b7154f60c7d1acc86d34e395b5db6deed82
+  revision: 1c9be5900ac22aebff26afbb15ac262cdb122f69
   branch: master
   specs:
     vets_json_schema (17.3.1)

--- a/app/models/form_profiles/va5655.rb
+++ b/app/models/form_profiles/va5655.rb
@@ -8,4 +8,13 @@ class FormProfiles::VA5655 < FormProfile
       returnUrl: '/veteran-information'
     }
   end
+
+  private
+
+  def va_file_number_last_four
+    (
+      BGS::PeopleService.new(user).find_person_by_participant_id[:file_nbr].presence ||
+      user.ssn.presence
+    )&.last(4)
+  end
 end

--- a/config/form_profile_mappings/5655.yml
+++ b/config/form_profile_mappings/5655.yml
@@ -1,3 +1,6 @@
+personalIdentification:
+  sSN: [identity_information, ssn_last_four]
+  fileNumber: [va_file_number_last_four]
 personalData:
   fullName: [identity_information, full_name]
   address: [contact_information, address]

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -582,6 +582,10 @@ RSpec.describe FormProfile, type: :model do
 
   let(:v5655_expected) do
     {
+      'personalIdentification' => {
+        'sSN' => user.ssn.last(4),
+        'fileNumber' => '7890'
+      },
       'personalData' => {
         'fullName' => full_name,
         'address' => address,

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -830,6 +830,12 @@ RSpec.describe FormProfile, type: :model do
     end
 
     context 'with a user that can prefill financial status report' do
+      before do
+        allow_any_instance_of(BGS::PeopleService).to(
+          receive(:find_person_by_participant_id).and_return({ file_nbr: '1234567890' })
+        )
+      end
+
       it 'returns a prefilled 5655 form' do
         expect_prefilled('5655')
       end


### PR DESCRIPTION
## Description of change
- Adds last four digits of fileNumber and SSN to the form prefill

## Associated Schema Change PR
https://github.com/department-of-veterans-affairs/vets-json-schema/pull/540

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15526

## Things to know about this PR
Tested locally
