### PR TITLE
update PDF to camel case

### DIFF
--- a/app/services/bgs/dependent_service.rb
+++ b/app/services/bgs/dependent_service.rb
@@ -16,7 +16,7 @@ module BGS
       vet_info = VetInfo.new(@user, bgs_person)
 
       BGS::SubmitForm686cJob.perform_async(@user.uuid, claim.id, vet_info.to_686c_form_hash)
-      VBMS::SubmitDependentsPDFJob.perform_async(claim.id, vet_info.to_686c_form_hash)
+      VBMS::SubmitDependentsPdfJob.perform_async(claim.id, vet_info.to_686c_form_hash)
     rescue => e
       report_error(e)
     end

--- a/app/workers/vbms/submit_dependents_pdf_job.rb
+++ b/app/workers/vbms/submit_dependents_pdf_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module VBMS
-  class SubmitDependentsPDFJob
+  class SubmitDependentsPdfJob
     class Invalid686cClaim < StandardError; end
     include Sidekiq::Worker
     include SentryLogging

--- a/spec/services/bgs/dependent_service_spec.rb
+++ b/spec/services/bgs/dependent_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe BGS::DependentService do
       VCR.use_cassette('bgs/dependent_service/submit_686c_form') do
         service = BGS::DependentService.new(user)
 
-        expect(VBMS::SubmitDependentsPDFJob).to receive(:perform_async).with(claim.id, vet_info)
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(claim.id, vet_info)
 
         service.submit_686c_form(claim)
       end

--- a/spec/workers/vbms/submit_dependents_pdf_job_spec.rb
+++ b/spec/workers/vbms/submit_dependents_pdf_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe VBMS::SubmitDependentsPDFJob do
+RSpec.describe VBMS::SubmitDependentsPdfJob do
   let(:invalid_dependency_claim) { create(:dependency_claim_no_vet_information) }
   let(:dependency_claim) { create(:dependency_claim) }
   let(:vet_info) do
@@ -45,7 +45,7 @@ RSpec.describe VBMS::SubmitDependentsPDFJob do
         job = described_class.new
 
         expect(job).to receive(:send_error_to_sentry).with(
-          an_instance_of(VBMS::SubmitDependentsPDFJob::Invalid686cClaim),
+          an_instance_of(VBMS::SubmitDependentsPdfJob::Invalid686cClaim),
           an_instance_of(Integer)
         )
 


### PR DESCRIPTION


## Description of change
Some new classes were recently added using PDF. Previous investigation of inflections had determined not to inflect it. This PR updates SubmitDependentsPDFJob and other classes using the acronym to the camelcase version (Pdf)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15531

## Testing
- [x] Passing test suite
