### PR TITLE
API-3070: Report All Upstream Status Dependencies in our Healthchecks - Claims API

### DIFF
--- a/modules/appeals_api/spec/requests/metadata_request_spec.rb
+++ b/modules/appeals_api/spec/requests/metadata_request_spec.rb
@@ -100,54 +100,54 @@ RSpec.describe 'Appeals Metadata Endpoint', type: :request do
           expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
         end
       end
+    end
 
-      context 'v1' do
-        it 'returns correct response and status when healthy' do
-          VCR.use_cassette('caseflow/health-check') do
-            get '/services/appeals/v1/upstream_healthcheck'
-            expect(response).to have_http_status(:ok)
+    context 'v1' do
+      it 'returns correct response and status when healthy' do
+        VCR.use_cassette('caseflow/health-check') do
+          get '/services/appeals/v1/upstream_healthcheck'
+          expect(response).to have_http_status(:ok)
 
-            parsed_response = JSON.parse(response.body)
-            expect(parsed_response['description']).to eq('Appeals API upstream health check')
-            expect(parsed_response['status']).to eq('UP')
-            expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['description']).to eq('Appeals API upstream health check')
+          expect(parsed_response['status']).to eq('UP')
+          expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
 
-            details = parsed_response['details']
-            expect(details['name']).to eq('All upstream services')
+          details = parsed_response['details']
+          expect(details['name']).to eq('All upstream services')
 
-            upstream_service = details['upstreamServices'].first
-            expect(details['upstreamServices'].size).to eq(1)
-            expect(upstream_service['description']).to eq('Caseflow')
-            expect(upstream_service['status']).to eq('UP')
-            expect(upstream_service['details']['name']).to eq('Caseflow')
-            expect(upstream_service['details']['statusCode']).to eq(200)
-            expect(upstream_service['details']['status']).to eq('OK')
-            expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
-          end
+          upstream_service = details['upstreamServices'].first
+          expect(details['upstreamServices'].size).to eq(1)
+          expect(upstream_service['description']).to eq('Caseflow')
+          expect(upstream_service['status']).to eq('UP')
+          expect(upstream_service['details']['name']).to eq('Caseflow')
+          expect(upstream_service['details']['statusCode']).to eq(200)
+          expect(upstream_service['details']['status']).to eq('OK')
+          expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
         end
+      end
 
-        it 'returns correct status when caseflow is not healthy' do
-          VCR.use_cassette('caseflow/health-check-down') do
-            get '/services/appeals/v1/upstream_healthcheck'
-            expect(response).to have_http_status(:service_unavailable)
+      it 'returns correct status when caseflow is not healthy' do
+        VCR.use_cassette('caseflow/health-check-down') do
+          get '/services/appeals/v1/upstream_healthcheck'
+          expect(response).to have_http_status(:service_unavailable)
 
-            parsed_response = JSON.parse(response.body)
-            expect(parsed_response['description']).to eq('Appeals API upstream health check')
-            expect(parsed_response['status']).to eq('DOWN')
-            expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['description']).to eq('Appeals API upstream health check')
+          expect(parsed_response['status']).to eq('DOWN')
+          expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
 
-            details = parsed_response['details']
-            expect(details['name']).to eq('All upstream services')
+          details = parsed_response['details']
+          expect(details['name']).to eq('All upstream services')
 
-            upstream_service = details['upstreamServices'].first
-            expect(details['upstreamServices'].size).to eq(1)
-            expect(upstream_service['description']).to eq('Caseflow')
-            expect(upstream_service['status']).to eq('DOWN')
-            expect(upstream_service['details']['name']).to eq('Caseflow')
-            expect(upstream_service['details']['statusCode']).to eq(503)
-            expect(upstream_service['details']['status']).to eq('Unavailable')
-            expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
-          end
+          upstream_service = details['upstreamServices'].first
+          expect(details['upstreamServices'].size).to eq(1)
+          expect(upstream_service['description']).to eq('Caseflow')
+          expect(upstream_service['status']).to eq('DOWN')
+          expect(upstream_service['details']['name']).to eq('Caseflow')
+          expect(upstream_service['details']['statusCode']).to eq(503)
+          expect(upstream_service['details']['status']).to eq('Unavailable')
+          expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
         end
       end
     end

--- a/modules/claims_api/app/controllers/claims_api/metadata_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/metadata_controller.rb
@@ -32,40 +32,45 @@ module ClaimsApi
     end
 
     def healthcheck
-      if ClaimsApi::HealthChecker.services_are_healthy?
-        render json: healthy_service_response
-      else
-        render json: unhealthy_service_response,
-               status: :service_unavailable
-      end
+      render json: {
+        description: 'Claims API health check',
+        status: 'UP',
+        time: Time.zone.now.to_formatted_s(:iso8601)
+      }
+    end
+
+    def upstream_healthcheck
+      health_checker = ClaimsApi::HealthChecker.new
+      time = Time.zone.now.to_formatted_s(:iso8601)
+
+      render json: {
+        description: 'Claims API upstream health check',
+        status: health_checker.services_are_healthy? ? 'UP' : 'DOWN',
+        time: time,
+        details: {
+          name: 'All upstream services',
+          upstreamServices: ClaimsApi::HealthChecker::SERVICES.map do |service|
+                              upstream_service_details(service, health_checker, time)
+                            end
+        }
+      }, status: health_checker.services_are_healthy? ? 200 : 503
     end
 
     private
 
-    def healthy_service_response
-      {
-        data: {
-          id: 'claims_healthcheck',
-          type: 'claims_healthcheck',
-          attributes: {
-            healthy: true,
-            date: Time.zone.now.to_formatted_s(:iso8601)
-          }
-        }
-      }.to_json
-    end
+    def upstream_service_details(service_name, health_checker, time)
+      healthy = health_checker.healthy_service?(service_name)
 
-    def unhealthy_service_response
       {
-        errors: [
-          {
-            title: 'ClaimsAPI Unavailable',
-            detail: 'ClaimsAPI is currently unavailable.',
-            code: '503',
-            status: '503'
-          }
-        ]
-      }.to_json
+        description: service_name.upcase,
+        status: healthy ? 'UP' : 'DOWN',
+        details: {
+          name: service_name.upcase,
+          statusCode: healthy ? 200 : 503,
+          status: healthy ? 'OK' : 'Unavailable',
+          time: time
+        }
+      }
     end
   end
 end

--- a/modules/claims_api/config/routes.rb
+++ b/modules/claims_api/config/routes.rb
@@ -4,6 +4,8 @@ ClaimsApi::Engine.routes.draw do
   match '/metadata', to: 'metadata#index', via: [:get]
   match '/v0/healthcheck', to: 'metadata#healthcheck', via: [:get]
   match '/v1/healthcheck', to: 'metadata#healthcheck', via: [:get]
+  match '/v0/upstream_healthcheck', to: 'metadata#upstream_healthcheck', via: [:get]
+  match '/v1/upstream_healthcheck', to: 'metadata#upstream_healthcheck', via: [:get]
   match '/v0/*path', to: 'application#cors_preflight', via: [:options]
   match '/v1/*path', to: 'application#cors_preflight', via: [:options]
 

--- a/modules/claims_api/lib/claims_api/health_checker.rb
+++ b/modules/claims_api/lib/claims_api/health_checker.rb
@@ -6,32 +6,57 @@ require 'evss/service'
 
 module ClaimsApi
   class HealthChecker
+    SERVICES = %w[evss mpi bgs vbms].freeze
     BGS_WSDL = "#{Settings.bgs.url}/VetRecordServiceBean/VetRecordWebService?WSDL"
 
-    def self.services_are_healthy?
+    def initialize
+      @evss_healthy = nil
+      @mpi_healthy = nil
+      @bgs_healthy = nil
+      @vbms_healthy = nil
+    end
+
+    def services_are_healthy?
       # TODO: we should add check for Okta and SAML Proxies being up as well
       mpi_is_healthy? && evss_is_healthy? && bgs_is_healthy? && vbms_is_healthy?
     end
 
-    def self.evss_is_healthy?
-      Settings.evss.mock_claims || EVSS::Service.service_is_up?
+    def healthy_service?(service)
+      case service
+      when /evss/i
+        evss_is_healthy?
+      when /mpi/i
+        mpi_is_healthy?
+      when /bgs/i
+        bgs_is_healthy?
+      when /vbms/i
+        vbms_is_healthy?
+      else
+        raise "ClaimsApi::HealthChecker doesn't recognize #{service}"
+      end
     end
 
-    def self.mpi_is_healthy?
-      Settings.mvi.mock || MVI::Service.service_is_up?
+    private
+
+    def evss_is_healthy?
+      @evss_healthy = Settings.evss.mock_claims || EVSS::Service.service_is_up?
     end
 
-    def self.bgs_is_healthy?
+    def mpi_is_healthy?
+      @mpi_healthy = Settings.mvi.mock || MVI::Service.service_is_up?
+    end
+
+    def bgs_is_healthy?
       service = BGS::Services.new(
         external_uid: 'healthcheck_uid',
         external_key: 'healthcheck_key'
       )
-      service.vet_record.healthy?
+      @bgs_healthy = service.vet_record.healthy?
     end
 
-    def self.vbms_is_healthy?
+    def vbms_is_healthy?
       response = Faraday.get(Settings.vbms.url)
-      response.status == 200
+      @vbms_healthy = response.status == 200
     end
   end
 end

--- a/modules/claims_api/spec/lib/health_checker_spec.rb
+++ b/modules/claims_api/spec/lib/health_checker_spec.rb
@@ -7,47 +7,48 @@ require 'mvi/service'
 describe ClaimsApi::HealthChecker do
   describe 'something' do
     it 'returns correct response and status when healthy' do
-      allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
-      allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
-      allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
-      allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
-      expect(ClaimsApi::HealthChecker.services_are_healthy?).to eq(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
+      expect(ClaimsApi::HealthChecker.new.services_are_healthy?).to eq(true)
     end
 
     it 'returns correct status when evss is not healthy' do
-      allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
-      allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
-      allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
-      allow(Breakers::Outage).to receive(:find_latest).and_return(OpenStruct.new(start_time: Time.zone.now))
-      expect(ClaimsApi::HealthChecker.services_are_healthy?).to eq(false)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
+      allow(Breakers::Outage).to receive(:find_latest)
+        .and_return(OpenStruct.new(start_time: Time.zone.now))
+      expect(ClaimsApi::HealthChecker.new.services_are_healthy?).to eq(false)
     end
 
     it 'returns correct status when mpi is not healthy' do
-      allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
-      allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
-      allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
       allow(MVI::Service).to receive(:service_is_up?).and_return(false)
-      expect(ClaimsApi::HealthChecker.services_are_healthy?).to eq(false)
+      expect(ClaimsApi::HealthChecker.new.services_are_healthy?).to eq(false)
     end
 
     it 'returns correct status when vbms is not healthy' do
-      allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
-      allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
-      allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
       # VBMS does not have upper level access yet, just return true
       # allow(Faraday).to receive(:get).and_return(OpenStruct.new(status: 503))
-      allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(false)
-      expect(ClaimsApi::HealthChecker.services_are_healthy?).to eq(false)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(false)
+      expect(ClaimsApi::HealthChecker.new.services_are_healthy?).to eq(false)
     end
 
     it 'returns correct status when bgs is not healthy' do
-      allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
-      allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
-      allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
       # BGS does not have upper level access yet, just return true
       # allow(Faraday).to receive(:get).and_return(OpenStruct.new(status: 503))
-      allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(false)
-      expect(ClaimsApi::HealthChecker.services_are_healthy?).to eq(false)
+      allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(false)
+      expect(ClaimsApi::HealthChecker.new.services_are_healthy?).to eq(false)
     end
   end
 end

--- a/modules/claims_api/spec/requests/metadata_request_spec.rb
+++ b/modules/claims_api/spec/requests/metadata_request_spec.rb
@@ -13,27 +13,17 @@ RSpec.describe 'Claims Status Metadata Endpoint', type: :request do
   end
 
   describe '#healthcheck' do
-    context 'v0' do
-      it 'returns a successful health check' do
-        get '/services/claims/v0/healthcheck'
+    %w[v0 v1].each do |version|
+      context version do
+        it 'returns a successful health check' do
+          get "/services/claims/#{version}/healthcheck"
 
-        parsed_response = JSON.parse(response.body)
-        expect(response).to have_http_status(:ok)
-        expect(parsed_response['description']).to eq('Claims API health check')
-        expect(parsed_response['status']).to eq('UP')
-        expect(parsed_response['time']).not_to be_nil
-      end
-    end
-
-    context 'v1' do
-      it 'returns a successful health check' do
-        get '/services/claims/v1/healthcheck'
-
-        parsed_response = JSON.parse(response.body)
-        expect(response).to have_http_status(:ok)
-        expect(parsed_response['description']).to eq('Claims API health check')
-        expect(parsed_response['status']).to eq('UP')
-        expect(parsed_response['time']).not_to be_nil
+          parsed_response = JSON.parse(response.body)
+          expect(response).to have_http_status(:ok)
+          expect(parsed_response['description']).to eq('Claims API health check')
+          expect(parsed_response['status']).to eq('UP')
+          expect(parsed_response['time']).not_to be_nil
+        end
       end
     end
   end
@@ -46,31 +36,68 @@ RSpec.describe 'Claims Status Metadata Endpoint', type: :request do
 
     after { Timecop.return }
 
-    context 'v0' do
-      it 'returns correct response and status when healthy' do
-        allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
-        allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
-        allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
-        allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
-        get '/services/claims/v0/upstream_healthcheck'
-        expect(response).to have_http_status(:ok)
+    %w[v0 v1].each do |version|
+      context version do
+        it 'returns correct response and status when healthy' do
+          allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
+          allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
+          allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
+          allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
+          get "/services/claims/#{version}/upstream_healthcheck"
+          expect(response).to have_http_status(:ok)
 
-        parsed_response = JSON.parse(response.body)
-        expect(parsed_response['description']).to eq('Claims API upstream health check')
-        expect(parsed_response['status']).to eq('UP')
-        expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['description']).to eq('Claims API upstream health check')
+          expect(parsed_response['status']).to eq('UP')
+          expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
 
-        details = parsed_response['details']
-        expect(details['name']).to eq('All upstream services')
+          details = parsed_response['details']
+          expect(details['name']).to eq('All upstream services')
 
-        expect(details['upstreamServices'].size).to eq(4)
-        details['upstreamServices'].each do |upstream_service|
-          expect(upstream_service['description']).to be_in(ClaimsApi::HealthChecker::SERVICES.map(&:upcase))
-          expect(upstream_service['status']).to eq('UP')
-          expect(upstream_service['details']['name']).to be_in(ClaimsApi::HealthChecker::SERVICES.map(&:upcase))
-          expect(upstream_service['details']['statusCode']).to eq(200)
-          expect(upstream_service['details']['status']).to eq('OK')
-          expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
+          expect(details['upstreamServices'].size).to eq(4)
+          details['upstreamServices'].each do |upstream_service|
+            expect(upstream_service['description']).to be_in(ClaimsApi::HealthChecker::SERVICES.map(&:upcase))
+            expect(upstream_service['status']).to eq('UP')
+            expect(upstream_service['details']['name']).to be_in(ClaimsApi::HealthChecker::SERVICES.map(&:upcase))
+            expect(upstream_service['details']['statusCode']).to eq(200)
+            expect(upstream_service['details']['status']).to eq('OK')
+            expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
+          end
+        end
+
+        ClaimsApi::HealthChecker::SERVICES.each do |upstream_service|
+          it "returns correct status when #{upstream_service} is not healthy" do
+            allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?)
+              .and_return(upstream_service != 'evss')
+            allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?)
+              .and_return(upstream_service != 'mpi')
+            allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?)
+              .and_return(upstream_service != 'bgs')
+            allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?)
+              .and_return(upstream_service != 'vbms')
+            get "/services/claims/#{version}/upstream_healthcheck"
+            expect(response).to have_http_status(:service_unavailable)
+
+            parsed_response = JSON.parse(response.body)
+            expect(parsed_response['description']).to eq('Claims API upstream health check')
+            expect(parsed_response['status']).to eq('DOWN')
+            expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+
+            details = parsed_response['details']
+            expect(details['name']).to eq('All upstream services')
+
+            expect(details['upstreamServices'].size).to eq(4)
+            details['upstreamServices'].each do |service_response|
+              service_under_test = service_response['description'] == upstream_service.upcase
+
+              expect(service_response['description']).to be_in(ClaimsApi::HealthChecker::SERVICES.map(&:upcase))
+              expect(service_response['status']).to eq(service_under_test ? 'DOWN' : 'UP')
+              expect(service_response['details']['name']).to be_in(ClaimsApi::HealthChecker::SERVICES.map(&:upcase))
+              expect(service_response['details']['statusCode']).to eq(service_under_test ? 503 : 200)
+              expect(service_response['details']['status']).to eq(service_under_test ? 'Unavailable' : 'OK')
+              expect(service_response['details']['time']).to eq('2020-09-21T00:00:00Z')
+            end
+          end
         end
       end
     end

--- a/modules/claims_api/spec/requests/metadata_request_spec.rb
+++ b/modules/claims_api/spec/requests/metadata_request_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'claims_api/health_checker'
 
 RSpec.describe 'Claims Status Metadata Endpoint', type: :request do
   describe '#get /metadata' do
@@ -11,96 +12,66 @@ RSpec.describe 'Claims Status Metadata Endpoint', type: :request do
     end
   end
 
-  context 'healthchecks' do
+  describe '#healthcheck' do
     context 'v0' do
-      it 'returns correct response and status when healthy' do
-        allow(ClaimsApi::HealthChecker).to receive(:services_are_healthy?).and_return(true)
+      it 'returns a successful health check' do
         get '/services/claims/v0/healthcheck'
+
         parsed_response = JSON.parse(response.body)
-        expect(response.status).to eq(200)
-        expect(parsed_response['data']['attributes']['healthy']).to eq(true)
-      end
-
-      it 'returns correct status when evss is not healthy' do
-        allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(false)
-        get '/services/claims/v0/healthcheck'
-        expect(response.status).to eq(503)
-      end
-
-      it 'returns correct status when mpi is not healthy' do
-        allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(false)
-        get '/services/claims/v0/healthcheck'
-        expect(response.status).to eq(503)
-      end
-
-      it 'returns correct status when vbms is not healthy' do
-        allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(false)
-        get '/services/claims/v0/healthcheck'
-        expect(response.status).to eq(503)
-      end
-
-      it 'returns correct status when bgs is not healthy' do
-        allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(false)
-        get '/services/claims/v0/healthcheck'
-        expect(response.status).to eq(503)
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['description']).to eq('Claims API health check')
+        expect(parsed_response['status']).to eq('UP')
+        expect(parsed_response['time']).not_to be_nil
       end
     end
 
     context 'v1' do
-      it 'returns correct response and status when healthy' do
-        allow(ClaimsApi::HealthChecker).to receive(:services_are_healthy?).and_return(true)
+      it 'returns a successful health check' do
         get '/services/claims/v1/healthcheck'
+
         parsed_response = JSON.parse(response.body)
-        expect(response.status).to eq(200)
-        expect(parsed_response['data']['attributes']['healthy']).to eq(true)
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['description']).to eq('Claims API health check')
+        expect(parsed_response['status']).to eq('UP')
+        expect(parsed_response['time']).not_to be_nil
       end
+    end
+  end
 
-      it 'returns correct status when evss is not healthy' do
-        allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(false)
-        get '/services/claims/v1/healthcheck'
-        expect(response.status).to eq(503)
-      end
+  describe '#upstream_healthcheck' do
+    before do
+      time = Time.utc(2020, 9, 21, 0, 0, 0)
+      Timecop.freeze(time)
+    end
 
-      it 'returns correct status when mpi is not healthy' do
-        allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(false)
-        get '/services/claims/v1/healthcheck'
-        expect(response.status).to eq(503)
-      end
+    after { Timecop.return }
 
-      it 'returns correct status when vbms is not healthy' do
-        allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(false)
-        get '/services/claims/v1/healthcheck'
-        expect(response.status).to eq(503)
-      end
+    context 'v0' do
+      it 'returns correct response and status when healthy' do
+        allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
+        allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
+        allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(true)
+        allow_any_instance_of(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
+        get '/services/claims/v0/upstream_healthcheck'
+        expect(response).to have_http_status(:ok)
 
-      it 'returns correct status when bgs is not healthy' do
-        allow(ClaimsApi::HealthChecker).to receive(:evss_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:mpi_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:vbms_is_healthy?).and_return(true)
-        allow(ClaimsApi::HealthChecker).to receive(:bgs_is_healthy?).and_return(false)
-        get '/services/claims/v1/healthcheck'
-        expect(response.status).to eq(503)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['description']).to eq('Claims API upstream health check')
+        expect(parsed_response['status']).to eq('UP')
+        expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+
+        details = parsed_response['details']
+        expect(details['name']).to eq('All upstream services')
+
+        expect(details['upstreamServices'].size).to eq(4)
+        details['upstreamServices'].each do |upstream_service|
+          expect(upstream_service['description']).to be_in(ClaimsApi::HealthChecker::SERVICES.map(&:upcase))
+          expect(upstream_service['status']).to eq('UP')
+          expect(upstream_service['details']['name']).to be_in(ClaimsApi::HealthChecker::SERVICES.map(&:upcase))
+          expect(upstream_service['details']['statusCode']).to eq(200)
+          expect(upstream_service['details']['status']).to eq('OK')
+          expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
+        end
       end
     end
   end

--- a/modules/vba_documents/spec/request/metadata_request_spec.rb
+++ b/modules/vba_documents/spec/request/metadata_request_spec.rb
@@ -92,54 +92,54 @@ RSpec.describe 'VBA Documents Metadata Endpoint', type: :request do
         expect(upstream_service['details']['status']).to eq('Unavailable')
         expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
       end
+    end
 
-      context 'v1' do
-        it 'returns correct response and status when healthy' do
-          allow(Breakers::Outage).to receive(:find_latest).and_return(nil)
-          get '/services/vba_documents/v1/upstream_healthcheck'
-          expect(response).to have_http_status(:ok)
+    context 'v1' do
+      it 'returns correct response and status when healthy' do
+        allow(Breakers::Outage).to receive(:find_latest).and_return(nil)
+        get '/services/vba_documents/v1/upstream_healthcheck'
+        expect(response).to have_http_status(:ok)
 
-          parsed_response = JSON.parse(response.body)
-          expect(parsed_response['description']).to eq('VBA Documents API upstream health check')
-          expect(parsed_response['status']).to eq('UP')
-          expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['description']).to eq('VBA Documents API upstream health check')
+        expect(parsed_response['status']).to eq('UP')
+        expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
 
-          details = parsed_response['details']
-          expect(details['name']).to eq('All upstream services')
+        details = parsed_response['details']
+        expect(details['name']).to eq('All upstream services')
 
-          upstream_service = details['upstreamServices'].first
-          expect(details['upstreamServices'].size).to eq(1)
-          expect(upstream_service['description']).to eq('Central Mail')
-          expect(upstream_service['status']).to eq('UP')
-          expect(upstream_service['details']['name']).to eq('Central Mail')
-          expect(upstream_service['details']['statusCode']).to eq(200)
-          expect(upstream_service['details']['status']).to eq('OK')
-          expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
-        end
+        upstream_service = details['upstreamServices'].first
+        expect(details['upstreamServices'].size).to eq(1)
+        expect(upstream_service['description']).to eq('Central Mail')
+        expect(upstream_service['status']).to eq('UP')
+        expect(upstream_service['details']['name']).to eq('Central Mail')
+        expect(upstream_service['details']['statusCode']).to eq(200)
+        expect(upstream_service['details']['status']).to eq('OK')
+        expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
+      end
 
-        it 'returns correct status when central_mail is not healthy' do
-          allow(Breakers::Outage).to receive(:find_latest).and_return(OpenStruct.new(start_time: Time.zone.now))
-          allow_any_instance_of(CentralMail::Service).to receive(:status).and_return(OpenStruct.new(status: 503))
-          get '/services/vba_documents/v1/upstream_healthcheck'
-          expect(response).to have_http_status(:service_unavailable)
+      it 'returns correct status when central_mail is not healthy' do
+        allow(Breakers::Outage).to receive(:find_latest).and_return(OpenStruct.new(start_time: Time.zone.now))
+        allow_any_instance_of(CentralMail::Service).to receive(:status).and_return(OpenStruct.new(status: 503))
+        get '/services/vba_documents/v1/upstream_healthcheck'
+        expect(response).to have_http_status(:service_unavailable)
 
-          parsed_response = JSON.parse(response.body)
-          expect(parsed_response['description']).to eq('VBA Documents API upstream health check')
-          expect(parsed_response['status']).to eq('DOWN')
-          expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['description']).to eq('VBA Documents API upstream health check')
+        expect(parsed_response['status']).to eq('DOWN')
+        expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
 
-          details = parsed_response['details']
-          expect(details['name']).to eq('All upstream services')
+        details = parsed_response['details']
+        expect(details['name']).to eq('All upstream services')
 
-          upstream_service = details['upstreamServices'].first
-          expect(details['upstreamServices'].size).to eq(1)
-          expect(upstream_service['description']).to eq('Central Mail')
-          expect(upstream_service['status']).to eq('DOWN')
-          expect(upstream_service['details']['name']).to eq('Central Mail')
-          expect(upstream_service['details']['statusCode']).to eq(503)
-          expect(upstream_service['details']['status']).to eq('Unavailable')
-          expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
-        end
+        upstream_service = details['upstreamServices'].first
+        expect(details['upstreamServices'].size).to eq(1)
+        expect(upstream_service['description']).to eq('Central Mail')
+        expect(upstream_service['status']).to eq('DOWN')
+        expect(upstream_service['details']['name']).to eq('Central Mail')
+        expect(upstream_service['details']['statusCode']).to eq(503)
+        expect(upstream_service['details']['status']).to eq('Unavailable')
+        expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
       end
     end
   end


### PR DESCRIPTION
## Description of change
Brings current claims healthcheck inline with current healthcheck standards and ensures consumers of this API know the status of its various dependencies as well as this specific service health.

## Original issue(s)
https://vajira.max.gov/browse/API-3070

## Things to know about this PR
This does change the functionality of the existing healthcheck endpoint. Previously it would present as down if any of this service's dependencies were down. That endpoint will still present up even if one of the downstream dependencies is down. This change includes a new endpoint, "upstream_healthcheck," which will present as down if any upstream dependencies are down and includes additional information about those dependencies.

Interacted with endpoints locally.
Updated specs to resolve existing tests and include new tests for the new endpoint.