### PR TITLE
Increase appeals timeout

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -332,7 +332,7 @@ caseflow:
   mock: true
   app_token: PUBLICDEMO123
   host: https://dsva-appeals-certification-dev-1895622301.us-gov-west-1.elb.amazonaws.com
-  timeout: 20
+  timeout: 40
 
 vic:
   url: https://some.fakesite.com

--- a/spec/lib/caseflow/configuration_spec.rb
+++ b/spec/lib/caseflow/configuration_spec.rb
@@ -19,7 +19,7 @@ describe Caseflow::Configuration do
   describe '.read_timeout' do
     context 'when Settings.mvi.timeout is set' do
       it 'uses the setting' do
-        expect(Caseflow::Configuration.instance.read_timeout).to eq(20)
+        expect(Caseflow::Configuration.instance.read_timeout).to eq(40)
       end
     end
   end


### PR DESCRIPTION
## Description of change
At peak traffic, 97/requests an hour are slower than 20s but average request time is about 700 ms.  Caseflow makes a series of requests to externals services and the more data there is the longer it takes. 

http://grafana.vfs.va.gov/d/000000035/appeals-status?viewPanel=13&orgId=1&from=now-14d&to=now
![Screen Shot 2020-10-30 at 11 47 43 AM](https://user-images.githubusercontent.com/19188/97726686-de833980-1aa5-11eb-90fd-b4a6821c8f04.png)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000
