### PR TITLE
[API 3200] PDF Header Missing Consumer Name

### DIFF
--- a/modules/appeals_api/config/schemas/200996_headers.json
+++ b/modules/appeals_api/config/schemas/200996_headers.json
@@ -13,7 +13,8 @@
         "X-VA-Birth-Date": { "$ref": "#/definitions/X-VA-Birth-Date" },
         "X-VA-File-Number": { "$ref": "#/definitions/X-VA-File-Number" },
         "X-VA-Service-Number": { "$ref": "#/definitions/X-VA-Service-Number" },
-        "X-VA-Insurance-Policy-Number": { "$ref": "#/definitions/X-VA-Insurance-Policy-Number" }
+        "X-VA-Insurance-Policy-Number": { "$ref": "#/definitions/X-VA-Insurance-Policy-Number" },
+        "X-Consumer-Username": { "$ref": "#/definitions/X-Consumer-Username" }
       },
       "additionalProperties": false,
       "required": [
@@ -73,6 +74,12 @@
       "allOf": [
         { "description": "veteran's insurance policy number" },
         { "$ref": "#/definitions/nonBlankStringMaxLength18" }
+      ]
+    },
+    "X-Consumer-Username": {
+      "allOf": [
+        { "description": "Consumer User Name (passed from Kong)" },
+        { "$ref": "#/definitions/nonBlankString" }
       ]
     },
     "nonBlankString": {


### PR DESCRIPTION
## Description of change
This PR fixes a bug where consumer user name was not interpolated in the stamp on the HLR generated PDF. 

## Original issue(s)
[PDF Header Missing Consumer Name](https://vajira.max.gov/browse/API-3200)

## Discussion 

The headers method inside of `HigherLevelReviewsController` stripped `X-Consumer-Username` from the headers stored in the HLR due to `X-Consumer-Username` being missing from `200996_headers.json`. 

```
 def headers
    HEADERS.reduce({}) do |acc, header_key|
      header_value = request.headers[header_key]

      header_value.nil? ? acc : acc.merge({ header_key => header_value })
    end
  end
```

I added `X-Consumer-Username` to `200996._headers.json` which should allow `X-Consumer-Username` to persist into the HLR model and be retrieved when stamping the PDF. 
