### PR TITLE
EDU: Add logging to spool file processing #14967

### DIFF
--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -10,6 +10,9 @@ module EducationForm
   class FormattingError < StandardError
   end
 
+  class DailySpoolFileLogging < StandardError
+  end
+
   class DailySpoolFileError < StandardError
   end
 
@@ -141,7 +144,6 @@ module EducationForm
     # Useful for debugging which records were or were not sent over successfully,
     # in case of network failures.
     def log_submissions(records, filename)
-      binding.pry
       ids = records.map { |r| r.record.id }
       log_info("Writing #{records.count} application(s) to #{filename}")
       log_info("IDs: #{ids}")
@@ -165,7 +167,7 @@ module EducationForm
 
     def log_info(message)
       if Flipper.enabled?(:sidekiq_create_daily_spool_file_logging)
-        log_exception_to_sentry(message)
+        log_exception_to_sentry(DailySpoolFileLogging.new(message))
       else
         logger.info(message)
       end

--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -119,8 +119,7 @@ module EducationForm
     end
 
     def inform_on_error(claim, region, error = nil)
-      form_type = "22-#{claim.form_type}"
-      StatsD.increment("worker.education_benefits_claim.failed_formatting.#{region}.#{form_type}")
+      StatsD.increment("worker.education_benefits_claim.failed_formatting.#{region}.22-#{claim.form_type}")
       exception = if error.present?
                     FormattingError.new("Could not format #{claim.confirmation_number}.\n\n#{error}")
                   else

--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -165,11 +165,7 @@ module EducationForm
     end
 
     def log_info(message)
-      if Flipper.enabled?(:sidekiq_create_daily_spool_file_logging)
-        log_exception_to_sentry(DailySpoolFileLogging.new(message))
-      else
-        logger.info(message)
-      end
+      log_exception_to_sentry(DailySpoolFileLogging.new(message), {}, {}, :info)
     end
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -301,3 +301,7 @@ features:
     enable_in_development: true
     description: >
       Updates to the daily education reports to remove old data that isn't needed in the new fiscal year
+  sidekiq_create_daily_spool_file_logging:
+    actor_type: user
+    description: >
+      Flips all info logging for create_daily_spool_files to be error for debugging purposes

--- a/config/features.yml
+++ b/config/features.yml
@@ -301,7 +301,3 @@ features:
     enable_in_development: true
     description: >
       Updates to the daily education reports to remove old data that isn't needed in the new fiscal year
-  sidekiq_create_daily_spool_file_logging:
-    actor_type: user
-    description: >
-      Flips all info logging for create_daily_spool_files to be error for debugging purposes

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
     FileUtils.remove_dir('tmp/spool_files')
   end
 
-  context 'scheduling' do 
+  context 'scheduling' do
     before do
       Flipper.disable('sidekiq_create_daily_spool_file_logging')
       allow(Rails.env).to receive('development?').and_return(true)
@@ -197,6 +197,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
   context 'write_files', run_at: '2016-09-17 03:00:00 EDT' do
     let(:filename) { '307_09172016_070000_vetsgov.spl' }
     let!(:second_record) { FactoryBot.create(:va1995) }
+
     before do
       Flipper.disable('sidekiq_create_daily_spool_file_logging')
     end

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -52,8 +52,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
 
     it 'logs a message on holidays', run_at: '2017-01-02 03:00:00 EDT' do
       expect(subject).not_to receive(:write_files)
-      expect(subject).to receive(:log_exception_to_sentry)
-                             .with("Skipping on a Holiday: New Year's Day", any_args).at_least(:once)
+      expect(subject).to receive('log_info').with("Skipping on a Holiday: New Year's Day")
       expect(subject.perform).to be false
     end
 
@@ -124,7 +123,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
       end
 
       it 'processes the valid messages' do
-        expect(subject).to receive(:log_exception_to_sentry).twice
+        expect(subject).to receive(:log_exception_to_sentry).at_least(:once)
         expect { subject.perform }.to change { EducationBenefitsClaim.unprocessed.count }.from(4).to(1)
         expect(Dir[spool_files].count).to eq(2)
       end
@@ -137,7 +136,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
 
       it 'prints a statement and exits', run_at: '2017-02-21 00:00:00 EDT' do
         expect(subject).not_to receive(:write_files)
-        expect(subject).to receive(:log_exception_to_sentry).with('No records to process.', any_args).at_least(:once)
+        expect(subject).to receive('log_info').with('No records to process.').once
         expect(subject.perform).to be(true)
       end
     end

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
 
   context 'scheduling' do
     before do
-      Flipper.disable('sidekiq_create_daily_spool_file_logging')
       allow(Rails.env).to receive('development?').and_return(true)
     end
 
@@ -66,10 +65,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
   end
 
   context '#format_application' do
-    before do
-      Flipper.disable('sidekiq_create_daily_spool_file_logging')
-    end
-
     it 'logs an error if the record is invalid' do
       application_1606.saved_claim.form = {}.to_json
       application_1606.saved_claim.save!(validate: false)
@@ -111,10 +106,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
   end
 
   context '#perform' do
-    before do
-      Flipper.disable('sidekiq_create_daily_spool_file_logging')
-    end
-
     context 'with a mix of valid and invalid record', run_at: '2016-09-16 03:00:00 EDT' do
       let(:spool_files) { Rails.root.join('tmp', 'spool_files', '*') }
 
@@ -152,10 +143,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
   end
 
   context '#group_submissions_by_region' do
-    before do
-      Flipper.disable('sidekiq_create_daily_spool_file_logging')
-    end
-
     it 'takes a list of records into chunked forms' do
       base_form = {
         veteranFullName: {
@@ -197,10 +184,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
   context 'write_files', run_at: '2016-09-17 03:00:00 EDT' do
     let(:filename) { '307_09172016_070000_vetsgov.spl' }
     let!(:second_record) { FactoryBot.create(:va1995) }
-
-    before do
-      Flipper.disable('sidekiq_create_daily_spool_file_logging')
-    end
 
     context 'in the development env' do
       let(:file_path) { "tmp/spool_files/#{filename}" }

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
     FileUtils.remove_dir('tmp/spool_files')
   end
 
-  context 'scheduling' do
+  context 'scheduling' do 
     before do
+      Flipper.disable('sidekiq_create_daily_spool_file_logging')
       allow(Rails.env).to receive('development?').and_return(true)
     end
 
@@ -65,6 +66,10 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
   end
 
   context '#format_application' do
+    before do
+      Flipper.disable('sidekiq_create_daily_spool_file_logging')
+    end
+
     it 'logs an error if the record is invalid' do
       application_1606.saved_claim.form = {}.to_json
       application_1606.saved_claim.save!(validate: false)
@@ -106,6 +111,10 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
   end
 
   context '#perform' do
+    before do
+      Flipper.disable('sidekiq_create_daily_spool_file_logging')
+    end
+
     context 'with a mix of valid and invalid record', run_at: '2016-09-16 03:00:00 EDT' do
       let(:spool_files) { Rails.root.join('tmp', 'spool_files', '*') }
 
@@ -143,6 +152,10 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
   end
 
   context '#group_submissions_by_region' do
+    before do
+      Flipper.disable('sidekiq_create_daily_spool_file_logging')
+    end
+
     it 'takes a list of records into chunked forms' do
       base_form = {
         veteranFullName: {
@@ -184,6 +197,9 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
   context 'write_files', run_at: '2016-09-17 03:00:00 EDT' do
     let(:filename) { '307_09172016_070000_vetsgov.spl' }
     let!(:second_record) { FactoryBot.create(:va1995) }
+    before do
+      Flipper.disable('sidekiq_create_daily_spool_file_logging')
+    end
 
     context 'in the development env' do
       let(:file_path) { "tmp/spool_files/#{filename}" }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Changing prometheus stat `worker_education_benefits_claim_failed_formatting` to be `worker_education_benefits_claim_failed_formatting_<region_id>_22_<type>`
-  Adding a `rescue` to code that writes data to the spool file for each region, other files will still be created

```
        rescue => error
          exception = SpoolWriteError.new("Error creating #{filename}.\n\n#{error}")
          log_exception_to_sentry(exception)
``` 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14967

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
