### PR TITLE
Provide a Way to Access All Active BIRLS IDs (MPI lib)

### DIFF
--- a/lib/mvi/models/mvi_profile.rb
+++ b/lib/mvi/models/mvi_profile.rb
@@ -25,6 +25,7 @@ module MVI
       attribute :edipi, String
       attribute :participant_id, String
       attribute :birls_id, String
+      attribute :birls_ids, Array[String]
       attribute :sec_id, String
       attribute :vet360_id, String
       attribute :historical_icns, Array[String]

--- a/lib/mvi/responses/id_parser.rb
+++ b/lib/mvi/responses/id_parser.rb
@@ -49,7 +49,7 @@ module MVI
 
       def parse(ids)
         ids = ids.map(&:attributes)
-        {
+        result = {
           icn: select_ids(select_extension(ids, PERMANENT_ICN_REGEX, VA_ROOT_OID))&.first,
           sec_id: select_ids(select_extension(ids, /^\w+\^PN\^200PROV\^USDVA\^A$/, VA_ROOT_OID))&.first,
           mhv_ids: select_ids(select_extension(ids, /^\w+\^PI\^200MH.{0,1}\^\w+\^\w+$/, VA_ROOT_OID)),
@@ -59,10 +59,12 @@ module MVI
           vha_facility_ids: select_facilities(select_extension(ids, /^\w+\^PI\^\w+\^USVHA\^\w+$/, VA_ROOT_OID)),
           cerner_facility_ids: select_facilities(select_extension(ids, /^\w+\^PI\^\w+\^USVHA\^C$/, VA_ROOT_OID)),
           cerner_id: select_ids(select_extension(ids, /^\w+\^PI\^200CRNR\^US\w+\^A$/, VA_ROOT_OID))&.first,
-          birls_id: select_ids(select_extension(ids, /^\w+\^PI\^200BRLS\^USVBA\^A$/, VA_ROOT_OID))&.first,
+          birls_ids: birls_ids(ids),
           vet360_id: select_ids(select_extension(ids, /^\w+\^PI\^200VETS\^USDVA\^A$/, VA_ROOT_OID))&.first,
           icn_with_aaid: ICNWithAAIDParser.new(full_icn_with_aaid(ids)).without_id_status
         }
+        result[:birls_id] = result[:birls_ids].first
+        result
       end
 
       def select_ids_with_extension(ids, pattern, root)
@@ -70,6 +72,10 @@ module MVI
       end
 
       private
+
+      def birls_ids(ids)
+        select_ids(select_extension(ids, /^\w+\^PI\^200BRLS\^USVBA\^A$/, VA_ROOT_OID)) || []
+      end
 
       def select_ids(extensions)
         return nil if extensions.empty?

--- a/lib/mvi/responses/profile_parser.rb
+++ b/lib/mvi/responses/profile_parser.rb
@@ -89,6 +89,7 @@ module MVI
           vha_facility_ids: parsed_mvi_ids[:vha_facility_ids],
           sec_id: parsed_mvi_ids[:sec_id],
           birls_id: sanitize_birls_id(parsed_mvi_ids[:birls_id]),
+          birls_ids: parsed_mvi_ids[:birls_ids].map { |id| sanitize_birls_id(id) }.compact,
           vet360_id: parsed_mvi_ids[:vet360_id],
           historical_icns: MVI::Responses::HistoricalIcnParser.new(@original_body).get_icns,
           icn_with_aaid: parsed_mvi_ids[:icn_with_aaid],

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -63,7 +63,9 @@ FactoryBot.define do
     active_mhv_ids { mhv_ids }
     edipi { Faker::Number.number(digits: 10) }
     participant_id { Faker::Number.number(digits: 10) }
-    birls_id { Faker::Number.number(digits: 10) }
+    birls = [Faker::Number.number(digits: 10)]
+    birls_id { birls.first }
+    birls_ids { birls }
     vet360_id { '123456789' }
     sec_id { '0001234567' }
     historical_icns { %w[1000123457V123456 1000123458V123456] }
@@ -97,7 +99,9 @@ FactoryBot.define do
       vha_facility_ids { %w[516 553 200HD 200IP 200MHV] }
       edipi { '1234567890' }
       participant_id { '12345678' }
-      birls_id { '796122306' }
+      birls = ['796122306']
+      birls_id { birls.first }
+      birls_ids { birls }
       vet360_id { '123456789' }
 
       trait :missing_attrs do
@@ -108,6 +112,8 @@ FactoryBot.define do
         ssn { '796122306' }
         home_phone { nil }
         icn { '1008714701V416111' }
+        birls_id { nil }
+        birls_ids { [] }
         mhv_ids { nil }
         active_mhv_ids { nil }
         vha_facility_ids { ['200MHS'] }
@@ -130,7 +136,9 @@ FactoryBot.define do
         vha_facility_ids { %w[200MH 200MH] }
         edipi { '1122334455' }
         participant_id { '12345678' }
-        birls_id { '123412345' }
+        birls = ['123412345']
+        birls_id { birls.first }
+        birls_ids { birls }
         vet360_id { nil }
       end
 

--- a/spec/lib/mvi/responses/id_parser_spec.rb
+++ b/spec/lib/mvi/responses/id_parser_spec.rb
@@ -17,6 +17,18 @@ describe MVI::Responses::IdParser do
       end
     end
 
+    context 'BIRLS' do
+      let(:birls_ids) do
+        [correlation_id('987654321^PI^200BRLS^USVBA^A'),
+         correlation_id('123456789^PI^200BRLS^USVBA^A')]
+      end
+
+      it 'finds all BIRLS IDs' do
+        expect(MVI::Responses::IdParser.new.parse(birls_ids)[:birls_ids]).to eq ['987654321','123456789']
+        expect(MVI::Responses::IdParser.new.parse(birls_ids)[:birls_id]).to eq '987654321'
+      end
+    end
+
     context 'icn_with_aaid' do
       let(:non_icn_id) { 'TKIP123456^PI^200IP^USVHA^A' }
 

--- a/spec/lib/mvi/responses/id_parser_spec.rb
+++ b/spec/lib/mvi/responses/id_parser_spec.rb
@@ -24,7 +24,7 @@ describe MVI::Responses::IdParser do
       end
 
       it 'finds all BIRLS IDs' do
-        expect(MVI::Responses::IdParser.new.parse(birls_ids)[:birls_ids]).to eq ['987654321','123456789']
+        expect(MVI::Responses::IdParser.new.parse(birls_ids)[:birls_ids]).to eq %w[987654321 123456789]
         expect(MVI::Responses::IdParser.new.parse(birls_ids)[:birls_id]).to eq '987654321'
       end
     end

--- a/spec/lib/mvi/responses/profile_parser_spec.rb
+++ b/spec/lib/mvi/responses/profile_parser_spec.rb
@@ -26,6 +26,7 @@ describe MVI::Responses::ProfileParser do
           :mvi_profile_response,
           :address_austin,
           birls_id: nil,
+          birls_ids: [],
           sec_id: nil,
           historical_icns: nil,
           search_token: 'WSDOC1609131753362231779394902'
@@ -45,6 +46,7 @@ describe MVI::Responses::ProfileParser do
             given_names: nil,
             suffix: nil,
             birls_id: nil,
+            birls_ids: [],
             sec_id: nil,
             historical_icns: nil,
             search_token: 'WSDOC1609131753362231779394902'
@@ -64,6 +66,7 @@ describe MVI::Responses::ProfileParser do
             :mvi_profile_response,
             address: nil,
             birls_id: nil,
+            birls_ids: [],
             sec_id: nil,
             historical_icns: nil,
             vet360_id: nil,
@@ -96,6 +99,8 @@ describe MVI::Responses::ProfileParser do
             :mvi_profile_response,
             :missing_attrs,
             :address_austin,
+            birls_id: '796122306',
+            birls_ids: ['796122306'],
             sec_id: '1008714701',
             historical_icns: nil,
             mhv_ids: ['1100792239'],
@@ -211,8 +216,9 @@ describe MVI::Responses::ProfileParser do
         :mvi_profile_response,
         :address_austin,
         historical_icns: nil,
-        birls_id: nil,
         sec_id: nil,
+        birls_id: nil,
+        birls_ids: [],
         search_token: 'WSDOC1609131753362231779394902'
       )
     end

--- a/spec/lib/mvi/service_spec.rb
+++ b/spec/lib/mvi/service_spec.rb
@@ -27,6 +27,8 @@ describe MVI::Service do
       given_names: %w[Mitchell G],
       vha_facility_ids: [],
       sec_id: '1008714701',
+      birls_id: '796122306',
+      birls_ids: ['796122306'],
       historical_icns: nil,
       icn_with_aaid: icn_with_aaid,
       full_mvi_ids: [


### PR DESCRIPTION
MVI::Responses::IdParser's `#parse` method returns the first active BIRLS ID found in the MPI response, and ignores the rest. A veteran could possibly have multiple BIRLS IDs (although probably only one is valid). As a developer, I would like all the BIRLS IDs returned so I can find the right one.