### PR TITLE
526 has future expiration date

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -600,46 +600,8 @@ module EVSS
         end
       end
 
-      ###
-      # Date calculations
-      ###
-
       def application_expiration_date
-        return (rad_date + 1.day + 365.days).iso8601 if greater_rad_date?
-        return (application_create_date + 365.days).iso8601 if greater_itf_date?
-
-        itf.expiration_date.iso8601
-      end
-
-      def greater_rad_date?
-        rad_date.present? && rad_date > application_create_date
-      end
-
-      def greater_itf_date?
-        itf.creation_date.nil? || itf.expiration_date.nil? || itf.creation_date > application_create_date
-      end
-
-      def application_create_date
-        # Application create date is the date the user began their application
-        @acd ||= InProgressForm.where(form_id: FormProfiles::VA526ez::FORM_ID, user_uuid: @user.uuid)
-                               .first.created_at
-      end
-
-      def rad_date
-        # retrieve the most recent Release from Active Duty (RAD) date
-        return @rd if @rd
-
-        service_episodes = @user.military_information.service_episodes_by_date
-        @rd = Time.zone.parse(service_episodes.first&.end_date.to_s)
-      end
-
-      def itf
-        # retrieve the active intent to file for compensation
-        return @itf if @itf
-
-        service = EVSS::IntentToFile::Service.new(@user)
-        response = service.get_active('compensation')
-        @itf = response.intent_to_file
+        1.year.from_now.iso8601
       end
 
       ###

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -12,7 +12,11 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
 
   before do
     User.create(user)
+    frozen_time = Time.zone.parse '2020-11-05 13:19:50 -0500'
+    Timecop.freeze(frozen_time)
   end
+
+  after { Timecop.return }
 
   describe '#translate' do
     context 'all claims' do
@@ -27,10 +31,8 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
 
       it 'returns correctly formatted json to send to EVSS' do
         VCR.use_cassette('evss/ppiu/payment_information') do
-          VCR.use_cassette('evss/intent_to_file/active_compensation') do
-            VCR.use_cassette('emis/get_military_service_episodes/valid', allow_playback_repeats: true) do
-              expect(subject.translate).to eq JSON.parse(evss_json)
-            end
+          VCR.use_cassette('emis/get_military_service_episodes/valid', allow_playback_repeats: true) do
+            expect(subject.translate).to eq JSON.parse(evss_json)
           end
         end
       end
@@ -52,10 +54,8 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
 
       it 'returns correctly formatted json to send to EVSS' do
         VCR.use_cassette('evss/ppiu/payment_information') do
-          VCR.use_cassette('evss/intent_to_file/active_compensation') do
-            VCR.use_cassette('emis/get_military_service_episodes/valid', allow_playback_repeats: true) do
-              expect(subject.translate).to eq JSON.parse(evss_json)
-            end
+          VCR.use_cassette('emis/get_military_service_episodes/valid', allow_playback_repeats: true) do
+            expect(subject.translate).to eq JSON.parse(evss_json)
           end
         end
       end
@@ -1336,87 +1336,8 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
   end
 
   describe '#application_expiration_date' do
-    let(:past) { Time.zone.now - 1.month }
-    let(:now) { Time.zone.now }
-    let(:future) { Time.zone.now + 1.month }
-
-    context 'when the RAD date is more recent than the application creation date' do
-      before do
-        allow(subject).to receive(:application_create_date).and_return(past)
-        allow(subject).to receive(:rad_date).and_return(now)
-      end
-
-      it 'returns the RAD date + 366 days' do
-        return_date = (now + 366.days).iso8601
-        expect(subject.send(:application_expiration_date)).to eq return_date
-      end
-    end
-
-    context 'when the RAD date does not exist' do
-      before do
-        allow(subject).to receive(:rad_date).and_return(nil)
-      end
-
-      let!(:itf) do
-        EVSS::IntentToFile::IntentToFile.new(
-          'status' => 'active',
-          'type' => 'compensation',
-          'creation_date' => nil,
-          'expiration_date' => nil
-        )
-      end
-
-      context 'when the ITF creation date is nil' do
-        before do
-          allow(subject).to receive(:application_create_date).and_return(now)
-          allow(subject).to receive(:itf).and_return(itf)
-        end
-
-        it 'returns the application creation date + 365 days' do
-          return_date = (now + 365.days).iso8601
-          expect(subject.send(:application_expiration_date)).to eq return_date
-        end
-      end
-
-      context 'when the ITF expiration date is nil' do
-        before do
-          allow(subject).to receive(:application_create_date).and_return(now)
-          itf.creation_date = past
-          allow(subject).to receive(:itf).and_return(itf)
-        end
-
-        it 'returns the application creation date + 365 days' do
-          return_date = (now + 365.days).iso8601
-          expect(subject.send(:application_expiration_date)).to eq return_date
-        end
-      end
-
-      context 'when the ITF creation date is more recent than the application creation date' do
-        before do
-          allow(subject).to receive(:application_create_date).and_return(past)
-          itf.creation_date = now
-          itf.expiration_date = future
-          allow(subject).to receive(:itf).and_return(itf)
-        end
-
-        it 'returns the application creation date + 365 days' do
-          return_date = (past + 365.days).iso8601
-          expect(subject.send(:application_expiration_date)).to eq return_date
-        end
-      end
-
-      context 'when the ITF creation date isolder than the application creation date' do
-        before do
-          allow(subject).to receive(:application_create_date).and_return(now)
-          itf.creation_date = past
-          itf.expiration_date = future
-          allow(subject).to receive(:itf).and_return(itf)
-        end
-
-        it 'returns the application creation date + 365 days' do
-          expect(subject.send(:application_expiration_date)).to eq itf.expiration_date.iso8601
-        end
-      end
+    it 'returns the application creation date + 365 days' do
+      expect(subject.send(:application_expiration_date)).to eq '2021-11-05T18:19:50Z'
     end
   end
 

--- a/spec/models/saved_claim/disability_compensation/form526_all_claim_bdd_spec.rb
+++ b/spec/models/saved_claim/disability_compensation/form526_all_claim_bdd_spec.rb
@@ -25,10 +25,8 @@ RSpec.describe SavedClaim::DisabilityCompensation::Form526AllClaim do
 
       it 'returns a hash of submission data' do
         VCR.use_cassette('evss/ppiu/payment_information') do
-          VCR.use_cassette('evss/intent_to_file/active_compensation') do
-            VCR.use_cassette('emis/get_military_service_episodes/valid', allow_playback_repeats: true) do
-              expect(JSON.parse(subject.to_submission_data(user))).to eq submission_data
-            end
+          VCR.use_cassette('emis/get_military_service_episodes/valid', allow_playback_repeats: true) do
+            expect(JSON.parse(subject.to_submission_data(user))).to eq submission_data
           end
         end
       end

--- a/spec/support/disability_compensation_form/all_claims_evss_submission.json
+++ b/spec/support/disability_compensation_form/all_claims_evss_submission.json
@@ -1,6 +1,6 @@
 {
     "form526": {
-        "applicationExpirationDate": "2015-08-28T19:53:45+00:00",
+        "applicationExpirationDate": "2021-11-05T18:19:50Z",
         "bddQualified": false,
         "claimantCertification": true,
         "directDeposit": {

--- a/spec/support/disability_compensation_form/bdd_evss_submission.json
+++ b/spec/support/disability_compensation_form/bdd_evss_submission.json
@@ -1,6 +1,6 @@
 {
     "form526": {
-        "applicationExpirationDate": "2015-08-28T19:53:45+00:00",
+        "applicationExpirationDate": "2021-08-01T00:00:00Z",
         "autoCestPDFGenerationDisabled": false,
         "bddQualified": true,
         "claimantCertification": true,

--- a/spec/support/disability_compensation_form/submissions/526_bdd.json
+++ b/spec/support/disability_compensation_form/submissions/526_bdd.json
@@ -4,7 +4,7 @@
       "claimantCertification": true,
       "standardClaim": true,
       "autoCestPDFGenerationDisabled": false,
-      "applicationExpirationDate": "2015-08-28T19:53:45+00:00",
+      "applicationExpirationDate": "2021-08-01T00:00:00Z",
       "bddQualified": true,
       "directDeposit": {
         "accountType": "CHECKING",


### PR DESCRIPTION
## Description of change
If a veteran submits a form 526 we'll say it's not expired (expires in one year).  There was some complicated logic that presumably was ported from eBenefits, but Paul Schute says it is not necessary. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12690
