### PR TITLE
increase form526 retry count

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_form526.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526.rb
@@ -7,8 +7,8 @@ module EVSS
   module DisabilityCompensationForm
     class SubmitForm526 < Job
       # Sidekiq has built in exponential back-off functionality for retrys
-      # A max retry attempt of 13 will result in a run time of ~25 hours
-      RETRY = 13
+      # A max retry attempt of 15 will result in a run time of ~36 hours
+      RETRY = 15
       STATSD_KEY_PREFIX = 'worker.evss.submit_form526'
 
       sidekiq_options retry: RETRY


### PR DESCRIPTION
## Description of change
[EVSS was down](http://grafana.vfs.va.gov/d/000000066/evss-526-submissions?orgId=1&from=1604709955087&to=1604803869104) for more than a day this weekend, so up the retry count to ~36h

<img width="1575" alt="Screen Shot 2020-11-10 at 12 18 55 PM" src="https://user-images.githubusercontent.com/19188/98708265-f92f9b00-234e-11eb-9eac-e8f179096c2a.png">

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
