### PR TITLE
update classname from Form to FormSwagger

### DIFF
--- a/modules/va_forms/app/controllers/va_forms/docs/v0/api_controller.rb
+++ b/modules/va_forms/app/controllers/va_forms/docs/v0/api_controller.rb
@@ -13,7 +13,7 @@ module VaForms
 
         SWAGGERED_CLASSES = [
           VaForms::V0::ControllerSwagger,
-          VaForms::Forms::Form,
+          VaForms::Forms::FormSwagger,
           VaForms::V0::SecuritySchemeSwagger,
           VaForms::V0::SwaggerRoot
         ].freeze

--- a/modules/va_forms/app/swagger/va_forms/forms/form_swagger.rb
+++ b/modules/va_forms/app/swagger/va_forms/forms/form_swagger.rb
@@ -2,7 +2,7 @@
 
 module VaForms
   module Forms
-    class Form
+    class FormSwagger
       include Swagger::Blocks
 
       swagger_component do


### PR DESCRIPTION


## Description of change
modules/va_forms/app/swagger/va_forms/forms/form_swagger.rb defines a class named Form, it should be FormSwagger to match it's filename. It's used in modules/va_forms/app/controllers/va_forms/docs/v0/api_controller.rb
## Original issue(s)
department-of-veterans-affairs/va.gov-team#15901

## Testing
- [x] Specs locally

