### PR TITLE
Decision review timeout matches Lighthouse timeout

### DIFF
--- a/lib/decision_review/configuration.rb
+++ b/lib/decision_review/configuration.rb
@@ -8,6 +8,8 @@ module DecisionReview
   # sets the base path, the base request headers, and a service name for breakers and metrics.
   #
   class Configuration < Common::Client::Configuration::REST
+    self.read_timeout = Settings.caseflow.timeout || 20 # using the same timeout as lighthouse
+
     ##
     # @return [String] Base path for decision review URLs.
     #

--- a/spec/lib/caseflow/configuration_spec.rb
+++ b/spec/lib/caseflow/configuration_spec.rb
@@ -17,7 +17,7 @@ describe Caseflow::Configuration do
   end
 
   describe '.read_timeout' do
-    context 'when Settings.mvi.timeout is set' do
+    context 'when Settings.caseflow.timeout is set' do
       it 'uses the setting' do
         expect(Caseflow::Configuration.instance.read_timeout).to eq(40)
       end

--- a/spec/lib/decision_review/configuration_spec.rb
+++ b/spec/lib/decision_review/configuration_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'caseflow/configuration'
+
+describe DecisionReview::Configuration do
+  describe '.read_timeout' do
+    context 'when Settings.caseflow.timeout is set' do
+      it 'uses the setting' do
+        expect(DecisionReview::Configuration.instance.read_timeout).to eq(40)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
HLR's decision review service should not time out if Lighthouse's Caseflow service has. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#16030

