### PR TITLE
Add Danger exclusion for generated docs

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -3,7 +3,7 @@ PR_SIZE = {
   RECOMMENDED_MAXIMUM: 250,
   ABSOLUTE_MAXIMUM:    1000,
 }
-EXCLUSIONS = ['Gemfile.lock', '.json', 'spec/fixtures/', '.txt', 'spec/support/vcr_cassettes/', 'app/swagger']
+EXCLUSIONS = ['Gemfile.lock', '.json', 'spec/fixtures/', '.txt', 'spec/support/vcr_cassettes/', 'app/swagger', 'modules/mobile/docs/index.html']
 
 # takes form {"some/file.rb"=>{:insertions=>4, :deletions=>1}}
 changed_files = git.diff.stats[:files]

--- a/Dangerfile
+++ b/Dangerfile
@@ -3,7 +3,7 @@ PR_SIZE = {
   RECOMMENDED_MAXIMUM: 250,
   ABSOLUTE_MAXIMUM:    1000,
 }
-EXCLUSIONS = ['Gemfile.lock', '.json', 'spec/fixtures/', '.txt', 'spec/support/vcr_cassettes/', 'app/swagger', 'modules/mobile/docs/index.html']
+EXCLUSIONS = ['Gemfile.lock', '.json', 'spec/fixtures/', '.txt', 'spec/support/vcr_cassettes/', 'app/swagger', 'modules/mobile/docs/']
 
 # takes form {"some/file.rb"=>{:insertions=>4, :deletions=>1}}
 changed_files = git.diff.stats[:files]


### PR DESCRIPTION
## Description of change
[My PR](https://github.com/department-of-veterans-affairs/vets-api/pull/5244) is blocked because Danger (rightfully) says there are too many lines of code modified. But many of the LOC changes are to a generated API doc file that we commit. I want to skip this error and get my code merged!

## Other options considered
There are a few options that I considered, this PR implements option 3.
### OPTION 1: break up my PR into two
This is a fine option, but as we build more into the mobile api, we will most likely run into this problem again. Breaking up the yaml from the generated docs is not semantic and I'd prefer not to do that.
### OPTION 2: gitignore modules/mobile/docs/index.html
This option is not bad, as the doc can be generated locally as needed. But then non-technical folks will not be able to consume the generated docs easily.
### OPTION 3: update master Dangerfile to exclude modules/mobile/docs/index.html
**This is the option I chose here**. This allows our team to continue committing generated docs alongside openapi specs.
### OPTION 4: update master Dangerfile to simplify `failure` message to make skipping an error possible
Danger allows failures to be ignored by placing this line in the PR description: `Danger: Ignore "[full message text here]"`. Since the failure messages in this project are very long, descriptive, and include html, it is difficult (and ugly) to ignore failures this way. Perhaps we can use `failure` with a simple message, and `message` with the details?
### OPTION 5: PR [danger/danger](https://github.com/danger/danger/) to allow a regex match for Danger: Ignore "" to make skipping long error messages possible
I like this solution as well, as I feel like long failure messages are valuable, but easily ignoring a failure is valuable too. This would probably take some work to get to know the danger project, then probably weeks or months to get the code approved, merged, and released.

## Things to know about this PR
* This will probably happen to someone else working in this repository. Are there other generated docs/dirs we should also exclude?
* I'd like the maintainers to consider option 4, especially if they feel the EXCLUSIONS list could get large. Imagine this code:
```
message(msg + file_summary + footer)
failure("This PR is too large")
```
It would still post all the details into the PR, but allow for PR authors to more easily ignore Danger failures as needed.