### PR TITLE
remove dashboard_show_covid19_alert feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -25,10 +25,6 @@ features:
     actor_type: cookie_id
     description: >
       Toggles whether COVID Research volunteer submissions will be delivered to genISIS
-  dashboard_show_covid19_alert:
-    actor_type: user
-    description: >
-      Allows for showing a special COVID19 alert on the My VA Dashboard
   dashboard_show_dashboard_2:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Removes the feature flag that will not be used [after this corresponding FE PR is merged.](https://github.com/department-of-veterans-affairs/vets-website/pull/14932)

https://github.com/department-of-veterans-affairs/vets-website/pull/14932 has been merged so this is clear to merge as well.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15737

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->