### PR TITLE
SAML cookie logging

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -217,16 +217,17 @@ module V1
     end
 
     def saml_response_stats(saml_response)
-      relay_state = JSON.parse(params[:RelayState] || '{}')
+      uuid = saml_response.in_response_to
+      tracker = SAMLRequestTracker.find(uuid)
       values = {
-        'id' => saml_response.in_response_to,
+        'id' => uuid,
         'authn' => saml_response.authn_context,
-        'type' => relay_state['type'],
-        'transaction_id' => relay_state['transaction_id']
+        'type' => tracker&.payload_attr(:type),
+        'transaction_id' => tracker&.payload_attr(:transaction_id)
       }
       Rails.logger.info("SSOe: SAML Response => #{values}")
       StatsD.increment(STATSD_SSO_SAMLRESPONSE_KEY,
-                       tags: ["type:#{relay_state['type']}",
+                       tags: ["type:#{tracker&.payload_attr(:type)}",
                               "context:#{saml_response.authn_context}",
                               VERSION_TAG])
     end

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -171,7 +171,8 @@ module SAML
     def relay_state_params
       rs_params = {
         originating_request_id: RequestStore.store['request_id'],
-        type: type
+        type: type,
+        transaction_id: @tracker.payload[:transaction_id]
       }
       rs_params[:review_instance_slug] = Settings.review_instance_slug unless Settings.review_instance_slug.nil?
       rs_params.to_json
@@ -212,10 +213,11 @@ module SAML
       uuid = previous_saml_uuid(params)
       previous = uuid && SAMLRequestTracker.find(uuid)
       type = previous&.payload_attr(:type) || params[:type]
+      transaction_id = previous&.payload_attr(:transaction_id) || SecureRandom.uuid
       # if created_at is set to nil (meaning no previous tracker to use), it
       # will be initialized to the current time when it is saved
       SAMLRequestTracker.new(
-        payload: { type: type }.compact,
+        payload: { type: type, transaction_id: transaction_id }.compact,
         created_at: previous&.created_at
       )
     end

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -171,8 +171,7 @@ module SAML
     def relay_state_params
       rs_params = {
         originating_request_id: RequestStore.store['request_id'],
-        type: type,
-        transaction_id: @tracker.payload[:transaction_id]
+        type: type
       }
       rs_params[:review_instance_slug] = Settings.review_instance_slug unless Settings.review_instance_slug.nil?
       rs_params.to_json

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -134,14 +134,17 @@ RSpec.describe V1::SessionsController, type: :controller do
             tracker = SAMLRequestTracker.find(SAMLRequestTracker.keys[0])
             expect(tracker.payload[:type]).to eq('custom')
             expect(tracker.payload[:authn_context]).to eq('myhealthevet')
-            expect(tracker.payload[:transaction_id]).not_to be_nil
+
+            # => mocked tracker doesn't have transaction_id, need to add it for testing
+            # expect(tracker.payload[:transaction_id]).not_to be_nil
 
             expect_saml_post_form(
               response.body,
               'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
               'originating_request_id' => nil,
-              'type' => 'custom',
-              'transaction_id' => tracker.payload[:transaction_id]
+              'type' => 'custom'
+              # => mocked tracker doesn't have transaction_id, need to add it for testing
+              # 'transaction_id' => tracker.payload[:transaction_id]
             )
           end
 

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -108,12 +108,18 @@ RSpec.describe V1::SessionsController, type: :controller do
                 .and trigger_statsd_increment(described_class::STATSD_SSO_SAMLREQUEST_KEY,
                                               tags: ["type:#{type}", "context:#{authn}", 'version:v1'], **once)
 
-              expect(response).to have_http_status(:ok)
-              expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
-                                    'originating_request_id' => nil, 'type' => type)
               expect(SAMLRequestTracker.keys.length).to eq(1)
-              expect(SAMLRequestTracker.find(SAMLRequestTracker.keys[0]).payload)
-                .to eq({ type: type, authn_context: authn })
+              tracker = SAMLRequestTracker.find(SAMLRequestTracker.keys[0])
+              expect(tracker.payload)
+                .to eq({ type: type, authn_context: authn, transaction_id: tracker.payload[:transaction_id] })
+              expect(response).to have_http_status(:ok)
+              expect_saml_post_form(
+                response.body,
+                'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+                'originating_request_id' => nil,
+                'type' => type,
+                'transaction_id' => tracker.payload[:transaction_id]
+              )
             end
           end
         end
@@ -135,16 +141,12 @@ RSpec.describe V1::SessionsController, type: :controller do
             expect(tracker.payload[:type]).to eq('custom')
             expect(tracker.payload[:authn_context]).to eq('myhealthevet')
 
-            # => mocked tracker doesn't have transaction_id, need to add it for testing
-            # expect(tracker.payload[:transaction_id]).not_to be_nil
-
             expect_saml_post_form(
               response.body,
               'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
               'originating_request_id' => nil,
-              'type' => 'custom'
-              # => mocked tracker doesn't have transaction_id, need to add it for testing
-              # 'transaction_id' => tracker.payload[:transaction_id]
+              'type' => 'custom',
+              'transaction_id' => tracker.payload[:transaction_id]
             )
           end
 
@@ -171,8 +173,14 @@ RSpec.describe V1::SessionsController, type: :controller do
               .to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY,
                                            tags: ['context:signup', 'version:v1'], **once)
             expect(response).to have_http_status(:ok)
-            expect_saml_post_form(response.body, 'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
-                                  'originating_request_id' => nil, 'type' => 'signup')
+            tracker = SAMLRequestTracker.find(SAMLRequestTracker.keys[0])
+            expect_saml_post_form(
+              response.body,
+              'https://pint.eauth.va.gov/isam/sps/saml20idp/saml20/login',
+              'originating_request_id' => nil,
+              'type' => 'signup',
+              'transaction_id' => tracker.payload[:transaction_id]
+            )
           end
         end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

This change cleans up SAML cookie content creation logic to reduce unnecessary random ID creation by storing the current SAML transaction ID in Redis, as well as including it in the `saml_request_stats` and `saml_response_stats` methods that generate the SAML values logged with Rails logger.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15179

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Manual testing has been done on logins to check for SAML transation IDs, unit tests still need to be updated as mocked SAML request trackers are not generating transaction IDs.
