### PR TITLE
Cache VA profile get_person calls that return 404s

### DIFF
--- a/lib/vet360/contact_information/person_response.rb
+++ b/lib/vet360/contact_information/person_response.rb
@@ -18,6 +18,10 @@ module Vet360
           person: Vet360::Models::Person.build_from(@response_body&.dig('bio'))
         )
       end
+
+      def cache?
+        super || status == 404
+      end
     end
   end
 end

--- a/spec/models/vet360_redis/contact_information_spec.rb
+++ b/spec/models/vet360_redis/contact_information_spec.rb
@@ -31,6 +31,22 @@ describe Vet360Redis::ContactInformation do
     Vet360::ContactInformation::PersonResponse.from(raw_response)
   end
 
+  context 'with a 404 from get_person', skip_vet360: true do
+    before do
+      expect(Settings.vet360.contact_information).to receive(:cache_enabled).and_return(true)
+      expect_any_instance_of(
+        Vet360::ContactInformation::Service
+      ).to receive(:get_person).once.and_return(
+        Vet360::ContactInformation::PersonResponse.new(404, person: nil)
+      )
+    end
+
+    it 'caches the empty response' do
+      expect(contact_info.email).to eq(nil)
+      expect(contact_info.home_phone).to eq(nil)
+    end
+  end
+
   describe '.new' do
     it 'creates an instance with user attributes' do
       expect(contact_info.user).to eq(user)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
cache 404 responses from va profile get_person api
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15971

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
testing in staging planned
<!-- Please describe testing done to verify the changes or any testing planned. -->
