### PR TITLE
Remove reference to feedback tool SSN field

### DIFF
--- a/app/models/gi_bill_feedback.rb
+++ b/app/models/gi_bill_feedback.rb
@@ -52,9 +52,6 @@ class GIBillFeedback < Common::RedisStore
     end
 
     transformed.merge!(get_user_details)
-    if transformed['social_security_number_last_four'].present?
-      transformed['profile_data']['SSN'] = transformed.delete('social_security_number_last_four')
-    end
 
     transformed['education_details'].tap do |education_details|
       school = education_details['school']

--- a/spec/factories/gi_bill_feedback.rb
+++ b/spec/factories/gi_bill_feedback.rb
@@ -27,7 +27,6 @@ FactoryBot.define do
           from: '2000-01-01',
           to: '2000-01-02'
         },
-        socialSecurityNumberLastFour: '1234',
         anonymousEmail: 'foo@foo.com',
         onBehalfOf: 'Myself',
         educationDetails: {

--- a/spec/fixtures/gibft/transform_form.json
+++ b/spec/fixtures/gibft/transform_form.json
@@ -45,8 +45,5 @@
   "entered_duty": "2000-01-01",
   "facility_code": "46123438",
   "release_from_duty": "2000-01-02",
-  "profile_data": {
-    "SSN": "1234"
-  },
   "email": "foo@foo.com"
 }

--- a/spec/models/gi_bill_feedback_spec.rb
+++ b/spec/models/gi_bill_feedback_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe GIBillFeedback, type: :model do
 
       it 'transforms the form' do
         form = gi_bill_feedback.parsed_form
-        form.delete('socialSecurityNumberLastFour')
         gi_bill_feedback.form = form.to_json
         gi_bill_feedback.send(:remove_instance_variable, :@parsed_form)
         expect(gi_bill_feedback.transform_form).to eq(get_fixture('gibft/transform_form_no_user'))


### PR DESCRIPTION
## Description of change
Removed usage of the `social_security_number_last_four` which is being removed from vets-website and the feedback tool schema.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15978

## Things to know about this PR
- vets-website PR: https://github.com/department-of-veterans-affairs/vets-website/pull/14924
- vets-json-schema PR: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/547