### PR TITLE
13827: Removal of stem_text_message_question feature flag.

### DIFF
--- a/app/workers/education_form/forms/va10203.rb
+++ b/app/workers/education_form/forms/va10203.rb
@@ -19,7 +19,6 @@ module EducationForm::Forms
     end
 
     def receive_text_message
-
       return false if @applicant.receiveTexts.nil?
 
       @applicant.receiveTexts

--- a/app/workers/education_form/forms/va10203.rb
+++ b/app/workers/education_form/forms/va10203.rb
@@ -19,7 +19,6 @@ module EducationForm::Forms
     end
 
     def receive_text_message
-      return nil unless Flipper.enabled?(:stem_text_message_question)
 
       return false if @applicant.receiveTexts.nil?
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -281,11 +281,6 @@ features:
     actor_type: user
     description: >
       This will toggle between an eBenefits link and a VA.gov link for the VR&E chapter 36 form
-  stem_text_message_question:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Add text message opt-in question to 10203 Personal Information chapter and layout changes
   form_1995_edu_updates:
     actor_type: user
     enable_in_development: true

--- a/spec/support/spool_helpers.rb
+++ b/spec/support/spool_helpers.rb
@@ -20,7 +20,6 @@ module SpoolHelpers
         end
 
         before do
-          allow(Flipper).to receive(:enabled?).with(:stem_text_message_question).and_return(true)
           allow(education_benefits_claim).to receive(:id).and_return(1)
           education_benefits_claim.instance_variable_set(:@application, nil)
         end


### PR DESCRIPTION
## Description of change
As a developer, I need to remove the feature flag for 10203 text message question because it will not be disabled going forward.

## Original issue(s)
[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13827)

## Things to know about this PR
This is the PR that contains the changes to remove the `stem_text_message_question` from `vets-api`

