### PR TITLE
API-3251: Updating the claim establisher job to pull and trigger flashes

### DIFF
--- a/lib/bgs/auth_headers.rb
+++ b/lib/bgs/auth_headers.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module BGS
+  class AuthHeaders
+    def initialize(user)
+      @user = user
+    end
+
+    def to_h
+      @headers ||= { 'va_bgs_authorization' => auth_json }
+    end
+
+    private
+
+    def auth_json
+      {
+        external_uid: @user.uuid,
+        external_key: @user.email
+      }.to_json
+    end
+  end
+end

--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -35,7 +35,7 @@ module ClaimsApi
                      .add_headers(
                        EVSS::AuthHeaders.new(target_veteran(with_gender: true)).to_h
                      )
-                     .merge(BGS::AuthHeaders.new(@current_user).to_h)
+      evss_headers = evss_headers.merge(BGS::AuthHeaders.new(@current_user).to_h) if @current_user.present?
 
       if request.headers['Mock-Override'] &&
          Settings.claims_api.disability_claims_mock_override

--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -36,7 +36,7 @@ module ClaimsApi
                        EVSS::AuthHeaders.new(target_veteran(with_gender: true)).to_h
                      )
                      .merge(BGS::AuthHeaders.new(@current_user).to_h)
-                     
+
       if request.headers['Mock-Override'] &&
          Settings.claims_api.disability_claims_mock_override
         evss_headers['Mock-Override'] = request.headers['Mock-Override']

--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -4,6 +4,7 @@ require 'json_schema/json_api_missing_attribute'
 require 'claims_api/form_schemas'
 require 'evss/disability_compensation_auth_headers'
 require 'evss/auth_headers'
+require 'bgs/auth_headers'
 
 module ClaimsApi
   class BaseFormController < ClaimsApi::ApplicationController
@@ -34,6 +35,8 @@ module ClaimsApi
                      .add_headers(
                        EVSS::AuthHeaders.new(target_veteran(with_gender: true)).to_h
                      )
+                     .merge(BGS::AuthHeaders.new(@current_user).to_h)
+                     
       if request.headers['Mock-Override'] &&
          Settings.claims_api.disability_claims_mock_override
         evss_headers['Mock-Override'] = request.headers['Mock-Override']

--- a/modules/claims_api/app/workers/claims_api/claim_establisher.rb
+++ b/modules/claims_api/app/workers/claims_api/claim_establisher.rb
@@ -52,11 +52,11 @@ module ClaimsApi
 
     def bgs_user(auth_headers)
       user = OpenStruct.new(ssn: auth_headers['va_eauth_pnid'],
-                                   uuid: nil,
-                                   email: nil,
-                                   icn: nil,
-                                   common_name: nil)
-      return user unless auth_headers['va_bgs_authorization'].present?
+                            uuid: nil,
+                            email: nil,
+                            icn: nil,
+                            common_name: nil)
+      return user if auth_headers['va_bgs_authorization'].blank?
 
       bgs_auth_headers = JSON.parse(auth_headers['va_bgs_authorization'])
       user.uuid = bgs_auth_headers['external_uid']

--- a/modules/claims_api/spec/fixtures/form_526_json_api.json
+++ b/modules/claims_api/spec/fixtures/form_526_json_api.json
@@ -3,6 +3,7 @@
     "type": "form/526",
     "attributes": {
       "veteran": {
+        "flashes": ["Hardship", "Homeless"],
         "currentlyVAEmployee": false,
         "currentMailingAddress": {
           "city": "Portland",

--- a/modules/claims_api/spec/workers/claim_establisher_spec.rb
+++ b/modules/claims_api/spec/workers/claim_establisher_spec.rb
@@ -11,7 +11,11 @@ RSpec.describe ClaimsApi::ClaimEstablisher, type: :job do
 
   let(:user) { FactoryBot.create(:user, :loa3) }
   let(:auth_headers) do
-    EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
+    EVSS::DisabilityCompensationAuthHeaders.new(user)
+    .add_headers(
+      EVSS::AuthHeaders.new(user).to_h
+    )
+    .merge(BGS::AuthHeaders.new(user).to_h)
   end
 
   let(:claim) do

--- a/modules/claims_api/spec/workers/claim_establisher_spec.rb
+++ b/modules/claims_api/spec/workers/claim_establisher_spec.rb
@@ -12,10 +12,8 @@ RSpec.describe ClaimsApi::ClaimEstablisher, type: :job do
   let(:user) { FactoryBot.create(:user, :loa3) }
   let(:auth_headers) do
     EVSS::DisabilityCompensationAuthHeaders.new(user)
-    .add_headers(
-      EVSS::AuthHeaders.new(user).to_h
-    )
-    .merge(BGS::AuthHeaders.new(user).to_h)
+                                           .add_headers(EVSS::AuthHeaders.new(user).to_h)
+                                           .merge(BGS::AuthHeaders.new(user).to_h)
   end
 
   let(:claim) do


### PR DESCRIPTION
## Description of change
Publish any flashes submitted with a 526 on successful claim establishment.

## Original issue(s)
https://vajira.max.gov/browse/API-3251

## Things to know about this PR
Tested hitting endpoint to submit 526 claim locally.
Updated specs.
