### PR TITLE
API-3366: Need to filter 526 and 2122 find_by methods using the source label

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -25,7 +25,9 @@ module ClaimsApi
             flashes: flashes,
             source: source_name
           )
-          auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5) unless auto_claim.id
+          unless auto_claim.id
+            auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5, source: source_name)
+          end
 
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
 
@@ -46,12 +48,6 @@ module ClaimsApi
 
         def validate_form_526
           super
-        end
-
-        private
-
-        def source_name
-          request.headers['X-Consumer-Username']
         end
       end
     end

--- a/modules/claims_api/app/controllers/claims_api/v0/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/power_of_attorney_controller.rb
@@ -17,7 +17,8 @@ module ClaimsApi
         before_action :validate_documents_page_size, only: %i[upload]
 
         def submit_form_2122
-          power_of_attorney = ClaimsApi::PowerOfAttorney.find_by(header_md5: header_md5)
+          power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(header_md5: header_md5,
+                                                                                          source_name: source_name)
           unless power_of_attorney&.status&.in?(%w[submitted pending])
             power_of_attorney = ClaimsApi::PowerOfAttorney.create(
               status: ClaimsApi::PowerOfAttorney::PENDING,
@@ -40,7 +41,8 @@ module ClaimsApi
         end
 
         def upload
-          power_of_attorney = ClaimsApi::PowerOfAttorney.find_by(id: params[:id])
+          power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(id: params[:id],
+                                                                                          source_name: source_name)
           power_of_attorney.set_file_data!(documents.first, params[:doc_type])
           power_of_attorney.status = 'submitted'
           power_of_attorney.save!
@@ -50,12 +52,14 @@ module ClaimsApi
         end
 
         def status
-          power_of_attorney = ClaimsApi::PowerOfAttorney.find_by(id: params[:id])
+          power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(id: params[:id],
+                                                                                          source_name: source_name)
           render json: power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
         end
 
         def active
-          power_of_attorney = ClaimsApi::PowerOfAttorney.find_by(header_md5: header_md5)
+          power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(header_md5: header_md5,
+                                                                                          source_name: source_name)
           render json: power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
         end
 
@@ -74,7 +78,7 @@ module ClaimsApi
 
         def source_data
           {
-            name: request.headers['X-Consumer-Username'],
+            name: source_name,
             icn: Settings.bgs.external_uid,
             email: Settings.bgs.external_key
           }

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -28,7 +28,10 @@ module ClaimsApi
             flashes: flashes,
             source: source_name
           )
-          auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5) unless auto_claim.id
+          unless auto_claim.id
+            auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5, source: source_name)
+          end
+
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
 
           render json: auto_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
@@ -50,11 +53,6 @@ module ClaimsApi
         end
 
         private
-
-        def source_name
-          user = header_request? ? @current_user : target_veteran
-          "#{user.first_name} #{user.last_name}"
-        end
 
         def validate_initial_claim
           if claims_service.claims_count.zero? && form_attributes['autoCestPDFGenerationDisabled'] == false

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -17,7 +17,8 @@ module ClaimsApi
         FORM_NUMBER = '2122'
 
         def submit_form_2122
-          power_of_attorney = ClaimsApi::PowerOfAttorney.find_by(header_md5: header_md5)
+          power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(header_md5: header_md5,
+                                                                                          source_name: source_name)
           unless power_of_attorney&.status&.in?(%w[submitted pending])
             power_of_attorney = ClaimsApi::PowerOfAttorney.create(
               status: ClaimsApi::PowerOfAttorney::PENDING,
@@ -62,7 +63,8 @@ module ClaimsApi
         end
 
         def active
-          power_of_attorney = ClaimsApi::PowerOfAttorney.find_by(header_md5: header_md5)
+          power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(header_md5: header_md5,
+                                                                                          source_name: source_name)
           if power_of_attorney
             render json: power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
           else
@@ -94,11 +96,6 @@ module ClaimsApi
             icn: current_user.icn,
             email: current_user.email
           }
-        end
-
-        def source_name
-          user = header_request? ? @current_user : target_veteran
-          "#{user.first_name} #{user.last_name}"
         end
 
         def find_poa_by_id

--- a/modules/claims_api/app/models/claims_api/power_of_attorney.rb
+++ b/modules/claims_api/app/models/claims_api/power_of_attorney.rb
@@ -18,6 +18,17 @@ module ClaimsApi
     before_validation :set_md5
     validates :md5, uniqueness: true
 
+    def self.find_using_identifier_and_source(source_name:, id: nil, header_md5: nil, md5: nil)
+      primary_identifier = {}
+      primary_identifier[:id] = id if id.present?
+      primary_identifier[:header_md5] = header_md5 if header_md5.present?
+      primary_identifier[:md5] = md5 if md5.present?
+      poa = ClaimsApi::PowerOfAttorney.find_by(primary_identifier)
+      return nil if poa.present? && poa.source_data['name'] != source_name
+
+      poa
+    end
+
     def sign_pdf
       signatures = convert_signatures_to_images
       page_1_path = insert_signatures(1, signatures[:veteran], signatures[:representative])

--- a/modules/claims_api/spec/requests/v0/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/claims_request_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
       it 'shows a single errored Claim with an error message', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         create(:auto_established_claim,
                auth_headers: { some: 'data' },
+               source: 'TestConsumer',
                evss_id: 600_118_851,
                id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9',
                status: 'errored',
@@ -73,6 +74,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
 
       it 'shows a single errored Claim without an error message', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         create(:auto_established_claim,
+               source: 'TestConsumer',
                auth_headers: { some: 'data' },
                evss_id: 600_118_851,
                id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9',
@@ -127,6 +129,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
 
       before do
         create(:auto_established_claim,
+               source: 'TestConsumer',
                auth_headers: { some: 'data' },
                evss_id: 600_118_851,
                id: auto_established_claim_id)

--- a/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Power of Attorney ', type: :request do
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
       'X-VA-EDIPI': '1007697216',
-      'X-Consumer-Username': 'TestConsumer',
+      'X-Consumer-Username': 'Abe Lincoln',
       'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',
       'X-VA-Gender': 'M',
@@ -53,7 +53,7 @@ RSpec.describe 'Power of Attorney ', type: :request do
       parsed = JSON.parse(response.body)
       token = parsed['data']['id']
       poa = ClaimsApi::PowerOfAttorney.find(token)
-      expect(poa.source_data['name']).to eq('TestConsumer')
+      expect(poa.source_data['name']).to eq('Abe Lincoln')
     end
 
     context 'validation' do

--- a/modules/claims_api/spec/requests/v1/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/claims_request_spec.rb
@@ -117,13 +117,14 @@ RSpec.describe 'EVSS Claims management', type: :request do
                  auth_headers: { some: 'data' },
                  evss_id: 600_118_851,
                  id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
+          expect_any_instance_of(ClaimsApi::UnsynchronizedEVSSClaimService).to receive(:update_from_remote)
+            .and_raise(StandardError.new('no claim found'))
           VCR.use_cassette('evss/claims/claim') do
             get(
               '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
               params: nil, headers: request_headers.merge(auth_header)
             )
-
-            # TODO: What is the expectation at this point...?
+            expect(response.code.to_i).to eq(404)
           end
         end
       end

--- a/modules/claims_api/spec/requests/v1/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/claims_request_spec.rb
@@ -72,35 +72,59 @@ RSpec.describe 'EVSS Claims management', type: :request do
       end
     end
 
-    it 'shows a single Claim through auto established claims', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
-      with_okta_user(scopes) do |auth_header|
-        create(:auto_established_claim,
-               auth_headers: { some: 'data' },
-               evss_id: 600_118_851,
-               id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
-        VCR.use_cassette('evss/claims/claim') do
-          get(
-            '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
-            params: nil, headers: request_headers.merge(auth_header)
-          )
-          expect(response).to match_response_schema('claims_api/claim')
+    context 'when source matches' do
+      it 'shows a single Claim through auto established claims', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+        with_okta_user(scopes) do |auth_header|
+          create(:auto_established_claim,
+                 source: 'abraham lincoln',
+                 auth_headers: { some: 'data' },
+                 evss_id: 600_118_851,
+                 id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
+          VCR.use_cassette('evss/claims/claim') do
+            get(
+              '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
+              params: nil, headers: request_headers.merge(auth_header)
+            )
+            expect(response).to match_response_schema('claims_api/claim')
+          end
+        end
+      end
+
+      it 'shows a single Claim through auto established claims when camel-inflected',
+         run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+        with_okta_user(scopes) do |auth_header|
+          create(:auto_established_claim,
+                 source: 'abraham lincoln',
+                 auth_headers: { some: 'data' },
+                 evss_id: 600_118_851,
+                 id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
+          VCR.use_cassette('evss/claims/claim') do
+            get(
+              '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
+              params: nil, headers: request_headers_camel.merge(auth_header)
+            )
+            expect(response).to match_camelized_response_schema('claims_api/claim')
+          end
         end
       end
     end
 
-    it 'shows a single Claim through auto established claims when camel-inflected',
-       run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
-      with_okta_user(scopes) do |auth_header|
-        create(:auto_established_claim,
-               auth_headers: { some: 'data' },
-               evss_id: 600_118_851,
-               id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
-        VCR.use_cassette('evss/claims/claim') do
-          get(
-            '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
-            params: nil, headers: request_headers_camel.merge(auth_header)
-          )
-          expect(response).to match_camelized_response_schema('claims_api/claim')
+    context 'when source does not match' do
+      it 'shows a single Claim through auto established claims', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+        with_okta_user(scopes) do |auth_header|
+          create(:auto_established_claim,
+                 source: 'oddball',
+                 auth_headers: { some: 'data' },
+                 evss_id: 600_118_851,
+                 id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
+          VCR.use_cassette('evss/claims/claim') do
+            get(
+              '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
+              params: nil, headers: request_headers.merge(auth_header)
+            )
+
+            # TODO: What is the expectation at this point...?
+          end
         end
       end
     end
@@ -118,22 +142,15 @@ RSpec.describe 'EVSS Claims management', type: :request do
       it 'shows a single errored Claim with an error message', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         with_okta_user(scopes) do |auth_header|
           create(:auto_established_claim,
+                 source: 'abraham lincoln',
                  auth_headers: auth_header,
                  evss_id: 600_118_851,
                  id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9',
                  status: 'errored',
                  evss_response: { 'messages' => [{ 'key' => 'Error', 'severity' => 'FATAL', 'text' => 'Failed' }] })
           VCR.use_cassette('evss/claims/claim') do
-            get(
-              '/services/claims/v0/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
-              params: nil,
-              headers: {
-                'X-VA-SSN' => '796-04-3735', 'X-VA-First-Name' => 'WESLEY',
-                'X-VA-Last-Name' => 'FORD', 'X-VA-EDIPI' => '1007697216',
-                'X-Consumer-Username' => 'TestConsumer', 'X-VA-User' => 'adhoc.test.user',
-                'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-VA-LOA' => '3'
-              }
-            )
+            headers = request_headers.merge(auth_header)
+            get('/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9', params: nil, headers: headers)
             expect(response.status).to eq(422)
           end
         end
@@ -142,22 +159,15 @@ RSpec.describe 'EVSS Claims management', type: :request do
       it 'shows a single errored Claim without an error message', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         with_okta_user(scopes) do |auth_header|
           create(:auto_established_claim,
+                 source: 'abraham lincoln',
                  auth_headers: auth_header,
                  evss_id: 600_118_851,
                  id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9',
                  status: 'errored',
                  evss_response: nil)
           VCR.use_cassette('evss/claims/claim') do
-            get(
-              '/services/claims/v0/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
-              params: nil,
-              headers: {
-                'X-VA-SSN' => '796-04-3735', 'X-VA-First-Name' => 'WESLEY',
-                'X-VA-Last-Name' => 'FORD', 'X-VA-EDIPI' => '1007697216',
-                'X-Consumer-Username' => 'TestConsumer', 'X-VA-User' => 'adhoc.test.user',
-                'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-VA-LOA' => '3'
-              }
-            )
+            headers = request_headers.merge(auth_header)
+            get('/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9', params: nil, headers: headers)
             expect(response.status).to eq(422)
           end
         end


### PR DESCRIPTION
## Description of change
Protect api from invalid source requesting information solely by id.

## Original issue(s)
https://vajira.max.gov/browse/API-3366

## Things to know about this PR
Spec tests.