### PR TITLE
Add feature toggle for VAOS flat facility page for Sacramento

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -141,6 +141,11 @@ features:
     enable_in_development: true
     description: >
       Enables the new VA facility choice page with a flat list
+  va_online_scheduling_flat_facility_page_sacramento:
+    actor_type: user
+    enable_in_development: true
+    description: >
+      Enables the new VA facility choice page with a flat list for users registered to Sacramento (612)
   va_online_scheduling_provider_selection:
     actor_type: user
     description: >


### PR DESCRIPTION
## Description of change
Adds a new feature toggle for VAOS which enables a new version of the flat facility page for users who are registered to the Sacramento VAMC.

Front end PR: https://github.com/department-of-veterans-affairs/vets-website/pull/14936

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15817