### PR TITLE
13860: Removal of 'education_reports_cleanup' feature flag.

### DIFF
--- a/app/workers/education_form/create_daily_fiscal_year_to_date_report.rb
+++ b/app/workers/education_form/create_daily_fiscal_year_to_date_report.rb
@@ -213,7 +213,7 @@ module EducationForm
       # Atlanta is to be excluded from FYTD reports after the 2017 fiscal year
       return true if fiscal_year > 2017 && region == :southern
       # St. Louis is to be excluded from FYTD reports after the 2020 fiscal year
-      return true if fiscal_year > 2020 && region == :central && Flipper.enabled?(:education_reports_cleanup)
+      return true if fiscal_year > 2020 && region == :central
 
       false
     end

--- a/config/features.yml
+++ b/config/features.yml
@@ -296,8 +296,3 @@ features:
     enable_in_development: true
     description: >
       Ask for a password when an encrypted PDF is detected before uploading
-  education_reports_cleanup:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Updates to the daily education reports to remove old data that isn't needed in the new fiscal year

--- a/spec/jobs/education_form/create_daily_fiscal_year_to_date_report_spec.rb
+++ b/spec/jobs/education_form/create_daily_fiscal_year_to_date_report_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe EducationForm::CreateDailyFiscalYearToDateReport, type: :aws_help
   let(:date) { Time.zone.today - 1.day }
 
   before do
-    allow(Flipper).to receive(:enabled?).with(:education_reports_cleanup).and_return(true)
     allow_any_instance_of(EducationBenefitsClaim).to receive(:create_education_benefits_submission)
   end
 


### PR DESCRIPTION
## Description of change
As a developer, I need to remove the 'education_reports_cleanup' feature flag toggle so that it is no longer configurable, and the new functionality is permanent.

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13860

## Things to know about this PR
Removal of a the `education_reports_cleanup` feature flag.

Tested manually
