### PR TITLE
update vaos logging middleware to use inflection

### DIFF
--- a/modules/vaos/app/services/vaos/middleware/vaos_logging.rb
+++ b/modules/vaos/app/services/vaos/middleware/vaos_logging.rb
@@ -5,7 +5,7 @@ module VAOS
     ##
     # Faraday middleware that logs various semantically relevant attributes needed for debugging and audit purposes
     #
-    class VaosLogging < Faraday::Middleware
+    class VAOSLogging < Faraday::Middleware
       def initialize(app)
         super(app)
       end
@@ -94,4 +94,4 @@ module VAOS
   end
 end
 
-Faraday::Middleware.register_middleware vaos_logging: VAOS::Middleware::VaosLogging
+Faraday::Middleware.register_middleware vaos_logging: VAOS::Middleware::VAOSLogging

--- a/modules/vaos/spec/services/middleware/vaos_logging_integration_spec.rb
+++ b/modules/vaos/spec/services/middleware/vaos_logging_integration_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe VAOS::Middleware::VaosLogging do
+describe VAOS::Middleware::VAOSLogging do
   let(:user) { build(:user, :vaos) }
   let(:service) { VAOS::AppointmentService.new(user) }
   let(:start_date) { Time.zone.parse('2020-06-02T07:00:00Z') }

--- a/modules/vaos/spec/services/middleware/vaos_logging_spec.rb
+++ b/modules/vaos/spec/services/middleware/vaos_logging_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require_relative '../../support/fixture_helper'
 
-describe VAOS::Middleware::VaosLogging do
+describe VAOS::Middleware::VAOSLogging do
   subject(:client) do
     Faraday.new do |conn|
       conn.use :vaos_logging


### PR DESCRIPTION
## Description of change
As part of the upgrade path for Zeitwerk, the VaosLogging middleware needs to be updated to use the VAOS inflection to properly autoload the classname. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15898

## Testing
- [x] Test suite passing locally
