### PR TITLE
update Gi to inflected version

### DIFF
--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -153,7 +153,7 @@ module V0
       Swagger::Requests::Notifications,
       Swagger::Requests::PensionClaims,
       Swagger::Requests::Preferences,
-      Swagger::Requests::Post911GiBillStatuses,
+      Swagger::Requests::Post911GIBillStatuses,
       Swagger::Requests::PPIU,
       Swagger::Requests::PreneedsClaims,
       Swagger::Requests::Prescriptions::Prescriptions,

--- a/app/swagger/swagger/requests/post911_gi_bill_statuses.rb
+++ b/app/swagger/swagger/requests/post911_gi_bill_statuses.rb
@@ -2,7 +2,7 @@
 
 module Swagger
   module Requests
-    class Post911GiBillStatuses
+    class Post911GIBillStatuses
       include Swagger::Blocks
 
       swagger_path '/v0/post911_gi_bill_status' do


### PR DESCRIPTION
Description of change
As part of the upgrade path for Zeitwerk, the Post911GiBillStatuses class needs to be updated to use the GI inflection to properly autoload the classname.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15887

## Testing
- [x] Test suite passing locally
