### PR TITLE
Api 3019 client credentials validation endpoint

### DIFF
--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -33,6 +33,15 @@ class OpenidApplicationController < ApplicationController
   def authenticate_token
     return false if token.blank?
 
+    #issued for a client vs a user
+    if token.is_client_credentials_token?
+      if token.payload["scp"].include?("launch/patient")
+        # TODO fetch launch context
+        # token.payload[:"icn"] = '1234V5678'
+      end
+      return true
+    end
+
     @session = Session.find(token)
     establish_session if @session.nil?
     return false if @session.nil?

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -36,7 +36,7 @@ class OpenidApplicationController < ApplicationController
     #issued for a client vs a user
     if token.is_client_credentials_token?
       if token.payload["scp"].include?("launch/patient")
-        # TODO fetch launch context
+        # API-3500 will fetch launch context
         # token.payload[:"icn"] = '1234V5678'
       end
       return true

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -33,9 +33,9 @@ class OpenidApplicationController < ApplicationController
   def authenticate_token
     return false if token.blank?
 
-    #issued for a client vs a user
-    if token.is_client_credentials_token?
-      if token.payload["scp"].include?("launch/patient")
+    # issued for a client vs a user
+    if token.client_credentials_token?
+      if token.payload['scp'].include?('launch/patient')
         # API-3500 will fetch launch context
         # token.payload[:"icn"] = '1234V5678'
       end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -64,6 +64,10 @@ class Token
     end
   end
 
+  def is_client_credentials_token?
+    payload["sub"] == payload["cid"]
+  end
+
   def identifiers
     # Here the `sub` field is the same value as the `uuid` field from the original upstream ID.me
     # SAML response. We use this as the primary identifier of the user because, despite openid user

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -64,7 +64,7 @@ class Token
     end
   end
 
-  def is_client_credentials_token?
+  def client_credentials_token?
     payload["sub"] == payload["cid"]
   end
 

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -65,7 +65,7 @@ class Token
   end
 
   def client_credentials_token?
-    payload["sub"] == payload["cid"]
+    payload['sub'] == payload['cid']
   end
 
   def identifiers

--- a/modules/openid_auth/app/controllers/openid_auth/application_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/application_controller.rb
@@ -7,7 +7,7 @@ module OpenidAuth
     skip_before_action :set_tags_and_extra_content, raise: false
 
     def validate_user
-      if !token.is_client_credentials_token?
+      if !token.client_credentials_token?
         raise Common::Exceptions::RecordNotFound, @current_user.uuid if @current_user.va_profile_status == 'NOT_FOUND'
         raise Common::Exceptions::BadGateway if @current_user.va_profile_status == 'SERVER_ERROR'
 

--- a/modules/openid_auth/app/controllers/openid_auth/application_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/application_controller.rb
@@ -7,7 +7,7 @@ module OpenidAuth
     skip_before_action :set_tags_and_extra_content, raise: false
 
     def validate_user
-      if !token.client_credentials_token?
+      unless token.client_credentials_token?
         raise Common::Exceptions::RecordNotFound, @current_user.uuid if @current_user.va_profile_status == 'NOT_FOUND'
         raise Common::Exceptions::BadGateway if @current_user.va_profile_status == 'SERVER_ERROR'
 

--- a/modules/openid_auth/app/controllers/openid_auth/application_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/application_controller.rb
@@ -7,11 +7,13 @@ module OpenidAuth
     skip_before_action :set_tags_and_extra_content, raise: false
 
     def validate_user
-      raise Common::Exceptions::RecordNotFound, @current_user.uuid if @current_user.va_profile_status == 'NOT_FOUND'
-      raise Common::Exceptions::BadGateway if @current_user.va_profile_status == 'SERVER_ERROR'
+      if !token.is_client_credentials_token?
+        raise Common::Exceptions::RecordNotFound, @current_user.uuid if @current_user.va_profile_status == 'NOT_FOUND'
+        raise Common::Exceptions::BadGateway if @current_user.va_profile_status == 'SERVER_ERROR'
 
-      obscure_token = Session.obscure_token(token.to_s)
-      Rails.logger.info("Logged in user with id #{@session.uuid}, token #{obscure_token}")
+        obscure_token = Session.obscure_token(token.to_s)
+        Rails.logger.info("Logged in user with id #{@session.uuid}, token #{obscure_token}")
+      end
     end
 
     def fetch_aud

--- a/modules/openid_auth/app/controllers/openid_auth/v0/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v0/validation_controller.rb
@@ -25,7 +25,7 @@ module OpenidAuth
         payload_object.va_identifiers[:icn] = payload_object.try(:icn)
 
         # Client Credentials token will not populate the @current_user, so only fill if not that token type
-        if !token.client_credentials_token? && payload_object[:icn].nil?
+        unless token.client_credentials_token? && !payload_object[:icn].nil?
           payload_object.va_identifiers[:icn] = @current_user.icn
         end
 

--- a/modules/openid_auth/app/controllers/openid_auth/v0/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v0/validation_controller.rb
@@ -22,7 +22,13 @@ module OpenidAuth
 
         # Sometimes we'll already have an `icn` in the token. If we do, copy if down into `va_identifiers`
         # for consistency. Otherwise use the ICN value we used to look up the MVI attributes.
-        payload_object.va_identifiers[:icn] = payload_object.try(:icn) || @current_user.icn
+        payload_object.va_identifiers[:icn] = payload_object.try(:icn)
+
+        # Client Credentials token will not populate the @current_user, so only fill if not that token type
+        if !token.is_client_credentials_token? && payload_object[:icn].nil?
+          payload_object.va_identifiers[:icn] = @current_user.icn
+        end
+
         payload_object
       end
     end

--- a/modules/openid_auth/app/controllers/openid_auth/v0/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v0/validation_controller.rb
@@ -25,7 +25,7 @@ module OpenidAuth
         payload_object.va_identifiers[:icn] = payload_object.try(:icn)
 
         # Client Credentials token will not populate the @current_user, so only fill if not that token type
-        unless token.client_credentials_token? && !payload_object[:icn].nil?
+        unless token.client_credentials_token? || !payload_object[:icn].nil?
           payload_object.va_identifiers[:icn] = @current_user.icn
         end
 

--- a/modules/openid_auth/app/controllers/openid_auth/v0/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v0/validation_controller.rb
@@ -25,7 +25,7 @@ module OpenidAuth
         payload_object.va_identifiers[:icn] = payload_object.try(:icn)
 
         # Client Credentials token will not populate the @current_user, so only fill if not that token type
-        if !token.is_client_credentials_token? && payload_object[:icn].nil?
+        if !token.client_credentials_token? && payload_object[:icn].nil?
           payload_object.va_identifiers[:icn] = @current_user.icn
         end
 

--- a/modules/openid_auth/app/controllers/openid_auth/v1/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v1/validation_controller.rb
@@ -25,7 +25,7 @@ module OpenidAuth
         payload_object.va_identifiers[:icn] = payload_object.try(:icn)
 
         # Client Credentials token will not populate the @current_user, so only fill if not that token type
-        if !token.client_credentials_token? && payload_object[:icn].nil?
+        unless token.client_credentials_token? && !payload_object[:icn].nil?
           payload_object.va_identifiers[:icn] = @current_user.icn
         end
 

--- a/modules/openid_auth/app/controllers/openid_auth/v1/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v1/validation_controller.rb
@@ -22,7 +22,13 @@ module OpenidAuth
 
         # Sometimes we'll already have an `icn` in the token. If we do, copy if down into `va_identifiers`
         # for consistency. Otherwise use the ICN value we used to look up the MVI attributes.
-        payload_object.va_identifiers[:icn] = payload_object.try(:icn) || @current_user.icn
+        payload_object.va_identifiers[:icn] = payload_object.try(:icn)
+
+        # Client Credentials token will not populate the @current_user, so only fill if not that token type
+        if !token.is_client_credentials_token? && payload_object[:icn].nil?
+          payload_object.va_identifiers[:icn] = @current_user.icn
+        end
+
         payload_object
       end
     end

--- a/modules/openid_auth/app/controllers/openid_auth/v1/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v1/validation_controller.rb
@@ -25,7 +25,7 @@ module OpenidAuth
         payload_object.va_identifiers[:icn] = payload_object.try(:icn)
 
         # Client Credentials token will not populate the @current_user, so only fill if not that token type
-        unless token.client_credentials_token? && !payload_object[:icn].nil?
+        unless token.client_credentials_token? || !payload_object[:icn].nil?
           payload_object.va_identifiers[:icn] = @current_user.icn
         end
 

--- a/modules/openid_auth/app/controllers/openid_auth/v1/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v1/validation_controller.rb
@@ -25,7 +25,7 @@ module OpenidAuth
         payload_object.va_identifiers[:icn] = payload_object.try(:icn)
 
         # Client Credentials token will not populate the @current_user, so only fill if not that token type
-        if !token.is_client_credentials_token? && payload_object[:icn].nil?
+        if !token.client_credentials_token? && payload_object[:icn].nil?
           payload_object.va_identifiers[:icn] = @current_user.icn
         end
 

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
         'sub' => '0oa1c01m77heEXUZt2p7'
       },
       {
-       'kid' => '1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU',
-       'alg' => 'RS256'
+        'kid' => '1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU',
+        'alg' => 'RS256'
       }
     ]
   end

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -44,19 +44,19 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
   end
   let(:client_credentials_jwt) do
     [{
-         'ver' => 1,
-         'jti' => 'AT.04f_GBSkMkWYbLgG5joGNlApqUthsZnYXhiyPc_5KZ0',
-         'iss' => 'https://example.com/oauth2/default',
-         'aud' => 'api://default',
-         'iat' => Time.current.utc.to_i,
-         'exp' => Time.current.utc.to_i + 3600,
-         'cid' => '0oa1c01m77heEXUZt2p7',
-         'uid' => '00u1zlqhuo3yLa2Xs2p7',
-         'scp' => %w[profile email launch/patient],
-         'sub' => '0oa1c01m77heEXUZt2p7'
+       'ver' => 1,
+       'jti' => 'AT.04f_GBSkMkWYbLgG5joGNlApqUthsZnYXhiyPc_5KZ0',
+       'iss' => 'https://example.com/oauth2/default',
+       'aud' => 'api://default',
+       'iat' => Time.current.utc.to_i,
+       'exp' => Time.current.utc.to_i + 3600,
+       'cid' => '0oa1c01m77heEXUZt2p7',
+       'uid' => '00u1zlqhuo3yLa2Xs2p7',
+       'scp' => %w[profile email launch/patient],
+       'sub' => '0oa1c01m77heEXUZt2p7'
      }, {
-         'kid' => '1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU',
-         'alg' => 'RS256'
+       'kid' => '1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU',
+       'alg' => 'RS256'
      }]
   end
   let(:json_api_response) do

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -43,21 +43,23 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
     }]
   end
   let(:client_credentials_jwt) do
-    [{
-       'ver' => 1,
-       'jti' => 'AT.04f_GBSkMkWYbLgG5joGNlApqUthsZnYXhiyPc_5KZ0',
-       'iss' => 'https://example.com/oauth2/default',
-       'aud' => 'api://default',
-       'iat' => Time.current.utc.to_i,
-       'exp' => Time.current.utc.to_i + 3600,
-       'cid' => '0oa1c01m77heEXUZt2p7',
-       'uid' => '00u1zlqhuo3yLa2Xs2p7',
-       'scp' => %w[profile email launch/patient],
-       'sub' => '0oa1c01m77heEXUZt2p7'
-     }, {
+    [
+      {
+        'ver' => 1,
+        'jti' => 'AT.04f_GBSkMkWYbLgG5joGNlApqUthsZnYXhiyPc_5KZ0',
+        'iss' => 'https://example.com/oauth2/default',
+        'aud' => 'api://default',
+        'iat' => Time.current.utc.to_i,
+        'exp' => Time.current.utc.to_i + 3600,
+        'cid' => '0oa1c01m77heEXUZt2p7',
+        'uid' => '00u1zlqhuo3yLa2Xs2p7',
+        'scp' => %w[profile email launch/patient],
+        'sub' => '0oa1c01m77heEXUZt2p7'
+      }, {
        'kid' => '1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU',
        'alg' => 'RS256'
-     }]
+      }
+    ]
   end
   let(:json_api_response) do
     {

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -42,6 +42,23 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
       'alg' => 'RS256'
     }]
   end
+  let(:client_credentials_jwt) do
+    [{
+         'ver' => 1,
+         'jti' => 'AT.04f_GBSkMkWYbLgG5joGNlApqUthsZnYXhiyPc_5KZ0',
+         'iss' => 'https://example.com/oauth2/default',
+         'aud' => 'api://default',
+         'iat' => Time.current.utc.to_i,
+         'exp' => Time.current.utc.to_i + 3600,
+         'cid' => '0oa1c01m77heEXUZt2p7',
+         'uid' => '00u1zlqhuo3yLa2Xs2p7',
+         'scp' => %w[profile email launch/patient],
+         'sub' => '0oa1c01m77heEXUZt2p7'
+     }, {
+         'kid' => '1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU',
+         'alg' => 'RS256'
+     }]
+  end
   let(:json_api_response) do
     {
       'data' => {
@@ -209,6 +226,30 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
 
         expect(response).to have_http_status(:bad_gateway)
         expect(JSON.parse(response.body)['errors'].first['code']).to eq '502'
+      end
+    end
+  end
+
+  context 'with client credentials jwt' do
+    before do
+      allow(JWT).to receive(:decode).and_return(client_credentials_jwt)
+    end
+
+    it 'v0 GET returns true if the user is a veteran' do
+      with_okta_configured do
+        get '/internal/auth/v0/validation', params: nil, headers: auth_header
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to be_a(String)
+        expect(JSON.parse(response.body)['data']['attributes'].keys).to eq(json_api_response['data']['attributes'].keys)
+      end
+    end
+
+    it 'v1 POST returns true if the user is a veteran' do
+      with_okta_configured do
+        post '/internal/auth/v1/validation', params: nil, headers: auth_header
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to be_a(String)
+        expect(JSON.parse(response.body)['data']['attributes'].keys).to eq(json_api_response['data']['attributes'].keys)
       end
     end
   end

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
         'uid' => '00u1zlqhuo3yLa2Xs2p7',
         'scp' => %w[profile email launch/patient],
         'sub' => '0oa1c01m77heEXUZt2p7'
-      }, {
+      },
+      {
        'kid' => '1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU',
        'alg' => 'RS256'
       }


### PR DESCRIPTION
## Description of change
Adds Lighthouse token validation support for Okta Client Credentials tokens.  These tokens do not contain normal parameters like uuid from Okta, so session & current_user build up has to be skipped.

## Original issue(s)
https://vajira.max.gov/browse/API-3019

## Things to know about this PR
* A follow on task, API-3500 will utilize a new OAuth proxy service to retrieve the launch context to populate the ICN in the token response.
* The V0 token validation endpoint is slated for removal (API-3589), but until then it has similar logic to skip the current_user.icn lookup if a client credentials token.
