### PR TITLE
update EvssDocument to use EVSS inflection

### DIFF
--- a/app/workers/evss/disability_compensation_form/evss_document.rb
+++ b/app/workers/evss/disability_compensation_form/evss_document.rb
@@ -9,7 +9,7 @@ module EVSS
     #
     # @!attribute pdf_path [String] The file path of the PDF
     #
-    class EvssDocument
+    class EVSSDocument
       # @return [String] the contents of the file
       #
       def file_body

--- a/app/workers/evss/disability_compensation_form/form8940_document.rb
+++ b/app/workers/evss/disability_compensation_form/form8940_document.rb
@@ -6,7 +6,7 @@ module EVSS
     #
     # @return [EVSSClaimDocument] An EVSS claim document ready for submission
     #
-    class Form8940Document < EvssDocument
+    class Form8940Document < EVSSDocument
       FORM_ID = '21-8940' # form id for PTSD IU
       DOC_TYPE = 'L149'
 


### PR DESCRIPTION


## Description of change
As part of the upgrade path for Zeitwerk, the EvssDocument classname needs to be updated to use the EVSS inflection to properly autoload.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15894

## Testing
- [x] Tests passing locally