### PR TITLE
Srsuddath 1 add typeahead feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -297,3 +297,13 @@ features:
     enable_in_development: true
     description: >
       Ask for a password when an encrypted PDF is detected before uploading
+  education_reports_cleanup:
+    actor_type: user
+    enable_in_development: true
+    description: >
+      Updates to the daily education reports to remove old data that isn't needed in the new fiscal year
+  search_typeahead_enabled:
+    actor_type: user
+    enable_in_development: true
+    description: >
+      Enables type ahead search functionality on the home page

--- a/config/features.yml
+++ b/config/features.yml
@@ -306,4 +306,4 @@ features:
     actor_type: user
     enable_in_development: true
     description: >
-      Enables type ahead search functionality on the home page
+      Enables type ahead search functionality


### PR DESCRIPTION

## Description of change
Add feature flag to toggle typeahead functionality for search.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14452

## Things to know about this PR
* Is there a feature flag? What is it?
Added a new feature flag: search_typeahead_enabled
