### PR TITLE
API-3609: Flashes - Assuming Homelessness/Terminally Ill flash from their sections of the 526 payload

### DIFF
--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -88,7 +88,7 @@ module ClaimsApi
       initial_flashes.push('Homeless') if homelessness.present?
       initial_flashes.push('Terminally Ill') if is_terminally_ill.present? && is_terminally_ill
 
-      initial_flashes.uniq
+      initial_flashes.present? ? initial_flashes.uniq : []
     end
 
     private

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -80,6 +80,17 @@ module ClaimsApi
       @uploader ||= ClaimsApi::SupportingDocumentUploader.new(id)
     end
 
+    def flashes
+      initial_flashes = JSON.parse(to_internal).dig('form526', 'veteran', 'flashes')
+      homelessness = JSON.parse(to_internal).dig('form526', 'veteran', 'homelessness')
+      is_terminally_ill = JSON.parse(to_internal).dig('form526', 'veteran', 'isTerminallyIll')
+
+      initial_flashes.push('Homeless') if homelessness.present?
+      initial_flashes.push('Terminally Ill') if is_terminally_ill.present? && is_terminally_ill
+
+      initial_flashes.uniq
+    end
+
     private
 
     def remove_encrypted_fields

--- a/modules/claims_api/app/workers/claims_api/claim_establisher.rb
+++ b/modules/claims_api/app/workers/claims_api/claim_establisher.rb
@@ -16,13 +16,13 @@ module ClaimsApi
 
       form_data = auto_claim.to_internal
       auth_headers = auto_claim.auth_headers
+      flashes = auto_claim.flashes
 
       response = service(auth_headers).submit_form526(form_data)
       auto_claim.evss_id = response.claim_id
       auto_claim.status = ClaimsApi::AutoEstablishedClaim::ESTABLISHED
       auto_claim.save
 
-      flashes = auto_claim.flashes
       ClaimsApi::FlashUpdater.perform_async(bgs_user(auth_headers), flashes) if flashes.present?
     rescue ::EVSS::DisabilityCompensationForm::ServiceException => e
       auto_claim.status = ClaimsApi::AutoEstablishedClaim::ERRORED

--- a/modules/claims_api/app/workers/claims_api/claim_establisher.rb
+++ b/modules/claims_api/app/workers/claims_api/claim_establisher.rb
@@ -22,7 +22,7 @@ module ClaimsApi
       auto_claim.status = ClaimsApi::AutoEstablishedClaim::ESTABLISHED
       auto_claim.save
 
-      flashes = JSON.parse(form_data).dig('form526', 'veteran', 'flashes')
+      flashes = auto_claim.flashes
       ClaimsApi::FlashUpdater.perform_async(bgs_user(auth_headers), flashes) if flashes.present?
     rescue ::EVSS::DisabilityCompensationForm::ServiceException => e
       auto_claim.status = ClaimsApi::AutoEstablishedClaim::ERRORED


### PR DESCRIPTION
## Description of change
Automatically adds "Homeless" and/or "Terminally Ill" flashes to claim if legacy content regarding these items was sent in the payload.

## Original issue(s)
https://vajira.max.gov/browse/API-3609

## Things to know about this PR
Will most likely have to be tweaked within this ticket: https://vajira.max.gov/browse/API-3260

Existing spec tests