### PR TITLE
Correctly Identify user for Sentry

### DIFF
--- a/app/controllers/concerns/sentry_controller_logging.rb
+++ b/app/controllers/concerns/sentry_controller_logging.rb
@@ -20,7 +20,7 @@ module SentryControllerLogging
 
   def user_context
     {
-      uuid: current_user&.uuid,
+      id: current_user&.uuid,
       authn_context: current_user&.authn_context,
       loa: current_user&.loa,
       mhv_icn: current_user&.mhv_icn

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe ApplicationController, type: :controller do
         )
         # since user IS signed in, this SHOULD get called
         expect(Raven).to receive(:user_context).with(
-          uuid: user.uuid,
+          id: user.uuid,
           authn_context: user.authn_context,
           loa: user.loa,
           mhv_icn: user.mhv_icn


### PR DESCRIPTION
## Description of change
Sentry expects id, not uuid. https://docs.sentry.io/platforms/ruby/enriching-events/identify-user/

The user's uuid is meaningless on its own but it rather useful in tracking down what the issue is in cases like a validation error where data is relevant.   We've been sending it all along, but not with the proper hash key. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#16216
