### PR TITLE
Adding Pension Questions to 686

### DIFF
--- a/app/models/bgs_dependents/base.rb
+++ b/app/models/bgs_dependents/base.rb
@@ -52,7 +52,8 @@ module BGSDependents
         living_expenses_paid_amount: optional_fields[:living_expenses_paid],
         child_prevly_married_ind: optional_fields[:child_prevly_married_ind],
         guardian_particpant_id: optional_fields[:guardian_particpant_id],
-        type: optional_fields[:type]
+        type: optional_fields[:type],
+        dep_has_income_ind: optional_fields[:dep_has_income_ind]
       }
     end
 

--- a/app/models/bgs_dependents/child.rb
+++ b/app/models/bgs_dependents/child.rb
@@ -24,6 +24,8 @@ module BGSDependents
     #   @return [String] reason child marriage ended
     # @!attribute family_relationship_type
     #   @return [String] family relationship type: Biological/Stepchild/Adopted Child/Other
+    # @!attribute child_income
+    #   @return [String] did this child have income in the last 365 days
     #
     attribute :ssn, String
     attribute :first, String
@@ -37,6 +39,7 @@ module BGSDependents
     attribute :place_of_birth_country, String
     attribute :reason_marriage_ended, String
     attribute :family_relationship_type, String
+    attribute :child_income, String
 
     CHILD_STATUS = {
       'stepchild' => 'Stepchild',
@@ -89,7 +92,8 @@ module BGSDependents
         place_of_birth_state: @child_info.dig('place_of_birth', 'state'),
         place_of_birth_city: @child_info.dig('place_of_birth', 'city'),
         reason_marriage_ended: @child_info.dig('previous_marriage_details', 'reason_marriage_ended'),
-        ever_married_ind: marriage_indicator
+        ever_married_ind: marriage_indicator,
+        child_income: @child_info['child_income'] ? 'Y' : 'N'
       }.merge(@child_info['full_name'])
     end
 

--- a/app/models/bgs_dependents/relationship.rb
+++ b/app/models/bgs_dependents/relationship.rb
@@ -24,7 +24,8 @@ module BGSDependents
         marage_trmntn_city_nm: dependent[:divorce_city],
         marage_trmntn_type_cd: dependent[:marriage_termination_type_code],
         mthly_support_from_vet_amt: dependent[:living_expenses_paid_amount],
-        child_prevly_married_ind: dependent[:child_prevly_married_ind]
+        child_prevly_married_ind: dependent[:child_prevly_married_ind],
+        dep_has_income_ind: dependent[:dep_has_income_ind]
       }
     end
   end

--- a/app/models/bgs_dependents/spouse.rb
+++ b/app/models/bgs_dependents/spouse.rb
@@ -26,6 +26,8 @@ module BGSDependents
     #   @return [String] Y/N indicates whether the person has ever been married
     # @!attribute martl_status_type_cd
     #   @return [String] marital status type: Married, Divorced, Widowed, Separated, Never Married
+    # @!attribute spouse_income
+    #   @return [String] did this spouse have income in the last 365 days
     #
     attribute :ssn, String
     attribute :first, String
@@ -38,6 +40,7 @@ module BGSDependents
     attribute :va_file_number, String
     attribute :ever_married_ind, String
     attribute :martl_status_type_cd, String
+    attribute :spouse_income, String
 
     def initialize(dependents_application)
       @dependents_application = dependents_application
@@ -67,7 +70,8 @@ module BGSDependents
         ever_married_ind: 'Y',
         martl_status_type_cd: marital_status,
         vet_ind: spouse_is_veteran,
-        address: spouse_address
+        address: spouse_address,
+        spouse_income: @dependents_application['does_live_with_spouse']['spouse_income'] ? 'Y' : 'N'
       }.merge(@spouse_information['full_name'])
 
       spouse_info.merge!({ 'va_file_number': @spouse_information['va_file_number'] }) if spouse_is_veteran == 'Y'

--- a/app/models/bgs_dependents/veteran.rb
+++ b/app/models/bgs_dependents/veteran.rb
@@ -34,7 +34,7 @@ module BGSDependents
       vet_info.to_h
     end
 
-    def veteran_response(participant, va_file_number, address, end_product, location_id)
+    def veteran_response(participant, va_file_number, address, end_product, location_id, net_worth_over_limit_ind)
       {
         vnp_participant_id: participant[:vnp_ptcpnt_id],
         first_name: first_name,
@@ -50,7 +50,8 @@ module BGSDependents
         address_zip_code: address[:zip_prefix_nbr],
         type: 'veteran',
         benefit_claim_type_end_product: end_product,
-        location_id: location_id
+        location_id: location_id,
+        net_worth_over_limit_ind: net_worth_over_limit_ind
       }
     end
 

--- a/app/models/bgs_dependents/veteran.rb
+++ b/app/models/bgs_dependents/veteran.rb
@@ -34,13 +34,13 @@ module BGSDependents
       vet_info.to_h
     end
 
-    def veteran_response(participant, va_file_number, address, end_product, location_id, net_worth_over_limit_ind)
+    def veteran_response(participant, address, claim_info)
       {
         vnp_participant_id: participant[:vnp_ptcpnt_id],
         first_name: first_name,
         last_name: last_name,
         vnp_participant_address_id: address[:vnp_ptcpnt_addrs_id],
-        file_number: va_file_number,
+        file_number: claim_info[:va_file_number],
         address_line_one: address[:addrs_one_txt],
         address_line_two: address[:addrs_two_txt],
         address_line_three: address[:addrs_three_txt],
@@ -49,9 +49,9 @@ module BGSDependents
         address_city: address[:city_nm],
         address_zip_code: address[:zip_prefix_nbr],
         type: 'veteran',
-        benefit_claim_type_end_product: end_product,
-        location_id: location_id,
-        net_worth_over_limit_ind: net_worth_over_limit_ind
+        benefit_claim_type_end_product: claim_info[:claim_type_end_product],
+        location_id: claim_info[:location_id],
+        net_worth_over_limit_ind: claim_info[:net_worth_over_limit_ind]
       }
     end
 

--- a/app/models/bgs_dependents/vnp_benefit_claim.rb
+++ b/app/models/bgs_dependents/vnp_benefit_claim.rb
@@ -23,7 +23,8 @@ module BGSDependents
         ptcpnt_mail_addrs_id: @veteran[:vnp_participant_address_id],
         vnp_ptcpnt_vet_id: @veteran[:vnp_participant_id],
         claim_jrsdtn_lctn_id: @veteran[:location_id],
-        intake_jrsdtn_lctn_id: @veteran[:location_id]
+        intake_jrsdtn_lctn_id: @veteran[:location_id],
+        net_worth_over_limit_ind: @veteran[:net_worth_over_limit_ind]
       }.merge(VNP_BENEFIT_CREATE_PARAMS)
     end
 

--- a/lib/bgs/children.rb
+++ b/lib/bgs/children.rb
@@ -43,7 +43,8 @@ module BGS
           {
             marriage_termination_type_code: formatted_info['reason_marriage_ended'],
             type: 'child',
-            child_prevly_married_ind: formatted_info['ever_married_ind']
+            child_prevly_married_ind: formatted_info['ever_married_ind'],
+            dep_has_income_ind: formatted_info['child_income']
           }
         )
       end

--- a/lib/bgs/marriages.rb
+++ b/lib/bgs/marriages.rb
@@ -56,7 +56,8 @@ module BGS
           marriage_country: @dependents_application['current_marriage_information']['location']['country'],
           marriage_state: @dependents_application['current_marriage_information']['location']['state'],
           marriage_city: @dependents_application['current_marriage_information']['location']['city'],
-          type: 'spouse'
+          type: 'spouse',
+          dep_has_income_ind: spouse_info['spouse_income']
         }
       )
     end

--- a/lib/bgs/vnp_veteran.rb
+++ b/lib/bgs/vnp_veteran.rb
@@ -10,12 +10,13 @@ module BGS
       @payload = payload.with_indifferent_access
       @veteran_info = veteran.formatted_params(@payload)
       @claim_type = claim_type
+      @va_file_number = @payload['veteran_information']['va_file_number']
     end
 
     def create
       participant = bgs_service.create_participant(@proc_id, @user.participant_id)
       claim_type_end_product = bgs_service.find_benefit_claim_type_increment(@claim_type)
-      va_file_number = @payload['veteran_information']['va_file_number']
+      # va_file_number = @payload['veteran_information']['va_file_number']
       person_params = veteran.create_person_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
       address_params = veteran.create_address_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
       address = bgs_service.create_address(address_params)
@@ -23,7 +24,17 @@ module BGS
       bgs_service.create_person(person_params)
       bgs_service.create_phone(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
       net_worth_over_limit_ind = @payload['dependents_application']['household_income'] ? 'Y' : 'N'
-      veteran.veteran_response(participant, va_file_number, address, claim_type_end_product, location_id, net_worth_over_limit_ind)
+      veteran.veteran_response(
+        participant,
+        address,
+        {
+          va_file_number: @va_file_number,
+          claim_type_end_product: claim_type_end_product,
+          location_id: location_id,
+          net_worth_over_limit_ind: net_worth_over_limit_ind
+        }
+      )
+
     end
 
     private

--- a/lib/bgs/vnp_veteran.rb
+++ b/lib/bgs/vnp_veteran.rb
@@ -34,7 +34,6 @@ module BGS
           net_worth_over_limit_ind: net_worth_over_limit_ind
         }
       )
-
     end
 
     private

--- a/lib/bgs/vnp_veteran.rb
+++ b/lib/bgs/vnp_veteran.rb
@@ -22,7 +22,8 @@ module BGS
       location_id = get_location_id(address[:zip_prefix_nbr], address[:cntry_nm], '')
       bgs_service.create_person(person_params)
       bgs_service.create_phone(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
-      veteran.veteran_response(participant, va_file_number, address, claim_type_end_product, location_id)
+      net_worth_over_limit_ind = @payload['dependents_application']['household_income'] ? 'Y' : 'N'
+      veteran.veteran_response(participant, va_file_number, address, claim_type_end_product, location_id, net_worth_over_limit_ind)
     end
 
     private

--- a/lib/bgs/vnp_veteran.rb
+++ b/lib/bgs/vnp_veteran.rb
@@ -16,7 +16,6 @@ module BGS
     def create
       participant = bgs_service.create_participant(@proc_id, @user.participant_id)
       claim_type_end_product = bgs_service.find_benefit_claim_type_increment(@claim_type)
-      # va_file_number = @payload['veteran_information']['va_file_number']
       person_params = veteran.create_person_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
       address_params = veteran.create_address_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
       address = bgs_service.create_address(address_params)

--- a/spec/lib/bgs/vnp_veteran_spec.rb
+++ b/spec/lib/bgs/vnp_veteran_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe BGS::VnpVeteran do
             address_zip_code: '21122',
             type: 'veteran',
             benefit_claim_type_end_product: '139',
-            location_id: '343'
+            location_id: '343',
+            net_worth_over_limit_ind: 'N'
           )
         end
       end

--- a/spec/models/bgs_dependents/child_spec.rb
+++ b/spec/models/bgs_dependents/child_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe BGSDependents::Child do
   let(:child_info) do
     {
       'does_child_live_with_you' => false,
+      'child_income' => false,
       'child_address_info' => {
         'person_child_lives_with' => { 'first' => 'Bill', 'middle' => 'Oliver', 'last' => 'Bradsky' },
         'address' => {
@@ -51,7 +52,8 @@ RSpec.describe BGSDependents::Child do
         'first' => 'John',
         'middle' => 'oliver',
         'last' => 'Hamm',
-        'suffix' => 'Sr.'
+        'suffix' => 'Sr.',
+        'child_income' => 'N'
       }
     end
 

--- a/spec/models/bgs_dependents/veteran_spec.rb
+++ b/spec/models/bgs_dependents/veteran_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe BGSDependents::Veteran do
   describe '#veteran_response' do
     it 'formats params veteran response' do
       expect(
-        vet.veteran_response({ vnp_ptcpnt_id: '149500' }, '1234', address, '134', '310')
+        vet.veteran_response({ vnp_ptcpnt_id: '149500' }, '1234', address, '134', '310', 'Y')
       ).to include(veteran_response_result_sample)
     end
   end

--- a/spec/models/bgs_dependents/veteran_spec.rb
+++ b/spec/models/bgs_dependents/veteran_spec.rb
@@ -48,7 +48,14 @@ RSpec.describe BGSDependents::Veteran do
   describe '#veteran_response' do
     it 'formats params veteran response' do
       expect(
-        vet.veteran_response({ vnp_ptcpnt_id: '149500' }, '1234', address, '134', '310', 'Y')
+        vet.veteran_response(
+          { vnp_ptcpnt_id: '149500' },
+          address,
+          { va_file_number: '1234',
+            claim_type_end_product: '134',
+            location_id: '310',
+            net_worth_over_limit_ind: 'Y' }
+        )
       ).to include(veteran_response_result_sample)
     end
   end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This PR is to update the VA Form 686c with a few yes/no questions for pension eligibility.  There are 2 APIs that are updated:
-  `VnpPtcpntRlnshpWebService` - added a flag for `depHasIncomeInd`
-  `VnpBnftClaimWebService` - added a flag for `netWorthOverLimitInd`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#8780

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is just an addition to existing functionality, no additional configuration or logging needed.  

<!-- Please describe testing done to verify the changes or any testing planned. -->
Specs have been updated to reflect the new data.