### PR TITLE
remove VeteranApi::ApplicationController

### DIFF
--- a/modules/veteran/app/controllers/veteran/application_controller.rb
+++ b/modules/veteran/app/controllers/veteran/application_controller.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module VeteranApi
-  class ApplicationController
-  end
-end


### PR DESCRIPTION
## Description of change
The modules/veteran/app/controllers/veteran/application_controller.rb file is not being used by any other code and causes a loading error for Zeitwork autloading. This PR removes the file.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15892

## Testing
- [x] Test suite passing
