### PR TITLE
API-3261: Flashes - Track the successes for Flashes by claim

### DIFF
--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -8,6 +8,9 @@ module ClaimsApi
     attr_encrypted(:form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
     attr_encrypted(:auth_headers, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
     attr_encrypted(:evss_response, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
+    attr_encrypted(:bgs_flash_responses, key: Settings.db_encryption_key,
+                                         marshal: true,
+                                         marshaler: JsonMarshal::Marshaller)
 
     after_create :log_flashes
 

--- a/modules/claims_api/app/workers/claims_api/flash_updater.rb
+++ b/modules/claims_api/app/workers/claims_api/flash_updater.rb
@@ -8,13 +8,19 @@ module ClaimsApi
     include Sidekiq::Worker
     include SentryLogging
 
-    def perform(user, flashes)
+    def perform(user, flashes, auto_claim_id: nil)
       service = bgs_service(user).claimant
 
       flashes.each do |flash_name|
         # Note: Assumption that duplicate flashes are ignored when submitted
         service.add_flash(file_number: user.ssn, flash_name: flash_name)
       rescue BGS::ShareError, BGS::PublicError => e
+        if auto_claim_id.present?
+          auto_claim = ClaimsApi::AutoEstablishedClaim.find(auto_claim_id)
+          auto_claim.bgs_flash_responses = [] if auto_claim.bgs_flash_responses.blank?
+          auto_claim.bgs_flash_responses = auto_claim.bgs_flash_responses + [{ key: e.code, text: e.message }]
+          auto_claim.save
+        end
         log_exception_to_sentry(e)
       end
     end

--- a/modules/claims_api/spec/workers/claim_establisher_spec.rb
+++ b/modules/claims_api/spec/workers/claim_establisher_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ClaimsApi::ClaimEstablisher, type: :job do
     claim
   end
 
-  it 'submits succesfully' do
+  it 'submits successfully' do
     expect do
       subject.perform_async(claim.id)
     end.to change(subject.jobs, :size).by(1)

--- a/modules/claims_api/spec/workers/claim_uploader_spec.rb
+++ b/modules/claims_api/spec/workers/claim_uploader_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ClaimsApi::ClaimUploader, type: :job do
     supporting_document
   end
 
-  it 'submits succesfully' do
+  it 'submits successfully' do
     expect do
       subject.perform_async(supporting_document.id)
     end.to change(subject.jobs, :size).by(1)

--- a/modules/vaos/spec/workers/extend_session_job_spec.rb
+++ b/modules/vaos/spec/workers/extend_session_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe VAOS::ExtendSessionJob, type: :job do
   end
 
   describe '.perform_async' do
-    it 'submits succesfully' do
+    it 'submits successfully' do
       expect do
         subject.perform_async(user.account_uuid)
       end.to change(subject.jobs, :size).by(1)

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe Users::Profile do
     end
 
     context '#veteran_status' do
-      context 'when a veteran status is succesfully returned' do
+      context 'when a veteran status is successfully returned' do
         it 'includes is_veteran' do
           expect(veteran_status[:is_veteran]).to eq(user.veteran?)
         end


### PR DESCRIPTION
## Description of change
Persists any responses from bgs if an exception occurs.

## Original issue(s)
https://vajira.max.gov/browse/API-3261

## Things to know about this PR
Requires database migration work found here: https://github.com/department-of-veterans-affairs/vets-api/pull/5335

Specs updated and added.