### PR TITLE
fix scoping for notification

### DIFF
--- a/app/swagger/swagger/schemas/dismissed_status.rb
+++ b/app/swagger/swagger/schemas/dismissed_status.rb
@@ -18,7 +18,7 @@ module Swagger
             property :status,
                      type: :string,
                      example: 'pending_mt',
-                     enum: ::Notification.subjects.keys.sort
+                     enum: ::Notification.statuses.keys.sort
             property :status_effective_at, type: :string, example: '2019-02-25T01:22:00.000Z'
             property :read_at, type: :string, example: '2019-02-26T21:20:50.151Z'
           end

--- a/app/swagger/swagger/schemas/dismissed_status.rb
+++ b/app/swagger/swagger/schemas/dismissed_status.rb
@@ -14,11 +14,11 @@ module Swagger
             property :subject,
                      type: :string,
                      example: 'form_10_10ez',
-                     enum: Notification.subjects.keys.sort
+                     enum: ::Notification.subjects.keys.sort
             property :status,
                      type: :string,
                      example: 'pending_mt',
-                     enum: Notification.statuses.keys.sort
+                     enum: ::Notification.subjects.keys.sort
             property :status_effective_at, type: :string, example: '2019-02-25T01:22:00.000Z'
             property :read_at, type: :string, example: '2019-02-26T21:20:50.151Z'
           end


### PR DESCRIPTION


## Description of change
Swagger::Schemas namespace has a Notification class. app/swagger/swagger/schemas/dismissed_status.rb refers to Notification but doesn't mean in the same namespace, so to refer to the Notification model, the scope must be escaped.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15888

## Things to know about this PR
 - [x] Test suite passing locally 
