### PR TITLE
fall back to identity provider birth date for evss headers

### DIFF
--- a/lib/evss/base_headers.rb
+++ b/lib/evss/base_headers.rb
@@ -10,9 +10,11 @@ module EVSS
     private
 
     def iso8601_birth_date
-      return nil unless @user&.va_profile&.birth_date
+      birth_date = @user&.va_profile&.birth_date
+      birth_date = @user.identity.birth_date if !birth_date && @user.is_a?(User)
+      return nil unless birth_date
 
-      DateTime.parse(@user.va_profile.birth_date).iso8601
+      DateTime.parse(birth_date).iso8601
     end
   end
 end

--- a/spec/lib/evss/disability_compensation_auth_headers_spec.rb
+++ b/spec/lib/evss/disability_compensation_auth_headers_spec.rb
@@ -11,11 +11,11 @@ describe EVSS::DisabilityCompensationAuthHeaders do
   let(:invalid_headers) { described_class.new(blank_gender_user) }
 
   # rubocop:disable all
-  it 'includes gender in the headers' do
+  it 'includes gender and birth date in the headers' do
     expect(valid_headers.add_headers(auth_headers)).to eq(
       'foo' => 'bar',
       'va_eauth_authorization' =>
-        '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":null,"firstName":"abraham","lastName":"lincoln","birthDate":null,"gender":"MALE"}}')
+        '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796111863","edi":null,"firstName":"abraham","lastName":"lincoln","birthDate":"1809-02-12T00:00:00+00:00","gender":"MALE"}}')
   end
   # rubocop:enable all
 


### PR DESCRIPTION
## Description of change
If we can't get the date of birth from MPI get it from the identity provider for EVSS headers.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#6298