### PR TITLE
spell out SCO and update filenames

### DIFF
--- a/app/models/saved_claim/education_benefits/va10203.rb
+++ b/app/models/saved_claim/education_benefits/va10203.rb
@@ -12,7 +12,7 @@ class SavedClaim::EducationBenefits::VA10203 < SavedClaim::EducationBenefits
     if Flipper.enabled?(:stem_sco_email, user) && user.present?
       authorized = user.authorize(:evss, :access?)
 
-      EducationForm::SendSCOEmail.perform_async(user.uuid, id) if authorized
+      EducationForm::SendSchoolCertifyingOfficialsEmail.perform_async(user.uuid, id) if authorized
     end
   end
 

--- a/app/workers/education_form/send_school_certifying_officials_email.rb
+++ b/app/workers/education_form/send_school_certifying_officials_email.rb
@@ -3,7 +3,7 @@
 require 'evss/gi_bill_status/service'
 
 module EducationForm
-  class SendSCOEmail
+  class SendSchoolCertifyingOfficialsEmail
     include Sidekiq::Worker
 
     def perform(user_uuid, claim_id)
@@ -97,7 +97,7 @@ module EducationForm
 
     def recipients
       scos = @institution[:versioned_school_certifying_officials]
-      EducationForm::SendSCOEmail.sco_emails(scos)
+      EducationForm::SendSchoolCertifyingOfficialsEmail.sco_emails(scos)
     end
 
     def stats_key

--- a/spec/jobs/education_form/send_school_certifying_officials_email_spec.rb
+++ b/spec/jobs/education_form/send_school_certifying_officials_email_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'gi/client' # required for stubbing, isn't loaded normally until GIDSRedis is loaded
 
-RSpec.describe EducationForm::SendSCOEmail, type: :model, form: :education_benefits do
+RSpec.describe EducationForm::SendSchoolCertifyingOfficialsEmail, type: :model, form: :education_benefits do
   subject { described_class.new }
 
   let(:claim) { create(:va10203) }

--- a/spec/mailers/previews/school_certifying_officials_mailer_preview.rb
+++ b/spec/mailers/previews/school_certifying_officials_mailer_preview.rb
@@ -19,7 +19,7 @@ class SchoolCertifyingOfficialsMailerPreview < ActionMailer::Preview
     return [] if institution.blank?
 
     scos = institution[:versioned_school_certifying_officials]
-    EducationForm::SendSCOEmail.sco_emails(scos)
+    EducationForm::SendSchoolCertifyingOfficialsEmail.sco_emails(scos)
   end
 
   def fake_applicant

--- a/spec/models/saved_claim/education_benefits/va10203_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va10203_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
         expect(FeatureFlipper).to receive(:send_email?).once.and_return(false)
       end
 
-      it 'does not call SendSCOEmail' do
-        expect { instance.after_submit(user) }.to change(EducationForm::SendSCOEmail.jobs, :size).by(0)
+      it 'does not call SendSchoolCertifyingOfficialsEmail' do
+        expect { instance.after_submit(user) }.to change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
       end
     end
 
@@ -37,8 +37,8 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
         allow(StemApplicantConfirmationMailer).to receive(:build).with(instance, nil).and_return(mail)
       end
 
-      it 'does not call SendSCOEmail' do
-        expect { instance.after_submit(nil) }.to change(EducationForm::SendSCOEmail.jobs, :size).by(0)
+      it 'does not call SendSchoolCertifyingOfficialsEmail' do
+        expect { instance.after_submit(nil) }.to change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
       end
     end
 
@@ -53,8 +53,8 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
         allow(StemApplicantConfirmationMailer).to receive(:build).with(instance, nil).and_return(mail)
       end
 
-      it 'calls SendSCOEmail' do
-        expect { instance.after_submit(user) }.to change(EducationForm::SendSCOEmail.jobs, :size).by(1)
+      it 'calls SendSchoolCertifyingOfficialsEmail' do
+        expect { instance.after_submit(user) }.to change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(1)
       end
 
       it 'calls StemApplicantConfirmationMailer' do
@@ -74,9 +74,9 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
         allow(StemApplicantConfirmationMailer).to receive(:build).with(instance, nil).and_return(mail)
       end
 
-      it 'does not call SendSCOEmail' do
+      it 'does not call SendSchoolCertifyingOfficialsEmail' do
         expect { instance.after_submit(user) }
-          .to change(EducationForm::SendSCOEmail.jobs, :size).by(0)
+          .to change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
       end
 
       it 'calls StemApplicantConfirmationMailer' do
@@ -98,9 +98,9 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
         allow(StemApplicantConfirmationMailer).to receive(:build).with(instance, nil).and_return(mail)
       end
 
-      it 'does not call SendSCOEmail' do
+      it 'does not call SendSchoolCertifyingOfficialsEmail' do
         expect { instance.after_submit(user) }
-          .to change(EducationForm::SendSCOEmail.jobs, :size).by(0)
+          .to change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
       end
 
       it 'calls StemApplicantConfirmationMailer' do

--- a/spec/models/saved_claim/education_benefits/va10203_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va10203_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
       it 'does not call SendSchoolCertifyingOfficialsEmail' do
         expect { instance.after_submit(user) }.to
-          change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
+        change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
       end
     end
 
@@ -40,7 +40,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
       it 'does not call SendSchoolCertifyingOfficialsEmail' do
         expect { instance.after_submit(nil) }.to
-          change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
+        change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
       it 'calls SendSchoolCertifyingOfficialsEmail' do
         expect { instance.after_submit(user) }.to
-          change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(1)
+        change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(1)
       end
 
       it 'calls StemApplicantConfirmationMailer' do

--- a/spec/models/saved_claim/education_benefits/va10203_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va10203_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
       end
 
       it 'calls SendSchoolCertifyingOfficialsEmail' do
-        expect { instance.after_submit(user) }.to change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(1)
+        expect { instance.after_submit(user) }.to
+          change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(1)
       end
 
       it 'calls StemApplicantConfirmationMailer' do

--- a/spec/models/saved_claim/education_benefits/va10203_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va10203_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
       end
 
       it 'does not call SendSchoolCertifyingOfficialsEmail' do
-        expect { instance.after_submit(user) }.to change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
+        expect { instance.after_submit(user) }.to
+          change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
       end
     end
 
@@ -38,7 +39,8 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
       end
 
       it 'does not call SendSchoolCertifyingOfficialsEmail' do
-        expect { instance.after_submit(nil) }.to change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
+        expect { instance.after_submit(nil) }.to
+          change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size).by(0)
       end
     end
 


### PR DESCRIPTION


## Description of change
This PR removes the SCO acronym in favor of the spelled out version. The acronym is very specific to an emailer and not necessarily an official VA adopted acronym. This PR renames EducationForm::SendSCOEmail to EducationForm::SendSchoolCertifyingOfficialsEmail and corresponding filenames to avoid the need of an acronym.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#15890

## Testing
- [x] Test suite passing locally
