### PR TITLE
MVI slo improvements and and additional error logging

### DIFF
--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -109,10 +109,18 @@ RSpec.describe V0::SessionsController, type: :controller do
               .with_params('op' => 'signup', 'clientId' => '123123')
           end
         end
+
+        context 'routes /v0/sessions/slo/new to SessionController#new' do
+          it 'redirects' do
+            get(:new, params: { type: :slo })
+            expect(get(:new, params: { type: :slo }))
+              .to redirect_to('https://int.eauth.va.gov/pkmslogout?filename=vagov-logout.html')
+          end
+        end
       end
 
       context 'routes requiring auth' do
-        %w[mfa verify slo].each do |type|
+        %w[mfa verify].each do |type|
           it "routes /sessions/#{type}/new to SessionsController#new with type: #{type}" do
             get(:new, params: { type: type })
             expect(response).to have_http_status(:unauthorized)
@@ -216,8 +224,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(cookies['vagov_session_dev']).not_to be_nil
           get(:new, params: { type: 'slo' })
           expect(response.location)
-            .to be_an_idme_saml_url('https://api.idmelabs.com/saml/SingleLogoutService?SAMLRequest=')
-            .with_relay_state('originating_request_id' => nil, 'type' => 'slo')
+            .to eq('https://int.eauth.va.gov/pkmslogout?filename=vagov-logout.html')
 
           # these should be destroyed.
           expect(Session.find(token)).to be_nil
@@ -226,7 +233,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(cookies['vagov_session_dev']).to be_nil
 
           # this should be created in redis
-          expect(SingleLogoutRequest.find(logout_request.uuid)).not_to be_nil
+          expect(SingleLogoutRequest.find(logout_request.uuid)).to be_nil
         end
       end
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Updates the v0 authentication logout route (`/sessions/slo/new`) to ONLY load the user and destroy the session before issuing an SLO call to ID.me (similar to what's happening in v1).  Previously the `authenticate` method would also "extend" the session, before issuing SLO.  While in the majority of cases this works, sometimes we need to query MPI to get data in order to "extend" the session.  If the [MPI query fails](http://sentry.vfs.va.gov/organizations/vsp/issues/6593/?environment=production&project=3&query=is%3Aunresolved+%22MVI%3A%3AErrors%3A%3AInvalidRequestError%22&statsPeriod=14d) this can result in an error for the user, but these are unnecessary as the user SHOULD NOT need to do this.

In addition, temporary logging of outgoing XML in the event that InvalidRequestError is returned has been added so that we can further improve the missing key/values validator added in #5151 and #5357   

## Original issue(s)
refs https://github.com/department-of-veterans-affairs/va.gov-team/issues/15180
Sentry error: http://sentry.vfs.va.gov/share/issue/63f9713d288e49dbb743bf0fa5ed24a0/

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [ ] manually test that if an unauthenticated user issues an SLO request to ID.me, that they are redirected back to the va.gov home page (double checking that ID.me doesn't issue an error if the user DOESN'T have a session)
v0 `sessions_controller_spec` updated for changers to pass, manual testing still needed.