### PR TITLE
Allow larger file for EVSS

### DIFF
--- a/app/uploaders/evss_claim_document_uploader.rb
+++ b/app/uploaders/evss_claim_document_uploader.rb
@@ -4,6 +4,7 @@
 class EVSSClaimDocumentUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
   include SetAWSConfig
+  include ValidateEvssFileSize
 
   def size_range
     1.byte...150.megabytes

--- a/app/uploaders/evss_claim_document_uploader.rb
+++ b/app/uploaders/evss_claim_document_uploader.rb
@@ -6,7 +6,7 @@ class EVSSClaimDocumentUploader < CarrierWave::Uploader::Base
   include SetAWSConfig
 
   def size_range
-    1.byte...50.megabytes
+    1.byte...150.megabytes
   end
 
   version :converted, if: :tiff? do

--- a/app/uploaders/supporting_evidence_attachment_uploader.rb
+++ b/app/uploaders/supporting_evidence_attachment_uploader.rb
@@ -4,6 +4,7 @@
 class SupportingEvidenceAttachmentUploader < CarrierWave::Uploader::Base
   include SetAWSConfig
   include ValidatePdf
+  include ValidateEvssFileSize
 
   def size_range
     1.byte...150.megabytes

--- a/app/uploaders/supporting_evidence_attachment_uploader.rb
+++ b/app/uploaders/supporting_evidence_attachment_uploader.rb
@@ -6,7 +6,7 @@ class SupportingEvidenceAttachmentUploader < CarrierWave::Uploader::Base
   include ValidatePdf
 
   def size_range
-    1.byte...50.megabytes
+    1.byte...150.megabytes
   end
 
   def initialize(guid)

--- a/app/uploaders/validate_evss_file_size.rb
+++ b/app/uploaders/validate_evss_file_size.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ValidateEvssFileSize
+  extend ActiveSupport::Concern
+
+  included do
+    before :store, :validate_file_size
+  end
+
+  def max_file_size_non_pdf
+    50.megabytes
+  end
+
+  # EVSS will split PDF's larger than 50mb before sending to VBA who has a limit of 50mb. so,
+  # PDF's can be larger than other files
+  def validate_file_size(file)
+    if file.content_type != 'application/pdf' && file.size > max_file_size_non_pdf
+      raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.max_size_error",
+                                                        max_size: '50MB')
+    end
+  end
+end

--- a/spec/services/evss_claim_service_spec.rb
+++ b/spec/services/evss_claim_service_spec.rb
@@ -36,17 +36,17 @@ RSpec.describe EVSSClaimService do
   end
 
   describe '#upload_document' do
-    let(:tempfile) do
+    let(:upload_file) do
       f = Tempfile.new(['file with spaces', '.txt'])
       f.write('test')
       f.rewind
-      f
+      Rack::Test::UploadedFile.new(f.path, 'image/jpeg')
     end
     let(:document) do
       EVSSClaimDocument.new(
         tracked_item_id: 1,
-        file_obj: tempfile,
-        file_name: File.basename(tempfile.path)
+        file_obj: upload_file,
+        file_name: File.basename(upload_file.path)
       )
     end
 

--- a/spec/uploaders/evss_claim_document_uploader_spec.rb
+++ b/spec/uploaders/evss_claim_document_uploader_spec.rb
@@ -7,17 +7,14 @@ RSpec.describe EVSSClaimDocumentUploader do
 
   let(:document_uploader) { described_class.new('1234', ['11', nil]) }
   let(:uploader_with_tiff) do
-    File.open('spec/fixtures/evss_claim/image.TIF') do |f|
-      document_uploader.store!(f)
-    end
-
+    f = Rack::Test::UploadedFile.new('spec/fixtures/evss_claim/image.TIF', 'image/tiff')
+    document_uploader.store!(f)
     document_uploader
   end
-  let(:uploader_with_jpg) do
-    File.open('spec/fixtures/evss_claim/converted_image.TIF.jpg') do |f|
-      document_uploader.store!(f)
-    end
 
+  let(:uploader_with_jpg) do
+    f = Rack::Test::UploadedFile.new('spec/fixtures/evss_claim/converted_image.TIF.jpg', 'image/jpeg')
+    document_uploader.store!(f)
     document_uploader
   end
 

--- a/spec/uploaders/validate_evss_file_size_spec.rb
+++ b/spec/uploaders/validate_evss_file_size_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ValidateEvssFileSize, uploader_helpers: true do
+  class ValidateEvssFileSizeTest < CarrierWave::Uploader::Base
+    include ValidateEvssFileSize
+  end
+
+  before do
+    allow_any_instance_of(described_class).to receive(:max_file_size_non_pdf).and_return(100)
+  end
+
+  def store_image
+    ValidateEvssFileSizeTest.new.store!(file)
+  end
+
+  context 'with a too large file that is not a PDF' do
+    let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/files/va.gif', 'image/gif') }
+
+    it 'raises an error' do
+      expect { store_image }.to raise_error CarrierWave::IntegrityError
+    end
+  end
+
+  context 'with a valid PDF' do
+    let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/files/doctors-note.pdf', 'application/pdf') }
+
+    it 'does not raise an error' do
+      expect { store_image }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
EVSS will accept PDF's that are larger than 50mb and the other files must be less than 50mb

## Original issue(s)
department-of-veterans-affairs/va.gov-team#16004

## Things to know about this PR
I'll wait until EVSS gives us the go-ahead before merging.
