### PR TITLE
get banking info from ppiu if submitted info is redacted

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -67,6 +67,10 @@ module EVSS
 
       private
 
+      def redacted(account_number, routing_number)
+        account_number&.include?('*') || routing_number&.include?('*')
+      end
+
       def input_form
         @form_content['form526']
       end
@@ -98,7 +102,7 @@ module EVSS
                     input_form['bankAccountNumber'].present? && input_form['bankRoutingNumber'].present?
         # if banking data is not included then it has not changed and will be retrieved
         # from the PPIU service
-        if !populated
+        if !populated || redacted(input_form['bankAccountNumber'], input_form['bankRoutingNumber'])
           get_banking_info
         else
           direct_deposit(


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
if a user submits a form with redacted banking info we should fetch the unredacted info from ppiu
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/11773

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
tested with unit tests
<!-- Please describe testing done to verify the changes or any testing planned. -->
