### PR TITLE
Doc Update for /contestable_issues

### DIFF
--- a/modules/appeals_api/app/swagger/appeals_api/v1/higher_level_reviews_controller_swagger.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/higher_level_reviews_controller_swagger.rb
@@ -140,8 +140,9 @@ class AppealsApi::V1::HigherLevelReviewsControllerSwagger
     operation :get, tags: HLR_TAG do
       key :operationId, 'getContestableIssues'
       key :summary, 'Returns all contestable issues for a specific veteran.'
-      desc = 'Returns all issues a Veteran could contest in a Higher-Level Review as of the `receiptDate` ' \
-        'and bound by `benefitType`. Associate these results when creating new Decision Reviews.'
+      desc = 'Returns all issues associated with a Veteran that have not previously been decided by a Higher-Level ' \
+        'Review as of the `receiptDate` and bound by `benefitType`. Not all issues returned are guaranteed to be ' \
+        'eligible for appeal. Associate these results when creating a new Higher-Level Review.'
       key :description, desc
       parameter name: 'X-VA-SSN', 'in': 'header', description: 'veteran\'s ssn' do
         key :description, 'Either X-VA-SSN or X-VA-File-Number is required'


### PR DESCRIPTION
## Description of change
Clarify the difference between `eligible` vs `contestable` in the docs of the /contestable_issues endpoint.

## Original issue(s)
https://vajira.max.gov/browse/API-3594

## Things to know about this PR
* Swagger documentation update