### PR TITLE
Trigger Pact consumer's can-i-deploy check after verification.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@
             command: |
               curl --request POST \
                    --url https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline \
-                   --user "${CIRCLE_TOKEN}:"
+                   --user "${CIRCLE_TOKEN}:" \
                    --header 'Content-Type: application/json' \
                    --data '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}'
     bundle_audit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,17 @@
       <<: *defaults
       steps:
         - add_pact_broker_artifact
+    notify_pact_consumers:
+      <<: *defaults
+      steps;
+        - run:
+            name: Notify Pact consumers to check verification status
+            command: |
+              curl --request POST \
+                   --url https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline \
+                   --user "${CIRCLE_TOKEN}:"
+                   --header 'Content-Type: application/json' \
+                   --data '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}'
     bundle_audit:
       <<: *defaults
       steps:
@@ -131,7 +142,7 @@
       when: << pipeline.parameters.verify_stable_pacts >>
       jobs:
         - verify_pacts
-        - pact_broker_artifact
+        - notify_pact_consumers
 
   commands:
     checkout_and_install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,11 @@
         - run:
             name: Notify Pact consumers to check verification status
             command: |
-              curl --request POST \
-                   --url https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline \
-                   --user "${CIRCLE_TOKEN}:" \
-                   --header 'Content-Type: application/json' \
-                   --data '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}'
+              curl -L -X POST \
+                   -u "${CIRCLE_TOKEN}:" \
+                   -H 'Content-Type: application/json' \
+                   -d '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}' \
+                   https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline
     bundle_audit:
       <<: *defaults
       steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@
         - add_pact_broker_artifact
     notify_pact_consumers:
       <<: *defaults
-      steps;
+      steps:
         - run:
             name: Notify Pact consumers to check verification status
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,9 @@
       when: << pipeline.parameters.verify_stable_pacts >>
       jobs:
         - verify_pacts
-        - notify_pact_consumers
+        - notify_pact_consumers:
+            requires:
+              - verify_pacts
 
   commands:
     checkout_and_install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,14 @@
 
   # Pipeline params are needed for API v2 in order to
   # trigger a conditional verification task workflow via webhook from the pact broker
-  # Triggering a specific job via v1.1 of the Circle API is being depreciated
+  # Triggering a specific job via v1.1 of the Circle API is being deprecated
   parameters:
     verify_stable_pacts:
       type: boolean
       default: false
+    consumer_branch:
+      type: string
+      default: ""
     consumer_name:
       type: string
       default: ""


### PR DESCRIPTION
## Description of change
Added a step in the `pact_verification` CircleCI workflow to trigger vets-website's `can-i-deploy` workflow.

## Original issue(s)
Related to department-of-veterans-affairs/va.gov-team#16325.

## Things to know about this PR
The newly added `notify_pact_consumers` job uses a parameter `consumer_branch`.
That parameter's expected to be passed in from the vets-website job that triggered the `pact_verification` workflow.
