### PR TITLE
Refactored Pact verification workflow to work independently of webhooks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,6 @@
     consumer_branch:
       type: string
       default: ""
-    consumer_job_id:
-      type: string
-      default: ""
     consumer_name:
       type: string
       default: ""
@@ -190,7 +187,7 @@
                   curl -L -X POST \
                        -u "${CIRCLE_TOKEN}:" \
                        -H 'Content-Type: application/json' \
-                       -d '{"jobs":["<< pipeline.parameters.consumer_job_id >>"]}' \
+                       -d '{"from_failed":true}' \
                        https://circleci.com/api/v2/workflow/<< pipeline.parameters.consumer_workflow_id >>/rerun
                 when: always
     add_pact_broker_artifact:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@
                   curl -L -X POST \
                        -u "${CIRCLE_TOKEN}:" \
                        -H 'Content-Type: application/json' \
-                       -d '{"parameters":{"from_failed":true}}' \
+                       -d '{"from_failed":true}' \
                        https://circleci.com/api/v2/workflow/<< pipeline.parameters.consumer_workflow >>/rerun
                 when: always
     add_pact_broker_artifact:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,13 @@
     consumer_branch:
       type: string
       default: ""
+    consumer_job_id:
+      type: string
+      default: ""
     consumer_name:
       type: string
       default: ""
-    consumer_workflow:
+    consumer_workflow_id:
       type: string
       default: ""
     consumer_version_tags:
@@ -182,13 +185,13 @@
     notify_pact_consumers:
         steps:
             - run:
-                name: Notify Pact consumers to check verification status
+                name: Notify Pact consumers to review verification status
                 command: |
                   curl -L -X POST \
                        -u "${CIRCLE_TOKEN}:" \
                        -H 'Content-Type: application/json' \
-                       -d '{"from_failed":true}' \
-                       https://circleci.com/api/v2/workflow/<< pipeline.parameters.consumer_workflow >>/rerun
+                       -d '{"jobs":["<< pipeline.parameters.consumer_job_id >>"]}' \
+                       https://circleci.com/api/v2/workflow/<< pipeline.parameters.consumer_workflow_id >>/rerun
                 when: always
     add_pact_broker_artifact:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@
             name: Notify Pact consumers to check verification status
             command: |
               curl -L -X POST \
-                   -u ${CIRCLE_TOKEN}: \
+                   -u "${PACT_CIRCLECI_TOKEN}:" \
                    -H 'Content-Type: application/json' \
                    -d '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}' \
                    https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@
     consumer_name:
       type: string
       default: ""
+    consumer_workflow:
+      type: string
+      default: ""
     consumer_version_tags:
       type: string
       default: ""
@@ -184,8 +187,8 @@
                   curl -L -X POST \
                        -u "${CIRCLE_TOKEN}:" \
                        -H 'Content-Type: application/json' \
-                       -d '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}' \
-                       https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline
+                       -d '{"parameters":{"from_failed":true}}' \
+                       https://circleci.com/api/v2/workflow/<< pipeline.parameters.consumer_workflow >>/rerun
                 when: always
     add_pact_broker_artifact:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,17 +59,13 @@
       <<: *defaults
       steps:
         - add_pact_broker_artifact
-    notify_pact_consumers:
+    verify_pacts_and_notify_consumers:
       <<: *defaults
       steps:
-        - run:
-            name: Notify Pact consumers to check verification status
-            command: |
-              curl -L -X POST \
-                   -u "${CIRCLE_TOKEN}:" \
-                   -H 'Content-Type: application/json' \
-                   -d '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}' \
-                   https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline
+        - checkout_and_install
+        - setup_test_db
+        - verify_stable_pacts
+        - notify_pact_consumers
     bundle_audit:
       <<: *defaults
       steps:
@@ -144,10 +140,7 @@
     pact_verification:
       when: << pipeline.parameters.verify_stable_pacts >>
       jobs:
-        - verify_pacts
-        - notify_pact_consumers:
-            requires:
-              - verify_pacts
+        - verify_pacts_and_notify_consumers
 
   commands:
     checkout_and_install:
@@ -183,6 +176,17 @@
             - run:
                 name: Verify stable pacts
                 command: bundle exec rake pact:verify
+    notify_pact_consumers:
+        steps:
+            - run:
+                name: Notify Pact consumers to check verification status
+                command: |
+                  curl -L -X POST \
+                       -u "${CIRCLE_TOKEN}:" \
+                       -H 'Content-Type: application/json' \
+                       -d '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}' \
+                       https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline
+                when: always
     add_pact_broker_artifact:
         steps:
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@
             command: |
               curl --request POST \
                    --url https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline \
-                   --user "${CIRCLE_TOKEN}:"
+                   --user "${CIRCLE_TOKEN}:" \
                    --header 'Content-Type: application/json' \
                    --data '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}'
     bundle_audit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,17 @@
       <<: *defaults
       steps:
         - add_pact_broker_artifact
+    notify_pact_consumers:
+      <<: *defaults
+      steps;
+        - run:
+            name: Notify Pact consumers to check verification status
+            command: |
+              curl --request POST \
+                   --url https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline \
+                   --user "${CIRCLE_TOKEN}:"
+                   --header 'Content-Type: application/json' \
+                   --data '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}'
     bundle_audit:
       <<: *defaults
       steps:
@@ -131,7 +142,7 @@
       when: << pipeline.parameters.verify_stable_pacts >>
       jobs:
         - verify_pacts
-        - pact_broker_artifact
+        - notify_pact_consumers
 
   commands:
     checkout_and_install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,11 @@
         - run:
             name: Notify Pact consumers to check verification status
             command: |
-              curl --request POST \
-                   --url https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline \
-                   --user "${CIRCLE_TOKEN}:" \
-                   --header 'Content-Type: application/json' \
-                   --data '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}'
+              curl -L -X POST \
+                   -u "${CIRCLE_TOKEN}:" \
+                   -H 'Content-Type: application/json' \
+                   -d '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}' \
+                   https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline
     bundle_audit:
       <<: *defaults
       steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@
             name: Notify Pact consumers to check verification status
             command: |
               curl -L -X POST \
-                   -u "${CIRCLE_TOKEN}:" \
+                   -u ${CIRCLE_TOKEN}: \
                    -H 'Content-Type: application/json' \
                    -d '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}' \
                    https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@
         - add_pact_broker_artifact
     notify_pact_consumers:
       <<: *defaults
-      steps;
+      steps:
         - run:
             name: Notify Pact consumers to check verification status
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,16 +13,7 @@
     consumer_branch:
       type: string
       default: ""
-    consumer_name:
-      type: string
-      default: ""
-    consumer_workflow_id:
-      type: string
-      default: ""
-    consumer_version_tags:
-      type: string
-      default: ""
-    consumer_version_number:
+    consumer_version:
       type: string
       default: ""
 
@@ -58,17 +49,10 @@
         - checkout_and_install
         - setup_test_db
         - verify_stable_pacts
-    pact_broker_artifact:
+    pact_verification_artifact:
       <<: *defaults
       steps:
-        - add_pact_broker_artifact
-    verify_pacts_and_notify_consumers:
-      <<: *defaults
-      steps:
-        - checkout_and_install
-        - setup_test_db
-        - verify_stable_pacts
-        - notify_pact_consumers
+        - add_pact_verification_artifact
     bundle_audit:
       <<: *defaults
       steps:
@@ -143,7 +127,8 @@
     pact_verification:
       when: << pipeline.parameters.verify_stable_pacts >>
       jobs:
-        - verify_pacts_and_notify_consumers
+        - verify_pacts
+        - pact_verification_artifact
 
   commands:
     checkout_and_install:
@@ -179,32 +164,19 @@
             - run:
                 name: Verify stable pacts
                 command: bundle exec rake pact:verify
-    notify_pact_consumers:
+    add_pact_verification_artifact:
         steps:
             - run:
-                name: Notify Pact consumers to review verification status
-                command: |
-                  curl -L -X POST \
-                       -u "${CIRCLE_TOKEN}:" \
-                       -H 'Content-Type: application/json' \
-                       -d '{"from_failed":true}' \
-                       https://circleci.com/api/v2/workflow/<< pipeline.parameters.consumer_workflow_id >>/rerun
-                when: always
-    add_pact_broker_artifact:
-        steps:
-            - run:
-               name: Create artifact for webhook info
+               name: Create artifact for consumer info
                command: |
-                 echo "Pact Broker Consumer Tagging Info:" >> /tmp/pact-broker-webhook-info;
+                 echo "Pact Consumer Info:" >> /tmp/pact-consumer-info;
 
-                 echo "Consumer Name:" << pipeline.parameters.consumer_name >> >> /tmp/pact-broker-webhook-info;
+                 echo "Consumer Branch:" << pipeline.parameters.consumer_branch >> >> /tmp/pact-consumer-info;
 
-                 echo "Consumer Version Tags:" << pipeline.parameters.consumer_version_tags >> >> /tmp/pact-broker-webhook-info;
-
-                 echo "Consumer Version Number:" << pipeline.parameters.consumer_version_number >> >> /tmp/pact-broker-webhook-info;
+                 echo "Consumer Version:" << pipeline.parameters.consumer_version >> >> /tmp/pact-consumer-info;
             - store_artifacts:
-                 path: /tmp/pact-broker-webhook-info
-                 destination: pact-broker-webhook-info
+                 path: /tmp/pact-consumer-info
+                 destination: pact-consumer-info
     bundle_audit:
         steps:
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@
             name: Notify Pact consumers to check verification status
             command: |
               curl -L -X POST \
-                   -u "${PACT_CIRCLECI_TOKEN}:" \
+                   -u "${CIRCLE_TOKEN}:" \
                    -H 'Content-Type: application/json' \
                    -d '{"branch":"<< pipeline.parameters.consumer_branch >>","parameters":{"check_deployability":true}}' \
                    https://circleci.com/api/v2/project/github/department-of-veterans-affairs/vets-website/pipeline

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,9 @@
       when: << pipeline.parameters.verify_stable_pacts >>
       jobs:
         - verify_pacts
-        - notify_pact_consumers
+        - notify_pact_consumers:
+            requires:
+              - verify_pacts
 
   commands:
     checkout_and_install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,14 @@
 
   # Pipeline params are needed for API v2 in order to
   # trigger a conditional verification task workflow via webhook from the pact broker
-  # Triggering a specific job via v1.1 of the Circle API is being depreciated
+  # Triggering a specific job via v1.1 of the Circle API is being deprecated
   parameters:
     verify_stable_pacts:
       type: boolean
       default: false
+    consumer_branch:
+      type: string
+      default: ""
     consumer_name:
       type: string
       default: ""


### PR DESCRIPTION
## Description of change
Added a step in the `pact_verification` CircleCI workflow to trigger vets-website's `can-i-deploy` workflow.

This is meant to build on top of #5288.

## Original issue(s)
Related to department-of-veterans-affairs/va.gov-team#16325.

## Things to know about this PR
The newly added `notify_pact_consumers` job uses a parameter `consumer_branch`.
That parameter's expected to be passed in from the vets-website job that triggered the `pact_verification` workflow.
