### PR TITLE
MVI FindProfileMessage log missing keys on raise

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -170,6 +170,7 @@ group :development, :test do
   gem 'rack-vcr'
   gem 'rainbow' # Used to colorize output for rake tasks
   gem 'rspec-instrumentation-matcher'
+  gem 'rspec-its'
   gem 'rspec-rails'
   gem 'rubocop', require: false
   gem 'rubocop-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -732,6 +732,9 @@ GEM
     rspec-instrumentation-matcher (0.0.9)
       activesupport
       rspec-expectations
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
@@ -1013,6 +1016,7 @@ DEPENDENCIES
   restforce
   rgeo-geojson
   rspec-instrumentation-matcher
+  rspec-its
   rspec-rails
   rspec-retry
   rspec_junit_formatter

--- a/lib/mpi/messages/find_profile_message.rb
+++ b/lib/mpi/messages/find_profile_message.rb
@@ -42,8 +42,10 @@ module MPI
         fields = FindProfileMessageFields.new(profile)
         fields.validate
 
-        raise ArgumentError, 'required keys are missing' if fields.missing_keys
-        raise ArgumentError, 'required values are missing' if fields.missing_values
+        raise ArgumentError, "required keys are missing: #{fields.missing_keys}" if fields.missing_keys.present?
+        if fields.missing_values.present?
+          raise ArgumentError, "required values are missing for keys: #{fields.missing_values}"
+        end
       end
 
       private

--- a/lib/mpi/messages/find_profile_message.rb
+++ b/lib/mpi/messages/find_profile_message.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'find_profile_message_fields'
 require_relative 'find_profile_message_helpers'
 
 module MPI
@@ -38,8 +39,11 @@ module MPI
       end
 
       def required_fields_present?(profile)
-        raise ArgumentError, 'required keys are missing' unless REQUIRED_FIELDS.all? { |k| profile.key?(k) }
-        raise ArgumentError, 'required values are missing' unless REQUIRED_FIELDS.all? { |k| profile[k].present? }
+        fields = FindProfileMessageFields.new(profile)
+        fields.validate
+
+        raise ArgumentError, 'required keys are missing' if fields.missing_keys
+        raise ArgumentError, 'required values are missing' if fields.missing_values
       end
 
       private

--- a/lib/mpi/messages/find_profile_message_fields.rb
+++ b/lib/mpi/messages/find_profile_message_fields.rb
@@ -18,12 +18,12 @@ module MPI
       end
 
       def valid?
-        !(@missing_keys || @missing_values)
+        @missing_keys.blank? && @missing_values.blank?
       end
 
       def validate
-        @missing_keys = !REQUIRED_FIELDS.all? { |k| @profile.key?(k) }
-        @missing_values = !REQUIRED_FIELDS.all? { |k| @profile[k].present? }
+        @missing_keys = REQUIRED_FIELDS - @profile.keys
+        @missing_values = REQUIRED_FIELDS.select { |key| @profile[key].nil? || @profile[key].blank? }
       end
     end
   end

--- a/lib/mpi/messages/find_profile_message_fields.rb
+++ b/lib/mpi/messages/find_profile_message_fields.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module MPI
+  module Messages
+    # validates the fields used to find profile messages
+    class FindProfileMessageFields
+      attr_reader :missing_keys, :missing_values
+
+      REQUIRED_FIELDS = %i[
+        given_names
+        last_name
+        birth_date
+        ssn
+      ].freeze
+
+      def initialize(profile)
+        @profile = profile
+      end
+
+      def valid?
+        !(@missing_keys || @missing_values)
+      end
+
+      def validate
+        @missing_keys = !REQUIRED_FIELDS.all? { |k| @profile.key?(k) }
+        @missing_values = !REQUIRED_FIELDS.all? { |k| @profile[k].present? }
+      end
+    end
+  end
+end

--- a/spec/lib/mpi/messages/find_profile_message_fields_spec.rb
+++ b/spec/lib/mpi/messages/find_profile_message_fields_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'mpi/messages/find_profile_message_fields'
+
+describe MPI::Messages::FindProfileMessageFields do
+  describe '.valid?' do
+    subject { described_class.new(profile) }
+
+    let(:missing_keys) { %i[given_names last_name birth_date ssn] }
+
+    before do
+      subject.validate
+    end
+
+    context 'missing keys and values' do
+      let(:profile) { {} }
+
+      its(:valid?) { is_expected.to be(false) }
+      its(:missing_keys) { is_expected.to be(true) }
+      its(:missing_values) { is_expected.to be(true) }
+    end
+
+    context 'missing values' do
+      let(:profile) { { given_names: nil, last_name: '', birth_date: nil, ssn: '' } }
+
+      its(:valid?) { is_expected.to be(false) }
+      its(:missing_keys) { is_expected.to be(false) }
+      its(:missing_values) { is_expected.to be(true) }
+    end
+
+    context 'valid-ish' do
+      let(:profile) { { given_names: 'Homer', last_name: 'Simpson', birth_date: '01/01/1972', ssn: '123-45-6789' } }
+
+      its(:valid?) { is_expected.to be(true) }
+      its(:missing_keys) { is_expected.to be(false) }
+      its(:missing_values) { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/lib/mpi/messages/find_profile_message_fields_spec.rb
+++ b/spec/lib/mpi/messages/find_profile_message_fields_spec.rb
@@ -13,7 +13,7 @@ describe MPI::Messages::FindProfileMessageFields do
       subject.validate
     end
 
-    context 'missing keys and values' do
+    context 'with missing keys and values' do
       let(:profile) { {} }
 
       its(:valid?) { is_expected.to be(false) }
@@ -21,7 +21,7 @@ describe MPI::Messages::FindProfileMessageFields do
       its(:missing_values) { is_expected.to match_array(missing_keys) }
     end
 
-    context 'missing values' do
+    context 'with missing values' do
       let(:profile) { { given_names: nil, last_name: '', birth_date: nil, ssn: '' } }
 
       its(:valid?) { is_expected.to be(false) }
@@ -29,7 +29,7 @@ describe MPI::Messages::FindProfileMessageFields do
       its(:missing_values) { is_expected.to match_array(missing_keys) }
     end
 
-    context 'valid-ish' do
+    context 'with required attributes' do
       let(:profile) { { given_names: 'Homer', last_name: 'Simpson', birth_date: '01/01/1972', ssn: '123-45-6789' } }
 
       its(:valid?) { is_expected.to be(true) }

--- a/spec/lib/mpi/messages/find_profile_message_fields_spec.rb
+++ b/spec/lib/mpi/messages/find_profile_message_fields_spec.rb
@@ -17,24 +17,24 @@ describe MPI::Messages::FindProfileMessageFields do
       let(:profile) { {} }
 
       its(:valid?) { is_expected.to be(false) }
-      its(:missing_keys) { is_expected.to be(true) }
-      its(:missing_values) { is_expected.to be(true) }
+      its(:missing_keys) { is_expected.to match_array(missing_keys) }
+      its(:missing_values) { is_expected.to match_array(missing_keys) }
     end
 
     context 'missing values' do
       let(:profile) { { given_names: nil, last_name: '', birth_date: nil, ssn: '' } }
 
       its(:valid?) { is_expected.to be(false) }
-      its(:missing_keys) { is_expected.to be(false) }
-      its(:missing_values) { is_expected.to be(true) }
+      its(:missing_keys) { is_expected.to be_blank }
+      its(:missing_values) { is_expected.to match_array(missing_keys) }
     end
 
     context 'valid-ish' do
       let(:profile) { { given_names: 'Homer', last_name: 'Simpson', birth_date: '01/01/1972', ssn: '123-45-6789' } }
 
       its(:valid?) { is_expected.to be(true) }
-      its(:missing_keys) { is_expected.to be(false) }
-      its(:missing_values) { is_expected.to be(false) }
+      its(:missing_keys) { is_expected.to be_blank }
+      its(:missing_values) { is_expected.to be_blank }
     end
   end
 end

--- a/spec/lib/mpi/messages/find_profile_message_spec.rb
+++ b/spec/lib/mpi/messages/find_profile_message_spec.rb
@@ -153,4 +153,26 @@ describe MPI::Messages::FindProfileMessage do
       end
     end
   end
+
+  describe '#required_fields_present?' do
+    subject { described_class.new(profile) }
+
+    let(:missing_keys) { ':given_names, :last_name, :birth_date, :ssn' }
+
+    context 'missing keys' do
+      let(:profile) { {} }
+
+      it 'raises with list of missing keys' do
+        expect { subject }.to raise_error('required keys are missing')
+      end
+    end
+
+    context 'missing values' do
+      let(:profile) { { given_names: nil, last_name: '', birth_date: nil, ssn: '' } }
+
+      it 'raises with list of keys for missing values' do
+        expect { subject }.to raise_error('required values are missing')
+      end
+    end
+  end
 end

--- a/spec/lib/mpi/messages/find_profile_message_spec.rb
+++ b/spec/lib/mpi/messages/find_profile_message_spec.rb
@@ -163,7 +163,7 @@ describe MPI::Messages::FindProfileMessage do
       let(:profile) { {} }
 
       it 'raises with list of missing keys' do
-        expect { subject }.to raise_error('required keys are missing')
+        expect { subject }.to raise_error(/#{missing_keys}/)
       end
     end
 
@@ -171,7 +171,7 @@ describe MPI::Messages::FindProfileMessage do
       let(:profile) { { given_names: nil, last_name: '', birth_date: nil, ssn: '' } }
 
       it 'raises with list of keys for missing values' do
-        expect { subject }.to raise_error('required values are missing')
+        expect { subject }.to raise_error(/#{missing_keys}/)
       end
     end
   end

--- a/spec/lib/mpi/messages/find_profile_message_spec.rb
+++ b/spec/lib/mpi/messages/find_profile_message_spec.rb
@@ -127,7 +127,7 @@ describe MPI::Messages::FindProfileMessage do
             last_name: 'Smith',
             birth_date: Time.new(1980, 1, 1).utc
           )
-        end.to raise_error(ArgumentError, 'required keys are missing')
+        end.to raise_error(ArgumentError, 'required keys are missing: [:ssn]')
       end
 
       it 'throws an argument error for empty value' do
@@ -138,7 +138,7 @@ describe MPI::Messages::FindProfileMessage do
             birth_date: Time.new(1980, 1, 1).utc,
             ssn: rand.to_s[2..11]
           )
-        end.to raise_error(ArgumentError, 'required values are missing')
+        end.to raise_error(ArgumentError, 'required values are missing for keys: [:last_name]')
       end
 
       it 'throws an argument error for nil value' do
@@ -149,7 +149,7 @@ describe MPI::Messages::FindProfileMessage do
             birth_date: Time.new(1980, 1, 1).utc,
             ssn: rand.to_s[2..11]
           )
-        end.to raise_error(ArgumentError, 'required values are missing')
+        end.to raise_error(ArgumentError, 'required values are missing for keys: [:last_name]')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'support/sidekiq/batch'
 require 'support/stub_emis'
 require 'support/okta_users_helpers'
 require 'pundit/rspec'
+require 'rspec/its'
 
 # By default run SimpleCov, but allow an environment variable to disable.
 unless ENV['NOCOVERAGE']


### PR DESCRIPTION
# Wat

To help Identity, et al, trace SSOe interaction errors.

## Before

We would raise an error with `required keys are missing` if any required profile keys were missing, and `required values are missing` if any required profile keys were present but had empty values. We did not however indicate which keys were missing, or were missing values.

## After

We now indicate which keys were missing, or were missing values, in the error message.
