### PR TITLE
update method from mvi to mpi

### DIFF
--- a/app/controllers/v0/profile/persons_controller.rb
+++ b/app/controllers/v0/profile/persons_controller.rb
@@ -7,7 +7,7 @@ module V0
     class PersonsController < ApplicationController
       include Vet360::Transactionable
 
-      after_action :invalidate_mvi_cache
+      after_action :invalidate_mpi_cache
 
       def initialize_vet360_id
         response    = Vet360::Person::Service.new(@current_user).init_vet360_id
@@ -22,7 +22,7 @@ module V0
 
       private
 
-      def invalidate_mvi_cache
+      def invalidate_mpi_cache
         mvi_cache = @current_user.mpi
         mvi_cache.mvi_response
         mvi_cache.destroy


### PR DESCRIPTION


## Description of change
app/controllers/v0/profile/persons_controller.rb has an after_action for `invalidate_mvi_cache` which is now renamed to `invalidate_mpi_cache`. This effort is part of the upgrade path for renaming mvi to mpi related to the Zeitwerk upgrade.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#14783

