### PR TITLE
Removed CC from SCO email

### DIFF
--- a/app/mailers/school_certifying_officials_mailer.rb
+++ b/app/mailers/school_certifying_officials_mailer.rb
@@ -16,8 +16,6 @@ class SchoolCertifyingOfficialsMailer < TransactionalEmailMailer
 
   def build(applicant, recipients, ga_client_id)
     @applicant = applicant
-    opt = { cc: applicant.email }
-    opt[:bcc] = STAGING_RECIPIENTS.clone if FeatureFlipper.staging_email?
-    super(recipients, ga_client_id, opt)
+    super(recipients, ga_client_id, {})
   end
 end

--- a/app/mailers/school_certifying_officials_mailer.rb
+++ b/app/mailers/school_certifying_officials_mailer.rb
@@ -7,13 +7,6 @@ class SchoolCertifyingOfficialsMailer < TransactionalEmailMailer
   GA_LABEL = 'school-certifying-officials-10203-submission-notification'
   TEMPLATE = 'school_certifying_officials'
 
-  STAGING_RECIPIENTS = %w[
-    Delli-Gatti_Michael@bah.com
-    roth_matthew@bah.com
-    shawkey_daniel@bah.com
-    sonntag_adam@bah.com
-  ].freeze
-
   def build(applicant, recipients, ga_client_id)
     @applicant = applicant
     super(recipients, ga_client_id, {})

--- a/app/mailers/stem_applicant_confirmation_mailer.rb
+++ b/app/mailers/stem_applicant_confirmation_mailer.rb
@@ -44,10 +44,7 @@ class StemApplicantConfirmationMailer < TransactionalEmailMailer
     @applicant = claim.open_struct_form
     @claim = claim
 
-    opt = {}
-    opt[:bcc] = STAGING_RECIPIENTS.clone if FeatureFlipper.staging_email?
-
-    super([@applicant.email], ga_client_id, opt)
+    super([@applicant.email], ga_client_id, {})
   end
 
   private

--- a/app/mailers/stem_applicant_confirmation_mailer.rb
+++ b/app/mailers/stem_applicant_confirmation_mailer.rb
@@ -7,13 +7,6 @@ class StemApplicantConfirmationMailer < TransactionalEmailMailer
   GA_LABEL = 'stem-applicant-confirmation-10203-submission-notification'
   TEMPLATE = 'stem_applicant_confirmation'
 
-  STAGING_RECIPIENTS = %w[
-    Delli-Gatti_Michael@bah.com
-    roth_matthew@bah.com
-    shawkey_daniel@bah.com
-    sonntag_adam@bah.com
-  ].freeze
-
   def first_and_last_name
     return '' if @applicant.veteranFullName.nil?
 

--- a/app/mailers/views/school_certifying_officials.html.erb
+++ b/app/mailers/views/school_certifying_officials.html.erb
@@ -70,7 +70,6 @@
       OMB Control Number: 2900-0878<br>
       OMB Expiration Date: 6/30/2023<br>
       <a href="https://www.va.gov/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203/introduction#privacy_policy/?utm_source=confirmation_email&utm_medium=email&utm_campaign=privacy_policy">Privacy Act Statement (available online)</a><br>
-      cc: <%= @applicant.email %>
     </p>
   </body>
 </html>

--- a/spec/mailers/school_certifying_officials_mailer_spec.rb
+++ b/spec/mailers/school_certifying_officials_mailer_spec.rb
@@ -33,21 +33,6 @@ RSpec.describe SchoolCertifyingOfficialsMailer, type: [:mailer] do
       it 'includes school student id' do
         expect(subject.body.raw_source).to include("Student's school ID number: #{applicant.schoolStudentId}")
       end
-      it 'includes email' do
-        expect(subject.body.raw_source).to include("cc: #{applicant.email}")
-      end
-    end
-
-    context 'when sending staging emails' do
-      before do
-        expect(FeatureFlipper).to receive(:staging_email?).twice.and_return(true)
-      end
-
-      it 'includes recipients' do
-        described_class.build(applicant, recipients, ga_client_id).deliver_now
-
-        expect(subject.bcc).to eq(SchoolCertifyingOfficialsMailer::STAGING_RECIPIENTS)
-      end
     end
   end
 end

--- a/spec/mailers/stem_applicant_confirmation_mailer_spec.rb
+++ b/spec/mailers/stem_applicant_confirmation_mailer_spec.rb
@@ -47,15 +47,5 @@ RSpec.describe StemApplicantConfirmationMailer, type: [:mailer] do
         expect(subject.body.raw_source).to include(EducationForm::EducationFacility::ADDRESSES[:eastern][1])
       end
     end
-
-    context 'when sending staging emails' do
-      before do
-        allow(FeatureFlipper).to receive(:staging_email?).and_return(true)
-      end
-
-      it 'includes recipients' do
-        expect(subject.bcc).to eq(SchoolCertifyingOfficialsMailer::STAGING_RECIPIENTS)
-      end
-    end
   end
 end


### PR DESCRIPTION
## Description of change
Removed references to email CC field from new education mailers becuase CC is not supported.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#16433

## Things to know about this PR
- Tested locally and QA reviewed
