### PR TITLE
Add ICN to the IAM user factories

### DIFF
--- a/spec/factories/iam_users.rb
+++ b/spec/factories/iam_users.rb
@@ -36,6 +36,7 @@ FactoryBot.define do
       stub_mpi(
         build(
           :mvi_profile,
+          icn: '24811694708759028',
           edipi: '1005079124',
           birls_id: '796121200',
           participant_id: '796121200',
@@ -55,6 +56,7 @@ FactoryBot.define do
         stub_mpi(
           build(
             :mvi_profile,
+            icn: '24811694708759028',
             edipi: nil,
             birls_id: '796121200',
             participant_id: '796121200',


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
A larger upcoming PR requires that the IAM user factories have a static ICN rather than the random one generated by the MVI Profile using Faker.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14838

## Things to know about this PR
N/A
