### PR TITLE
Ordering applications by name ascending

### DIFF
--- a/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
+++ b/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
@@ -10,7 +10,7 @@ module AppsApi
 
       def index
         render json: {
-          data: DirectoryApplication.all
+          data: DirectoryApplication.order('LOWER(name)')
         }
       end
 


### PR DESCRIPTION
Signed-off-by: Braden Shipley <bradenrshipley@gmail.com>
## Description of change
Changing the return order of directory applications to be alphabetical. Prior to this change they were returning in the order they were created.