### PR TITLE
reference master branch on vets json schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,8 +65,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 17c2992bce1572a67490d76193e0568177810399
-  branch: 10-10cg-new-version
+  revision: b3fa63878e35f64c2393858810e039dab0dfb8b8
+  branch: master
   specs:
     vets_json_schema (18.0.0)
       multi_json (~> 1.0)


### PR DESCRIPTION
**Description**
Set the vets-json-schema reference back to master in Gemfile.lock.

**What happened**
In a [previous PR](https://github.com/department-of-veterans-affairs/vets-api/pull/5264#discussion_r525576625) I used GitHub's suggested commit feature to update Gemfile to reference the master branch before merging. This updates Gemfile but left Gemfile.lock pointing to the previous branch. This PR just runs `bundle update vets_json_schema` to update Gemfile.lock to reference the correct branch and SHA.