### PR TITLE
Api 3500 lighthouse client credentials smart launch fetching

### DIFF
--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -36,9 +36,7 @@ class OpenidApplicationController < ApplicationController
 
     # issued for a client vs a user
     if token.client_credentials_token?
-      if token.payload['scp'].include?('launch/patient')
-        token.payload[:icn] = fetch_smart_launch_context
-      end
+      token.payload[:icn] = fetch_smart_launch_context if token.payload['scp'].include?('launch/patient')
       return true
     end
 

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -92,15 +92,14 @@ class OpenidApplicationController < ApplicationController
 
   def fetch_smart_launch_context
     response = RestClient.get(Settings.oidc.smart_launch_url,
-                              {:Authorization => 'Bearer ' + token.token_string})
+                              { Authorization: 'Bearer ' + token.token_string })
     unless response.nil? || response.code != 200
       json_response = JSON.parse(response.body)
       json_response['launch']
     end
-
   rescue => e
-      log_message_to_sentry('Error retrieving smart launch context for OIDC token', :error)
-      return nil
+    log_message_to_sentry('Error retrieving smart launch context for OIDC token: ' + e.message, :error)
+    nil
   end
 
   attr_reader :current_user, :session, :scopes

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -3,6 +3,7 @@
 require 'feature_flipper'
 require 'common/exceptions'
 require 'common/client/errors'
+require 'rest-client'
 require 'saml/settings_service'
 require 'sentry_logging'
 require 'oidc/key_service'
@@ -36,8 +37,7 @@ class OpenidApplicationController < ApplicationController
     # issued for a client vs a user
     if token.client_credentials_token?
       if token.payload['scp'].include?('launch/patient')
-        # API-3500 will fetch launch context
-        # token.payload[:"icn"] = '1234V5678'
+        token.payload[:icn] = fetch_smart_launch_context
       end
       return true
     end
@@ -88,6 +88,16 @@ class OpenidApplicationController < ApplicationController
 
   def fetch_aud
     Settings.oidc.isolated_audience.default
+  end
+
+  def fetch_smart_launch_context
+    response = RestClient.get Settings.oidc.smart_launch_url,
+                              {:Authorization => 'Bearer ' + token.token_string}
+    unless response.nil? || response.code != 200
+      json_response = JSON.parse(response.body)
+      json_response['launch']
+    end
+
   end
 
   attr_reader :current_user, :session, :scopes

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -98,6 +98,9 @@ class OpenidApplicationController < ApplicationController
       json_response['launch']
     end
 
+  rescue => e
+      log_message_to_sentry('Error retrieving smart launch context for OIDC token', :error)
+      return nil
   end
 
   attr_reader :current_user, :session, :scopes

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -91,8 +91,8 @@ class OpenidApplicationController < ApplicationController
   end
 
   def fetch_smart_launch_context
-    response = RestClient.get Settings.oidc.smart_launch_url,
-                              {:Authorization => 'Bearer ' + token.token_string}
+    response = RestClient.get(Settings.oidc.smart_launch_url,
+                              {:Authorization => 'Bearer ' + token.token_string})
     unless response.nil? || response.code != 200
       json_response = JSON.parse(response.body)
       json_response['launch']

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -415,6 +415,7 @@ oidc:
     claims: ~
   base_api_url: https://example.com
   base_api_token: ~
+  smart_launch_url: ~
 
 sentry:
   dsn: ~

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
       }
     ]
   end
+  let(:launch_response) do
+    instance_double(RestClient::Response,
+                    code: 200,
+                            body: {'launch' => '1234V5678'
+                    }.to_json)
+  end
   let(:json_api_response) do
     {
       'data' => {
@@ -236,6 +242,7 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
   context 'with client credentials jwt' do
     before do
       allow(JWT).to receive(:decode).and_return(client_credentials_jwt)
+      allow(RestClient).to receive(:get).and_return(launch_response)
     end
 
     it 'v0 GET returns true if the user is a veteran' do

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -65,8 +65,12 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
   let(:launch_response) do
     instance_double(RestClient::Response,
                     code: 200,
-                            body: {'launch' => '1234V5678'
+                            body: {'launch' => '73806470379396828'
                     }.to_json)
+  end
+  let(:failed_launch_response) do
+    instance_double(RestClient::Response,
+                    code: 401)
   end
   let(:json_api_response) do
     {
@@ -245,13 +249,21 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
       allow(RestClient).to receive(:get).and_return(launch_response)
     end
 
-    it 'v0 GET returns true if the user is a veteran' do
+    it 'v1 POST returns true if the user is a veteran' do
       with_okta_configured do
-        get '/internal/auth/v0/validation', params: nil, headers: auth_header
+        post '/internal/auth/v1/validation', params: nil, headers: auth_header
         expect(response).to have_http_status(:ok)
         expect(response.body).to be_a(String)
         expect(JSON.parse(response.body)['data']['attributes'].keys).to eq(json_api_response['data']['attributes'].keys)
+        expect(JSON.parse(response.body)['data']['attributes']['va_identifiers']['icn']).to eq('73806470379396828')
       end
+    end
+  end
+
+  context 'with client credentials jwt and failed launch lookup' do
+    before do
+      allow(JWT).to receive(:decode).and_return(client_credentials_jwt)
+      allow(RestClient).to receive(:get).and_return(failed_launch_response)
     end
 
     it 'v1 POST returns true if the user is a veteran' do
@@ -260,6 +272,7 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
         expect(response).to have_http_status(:ok)
         expect(response.body).to be_a(String)
         expect(JSON.parse(response.body)['data']['attributes'].keys).to eq(json_api_response['data']['attributes'].keys)
+        expect(JSON.parse(response.body)['data']['attributes']['va_identifiers']['icn']).to eq(nil)
       end
     end
   end

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
   end
   let(:launch_response) do
     instance_double(RestClient::Response,
-                    code: 200,
-                            body: {launch: '73806470379396828'}.to_json)
+                      code: 200,
+                      body: { launch: '73806470379396828' }.to_json)
   end
   let(:failed_launch_response) do
     instance_double(RestClient::Response,

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -65,8 +65,7 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
   let(:launch_response) do
     instance_double(RestClient::Response,
                     code: 200,
-                            body: {'launch' => '73806470379396828'
-                    }.to_json)
+                            body: {launch: '73806470379396828'}.to_json)
   end
   let(:failed_launch_response) do
     instance_double(RestClient::Response,

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
   end
   let(:launch_response) do
     instance_double(RestClient::Response,
-                      code: 200,
-                      body: { launch: '73806470379396828' }.to_json)
+                    code: 200,
+                    body: { launch: '73806470379396828' }.to_json)
   end
   let(:failed_launch_response) do
     instance_double(RestClient::Response,


### PR DESCRIPTION
## Description of change
This change adds support for Lighthouse Client Credentials tokens to fetch the smart launch context from the OAuth proxy `token.payload['scp'].include?('launch/patient')`.

The Lighthouse OAuth proxy has been added as an entry in the devops fwd proxy.
https://github.com/department-of-veterans-affairs/devops/pull/8066

An accompanying devops PR will configure the url per environment starting with dev.

## Original issue(s)
https://vajira.max.gov/browse/API-3500

## Things to know about this PR

* A new `Settings.oidc.smart_launch_url` is required, it will vary by environment and will be specified in an accompanying Devops PR.
* At this time, Client Credentials tokens are only enabled for use in Dev and Sandbox