### PR TITLE
Adding bootsnap gem to improve dev and test environment performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,6 +154,7 @@ end
 # rubocop:disable Metrics/BlockLength
 group :development, :test do
   gem 'awesome_print', '~> 1.8' # Pretty print your Ruby objects in full color and with proper indentation
+  gem 'bootsnap', require: false
   gem 'brakeman', '~> 4.7'
   gem 'bundler-audit'
   gem 'byebug', platforms: :ruby # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,8 @@ GEM
       i18n
     benchmark-ips (2.8.2)
     bindex (0.8.1)
+    bootsnap (1.5.1)
+      msgpack (~> 1.0)
     brakeman (4.9.0)
     breakers (0.4.0)
       faraday (>= 0.7.4, < 0.18)
@@ -501,6 +503,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
+    msgpack (1.3.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -880,6 +883,7 @@ DEPENDENCIES
   benchmark-ips
   betamocks!
   bgs_ext!
+  bootsnap
   brakeman (~> 4.7)
   breakers
   bundler-audit

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,3 +3,8 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+
+# Bootsnap is used to speed up application load time. Enabled for development/test
+# environments. If RAILS_ENV isn't set, assumption is that we are in a development/test
+# environment
+require 'bootsnap/setup' if %w[development test].include?(ENV['RAILS_ENV'])

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -5,6 +5,5 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 
 # Bootsnap is used to speed up application load time. Enabled for development/test
-# environments. If RAILS_ENV isn't set, assumption is that we are in a development/test
-# environment
+# environments.
 require 'bootsnap/setup' if %w[development test].include?(ENV['RAILS_ENV'])


### PR DESCRIPTION
## Description of change
This PR adds the `bootsnap` gem for `test` and `development` environments to speed up the process of file loading. The speed improvements should be fairly dramatic (I was seeing specs load in roughly half the time). Production deployment should be tested since the `boot.rb` file was changed, but if working properly, production should not be affected.

`bootsnap` simply caches files that Rails loads, and it watches for file changes to update these files. It basically makes `spring` unnecessary, and is a lot safer than `spring` anyway.

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-api/issues/5378

## Things to know about this PR
- This solution assumes `ENV['RAILS_ENV']` is defined by time we initialize Rails in `boot.rb`. I've seen application implementations where this is a problem. If so, we have a workaround where we can attempt to load `bootsnap` regardless of environment, rescue the expected error on production, and continue with initialization. I like the current attempt better so hopefully this works with our implementation. EDIT: I've updated this to default to NOT loading bootsnap if the RAILS_ENV var isn't there. This way it'll only be loaded if the variable is specifically set to either `development` or `test`
- We can actually implement this on production as well, and expect a certain amount of speed benefits. However, it requires the production file system to not be read-only, and this constraint is significant. It's worth looking into this, but might not be possible depending on our production environment.

## How to Test?
-  Run specs or Rails console, try to measure the time it takes to boot to console or start running specs
- `bundle` to load the Gem
- Re-run specs or re-open Rails console a couple times, should see boot times dramatically improve