### PR TITLE
Veteran Verification fix for mock-emis URI build up

### DIFF
--- a/modules/veteran_verification/app/services/emis/mock_military_information_configuration_v2.rb
+++ b/modules/veteran_verification/app/services/emis/mock_military_information_configuration_v2.rb
@@ -5,9 +5,7 @@ module EMIS
   # Configuration for {EMIS::MockMilitaryInformationService}
   class MockMilitaryInformationConfigurationV2 < MilitaryInformationConfigurationV2
     def base_path
-      emis_url = URI.join(Settings.vet_verification.mock_emis_host, Settings.emis.military_information_url.v2).to_s
-      Rails.logger.info("Mock-emis URL: #{emis_url}")
-      emis_url
+      URI.parse(Settings.vet_verification.mock_emis_host + Settings.emis.military_information_url.v2).to_s
     end
   end
 end


### PR DESCRIPTION
## Description of change
This PR corrects an issue with the URI build up for the Veteran Verification API call to the mock-emis service.

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-api/pull/5262
