### PR TITLE
Only skip authentication for some attachment controllers

### DIFF
--- a/app/controllers/concerns/form_attachment_create.rb
+++ b/app/controllers/concerns/form_attachment_create.rb
@@ -3,10 +3,6 @@
 module FormAttachmentCreate
   extend ActiveSupport::Concern
 
-  included do
-    skip_before_action(:authenticate, raise: false)
-  end
-
   def create
     form_attachment_model = self.class::FORM_ATTACHMENT_MODEL
     form_attachment = form_attachment_model.new

--- a/app/controllers/v0/hca_attachments_controller.rb
+++ b/app/controllers/v0/hca_attachments_controller.rb
@@ -4,6 +4,8 @@ module V0
   class HCAAttachmentsController < ApplicationController
     include FormAttachmentCreate
 
+    skip_before_action(:authenticate, raise: false)
+
     FORM_ATTACHMENT_MODEL = HCAAttachment
   end
 end

--- a/app/controllers/v0/preneeds/preneed_attachments_controller.rb
+++ b/app/controllers/v0/preneeds/preneed_attachments_controller.rb
@@ -4,6 +4,7 @@ module V0
   module Preneeds
     class PreneedAttachmentsController < PreneedsController
       include FormAttachmentCreate
+      skip_before_action(:authenticate, raise: false)
 
       FORM_ATTACHMENT_MODEL = ::Preneeds::PreneedAttachment
     end

--- a/app/controllers/v0/vic/supporting_documentation_attachments_controller.rb
+++ b/app/controllers/v0/vic/supporting_documentation_attachments_controller.rb
@@ -4,6 +4,7 @@ module V0
   module VIC
     class SupportingDocumentationAttachmentsController < BaseController
       include FormAttachmentCreate
+      skip_before_action(:authenticate, raise: false)
 
       FORM_ATTACHMENT_MODEL = ::VIC::SupportingDocumentationAttachment
     end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -817,11 +817,13 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
           :post,
           '/v0/upload_supporting_evidence',
           200,
-          '_data' => {
-            'supporting_evidence_attachment' => {
-              'file_data' => fixture_file_upload('spec/fixtures/pdf_fill/extras.pdf')
+          headers.update(
+            '_data' => {
+              'supporting_evidence_attachment' => {
+                'file_data' => fixture_file_upload('spec/fixtures/pdf_fill/extras.pdf')
+              }
             }
-          }
+          )
         )
       end
 
@@ -830,7 +832,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
           :post,
           '/v0/upload_supporting_evidence',
           400,
-          ''
+          headers
         )
       end
 
@@ -839,11 +841,13 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
           :post,
           '/v0/upload_supporting_evidence',
           422,
-          '_data' => {
-            'supporting_evidence_attachment' => {
-              'file_data' => fixture_file_upload('spec/fixtures/files/malformed-pdf.pdf')
+          headers.update(
+            '_data' => {
+              'supporting_evidence_attachment' => {
+                'file_data' => fixture_file_upload('spec/fixtures/files/malformed-pdf.pdf')
+              }
             }
-          }
+          )
         )
       end
     end

--- a/spec/request/upload_supporting_evidence_spec.rb
+++ b/spec/request/upload_supporting_evidence_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Upload supporting evidence', type: :request do
   include SchemaMatchers
+  let(:user) { build(:disabilities_compensation_user) }
 
   let(:pdf_file) do
     fixture_file_upload('files/doctors-note.pdf', 'application/pdf')
@@ -11,6 +12,10 @@ RSpec.describe 'Upload supporting evidence', type: :request do
 
   let(:encrypted_pdf_file) do
     fixture_file_upload('files/password_is_test.pdf', 'application/pdf')
+  end
+
+  before do
+    sign_in_as(user)
   end
 
   describe 'Post /v0/upload_supporting_evidence' do


### PR DESCRIPTION
## Description of change
Rather than excluding all form attachment controllers from authenticating, it should be done on a case-by-case basis. upload_supporting_evidence is called from form 526 which requires all users to be authenticated.  By not skipping authentication, it will make it easier to troubleshoot which users are having problems with uploads, now that the user's uuid is in sentry.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#16216