### PR TITLE
API-3572 Hearing Page for NOD pdf

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -127,6 +127,10 @@ module AppealsApi
       form_data&.dig('data', 'attributes', 'hearingTypePreference')
     end
 
+    def valid_hearing_type?
+      board_review_hearing_selected? && includes_hearing_type?
+    end
+
     private
 
     def validate_auth_headers_against_schema

--- a/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_constructor.rb
+++ b/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_constructor.rb
@@ -30,6 +30,7 @@ module AppealsApi
       return @pdf_options if @pdf_options
 
       options = {
+        additional_pages: [],
         "F[0].Page_1[0].VeteransFirstName[0]": nod_pdf_options.veteran_name,
         "F[0].Page_1[0].VeteransSocialSecurityNumber_FirstThreeNumbers[0]": nod_pdf_options.veteran_ssn,
         "F[0].Page_1[0].VAFileNumber[0]": nod_pdf_options.veteran_file_number,
@@ -52,6 +53,8 @@ module AppealsApi
         "F[0].Page_1[0].DateSigned[2]": nod_pdf_options.date_signed
       }
 
+      insert_administrative_page(options)
+
       # Fill in issue dates. The issue details are added by #insert_manual_fields
       nod_pdf_options.contestable_issues.take(5).each_with_index do |issue, index|
         options[:"F[0].Page_1[0].Percentage2[#{index}]"] = issue['attributes']['decisionDate']
@@ -65,6 +68,24 @@ module AppealsApi
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
     # rubocop:enable Metrics/AbcSize
+
+    def merge_page(temp_path, output_path)
+      return temp_path if pdf_options[:additional_pages].blank?
+
+      rand_path = Common::FileHelpers.random_file_path
+      Prawn::Document.generate(rand_path) do |pdf|
+        pdf_options[:additional_pages].each_with_index do |txt, index|
+          next if txt.blank?
+
+          pdf.start_new_page unless index.zero?
+          pdf.text txt, inline_format: true
+        end
+      end
+      pdf = CombinePDF.load(temp_path) << CombinePDF.load(rand_path)
+      pdf.save output_path
+      File.delete(rand_path) if File.exist?(rand_path)
+      output_path
+    end
 
     def stamp_pdf(pdf_path, consumer_name)
       stamped_path = super
@@ -99,14 +120,19 @@ module AppealsApi
       output_path
     end
 
+    def insert_administrative_page(pdf_options)
+      return if nod_pdf_options.hearing_type.blank?
+
+      pdf_options[:additional_pages] << "Hearing type requested: #{nod_pdf_options.hearing_type.humanize}"
+    end
+
     def insert_extra_issues_page(pdf_options)
+      lines = []
       # The first five issues are given space on the form, so drop them.
-      # Reverse the order since :additional_page pdf options tends to write to the page in reverse order.
-      # e.g. without the reversal, [6,7,8] would place Issue 8 at top of the page.
-      nod_pdf_options.contestable_issues.drop(5).reverse.each do |issue|
-        text = "Issue: #{issue['attributes']['issue']} - Decision Date: #{issue['attributes']['decisionDate']}"
-        pdf_options[:additional_page] = "#{text}\n#{pdf_options[:additional_page]}"
+      nod_pdf_options.contestable_issues.drop(5).each do |issue|
+        lines << "Issue: #{issue['attributes']['issue']} - Decision Date: #{issue['attributes']['decisionDate']}"
       end
+      pdf_options[:additional_pages] << lines.join("\n")
     end
   end
 end

--- a/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_options.rb
+++ b/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_options.rb
@@ -38,6 +38,10 @@ module AppealsApi
       dob 'Claimant'
     end
 
+    def hearing_type
+      return @notice_of_disagreement.hearing_type if @notice_of_disagreement.valid_hearing_type?
+    end
+
     def contact_info
       @notice_of_disagreement.veteran_contact_info || @notice_of_disagreement.claimant_contact_info
     end

--- a/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
@@ -45,9 +45,10 @@ RSpec.describe AppealsApi::NoticeOfDisagreementPdfSubmitJob, type: :job do
       Timecop.freeze(Time.zone.parse('2020-01-01T08:00:00Z'))
       generated_pdf = described_class.new.generate_pdf(notice_of_disagreement.id)
       reader = PDF::Reader.new(generated_pdf)
-      expect(reader.pages.size).to eq 4
+      expect(reader.pages.size).to eq 5
       expect(reader.pages.first.text).to include rep_name
-      expect(reader.pages[3].text).to include extra_issue
+      expect(reader.pages[3].text).to include 'Hearing type requested: Central office'
+      expect(reader.pages[4].text).to include extra_issue
       File.delete(generated_pdf) if File.exist?(generated_pdf)
       Timecop.return
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
WIP

Add additional administrative page to pdf where necessary. Currently adds the hearing type requested by the Veteran. Is a separate page since Issues have their own callout for separate pages in the form.

## Original issue(s)
https://vajira.max.gov/browse/API-3338