### PR TITLE
API-3752 Hearing page for NOD pdf

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -123,7 +123,7 @@ module AppealsApi
       form_data&.dig('data', 'attributes', 'boardReviewOption')
     end
 
-    def hearing_type
+    def hearing_type_preference
       form_data&.dig('data', 'attributes', 'hearingTypePreference')
     end
 
@@ -174,7 +174,7 @@ module AppealsApi
     end
 
     def validate_hearing_type_selection
-      return if board_review_hearing_selected? && includes_hearing_type?
+      return if board_review_hearing_selected? && includes_hearing_type_preference?
 
       if hearing_type_missing?
         errors.add :form_data, I18n.t('appeals_api.errors.hearing_type_preference_missing')
@@ -187,16 +187,16 @@ module AppealsApi
       board_review_option == 'hearing'
     end
 
-    def includes_hearing_type?
-      hearing_type.present?
+    def includes_hearing_type_preference?
+      hearing_type_preference.present?
     end
 
     def hearing_type_missing?
-      board_review_hearing_selected? && !includes_hearing_type?
+      board_review_hearing_selected? && !includes_hearing_type_preference?
     end
 
     def unexpected_hearing_type_inclusion?
-      !board_review_hearing_selected? && includes_hearing_type?
+      !board_review_hearing_selected? && includes_hearing_type_preference?
     end
 
     def validate_address

--- a/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_constructor.rb
+++ b/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_constructor.rb
@@ -30,6 +30,7 @@ module AppealsApi
       return @pdf_options if @pdf_options
 
       options = {
+        additional_pages: [],
         "F[0].Page_1[0].VeteransFirstName[0]": nod_pdf_options.veteran_name,
         "F[0].Page_1[0].VeteransSocialSecurityNumber_FirstThreeNumbers[0]": nod_pdf_options.veteran_ssn,
         "F[0].Page_1[0].VAFileNumber[0]": nod_pdf_options.veteran_file_number,
@@ -57,6 +58,7 @@ module AppealsApi
         options[:"F[0].Page_1[0].Percentage2[#{index}]"] = issue['attributes']['decisionDate']
       end
 
+      insert_administrative_page(options)
       insert_extra_issues_page(options) if nod_pdf_options.contestable_issues.size > 5
 
       @pdf_options = options
@@ -65,6 +67,25 @@ module AppealsApi
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
     # rubocop:enable Metrics/AbcSize
+
+    # TODO: Remove this override by refactoring BasePdfConstructor & HigherLevelReviewPdfConstructor to use
+    #       `additional_pages` key in this manner instead of `additional_page` key
+    def merge_page(temp_path, output_path)
+      return temp_path if pdf_options[:additional_pages].blank?
+
+      rand_path = "#{Common::FileHelpers.random_file_path}.pdf"
+      Prawn::Document.generate(rand_path) do |pdf|
+        pdf_options[:additional_pages].each_with_index do |txt, index|
+          pdf.start_new_page unless index.zero?
+          pdf.text txt, inline_format: true
+        end
+      end
+      pdf = CombinePDF.load(temp_path) << CombinePDF.load(rand_path)
+      pdf.save output_path
+      File.delete temp_path if File.exist? temp_path
+      File.delete rand_path if File.exist? rand_path
+      output_path
+    end
 
     def stamp_pdf(pdf_path, consumer_name)
       stamped_path = super
@@ -99,14 +120,19 @@ module AppealsApi
       output_path
     end
 
+    def insert_administrative_page(pdf_options)
+      return if nod_pdf_options.hearing_type_preference.blank?
+
+      pdf_options[:additional_pages] << "Hearing type requested: #{nod_pdf_options.hearing_type_preference.humanize}"
+    end
+
     def insert_extra_issues_page(pdf_options)
+      lines = []
       # The first five issues are given space on the form, so drop them.
-      # Reverse the order since :additional_page pdf options tends to write to the page in reverse order.
-      # e.g. without the reversal, [6,7,8] would place Issue 8 at top of the page.
-      nod_pdf_options.contestable_issues.drop(5).reverse.each do |issue|
-        text = "Issue: #{issue['attributes']['issue']} - Decision Date: #{issue['attributes']['decisionDate']}"
-        pdf_options[:additional_page] = "#{text}\n#{pdf_options[:additional_page]}"
+      nod_pdf_options.contestable_issues.drop(5).each do |issue|
+        lines << "Issue: #{issue['attributes']['issue']} - Decision Date: #{issue['attributes']['decisionDate']}"
       end
+      pdf_options[:additional_pages] << lines.join("\n")
     end
   end
 end

--- a/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_options.rb
+++ b/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_options.rb
@@ -38,6 +38,10 @@ module AppealsApi
       dob 'Claimant'
     end
 
+    def hearing_type_preference
+      @notice_of_disagreement.hearing_type_preference
+    end
+
     def contact_info
       @notice_of_disagreement.veteran_contact_info || @notice_of_disagreement.claimant_contact_info
     end

--- a/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
@@ -46,10 +46,11 @@ RSpec.describe AppealsApi::NoticeOfDisagreementPdfSubmitJob, type: :job do
       Timecop.freeze(Time.zone.parse('2020-01-01T08:00:00Z'))
       generated_pdf = described_class.new.generate_pdf(notice_of_disagreement.id)
       reader = PDF::Reader.new(generated_pdf)
-      expect(reader.pages.size).to eq 4
+      expect(reader.pages.size).to eq 5
       expect(reader.pages.first.text).to include email
       expect(reader.pages.first.text).to include rep_name
-      expect(reader.pages[3].text).to include extra_issue
+      expect(reader.pages[3].text).to include 'Hearing type requested: Central office'
+      expect(reader.pages[4].text).to include extra_issue
       File.delete(generated_pdf) if File.exist?(generated_pdf)
       Timecop.return
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Add additional administrative page to pdf where necessary. Currently adds the hearing type requested by the Veteran. Is a separate page since Issues have their own callout for separate pages in the form.

## Original issue(s)
https://vajira.max.gov/browse/API-3752