### PR TITLE
consistent User#birth_date format

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,7 @@ class User < Common::RedisStore
   end
 
   def birth_date
-    identity.birth_date || (mhv_icn.present? ? mpi&.profile&.birth_date : nil)
+    identity.birth_date || (mhv_icn.present? ? mpi&.profile&.birth_date&.to_date&.to_s : nil)
   end
 
   def zip

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe User, type: :model do
         end
 
         it 'fetches birth_date from MVI' do
-          expect(user.birth_date).to be(user.va_profile.birth_date)
+          expect(user.birth_date).to be(user.va_profile.birth_date.to_date.to_s)
         end
 
         it 'fetches zip from MVI' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe User, type: :model do
         end
 
         it 'fetches birth_date from MVI' do
-          expect(user.birth_date).to be(user.va_profile.birth_date.to_date.to_s)
+          expect(user.birth_date).to eq(user.va_profile.birth_date.to_date.to_s)
         end
 
         it 'fetches zip from MVI' do


### PR DESCRIPTION
## Description of change
When I call @current_user.birth_date, I'd expect the date to be returned in the same format.  I don't anticipate any issues with this global change because we were already returning the dashed format most of the time. 

Before the dates were both strings in different formats: 

`@current_user.mpi&.profile&.birth_date => "19801201" `
`@current_user.identity.birth_date => "1980-12-01"`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#16649

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
