### PR TITLE
Parsing birls_id and participant_id on the user model from the User I…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,10 +129,8 @@ class User < Common::RedisStore
   delegate :common_name, to: :identity, allow_nil: true
 
   # mpi attributes
-  delegate :birls_id, to: :mpi
   delegate :icn, to: :mpi
   delegate :icn_with_aaid, to: :mpi
-  delegate :participant_id, to: :mpi
   delegate :vet360_id, to: :mpi
   delegate :search_token, to: :mpi
 
@@ -146,6 +144,14 @@ class User < Common::RedisStore
 
   def sec_id
     identity.sec_id || va_profile&.sec_id
+  end
+
+  def birls_id
+    identity&.birls_id || mpi&.birls_id
+  end
+
+  def participant_id
+    identity&.participant_id || mpi&.participant_id
   end
 
   def va_profile

--- a/app/models/user_identity.rb
+++ b/app/models/user_identity.rb
@@ -20,6 +20,8 @@ class UserIdentity < Common::RedisStore
   attribute :common_name
   attribute :gender
   attribute :birth_date
+  attribute :birls_id
+  attribute :participant_id
   attribute :zip
   attribute :ssn
   attribute :loa

--- a/lib/mpi/responses/id_parser.rb
+++ b/lib/mpi/responses/id_parser.rb
@@ -56,6 +56,7 @@ module MPI
           active_mhv_ids: select_ids(select_extension(ids, /^\w+\^PI\^200MH.{0,1}\^\w+\^A$/, VA_ROOT_OID)),
           edipi: select_ids(select_extension(ids, /^\w+\^NI\^200DOD\^USDOD\^A$/, DOD_ROOT_OID))&.first,
           vba_corp_id: select_ids(select_extension(ids, /^\w+\^PI\^200CORP\^USVBA\^A$/, VA_ROOT_OID))&.first,
+          idme_id: select_ids(select_extension(ids, /^\w+\^PN\^200VIDM\^USDVA\^A$/, VA_ROOT_OID))&.first,
           vha_facility_ids: select_facilities(select_extension(ids, /^\w+\^PI\^\w+\^USVHA\^\w+$/, VA_ROOT_OID)),
           cerner_facility_ids: select_facilities(select_extension(ids, /^\w+\^PI\^\w+\^USVHA\^C$/, VA_ROOT_OID)),
           cerner_id: select_ids(select_extension(ids, /^\w+\^PI\^200CRNR\^US\w+\^A$/, VA_ROOT_OID))&.first,
@@ -65,6 +66,15 @@ module MPI
         }
         result[:birls_id] = result[:birls_ids].first
         result
+      end
+
+      def parse_string(ids, root_oid = VA_ROOT_OID)
+        return unless ids
+
+        mapped_ids = ids.split('|').map do |id|
+          OpenStruct.new(attributes: { extension: id, root: root_oid })
+        end
+        parse(mapped_ids)
       end
 
       def select_ids_with_extension(ids, pattern, root)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,6 +16,8 @@ FactoryBot.define do
       ssn { '796111863' }
       idme_uuid { 'b2fab2b5-6af0-45e1-a9e2-394347af91ef' }
       sec_id { nil }
+      participant_id { nil }
+      birls_id { nil }
       mhv_icn { nil }
       multifactor { false }
       mhv_correlation_id { nil }
@@ -51,6 +53,8 @@ FactoryBot.define do
                              ssn: t.ssn,
                              idme_uuid: t.idme_uuid,
                              sec_id: t.sec_id,
+                             participant_id: t.participant_id,
+                             birls_id: t.birls_id,
                              mhv_icn: t.mhv_icn,
                              loa: t.loa,
                              multifactor: t.multifactor,

--- a/spec/lib/mpi/responses/id_parser_spec.rb
+++ b/spec/lib/mpi/responses/id_parser_spec.rb
@@ -17,6 +17,19 @@ describe MPI::Responses::IdParser do
       end
     end
 
+    context 'idme_id' do
+      let(:expected_idme_id) { 'someidmeid' }
+      let(:ids_to_parse) do
+        [correlation_id('87654321^PI^200CORP^USVBA^H'),
+         correlation_id("#{expected_idme_id}^PN^200VIDM^USDVA^A"),
+         correlation_id('12345678^PI^200CORP^USVBA^A')]
+      end
+
+      it 'correctly parses the idme_id from ids to parse' do
+        expect(MPI::Responses::IdParser.new.parse(ids_to_parse)[:idme_id]).to eq expected_idme_id
+      end
+    end
+
     context 'BIRLS' do
       let(:birls_ids) do
         [correlation_id('987654321^PI^200BRLS^USVBA^A'),
@@ -89,6 +102,40 @@ describe MPI::Responses::IdParser do
           expect_invalid_icn_to_return_nil('12345678901234567^AA^200M^USVHA^P')
           expect_invalid_icn_to_return_nil('12345678901234567^PI^200M^USVHA^P')
         end
+      end
+    end
+  end
+
+  describe '#parse_string' do
+    context 'when input ids is nil' do
+      it 'returns nil'
+    end
+
+    context 'input ids is a string of parsable ids separated by |' do
+      let(:ids) { "#{expected_vba_corp_id}^PI^200CORP^USVBA^A|#{expected_idme_id}^PN^200VIDM^USDVA^A" }
+      let(:expected_idme_id) { '12331231' }
+      let(:expected_vba_corp_id) { '87654321' }
+      let(:expected_parsed_result) do
+        {
+          icn: nil,
+          sec_id: nil,
+          mhv_ids: nil,
+          active_mhv_ids: nil,
+          edipi: nil,
+          vba_corp_id: expected_vba_corp_id,
+          idme_id: expected_idme_id,
+          vha_facility_ids: nil,
+          cerner_facility_ids: nil,
+          cerner_id: nil,
+          birls_ids: [],
+          vet360_id: nil,
+          icn_with_aaid: nil,
+          birls_id: nil
+        }
+      end
+
+      it 'creates a hash with correctly parsed ids' do
+        expect(MPI::Responses::IdParser.new.parse_string(ids)).to eq expected_parsed_result
       end
     end
   end

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -112,6 +112,8 @@ RSpec.describe SAML::User do
             account_type: 'N/A'
           },
           sec_id: nil,
+          participant_id: nil,
+          birls_id: nil,
           common_name: nil
         )
       end
@@ -148,6 +150,8 @@ RSpec.describe SAML::User do
             account_type: 'N/A'
           },
           sec_id: nil,
+          participant_id: nil,
+          birls_id: nil,
           common_name: nil
         )
       end
@@ -182,6 +186,8 @@ RSpec.describe SAML::User do
           loa: { current: 3, highest: 3 },
           sign_in: { service_name: 'idme', account_type: 'N/A' },
           sec_id: '1008830476',
+          participant_id: nil,
+          birls_id: nil,
           common_name: 'vets.gov.user+262@example.com'
         )
       end
@@ -217,6 +223,8 @@ RSpec.describe SAML::User do
           loa: { current: 1, highest: 3 },
           sign_in: { service_name: 'myhealthevet', account_type: 'Advanced' },
           sec_id: nil,
+          participant_id: nil,
+          birls_id: nil,
           multifactor: multifactor,
           common_name: nil
         )
@@ -255,6 +263,8 @@ RSpec.describe SAML::User do
           loa: { current: 3, highest: 3 },
           sign_in: { service_name: 'myhealthevet', account_type: 'Advanced' },
           sec_id: '1013183292',
+          participant_id: nil,
+          birls_id: nil,
           multifactor: multifactor,
           common_name: 'alexmac_0@example.com'
         )
@@ -291,6 +301,8 @@ RSpec.describe SAML::User do
             account_type: 'Basic'
           },
           sec_id: nil,
+          birls_id: nil,
+          participant_id: nil,
           multifactor: true,
           common_name: nil
         )
@@ -330,6 +342,8 @@ RSpec.describe SAML::User do
             account_type: 'Premium'
           },
           sec_id: '1012853550',
+          participant_id: nil,
+          birls_id: nil,
           multifactor: multifactor,
           common_name: 'k+tristan@example.com'
         )
@@ -370,6 +384,8 @@ RSpec.describe SAML::User do
             account_type: 'Premium'
           },
           sec_id: '1012853550',
+          participant_id: nil,
+          birls_id: nil,
           multifactor: multifactor,
           common_name: 'k+tristan@example.com'
         )
@@ -647,6 +663,8 @@ RSpec.describe SAML::User do
             account_type: '1'
           },
           sec_id: nil,
+          participant_id: nil,
+          birls_id: nil,
           multifactor: multifactor
         )
       end
@@ -681,6 +699,8 @@ RSpec.describe SAML::User do
             account_type: '2'
           },
           sec_id: '1013173963',
+          participant_id: nil,
+          birls_id: nil,
           multifactor: false,
           common_name: 'iam.tester@example.com'
         )
@@ -721,6 +741,8 @@ RSpec.describe SAML::User do
             account_type: '2'
           },
           sec_id: '0000028007',
+          participant_id: '600043180',
+          birls_id: '796123607',
           multifactor: multifactor,
           common_name: 'dslogon10923109@gmail.com'
         )
@@ -760,6 +782,8 @@ RSpec.describe SAML::User do
             account_type: '2'
           },
           sec_id: '0000028007',
+          participant_id: '600043180',
+          birls_id: '796123607',
           multifactor: multifactor,
           common_name: 'dslogon10923109@gmail.com'
         )
@@ -798,6 +822,8 @@ RSpec.describe SAML::User do
             account_type: 'N/A'
           },
           sec_id: '1012779219',
+          participant_id: nil,
+          birls_id: nil,
           multifactor: multifactor,
           common_name: 'SOFIA MCKIBBENS'
         )
@@ -851,6 +877,8 @@ RSpec.describe SAML::User do
             account_type: 'N/A'
           },
           sec_id: '1013062086',
+          participant_id: nil,
+          birls_id: nil,
           multifactor: multifactor,
           common_name: 'mhvzack@mhv.va.gov'
         )
@@ -889,6 +917,8 @@ RSpec.describe SAML::User do
             account_type: 'N/A'
           },
           sec_id: '1012827134',
+          participant_id: '600152411',
+          birls_id: '666271151',
           multifactor: multifactor,
           common_name: 'vets.gov.user+262@gmail.com'
         )

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,84 @@ RSpec.describe User, type: :model do
   let(:loa_one) { { current: LOA::ONE, highest: LOA::ONE } }
   let(:loa_three) { { current: LOA::THREE, highest: LOA::THREE } }
 
+  describe '#birls_id' do
+    let(:user) { build(:user, birls_id: identity_birls_id) }
+    let(:mpi_profile) { build(:mvi_profile, birls_id: mpi_birls_id) }
+    let(:identity_birls_id) { 'some_identity_birls_id' }
+    let(:mpi_birls_id) { 'some_mpi_birls_id' }
+
+    before do
+      allow(user).to receive(:mpi).and_return(mpi_profile)
+    end
+
+    context 'when birls_id on User Identity exists' do
+      let(:identity_birls_id) { 'some_identity_birls_id' }
+
+      it 'returns birls_id off the User Identity' do
+        expect(user.birls_id).to eq(identity_birls_id)
+      end
+    end
+
+    context 'when birls_id on identity does not exist' do
+      let(:identity_birls_id) { nil }
+
+      context 'and birls_id on MPI Data exists' do
+        let(:mpi_birls_id) { 'some_mpi_birls_id' }
+
+        it 'returns birls_id from the MPI Data' do
+          expect(user.birls_id).to eq(mpi_birls_id)
+        end
+      end
+
+      context 'and birls_id on MPI Data does not exist' do
+        let(:mpi_birls_id) { nil }
+
+        it 'returns nil' do
+          expect(user.birls_id).to eq(nil)
+        end
+      end
+    end
+  end
+
+  describe '#participant_id' do
+    let(:user) { build(:user, participant_id: identity_participant_id) }
+    let(:mpi_profile) { build(:mvi_profile, participant_id: mpi_participant_id) }
+    let(:identity_participant_id) { 'some_identity_participant_id' }
+    let(:mpi_participant_id) { 'some_mpi_participant_id' }
+
+    before do
+      allow(user).to receive(:mpi).and_return(mpi_profile)
+    end
+
+    context 'when participant_id on User Identity exists' do
+      let(:identity_participant_id) { 'some_identity_participant_id' }
+
+      it 'returns participant_id off the User Identity' do
+        expect(user.participant_id).to eq(identity_participant_id)
+      end
+    end
+
+    context 'when participant_id on identity does not exist' do
+      let(:identity_participant_id) { nil }
+
+      context 'and participant_id on MPI Data exists' do
+        let(:mpi_participant_id) { 'some_mpi_participant_id' }
+
+        it 'returns participant_id from the MPI Data' do
+          expect(user.participant_id).to eq(mpi_participant_id)
+        end
+      end
+
+      context 'and participant_id on MPI Data does not exist' do
+        let(:mpi_participant_id) { nil }
+
+        it 'returns nil' do
+          expect(user.participant_id).to eq(nil)
+        end
+      end
+    end
+  end
+
   describe '#all_emails' do
     let(:user) { build(:user, :loa3) }
     let(:vet360_email) { user.vet360_contact_info.email.email_address }


### PR DESCRIPTION
…dentity model before falling back to the MPI Data model



## Description of change
This PR saves a user's birls_id and participant_id on the User Identity model, in order to reduce the necessary calls out to the MPI data object. Basically, we are caching these fields in a redis storage so they can be retrieved over and over with less performance impact.



## Original issue(s)
https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/16415

## Things to know about this PR
- We need to make sure that the birls_id and participant_id don't contain any information that may need to be additionally encrypted now that it is stored in an additional place. 
- One data point, Joe stated that his birls_id is his SSN, so it's possible that we need to make sure we keep security in mind when storing this.



## Dev Acceptance:
- Set a breakpoint in `app/models/user_session_form.rb`, line 26, after `@user_identity` is set as an instance variable for the `User` model
- Logged in locally with: `http://localhost:3000/v1/sessions/idme/new`
- Skipped the breakpoint the first time (this is called, then user is upleveled with `loa` values, then this line is called again)
- Confirmed that `user.birls_id`, `user.participant_id` exists
- Confirmed that `user.identity.birls_id`, `user.identity.participant_id` exists.

