### PR TITLE
added directory#show

### DIFF
--- a/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
+++ b/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
@@ -15,14 +15,10 @@ module AppsApi
       end
 
       def show
-        if params[:name] == 'scopes'
-          redirect_to v0_scopes_path
-        else
-          app = DirectoryApplication.find_by(name: params[:name])
-          render json: {
-            data: app
-          }
-        end
+        app = DirectoryApplication.find_by(name: params[:id])
+        render json: {
+          data: app
+        }
       end
 
       def scopes

--- a/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
+++ b/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
@@ -14,6 +14,17 @@ module AppsApi
         }
       end
 
+      def show
+        if params[:name] == 'scopes'
+          redirect_to v0_scopes_path
+        else
+          app = DirectoryApplication.find_by(name: params[:name])
+          render json: {
+            data: app
+          }
+        end
+      end
+
       def scopes
         directory_service = Okta::DirectoryService.new
         parsed_scopes = directory_service.scopes(params[:category])

--- a/modules/apps_api/config/routes.rb
+++ b/modules/apps_api/config/routes.rb
@@ -6,9 +6,10 @@ AppsApi::Engine.routes.draw do
   match '/v0/healthcheck', to: 'metadata#healthcheck', via: [:get]
 
   namespace :v0, defaults: { format: 'json' } do
-    get 'directory', to: 'directory#index'
-    get 'directory/scopes/:category', to: 'directory#scopes', as: 'scopes', defaults: { category: 'unknown_category' }
-    get 'directory/:name', to: 'directory#show'
+    scope_default = { category: 'unknown_category' }
+    get 'directory/scopes/:category', to: 'directory#scopes', defaults: scope_default
+    get 'directory/scopes', to: 'directory#scopes', defaults: scope_default
+    resources 'directory', only: %i[index show]
   end
   namespace :docs do
     namespace :v0 do

--- a/modules/apps_api/config/routes.rb
+++ b/modules/apps_api/config/routes.rb
@@ -6,8 +6,9 @@ AppsApi::Engine.routes.draw do
   match '/v0/healthcheck', to: 'metadata#healthcheck', via: [:get]
 
   namespace :v0, defaults: { format: 'json' } do
-    get 'directory/scopes/:category', to: 'directory#scopes'
-    resources :directory, only: %i[index]
+    get 'directory', to: 'directory#index'
+    get 'directory/scopes/:category', to: 'directory#scopes', as: 'scopes', defaults: { category: 'unknown_category' }
+    get 'directory/:name', to: 'directory#show'
   end
   namespace :docs do
     namespace :v0 do

--- a/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
+++ b/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
@@ -61,8 +61,6 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
     it '204s when given a null category' do
       VCR.use_cassette('okta/verification-scopes') do
         get '/services/apps/v0/directory/scopes'
-        expect(response).to have_http_status(:found)
-        follow_redirect!
         expect(response).to have_http_status(:no_content)
       end
     end

--- a/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
+++ b/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
@@ -11,6 +11,19 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
     end
   end
 
+  describe '#get /services/apps/v0/directory/:name' do
+    it 'returns a single application' do
+      get '/services/apps/v0/directory/Apple%20Health'
+      body = JSON.parse(response.body)
+      expect(body.length).to be(1)
+    end
+    it 'returns an app when passing the :name param' do
+      get '/services/apps/v0/directory/iBlueButton'
+      body = JSON.parse(response.body)
+      expect(body).not_to be_empty
+    end
+  end
+
   describe '#get /services/apps/v0/directory/scopes/:category' do
     it 'returns a populated list of health scopes' do
       VCR.use_cassette('okta/health-scopes') do
@@ -45,10 +58,12 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
         expect(response).to have_http_status(:no_content)
       end
     end
-    it '404s when given a null category' do
+    it '204s when given a null category' do
       VCR.use_cassette('okta/verification-scopes') do
-        get '/services/apps/v0/directory/scopes/'
-        expect(response).to have_http_status(:not_found)
+        get '/services/apps/v0/directory/scopes'
+        expect(response).to have_http_status(:found)
+        follow_redirect!
+        expect(response).to have_http_status(:no_content)
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: Braden Shipley <bradenrshipley@gmail.com>
## Description of change
Added show method to the directory controller to allow for getting a single application in the directory. Previously there was only an index method that returned all records. The `routes.rb` for the apps_api module has been updated.
## Original issue(s)
https://vajira.max.gov/browse/API-3843?workflowName=Lighthouse+Default+Workflow&stepId=3

## Things to know about this PR
tests have been updated to account for new route method.