### PR TITLE
Add nod show endpoint and surface status

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements_controller.rb
@@ -5,12 +5,12 @@ require 'appeals_api/form_schemas'
 class AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController < AppealsApi::ApplicationController
   include AppealsApi::JsonFormatValidation
 
-  FORM_NUMBER = '10182'
-
   skip_before_action(:authenticate)
   before_action :validate_json_format, if: -> { request.post? }
   before_action :new_notice_of_disagreement, only: %i[create validate]
+  before_action :find_notice_of_disagreement, only: %i[show]
 
+  FORM_NUMBER = '10182'
   HEADERS = JSON.parse(
     File.read(
       AppealsApi::Engine.root.join('config/schemas/10182_headers.json')
@@ -24,6 +24,10 @@ class AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController < Appeals
     else
       render_model_errors
     end
+  end
+
+  def show
+    render_notice_of_disagreement
   end
 
   def validate
@@ -60,6 +64,24 @@ class AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController < Appeals
   def render_model_errors
     errors = @notice_of_disagreement.errors.to_a.map { |error| { status: 422, detail: error } }
     render json: { errors: errors }, status: 422
+  end
+
+  def find_notice_of_disagreement
+    @id = params[:id]
+    @notice_of_disagreement = AppealsApi::NoticeOfDisagreement.find(@id)
+  rescue ActiveRecord::RecordNotFound
+    render_notice_of_disagreement_not_found
+  end
+
+  def render_notice_of_disagreement_not_found
+    render(
+      status: :not_found,
+      json: {
+        errors: [
+          { status: 404, detail: I18n.t('appeals_api.errors.nod_not_found', id: @id) }
+        ]
+      }
+    )
   end
 
   def render_notice_of_disagreement

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -86,7 +86,9 @@ module AppealsApi
 
     FORM_SCHEMA = load_json_schema '10182'
     AUTH_HEADERS_SCHEMA = load_json_schema '10182_headers'
+    STATUSES = %w[pending].freeze
 
+    validates :status, inclusion: { 'in': STATUSES }
     validate(
       :validate_auth_headers_against_schema,
       :validate_form_data_against_schema,

--- a/modules/appeals_api/app/serializers/appeals_api/notice_of_disagreement_serializer.rb
+++ b/modules/appeals_api/app/serializers/appeals_api/notice_of_disagreement_serializer.rb
@@ -3,6 +3,6 @@
 class AppealsApi::NoticeOfDisagreementSerializer
   include FastJsonapi::ObjectSerializer
   set_key_transform :camel_lower
-  attributes :updated_at, :created_at, :form_data
+  attributes :status, :updated_at, :created_at, :form_data
   set_type :noticeOfDisagreement
 end

--- a/modules/appeals_api/config/locales/en.yml
+++ b/modules/appeals_api/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
       errors:
         claimant_info: "if any claimant info is present, claimant %{field} must also be present"
         contact_info_presence: "at least one must be included: '/data/attributes/veteran', '/data/attributes/claimant'"
-        hearing_type_preference_missing: "if '/data/attributes/boardReviewOption' 'hearing' is selected, '/data/attributes/hearingTypePreference' must also be present"
         hearing_type_preference_inclusion: "if '/data/attributes/boardReviewOption' 'direct_review' or 'evidence_submission' is selected, '/data/attributes/hearingTypePreference' must not be selected"
+        hearing_type_preference_missing: "if '/data/attributes/boardReviewOption' 'hearing' is selected, '/data/attributes/hearingTypePreference' must also be present"
+        nod_not_found: "NoticeOfDisagreement with uuid %{id} not found."
         not_homeless_address_missing: "at least one must be included: '/data/attributes/veteran/address', '/data/attributes/claimant/address'"

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -23,7 +23,7 @@ AppealsApi::Engine.routes.draw do
       namespace :notice_of_disagreements do
         get 'contestable_issues', to: 'contestable_issues#index'
       end
-      resources :notice_of_disagreements, only: %i[create] do
+      resources :notice_of_disagreements, only: %i[create show] do
         collection do
           get 'schema', to: 'notice_of_disagreements#schema'
           post 'validate', to: 'notice_of_disagreements#validate'

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
@@ -27,6 +27,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController, type:
       it 'with all headers' do
         post(path, params: @data, headers: @headers)
         expect(parsed['data']['type']).to eq('noticeOfDisagreement')
+        expect(parsed['data']['attributes']['status']).to eq('pending')
       end
 
       it 'with the minimum required headers' do
@@ -82,6 +83,26 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController, type:
     it 'renders the json schema' do
       get path
       expect(response.status).to eq(200)
+    end
+  end
+
+  describe '#show' do
+    let(:path) { base_path 'notice_of_disagreements/' }
+
+    it 'returns a notice_of_disagreement with all of its data' do
+      uuid = create(:notice_of_disagreement).id
+      get("#{path}#{uuid}")
+      expect(response.status).to eq(200)
+      expect(parsed.dig('data', 'attributes', 'formData')).to be_a Hash
+    end
+
+    it 'returns an error when given a bad uuid' do
+      uuid = 0
+      get("#{path}#{uuid}")
+      binding.pry
+      expect(response.status).to eq(404)
+      expect(parsed['errors']).to be_an Array
+      expect(parsed['errors']).not_to be_empty
     end
   end
 end

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
@@ -99,7 +99,6 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController, type:
     it 'returns an error when given a bad uuid' do
       uuid = 0
       get("#{path}#{uuid}")
-      binding.pry
       expect(response.status).to eq(404)
       expect(parsed['errors']).to be_an Array
       expect(parsed['errors']).not_to be_empty


### PR DESCRIPTION
## Description of change
Notice of disagreement show endpoint implemented. Includes newly migrated status - only designed to handle the default 'pending' status for now.

## Original issue(s)
https://vajira.max.gov/browse/API-3628

## Things to know about this PR
Documentation update to follow once feedback on PR received.

## Testing
NOD controller spec updated to check for status = 'pending'
