### PR TITLE
rubocop ignore migrations for all modules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ AllCops:
     - db/migrate/*.rb
     - 'script/**/*'
     - 'vendor/**/*'
+    - modules/**/db/migrate/*.rb
 
 # This allows you to use have writers like self.method_name(name) vs self.method_name=(name)
 Style/TrivialAccessors:


### PR DESCRIPTION
## Description of change
Adds config to the root-level rubocop to ignore the db migration files for all sub-modules.

## Why?
In short, PR's were excluding `module/whatever/db/migration/*.rb` when running `rubocop`, whereas `master` CI would still run on these files. This meant that if a linting error was introduced in one of these files in a PR the CI would not catch it. Once merged however, the `master` CI `rubocop` would run on that file and fail. [This ultimately blocked a daily deploy](https://dsva.slack.com/archives/C0MQ281DJ/p1606763358227700?thread_ts=1606762827.226800&cid=C0MQ281DJ).

## Even More Context
- [I logged a bug with rubocop](https://github.com/rubocop-hq/rubocop/issues/9132) that goes into the gory details of how using `--force-exclusion` behaves differently than when not using it.
- PR's only lint the files that were changed in the PR - this was an optimization to speed up PR CI runs ([PR link](https://github.com/department-of-veterans-affairs/vets-api/pull/4036)).

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
