### PR TITLE
13444 refactor okta grant caching

### DIFF
--- a/app/models/okta_redis/grants.rb
+++ b/app/models/okta_redis/grants.rb
@@ -9,12 +9,11 @@ module OktaRedis
     CLASS_NAME = 'GrantsService'
 
     def all
-      okta_response.body
+      @all_grants ||= service.grants(@user.okta_profile.id).body
     end
 
     def delete_grants(grant_ids)
       grant_ids.map { |grant| delete_grant(grant) }
-      OktaRedis::Grants.delete(cache_key)
       true
     end
 
@@ -26,15 +25,6 @@ module OktaRedis
         raise 'Unable to delete grant'
       end
       delete_response
-    end
-
-    private
-
-    def okta_response
-      do_cached_with(key: cache_key) do
-        grants_response = service.grants(@user.okta_profile.id)
-        grants_response.success? ? grants_response : []
-      end
     end
   end
 end

--- a/app/models/okta_redis/grants.rb
+++ b/app/models/okta_redis/grants.rb
@@ -13,20 +13,19 @@ module OktaRedis
     end
 
     def delete_grants(grant_ids)
-      success = grant_ids.reduce(true) { |memo, grant| delete_grant(grant) && memo }
-      OktaRedis::Grants.delete(cache_key) if success
-      success
+      grant_ids.map { |grant| delete_grant(grant) }
+      OktaRedis::Grants.delete(cache_key)
+      true
     end
 
     def delete_grant(grant_id)
       delete_response = service.delete_grant(@user.okta_profile.id, grant_id)
-      if delete_response.success?
-        true
-      else
+      unless delete_response.success?
         log_message_to_sentry("Error deleting grant #{grant_id}", :error,
                               body: delete_response.body)
         raise 'Unable to delete grant'
       end
+      delete_response
     end
 
     private

--- a/app/models/okta_redis/grants.rb
+++ b/app/models/okta_redis/grants.rb
@@ -14,7 +14,6 @@ module OktaRedis
 
     def delete_grants(grant_ids)
       grant_ids.map { |grant| delete_grant(grant) }
-      true
     end
 
     def delete_grant(grant_id)


### PR DESCRIPTION
This PR removes the use of Redis to cache connected applications (grants) for a user. (See "original issue" below for reason this change is needed.)

## Description of change
* the `all` method just use in-memory caching to prevent additional requests to okta during a single request to the api
* delete no longer needs to delete a cache key since the cache isn't used
* delete also refactored to not track a boolean since the logic breaks with the exception, not a `false`-y value.

## of interest
The `Grant` class should probably not inherit from `Model` which inherits from `Common::RedisStore` but the way this code is accessed is through the `App` service referencing some meta programming in the user class.  Untangling that is a bigger project, so feedback on other changes this PR should include are welcome.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#13444