### PR TITLE
Pass Regional Office in SOJ field for 686c Submission

### DIFF
--- a/app/models/bgs_dependents/veteran.rb
+++ b/app/models/bgs_dependents/veteran.rb
@@ -50,6 +50,7 @@ module BGSDependents
         address_zip_code: address[:zip_prefix_nbr],
         type: 'veteran',
         benefit_claim_type_end_product: claim_info[:claim_type_end_product],
+        regional_office_number: claim_info[:regional_office_number],
         location_id: claim_info[:location_id],
         net_worth_over_limit_ind: claim_info[:net_worth_over_limit_ind]
       }

--- a/lib/bgs/benefit_claim.rb
+++ b/lib/bgs/benefit_claim.rb
@@ -57,7 +57,8 @@ module BGS
         country: @veteran[:address_country],
         date_of_claim: Time.current.strftime('%m/%d/%Y'),
         end_product_name: @end_product_name,
-        end_product_code: @end_product_code
+        end_product_code: @end_product_code,
+        soj: @veteran[:regional_office_number]
       }.merge(BENEFIT_CLAIM_PARAM_CONSTANTS)
     end
 

--- a/lib/bgs/vnp_veteran.rb
+++ b/lib/bgs/vnp_veteran.rb
@@ -43,7 +43,7 @@ module BGS
 
     def get_regional_office(zip, country, province)
       # find the regional office number closest to the Veteran's zip code
-      regional_office_number = bgs_service.get_regional_office_by_zip_code(
+      bgs_service.get_regional_office_by_zip_code(
         zip, country, province, 'CP', @user.ssn
       )
     end

--- a/lib/bgs/vnp_veteran.rb
+++ b/lib/bgs/vnp_veteran.rb
@@ -13,6 +13,7 @@ module BGS
       @va_file_number = @payload['veteran_information']['va_file_number']
     end
 
+    # rubocop:disable Metrics/MethodLength
     def create
       participant = bgs_service.create_participant(@proc_id, @user.participant_id)
       claim_type_end_product = bgs_service.find_benefit_claim_type_increment(@claim_type)
@@ -36,6 +37,7 @@ module BGS
         }
       )
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/lib/bgs/vnp_veteran.rb
+++ b/lib/bgs/vnp_veteran.rb
@@ -13,16 +13,13 @@ module BGS
       @va_file_number = @payload['veteran_information']['va_file_number']
     end
 
-    # rubocop:disable Metrics/MethodLength
     def create
       participant = bgs_service.create_participant(@proc_id, @user.participant_id)
       claim_type_end_product = bgs_service.find_benefit_claim_type_increment(@claim_type)
-      person_params = veteran.create_person_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
-      address_params = veteran.create_address_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
-      address = bgs_service.create_address(address_params)
+      address = create_address(participant)
       regional_office_number = get_regional_office(address[:zip_prefix_nbr], address[:cntry_nm], '')
       location_id = get_location_id(regional_office_number)
-      bgs_service.create_person(person_params)
+      create_person(participant)
       bgs_service.create_phone(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
       net_worth_over_limit_ind = @payload['dependents_application']['household_income'] ? 'Y' : 'N'
       veteran.veteran_response(
@@ -37,9 +34,18 @@ module BGS
         }
       )
     end
-    # rubocop:enable Metrics/MethodLength
 
     private
+
+    def create_person(participant)
+      person_params = veteran.create_person_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
+      bgs_service.create_person(person_params)
+    end
+
+    def create_address(participant)
+      address_params = veteran.create_address_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
+      bgs_service.create_address(address_params)
+    end
 
     def get_regional_office(zip, country, province)
       # find the regional office number closest to the Veteran's zip code

--- a/lib/bgs/vnp_veteran.rb
+++ b/lib/bgs/vnp_veteran.rb
@@ -19,7 +19,8 @@ module BGS
       person_params = veteran.create_person_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
       address_params = veteran.create_address_params(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
       address = bgs_service.create_address(address_params)
-      location_id = get_location_id(address[:zip_prefix_nbr], address[:cntry_nm], '')
+      regional_office_number = get_regional_office(address[:zip_prefix_nbr], address[:cntry_nm], '')
+      location_id = get_location_id(regional_office_number)
       bgs_service.create_person(person_params)
       bgs_service.create_phone(@proc_id, participant[:vnp_ptcpnt_id], @veteran_info)
       net_worth_over_limit_ind = @payload['dependents_application']['household_income'] ? 'Y' : 'N'
@@ -29,6 +30,7 @@ module BGS
         {
           va_file_number: @va_file_number,
           claim_type_end_product: claim_type_end_product,
+          regional_office_number: regional_office_number,
           location_id: location_id,
           net_worth_over_limit_ind: net_worth_over_limit_ind
         }
@@ -37,13 +39,16 @@ module BGS
 
     private
 
-    def get_location_id(zip, country, province)
+    def get_regional_office(zip, country, province)
       # find the regional office number closest to the Veteran's zip code
       regional_office_number = bgs_service.get_regional_office_by_zip_code(
         zip, country, province, 'CP', @user.ssn
       )
+    end
+
+    def get_location_id(regional_office_number)
       # retrieve the list of all regional offices
-      # match the regional number above to find the corresponding location id
+      # match the regional number to find the corresponding location id
       regional_offices = bgs_service.find_regional_offices
       return '347' if regional_offices.nil? # return default value 347 if regional office is not found
 

--- a/spec/lib/bgs/vnp_veteran_spec.rb
+++ b/spec/lib/bgs/vnp_veteran_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe BGS::VnpVeteran do
             address_zip_code: '21122',
             type: 'veteran',
             benefit_claim_type_end_product: '139',
+            regional_office_number: '313',
             location_id: '343',
             net_worth_over_limit_ind: 'N'
           )


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
During integration testing for Dependency Claims (VA Form 686c), it was determined that we need to populate the SOJ field with the Regional Office number closest to the Veteran (based on their zip code).  This PR updates the Form 686c submission process to pass the SOJ field to BGS.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#16696
department-of-veterans-affairs/va.gov-team#12425

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is a minor PR update to an existing feature so no new settings or logging have been added.

## Testing
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] Local testing done
- [x] Specs updated
- [x] Staging testing planned