### PR TITLE
Update Puma to 4.3.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'veteran_confirmation', path: 'modules/veteran_confirmation'
 gem 'veteran_verification', path: 'modules/veteran_verification'
 
 # Anchored versions, do not change
-gem 'puma', '~> 4.3.5'
+gem 'puma', '~> 4.3.7'
 gem 'puma-plugin-statsd', '~> 0.1.0'
 gem 'rails', '~> 6.0.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,7 +640,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (4.3.5)
+    puma (4.3.7)
       nio4r (~> 2.0)
     puma-plugin-statsd (0.1.0)
       json
@@ -998,7 +998,7 @@ DEPENDENCIES
   pg
   prawn
   pry-byebug
-  puma (~> 4.3.5)
+  puma (~> 4.3.7)
   puma-plugin-statsd (~> 0.1.0)
   pundit
   rack


### PR DESCRIPTION
There's [a bug in Puma 4.3.5](https://github.com/puma/puma/issues/2304) which prevents some compilers from building the native extensions required for Puma.

I was running into this issue on macOS Big Sur. Updating fixed it.