### PR TITLE
Saml response errors

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -292,7 +292,12 @@ module V1
     # rubocop:disable Metrics/ParameterLists
     def handle_callback_error(exc, status, response, level = :error, context = {},
                               code = '007', tag = nil)
-      log_message_to_sentry(exc.message, level, extra_context: context)
+      message = exc.message
+      # replaces bundled Sentry error message with specific XML messages
+      if response.normalized_errors.count > 1 && (detail_message = response.status_detail)
+        message = detail_message
+      end
+      log_message_to_sentry(message, level, extra_context: context)
       redirect_to url_service.login_redirect_url(auth: 'fail', code: code) unless performed?
       login_stats(:failure, exc) unless response.nil?
       callback_stats(status, response, tag)

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -292,11 +292,12 @@ module V1
     # rubocop:disable Metrics/ParameterLists
     def handle_callback_error(exc, status, response, level = :error, context = {},
                               code = '007', tag = nil)
-      message = exc.message
       # replaces bundled Sentry error message with specific XML messages
-      if response.normalized_errors.count > 1 && (detail_message = response.status_detail)
-        message = detail_message
-      end
+      message = if response.normalized_errors.count > 1 && response.status_detail
+                  response.status_detail
+                else
+                  exc.message
+                end
       log_message_to_sentry(message, level, extra_context: context)
       redirect_to url_service.login_redirect_url(auth: 'fail', code: code) unless performed?
       login_stats(:failure, exc) unless response.nil?

--- a/lib/saml/responses/login.rb
+++ b/lib/saml/responses/login.rb
@@ -19,7 +19,7 @@ module SAML
       def status_detail
         @status_detail ||= begin
           node = REXML::XPath.first(
-            @document,
+            decrypted_document || document,
             '/p:Response/p:Status/p:StatusDetail',
             { 'p' => PROTOCOL }
           )

--- a/lib/saml/responses/login.rb
+++ b/lib/saml/responses/login.rb
@@ -15,6 +15,17 @@ module SAML
                               message
                             end
       end
+
+      def status_detail
+        @status_detail ||= begin
+          node = REXML::XPath.first(
+            @document,
+            '/p:Response/p:Status/p:StatusDetail',
+            { 'p' => PROTOCOL }
+          )
+          node.nil? ? nil : node.each_element_with_text.join(', ')
+        end
+      end
     end
   end
 end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -691,6 +691,7 @@ RSpec.describe V1::SessionsController, type: :controller do
 
         it 'logs status_detail message to sentry' do
           expect(controller).to receive(:log_message_to_sentry)
+          # add status_detail error specific test here
           post(:saml_callback)
         end
       end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -678,6 +678,23 @@ RSpec.describe V1::SessionsController, type: :controller do
         end
       end
 
+      context 'when saml response error contains status_detail' do
+        status_detail_xml = '<samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder">'\
+        '</samlp:StatusCode>'\
+        '<samlp:StatusDetail>'\
+        '<fim:FIMStatusDetail MessageID="could_not_perform_token_exchange"></fim:FIMStatusDetail>'\
+        '</samlp:StatusDetail>'\
+
+        before do
+          allow(SAML::Responses::Login).to receive(:new).and_return(saml_response_detail_error(status_detail_xml))
+        end
+
+        it 'logs status_detail message to sentry' do
+          expect(controller).to receive(:log_message_to_sentry)
+          post(:saml_callback)
+        end
+      end
+
       context 'when saml response contains multiple errors (known or otherwise)' do
         let(:multi_error_uuid) { '2222' }
 

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -691,7 +691,27 @@ RSpec.describe V1::SessionsController, type: :controller do
 
         it 'logs status_detail message to sentry' do
           expect(controller).to receive(:log_message_to_sentry)
-          # add status_detail error specific test here
+            .with(
+              "<fim:FIMStatusDetail MessageID='could_not_perform_token_exchange'/>",
+              :error,
+              extra_context: [
+                { code: '007',
+                  tag: :unknown,
+                  short_message: 'Other SAML Response Error(s)',
+                  level: :error,
+                  full_message: 'Test1' },
+                { code: '007',
+                  tag: :unknown,
+                  short_message: 'Other SAML Response Error(s)',
+                  level: :error,
+                  full_message: 'Test2' },
+                { code: '007',
+                  tag: :unknown,
+                  short_message: 'Other SAML Response Error(s)',
+                  level: :error,
+                  full_message: 'Test3' }
+              ]
+            )
           post(:saml_callback)
         end
       end

--- a/spec/lib/saml/responses/login_spec.rb
+++ b/spec/lib/saml/responses/login_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/saml/response_builder'
+
+RSpec.describe SAML::Responses::Login do
+  include SAML::ResponseBuilder
+
+  status_detail = '<samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder"></samlp:StatusCode>'\
+                  '<samlp:StatusDetail>'\
+                  '<fim:FIMStatusDetail MessageID="could_not_perform_token_exchange"></fim:FIMStatusDetail>'\
+                  '</samlp:StatusDetail>'
+  no_detail = '<samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />'
+
+  let(:document_with_detail) { document_status_detail(status_detail) }
+  let(:document_no_detail) { document_status_detail(no_detail) }
+
+  describe '#status_detail' do
+    it 'returns status_detail when found' do
+      saml_response = SAML::Responses::Login.new(document_with_detail.to_s)
+      expect(saml_response.status_detail).to eq("<fim:FIMStatusDetail MessageID='could_not_perform_token_exchange'/>")
+    end
+
+    it 'returns nil when not found' do
+      saml_response = SAML::Responses::Login.new(document_no_detail.to_s)
+      expect(saml_response.status_detail).to be_nil
+    end
+  end
+end

--- a/spec/support/saml/response_builder.rb
+++ b/spec/support/saml/response_builder.rb
@@ -139,10 +139,10 @@ module SAML
 
     def saml_response_detail_error(status_detail_xml)
       build_invalid_saml_response(
-        status_message: 'test error message',
+        status_message: 'Status Detail Error Message',
         in_response_to: uuid,
         decrypted_document: document_status_detail(status_detail_xml),
-        errors: %w[test1 test2 test3]
+        errors: %w[Test1 Test2 Test3]
       )
     end
 

--- a/spec/support/saml/response_builder.rb
+++ b/spec/support/saml/response_builder.rb
@@ -137,6 +137,15 @@ module SAML
       )
     end
 
+    def saml_response_detail_error(status_detail_xml)
+      build_invalid_saml_response(
+        status_message: 'test error message',
+        in_response_to: uuid,
+        decrypted_document: document_status_detail(status_detail_xml),
+        errors: %w[test1 test2 test3]
+      )
+    end
+
     def document_partial(authn_context = '')
       REXML::Document.new(
         <<-XML
@@ -149,6 +158,23 @@ module SAML
               </saml:AuthnContext>
             </saml:AuthnStatement>
           </saml:Assertion>
+        </samlp:Response>
+        XML
+      )
+    end
+
+    def document_status_detail(status = '')
+      REXML::Document.new(
+        <<-XML
+        <samlp:Response
+          xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+          xmlns:fim="urn:ibm:names:ITFIM:saml"
+          xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+          xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Destination="https://api.va.gov/v1/sessions/callback" ID="FIMRSP_9bbcd6a3-0175-10e5-8532-9199cd4142f8" InResponseTo="_a9ea0b44-5b5d-40dd-ae46-de5dafa71983" IssueInstant="2020-11-06T04:07:25Z" Version="2.0">
+          <saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">https://eauth.va.gov/isam/sps/saml20idp/saml20</saml:Issuer>
+          <samlp:Status>
+            #{status}
+          </samlp:Status>
         </samlp:Response>
         XML
       )


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This change improves the `handle_callback_error` function to attempt to tease out more specific `status_detail` information in a failed SAML response to be logged to Sentry instead of logging them all together in a bundle, which does not provide much actionable data to go off of.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15009

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Unit testing was included for the new status_detail method and updated to include a status_detail test case for saml_callback method; manual testing was done with the logged error SAML response via an API client and by attempting to submit a SAML form to ID.ME with an expired timestamp.
