### PR TITLE
Fix for CH36 add veteranSocialSecurityNumber field

### DIFF
--- a/app/controllers/v0/education_career_counseling_claims_controller.rb
+++ b/app/controllers/v0/education_career_counseling_claims_controller.rb
@@ -13,7 +13,7 @@ module V0
         raise Common::Exceptions::ValidationErrors, claim
       end
 
-      claim.process_attachments!
+      claim.send_to_central_mail!
 
       Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}"
       clear_saved_form(claim.form_id)

--- a/app/models/saved_claim/education_career_counseling_claim.rb
+++ b/app/models/saved_claim/education_career_counseling_claim.rb
@@ -46,7 +46,7 @@ class SavedClaim::EducationCareerCounselingClaim < CentralMailClaim
       update(form: form_copy.to_json)
     end
 
-    log_message_to_sentry(guid, :warn, {attachment_id: guid}, { team: 'vfs-ebenefits' })
+    log_message_to_sentry(guid, :warn, { attachment_id: guid }, { team: 'vfs-ebenefits' })
     process_attachments!
   end
 

--- a/spec/factories/education_career_counseling_claim.rb
+++ b/spec/factories/education_career_counseling_claim.rb
@@ -37,7 +37,8 @@ FactoryBot.define do
         },
         veteranFullName: {
           first: 'MARK', middle: 'WEBB', last: 'WEBB'
-        }
+        },
+        veteranSocialSecurityNumber: '796104437'
       }.to_json
     }
   end

--- a/spec/factories/education_career_counseling_claim_no_vet_information.rb
+++ b/spec/factories/education_career_counseling_claim_no_vet_information.rb
@@ -11,9 +11,9 @@ FactoryBot.define do
             first: 'Dardan',
             middle: 'Adam',
             last: 'Testy',
-            suffix: 'Jr.',
-            ssn: '333224444'
+            suffix: 'Jr.'
           },
+          ssn: '333224444',
           dateOfBirth: '1964-12-26',
           VAFileNumber: '22334455',
           emailAddress: 'vet123@test.com',

--- a/spec/models/saved_claim/education_career_counseling_claim_spec.rb
+++ b/spec/models/saved_claim/education_career_counseling_claim_spec.rb
@@ -29,4 +29,17 @@ RSpec.describe SavedClaim::EducationCareerCounselingClaim do
       expect(claim.regional_office).to eq([])
     end
   end
+
+  describe '#send_to_central_mail!' do
+    it 'formats data before sending to central mail' do
+      expect(claim).to receive(:update).with(form: a_string_including('"veteranSocialSecurityNumber":"333224444"'))
+
+      claim.send_to_central_mail!
+    end
+
+    it 'calls process_attachments! method' do
+      expect(claim).to receive(:process_attachments!)
+      claim.send_to_central_mail!
+    end
+  end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This PR is to fix the CH36 form submission to CentralMail.  CentralMail expects a field called "veteranSocialSecurityNumber" to be at the root level of the hash/payload, so this PR is a fix to ensure that this value is set and in the appropriate location/level.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#16219

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is a minor bug fix PR so no additional settings or logging was necessary.
<!-- Please describe testing done to verify the changes or any testing planned. -->
## Testing 
- [x] Local testing done
- [x] Specs added
- [x] Staging testing planned