### PR TITLE
API-3036: 2122 (John Doe) Http 500 Error

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -93,9 +93,19 @@ module ClaimsApi
         def source_data
           {
             name: source_name,
-            icn: current_user.icn,
+            icn: nullable_icn,
             email: current_user.email
           }
+        end
+
+        def nullable_icn
+          current_user.icn
+        rescue => e
+          log_message_to_sentry('Failed to retrieve icn for consumer',
+                                :warning,
+                                body: e.message)
+
+          nil
         end
 
         def find_poa_by_id

--- a/modules/claims_api/app/controllers/concerns/claims_api/mpi_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/mpi_verification.rb
@@ -12,9 +12,18 @@ module ClaimsApi
       rescue => e
         log_message_to_sentry('MPIError in claims',
                               :warning,
-                              body: target_veteran.mpi&.response&.error&.inspect || e.message)
+                              body: inspected_error || e.message)
+
         render json: { errors: [{ status: 400, detail: 'Not enough Veteran information, functionality limited.' }] },
                status: :bad_request
+      end
+
+      private
+
+      def inspected_error
+        target_veteran.mpi&.response&.error&.inspect
+      rescue
+        nil
       end
     end
   end

--- a/spec/lib/common/exceptions/parameters_missing_spec.rb
+++ b/spec/lib/common/exceptions/parameters_missing_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Common::Exceptions::ParametersMissing do
+  context 'with no attributes provided' do
+    it do
+      expect { described_class.new }
+        .to raise_error(ArgumentError, 'wrong number of arguments (given 0, expected 1)')
+    end
+  end
+
+  context 'with param provided' do
+    subject { described_class.new(%w[first_parameter second_parameter]) }
+
+    it 'implements #errors which returns an array' do
+      expect(subject.errors).to be_an(Array)
+    end
+
+    it 'the errors object has all relevant keys' do
+      expect(subject.errors.first.to_hash)
+        .to eq(title: 'Missing parameter',
+               detail: 'The required parameter "first_parameter", is missing',
+               code: '108',
+               status: '400')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
System is returning a generic 500 response if the endpoint consumer has not provided Veteran information in the auth headers and said consumer is not in MPI. This should resolve that and respond with a 400 response as expected.

## Original issue(s)
https://vajira.max.gov/browse/API-3036

## Things to know about this PR
Tested locally