### PR TITLE
need to set last_signed_in for mobile iam users

### DIFF
--- a/lib/iam_ssoe_oauth/session_manager.rb
+++ b/lib/iam_ssoe_oauth/session_manager.rb
@@ -61,6 +61,7 @@ module IAMSSOeOAuth
 
     def build_user(user_identity)
       user = IAMUser.build_from_user_identity(user_identity)
+      user.last_signed_in = Time.now.utc
       user.save
       user
     end

--- a/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
+++ b/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
@@ -19,7 +19,6 @@ describe 'IAMSSOeOAuth::SessionManager' do
       before do
         VCR.use_cassette('iam_ssoe_oauth/introspect_active') do
           @user = session_manager.find_or_create_user
-          expect(@user.last_signed_in).not_to be_nil
         end
       end
 
@@ -33,6 +32,10 @@ describe 'IAMSSOeOAuth::SessionManager' do
 
       it 'creates a user identity' do
         expect(@user.identity).not_to be_nil
+      end
+
+      it 'last_signed_in is set and is a time' do
+      expect(@user.last_signed_in).to be_a_kind_of(Time)
       end
     end
   end

--- a/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
+++ b/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
@@ -35,7 +35,7 @@ describe 'IAMSSOeOAuth::SessionManager' do
       end
 
       it 'last_signed_in is set and is a time' do
-      expect(@user.last_signed_in).to be_a_kind_of(Time)
+        expect(@user.last_signed_in).to be_a_kind_of(Time)
       end
     end
   end

--- a/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
+++ b/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
@@ -19,6 +19,7 @@ describe 'IAMSSOeOAuth::SessionManager' do
       before do
         VCR.use_cassette('iam_ssoe_oauth/introspect_active') do
           @user = session_manager.find_or_create_user
+          expect(@user.last_signed_in).not_to be_nil
         end
       end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Needed to set last_signed_in for mobile iam users in order to user EVSS services

## Original issue(s)
No issue created, hot fix

## Things to know about this PR
Set last_signed_in and updated tests to check that the field is non-null