### PR TITLE
Migrations for covid_vaccine schema

### DIFF
--- a/db/migrate/20201205223834_add_covid_registration_submissions.rb
+++ b/db/migrate/20201205223834_add_covid_registration_submissions.rb
@@ -1,0 +1,15 @@
+class AddCovidRegistrationSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :covid_vaccine_registration_submissions, id: :serial do |t|
+      t.string "sid", null: false
+      t.uuid "account_id", null: true
+      t.string "encrypted_form_data"
+      t.string "encrypted_form_data_iv"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index ["sid"], name: "index_covid_vaccine_registry_submissions_on_sid", unique: true
+      t.index ["encrypted_form_data_iv"], name: "index_covid_vaccine_registry_submissions_on_iv", unique: true
+      t.index ["account_id", "created_at"], name: "index_covid_vaccine_registry_submissions_2"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_04_151120) do
+ActiveRecord::Schema.define(version: 2020_12_05_223834) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -167,6 +167,18 @@ ActiveRecord::Schema.define(version: 2020_12_04_151120) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "auto_established_claim_id"
+  end
+
+  create_table "covid_vaccine_registration_submissions", id: :serial, force: :cascade do |t|
+    t.string "sid", null: false
+    t.uuid "account_id"
+    t.string "encrypted_form_data"
+    t.string "encrypted_form_data_iv"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "created_at"], name: "index_covid_vaccine_registry_submissions_2"
+    t.index ["encrypted_form_data_iv"], name: "index_covid_vaccine_registry_submissions_on_iv", unique: true
+    t.index ["sid"], name: "index_covid_vaccine_registry_submissions_on_sid", unique: true
   end
 
   create_table "directory_applications", force: :cascade do |t|


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
DB migration and schema update for covid_vaccine module. This migration is tested in dev/review instances, extracted from this PR: https://github.com/department-of-veterans-affairs/vets-api/pull/5439/commits
so that we can apply it separately. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
This feature does store PII in the `encrypted_form_data` table - this contains the raw submission to the covid vaccine registration endpoint. This storage is approved by product owner @batemapf. Vets-api is not the source of truth for this data, but we're retaining it in case we need to replay submissions to the underlying system.
