### PR TITLE
Change location of appeals_api temp pdf files

### DIFF
--- a/modules/appeals_api/lib/appeals_api/base_pdf_constructor.rb
+++ b/modules/appeals_api/lib/appeals_api/base_pdf_constructor.rb
@@ -23,7 +23,7 @@ module AppealsApi
 
     def fill_pdf
       pdftk = PdfForms.new(Settings.binaries.pdftk)
-      temp_path = "#{Rails.root}/tmp/#{appeal.id}"
+      temp_path = "/tmp/#{appeal.id}"
       output_path = temp_path + '-final.pdf'
       pdftk.fill_form(
         "#{PDF_TEMPLATE}/#{self.class.form_title}.pdf",

--- a/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_constructor.rb
+++ b/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_constructor.rb
@@ -100,7 +100,7 @@ module AppealsApi
     # For inserting items into the pdf that require special insertion (e.g. where fields cannot hold enough text)
     def insert_manual_fields(pdf_template)
       pdftk = PdfForms.new(Settings.binaries.pdftk)
-      temp_file = "#{::Common::FileHelpers.random_file_path}.pdf"
+      temp_file = "/#{::Common::FileHelpers.random_file_path}.pdf"
       output_path = "#{pdf_template}-final.pdf"
 
       Prawn::Document.generate(temp_file) do |pdf|

--- a/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_constructor.rb
+++ b/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_constructor.rb
@@ -73,7 +73,7 @@ module AppealsApi
     def merge_page(temp_path, output_path)
       return temp_path if pdf_options[:additional_pages].blank?
 
-      rand_path = "#{Common::FileHelpers.random_file_path}.pdf"
+      rand_path = "/#{Common::FileHelpers.random_file_path}.pdf"
       Prawn::Document.generate(rand_path) do |pdf|
         pdf_options[:additional_pages].each_with_index do |txt, index|
           pdf.start_new_page unless index.zero?
@@ -82,8 +82,6 @@ module AppealsApi
       end
       pdf = CombinePDF.load(temp_path) << CombinePDF.load(rand_path)
       pdf.save output_path
-      File.delete temp_path if File.exist? temp_path
-      File.delete rand_path if File.exist? rand_path
       output_path
     end
 


### PR DESCRIPTION
This PR address [API-3827](https://vajira.max.gov/browse/API-3827)

## Description of change
Instead of saving temp pdf files (that are created in the process of building up to the final pdfs) in `Rails.root/tmp` we are saving temp files in `/tmp` to allow for easier cleanup.

## To test
- Remove any pre-existing tmp files in `Rails.root/tmp`
- Run all the spec in the appeals_api module `rspec modules/appeals_api/spec`
- Verify that there are no pdfs files at `Rails.root/tmp`

