### PR TITLE
update claim_guid column on form1010cg_submissions as uuid type

### DIFF
--- a/db/migrate/20201208215916_set_guid_as_uuid_on_form1010cg_submissions.rb
+++ b/db/migrate/20201208215916_set_guid_as_uuid_on_form1010cg_submissions.rb
@@ -1,0 +1,18 @@
+class SetGuidAsUuidOnForm1010cgSubmissions < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    # Column and table are not yet in use. The model is not connected to ActiveRecord.
+    safety_assured do
+      remove_column :form1010cg_submissions, :claim_guid
+      add_column :form1010cg_submissions, :claim_guid, :uuid, null: false
+      add_index :form1010cg_submissions, :claim_guid, unique: true, algorithm: :concurrently
+    end
+  end
+
+  def down
+    remove_column :form1010cg_submissions, :claim_guid
+    add_column :form1010cg_submissions, :claim_guid, :string, null: false
+    add_index :form1010cg_submissions, :claim_guid, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_07_173935) do
+ActiveRecord::Schema.define(version: 2020_12_08_215916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -292,11 +292,11 @@ ActiveRecord::Schema.define(version: 2020_12_07_173935) do
   create_table "form1010cg_submissions", force: :cascade do |t|
     t.string "carma_case_id", limit: 18, null: false
     t.datetime "accepted_at", null: false
-    t.string "claim_guid", null: false
     t.json "metadata"
     t.json "attachments"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "claim_guid", null: false
     t.index ["carma_case_id"], name: "index_form1010cg_submissions_on_carma_case_id", unique: true
     t.index ["claim_guid"], name: "index_form1010cg_submissions_on_claim_guid", unique: true
   end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

**Description**
Made a migration yesterday https://github.com/department-of-veterans-affairs/vets-api/pull/5444 to create the `form1010cg_submissions` table but mistyped the data type for `claim_guid`. This removes the column, creates it again (as uuid), and adds the index.

**Original issue(s)**
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10280
