### PR TITLE
[API-3631] Fail gracefully on ITF submit calls for invalid VSRs

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -88,8 +88,6 @@ module ClaimsApi
     end
 
     def intent_to_file_options
-      participant_claimant_id = form_type == 'burial' ? @current_user.participant_id : target_veteran.participant_id
-
       {
         intent_to_file_type_code: ClaimsApi::IntentToFile::ITF_TYPES[form_type],
         participant_claimant_id: form_attributes['participant_claimant_id'] || participant_claimant_id,
@@ -98,6 +96,18 @@ module ClaimsApi
         submitter_application_icn_type_code: ClaimsApi::IntentToFile::SUBMITTER_CODE,
         ssn: target_veteran.ssn
       }
+    end
+
+    def participant_claimant_id
+      if form_type == 'burial'
+        begin
+          @current_user.participant_id
+        rescue ArgumentError
+          raise Common::Exceptions::Forbidden, detail: "Representative cannot file for type 'burial'"
+        end
+      else
+        target_veteran.participant_id
+      end
     end
 
     def received_date

--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -103,7 +103,7 @@ module ClaimsApi
         begin
           @current_user.participant_id
         rescue ArgumentError
-          raise Common::Exceptions::Forbidden, detail: "Representative cannot file for type 'burial'"
+          raise ::Common::Exceptions::Forbidden, detail: "Representative cannot file for type 'burial'"
         end
       else
         target_veteran.participant_id

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
@@ -20,6 +20,9 @@ module ClaimsApi
           bgs_response = bgs_service.intent_to_file.insert_intent_to_file(intent_to_file_options)
           render json: bgs_response,
                  serializer: ClaimsApi::IntentToFileSerializer
+        rescue Common::Exceptions::Forbidden => e
+          render json: { errors: [{ status: 403, detail: e.errors[0]&.detail }] },
+                 status: :forbidden
         rescue Savon::SOAPFault => e
           error = {
             errors: [

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
@@ -20,9 +20,6 @@ module ClaimsApi
           bgs_response = bgs_service.intent_to_file.insert_intent_to_file(intent_to_file_options)
           render json: bgs_response,
                  serializer: ClaimsApi::IntentToFileSerializer
-        rescue Common::Exceptions::Forbidden => e
-          render json: { errors: [{ status: 403, detail: e.errors[0]&.detail }] },
-                 status: :forbidden
         rescue Savon::SOAPFault => e
           error = {
             errors: [

--- a/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
@@ -312,7 +312,9 @@ module ClaimsApi
                     property :type do
                       key :type, :string
                       key :example, 'compensation'
-                      key :description, 'Required by JSON API standard'
+                      key :description, 'For type "burial", the request must be made by a valid Veteran Representative.
+                      If the Representative is not a Veteran or a VA employee, this method is currently not available to them,
+                      and they should use the Benefits Intake API as an alternative.'
                       key :enum, %w[
                         compensation
                         burial

--- a/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
@@ -61,9 +61,20 @@ RSpec.describe 'Intent to file', type: :request do
     it 'posts a 422 error with detail when BGS returns a 500 response' do
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file_500') do
-          data['attributes'] = { type: 'pension' }
+          data[:data][:attributes] = { type: 'pension' }
           post path, params: data.to_json, headers: headers.merge(auth_header)
           expect(response.status).to eq(422)
+        end
+      end
+    end
+
+    it 'posts a 403 when a representative who doesn\'t have an MPI account tries to post type "burial"' do
+      with_okta_user(scopes) do |auth_header|
+        VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file') do
+          expect_any_instance_of(OpenidUser).to receive(:participant_id).and_raise(ArgumentError.new('whatever'))
+          data[:data][:attributes] = { type: 'burial' }
+          post path, params: data.to_json, headers: headers.merge(auth_header)
+          expect(response.status).to eq(403)
         end
       end
     end

--- a/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Intent to file', type: :request do
     end
 
     it 'posts a 403 when a representative who doesn\'t have an MPI account tries to post type "burial"' do
-      expect_any_instance_of(OpenidUser).to receive(:participant_id).and_raise(ArgumentError.new('whatever'))
+      allow_any_instance_of(OpenidUser).to receive(:participant_id).and_raise(ArgumentError.new('whatever'))
 
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file') do

--- a/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
@@ -69,9 +69,10 @@ RSpec.describe 'Intent to file', type: :request do
     end
 
     it 'posts a 403 when a representative who doesn\'t have an MPI account tries to post type "burial"' do
+      expect_any_instance_of(OpenidUser).to receive(:participant_id).and_raise(ArgumentError.new('whatever'))
+
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file') do
-          expect_any_instance_of(OpenidUser).to receive(:participant_id).and_raise(ArgumentError.new('whatever'))
           data[:data][:attributes] = { type: 'burial' }
           post path, params: data.to_json, headers: headers.merge(auth_header)
           p '!!!!!!!!!!!!!!!!!!!'

--- a/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
@@ -74,10 +74,6 @@ RSpec.describe 'Intent to file', type: :request do
           expect_any_instance_of(OpenidUser).to receive(:participant_id).and_raise(ArgumentError.new('whatever'))
           data[:data][:attributes] = { type: 'burial' }
           post path, params: data.to_json, headers: headers.merge(auth_header)
-          p '!!!!!!!!!!!!!!!!!!!'
-          p response.status
-          p JSON.parse(response.body)
-          p '!!!!!!!!!!!!!!!!!!!'
           expect(response.status).to eq(403)
         end
       end

--- a/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
@@ -69,10 +69,9 @@ RSpec.describe 'Intent to file', type: :request do
     end
 
     it 'posts a 403 when a representative who doesn\'t have an MPI account tries to post type "burial"' do
-      allow_any_instance_of(OpenidUser).to receive(:participant_id).and_raise(ArgumentError.new('whatever'))
-
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file') do
+          expect_any_instance_of(OpenidUser).to receive(:participant_id).and_raise(ArgumentError.new('whatever'))
           data[:data][:attributes] = { type: 'burial' }
           post path, params: data.to_json, headers: headers.merge(auth_header)
           p '!!!!!!!!!!!!!!!!!!!'

--- a/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
@@ -74,6 +74,10 @@ RSpec.describe 'Intent to file', type: :request do
           expect_any_instance_of(OpenidUser).to receive(:participant_id).and_raise(ArgumentError.new('whatever'))
           data[:data][:attributes] = { type: 'burial' }
           post path, params: data.to_json, headers: headers.merge(auth_header)
+          p '!!!!!!!!!!!!!!!!!!!'
+          p response.status
+          p JSON.parse(response.body)
+          p '!!!!!!!!!!!!!!!!!!!'
           expect(response.status).to eq(403)
         end
       end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
VSRs that are absent in MPI cannot submit ITFs for type `burial`. This rescues that error and provides a more accurate description of that error in the response.

## Original issue(s)
https://vajira.max.gov/browse/API-3631

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
