### PR TITLE
16989 create pact tests covid vaccine

### DIFF
--- a/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
+++ b/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
@@ -14,14 +14,4 @@ Pact.provider_states_for 'Coronavirus Vaccination' do
   provider_state 'unauthenticated user application data' do
     no_op
   end
-
-  # provider_state 'template' do
-  #   set_up do
-  #   end
-
-  #   tear_down do
-  #   end
-
-	# # no_op - define no_op if a provider state is not necessary
-  # end
 end

--- a/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
+++ b/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
@@ -2,22 +2,23 @@
 
 Pact.provider_states_for 'CoronavirusVaccination' do
 
-  provider_state 'authenticated user application data' do
-    set_up do
-    end
+  # provider_state 'authenticated user application data' do
+  #   set_up do
+  #   end
 
-    tear_down do
-    end
+  #   tear_down do
+  #   end
 
-	# no_op - define no_op if a provider state is not necessary
-  end
+	# # no_op - define no_op if a provider state is not necessary
+  # end
 
   provider_state 'unauthenticated user application data' do
-    set_up do
-    end
+    no_op
+    # set_up do
+    # end
 
-    tear_down do
-    end
+    # tear_down do
+    # end
 
 	# no_op - define no_op if a provider state is not necessary
   end

--- a/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
+++ b/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Pact.provider_states_for 'Coronavirus Vaccination' do
-
   provider_state 'authenticated user application data' do
     set_up do
       build_user_and_stub_session

--- a/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
+++ b/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Pact.provider_states_for 'CoronavirusVaccination' do
+
+  # define multiple provider states as needed for each interaction in the pact 	
+  provider_state 'interaction string' do
+    set_up do
+    end
+
+    tear_down do
+    end
+
+	# no_op - define no_op if a provider state is not necessary
+  end
+end

--- a/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
+++ b/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
@@ -1,8 +1,21 @@
 # frozen_string_literal: true
 
-Pact.provider_states_for 'CoronavirusVaccination' do
+Pact.provider_states_for 'Coronavirus Vaccination' do
 
-  # provider_state 'authenticated user application data' do
+  provider_state 'authenticated user application data' do
+    set_up do
+      build_user_and_stub_session
+    end
+
+    tear_down do
+    end
+  end
+
+  provider_state 'unauthenticated user application data' do
+    no_op
+  end
+
+  # provider_state 'template' do
   #   set_up do
   #   end
 
@@ -11,15 +24,4 @@ Pact.provider_states_for 'CoronavirusVaccination' do
 
 	# # no_op - define no_op if a provider state is not necessary
   # end
-
-  provider_state 'unauthenticated user application data' do
-    no_op
-    # set_up do
-    # end
-
-    # tear_down do
-    # end
-
-	# no_op - define no_op if a provider state is not necessary
-  end
 end

--- a/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
+++ b/spec/service_consumers/provider_states_for/coronavirus_vaccination.rb
@@ -2,8 +2,17 @@
 
 Pact.provider_states_for 'CoronavirusVaccination' do
 
-  # define multiple provider states as needed for each interaction in the pact 	
-  provider_state 'interaction string' do
+  provider_state 'authenticated user application data' do
+    set_up do
+    end
+
+    tear_down do
+    end
+
+	# no_op - define no_op if a provider state is not necessary
+  end
+
+  provider_state 'unauthenticated user application data' do
     set_up do
     end
 


### PR DESCRIPTION
## Description of change
Regarding ticket - https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/16989

Create Pact provider state file for the following states for the Coronavirus Vaccination app:
- authenticated user application data
- unauthenticated user application data

The consumer (FE) tests which create the Pact contracts are currently in this branch - https://github.com/department-of-veterans-affairs/vets-website/tree/16989_create_pact_tests