### PR TITLE
Turning off GDIT submissions for GCIO transition for va.gov code

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -161,7 +161,7 @@ class Form526Submission < ApplicationRecord
   end
 
   def submit_form_4142
-    CentralMail::SubmitForm4142Job.perform_async(id)
+    # CentralMail::SubmitForm4142Job.perform_async(id)
   end
 
   def submit_form_0781

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Form526Submission do
         File.read('spec/support/disability_compensation_form/submissions/with_4142.json')
       end
 
-      it 'queues a 4142 job' do
+      xit 'queues a 4142 job' do
         expect do
           subject.perform_ancillary_jobs('some name')
         end.to change(CentralMail::SubmitForm4142Job.jobs, :size).by(1)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
We turned off all of the jobs sending data to GDIT on the Lighthouse side of the isle and realized there were a few that still needed to be turned off on the va.gov side as well.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
