### PR TITLE
Clean up appeals_api base pdf constructor

### DIFF
--- a/modules/appeals_api/lib/appeals_api/base_pdf_constructor.rb
+++ b/modules/appeals_api/lib/appeals_api/base_pdf_constructor.rb
@@ -35,22 +35,22 @@ module AppealsApi
     end
 
     def merge_page(temp_path, output_path)
-      new_path = if pdf_options[:additional_page]
-                   pdf = CombinePDF.new
-                   pdf << CombinePDF.load(temp_path)
-                   pdf << CombinePDF.load(add_page(pdf_options[:additional_page], temp_path))
-                   pdf.save(output_path)
-                   output_path
-                 else
-                   temp_path
-                 end
-      new_path
+      return temp_path if pdf_options[:additional_pages].blank?
+
+      additional_pages_path = add_pages(pdf_options[:additional_pages])
+
+      pdf = CombinePDF.load(temp_path) << CombinePDF.load(additional_pages_path)
+      pdf.save(output_path)
+      output_path
     end
 
-    def add_page(text, temp_path)
-      output_path = temp_path + '-additional_page.pdf'
-      Prawn::Document.generate output_path do
-        text text
+    def add_pages(additional_text_pages)
+      output_path = "/#{Common::FileHelpers.random_file_path}.pdf"
+      Prawn::Document.generate(output_path) do |pdf|
+        Array(additional_text_pages).each_with_index do |txt, index|
+          pdf.start_new_page unless index.zero?
+          pdf.text txt, inline_format: true
+        end
       end
       output_path
     end

--- a/modules/appeals_api/lib/appeals_api/higher_level_review_pdf_constructor.rb
+++ b/modules/appeals_api/lib/appeals_api/higher_level_review_pdf_constructor.rb
@@ -87,7 +87,7 @@ module AppealsApi
           end
         else
           text = "Issue: #{issue['attributes']['issue']} - Decision Date: #{issue['attributes']['decisionDate']}"
-          options[:additional_page] = "#{text}\n#{options[:additional_page]}"
+          options[:additional_pages] = "#{text}\n#{options[:additional_page]}"
         end
       end
       @pdf_options = options

--- a/modules/appeals_api/lib/appeals_api/higher_level_review_pdf_constructor.rb
+++ b/modules/appeals_api/lib/appeals_api/higher_level_review_pdf_constructor.rb
@@ -5,6 +5,8 @@ require_relative './base_pdf_constructor'
 
 module AppealsApi
   class HigherLevelReviewPdfConstructor < BasePdfConstructor
+    MAX_NUMBER_OF_ISSUES_ON_MAIN_FORM = 6
+
     def initialize(higher_level_review_id)
       @higher_level_review_id = higher_level_review_id
     end
@@ -74,7 +76,7 @@ module AppealsApi
       }
 
       appeal.contestable_issues.each_with_index do |issue, index|
-        if index < 6
+        if index < MAX_NUMBER_OF_ISSUES_ON_MAIN_FORM
           if index.zero?
             options[:"F[0].#subform[3].SPECIFICISSUE#{index + 1}[1]"] = issue['attributes']['issue']
             options[:'F[0].#subform[3].DateofDecision[5]'] = issue['attributes']['decisionDate']
@@ -87,7 +89,7 @@ module AppealsApi
           end
         else
           text = "Issue: #{issue['attributes']['issue']} - Decision Date: #{issue['attributes']['decisionDate']}"
-          options[:additional_pages] = "#{text}\n#{options[:additional_page]}"
+          options[:additional_pages] = "#{text}\n#{options[:additional_pages]}"
         end
       end
       @pdf_options = options

--- a/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_constructor.rb
+++ b/modules/appeals_api/lib/appeals_api/notice_of_disagreement_pdf_constructor.rb
@@ -68,23 +68,6 @@ module AppealsApi
     # rubocop:enable Metrics/PerceivedComplexity
     # rubocop:enable Metrics/AbcSize
 
-    # TODO: Remove this override by refactoring BasePdfConstructor & HigherLevelReviewPdfConstructor to use
-    #       `additional_pages` key in this manner instead of `additional_page` key
-    def merge_page(temp_path, output_path)
-      return temp_path if pdf_options[:additional_pages].blank?
-
-      rand_path = "/#{Common::FileHelpers.random_file_path}.pdf"
-      Prawn::Document.generate(rand_path) do |pdf|
-        pdf_options[:additional_pages].each_with_index do |txt, index|
-          pdf.start_new_page unless index.zero?
-          pdf.text txt, inline_format: true
-        end
-      end
-      pdf = CombinePDF.load(temp_path) << CombinePDF.load(rand_path)
-      pdf.save output_path
-      output_path
-    end
-
     def stamp_pdf(pdf_path, consumer_name)
       stamped_path = super
       CentralMail::DatestampPdf.new(stamped_path).run(

--- a/modules/appeals_api/spec/fixtures/valid_200996_extra.json
+++ b/modules/appeals_api/spec/fixtures/valid_200996_extra.json
@@ -87,8 +87,15 @@
       {
         "type": "contestableIssue",
         "attributes": {
-          "issue": "sleep apnea",
+          "issue": "left shoulder",
           "decisionDate": "1900-01-07"
+        }
+      },
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "issue": "sleep apnea",
+          "decisionDate": "1900-01-08"
         }
       }
     ]

--- a/modules/appeals_api/spec/lib/higher_level_review_pdf_constructor_spec.rb
+++ b/modules/appeals_api/spec/lib/higher_level_review_pdf_constructor_spec.rb
@@ -13,7 +13,8 @@ describe AppealsApi::HigherLevelReviewPdfConstructor do
   it 'builds the extra pdf options' do
     higher_level_review = create(:extra_higher_level_review)
     constructor = AppealsApi::HigherLevelReviewPdfConstructor.new(higher_level_review.id)
-    options = valid_pdf_options.merge(additional_pages: "Issue: sleep apnea - Decision Date: 1900-01-07\n")
+    extra_page = "Issue: sleep apnea - Decision Date: 1900-01-08\nIssue: left shoulder - Decision Date: 1900-01-07\n"
+    options = valid_pdf_options.merge(additional_pages: extra_page)
     expect(constructor.pdf_options).to eq(options)
   end
 

--- a/modules/appeals_api/spec/lib/higher_level_review_pdf_constructor_spec.rb
+++ b/modules/appeals_api/spec/lib/higher_level_review_pdf_constructor_spec.rb
@@ -13,7 +13,7 @@ describe AppealsApi::HigherLevelReviewPdfConstructor do
   it 'builds the extra pdf options' do
     higher_level_review = create(:extra_higher_level_review)
     constructor = AppealsApi::HigherLevelReviewPdfConstructor.new(higher_level_review.id)
-    options = valid_pdf_options.merge(additional_page: "Issue: sleep apnea - Decision Date: 1900-01-07\n")
+    options = valid_pdf_options.merge(additional_pages: "Issue: sleep apnea - Decision Date: 1900-01-07\n")
     expect(constructor.pdf_options).to eq(options)
   end
 

--- a/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
@@ -106,10 +106,14 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
     #   expect(generated_pdf_md5).to eq(expected_pdf_md5)
     #   Timecop.return
     # end
-    it 'generates the correct number of pages' do
+    it 'generates the correct number of pages and extra content on additional page' do
       Timecop.freeze(Time.zone.parse('2020-01-01T08:00:00Z'))
       path = described_class.new.generate_pdf(extra_higher_level_review.id)
       expect(PdfInfo::Metadata.read(path).pages).to eq(3)
+
+      reader = PDF::Reader.new(path)
+      expect(reader.page(3).text).to include('left shoulder', 'sleep apnea')
+
       File.delete(path) if File.exist?(path)
       Timecop.return
     end


### PR DESCRIPTION
This PR addresses [API-3830](https://vajira.max.gov/browse/API-3830)

## Description of change
This updates the `BasePdfConstructor#merge_page` method so both the HLR and NOD subclasses can use it without having to override it.