### PR TITLE
Fixing whitespace code for Dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -12,7 +12,7 @@ excluded_changed_files = changed_files.select { |key| EXCLUSIONS.any? { |exclusi
 filtered_changed_files = changed_files.reject { |key| EXCLUSIONS.any? { |exclusion| key.include?(exclusion) } }
 
 # ignores whitespace for the purpose of determining lines of code changed
-changes = `git diff -w --stat`.split("\n")
+changes = `git diff master... -w --stat`.split("\n")
 lines_of_code = changes.sum(0) do |change|
   if change == changes.last || EXCLUSIONS.any? { |exclusion| change.match(exclusion) }
     0


### PR DESCRIPTION
## Description of change
The code that was added to not count whitespace when determining lines of code changed was not working properly and thus dangerbot was not alerting when PRs exceeded the LOC limit. This change should fix that issue.
