### PR TITLE
Fix vetext params and request method

### DIFF
--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/registration_service.rb
@@ -27,6 +27,7 @@ module CovidVaccine
         # TODO: error handling
         response = CovidVaccine::V0::VetextService.new.put_vaccine_registry(attributes)
         Rails.logger.info("Vetext Response: #{response}")
+
         CovidVaccine::V0::RegistrationSubmission.create({ sid: response[:sid],
                                                           account_id: account_id,
                                                           form_data: attributes })
@@ -35,10 +36,8 @@ module CovidVaccine
       def form_attributes(form_data)
         {
           vaccine_interest: form_data['vaccine_interest'],
-          date_vaccine_received: form_data['date_vaccine_received'],
-          reason_undecided: form_data['reason_undecided'],
-          contact: form_data['contact_preference'],
-          contact_method: form_data['contact_method'],
+          zip_code: form_data['zip_code'],
+          time_at_zip: form_data['zip_code_details'],
           phone: form_data['phone'],
           email: form_data['email'],
           # Values below this point will get merged over by values
@@ -47,14 +46,6 @@ module CovidVaccine
           last_name: form_data['last_name'],
           date_of_birth: form_data['birth_date'],
           patient_ssn: form_data['ssn']
-        }.merge(facility_attrs(form_data))
-      end
-
-      def facility_attrs(form_data)
-        {
-          # TODO: verify this v questionable logic
-          sta6a: form_data['preferred_facility']&.delete_prefix('vha_'),
-          sta3n: form_data['preferred_facility']&.delete_prefix('vha_')&.slice(0, 3)
         }
       end
 

--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/registration_service.rb
@@ -9,7 +9,6 @@ module CovidVaccine
         attributes = form_attributes(form_data)
         attributes.merge!(attributes_from_mpi(form_data))
         attributes.merge!({ authenticated: false }).compact!
-        Rails.logger.info("Vetext Payload: #{attributes.to_json}")
         submit(attributes, account_id)
       end
 
@@ -17,7 +16,6 @@ module CovidVaccine
         attributes = form_attributes(form_data)
         attributes.merge!(attributes_from_user(user))
         attributes.merge!({ authenticated: true }).compact!
-        Rails.logger.info("Vetext Payload: #{attributes.to_json}")
         submit(attributes, user.account_uuid)
       end
 

--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/vetext_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/vetext_service.rb
@@ -14,7 +14,7 @@ module CovidVaccine
 
       def put_vaccine_registry(vaccine_registry_attributes)
         with_monitoring do
-          response = perform(:put, url, vaccine_registry_attributes, headers)
+          response = perform(:post, url, vaccine_registry_attributes, headers)
           # test success
           # test failures
           response.body

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/registration_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/registration_service_spec.rb
@@ -6,17 +6,15 @@ describe CovidVaccine::V0::RegistrationService do
   subject { described_class.new }
 
   let(:form_data) do
-    { 'vaccine_interest' => 'YES', 'contact_preference' => 'true',
-      'contact_method' => 'email', 'phone' => '650-555-1212',
+    { 'vaccine_interest' => 'INTERESTED', 'phone' => '650-555-1212',
       'email' => 'foo@bar.com', 'first_name' => 'Sean',
       'last_name' => 'Gptestkfive', 'birth_date' => '1972-03-21',
-      'ssn' => '666512797', 'preferred_facility' => 'vha_648' }
+      'ssn' => '666512797', 'zip_code' => '97412', 'zip_code_details' => 'Yes' }
   end
   let(:sparse_form_data) do
-    { 'vaccine_interest' => 'YES', 'contact_preference' => 'true',
-      'contact_method' => 'email', 'phone' => '650-555-1212',
+    { 'vaccine_interest' => 'NOT INTERESTED', 'phone' => '650-555-1212',
       'email' => 'foo@bar.com', 'first_name' => 'Sean',
-      'last_name' => 'Gptestkfive', 'preferred_facility' => 'vha_648' }
+      'last_name' => 'Gptestkfive', 'zip_code' => '97412', 'zip_code_details' => 'Yes' }
   end
   let(:mvi_profile) { build(:mvi_profile) }
   let(:mvi_profile_response) do
@@ -36,7 +34,16 @@ describe CovidVaccine::V0::RegistrationService do
     context 'unauthenticated' do
       it 'coerces input to vetext format' do
         expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
-          .with(hash_including(contact: 'true'))
+          .with(hash_including(:first_name,
+                               :last_name,
+                               :patient_ssn,
+                               :date_of_birth,
+                               :patient_icn,
+                               :phone,
+                               :email,
+                               :zip_code,
+                               :time_at_zip,
+                               :authenticated))
           .and_return({ sid: SecureRandom.uuid })
         expect_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_profile_response)

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/vetext_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/vetext_service_spec.rb
@@ -25,7 +25,7 @@ describe CovidVaccine::V0::VetextService do
 
   describe '#put_vaccine_registry' do
     it 'creates a new vaccine registry with valid attributes' do
-      VCR.use_cassette('covid_vaccine/vetext/put_vaccine_registry_200', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('covid_vaccine/vetext/put_vaccine_registry_200', match_requests_on: %i[method path]) do
         response = subject.put_vaccine_registry(registry_attributes)
         expect(response[:sid]).to eq('C4471842B588278B6D160738877782115')
       end
@@ -33,7 +33,7 @@ describe CovidVaccine::V0::VetextService do
 
     # Need to discuss error handling with VEText developers. This isn't even JSON.
     xit 'raises a BackendServiceException with invalid attribute' do
-      VCR.use_cassette('covid_vaccine/vetext/put_vaccine_registry_error', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('covid_vaccine/vetext/put_vaccine_registry_error', match_requests_on: %i[method path]) do
         expect { subject.put_vaccine_registry(date_vaccine_reeceived: '') }
           .to raise_error(Common::Exceptions::BackendServiceException)
       end

--- a/spec/support/vcr_cassettes/covid_vaccine/vetext/put_vaccine_registry_200.yml
+++ b/spec/support/vcr_cassettes/covid_vaccine/vetext/put_vaccine_registry_200.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: put
+    method: post
     uri: https://something.fake.va.gov/api/vetext/pub/covid/vaccine/registry
     body:
       encoding: UTF-8


### PR DESCRIPTION
## Description of change
Fixes the method used for submissions to VEText, and reconciles the expected form data
parameters with what the frontend is sending.

This is a subset of https://github.com/department-of-veterans-affairs/vets-api/pull/5476/files
without the facility API changes to facilitate a quicker fix for current staging env. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR


<!-- Please describe testing done to verify the changes or any testing planned. -->
