### PR TITLE
Exclude .tsv (tab-separated-value) from Dangerbot

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -3,7 +3,7 @@ PR_SIZE = {
   RECOMMENDED_MAXIMUM: 200,
   ABSOLUTE_MAXIMUM:    500,
 }
-EXCLUSIONS = ['Gemfile.lock', '.json', 'spec/fixtures/', '.txt', 'spec/support/vcr_cassettes/', 'app/swagger', 'modules/mobile/docs/']
+EXCLUSIONS = ['Gemfile.lock', '.json', 'spec/fixtures/', '.txt', '.tsv', 'spec/support/vcr_cassettes/', 'app/swagger', 'modules/mobile/docs/']
 
 # takes form {"some/file.rb"=>{:insertions=>4, :deletions=>1}}
 changed_files = git.diff.stats[:files]


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Added a .tsv in place of a .txt file in https://github.com/department-of-veterans-affairs/vets-api/pull/5476/files
to better represent the format. This excludes that datafile from Dangerbot checks.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
