### PR TITLE
Adds serialized submission attributes to post/get

### DIFF
--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../../serializers/covid_vaccine/v0/registration_submission_serializer'
+require_relative '../../../serializers/covid_vaccine/v0/registration_summary_serializer'
 
 module CovidVaccine
   module V0
@@ -18,7 +19,7 @@ module CovidVaccine
                  else
                    svc.register(params[:registration])
                  end
-        render json: result, serializer: CovidVaccine::V0::RegistrationSubmissionSerializer
+        render json: result, serializer: CovidVaccine::V0::RegistrationSummarySerializer
       end
 
       def show

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/registration_submission.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/registration_submission.rb
@@ -5,6 +5,10 @@ module CovidVaccine
     class RegistrationSubmission < ApplicationRecord
       scope :for_user, ->(user) { where(account_id: user.account_uuid).order(created_at: :asc) }
 
+      after_initialize do |reg|
+        reg.form_data&.symbolize_keys!
+      end
+
       attr_encrypted :form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller
     end
   end

--- a/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
+++ b/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
@@ -4,9 +4,31 @@ module CovidVaccine
   module V0
     class RegistrationSubmissionSerializer < ActiveModel::Serializer
       attribute :created_at
+      attribute :vaccine_interest
+      attribute :zip_code
+      attribute :zip_code_details
+      attribute :phone
+      attribute :email
+      attribute :first_name
+      attribute :last_name
+      attribute :birth_date
 
       def id
         object.sid
+      end
+
+      %i[vaccine_interest zip_code phone email first_name last_name].each do |attr|
+        define_method attr do
+          object.form_data[attr]
+        end
+      end
+
+      def zip_code_details
+        object.form_data[:time_at_zip]
+      end
+
+      def birth_date
+        object.form_data[:date_of_birth]
       end
     end
   end

--- a/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_summary_serializer.rb
+++ b/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_summary_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module CovidVaccine
+  module V0
+    class RegistrationSummarySerializer < ActiveModel::Serializer
+      attribute :created_at
+      attribute :vaccine_interest
+      attribute :zip_code
+
+      def id
+        object.sid
+      end
+
+      %i[vaccine_interest zip_code].each do |attr|
+        define_method attr do
+          object.form_data[attr]
+        end
+      end
+    end
+  end
+end

--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/vetext_configuration.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/vetext_configuration.rb
@@ -16,7 +16,7 @@ module CovidVaccine
       end
 
       def connection
-        Faraday.new(base_path, headers: base_request_headers, request: request_options) do |c|
+        Faraday.new(base_path, headers: base_request_headers, request: request_options, ssl: { verify: false }) do |c|
           c.use :breakers
           c.request :camelcase
           c.request :json

--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/vetext_configuration.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/vetext_configuration.rb
@@ -16,7 +16,7 @@ module CovidVaccine
       end
 
       def connection
-        Faraday.new(base_path, headers: base_request_headers, request: request_options, ssl: { verify: false }) do |c|
+        Faraday.new(base_path, headers: base_request_headers, request: request_options) do |c|
           c.use :breakers
           c.request :camelcase
           c.request :json

--- a/modules/covid_vaccine/spec/factories/registration_submissions.rb
+++ b/modules/covid_vaccine/spec/factories/registration_submissions.rb
@@ -4,5 +4,18 @@ FactoryBot.define do
   factory :covid_vaccine_registration_submission, class: 'CovidVaccine::V0::RegistrationSubmission' do
     sid { SecureRandom.uuid }
     account_id { SecureRandom.uuid }
+
+    form_data {
+      {
+        vaccine_interest: 'INTERESTED',
+        zip_code: '97212',
+        time_at_zip: 'YES',
+        phone: '808-555-1212',
+        email: 'foo@example.com',
+        first_name: 'Jon',
+        last_name: 'Doe',
+        date_of_birth: '1900-01-01'
+      }
+    }
   end
 end

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/registration_request_spec.rb
@@ -21,12 +21,16 @@ RSpec.describe 'Covid Vaccine Registration', type: :request do
       date_of_birth: '2/2/1952',
       phone: '555-555-1234',
       email: 'jane.doe@email.com',
-      patient_ssn: '000-00-0022'
+      ssn: '000-00-0022',
+      zip_code: '94402'
     }
   end
 
   let(:expected_response_attributes) do
     %w[first_name last_name birth_date zip_code zip_code_details phone email vaccine_interest created_at]
+  end
+  let(:summary_response_attributes) do
+    %w[zip_code vaccine_interest created_at]
   end
 
   describe 'registration#create' do
@@ -74,11 +78,10 @@ RSpec.describe 'Covid Vaccine Registration', type: :request do
           post '/covid_vaccine/v0/registration', params: { registration: registration_attributes }
           expect(response).to have_http_status(:ok)
           body = JSON.parse(response.body)
-          expect(body['data']['attributes']).to include(*expected_response_attributes)
-          expect(body['data']['attributes']).not_to include('ssn', 'patient_ssn')
-          expect(body['data']['attributes']).to include('first_name' => 'Judy',
-                                                        'last_name' => 'Morrison',
-                                                        'email' => 'jane.doe@email.com')
+          expect(body['data']['attributes']).to include(*summary_response_attributes)
+          expect(body['data']['attributes']).not_to include(*(expected_response_attributes
+                                                              - summary_response_attributes))
+          expect(body['data']['attributes']).to include('zip_code' => '94402')
         end
       end
     end

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/vetext_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/vetext_service_spec.rb
@@ -25,15 +25,15 @@ describe CovidVaccine::V0::VetextService do
 
   describe '#put_vaccine_registry' do
     it 'creates a new vaccine registry with valid attributes' do
-      VCR.use_cassette('covid_vaccine/vetext/put_vaccine_registry_200', match_requests_on: %i[method path]) do
+      VCR.use_cassette('covid_vaccine/vetext/post_vaccine_registry_200', match_requests_on: %i[method path]) do
         response = subject.put_vaccine_registry(registry_attributes)
-        expect(response[:sid]).to eq('C4471842B588278B6D160738877782115')
+        expect(response[:sid]).to eq('FA82BF279B8673EDF2160766351113753298')
       end
     end
 
     # Need to discuss error handling with VEText developers. This isn't even JSON.
     xit 'raises a BackendServiceException with invalid attribute' do
-      VCR.use_cassette('covid_vaccine/vetext/put_vaccine_registry_error', match_requests_on: %i[method path]) do
+      VCR.use_cassette('covid_vaccine/vetext/post_vaccine_registry_error', match_requests_on: %i[method path]) do
         expect { subject.put_vaccine_registry(date_vaccine_reeceived: '') }
           .to raise_error(Common::Exceptions::BackendServiceException)
       end

--- a/spec/support/vcr_cassettes/covid_vaccine/vetext/post_vaccine_registry_200.yml
+++ b/spec/support/vcr_cassettes/covid_vaccine/vetext/post_vaccine_registry_200.yml
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 11 Dec 2020 04:53:02 GMT
+      - Fri, 11 Dec 2020 05:11:51 GMT
       Server:
       - Apache/2.4.46 (Unix) OpenSSL/1.1.1d
       Content-Type:
@@ -34,6 +34,6 @@ http_interactions:
       - '46'
     body:
       encoding: UTF-8
-      string: '{"sid":"FA82BF279B8673EDF2160766238295153294"}'
-  recorded_at: Fri, 11 Dec 2020 04:53:03 GMT
+      string: '{"sid":"FA82BF279B8673EDF2160766351113753298"}'
+  recorded_at: Fri, 11 Dec 2020 05:11:51 GMT
 recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/covid_vaccine/vetext/post_vaccine_registry_loa1.yml
+++ b/spec/support/vcr_cassettes/covid_vaccine/vetext/post_vaccine_registry_loa1.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://localhost:2002/api/vetext/pub/covid/vaccine/registry
     body:
       encoding: UTF-8
-      string: '{"vaccineInterest":"yes","authenticated":true,"dateVaccineReceived":"","contact":true,"contactMethod":"phone","reasonUndecided":"","firstName":"Jane","lastName":"Doe","dateOfBirth":"2/2/1952","phone":"555-555-1234","email":"jane.doe@email.com","patientSsn":"000-00-0022"}'
+      string: '{"vaccineInterest":"yes","zipCode":"94402","timeAtZip":"yes","phone":"555-555-1234","email":"jane.doe@email.com","firstName":"Lean","lastName":"Bartell","dateOfBirth":"1981-10-26","patientSsn":"715130642","patientIcn":"75233388971184289","authenticated":false}'
     headers:
       Accept:
       - application/json
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 11 Dec 2020 04:53:02 GMT
+      - Fri, 11 Dec 2020 05:09:16 GMT
       Server:
       - Apache/2.4.46 (Unix) OpenSSL/1.1.1d
       Content-Type:
@@ -34,6 +34,6 @@ http_interactions:
       - '46'
     body:
       encoding: UTF-8
-      string: '{"sid":"FA82BF279B8673EDF2160766238295153294"}'
-  recorded_at: Fri, 11 Dec 2020 04:53:03 GMT
+      string: '{"sid":"FA82BF279B8673EDF2160766335651453297"}'
+  recorded_at: Fri, 11 Dec 2020 05:09:16 GMT
 recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/covid_vaccine/vetext/post_vaccine_registry_loa3.yml
+++ b/spec/support/vcr_cassettes/covid_vaccine/vetext/post_vaccine_registry_loa3.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://localhost:2002/api/vetext/pub/covid/vaccine/registry
     body:
       encoding: UTF-8
-      string: '{"vaccineInterest":"yes","authenticated":true,"dateVaccineReceived":"","contact":true,"contactMethod":"phone","reasonUndecided":"","firstName":"Jane","lastName":"Doe","dateOfBirth":"2/2/1952","phone":"555-555-1234","email":"jane.doe@email.com","patientSsn":"000-00-0022"}'
+      string: '{"vaccineInterest":"yes","zipCode":"94402","timeAtZip":"yes","phone":"555-555-1234","email":"jane.doe@email.com","firstName":"Judy","lastName":"Morrison","dateOfBirth":"1953-04-01","patientSsn":"796061976","patientIcn":"80000374487447678","authenticated":true}'
     headers:
       Accept:
       - application/json
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 11 Dec 2020 04:53:02 GMT
+      - Fri, 11 Dec 2020 04:56:01 GMT
       Server:
       - Apache/2.4.46 (Unix) OpenSSL/1.1.1d
       Content-Type:
@@ -34,6 +34,6 @@ http_interactions:
       - '46'
     body:
       encoding: UTF-8
-      string: '{"sid":"FA82BF279B8673EDF2160766238295153294"}'
-  recorded_at: Fri, 11 Dec 2020 04:53:03 GMT
+      string: '{"sid":"FA82BF279B8673EDF2160766256123953295"}'
+  recorded_at: Fri, 11 Dec 2020 04:56:01 GMT
 recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/covid_vaccine/vetext/post_vaccine_registry_unauth.yml
+++ b/spec/support/vcr_cassettes/covid_vaccine/vetext/post_vaccine_registry_unauth.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://localhost:2002/api/vetext/pub/covid/vaccine/registry
     body:
       encoding: UTF-8
-      string: '{"vaccineInterest":"yes","authenticated":true,"dateVaccineReceived":"","contact":true,"contactMethod":"phone","reasonUndecided":"","firstName":"Jane","lastName":"Doe","dateOfBirth":"2/2/1952","phone":"555-555-1234","email":"jane.doe@email.com","patientSsn":"000-00-0022"}'
+      string: '{"vaccineInterest":"yes","zipCode":"94402","timeAtZip":"yes","phone":"555-555-1234","email":"jane.doe@email.com","firstName":"Lekisha","lastName":"Smith","dateOfBirth":"1978-09-22","patientSsn":"615946775","patientIcn":"65121115587223357","authenticated":false}'
     headers:
       Accept:
       - application/json
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 11 Dec 2020 04:53:02 GMT
+      - Fri, 11 Dec 2020 05:09:15 GMT
       Server:
       - Apache/2.4.46 (Unix) OpenSSL/1.1.1d
       Content-Type:
@@ -34,6 +34,6 @@ http_interactions:
       - '46'
     body:
       encoding: UTF-8
-      string: '{"sid":"FA82BF279B8673EDF2160766238295153294"}'
-  recorded_at: Fri, 11 Dec 2020 04:53:03 GMT
+      string: '{"sid":"FA82BF279B8673EDF2160766335598353296"}'
+  recorded_at: Fri, 11 Dec 2020 05:09:16 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Description of change
Serializes the submitted/persisted covid_vaccine form submission attributes back as
a response to the `GET` operation. 

## Things to know about this PR
- The GET operation does now return PII but will only return a result to an LOA3 user. Anonymous or LOA1 users will not receive any of those attributes. 
- The POST operation only returns a summary of the submission - created at time, vaccine interest, and zip code