### PR TITLE
Instrument registration flow

### DIFF
--- a/modules/covid_vaccine/config/initializers/statsd.rb
+++ b/modules/covid_vaccine/config/initializers/statsd.rb
@@ -13,9 +13,7 @@ CovidVaccine::V0::RegistrationService.statsd_measure :attributes_from_mpi,
 CovidVaccine::V0::RegistrationService.statsd_measure :submit,
                                                      'covid_vaccine.vetext_submit.measure'
 CovidVaccine::V0::RegistrationService.statsd_count_success :attributes_from_mpi,
-                                                           'covid_vaccine.mpi_query' do |result|
-  result.present?
-end
+                                                           'covid_vaccine.mpi_query', &:present?
 CovidVaccine::V0::RegistrationService.statsd_count_success :submit,
                                                            'covid_vaccine.vetext_submit'
 

--- a/modules/covid_vaccine/config/initializers/statsd.rb
+++ b/modules/covid_vaccine/config/initializers/statsd.rb
@@ -6,3 +6,20 @@ vetext_endpoints.each do |endpoint|
   StatsD.increment("api.vetext.#{endpoint}.total", 0)
   StatsD.increment("api.vetext.#{endpoint}.fail", 0)
 end
+
+CovidVaccine::V0::RegistrationService.extend StatsD::Instrument
+CovidVaccine::V0::RegistrationService.statsd_measure :attributes_from_mpi,
+                                                     'covid_vaccine.mpi_query.measure'
+CovidVaccine::V0::RegistrationService.statsd_measure :submit,
+                                                     'covid_vaccine.vetext_submit.measure'
+CovidVaccine::V0::RegistrationService.statsd_count_success :attributes_from_mpi,
+                                                           'covid_vaccine.mpi_query' do |result|
+  result.present?
+end
+CovidVaccine::V0::RegistrationService.statsd_count_success :submit,
+                                                           'covid_vaccine.vetext_submit'
+
+StatsD.increment('covid_vaccine.mpi_query.success', 0)
+StatsD.increment('covid_vaccine.mpi_query.failure', 0)
+StatsD.increment('covid_vaccine.vetext_submit.success', 0)
+StatsD.increment('covid_vaccine.vetext_submit.failure', 0)


### PR DESCRIPTION

## Description of change
Adds Statsd instrumentation around the potentially expensive parts of the registration flow -
the MPI query and the vetext call. 
(Facilities query instrumentation added in that PR). 

Tested locally and verified stats measure and increment calls appearing in logs.

