### PR TITLE
Adds setting stub for covid vaccine vanotify use

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -625,6 +625,7 @@ vanotify:
   api_key: fake_secret
   template_id:
     form526_confirmation_email: fake_template_id
+    covid_vaccine_registration: fake_template_id
   mock: false
 
 # Settings to connect to the drupal forms graphql api


### PR DESCRIPTION
## Description of change
Adds the baseline settings.yml value for covid vaccine module's use of VANotify. The env-specific values are already set in the devops repo, and the implementation work is restricted to a codeowners module so can happen in a separate PR:

https://github.com/department-of-veterans-affairs/vets-api/pull/5478/files

## Things to know about this PR


<!-- Please describe testing done to verify the changes or any testing planned. -->
