### PR TITLE
fix example and update additional doc around burial

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/forms/form_0966_v1_example.json
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_0966_v1_example.json
@@ -1,7 +1,6 @@
 {
   "type": "form/0966",
   "attributes": {
-    "type": "compensation",
-    "participant_claimant_id": 123456789
+    "type": "compensation"
   }
 }

--- a/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
@@ -137,7 +137,9 @@ module ClaimsApi
                     property :type do
                       key :type, :string
                       key :example, 'compensation'
-                      key :description, 'Required by JSON API standard'
+                      key :description, 'For type "burial", the request must be made by a valid Veteran Representative.
+                      If the Representative is not a Veteran or a VA employee, this method is currently not available to them,
+                      and they should use the Benefits Intake API as an alternative.'
                       key :enum, %w[
                         compensation
                         burial


### PR DESCRIPTION
## Description of change
Additional endpoint schema documentation for burial needed to be updated. Also removed participant_id from v1 0966 post endpoint. 

## Original issue(s)
https://vajira.max.gov/browse/API-3631

## Things to know about this PR
Viewed in developer-portal locally