### PR TITLE
ignores missing id.me uuid for v0 and inbound v1 logins [#17306]

### DIFF
--- a/lib/saml/user.rb
+++ b/lib/saml/user.rb
@@ -35,7 +35,8 @@ module SAML
         saml_response: Base64.encode64(saml_response&.response || '')
       )
 
-      @user_attributes = user_attributes_class.new(saml_attributes, authn_context)
+      @user_attributes = user_attributes_class.new(saml_attributes, authn_context, saml_response.settings)
+
       Raven.tags_context(
         sign_in_service_name: user_attributes.sign_in&.fetch(:service_name, nil),
         sign_in_account_type: user_attributes.sign_in&.fetch(:account_type, nil)

--- a/lib/saml/user_attributes/base.rb
+++ b/lib/saml/user_attributes/base.rb
@@ -7,9 +7,10 @@ module SAML
 
       attr_reader :attributes, :authn_context, :warnings
 
-      def initialize(saml_attributes, authn_context)
+      def initialize(saml_attributes, authn_context, saml_settings = nil)
         @attributes = saml_attributes # never default this to {}
         @authn_context = authn_context
+        @saml_settings = saml_settings
         @warnings = []
       end
 

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -16,7 +16,7 @@ module SAML
 
       attr_reader :attributes, :authn_context, :warnings
 
-      def initialize(saml_attributes, authn_context, saml_settings)
+      def initialize(saml_attributes, authn_context, saml_settings = nil)
         @attributes = saml_attributes # never default this to {}
         @authn_context = authn_context
         @saml_settings = saml_settings
@@ -199,9 +199,11 @@ module SAML
       private
 
       def should_raise_idme_uuid_error
-        is_v1 = @saml_settings.assertion_consumer_service_url =~ %r{/v1/}
-        if !idme_uuid && is_v1 && (@authn_context != INBOUND_AUTHN_CONTEXT)
-          true
+        if !idme_uuid
+          if @saml_settings.nil? ||
+             @saml_settings.assertion_consumer_service_url =~ %r{/v1/} && (@authn_context != INBOUND_AUTHN_CONTEXT)
+            true
+          end
         else
           false
         end

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -186,7 +186,7 @@ module SAML
 
       # Raise any fatal exceptions due to validation issues
       def validate!
-        unless idme_uuid
+        if should_raise_idme_uuid_error
           data = SAML::UserAttributeError::ERRORS[:idme_uuid_missing].merge({ identifier: mhv_icn })
           raise SAML::UserAttributeError, data
         end
@@ -196,6 +196,15 @@ module SAML
       end
 
       private
+
+      def should_raise_idme_uuid_error
+        is_v1 = caller_locations(5)[0].to_s =~ %r{/controllers/v1}
+        if !idme_uuid && is_v1 && (@authn_context != INBOUND_AUTHN_CONTEXT)
+          true
+        else
+          false
+        end
+      end
 
       def mvi_ids
         return @mvi_ids if @mvi_ids

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -16,9 +16,10 @@ module SAML
 
       attr_reader :attributes, :authn_context, :warnings
 
-      def initialize(saml_attributes, authn_context)
+      def initialize(saml_attributes, authn_context, saml_settings)
         @attributes = saml_attributes # never default this to {}
         @authn_context = authn_context
+        @saml_settings = saml_settings
         @warnings = []
       end
 
@@ -198,7 +199,7 @@ module SAML
       private
 
       def should_raise_idme_uuid_error
-        is_v1 = caller_locations(5)[0].to_s =~ %r{/controllers/v1}
+        is_v1 = @saml_settings.assertion_consumer_service_url =~ %r{/v1/}
         if !idme_uuid && is_v1 && (@authn_context != INBOUND_AUTHN_CONTEXT)
           true
         else

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -199,14 +199,14 @@ module SAML
       private
 
       def should_raise_idme_uuid_error
-        if !idme_uuid
-          if @saml_settings.nil? ||
-             @saml_settings.assertion_consumer_service_url =~ %r{/v1/} && (@authn_context != INBOUND_AUTHN_CONTEXT)
-            true
-          end
-        else
-          false
-        end
+        return false if idme_uuid
+
+        @saml_settings.nil? || auth_context_is_v1_and_not_inbound
+      end
+
+      def auth_context_is_v1_and_not_inbound
+        @saml_settings.assertion_consumer_service_url =~ %r{/v1/} &&
+          @authn_context != INBOUND_AUTHN_CONTEXT
       end
 
       def mvi_ids

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -238,7 +238,8 @@ RSpec.describe V1::SessionsController, type: :controller do
             level_of_assurance: ['3'],
             attributes: invalid_attributes,
             in_response_to: login_uuid,
-            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
+            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
+            settings: rubysaml_settings
           )
         end
 
@@ -859,7 +860,8 @@ RSpec.describe V1::SessionsController, type: :controller do
             level_of_assurance: ['3'],
             attributes: saml_attributes,
             existing_attributes: nil,
-            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
+            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
+            settings: rubysaml_settings
           )
         end
         let(:saml_user) { SAML::User.new(saml_response) }
@@ -886,7 +888,8 @@ RSpec.describe V1::SessionsController, type: :controller do
             level_of_assurance: ['3'],
             attributes: saml_attributes,
             existing_attributes: nil,
-            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
+            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
+            settings: rubysaml_settings
           )
         end
         let(:saml_user) { SAML::User.new(saml_response) }
@@ -913,7 +916,8 @@ RSpec.describe V1::SessionsController, type: :controller do
             level_of_assurance: ['3'],
             attributes: saml_attributes,
             existing_attributes: nil,
-            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
+            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
+            settings: rubysaml_settings
           )
         end
         let(:saml_user) { SAML::User.new(saml_response) }

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -238,8 +238,7 @@ RSpec.describe V1::SessionsController, type: :controller do
             level_of_assurance: ['3'],
             attributes: invalid_attributes,
             in_response_to: login_uuid,
-            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
-            settings: rubysaml_settings
+            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
           )
         end
 
@@ -860,8 +859,7 @@ RSpec.describe V1::SessionsController, type: :controller do
             level_of_assurance: ['3'],
             attributes: saml_attributes,
             existing_attributes: nil,
-            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
-            settings: rubysaml_settings
+            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
           )
         end
         let(:saml_user) { SAML::User.new(saml_response) }
@@ -888,8 +886,7 @@ RSpec.describe V1::SessionsController, type: :controller do
             level_of_assurance: ['3'],
             attributes: saml_attributes,
             existing_attributes: nil,
-            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
-            settings: rubysaml_settings
+            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
           )
         end
         let(:saml_user) { SAML::User.new(saml_response) }
@@ -916,8 +913,7 @@ RSpec.describe V1::SessionsController, type: :controller do
             level_of_assurance: ['3'],
             attributes: saml_attributes,
             existing_attributes: nil,
-            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
-            settings: rubysaml_settings
+            issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
           )
         end
         let(:saml_user) { SAML::User.new(saml_response) }

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe SAML::User do
     let(:highest_attained_loa) { '1' }
     let(:multifactor) { false }
     let(:existing_saml_attributes) { nil }
+    let(:callback_url) { 'http://http://127.0.0.1:3000/v1/sessions/callback/v1/sessions/callback' }
+    let(:rubysaml_settings) { build(:rubysaml_settings_v1, assertion_consumer_service_url: callback_url) }
 
     let(:saml_response) do
       build_saml_response(
@@ -20,7 +22,8 @@ RSpec.describe SAML::User do
         level_of_assurance: [highest_attained_loa],
         attributes: saml_attributes,
         existing_attributes: existing_saml_attributes,
-        issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20'
+        issuer: 'https://int.eauth.va.gov/FIM/sps/saml20fedCSP/saml20',
+        settings: rubysaml_settings
       )
     end
 
@@ -835,15 +838,13 @@ RSpec.describe SAML::User do
                 va_eauth_uid: ['NOT_FOUND'])
         end
 
-        it 'does not validate' do
-          expect { subject.validate! }.to raise_error { |error|
-            expect(error).to be_a(SAML::UserAttributeError)
-            expect(error.message).to eq('User attributes is missing an ID.me UUID')
-            expect(error.identifier).to eq('1012779219V964737')
-          }
+        it 'validates' do
+          expect { subject.validate! }.not_to raise_error
         end
       end
     end
+
+    # Add new test to have should_raise_idme_uuid_error return true
 
     context 'MHV premium inbound user' do
       let(:authn_context) { SAML::UserAttributes::SSOe::INBOUND_AUTHN_CONTEXT }

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -793,6 +793,24 @@ RSpec.describe SAML::User do
       end
     end
 
+    context 'DSLogon premium user without idme uuid' do
+      let(:authn_context) { 'dslogon' }
+      let(:highest_attained_loa) { '3' }
+      let(:multifactor) { true }
+      let(:saml_attributes) do
+        build(:ssoe_idme_dslogon_level2,
+              va_eauth_uid: ['NOT_FOUND'])
+      end
+
+      it 'does not validate' do
+        expect { subject.validate! }.to raise_error { |error|
+          expect(error).to be_a(SAML::UserAttributeError)
+          expect(error.message).to eq('User attributes is missing an ID.me UUID')
+          expect(error.identifier).to eq('1012740600V714187')
+        }
+      end
+    end
+
     context 'DSLogon premium inbound user' do
       let(:authn_context) { SAML::UserAttributes::SSOe::INBOUND_AUTHN_CONTEXT }
       let(:highest_attained_loa) { '3' }
@@ -843,8 +861,6 @@ RSpec.describe SAML::User do
         end
       end
     end
-
-    # Add new test to have should_raise_idme_uuid_error return true
 
     context 'MHV premium inbound user' do
       let(:authn_context) { SAML::UserAttributes::SSOe::INBOUND_AUTHN_CONTEXT }

--- a/spec/support/saml/response_builder.rb
+++ b/spec/support/saml/response_builder.rb
@@ -24,42 +24,43 @@ module SAML
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/ParameterLists, Metrics/AbcSize
     def build_saml_response(
       authn_context:, level_of_assurance:,
-      attributes: nil, issuer: nil, existing_attributes: nil, in_response_to: nil
+      attributes: nil, issuer: nil, existing_attributes: nil, in_response_to: nil, settings: nil
     )
-      verifying = [LOA::IDME_LOA3, LOA::IDME_LOA3_VETS, 'myhealthevet_loa3', 'dslogon_loa3'].include?(authn_context)
+    verifying = [LOA::IDME_LOA3, LOA::IDME_LOA3_VETS, 'myhealthevet_loa3', 'dslogon_loa3'].include?(authn_context)
 
-      if authn_context.present?
-        if authn_context.include?('multifactor') && existing_attributes.present?
-          previous_context = authn_context.gsub(/multifactor|_multifactor/, '').presence || LOA::IDME_LOA1_VETS
-          create_user_identity(
-            authn_context: previous_context,
-            level_of_assurance: level_of_assurance,
-            attributes: existing_attributes,
-            issuer: issuer
-          )
-        end
-
-        if verifying && existing_attributes.present?
-          previous_context = authn_context.gsub(/_loa3/, '')
-                                          .gsub(%r{loa/3/vets}, 'loa/1/vets')
-                                          .gsub(%r{loa/3}, 'loa/1/vets')
-          create_user_identity(
-            authn_context: previous_context,
-            level_of_assurance: '1',
-            attributes: existing_attributes,
-            issuer: issuer
-          )
-        end
+    if authn_context.present?
+      if authn_context.include?('multifactor') && existing_attributes.present?
+        previous_context = authn_context.gsub(/multifactor|_multifactor/, '').presence || LOA::IDME_LOA1_VETS
+        create_user_identity(
+          authn_context: previous_context,
+          level_of_assurance: level_of_assurance,
+          attributes: existing_attributes,
+          issuer: issuer
+        )
       end
 
-      saml_response = SAML::Responses::Login.new(document_partial(authn_context).to_s)
-      allow(saml_response).to receive(:issuer_text).and_return(issuer)
-      allow(saml_response).to receive(:assertion_encrypted?).and_return(true)
-      allow(saml_response).to receive(:attributes).and_return(attributes)
-      allow(saml_response).to receive(:validate).and_return(true)
-      allow(saml_response).to receive(:decrypted_document).and_return(document_partial(authn_context))
-      allow(saml_response).to receive(:in_response_to).and_return(in_response_to)
-      saml_response
+      if verifying && existing_attributes.present?
+        previous_context = authn_context.gsub(/_loa3/, '')
+                                        .gsub(%r{loa/3/vets}, 'loa/1/vets')
+                                        .gsub(%r{loa/3}, 'loa/1/vets')
+        create_user_identity(
+          authn_context: previous_context,
+          level_of_assurance: '1',
+          attributes: existing_attributes,
+          issuer: issuer
+        )
+      end
+    end
+
+    saml_response = SAML::Responses::Login.new(document_partial(authn_context).to_s)
+    allow(saml_response).to receive(:issuer_text).and_return(issuer)
+    allow(saml_response).to receive(:assertion_encrypted?).and_return(true)
+    allow(saml_response).to receive(:attributes).and_return(attributes)
+    allow(saml_response).to receive(:validate).and_return(true)
+    allow(saml_response).to receive(:decrypted_document).and_return(document_partial(authn_context))
+    allow(saml_response).to receive(:in_response_to).and_return(in_response_to)
+    allow(saml_response).to receive(:settings).and_return(settings)
+    saml_response
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/ParameterLists, Metrics/AbcSize
 

--- a/spec/support/saml/response_builder.rb
+++ b/spec/support/saml/response_builder.rb
@@ -26,41 +26,41 @@ module SAML
       authn_context:, level_of_assurance:,
       attributes: nil, issuer: nil, existing_attributes: nil, in_response_to: nil, settings: nil
     )
-    verifying = [LOA::IDME_LOA3, LOA::IDME_LOA3_VETS, 'myhealthevet_loa3', 'dslogon_loa3'].include?(authn_context)
+      verifying = [LOA::IDME_LOA3, LOA::IDME_LOA3_VETS, 'myhealthevet_loa3', 'dslogon_loa3'].include?(authn_context)
 
-    if authn_context.present?
-      if authn_context.include?('multifactor') && existing_attributes.present?
-        previous_context = authn_context.gsub(/multifactor|_multifactor/, '').presence || LOA::IDME_LOA1_VETS
-        create_user_identity(
-          authn_context: previous_context,
-          level_of_assurance: level_of_assurance,
-          attributes: existing_attributes,
-          issuer: issuer
-        )
+      if authn_context.present?
+        if authn_context.include?('multifactor') && existing_attributes.present?
+          previous_context = authn_context.gsub(/multifactor|_multifactor/, '').presence || LOA::IDME_LOA1_VETS
+          create_user_identity(
+            authn_context: previous_context,
+            level_of_assurance: level_of_assurance,
+            attributes: existing_attributes,
+            issuer: issuer
+          )
+        end
+
+        if verifying && existing_attributes.present?
+          previous_context = authn_context.gsub(/_loa3/, '')
+                                          .gsub(%r{loa/3/vets}, 'loa/1/vets')
+                                          .gsub(%r{loa/3}, 'loa/1/vets')
+          create_user_identity(
+            authn_context: previous_context,
+            level_of_assurance: '1',
+            attributes: existing_attributes,
+            issuer: issuer
+          )
+        end
       end
 
-      if verifying && existing_attributes.present?
-        previous_context = authn_context.gsub(/_loa3/, '')
-                                        .gsub(%r{loa/3/vets}, 'loa/1/vets')
-                                        .gsub(%r{loa/3}, 'loa/1/vets')
-        create_user_identity(
-          authn_context: previous_context,
-          level_of_assurance: '1',
-          attributes: existing_attributes,
-          issuer: issuer
-        )
-      end
-    end
-
-    saml_response = SAML::Responses::Login.new(document_partial(authn_context).to_s)
-    allow(saml_response).to receive(:issuer_text).and_return(issuer)
-    allow(saml_response).to receive(:assertion_encrypted?).and_return(true)
-    allow(saml_response).to receive(:attributes).and_return(attributes)
-    allow(saml_response).to receive(:validate).and_return(true)
-    allow(saml_response).to receive(:decrypted_document).and_return(document_partial(authn_context))
-    allow(saml_response).to receive(:in_response_to).and_return(in_response_to)
-    allow(saml_response).to receive(:settings).and_return(settings)
-    saml_response
+      saml_response = SAML::Responses::Login.new(document_partial(authn_context).to_s)
+      allow(saml_response).to receive(:issuer_text).and_return(issuer)
+      allow(saml_response).to receive(:assertion_encrypted?).and_return(true)
+      allow(saml_response).to receive(:attributes).and_return(attributes)
+      allow(saml_response).to receive(:validate).and_return(true)
+      allow(saml_response).to receive(:decrypted_document).and_return(document_partial(authn_context))
+      allow(saml_response).to receive(:in_response_to).and_return(in_response_to)
+      allow(saml_response).to receive(:settings).and_return(settings)
+      saml_response
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/ParameterLists, Metrics/AbcSize
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
In an effort to reduce the amount of non-necessary errors logged to sentry, we are only raising and logging an error for missing idme_uuids when the login request is:
* outbound
* using v1 sessions_controller

This change prevents an error from being raised if the idme_uuid is missing and either the login request is inbound or the sessions_controller for the request is v0.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#17306

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
* Unit tests updated to include passing/failing cases for `should_raise_idme_uuid_error`
* Unit tests for other sessions_controller methods updated where new inclusion of `saml_response.settings` is needed
* Manual testing with hard-coded missing_uuid values for inbound and outbound logins