### PR TITLE
Add allow_online_10_10cg_submissions feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -329,6 +329,10 @@ features:
     enable_in_development: true
     description: >
       Enables type ahead search functionality
+  allow_online_10_10cg_submissions:
+    actor_type: cookie_id
+    description: >
+      Allows (unauthenticated) users to submit a 10-10CG through VA.gov. When disabled, this will redirect visitors from the form's home page to the home page (va.gov).
   async_10_10_cg_attachments:
     actor_type: cookie_id
     description: >

--- a/config/features.yml
+++ b/config/features.yml
@@ -332,7 +332,7 @@ features:
   allow_online_10_10cg_submissions:
     actor_type: cookie_id
     description: >
-      Allows (unauthenticated) users to submit a 10-10CG through VA.gov. When disabled, this will redirect visitors from the form's home page to the home page (va.gov).
+      Allows (unauthenticated) users to submit a 10-10CG through VA.gov. When enabled, this will redirect visitors from the form's page to the home page (va.gov).
   async_10_10_cg_attachments:
     actor_type: cookie_id
     description: >


### PR DESCRIPTION
**Description**
This feature flag is still being used by the front-end but was removed in a [previous PR](https://github.com/department-of-veterans-affairs/vets-api/commit/651ef0461afd268557c1525fd7b167ebc3cb1fb6). Needs to be added back in so the 10-10CG form doesn't redirect visitors.
