### PR TITLE
Removes db table that was inadvertently added back

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -313,15 +313,6 @@ ActiveRecord::Schema.define(version: 2020_12_08_215916) do
     t.index ["job_id"], name: "index_form526_job_statuses_on_job_id", unique: true
   end
 
-  create_table "form526_opt_ins", id: :serial, force: :cascade do |t|
-    t.string "user_uuid", null: false
-    t.string "encrypted_email", null: false
-    t.string "encrypted_email_iv", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_uuid"], name: "index_form526_opt_ins_on_user_uuid", unique: true
-  end
-
   create_table "form526_submissions", id: :serial, force: :cascade do |t|
     t.string "user_uuid", null: false
     t.integer "saved_claim_id", null: false


### PR DESCRIPTION
Removes form526_opt_ins table that was removed in
9bc0045041f390427599031dbd4562e8800f0c2e
but then added back accidentally in
17653c161ebfc88f3cc79c144a781bd47b4da35f

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
https://dsva.slack.com/archives/CQHBJ5U06/p1607724582144200

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
