### PR TITLE
COVID module asynchronous submission processing

### DIFF
--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
@@ -9,8 +9,7 @@ module CovidVaccine
       def create
         raw_form_data = params[:registration].merge(attributes_from_user)
         account_id = @current_user&.account_uuid
-        binding.pry
-        record = CovidVaccine::V0::RegistrationSubmission.create({ account_id: account_id,
+        record = CovidVaccine::V0::RegistrationSubmission.create!({ account_id: account_id,
                                                                    raw_form_data: raw_form_data })
 
         CovidVaccine::SubmissionJob.perform_async(record.id, user_type)

--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
@@ -7,19 +7,14 @@ module CovidVaccine
   module V0
     class RegistrationController < CovidVaccine::ApplicationController
       def create
-        svc = CovidVaccine::V0::RegistrationService.new
-        result = if @current_user
-                   if @current_user.loa3?
-                     svc.register_loa3_user(params[:registration], @current_user)
-                   else
-                     # Authenticated-but-LOA1 users are treated equivalently as unauthenticated
-                     # users since we have to perform a speculative MVI lookup for them
-                     svc.register(params[:registration], @current_user.account_uuid)
-                   end
-                 else
-                   svc.register(params[:registration])
-                 end
-        render json: result, serializer: CovidVaccine::V0::RegistrationSummarySerializer, status: :created
+        raw_form_data = params[:registration].merge(attributes_from_user)
+        account_id = @current_user&.account_uuid
+        binding.pry
+        record = CovidVaccine::V0::RegistrationSubmission.create({ account_id: account_id,
+                                                                   raw_form_data: raw_form_data })
+
+        CovidVaccine::SubmissionJob.perform_async(record.id, user_type)
+        render json: record, serializer: CovidVaccine::V0::RegistrationSummarySerializer, status: :created
       end
 
       def show
@@ -27,6 +22,29 @@ module CovidVaccine
         raise Common::Exceptions::RecordNotFound, nil if submission.blank?
 
         render json: submission, serializer: CovidVaccine::V0::RegistrationSubmissionSerializer
+      end
+
+      private
+
+      # Merge in these attributes from the authenticated user, since
+      # we won't have access to that object from the submission worker
+      def attributes_from_user
+        return {} unless @current_user&.loa3?
+
+        {
+          'first_name' => @current_user.first_name,
+          'last_name' => @current_user.last_name,
+          'birth_date' => @current_user.birth_date,
+          'ssn' => @current_user.ssn,
+          'icn' => @current_user.icn
+        }
+      end
+
+      def user_type
+        return 'unauthenticated' if @current_user.blank?
+        return 'loa3' if @current_user&.loa3?
+
+        'loa1'
       end
     end
   end

--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
@@ -10,7 +10,7 @@ module CovidVaccine
         raw_form_data = params[:registration].merge(attributes_from_user)
         account_id = @current_user&.account_uuid
         record = CovidVaccine::V0::RegistrationSubmission.create!({ account_id: account_id,
-                                                                   raw_form_data: raw_form_data })
+                                                                    raw_form_data: raw_form_data })
 
         CovidVaccine::SubmissionJob.perform_async(record.id, user_type)
         render json: record, serializer: CovidVaccine::V0::RegistrationSummarySerializer, status: :created

--- a/modules/covid_vaccine/app/jobs/covid_vaccine/submission_job.rb
+++ b/modules/covid_vaccine/app/jobs/covid_vaccine/submission_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'sentry_logging'
+
+module CovidVaccine
+  class SubmissionJob
+    include Sidekiq::Worker
+    include SentryLogging
+    sidekiq_options expires_in: 1.day, retry: 10
+
+    def perform(record_id, user_type)
+      partial = CovidVaccine::V0::RegistrationSubmission.find(record_id)
+      CovidVaccine::V0::Services.new.register(partial, user_type)
+    rescue => e
+      handle_errors(e)
+    end
+
+    def handle_errors(ex)
+      log_exception_to_sentry(ex)
+      raise ex
+    end
+  end
+end

--- a/modules/covid_vaccine/app/jobs/covid_vaccine/submission_job.rb
+++ b/modules/covid_vaccine/app/jobs/covid_vaccine/submission_job.rb
@@ -6,11 +6,10 @@ module CovidVaccine
   class SubmissionJob
     include Sidekiq::Worker
     include SentryLogging
-    sidekiq_options expires_in: 1.day, retry: 10
 
     def perform(record_id, user_type)
       partial = CovidVaccine::V0::RegistrationSubmission.find(record_id)
-      CovidVaccine::V0::Services.new.register(partial, user_type)
+      CovidVaccine::V0::RegistrationService.new.register(partial, user_type)
     rescue => e
       handle_errors(e)
     end

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/registration_submission.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/registration_submission.rb
@@ -10,6 +10,7 @@ module CovidVaccine
       end
 
       attr_encrypted :form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller
+      attr_encrypted :raw_form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller
     end
   end
 end

--- a/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
+++ b/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
@@ -16,7 +16,9 @@ module CovidVaccine
       def id
         object.sid
       end
-
+      
+      # TODO: Make robust to selecting from raw_form_data or form_data
+      # in case GET is called before submission
       %i[vaccine_interest zip_code phone email first_name last_name].each do |attr|
         define_method attr do
           object.form_data[attr]

--- a/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
+++ b/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_submission_serializer.rb
@@ -16,21 +16,11 @@ module CovidVaccine
       def id
         object.sid
       end
-      
-      # TODO: Make robust to selecting from raw_form_data or form_data
-      # in case GET is called before submission
-      %i[vaccine_interest zip_code phone email first_name last_name].each do |attr|
+
+      %i[vaccine_interest zip_code zip_code_details phone email first_name last_name birth_date].each do |attr|
         define_method attr do
-          object.form_data[attr]
+          object.raw_form_data[attr.to_s]
         end
-      end
-
-      def zip_code_details
-        object.form_data[:time_at_zip]
-      end
-
-      def birth_date
-        object.form_data[:date_of_birth]
       end
     end
   end

--- a/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_summary_serializer.rb
+++ b/modules/covid_vaccine/app/serializers/covid_vaccine/v0/registration_summary_serializer.rb
@@ -8,12 +8,12 @@ module CovidVaccine
       attribute :zip_code
 
       def id
-        object.sid
+        nil
       end
 
       %i[vaccine_interest zip_code].each do |attr|
         define_method attr do
-          object.form_data[attr]
+          object.raw_form_data[attr]
         end
       end
     end

--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/facility_lookup_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/facility_lookup_service.rb
@@ -57,6 +57,7 @@ module CovidVaccine
         }
       rescue
         # For now just bail on any exception while getting facilities
+        # TODO Add Sentry logging
         {}
       end
 

--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/registration_service.rb
@@ -5,39 +5,29 @@ module CovidVaccine
     class RegistrationService
       REQUIRED_QUERY_TRAITS = %w[first_name last_name birth_date ssn].freeze
 
-      def register(form_data, account_id = nil)
-        attributes = form_attributes(form_data)
-        attributes.merge!(attributes_from_mpi(form_data)) if query_traits_present(form_data)
-        attributes.merge!(facility_attributes(form_data))
-        attributes.merge!({ authenticated: false }).compact!
-        user_type = account_id.present? ? 'loa1' : 'unauthenticated'
-        submit_and_save(attributes, account_id, user_type)
-      end
-
-      def register_loa3_user(form_data, user)
-        attributes = form_attributes(form_data)
-        attributes.merge!(attributes_from_user(user))
-        attributes.merge!(facility_attributes(form_data))
-        attributes.merge!({ authenticated: true }).compact!
-        submit_and_save(attributes, user.account_uuid, 'loa3')
+      def register(submission, user_type)
+        raw_form_data = submission.raw_form_data
+        vetext_attributes = form_attributes(raw_form_data)
+        vetext_attributes.merge!(attributes_from_mpi(raw_form_data)) if should_query_mpi?(raw_form_data, user_type)
+        vetext_attributes.merge!(facility_attributes(raw_form_data))
+        vetext_attributes.merge!({ authenticated: (user_type == 'loa3') }).compact!
+        submit_and_save(vetext_attributes, submission, user_type)
       end
 
       private
 
-      def submit_and_save(attributes, account_id, user_type = '')
+      def submit_and_save(attributes, submission, user_type)
         # TODO: error handling
         audit_log(attributes, user_type)
         response = submit(attributes)
         Rails.logger.info("Covid_Vaccine Vetext Response: #{response}")
-        record = CovidVaccine::V0::RegistrationSubmission.create({ sid: response[:sid],
-                                                                   account_id: account_id,
-                                                                   form_data: attributes })
-        submit_confirmation_email(attributes[:email], record.created_at, response[:sid])
-        record
+        submission.update!(sid: response[:sid], form_data: attributes)
+        submit_confirmation_email(attributes[:email], submission.created_at, response[:sid])
+        submission
       end
 
       def submit_confirmation_email(email, date, sid)
-        return if email.empty?
+        return if email.blank?
 
         formatted_date = date.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.')
         CovidVaccine::RegistrationEmailJob.perform_async(email, formatted_date, sid)
@@ -74,27 +64,16 @@ module CovidVaccine
           first_name: form_data['first_name'],
           last_name: form_data['last_name'],
           date_of_birth: form_data['birth_date'],
-          patient_ssn: form_data['ssn']
+          patient_ssn: form_data['ssn'],
+          # This value was only injected from controller if 
+          # user was authenticated at LOA3
+          patient_icn: form_data['icn']
         }
       end
 
       def facility_attributes(form_data)
         svc = CovidVaccine::V0::FacilityLookupService.new
         svc.facilities_for(form_data['zip_code'])
-      end
-
-      def attributes_from_user(user)
-        return {} unless user.loa3?
-
-        {
-          first_name: user.first_name,
-          last_name: user.last_name,
-          date_of_birth: user.birth_date,
-          patient_ssn: user.ssn,
-          patient_icn: user.icn
-          # Not currently supported
-          # zip: user.zip
-        }
       end
 
       def attributes_from_mpi(form_data)
@@ -120,8 +99,10 @@ module CovidVaccine
         end
       end
 
-      def query_traits_present(form_data)
-        (REQUIRED_QUERY_TRAITS & form_data.keys).size == REQUIRED_QUERY_TRAITS.size
+      # if user_type == loa3, then we already had the information from their
+      # authenticated session and added it to the raw form data
+      def should_query_mpi?(form_data, user_type)
+        user_type != 'loa3' && (REQUIRED_QUERY_TRAITS & form_data.keys).size == REQUIRED_QUERY_TRAITS.size
       end
     end
   end

--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/registration_service.rb
@@ -65,7 +65,7 @@ module CovidVaccine
           last_name: form_data['last_name'],
           date_of_birth: form_data['birth_date'],
           patient_ssn: form_data['ssn'],
-          # This value was only injected from controller if 
+          # This value was only injected from controller if
           # user was authenticated at LOA3
           patient_icn: form_data['icn']
         }

--- a/modules/covid_vaccine/config/initializers/statsd.rb
+++ b/modules/covid_vaccine/config/initializers/statsd.rb
@@ -7,6 +7,13 @@ vetext_endpoints.each do |endpoint|
   StatsD.increment("api.vetext.#{endpoint}.fail", 0)
 end
 
+CovidVaccine::SubmissionJob.extend StatsD::Instrument
+CovidVaccine::SubmissionJob.statsd_count_success :perform,
+                                                 'covid_vaccine.submission_job'
+
+StatsD.increment('covid_vaccine.submission_job.success', 0)
+StatsD.increment('covid_vaccine.submission_job.failure', 0)
+
 CovidVaccine::V0::RegistrationService.extend StatsD::Instrument
 CovidVaccine::V0::RegistrationService.statsd_measure :facility_attributes,
                                                      'covid_vaccine.facility_query.measure'

--- a/modules/covid_vaccine/spec/factories/registration_submissions.rb
+++ b/modules/covid_vaccine/spec/factories/registration_submissions.rb
@@ -21,18 +21,18 @@ FactoryBot.define do
         sta6a: '648GI'
       }
     }
-     
+
     raw_form_data {
       {
-        'vaccine_interest' => 'INTERESTED', 
+        'vaccine_interest' => 'INTERESTED',
         'zip_code' => '97212',
         'zip_code_details' => 'YES',
         'phone' => '808-555-1212',
-        'email' => 'foo@example.com', 
+        'email' => 'foo@example.com',
         'first_name' => 'Jon',
-        'last_name' => 'Doe', 
+        'last_name' => 'Doe',
         'birth_date' => '1900-01-01',
-        'ssn' => '6665123456', 
+        'ssn' => '6665123456'
       }
     }
   end
@@ -49,13 +49,13 @@ FactoryBot.define do
   trait :lacking_pii_traits do
     raw_form_data {
       {
-        'vaccine_interest' => 'INTERESTED', 
+        'vaccine_interest' => 'INTERESTED',
         'zip_code' => '97212',
         'zip_code_details' => 'YES',
         'phone' => '808-555-1212',
-        'email' => 'foo@example.com', 
+        'email' => 'foo@example.com',
         'first_name' => 'Jon',
-        'last_name' => 'Doe', 
+        'last_name' => 'Doe'
       }
     }
   end
@@ -63,19 +63,17 @@ FactoryBot.define do
   trait :from_loa3 do
     raw_form_data {
       {
-        'vaccine_interest' => 'INTERESTED', 
+        'vaccine_interest' => 'INTERESTED',
         'zip_code' => '97212',
         'zip_code_details' => 'YES',
         'phone' => '808-555-1212',
-        'email' => 'foo@example.com', 
+        'email' => 'foo@example.com',
         'first_name' => 'Jonathan',
-        'last_name' => 'Doe-Roe', 
+        'last_name' => 'Doe-Roe',
         'birth_date' => '1900-01-01',
-        'ssn' => '6665123456', 
+        'ssn' => '6665123456',
         'icn' => '123456V123456'
       }
     }
   end
-
 end
-

--- a/modules/covid_vaccine/spec/factories/registration_submissions.rb
+++ b/modules/covid_vaccine/spec/factories/registration_submissions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :covid_vaccine_registration_submission, class: 'CovidVaccine::V0::RegistrationSubmission' do
+  factory :covid_vax_registration, class: 'CovidVaccine::V0::RegistrationSubmission' do
     sid { SecureRandom.uuid }
     account_id { SecureRandom.uuid }
 
@@ -14,8 +14,68 @@ FactoryBot.define do
         email: 'foo@example.com',
         first_name: 'Jon',
         last_name: 'Doe',
-        date_of_birth: '1900-01-01'
+        date_of_birth: '1900-01-01',
+        patient_ssn: '666123456',
+        patient_icn: '123456V123456',
+        sta3n: '648',
+        sta6a: '648GI'
+      }
+    }
+     
+    raw_form_data {
+      {
+        'vaccine_interest' => 'INTERESTED', 
+        'zip_code' => '97212',
+        'zip_code_details' => 'YES',
+        'phone' => '808-555-1212',
+        'email' => 'foo@example.com', 
+        'first_name' => 'Jon',
+        'last_name' => 'Doe', 
+        'birth_date' => '1900-01-01',
+        'ssn' => '6665123456', 
       }
     }
   end
+
+  trait :unsubmitted do
+    sid { nil }
+    form_data { nil }
+  end
+
+  trait :anonymous do
+    account_id { nil }
+  end
+
+  trait :lacking_pii_traits do
+    raw_form_data {
+      {
+        'vaccine_interest' => 'INTERESTED', 
+        'zip_code' => '97212',
+        'zip_code_details' => 'YES',
+        'phone' => '808-555-1212',
+        'email' => 'foo@example.com', 
+        'first_name' => 'Jon',
+        'last_name' => 'Doe', 
+      }
+    }
+  end
+
+  trait :from_loa3 do
+    raw_form_data {
+      {
+        'vaccine_interest' => 'INTERESTED', 
+        'zip_code' => '97212',
+        'zip_code_details' => 'YES',
+        'phone' => '808-555-1212',
+        'email' => 'foo@example.com', 
+        'first_name' => 'Jonathan',
+        'last_name' => 'Doe-Roe', 
+        'birth_date' => '1900-01-01',
+        'ssn' => '6665123456', 
+        'icn' => '123456V123456'
+      }
+    }
+  end
+
 end
+

--- a/modules/covid_vaccine/spec/jobs/covid_vaccine/submission_job_spec.rb
+++ b/modules/covid_vaccine/spec/jobs/covid_vaccine/submission_job_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CovidVaccine::SubmissionJob, type: :worker do
+  subject { described_class.new }
+
+  describe '#perform' do
+    let(:pending_submission) { create(:covid_vax_registration, :unsubmitted) }
+    let(:user_type) { 'loa3' }
+    let(:expected_attributes) do
+      %w[vaccine_interest zip_code time_at_zip phone email first_name last_name
+         date_of_birth patient_ssn zip_lat zip_lon sta3n authenticated]
+    end
+
+    it 'updates the submission object' do
+      VCR.use_cassette('covid_vaccine/vetext/post_vaccine_registry_loa3', match_requests_on: %i[method path]) do
+        VCR.use_cassette('covid_vaccine/facilities/query_97212', match_requests_on: %i[method path]) do
+          subject.perform(pending_submission.id, user_type)
+          pending_submission.reload
+          expect(pending_submission.sid).to be_truthy
+          expect(pending_submission.form_data).to be_truthy
+          expect(pending_submission.form_data).to include(*expected_attributes)
+        end
+      end
+    end
+
+    describe 'with vetext failure' do
+      it 'raises an error' do
+        with_settings(Settings.sentry, dsn: 'T') do
+          VCR.use_cassette('covid_vaccine/facilities/query_97212', match_requests_on: %i[method path]) do
+            expect(Raven).to receive(:capture_exception)
+            expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+              .and_raise(Common::Exceptions::BackendServiceException, 'VA900')
+            expect { subject.perform(pending_submission.id, user_type) }.to raise_error(StandardError)
+          end
+        end
+      end
+
+      it 'leaves submission unmodified' do
+        VCR.use_cassette('covid_vaccine/facilities/query_97212', match_requests_on: %i[method path]) do
+          expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+            .and_raise(Common::Exceptions::BackendServiceException, 'VA900')
+          expect { subject.perform(pending_submission.id, user_type) }.to raise_error(StandardError)
+          pending_submission.reload
+          expect(pending_submission.sid).to be_nil
+          expect(pending_submission.form_data).to be_nil
+        end
+      end
+    end
+
+    it 'raises an error if submission is missing' do
+      with_settings(Settings.sentry, dsn: 'T') do
+        expect(Raven).to receive(:capture_exception)
+        expect { subject.perform('fakeid', user_type) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/registration_request_spec.rb
@@ -97,8 +97,7 @@ RSpec.describe 'Covid Vaccine Registration', type: :request do
           .and_return(mvi_profile_response)
         VCR.use_cassette('covid_vaccine/vetext/post_vaccine_registry_unauth', match_requests_on: %i[method path]) do
           expect { post '/covid_vaccine/v0/registration', params: { registration: registration_attributes } }
-            .to change(CovidVaccine::RegistrationEmailJob.jobs, :size)
-            .by(1)
+            .to change(CovidVaccine::SubmissionJob.jobs, :size).by(1)
             .and change(CovidVaccine::V0::RegistrationSubmission, :count).by(1)
           expect(response).to have_http_status(:created)
           expect(JSON.parse(response.body)['data']['id']).to eq('FA82BF279B8673EDF2160766335598353296')
@@ -116,8 +115,7 @@ RSpec.describe 'Covid Vaccine Registration', type: :request do
           .and_return(mvi_profile_response)
         VCR.use_cassette('covid_vaccine/vetext/post_vaccine_registry_loa1', match_requests_on: %i[method path]) do
           expect { post '/covid_vaccine/v0/registration', params: { registration: registration_attributes } }
-            .to change(CovidVaccine::RegistrationEmailJob.jobs, :size)
-            .by(1)
+            .to change(CovidVaccine::SubmissionJob.jobs, :size).by(1)
             .and change(CovidVaccine::V0::RegistrationSubmission, :count).by(1)
           expect(response).to have_http_status(:created)
           expect(JSON.parse(response.body)['data']['id']).to eq('FA82BF279B8673EDF2160766335651453297')
@@ -133,8 +131,7 @@ RSpec.describe 'Covid Vaccine Registration', type: :request do
       it 'returns a sid' do
         VCR.use_cassette('covid_vaccine/vetext/post_vaccine_registry_loa3', match_requests_on: %i[method path]) do
           expect { post '/covid_vaccine/v0/registration', params: { registration: registration_attributes } }
-            .to change(CovidVaccine::RegistrationEmailJob.jobs, :size)
-            .by(1)
+            .to change(CovidVaccine::SubmissionJob.jobs, :size).by(1)
             .and change(CovidVaccine::V0::RegistrationSubmission, :count).by(1)
           expect(response).to have_http_status(:created)
           body = JSON.parse(response.body)
@@ -194,7 +191,7 @@ RSpec.describe 'Covid Vaccine Registration', type: :request do
 
       context 'with a previous submission' do
         let!(:submission) do
-          create(:covid_vaccine_registration_submission,
+          create(:covid_vax_registration,
                  account_id: loa3_user.account_uuid)
         end
 
@@ -212,12 +209,12 @@ RSpec.describe 'Covid Vaccine Registration', type: :request do
 
       context 'with multiple submissions' do
         let!(:submission1) do
-          create(:covid_vaccine_registration_submission,
+          create(:covid_vax_registration,
                  account_id: loa3_user.account_uuid,
                  created_at: Time.zone.now - 2.minutes)
         end
         let!(:submission2) do
-          create(:covid_vaccine_registration_submission,
+          create(:covid_vax_registration,
                  account_id: loa3_user.account_uuid,
                  created_at: Time.zone.now - 1.minute)
         end

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/registration_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/registration_service_spec.rb
@@ -16,6 +16,12 @@ describe CovidVaccine::V0::RegistrationService do
       'email' => 'foo@bar.com', 'first_name' => 'Sean',
       'last_name' => 'Gptestkfive', 'zip_code' => '97412', 'zip_code_details' => 'Yes' }
   end
+  let(:submission) { build(:covid_vax_registration, :unsubmitted) }
+  let(:insufficient_submission) { build(:covid_vax_registration, 
+                                        :unsubmitted, 
+                                        :lacking_pii_traits) }
+  let(:loa3_submission) { build(:covid_vax_registration, :unsubmitted, :from_loa3) }
+
   let(:mvi_profile) { build(:mvi_profile) }
   let(:mvi_profile_response) do
     MPI::Responses::FindProfileResponse.new(
@@ -50,26 +56,35 @@ describe CovidVaccine::V0::RegistrationService do
                                :zip_lat,
                                :zip_lon,
                                :sta3n,
-                               :sta6a,
                                :authenticated))
           .and_return({ sid: SecureRandom.uuid })
         expect_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_profile_response)
 
-        expect { subject.register(form_data) }
+        expect { subject.register(submission, 'unauthenticated') }
           .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
       end
 
-      it 'saves a submission record' do
+      it 'passes authenticated attribute as false' do
+        expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+          .with(hash_including(:authenticated => false))
+          .and_return({ sid: SecureRandom.uuid })
+        expect_any_instance_of(MPI::Service).to receive(:find_profile)
+          .and_return(mvi_profile_response)
+        expect { subject.register(submission, 'unauthenticated') }
+          .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
+      end
+
+      it 'updates submission record' do
         sid = SecureRandom.uuid
         expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
           .and_return({ sid: sid })
         expect_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_profile_response)
 
-        expect { subject.register(form_data) }
+        expect { subject.register(submission, 'unauthenticated') }
           .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
-        expect(CovidVaccine::V0::RegistrationSubmission.find_by(sid: sid)).to be_truthy
+        expect(submission.reload.sid).to be_truthy
       end
 
       context 'with sufficient traits' do
@@ -79,7 +94,7 @@ describe CovidVaccine::V0::RegistrationService do
           expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
             .with(hash_including(first_name: mvi_profile.given_names&.first))
             .and_return({ sid: SecureRandom.uuid })
-          expect { subject.register(form_data) }
+          expect { subject.register(submission, 'unauthenticated') }
             .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
         end
 
@@ -87,9 +102,9 @@ describe CovidVaccine::V0::RegistrationService do
           expect_any_instance_of(MPI::Service).to receive(:find_profile)
             .and_return(mvi_profile_not_found)
           expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
-            .with(hash_including(first_name: form_data['first_name']))
+            .with(hash_including(first_name: submission.raw_form_data['first_name']))
             .and_return({ sid: SecureRandom.uuid })
-          expect { subject.register(form_data) }
+          expect { subject.register(submission, 'unauthenticated') }
             .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
         end
       end
@@ -99,7 +114,7 @@ describe CovidVaccine::V0::RegistrationService do
           expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
             .and_return({ sid: SecureRandom.uuid })
           expect_any_instance_of(MPI::Service).not_to receive(:find_profile)
-          expect { subject.register(sparse_form_data) }
+          expect { subject.register(insufficient_submission, 'unauthenticated') }
             .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
         end
       end
@@ -110,9 +125,9 @@ describe CovidVaccine::V0::RegistrationService do
 
       it 'uses traits from proofed user' do
         expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
-          .with(hash_including(first_name: user.first_name))
+          .with(hash_including(first_name: loa3_submission.raw_form_data['first_name']))
           .and_return({ sid: SecureRandom.uuid })
-        expect { subject.register_loa3_user(form_data, user) }
+        expect { subject.register(loa3_submission, 'loa3') }
           .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
       end
 
@@ -120,13 +135,44 @@ describe CovidVaccine::V0::RegistrationService do
         expect_any_instance_of(MPI::Service).not_to receive(:find_profile)
         expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
           .and_return({ sid: SecureRandom.uuid })
-        expect { subject.register_loa3_user(form_data, user) }
+        expect { subject.register(loa3_submission, 'loa3') }
+          .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
+      end
+
+      it 'passes authenticated attribute as true' do
+        expect_any_instance_of(MPI::Service).not_to receive(:find_profile)
+        expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+          .with(hash_including(:authenticated => true))
+          .and_return({ sid: SecureRandom.uuid })
+        expect { subject.register(loa3_submission, 'loa3') }
           .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
       end
     end
 
     context 'authenticated LOA1' do
       let(:user) { build(:user, :mhv, :loa1) }
+
+      context 'with sufficient traits' do
+        it 'injects user traits from MPI when found' do
+          expect_any_instance_of(MPI::Service).to receive(:find_profile)
+            .and_return(mvi_profile_response)
+          expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+            .with(hash_including(first_name: mvi_profile.given_names&.first))
+            .and_return({ sid: SecureRandom.uuid })
+          expect { subject.register(submission, 'loa1') }
+            .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
+        end
+      end
+
+      it 'passes authenticated attribute as false' do
+        expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+          .with(hash_including(:authenticated => false))
+          .and_return({ sid: SecureRandom.uuid })
+        expect_any_instance_of(MPI::Service).to receive(:find_profile)
+          .and_return(mvi_profile_response)
+        expect { subject.register(submission, 'loa1') }
+          .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
+      end
     end
   end
 end

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/registration_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/registration_service_spec.rb
@@ -17,9 +17,11 @@ describe CovidVaccine::V0::RegistrationService do
       'last_name' => 'Gptestkfive', 'zip_code' => '97412', 'zip_code_details' => 'Yes' }
   end
   let(:submission) { build(:covid_vax_registration, :unsubmitted) }
-  let(:insufficient_submission) { build(:covid_vax_registration, 
-                                        :unsubmitted, 
-                                        :lacking_pii_traits) }
+  let(:insufficient_submission) do
+    build(:covid_vax_registration,
+          :unsubmitted,
+          :lacking_pii_traits)
+  end
   let(:loa3_submission) { build(:covid_vax_registration, :unsubmitted, :from_loa3) }
 
   let(:mvi_profile) { build(:mvi_profile) }
@@ -67,7 +69,7 @@ describe CovidVaccine::V0::RegistrationService do
 
       it 'passes authenticated attribute as false' do
         expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
-          .with(hash_including(:authenticated => false))
+          .with(hash_including(authenticated: false))
           .and_return({ sid: SecureRandom.uuid })
         expect_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_profile_response)
@@ -142,7 +144,7 @@ describe CovidVaccine::V0::RegistrationService do
       it 'passes authenticated attribute as true' do
         expect_any_instance_of(MPI::Service).not_to receive(:find_profile)
         expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
-          .with(hash_including(:authenticated => true))
+          .with(hash_including(authenticated: true))
           .and_return({ sid: SecureRandom.uuid })
         expect { subject.register(loa3_submission, 'loa3') }
           .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
@@ -166,7 +168,7 @@ describe CovidVaccine::V0::RegistrationService do
 
       it 'passes authenticated attribute as false' do
         expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
-          .with(hash_including(:authenticated => false))
+          .with(hash_including(authenticated: false))
           .and_return({ sid: SecureRandom.uuid })
         expect_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_profile_response)

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/vetext_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/vetext_service_spec.rb
@@ -43,5 +43,19 @@ describe CovidVaccine::V0::VetextService do
           .to raise_error(Common::Exceptions::BackendServiceException, exception_message)
       end
     end
+
+    it 'raises a BackendServiceException on a 500 error' do
+      VCR.use_cassette('covid_vaccine/vetext/post_vaccine_registry_500', match_requests_on: %i[method path]) do
+        expect { subject.put_vaccine_registry(registry_attributes) }
+          .to raise_error(Common::Exceptions::BackendServiceException, /VETEXT_502/)
+      end
+    end
+
+    it 'raises a BackendServiceException on a 599 error' do
+      VCR.use_cassette('covid_vaccine/vetext/post_vaccine_registry_599', match_requests_on: %i[method path]) do
+        expect { subject.put_vaccine_registry(registry_attributes) }
+          .to raise_error(Common::Exceptions::BackendServiceException, /VA900/)
+      end
+    end
   end
 end

--- a/spec/support/vcr_cassettes/covid_vaccine/facilities/query_97212.yml
+++ b/spec/support/vcr_cassettes/covid_vaccine/facilities/query_97212.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/va_facilities/v0/nearby?lat=45.544236&lng=-122.643468
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Apikey:
+      - "<LIGHTHOUSE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Sat, 12 Dec 2020 23:10:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '167'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Via:
+      - kong/1.2.2
+      X-Kong-Proxy-Latency:
+      - '9'
+      X-Kong-Upstream-Latency:
+      - '575'
+      X-Ratelimit-Limit-Minute:
+      - '60'
+      X-Ratelimit-Remaining-Minute:
+      - '59'
+      Cache-Control:
+      - ''
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - TS0164a718=01874af5a4f625887a0e3c68fb63780569df1e207c4c155b1e1de6757340ff4b51d888549b680059b272a93bcd0cafe2025776e876;
+        Max-Age=900; Path=/
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":[{"id":"vha_648","type":"nearby_facility","attributes":{"min_time":10,"max_time":20}},{"id":"vha_648A4","type":"nearby_facility","attributes":{"min_time":10,"max_time":20}},{"id":"vha_648GE","type":"nearby_facility","attributes":{"min_time":10,"max_time":20}},{"id":"vha_648GI","type":"nearby_facility","attributes":{"min_time":10,"max_time":20}},{"id":"vha_648GF","type":"nearby_facility","attributes":{"min_time":20,"max_time":30}},{"id":"vha_648GG","type":"nearby_facility","attributes":{"min_time":20,"max_time":30}},{"id":"vha_648GB","type":"nearby_facility","attributes":{"min_time":60,"max_time":70}},{"id":"vha_648GJ","type":"nearby_facility","attributes":{"min_time":80,"max_time":90}},{"id":"vha_663GD","type":"nearby_facility","attributes":{"min_time":80,"max_time":90}}]}'
+  recorded_at: Sat, 12 Dec 2020 23:10:30 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/covid_vaccine/registration_facilities.yml
+++ b/spec/support/vcr_cassettes/covid_vaccine/registration_facilities.yml
@@ -247,4 +247,63 @@ http_interactions:
         x62160","mental_health_clinic":"206-764-2007","enrollment_coordinator":"800-329-8387
         x76542"},"hours":{"friday":"24/7","monday":"24/7","sunday":"24/7","tuesday":"24/7","saturday":"24/7","thursday":"24/7","wednesday":"24/7"},"services":{"other":[],"health":["Audiology","Cardiology","DentalServices","Dermatology","EmergencyCare","Gastroenterology","Gynecology","MentalHealthCare","Nutrition","Ophthalmology","Optometry","Orthopedics","Podiatry","PrimaryCare","SpecialtyCare","Urology","WomensHealth"],"last_updated":"2020-11-30"},"satisfaction":{"health":{"primary_care_urgent":0.9100000262260437,"primary_care_routine":0.8500000238418579,"specialty_care_urgent":0.7599999904632568},"effective_date":"2020-04-16"},"wait_times":{"health":[{"service":"Audiology","new":15.979591,"established":16.787234},{"service":"Cardiology","new":28.453125,"established":24.653543},{"service":"Dermatology","new":29.283333,"established":31.7},{"service":"Gastroenterology","new":21.0,"established":14.846153},{"service":"Gynecology","new":12.090909,"established":7.663636},{"service":"MentalHealthCare","new":10.966666,"established":3.161341},{"service":"Ophthalmology","new":12.9,"established":11.241031},{"service":"Optometry","new":22.67647,"established":30.69463},{"service":"Orthopedics","new":14.676056,"established":8.924528},{"service":"PrimaryCare","new":7.3,"established":3.786206},{"service":"SpecialtyCare","new":18.776744,"established":12.030551},{"service":"Urology","new":17.125,"established":5.163461},{"service":"WomensHealth","new":19.333333,"established":6.041666}],"effective_date":"2020-11-30"},"mobile":false,"active_status":"A","operating_status":{"code":"NORMAL"},"visn":"20"}}],"links":{"self":"https://sandbox-api.va.gov/services/va_facilities/v0/facilities?lat=44.20493&long=-123.54782&type=health&page=1&per_page=30","first":"https://sandbox-api.va.gov/services/va_facilities/v0/facilities?lat=44.20493&long=-123.54782&type=health&page=1&per_page=30","prev":null,"next":"https://sandbox-api.va.gov/services/va_facilities/v0/facilities?lat=44.20493&long=-123.54782&type=health&page=2&per_page=30","last":"https://sandbox-api.va.gov/services/va_facilities/v0/facilities?lat=44.20493&long=-123.54782&type=health&page=44&per_page=30"},"meta":{"pagination":{"current_page":1,"per_page":30,"total_pages":44,"total_entries":1301},"distances":[{"id":"vha_653QA","distance":25.06},{"id":"vha_653BY","distance":25.84},{"id":"vha_648GH","distance":38.65},{"id":"vha_648GB","distance":55.48},{"id":"vha_648GK","distance":59.08},{"id":"vha_653GA","distance":65.10},{"id":"vha_653","distance":68.06},{"id":"vha_648GG","distance":90.46},{"id":"vha_648GF","distance":97.52},{"id":"vha_648","distance":98.80},{"id":"vha_648GI","distance":100.49},{"id":"vha_648GE","distance":106.58},{"id":"vha_648A4","distance":108.30},{"id":"vha_648GA","distance":113.58},{"id":"vha_692GB","distance":124.02},{"id":"vha_692","distance":127.08},{"id":"vha_648GD","distance":133.71},{"id":"vha_648GJ","distance":152.79},{"id":"vha_653GB","distance":153.36},{"id":"vha_692GA","distance":161.66},{"id":"vha_663GD","distance":173.93},{"id":"vha_612GJ","distance":178.01},{"id":"vha_663A4","distance":208.42},{"id":"vha_663HK","distance":208.42},{"id":"vha_687QB","distance":219.76},{"id":"vha_663GF","distance":221.30},{"id":"vha_687HA","distance":221.80},{"id":"vha_531GH","distance":226.95},{"id":"vha_662GC","distance":238.79},{"id":"vha_663","distance":239.47}]}}'
   recorded_at: Thu, 10 Dec 2020 19:30:57 GMT
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/va_facilities/v0/nearby?lat=45.544236&lng=-122.643468
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Apikey:
+      - "<LIGHTHOUSE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 11 Dec 2020 23:43:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '167'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Via:
+      - kong/1.2.2
+      X-Kong-Proxy-Latency:
+      - '1'
+      X-Kong-Upstream-Latency:
+      - '750'
+      X-Ratelimit-Limit-Minute:
+      - '60'
+      X-Ratelimit-Remaining-Minute:
+      - '59'
+      Cache-Control:
+      - ''
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - TS0108eb76=01c8917e48e2a79dce0d38d886cf6ded4169d25055697cfa610de6f6c739374583040fcd9798058baa70573c00c47bfca7404d6320;
+        Max-Age=900; Path=/
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":[{"id":"vha_648","type":"nearby_facility","attributes":{"min_time":10,"max_time":20}},{"id":"vha_648A4","type":"nearby_facility","attributes":{"min_time":10,"max_time":20}},{"id":"vha_648GE","type":"nearby_facility","attributes":{"min_time":10,"max_time":20}},{"id":"vha_648GI","type":"nearby_facility","attributes":{"min_time":10,"max_time":20}},{"id":"vha_648GF","type":"nearby_facility","attributes":{"min_time":20,"max_time":30}},{"id":"vha_648GG","type":"nearby_facility","attributes":{"min_time":20,"max_time":30}},{"id":"vha_648GB","type":"nearby_facility","attributes":{"min_time":60,"max_time":70}},{"id":"vha_648GJ","type":"nearby_facility","attributes":{"min_time":80,"max_time":90}},{"id":"vha_663GD","type":"nearby_facility","attributes":{"min_time":80,"max_time":90}}]}'
+  recorded_at: Fri, 11 Dec 2020 23:43:51 GMT
 recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/covid_vaccine/vetext/post_vaccine_registry_599.yml
+++ b/spec/support/vcr_cassettes/covid_vaccine/vetext/post_vaccine_registry_599.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://localhost:2002/api/vetext/pub/covid/vaccine/registry
+    body:
+      encoding: UTF-8
+      string: '{"dateVaccineReeceived":""}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - Basic fake_token
+      Referer:
+      - https://review-instance.va.gov
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 599
+      message: Network Connect Timeout Error
+    headers:
+      Date:
+      - Tue, 08 Dec 2020 01:08:47 GMT
+      Server:
+      - Apache/2.4.46 (Unix) OpenSSL/1.1.1d
+      Content-Type:
+      - text/html;charset=UTF-8
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Tue, 08 Dec 2020 01:08:47 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Description of change
Updates covid_vaccine submission to be asynchronous. 
Saves raw submission to db, then spawns worker to perform the MPI and facilities queries and vetext submision. This means submission from frontend is much faster and decoupled from
failures in any backend systems. 

Return value of POST is unchanged, except that the `id` attribute will always be blank. 

Return value of GET changes slightly in that the fields will be closer to what was submitted rather than reflecting what was posted to vetext. There is still possibility that for LOA3 users, if first/last/dob/etc in current_user are different than what was submitted, that's what will get returned. 

Note DB migration is being submitted separately as:
https://github.com/department-of-veterans-affairs/vets-api/pull/5500
will rebase once that's merged to clear dangerbot.

## Things to know about this PR

<!-- Please describe testing done to verify the changes or any testing planned. -->
Tested locally and confirmed POST endpoint and sidekiq worker processing.