### PR TITLE
Adds migrations to allow async covid registration

### DIFF
--- a/db/migrate/20201211213957_add_columns_for_covid_async_submission.rb
+++ b/db/migrate/20201211213957_add_columns_for_covid_async_submission.rb
@@ -1,0 +1,8 @@
+class AddColumnsForCovidAsyncSubmission < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :covid_vaccine_registration_submissions, :sid, true
+
+    add_column :covid_vaccine_registration_submissions, :encrypted_raw_form_data, :string
+    add_column :covid_vaccine_registration_submissions, :encrypted_raw_form_data_iv, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_08_215916) do
+ActiveRecord::Schema.define(version: 2020_12_11_213957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -170,12 +170,14 @@ ActiveRecord::Schema.define(version: 2020_12_08_215916) do
   end
 
   create_table "covid_vaccine_registration_submissions", id: :serial, force: :cascade do |t|
-    t.string "sid", null: false
+    t.string "sid"
     t.uuid "account_id"
     t.string "encrypted_form_data"
     t.string "encrypted_form_data_iv"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "encrypted_raw_form_data"
+    t.string "encrypted_raw_form_data_iv"
     t.index ["account_id", "created_at"], name: "index_covid_vaccine_registry_submissions_2"
     t.index ["encrypted_form_data_iv"], name: "index_covid_vaccine_registry_submissions_on_iv", unique: true
     t.index ["sid"], name: "index_covid_vaccine_registry_submissions_on_sid", unique: true


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Updates covid_vaccine schema in preparation for the changes in this PR to support asynchronous form processing:
https://github.com/department-of-veterans-affairs/vets-api/pull/5499

- Adds an encrypted raw_form_data field for the submission received from the user
- Makes sid nullable, so that we can create a record before submitting to the vetext API

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
* raw_form_data column may contain PII but is encrypted

* Tested locally with async submission process