### PR TITLE
bumped version number for vets-json-schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,10 +65,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 16deab49594cd8b284c57200f7c1e1b05557a6f9
+  revision: c12156e77d9cbffa439ee0ec2ddf42b805658023
   branch: master
   specs:
-    vets_json_schema (18.2.0)
+    vets_json_schema (18.4.0)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 


### PR DESCRIPTION
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/17141)

This PR is to bump the version number for `vets-json-schema` in vets-website for changes that were made as a result of the above ticklet