### PR TITLE
[17323] Improving the SSN Mismatch logs on the session controllers so…

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -238,7 +238,11 @@ module V0
       # action if this appears to be happening frequently.
       if current_user.ssn_mismatch?
         additional_context = StringHelpers.heuristics(current_user.identity.ssn, current_user.va_profile.ssn)
-        log_message_to_sentry('SSNS DO NOT MATCH!!', :warn, identity_compared_with_mpi: additional_context)
+        log_message_to_sentry(
+          'SessionsController version:v0 message:SSN from MPI Lookup does not match UserIdentity cache',
+          :warn,
+          identity_compared_with_mpi: additional_context
+        )
       end
     end
 

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -335,7 +335,11 @@ module V1
       # action if this appears to be happening frequently.
       if current_user.ssn_mismatch?
         additional_context = StringHelpers.heuristics(current_user.identity.ssn, current_user.va_profile.ssn)
-        log_message_to_sentry('SSNS DO NOT MATCH!!', :warn, identity_compared_with_mpi: additional_context)
+        log_message_to_sentry(
+          'SessionsController version:v1 message:SSN from MPI Lookup does not match UserIdentity cache',
+          :warn,
+          identity_compared_with_mpi: additional_context
+        )
       end
     end
 

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -336,6 +336,10 @@ RSpec.describe V0::SessionsController, type: :controller do
 
       context 'verifying' do
         let(:authn_context) { LOA::IDME_LOA3_VETS }
+        let(:version) { 'v0' }
+        let(:expected_ssn_log) do
+          "SessionsController version:#{version} message:SSN from MPI Lookup does not match UserIdentity cache"
+        end
 
         it 'uplevels an LOA 1 session to LOA 3', :aggregate_failures do
           existing_user = User.find(uuid)
@@ -345,7 +349,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(existing_user.ssn).to eq('796111863')
           allow(StringHelpers).to receive(:levenshtein_distance).and_return(8)
           expect(controller).to receive(:log_message_to_sentry).with(
-            'SSNS DO NOT MATCH!!',
+            expected_ssn_log,
             :warn,
             identity_compared_with_mpi: {
               length: [9, 9],

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -397,6 +397,10 @@ RSpec.describe V1::SessionsController, type: :controller do
 
       context 'verifying' do
         let(:authn_context) { LOA::IDME_LOA3 }
+        let(:version) { 'v1' }
+        let(:expected_ssn_log) do
+          "SessionsController version:#{version} message:SSN from MPI Lookup does not match UserIdentity cache"
+        end
 
         it 'uplevels an LOA 1 session to LOA 3', :aggregate_failures do
           SAMLRequestTracker.create(
@@ -410,7 +414,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           expect(existing_user.ssn).to eq('796111863')
           allow(StringHelpers).to receive(:levenshtein_distance).and_return(8)
           expect(controller).to receive(:log_message_to_sentry).with(
-            'SSNS DO NOT MATCH!!',
+            expected_ssn_log,
             :warn,
             identity_compared_with_mpi: {
               length: [9, 9],


### PR DESCRIPTION
… they now differentiate between the controller versions


## Description of change
This PR updates the SSN Mismatch log in the Sessions Controller v0/v1 routes, so it is more descriptive and differentiates between the controller version. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team/issues/17323

## Things to know about this PR
- This may change Sentry logs around the SSN mismatch, so we may want to watch for this and merge the Sentry log before/after the change

- I just ran specs, to confirm. I didn't attempt to recreate the SSN mismatch error, but shouldn't be a big deal since this is only a change in logs. We'll be able to easily see the change in Sentry Staging environment
