### PR TITLE
corrected privacy and tos url

### DIFF
--- a/modules/apps_api/lib/apps_api/directory_application_creator.rb
+++ b/modules/apps_api/lib/apps_api/directory_application_creator.rb
@@ -47,8 +47,8 @@ module AppsApi
           'Coral Health is a free personal healthcare management app that is used to track medications,'\
           ' get medication reminders, consolidate official medical records,'\
           ' and monitor health trends and issues over time.'
-        app.privacy_url = 'https://mycoralhealth.com/privacy-policy.html'
-        app.tos_url = 'https://mycoralhealth.com/terms-of-service.html'
+        app.privacy_url = 'https://mycoralhealth.com/privacy-policy'
+        app.tos_url = 'https://mycoralhealth.com/terms-of-service'
         app.save
       end
 


### PR DESCRIPTION
## Description of change
This is not scalable. Endpoints to create and update records are in development, being tracked under https://vajira.max.gov/browse/API-4055. 
Corrected privacy and terms of service urls for Coral Health.

## Things to know about this PR
No other changes