### PR TITLE
add reference as one of the attributes we send to VANotify

### DIFF
--- a/modules/covid_vaccine/app/jobs/covid_vaccine/registration_email_job.rb
+++ b/modules/covid_vaccine/app/jobs/covid_vaccine/registration_email_job.rb
@@ -20,7 +20,8 @@ module CovidVaccine
         personalisation: {
           'date' => date,
           'confirmation_id' => confirmation_id
-        }
+        },
+        reference: confirmation_id
       )
       StatsD.increment(STATSD_SUCCESS_NAME)
     rescue => e

--- a/modules/covid_vaccine/app/jobs/covid_vaccine/registration_email_job.rb
+++ b/modules/covid_vaccine/app/jobs/covid_vaccine/registration_email_job.rb
@@ -12,24 +12,29 @@ module CovidVaccine
     STATSD_ERROR_NAME = 'worker.covid_vaccine_registration_email.error'
     STATSD_SUCCESS_NAME = 'worker.covid_vaccine_registration_email.success'
 
-    def perform(email, date, confirmation_id)
+    def perform(email, date, sid)
       @notify_client ||= VaNotify::Service.new
-      @notify_client.send_email(
+      response = @notify_client.send_email(
         email_address: email,
         template_id: Settings.vanotify.template_id.covid_vaccine_registration,
         personalisation: {
           'date' => date,
-          'confirmation_id' => confirmation_id
+          'confirmation_id' => sid
         },
-        reference: confirmation_id
+        reference: sid
+      )
+
+      Rails.logger.info(
+        'CovidVaccine::RegistrationEmailJob submitted to VaNotify',
+        { sid: sid, va_notify_id: response[:id] }
       )
       StatsD.increment(STATSD_SUCCESS_NAME)
     rescue => e
-      handle_errors(e)
+      handle_errors(e, sid)
     end
 
-    def handle_errors(ex)
-      log_exception_to_sentry(ex)
+    def handle_errors(ex, sid)
+      log_exception_to_sentry(ex, { sid: sid })
       StatsD.increment(STATSD_ERROR_NAME)
 
       raise ex

--- a/modules/covid_vaccine/spec/jobs/covid_vaccine/registration_email_job_spec.rb
+++ b/modules/covid_vaccine/spec/jobs/covid_vaccine/registration_email_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CovidVaccine::RegistrationEmailJob, type: :worker do
     end
 
     it 'executes perform' do
-      instance = instance_double(VaNotify::Service, send_email: nil)
+      instance = instance_double(VaNotify::Service, send_email: { id: '123456789' })
       allow(VaNotify::Service).to receive(:new).and_return(instance)
 
       expect(instance)
@@ -36,6 +36,13 @@ RSpec.describe CovidVaccine::RegistrationEmailJob, type: :worker do
           }
         )
       described_class.perform_async(email, date, confirmation_id)
+      expect(Rails.logger).to receive(:info).with(
+        'CovidVaccine::RegistrationEmailJob submitted to VaNotify',
+        { sid: 'confirmation_id_uuid', va_notify_id: '123456789' }
+      ).once
+      expect(Rails.logger).to receive(:info).with(
+        '[StatsD] increment worker.covid_vaccine_registration_email.success:1'
+      ).once
       expect { described_class.perform_one }.to change(described_class.jobs, :size).from(1).to(0)
     end
 
@@ -43,10 +50,15 @@ RSpec.describe CovidVaccine::RegistrationEmailJob, type: :worker do
       allow(VaNotify::Service).to receive(:new).and_raise(StandardError)
 
       described_class.perform_async(email, date, confirmation_id)
-      expect { described_class.perform_one }
-        .to raise_error(StandardError)
-        .and change(described_class.jobs, :size).from(1).to(0)
-      # I cant think of a good way to test retry logic, but maybe I should just trust that Sidekiq does that.
+      expect(Raven).to receive(:capture_exception).with(StandardError, { level: 'error' })
+      expect(Raven).to receive(:extra_context).with(sid: 'confirmation_id_uuid')
+      expect(Rails.logger).to receive(:info).with(
+        '[StatsD] increment worker.covid_vaccine_registration_email.error:1'
+      ).once
+
+      with_settings(Settings.sentry, dsn: 'T') do
+        expect { described_class.perform_one }.to raise_error(StandardError)
+      end
     end
   end
 end

--- a/modules/covid_vaccine/spec/jobs/covid_vaccine/registration_email_job_spec.rb
+++ b/modules/covid_vaccine/spec/jobs/covid_vaccine/registration_email_job_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe CovidVaccine::RegistrationEmailJob, type: :worker do
             personalisation: {
               'date' => date,
               'confirmation_id' => confirmation_id
-            }
+            },
+            reference: confirmation_id
           }
         )
       described_class.perform_async(email, date, confirmation_id)


### PR DESCRIPTION
## Description of change
Note: I've only verified that VaNotify service receives this reference attribute and that it sends it to Notification gem. I have not done an end to end verification that the reference attribute can actually get serialized and gets sent to VaNotify. 

## Original issue(s)
On going work for Covid-Vaccine... we want to be able to pass the confirmation id to VANotify so that we can later go to them with that confirmation_id if any reconciliation is needed to verify why or why not an email was sent.

Tagging @philherbert since he is most familiar with the notification gem and VaNotify as an integration on vets-api. 