### PR TITLE
Log when Form 10-10CG Attachment Job is successful

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -7,6 +7,8 @@ module V0
 
     rescue_from ::Form1010cg::Service::InvalidVeteranStatus, with: :backend_service_outage
 
+    AUDITOR = Form1010cg::Auditor.new(Rails.logger)
+
     def create
       auditor.record(:submission_attempt)
 
@@ -83,7 +85,7 @@ module V0
     end
 
     def auditor
-      Form1010cg::Auditor.instance
+      self.class::AUDITOR
     end
   end
 end

--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -7,7 +7,7 @@ module V0
 
     rescue_from ::Form1010cg::Service::InvalidVeteranStatus, with: :backend_service_outage
 
-    AUDITOR = Form1010cg::Auditor.new(Rails.logger)
+    AUDITOR = Form1010cg::Auditor.new
 
     def create
       auditor.record(:submission_attempt)

--- a/app/services/form1010cg/auditor.rb
+++ b/app/services/form1010cg/auditor.rb
@@ -2,7 +2,7 @@
 
 module Form1010cg
   class Auditor
-    include Singleton
+    attr_reader :logger
 
     STATSD_KEY_PREFIX   = 'api.form1010cg'
     LOGGER_PREFIX       = 'Form 10-10CG'
@@ -23,6 +23,10 @@ module Form1010cg
         ),
         pdf_download: STATSD_KEY_PREFIX + '.pdf_download'
       )
+    end
+
+    def initialize(logger)
+      @logger = logger
     end
 
     def record(event, **context)
@@ -60,6 +64,15 @@ module Form1010cg
       increment self.class.metrics.pdf_download
     end
 
+    def record_attachments_delivered(claim_guid:, carma_case_id:, attachments:)
+      log(
+        'Attachments Delivered',
+        claim_guid: claim_guid,
+        carma_case_id: carma_case_id,
+        attachments: attachments
+      )
+    end
+
     def log_mpi_search_result(claim_guid:, form_subject:, result:)
       result_label = case result
                      when :found
@@ -80,7 +93,7 @@ module Form1010cg
     end
 
     def log(message, context_hash = {})
-      Rails.logger.send :info, "[#{LOGGER_PREFIX}] #{message}", deep_apply_filter(context_hash)
+      logger.send :info, "[#{LOGGER_PREFIX}] #{message}", deep_apply_filter(context_hash)
     end
 
     def deep_apply_filter(value)

--- a/app/services/form1010cg/auditor.rb
+++ b/app/services/form1010cg/auditor.rb
@@ -25,7 +25,7 @@ module Form1010cg
       )
     end
 
-    def initialize(logger)
+    def initialize(logger = Rails.logger)
       @logger = logger
     end
 

--- a/app/services/form1010cg/service.rb
+++ b/app/services/form1010cg/service.rb
@@ -16,6 +16,7 @@ module Form1010cg
                   :submission # Form1010cg::Submission
 
     NOT_FOUND = 'NOT_FOUND'
+    AUDITOR = Form1010cg::Auditor.new(Rails.logger)
 
     def self.submit_attachment!(carma_case_id, veteran_name, document_type, file_path)
       raise 'invalid veteran_name' if veteran_name.try(:[], 'first').nil? || veteran_name.try(:[], 'last').nil?
@@ -233,7 +234,7 @@ module Form1010cg
     end
 
     def log_mpi_search_result(form_subject, result)
-      Form1010cg::Auditor.instance.log_mpi_search_result(
+      self.class::AUDITOR.log_mpi_search_result(
         claim_guid: claim.guid,
         form_subject: form_subject,
         result: result

--- a/app/services/form1010cg/service.rb
+++ b/app/services/form1010cg/service.rb
@@ -16,7 +16,7 @@ module Form1010cg
                   :submission # Form1010cg::Submission
 
     NOT_FOUND = 'NOT_FOUND'
-    AUDITOR = Form1010cg::Auditor.new(Rails.logger)
+    AUDITOR = Form1010cg::Auditor.new
 
     def self.submit_attachment!(carma_case_id, veteran_name, document_type, file_path)
       raise 'invalid veteran_name' if veteran_name.try(:[], 'first').nil? || veteran_name.try(:[], 'last').nil?

--- a/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
+++ b/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
@@ -3,6 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
+  describe '::auditor' do
+    it 'is an instance of Form1010cg::Auditor' do
+      expect(described_class::AUDITOR).to be_an_instance_of(Form1010cg::Auditor)
+    end
+
+    it 'is using Rails.logger' do
+      expect(described_class::AUDITOR.logger).to eq(Rails.logger)
+    end
+
+    it 'is always the same instance of Form1010cg::Auditor' do
+      expect(described_class::AUDITOR.object_id).to eq(described_class::AUDITOR.object_id)
+    end
+  end
+
   it 'inherits from ActionController::API' do
     expect(described_class.ancestors).to include(ActionController::API)
   end
@@ -103,8 +117,8 @@ RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
   describe '#create' do
     it_behaves_like '10-10CG request with missing param: caregivers_assistance_claim', :create do
       before do
-        expect(Form1010cg::Auditor.instance).to receive(:record).with(:submission_attempt)
-        expect(Form1010cg::Auditor.instance).to receive(:record).with(
+        expect(described_class::AUDITOR).to receive(:record).with(:submission_attempt)
+        expect(described_class::AUDITOR).to receive(:record).with(
           :submission_failure_client_data,
           errors: ['param is missing or the value is empty: caregivers_assistance_claim']
         )
@@ -113,8 +127,8 @@ RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
 
     it_behaves_like '10-10CG request with missing param: form', :create do
       before do
-        expect(Form1010cg::Auditor.instance).to receive(:record).with(:submission_attempt)
-        expect(Form1010cg::Auditor.instance).to receive(:record).with(
+        expect(described_class::AUDITOR).to receive(:record).with(:submission_attempt)
+        expect(described_class::AUDITOR).to receive(:record).with(
           :submission_failure_client_data,
           errors: ['param is missing or the value is empty: form']
         )
@@ -127,8 +141,8 @@ RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
         # mocked claim that is passed into the src code for testing
         expected_errors = build(:caregivers_assistance_claim, form: form_data).tap(&:valid?).errors.messages
 
-        expect(Form1010cg::Auditor.instance).to receive(:record).with(:submission_attempt)
-        expect(Form1010cg::Auditor.instance).to receive(:record).with(
+        expect(described_class::AUDITOR).to receive(:record).with(:submission_attempt)
+        expect(described_class::AUDITOR).to receive(:record).with(
           :submission_failure_client_data,
           claim_guid: claim.guid,
           errors: expected_errors
@@ -158,8 +172,8 @@ RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
       expect(Form1010cg::Service).to receive(:new).with(claim).and_return(service)
       expect(service).to receive(:process_claim!).and_return(submission)
 
-      expect(Form1010cg::Auditor.instance).to receive(:record).with(:submission_attempt)
-      expect(Form1010cg::Auditor.instance).to receive(:record).with(
+      expect(described_class::AUDITOR).to receive(:record).with(:submission_attempt)
+      expect(described_class::AUDITOR).to receive(:record).with(
         :submission_success,
         claim_guid: claim.guid,
         carma_case_id: submission.carma_case_id,
@@ -197,8 +211,8 @@ RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
         expect(Form1010cg::Service).to receive(:new).with(claim).and_return(service)
         expect(service).to receive(:process_claim!).and_raise(Form1010cg::Service::InvalidVeteranStatus)
 
-        expect(Form1010cg::Auditor.instance).to receive(:record).with(:submission_attempt)
-        expect(Form1010cg::Auditor.instance).to receive(:record).with(
+        expect(described_class::AUDITOR).to receive(:record).with(:submission_attempt)
+        expect(described_class::AUDITOR).to receive(:record).with(
           :submission_failure_client_qualification,
           claim_guid: claim.guid
         )
@@ -252,8 +266,8 @@ RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
         expect(Form1010cg::Service).to receive(:new).with(claim).and_return(service)
         expect(service).to receive(:process_claim!).and_raise(Form1010cg::Service::InvalidVeteranStatus)
 
-        expect(Form1010cg::Auditor.instance).to receive(:record).with(:submission_attempt)
-        expect(Form1010cg::Auditor.instance).to receive(:record).with(
+        expect(described_class::AUDITOR).to receive(:record).with(:submission_attempt)
+        expect(described_class::AUDITOR).to receive(:record).with(
           :submission_failure_client_qualification,
           claim_guid: claim.guid
         )
@@ -295,7 +309,8 @@ RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
       )
 
       expect(SecureRandom).to receive(:uuid).and_return('file-name-uuid') # When controller generates it for filename
-      expect(Form1010cg::Auditor.instance).to receive(:record).with(:pdf_download)
+
+      expect(described_class::AUDITOR).to receive(:record).with(:pdf_download)
 
       post :download_pdf, params: params
 

--- a/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
+++ b/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
     it 'is using Rails.logger' do
       expect(described_class::AUDITOR.logger).to eq(Rails.logger)
     end
-
-    it 'is always the same instance of Form1010cg::Auditor' do
-      expect(described_class::AUDITOR.object_id).to eq(described_class::AUDITOR.object_id)
-    end
   end
 
   it 'inherits from ActionController::API' do

--- a/spec/services/form1010cg/auditor_spec.rb
+++ b/spec/services/form1010cg/auditor_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Form1010cg::Auditor do
   let(:subject) do
-    described_class.instance
+    described_class.new(Rails.logger)
   end
 
   before(:all) do
@@ -21,11 +21,14 @@ RSpec.describe Form1010cg::Auditor do
     StatsD.backend = @_statsd_logger
   end
 
-  it 'is a singleton' do
-    expect(described_class.ancestors).to include(Singleton)
+  describe '::new' do
+    it 'accepts a logger' do
+      expect(described_class.new(Rails.logger).logger).to eq(Rails.logger)
+      expect(described_class.new(Sidekiq.logger).logger).to eq(Sidekiq.logger)
+    end
   end
 
-  describe ':metrics' do
+  describe '::metrics' do
     it 'provides StatsD metric values' do
       expect(
         described_class.metrics.submission.attempt
@@ -250,6 +253,22 @@ RSpec.describe Form1010cg::Auditor do
     end
   end
 
+  describe '#record_attachments_delivered' do
+    let(:subject) do
+      described_class.new(Sidekiq.logger)
+    end
+
+    context 'logs' do
+      it '[Form 10-10CG] Attachments Delivered' do
+        expected_message = '[Form 10-10CG] Attachments Delivered'
+        expected_context = { claim_guid: 'uuid-123', carma_case_id: 'CASE_123', attachments: :ATTACHMENTS_HASH }
+
+        expect(Sidekiq.logger).to receive(:info).with(expected_message, expected_context)
+        subject.record_attachments_delivered(expected_context)
+      end
+    end
+  end
+
   describe '#log_mpi_search_result' do
     context 'requires' do
       it 'claim_guid:, form_subject:, result:' do
@@ -338,7 +357,7 @@ RSpec.describe Form1010cg::Auditor do
       end
 
       context 'for :submission_failure_client_data' do
-        it 'calls :record submission_failure_client_data' do
+        it 'calls :record_submission_failure_client_data' do
           context = { claim_guid: 'uuid-123', errors: %w[error1 error2] }
 
           expect(subject).to receive(:record_submission_failure_client_data).with(context)
@@ -347,7 +366,7 @@ RSpec.describe Form1010cg::Auditor do
       end
 
       context 'for :submission_failure_client_qualification' do
-        it 'calls :record submission_failure_client_qualification' do
+        it 'calls :record_submission_failure_client_qualification' do
           context = { claim_guid: 'uuid-123' }
 
           expect(subject).to receive(:record_submission_failure_client_qualification).with(context)
@@ -356,9 +375,22 @@ RSpec.describe Form1010cg::Auditor do
       end
 
       context 'for :pdf_download' do
-        it 'calls :record pdf_download' do
+        it 'calls :record_pdf_download' do
           expect(subject).to receive(:record_pdf_download)
           subject.record(:pdf_download)
+        end
+      end
+
+      context 'for :attachments_delivered' do
+        it 'calls :record_attachments_delivered' do
+          context = {
+            claim_guid: 'uuid-123',
+            carma_case_id: 'CASE_123',
+            attachments: {}
+          }
+
+          expect(subject).to receive(:record_attachments_delivered).with(context)
+          subject.record(:attachments_delivered, context)
         end
       end
     end

--- a/spec/services/form1010cg/auditor_spec.rb
+++ b/spec/services/form1010cg/auditor_spec.rb
@@ -3,10 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Form1010cg::Auditor do
-  let(:subject) do
-    described_class.new(Rails.logger)
-  end
-
   before(:all) do
     # StatsD is configured to use Rails.logger in order to output the stats that are being incremented in our app.
     # Since our methods calls StatsD#increment, it will create a log output using Rails.logger.
@@ -25,6 +21,10 @@ RSpec.describe Form1010cg::Auditor do
     it 'accepts a logger' do
       expect(described_class.new(Rails.logger).logger).to eq(Rails.logger)
       expect(described_class.new(Sidekiq.logger).logger).to eq(Sidekiq.logger)
+    end
+
+    it 'sets the default logger to Rails.logger' do
+      expect(described_class.new.logger).to eq(Rails.logger)
     end
   end
 

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe Form1010cg::Service do
     it 'is using Rails.logger' do
       expect(described_class::AUDITOR.logger).to eq(Rails.logger)
     end
-
-    it 'is always the same instance of Form1010cg::Auditor' do
-      expect(described_class::AUDITOR.object_id).to eq(described_class::AUDITOR.object_id)
-    end
   end
 
   describe '::new' do

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -9,6 +9,20 @@ RSpec.describe Form1010cg::Service do
   let(:subject) { described_class.new build(:caregivers_assistance_claim) }
   let(:default_email_on_mvi_search) { 'no-email@example.com' }
 
+  describe '::auditor' do
+    it 'is an instance of Form1010cg::Auditor' do
+      expect(described_class::AUDITOR).to be_an_instance_of(Form1010cg::Auditor)
+    end
+
+    it 'is using Rails.logger' do
+      expect(described_class::AUDITOR.logger).to eq(Rails.logger)
+    end
+
+    it 'is always the same instance of Form1010cg::Auditor' do
+      expect(described_class::AUDITOR.object_id).to eq(described_class::AUDITOR.object_id)
+    end
+  end
+
   describe '::new' do
     it 'requires a claim' do
       expect { described_class.new }.to raise_error do |e|
@@ -403,7 +417,7 @@ RSpec.describe Form1010cg::Service do
             double(status: 'OK', profile: double(icn: :ICN_123))
           )
 
-          expect(Form1010cg::Auditor.instance).to receive(:log_mpi_search_result).with(
+          expect(described_class::AUDITOR).to receive(:log_mpi_search_result).with(
             claim_guid: subject.claim.guid,
             form_subject: form_subject,
             result: :found
@@ -419,7 +433,7 @@ RSpec.describe Form1010cg::Service do
             double(status: 'NOT_FOUND', error: double)
           )
 
-          expect(Form1010cg::Auditor.instance).to receive(:log_mpi_search_result).with(
+          expect(described_class::AUDITOR).to receive(:log_mpi_search_result).with(
             claim_guid: subject.claim.guid,
             form_subject: form_subject,
             result: :not_found
@@ -445,7 +459,7 @@ RSpec.describe Form1010cg::Service do
 
         # Only testing for caregivers, since veteran requires an SSN
         %w[primaryCaregiver secondaryCaregiverOne secondaryCaregiverTwo].each do |form_subject|
-          expect(Form1010cg::Auditor.instance).to receive(:log_mpi_search_result).with(
+          expect(described_class::AUDITOR).to receive(:log_mpi_search_result).with(
             claim_guid: subject.claim.guid,
             form_subject: form_subject,
             result: :skipped
@@ -461,7 +475,7 @@ RSpec.describe Form1010cg::Service do
         )
 
         # Exception would be raised if this is called more (or less than) than one time
-        expect(Form1010cg::Auditor.instance).to receive(:log_mpi_search_result).with(
+        expect(described_class::AUDITOR).to receive(:log_mpi_search_result).with(
           claim_guid: subject.claim.guid,
           form_subject: 'veteran',
           result: :found

--- a/spec/workers/form1010cg/deliver_pdf_to_carma_job_spec.rb
+++ b/spec/workers/form1010cg/deliver_pdf_to_carma_job_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Form1010cg::DeliverPdfToCARMAJob do
 
       shared_examples 'a successful job' do
         let(:attachments) { double('attachments') }
+        let(:auditor) { double('auditor') }
 
         before do
           expect_any_instance_of(SavedClaim::CaregiversAssistanceClaim).to receive(:to_pdf).and_return(pdf_file_path)
@@ -38,7 +39,6 @@ RSpec.describe Form1010cg::DeliverPdfToCARMAJob do
 
           expect(attachments).to receive(:to_hash).and_return(:ATTACHMENTS_HASH)
 
-          auditor = double
           expect(Form1010cg::Auditor).to receive(:new).with(Sidekiq.logger).and_return(auditor)
           expect(auditor).to receive(:record).with(
             :attachments_delivered,

--- a/spec/workers/form1010cg/deliver_pdf_to_carma_job_spec.rb
+++ b/spec/workers/form1010cg/deliver_pdf_to_carma_job_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Form1010cg::DeliverPdfToCARMAJob do
       end
 
       shared_examples 'a successful job' do
+        let(:attachments) { double('attachments') }
+
         before do
           expect_any_instance_of(SavedClaim::CaregiversAssistanceClaim).to receive(:to_pdf).and_return(pdf_file_path)
           expect(Form1010cg::Service).to receive(:submit_attachment!).with(
@@ -32,7 +34,18 @@ RSpec.describe Form1010cg::DeliverPdfToCARMAJob do
             claim.veteran_data['fullName'],
             '10-10CG',
             pdf_file_path
-          ).and_return(:submission)
+          ).and_return(attachments)
+
+          expect(attachments).to receive(:to_hash).and_return(:ATTACHMENTS_HASH)
+
+          auditor = double
+          expect(Form1010cg::Auditor).to receive(:new).with(Sidekiq.logger).and_return(auditor)
+          expect(auditor).to receive(:record).with(
+            :attachments_delivered,
+            claim_guid: claim_guid,
+            carma_case_id: submission.carma_case_id,
+            attachments: :ATTACHMENTS_HASH
+          )
         end
 
         after do
@@ -121,7 +134,7 @@ RSpec.describe Form1010cg::DeliverPdfToCARMAJob do
             it_behaves_like 'a successful job' do
               before do
                 expect(File).to receive(:delete).with(pdf_file_path).and_raise(pdf_delete_exception)
-                expect(Rails.logger).to receive(:error).with(pdf_delete_exception)
+                expect(Sidekiq.logger).to receive(:error).with(pdf_delete_exception)
               end
             end
           end


### PR DESCRIPTION
Fixes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17468

**Summary**
- [x] Update `Form1010cg::Auditor` to accept a logger
- [x] Update reference of `Form1010cg::Auditor`
- [x] Add a Logging event for **Attachments Delivered**
- [x] Log when `Form1010cg::DeliverPdfToCARMAJob` succeeds
