### PR TITLE
Adding basic validations to the CovidVaccine form data

### DIFF
--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
@@ -6,6 +6,8 @@ require_relative '../../../serializers/covid_vaccine/v0/registration_summary_ser
 module CovidVaccine
   module V0
     class RegistrationController < CovidVaccine::ApplicationController
+      before_action :validate_raw_form_data, only: :create
+
       def create
         raw_form_data = params[:registration].merge(attributes_from_user)
         account_id = @current_user&.account_uuid
@@ -24,6 +26,11 @@ module CovidVaccine
       end
 
       private
+
+      def validate_raw_form_data
+        form_data = CovidVaccine::V0::RawFormData.new(params[:registration] || {})
+        raise Common::Exceptions::ValidationErrors, form_data unless form_data.valid?
+      end
 
       # Merge in these attributes from the authenticated user, since
       # we won't have access to that object from the submission worker

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/raw_form_data.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/raw_form_data.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module CovidVaccine
+  module V0
+    class RawFormData
+      include ActiveModel::Validations
+
+      ATTRIBUTES = %w[email zip_code vaccine_interest].freeze
+      ZIP_REGEX = /\A^\d{5}(-\d{4})?$\z/.freeze
+
+      attr_accessor(*ATTRIBUTES)
+
+      validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+      validates :vaccine_interest, presence: true
+      validates :zip_code, format: { with: ZIP_REGEX, message: 'should be in the form 12345 or 12345-1234' }
+
+      def initialize(attributes = {})
+        attributes.each do |name, value|
+          send("#{name}=", value) if name.to_s.in?(ATTRIBUTES)
+        end
+      end
+    end
+  end
+end

--- a/modules/covid_vaccine/spec/models/covid_vaccine/v0/raw_form_data_spec.rb
+++ b/modules/covid_vaccine/spec/models/covid_vaccine/v0/raw_form_data_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CovidVaccine::V0::RawFormData, type: :model do
+  subject { described_class.new(attributes) }
+
+  describe 'with valid attributes' do
+    let(:attributes) { { email: 'jane.doe@email.com', zip_code: '12345-1234', vaccine_interest: 'yes' } }
+
+    it 'is valid with valid attributes' do
+      expect(subject).to be_valid
+    end
+  end
+
+  describe '', :aggregate_failures do
+    context 'without presence of email' do
+      let(:attributes) { { zip_code: '12345-1234', vaccine_interest: 'yes' } }
+
+      it 'is not valid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.full_messages)
+          .to eq(['Email is invalid'])
+      end
+    end
+
+    context 'with an invalid email address' do
+      let(:attributes) { { email: 'jane.doe@', zip_code: '12345-1234', vaccine_interest: 'yes' } }
+
+      it 'is not valid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.full_messages)
+          .to eq(['Email is invalid'])
+      end
+    end
+
+    context 'without presence of zip_code' do
+      let(:attributes) { { email: 'jane.doe@email.com', vaccine_interest: 'yes' } }
+
+      it 'is not valid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.full_messages)
+          .to eq(['Zip code should be in the form 12345 or 12345-1234'])
+      end
+    end
+
+    context 'with an invalid zip_code' do
+      let(:attributes) { { email: 'jane.doe@email.com', zip_code: '1234', vaccine_interest: 'yes' } }
+
+      it 'is not valid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.full_messages)
+          .to eq(['Zip code should be in the form 12345 or 12345-1234'])
+      end
+    end
+
+    context 'without presence of vaccine_interest' do
+      let(:attributes) { { email: 'jane.doe@email.com', zip_code: '12345-1234' } }
+
+      it 'is not valid without the presence of vaccine_interest' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.full_messages)
+          .to eq(["Vaccine interest can't be blank"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This introduces validations on `%w[email zip_code vaccine_interest]`.

email validation is performed using REGEX from `URI::MailTo::EMAIL_REGEXP`
zip_code validation is performed using REGEX = /\A^\d{5}(-\d{4})?$\z/
vaccine_interest is just a non blank, presence check.
