### PR TITLE
Create dir before creating file in Form 10-10cg attachment job spec

### DIFF
--- a/spec/workers/form1010cg/deliver_pdf_to_carma_job_spec.rb
+++ b/spec/workers/form1010cg/deliver_pdf_to_carma_job_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe Form1010cg::DeliverPdfToCARMAJob do
         submission.save!
 
         # Create the file contents of the claim to match the request body in the VCR (carma/attachments/upload/201)
+        Dir.mkdir('tmp/pdfs') unless File.exist?('tmp/pdfs')
         File.open(file_path, 'w') { |f| f.write('<PDF_CONTENTS>') }
         expect_any_instance_of(SavedClaim::CaregiversAssistanceClaim).to receive(:to_pdf).and_return(file_path)
       end


### PR DESCRIPTION
**Description**
Create the `tmp/pdfs` directory before creating a fixture file in `Form1010cg::DeliverPdfToCARMAJob` spec. This is to resolve the issue of Jenkins build failing because the file in the test cannot be generated.

```

[2020-12-15T14:33:32.395Z] Failures:
[2020-12-15T14:33:32.395Z] 
[2020-12-15T14:33:32.395Z]   1) Form1010cg::DeliverPdfToCARMAJob#perform integration processes attachment
[2020-12-15T14:33:32.395Z]      Got 1 failure and 1 other error:
[2020-12-15T14:33:32.395Z] 
[2020-12-15T14:33:32.395Z]      1.1) Failure/Error: File.open(file_path, 'w') { |f| f.write('<PDF_CONTENTS>') }
[2020-12-15T14:33:32.395Z] 
[2020-12-15T14:33:32.395Z]           Errno::ENOENT:
[2020-12-15T14:33:32.395Z]             No such file or directory @ rb_sysopen - tmp/pdfs/10-10CG_c41b7fe0-f1f3-4611-9c56-a97fb3884cf8.pdf
[2020-12-15T14:33:32.395Z]           # ./spec/workers/form1010cg/deliver_pdf_to_carma_job_spec.rb:176:in `initialize'
[2020-12-15T14:33:32.395Z]           # ./spec/workers/form1010cg/deliver_pdf_to_carma_job_spec.rb:176:in `open'
[2020-12-15T14:33:32.396Z]           # ./spec/workers/form1010cg/deliver_pdf_to_carma_job_spec.rb:176:in `block (4 levels) in <top (required)>'
[2020-12-15T14:33:32.396Z]           # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
[2020-12-15T14:33:32.396Z]           # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
[2020-12-15T14:33:32.396Z]           # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
[2020-12-15T14:33:32.396Z]           # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
[2020-12-15T14:33:32.396Z]           # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
[2020-12-15T14:33:32.396Z]           # ./spec/spec_helper.rb:140:in `block (2 levels) in <top (required)>'
```

example: http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-api/detail/PR-5427/29/pipeline/
