### PR TITLE
Tightens up guard around covid vaccine MPI query

### DIFF
--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/raw_form_data.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/raw_form_data.rb
@@ -5,7 +5,7 @@ module CovidVaccine
     class RawFormData
       include ActiveModel::Validations
 
-      ATTRIBUTES = %w[email zip_code vaccine_interest].freeze
+      ATTRIBUTES = %w[email zip_code vaccine_interest birth_date].freeze
       ZIP_REGEX = /\A^\d{5}(-\d{4})?$\z/.freeze
 
       attr_accessor(*ATTRIBUTES)
@@ -13,6 +13,8 @@ module CovidVaccine
       validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
       validates :vaccine_interest, presence: true
       validates :zip_code, format: { with: ZIP_REGEX, message: 'should be in the form 12345 or 12345-1234' }
+      validates :birth_date, format: /\A\d{4}-\d{2}-\d{2}\z/, allow_blank: true
+
 
       def initialize(attributes = {})
         attributes.each do |name, value|

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/raw_form_data.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/raw_form_data.rb
@@ -13,7 +13,7 @@ module CovidVaccine
       validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
       validates :vaccine_interest, presence: true
       validates :zip_code, format: { with: ZIP_REGEX, message: 'should be in the form 12345 or 12345-1234' }
-      validates :birth_date, format: /\A\d{4}-\d{2}-\d{2}\z/, allow_blank: true
+      validates :birth_date, format: { with: /\A\d{4}-\d{2}-\d{2}\z/, message: 'should be in the form yyyy-mm-dd' }, allow_blank: true
 
 
       def initialize(attributes = {})

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/raw_form_data.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/raw_form_data.rb
@@ -13,8 +13,8 @@ module CovidVaccine
       validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
       validates :vaccine_interest, presence: true
       validates :zip_code, format: { with: ZIP_REGEX, message: 'should be in the form 12345 or 12345-1234' }
-      validates :birth_date, format: { with: /\A\d{4}-\d{2}-\d{2}\z/, message: 'should be in the form yyyy-mm-dd' }, allow_blank: true
-
+      validates :birth_date, format: { with: /\A\d{4}-\d{2}-\d{2}\z/, message: 'should be in the form yyyy-mm-dd' },
+                             allow_blank: true
 
       def initialize(attributes = {})
         attributes.each do |name, value|

--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/registration_service.rb
@@ -99,10 +99,22 @@ module CovidVaccine
         end
       end
 
-      # if user_type == loa3, then we already had the information from their
-      # authenticated session and added it to the raw form data
+      ## Guard around MPI query
+      # 1. If user_type == loa3, we already have their information from MPI in the
+      # authenticated session
+      # 2. If not all of the required MPI query keys are present, we can't query MPI
+      # 3. If a partial, unparseable date of birth was submitted, we can't query MPI
+      #
       def should_query_mpi?(form_data, user_type)
-        user_type != 'loa3' && (REQUIRED_QUERY_TRAITS & form_data.keys).size == REQUIRED_QUERY_TRAITS.size
+        return false if user_type == 'loa3'
+        return false unless (REQUIRED_QUERY_TRAITS & form_data.keys).size == REQUIRED_QUERY_TRAITS.size
+
+        begin
+          Date.parse(form_data['birth_date'])
+        rescue ArgumentError
+          return false
+        end
+        true
       end
     end
   end

--- a/modules/covid_vaccine/spec/factories/registration_submissions.rb
+++ b/modules/covid_vaccine/spec/factories/registration_submissions.rb
@@ -60,6 +60,22 @@ FactoryBot.define do
     }
   end
 
+  trait :invalid_dob do
+    raw_form_data {
+      {
+        'vaccine_interest' => 'INTERESTED',
+        'zip_code' => '97212',
+        'zip_code_details' => 'YES',
+        'phone' => '808-555-1212',
+        'email' => 'foo@example.com',
+        'first_name' => 'Jon',
+        'last_name' => 'Doe',
+        'birth_date' => '1900-01-XX',
+        'ssn' => '6665123456'
+      }
+    }
+  end
+
   trait :from_loa3 do
     raw_form_data {
       {

--- a/modules/covid_vaccine/spec/models/covid_vaccine/v0/raw_form_data_spec.rb
+++ b/modules/covid_vaccine/spec/models/covid_vaccine/v0/raw_form_data_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CovidVaccine::V0::RawFormData, type: :model do
       let(:attributes) { { email: 'jane.doe@email.com', zip_code: '12345-1234',
                            vaccine_interest: 'yes', birth_date: '' } }
 
-      it 'is not valid without the presence of vaccine_interest' do
+      it 'is valid' do
         expect(subject).to be_valid
       end
     end
@@ -79,7 +79,9 @@ RSpec.describe CovidVaccine::V0::RawFormData, type: :model do
 
       it 'is not valid' do
         expect(subject).not_to be_valid
-      end
+        expect(subject.errors.full_messages)
+          .to eq(["Birth date should be in the form yyyy-mm-dd"])
+       end
     end
 
   end

--- a/modules/covid_vaccine/spec/models/covid_vaccine/v0/raw_form_data_spec.rb
+++ b/modules/covid_vaccine/spec/models/covid_vaccine/v0/raw_form_data_spec.rb
@@ -63,5 +63,24 @@ RSpec.describe CovidVaccine::V0::RawFormData, type: :model do
           .to eq(["Vaccine interest can't be blank"])
       end
     end
+
+    context 'without presence of birth_date' do
+      let(:attributes) { { email: 'jane.doe@email.com', zip_code: '12345-1234',
+                           vaccine_interest: 'yes', birth_date: '' } }
+
+      it 'is not valid without the presence of vaccine_interest' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'with a structurally invalid birth_date' do
+      let(:attributes) { { email: 'jane.doe@email.com', zip_code: '12345-1234',
+                           vaccine_interest: 'yes', birth_date: '1999-01-XX' } }
+
+      it 'is not valid' do
+        expect(subject).not_to be_valid
+      end
+    end
+
   end
 end

--- a/modules/covid_vaccine/spec/models/covid_vaccine/v0/raw_form_data_spec.rb
+++ b/modules/covid_vaccine/spec/models/covid_vaccine/v0/raw_form_data_spec.rb
@@ -65,8 +65,10 @@ RSpec.describe CovidVaccine::V0::RawFormData, type: :model do
     end
 
     context 'without presence of birth_date' do
-      let(:attributes) { { email: 'jane.doe@email.com', zip_code: '12345-1234',
-                           vaccine_interest: 'yes', birth_date: '' } }
+      let(:attributes) do
+        { email: 'jane.doe@email.com', zip_code: '12345-1234',
+          vaccine_interest: 'yes', birth_date: '' }
+      end
 
       it 'is valid' do
         expect(subject).to be_valid
@@ -74,15 +76,16 @@ RSpec.describe CovidVaccine::V0::RawFormData, type: :model do
     end
 
     context 'with a structurally invalid birth_date' do
-      let(:attributes) { { email: 'jane.doe@email.com', zip_code: '12345-1234',
-                           vaccine_interest: 'yes', birth_date: '1999-01-XX' } }
+      let(:attributes) do
+        { email: 'jane.doe@email.com', zip_code: '12345-1234',
+          vaccine_interest: 'yes', birth_date: '1999-01-XX' }
+      end
 
       it 'is not valid' do
         expect(subject).not_to be_valid
         expect(subject.errors.full_messages)
-          .to eq(["Birth date should be in the form yyyy-mm-dd"])
-       end
+          .to eq(['Birth date should be in the form yyyy-mm-dd'])
+      end
     end
-
   end
 end

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/registration_request_spec.rb
@@ -116,13 +116,13 @@ RSpec.describe 'Covid Vaccine Registration', type: :request do
       end
 
       it 'returns an error on a malformed date' do
-        invalid_date_attributes = registration_attributes.merge({birth_date: '2000-01-XX'})
+        invalid_date_attributes = registration_attributes.merge({ birth_date: '2000-01-XX' })
         post '/covid_vaccine/v0/registration', params: { registration: invalid_date_attributes }
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it 'allows a non-existent date' do
-        blank_date_attributes = registration_attributes.merge({birth_date: ''})
+        blank_date_attributes = registration_attributes.merge({ birth_date: '' })
         post '/covid_vaccine/v0/registration', params: { registration: blank_date_attributes }
         expect(response).to have_http_status(:created)
       end

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/registration_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Covid Vaccine Registration', type: :request do
       authenticated: true,
       first_name: 'Jane',
       last_name: 'Doe',
-      birth_date: '2/2/1952',
+      birth_date: '1952-02-02',
       phone: '555-555-1234',
       email: 'jane.doe@email.com',
       ssn: '000-00-0022',
@@ -113,6 +113,18 @@ RSpec.describe 'Covid Vaccine Registration', type: :request do
             ]
           }
         )
+      end
+
+      it 'returns an error on a malformed date' do
+        invalid_date_attributes = registration_attributes.merge({birth_date: '2000-01-XX'})
+        post '/covid_vaccine/v0/registration', params: { registration: invalid_date_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'allows a non-existent date' do
+        blank_date_attributes = registration_attributes.merge({birth_date: ''})
+        post '/covid_vaccine/v0/registration', params: { registration: blank_date_attributes }
+        expect(response).to have_http_status(:created)
       end
 
       it 'returns a submission summary' do

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/registration_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/registration_service_spec.rb
@@ -120,6 +120,22 @@ describe CovidVaccine::V0::RegistrationService do
             .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
         end
       end
+
+      context 'with an unparseable date attribute' do
+        let(:bad_date_submission) do
+          build(:covid_vax_registration,
+                :unsubmitted,
+                :invalid_dob)
+        end
+
+        it 'omits MPI query' do
+          expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+            .and_return({ sid: SecureRandom.uuid })
+          expect_any_instance_of(MPI::Service).not_to receive(:find_profile)
+          expect { subject.register(bad_date_submission, 'unauthenticated') }
+            .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
+        end
+      end
     end
 
     context 'authenticated LOA3' do


### PR DESCRIPTION


## Description of change
Adds check that date is valid enough to be turned into an MPI query,
since it is possible for a partial date like '2000-12-XX" to be submitted.

Solves this Sentry issue: http://sentry.vfs.va.gov/organizations/vsp/issues/11421/events/523bfe0e64124ad989fbed943b7ee779/?query=is%3Aunresolved+CovidVaccine&statsPeriod=14d

We can also tighten up the frontend submission, but we want to add this PR so that current submissions with this issue will be retried succesfully by sidekiq.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR


<!-- Please describe testing done to verify the changes or any testing planned. -->
Added spec based on observed production behavior.