### PR TITLE
[bugfix] Add missing tag to bdd metrics

### DIFF
--- a/app/workers/evss/disability_compensation_form/job_status.rb
+++ b/app/workers/evss/disability_compensation_form/job_status.rb
@@ -70,7 +70,7 @@ module EVSS
       def job_success
         upsert_job_status(Form526JobStatus::STATUS[:success])
         log_info('success')
-        metrics.increment_success
+        metrics.increment_success(@is_bdd)
       rescue => e
         Rails.logger.error('error tracking job success', error: e, class: klass)
       end

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -54,7 +54,9 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
             updated_at: Time.now.utc
           }
           Form526JobStatus.upsert(values, unique_by: :job_id)
-
+          expect_any_instance_of(EVSS::DisabilityCompensationForm::Metrics).to(
+            receive(:increment_success).with(false).once
+          )
           described_class.drain
           job_status = Form526JobStatus.where(job_id: values[:job_id]).first
           expect(job_status.status).to eq 'success'


### PR DESCRIPTION
## Description of change
This graph was missing the bdd tag for success http://grafana.vfs.va.gov/d/000000066/form-526-disability-compensation?viewPanel=24&orgId=1&from=now-7d&to=now


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
