### PR TITLE
Avoids reporting CovidVaX RecordNotFound to Sentry

### DIFF
--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
@@ -6,6 +6,8 @@ require_relative '../../../serializers/covid_vaccine/v0/registration_summary_ser
 module CovidVaccine
   module V0
     class RegistrationController < CovidVaccine::ApplicationController
+      include IgnoreNotFound
+
       before_action :validate_raw_form_data, only: :create
 
       def create


### PR DESCRIPTION
## Description of change
Adds mix-in to avoid reporting the expected RecordNotFound errors from the `#show` method in Sentry.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
