### PR TITLE
17325 prevent multiple mhv id error from logging sentry

### DIFF
--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -743,6 +743,29 @@ RSpec.describe V0::SessionsController, type: :controller do
           end
         end
       end
+
+      context 'when user has multiple distinct mhv ids' do
+        let(:expected_error_message) { SAML::UserAttributeError::ERRORS[:multiple_mhv_ids][:message] }
+        let(:expected_warn_message) do
+          "SessionsController version:v0 context:{} message:#{expected_error_message}"
+        end
+
+        before do
+          allow(UserSessionForm).to receive(:new).and_raise(
+            SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_mhv_ids]
+          )
+        end
+
+        it 'logs an info message to rails logger' do
+          expect(Rails.logger).to receive(:warn).with(expected_warn_message)
+          post(:saml_callback)
+        end
+
+        it 'does not log to sentry' do
+          expect(controller).not_to receive(:log_message_to_sentry)
+          post(:saml_callback)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION


## Description of change
This PR prevents the specific SAML callback error, when a user has multiple MHV IDs, from logging to sentry, instead choosing simply to log a warning to the Rails logger. We are doing this because although this results in an error response, it is expected and the user has a route to fix the issue, despite not being to log in. We decided this sort of error was just polluting Sentry at the moment.

## Original issue(s)
department-of-veterans-affairs/va.gov-team/issues/17325

## Things to know about this PR
* We should watch sentry after merging this PR to make sure we are indeed not getting this type of error anymore.
* It may be useful to set up a dashboard and come up with some metrics for the multiple mhv id error

* To test this, in `lib/saml/user_attributes/ssoe.rb`, I hacked the `def mhv_id_mismatch?`to just return `true`,
* Then confirmed that the user was not logged in, and in the Rails console, confirmed that a warning `SessionsController version:v1 context:{} message:User attributes contain multiple distinct MHV ID values` was logged
