### PR TITLE
fix non-performant query

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -31,8 +31,20 @@ class Account < ApplicationRecord
   redis REDIS_CONFIG[:user_account_details][:namespace]
   redis_ttl REDIS_CONFIG[:user_account_details][:each_ttl]
 
-  scope :idme_uuid_match, ->(v) { where(idme_uuid: v).where.not(idme_uuid: nil) }
-  scope :sec_id_match, ->(v) { where(sec_id: v).where.not(sec_id: nil) }
+  scope :idme_uuid_match, lambda { |v|
+                            if v.present?
+                              where(idme_uuid: v)
+                            else
+                              where('1 = 0')
+                            end
+                          }
+  scope :sec_id_match, lambda { |v|
+                         if v.present?
+                           where(sec_id: v)
+                         else
+                           where('1 = 0')
+                         end
+                       }
 
   # Returns the one Account record for the passed in user.
   #


### PR DESCRIPTION
## Description of change
our least performant query is 

`SELECT "accounts".* FROM "accounts" WHERE ("accounts"."idme_uuid" = $1 AND "accounts"."idme_uuid" IS NOT NULL OR "accounts"."sec_id" IS NULL AND "accounts"."sec_id" IS NOT NULL)`

{"total"=>44972.5460984851, "avg"=>1267.0309644372}

It's meant to be “match whichever id we have, but make sure we don’t match a nil id”

but `OR "accounts"."sec_id" IS NULL AND "accounts"."sec_id" IS NOT NULL` is bad news when `OR 1=0` would do. 
## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
