### PR TITLE
API-4100: ClaimsApi::ReportUnsuccessfulSubmissions erroring out due to the gsub of an array type

### DIFF
--- a/modules/claims_api/app/workers/claims_api/report_unsuccessful_submissions.rb
+++ b/modules/claims_api/app/workers/claims_api/report_unsuccessful_submissions.rb
@@ -30,8 +30,8 @@ module ClaimsApi
       generized_errors = errored.map do |error|
         if error.evss_response.present?
           uuid_regex = /[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/
-          error.evss_response = error.evss_response.gsub(uuid_regex, '%<uuid>')
-          error.evss_response = error.evss_response.gsub(/\d{5,}/, '%<number>')
+          error.evss_response = error.evss_response.to_s.gsub(uuid_regex, '%<uuid>')
+          error.evss_response = error.evss_response.to_s.gsub(/\d{5,}/, '%<number>')
           begin
             error.evss_response = JSON.parse(error.evss_response.gsub('=>', ':'))
           rescue

--- a/modules/claims_api/spec/workers/report_unsuccessful_submissions_spec.rb
+++ b/modules/claims_api/spec/workers/report_unsuccessful_submissions_spec.rb
@@ -3,7 +3,26 @@
 require 'rails_helper'
 
 RSpec.describe ClaimsApi::ReportUnsuccessfulSubmissions, type: :job do
-  let(:errored_upload) { FactoryBot.create(:auto_established_claim, :status_errored, source: 'test consumer') }
+  let(:errored_upload) do
+    FactoryBot.create(:auto_established_claim,
+                      :status_errored,
+                      source: 'test consumer',
+                      evss_response: nil)
+    FactoryBot.create(:auto_established_claim,
+                      :status_errored,
+                      source: 'test consumer',
+                      evss_response: 'random string')
+
+    evss_response_array = [{ 'key' => 'key-here', 'severity' => 'FATAL', 'text' => 'message-here' }]
+    FactoryBot.create(:auto_established_claim,
+                      :status_errored,
+                      source: 'test consumer',
+                      evss_response: evss_response_array)
+    FactoryBot.create(:auto_established_claim,
+                      :status_errored,
+                      source: 'test consumer',
+                      evss_response: evss_response_array.to_json)
+  end
   let(:pending) { FactoryBot.create(:auto_established_claim, source: 'test consumer') }
 
   describe '#perform' do
@@ -30,6 +49,19 @@ RSpec.describe ClaimsApi::ReportUnsuccessfulSubmissions, type: :job do
       end
     end
 
+    it 'group errors' do
+      with_settings(Settings.claims_api,
+                    report_enabled: true) do
+        errored_upload
+
+        job = described_class.new
+        job.perform
+        grouped_errors = job.errored_grouped
+
+        expect(grouped_errors.count).to eq(3)
+      end
+    end
+
     it 'calculate totals' do
       with_settings(Settings.claims_api,
                     report_enabled: true) do
@@ -41,7 +73,7 @@ RSpec.describe ClaimsApi::ReportUnsuccessfulSubmissions, type: :job do
         totals = job.totals
 
         expect(totals.first.keys).to eq(['test consumer'])
-        expect(totals.first.values.first[:error_rate]).to eq('50%')
+        expect(totals.first.values.first[:error_rate]).to eq('80%')
       end
     end
   end


### PR DESCRIPTION
## Description of change
Resolve report issue if evss_response is anything but a string

## Original issue(s)
https://vajira.max.gov/browse/API-4100

## Things to know about this PR
Tested via email previews.
Added spec test.
