### PR TITLE
API-4095 Veteran Confirmation - Handle empty EMIS responses

### DIFF
--- a/modules/veteran_confirmation/app/services/veteran_confirmation/status_service.rb
+++ b/modules/veteran_confirmation/app/services/veteran_confirmation/status_service.rb
@@ -25,7 +25,7 @@ module VeteranConfirmation
       emis_resp = veteran_status_service.get_veteran_status(edipi_or_icn_option(mvi_resp.profile))
       return NOT_CONFIRMED if emis_resp.error?
 
-      emis_resp.items.first.title38_status_code == 'V1' ? CONFIRMED : NOT_CONFIRMED
+      emis_resp.items.first&.title38_status_code == 'V1' ? CONFIRMED : NOT_CONFIRMED
     end
 
     private

--- a/modules/veteran_confirmation/spec/services/veteran_confirmation/status_service_spec.rb
+++ b/modules/veteran_confirmation/spec/services/veteran_confirmation/status_service_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe VeteranConfirmation::StatusService do
       response
     end
 
+    let(:empty_veteran_status_response) do
+      response = double
+      allow(response).to receive(:items).and_return([])
+      allow(response).to receive(:error?).and_return(false)
+      response
+    end
+
     let(:emis_error) { EMIS::Responses::ErrorResponse.new('Failed in eMIS') }
 
     context 'when betamocks emis passed valid attributes' do
@@ -111,6 +118,18 @@ RSpec.describe VeteranConfirmation::StatusService do
 
         expect_any_instance_of(EMIS::VeteranStatusService).to receive(:get_veteran_status)
           .and_return(emis_error)
+
+        result = subject.get_by_attributes(valid_attributes)
+
+        expect(result).to eq('not confirmed')
+      end
+
+      it 'does not confirm if EMIS returns an empty response' do
+        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+          .and_return(mvi_profile)
+
+        expect_any_instance_of(EMIS::VeteranStatusService).to receive(:get_veteran_status)
+          .and_return(empty_veteran_status_response)
 
         result = subject.get_by_attributes(valid_attributes)
 


### PR DESCRIPTION
## Description of change
API-4095 Veteran Confirmation - Handle empty EMIS responses


## Original issue(s)
https://vajira.max.gov/browse/API-4095

## Things to know about this PR
Handles empty eMIS response rather than hitting `undefined method `title38_status_code' for nil:NilClass`.

Tested locally and also added rspec for empty items array case.