### PR TITLE
Api 3866 remove unecessary swss headers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ PATH
 
 GEM
   remote: https://rubygems.org/
+  remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.0.3)
     aasm (5.0.6)
@@ -331,6 +332,7 @@ GEM
     e2mmap (0.1.0)
     ecma-re-validator (0.2.0)
       regexp_parser (~> 1.2)
+    einhorn (0.7.4)
     encryptor (3.0.0)
     equalizer (0.0.11)
     erubi (1.9.0)
@@ -766,6 +768,13 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 4.2)
+    sidekiq-ent (1.8.1)
+      einhorn (= 0.7.4)
+      sidekiq (>= 5.2.3)
+      sidekiq-pro (>= 4.0.4)
+    sidekiq-pro (5.0.0)
+      concurrent-ruby (>= 1.0.5)
+      sidekiq (>= 5.2.7)
     sidekiq-scheduler (3.0.1)
       e2mmap
       redis (>= 3, < 5)
@@ -988,6 +997,8 @@ DEPENDENCIES
   sentry-raven
   shrine
   sidekiq (~> 5.0)
+  sidekiq-ent!
+  sidekiq-pro!
   sidekiq-scheduler (~> 3.0)
   simplecov (< 0.18)
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,6 @@ PATH
 
 GEM
   remote: https://rubygems.org/
-  remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.0.3)
     aasm (5.0.6)
@@ -332,7 +331,6 @@ GEM
     e2mmap (0.1.0)
     ecma-re-validator (0.2.0)
       regexp_parser (~> 1.2)
-    einhorn (0.7.4)
     encryptor (3.0.0)
     equalizer (0.0.11)
     erubi (1.9.0)
@@ -768,13 +766,6 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 4.2)
-    sidekiq-ent (1.8.1)
-      einhorn (= 0.7.4)
-      sidekiq (>= 5.2.3)
-      sidekiq-pro (>= 4.0.4)
-    sidekiq-pro (5.0.0)
-      concurrent-ruby (>= 1.0.5)
-      sidekiq (>= 5.2.7)
     sidekiq-scheduler (3.0.1)
       e2mmap
       redis (>= 3, < 5)
@@ -997,8 +988,6 @@ DEPENDENCIES
   sentry-raven
   shrine
   sidekiq (~> 5.0)
-  sidekiq-ent!
-  sidekiq-pro!
   sidekiq-scheduler (~> 3.0)
   simplecov (< 0.18)
   spring

--- a/lib/okta/service.rb
+++ b/lib/okta/service.rb
@@ -34,10 +34,6 @@ module Okta
       end
     end
 
-    def get_url_no_token(url)
-      Okta::Response.new call_no_token('get', url)
-    end
-
     def app(app_id)
       with_monitoring do
         get_url_with_token("#{APP_API_BASE_PATH}/#{app_id}")
@@ -94,6 +90,10 @@ module Okta
       define_method("#{http_verb}_url_with_token".to_sym) do |url|
         Okta::Response.new call_with_token(http_verb, url)
       end
+    end
+
+    def get_url_no_token(url)
+      Okta::Response.new call_no_token('get', url)
     end
   end
 end

--- a/lib/okta/service.rb
+++ b/lib/okta/service.rb
@@ -65,16 +65,16 @@ module Okta
     def metadata(iss)
       proxied_iss = iss.gsub(Settings.oidc.issuer_prefix, Settings.oidc.base_api_url + 'oauth2')
       with_monitoring do
-        get(proxied_iss + '/.well-known/openid-configuration', {},
-            { 'Content-Type' => 'application/json', 'accept' => 'application/json' }, {})
+        Okta::Response.new get(proxied_iss + '/.well-known/openid-configuration', {},
+                               { 'Content-Type' => 'application/json', 'accept' => 'application/json' }, {})
       end
     end
 
     def oidc_jwks_keys(iss)
       url = metadata(iss).body['jwks_uri']
       with_monitoring do
-        get(url, {},
-            { 'Content-Type' => 'application/json', 'accept' => 'application/json' }, {})
+        Okta::Response.new get(url, {},
+                               { 'Content-Type' => 'application/json', 'accept' => 'application/json' }, {})
       end
     end
 

--- a/lib/okta/service.rb
+++ b/lib/okta/service.rb
@@ -65,14 +65,16 @@ module Okta
     def metadata(iss)
       proxied_iss = iss.gsub(Settings.oidc.issuer_prefix, Settings.oidc.base_api_url + 'oauth2')
       with_monitoring do
-        get_url_with_token(proxied_iss + '/.well-known/openid-configuration')
+        get(proxied_iss + '/.well-known/openid-configuration', {},
+            { 'Content-Type' => 'application/json', 'accept' => 'application/json' }, {})
       end
     end
 
     def oidc_jwks_keys(iss)
       url = metadata(iss).body['jwks_uri']
       with_monitoring do
-        get_url_with_token(url)
+        get(url, {},
+            { 'Content-Type' => 'application/json', 'accept' => 'application/json' }, {})
       end
     end
 

--- a/lib/okta/service.rb
+++ b/lib/okta/service.rb
@@ -34,6 +34,10 @@ module Okta
       end
     end
 
+    def get_url_no_token(url)
+      Okta::Response.new call_no_token('get', url)
+    end
+
     def app(app_id)
       with_monitoring do
         get_url_with_token("#{APP_API_BASE_PATH}/#{app_id}")
@@ -89,12 +93,6 @@ module Okta
     %i[get post put delete].each do |http_verb|
       define_method("#{http_verb}_url_with_token".to_sym) do |url|
         Okta::Response.new call_with_token(http_verb, url)
-      end
-    end
-
-    %i[get].each do |http_verb|
-      define_method("#{http_verb}_url_no_token".to_sym) do |url|
-        Okta::Response.new call_no_token(http_verb, url)
       end
     end
   end

--- a/lib/okta/service.rb
+++ b/lib/okta/service.rb
@@ -26,7 +26,7 @@ module Okta
       end
     end
 
-    def call(action, url)
+    def call_no_token(action, url)
       connection.send(action) do |req|
         req.url url
         req.headers['Content-Type'] = 'application/json'
@@ -73,14 +73,14 @@ module Okta
     def metadata(iss)
       proxied_iss = iss.gsub(Settings.oidc.issuer_prefix, Settings.oidc.base_api_url + 'oauth2')
       with_monitoring do
-        get_url(proxied_iss + '/.well-known/openid-configuration')
+        get_url_no_token(proxied_iss + '/.well-known/openid-configuration')
       end
     end
 
     def oidc_jwks_keys(iss)
       url = metadata(iss).body['jwks_uri']
       with_monitoring do
-        get_url(url)
+        get_url_no_token(url)
       end
     end
 
@@ -93,8 +93,8 @@ module Okta
     end
 
     %i[get post put delete].each do |http_verb|
-      define_method("#{http_verb}_url".to_sym) do |url|
-        Okta::Response.new call(http_verb, url)
+      define_method("#{http_verb}_url_no_token".to_sym) do |url|
+        Okta::Response.new call_no_token(http_verb, url)
       end
     end
   end

--- a/lib/okta/service.rb
+++ b/lib/okta/service.rb
@@ -92,7 +92,7 @@ module Okta
       end
     end
 
-    %i[get post put delete].each do |http_verb|
+    %i[get].each do |http_verb|
       define_method("#{http_verb}_url_no_token".to_sym) do |url|
         Okta::Response.new call_no_token(http_verb, url)
       end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

Calls to the okta metadata endpoint and keys endpoint do not require a ssws key. Vets-API calls were using this key. Since it is sensitive information, the key should not be used when unnecessary.

## Original issue(s)
https://vajira.max.gov/browse/API-3866
## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
[API3866_Tests.docx](https://github.com/department-of-veterans-affairs/vets-api/files/5712439/API3866_Tests.docx)