### PR TITLE
Add db indexes

### DIFF
--- a/db/migrate/20201217223026_add_missing_indexes.rb
+++ b/db/migrate/20201217223026_add_missing_indexes.rb
@@ -1,0 +1,14 @@
+class AddMissingIndexes < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :async_transactions, :created_at, algorithm: :concurrently
+    add_index :base_facilities, :lat, algorithm: :concurrently
+    add_index :claims_api_auto_established_claims, :evss_id, algorithm: :concurrently
+    add_index :claims_api_auto_established_claims, :md5, algorithm: :concurrently
+    add_index :education_benefits_submissions, :created_at, algorithm: :concurrently
+    add_index :evss_claims, :evss_id, algorithm: :concurrently
+    add_index :evss_claims, :updated_at, algorithm: :concurrently
+    add_index :mhv_accounts, :mhv_correlation_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_11_213957) do
+ActiveRecord::Schema.define(version: 2020_12_17_223026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2020_12_11_213957) do
     t.datetime "updated_at", null: false
     t.string "encrypted_metadata"
     t.string "encrypted_metadata_iv"
+    t.index ["created_at"], name: "index_async_transactions_on_created_at"
     t.index ["source_id"], name: "index_async_transactions_on_source_id"
     t.index ["transaction_id", "source"], name: "index_async_transactions_on_transaction_id_and_source", unique: true
     t.index ["transaction_id"], name: "index_async_transactions_on_transaction_id"
@@ -97,6 +98,7 @@ ActiveRecord::Schema.define(version: 2020_12_11_213957) do
     t.boolean "mobile"
     t.string "active_status"
     t.string "visn"
+    t.index ["lat"], name: "index_base_facilities_on_lat"
     t.index ["location"], name: "index_base_facilities_on_location", using: :gist
     t.index ["name"], name: "index_base_facilities_on_name", opclass: :gin_trgm_ops, using: :gin
     t.index ["unique_id", "facility_type"], name: "index_base_facilities_on_unique_id_and_facility_type", unique: true
@@ -135,6 +137,8 @@ ActiveRecord::Schema.define(version: 2020_12_11_213957) do
     t.string "encrypted_bgs_flash_responses"
     t.string "encrypted_bgs_flash_responses_iv"
     t.string "flashes", default: [], array: true
+    t.index ["evss_id"], name: "index_claims_api_auto_established_claims_on_evss_id"
+    t.index ["md5"], name: "index_claims_api_auto_established_claims_on_md5"
     t.index ["source"], name: "index_claims_api_auto_established_claims_on_source"
   end
 
@@ -251,6 +255,7 @@ ActiveRecord::Schema.define(version: 2020_12_11_213957) do
     t.boolean "transfer_of_entitlement", default: false, null: false
     t.boolean "chapter1607", default: false, null: false
     t.boolean "vettec", default: false
+    t.index ["created_at"], name: "index_education_benefits_submissions_on_created_at"
     t.index ["education_benefits_claim_id"], name: "index_education_benefits_claim_id", unique: true
     t.index ["region", "created_at", "form_type"], name: "index_edu_benefits_subs_ytd"
   end
@@ -263,6 +268,8 @@ ActiveRecord::Schema.define(version: 2020_12_11_213957) do
     t.string "user_uuid", null: false
     t.json "list_data", default: {}, null: false
     t.boolean "requested_decision", default: false, null: false
+    t.index ["evss_id"], name: "index_evss_claims_on_evss_id"
+    t.index ["updated_at"], name: "index_evss_claims_on_updated_at"
     t.index ["user_uuid"], name: "index_evss_claims_on_user_uuid"
   end
 
@@ -412,6 +419,7 @@ ActiveRecord::Schema.define(version: 2020_12_11_213957) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "mhv_correlation_id"
+    t.index ["mhv_correlation_id"], name: "index_mhv_accounts_on_mhv_correlation_id"
     t.index ["user_uuid", "mhv_correlation_id"], name: "index_mhv_accounts_on_user_uuid_and_mhv_correlation_id", unique: true
   end
 


### PR DESCRIPTION
## Description of change
As an additional follow-up to the outage on 12/15, look add missing indexes.

I got the data to find the missing indexes using pghero.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/17692
## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->


queries fixed by indexes:

|total in minutes  | average time in ms| query| notes|
|------------------|-------------------|---------------------------------|---|
| 100.306020547243 | 0.218478372151198 |SELECT  "evss_claims".* FROM "evss_claims" WHERE "evss_claims"."user_uuid" = $1 AND "evss_claims"."evss_id" = $2 LIMIT $3"}| not that that query needs help, but evss_claims would filter to 1 row, where user_uuid filters to 12 |
| 142.275733151266 | 674.399114321061 |SELECT COUNT(*) FROM "education_benefits_submissions" WHERE "education_benefits_submissions"."created_at" BETWEEN $1 AND $2 AND "education_benefits_submissions"."region" = $3 AND "education_benefits_submissions"."form_type" = $4 AND "education_benefits_submissions"."status" = $5 AND "education_benefits_submissions"."chapter33" = $6"}| |
| 40.0990212332169 | 28.8682929854457 |SELECT  "claims_api_auto_established_claims".* FROM "claims_api_auto_established_claims" WHERE "claims_api_auto_established_claims"."evss_id" = $1 LIMIT $2"}| |
| 44.04208801395 | 9080.84288947422 |SELECT  "async_transactions".* FROM "async_transactions" WHERE (created_at < $3) AND "async_transactions"."status" = $1 ORDER BY "async_transactions"."id" ASC LIMIT $2"}| |
| 5.34953631171667 | 336.096522202094 |SELECT  "async_transactions".* FROM "async_transactions" WHERE (created_at < $4) AND "async_transactions"."status" = $1 AND "async_transactions"."id" > $2 ORDER BY "async_transactions"."id" ASC LIMIT $3"}| |
| 584.611411247104 | 0.239692143569745 |SELECT  "evss_claims".* FROM "evss_claims" WHERE "evss_claims"."user_uuid" = $1 AND "evss_claims"."evss_id" = $2 ORDER BY "evss_claims"."id" ASC LIMIT $3"}| |
| 64.0242412392838 | 39.803693652026 |SELECT  $3 AS one FROM "claims_api_auto_established_claims" WHERE "claims_api_auto_established_claims"."md5" = $1 LIMIT $2"}| |
| 73.2800941762667 | 15161.3987950897 |SELECT COUNT(*) FROM "evss_claims" WHERE (updated_at < $1)"}| |
| 754.036868236034 | 156007.627910904 |DELETE FROM "evss_claims" WHERE (updated_at < $1)"}| |
| 82.8172305868339 | 3.26923025593776 |SELECT "base_facilities".* FROM "base_facilities" WHERE "base_facilities"."facility_type" = $1 AND "base_facilities"."lat" BETWEEN $2 AND $3 AND "base_facilities"."long" BETWEEN $4 AND $5 AND "base_facilities"."facility_type" != $6"}|  |
| 9.61162058935 | 529.080032441285 |SELECT COUNT(*) FROM "mhv_accounts" WHERE "mhv_accounts"."mhv_correlation_id" IS NULL AND "mhv_accounts"."registered_at" IS NOT NULL"}| |
| 95.9398643907493 | 40.478108877329 |SELECT  $4 AS one FROM "claims_api_auto_established_claims" WHERE "claims_api_auto_established_claims"."md5" = $1 AND "claims_api_auto_established_claims"."id" != $2 LIMIT $3"}| |

