### PR TITLE
add coronavirus-vaccination to app list

### DIFF
--- a/lib/statsd_middleware.rb
+++ b/lib/statsd_middleware.rb
@@ -29,6 +29,7 @@ class StatsdMiddleware
     burials
     claims-status
     coronavirus-research
+    coronavirus-vaccination
     covid19screen
     dashboard
     dependents-view-dependents


### PR DESCRIPTION
This was found in the rails logs a warn, adding to the source app names to ensure logging is properly configured for coronavirus-vaccination.

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Adding coronavirus-vaccination app to list of apps for statsd

## Original issue(s)
small change to update the app list.

## Things to know about this PR
minor change to update the app list for statsd
