### PR TITLE
Enable https://staging-api.va.gov/rails/mailers/

### DIFF
--- a/docs/setup/mailer.md
+++ b/docs/setup/mailer.md
@@ -14,3 +14,5 @@
 These previews are available at:
 
 http://localhost:3000/rails/mailers
+
+https://staging-api.va.gov/rails/mailers/

--- a/lib/config_helper.rb
+++ b/lib/config_helper.rb
@@ -7,6 +7,7 @@ module ConfigHelper
 
   def setup_action_mailer(config)
     config.action_mailer.preview_path = Rails.root.join('spec', 'mailers', 'previews')
+    config.action_mailer.show_previews = Rails.env.development? || FeatureFlipper.staging_email?
 
     if FeatureFlipper.send_email?
       config.action_mailer.delivery_method = :govdelivery_tms


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
this should make both http://localhost:3000/rails/mailers and https://staging-api.va.gov/rails/mailers/ available to use. This should not enable this in production

## Original issue(s)
department-of-veterans-affairs/va.gov-team#17363

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
