### PR TITLE
Clamping the max results to 50

### DIFF
--- a/lib/facilities/ppms/v0/client.rb
+++ b/lib/facilities/ppms/v0/client.rb
@@ -13,6 +13,9 @@ module Facilities
       # Dev swagger site for testing endpoints
       # https://dev.dws.ppms.va.gov/swagger
       class Client < Common::Client::Base
+        MIN_RESULTS = 1
+        MAX_RESULTS = 50
+
         configuration Facilities::PPMS::V0::Configuration
 
         # https://dev.dws.ppms.va.gov/swagger/ui/index#!/GlobalFunctions/GlobalFunctions_ProviderLocator
@@ -150,13 +153,15 @@ module Facilities
             driveTime: 10_000,
             posCodes: pos_code,
             network: 0,
-            maxResults: per_page * page + 1
+            maxResults: (per_page * page + 1).clamp(MIN_RESULTS,MAX_RESULTS)
           }
         end
 
         def provider_locator_params(params)
           page = Integer(params[:page] || 1)
+
           per_page = Integer(params[:per_page] || BaseFacility.per_page)
+
 
           specialty_code = params.slice(:services, :specialties).values.first
           specialty = "'#{specialty_code ? specialty_code[0] : 'null'}'"
@@ -173,7 +178,7 @@ module Facilities
             gender: 0,
             primarycare: 0,
             acceptingnewpatients: 0,
-            maxResults: per_page * page + 1
+            maxResults: (per_page * page + 1).clamp(MIN_RESULTS,MAX_RESULTS)
           }
         end
       end

--- a/lib/facilities/ppms/v0/client.rb
+++ b/lib/facilities/ppms/v0/client.rb
@@ -153,7 +153,7 @@ module Facilities
             driveTime: 10_000,
             posCodes: pos_code,
             network: 0,
-            maxResults: (per_page * page + 1).clamp(MIN_RESULTS,MAX_RESULTS)
+            maxResults: (per_page * page + 1).clamp(MIN_RESULTS, MAX_RESULTS)
           }
         end
 
@@ -161,7 +161,6 @@ module Facilities
           page = Integer(params[:page] || 1)
 
           per_page = Integer(params[:per_page] || BaseFacility.per_page)
-
 
           specialty_code = params.slice(:services, :specialties).values.first
           specialty = "'#{specialty_code ? specialty_code[0] : 'null'}'"
@@ -178,7 +177,7 @@ module Facilities
             gender: 0,
             primarycare: 0,
             acceptingnewpatients: 0,
-            maxResults: (per_page * page + 1).clamp(MIN_RESULTS,MAX_RESULTS)
+            maxResults: (per_page * page + 1).clamp(MIN_RESULTS, MAX_RESULTS)
           }
         end
       end

--- a/lib/facilities/ppms/v1/client.rb
+++ b/lib/facilities/ppms/v1/client.rb
@@ -150,7 +150,7 @@ module Facilities
           {
             address: [cnr[:latitude], cnr[:longitude]].join(','),
             radius: cnr[:radius],
-            maxResults: (per_page * page + 1).clamp(MIN_RESULTS,MAX_RESULTS)
+            maxResults: (per_page * page + 1).clamp(MIN_RESULTS, MAX_RESULTS)
           }
         end
 

--- a/lib/facilities/ppms/v1/client.rb
+++ b/lib/facilities/ppms/v1/client.rb
@@ -13,6 +13,9 @@ module Facilities
       # Dev swagger site for testing endpoints
       # https://dev.dws.ppms.va.gov/swagger
       class Client < Common::Client::Base
+        MIN_RESULTS = 1
+        MAX_RESULTS = 50
+
         configuration Facilities::PPMS::V1::Configuration
 
         # https://dev.dws.ppms.va.gov/swagger/ui/index#!/GlobalFunctions/GlobalFunctions_ProviderLocator
@@ -147,7 +150,7 @@ module Facilities
           {
             address: [cnr[:latitude], cnr[:longitude]].join(','),
             radius: cnr[:radius],
-            maxResults: per_page * page + 1
+            maxResults: (per_page * page + 1).clamp(MIN_RESULTS,MAX_RESULTS)
           }
         end
 


### PR DESCRIPTION
Someone seems to be trying to download all of PPMS Data through the facilities API

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Clamping the max results to 50 `(maxResults = page * per_page)`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#17782

## Things to know about this PR
PPMS doesn't provide a paginated API, we are limiting the number of results to 50
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
