### PR TITLE
Form 674 PDF Submission to VBMS

### DIFF
--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -107,8 +107,7 @@ class SavedClaim::DependencyClaim < SavedClaim
   def partitioned_686_674_params
     dependent_data = parsed_form
 
-    keys = STUDENT_ATTENDING_COLLEGE_KEYS.map { |i| i }
-    keys << 'veteran_contact_information' << 'household_income'
+    keys = (STUDENT_ATTENDING_COLLEGE_KEYS.dup << %w[veteran_contact_information household_income]).flatten
 
     college_student_data = { 'dependents_application' => dependent_data['dependents_application'].extract!(*keys) }
 

--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -34,7 +34,9 @@ class SavedClaim::DependencyClaim < SavedClaim
   validate :validate_686_form_data, on: :run_686_form_jobs
   validate :address_exists
 
-  def upload_pdf
+  def upload_pdf(form_id)
+    self.form_id = form_id
+
     form_path = PdfFill::Filler.fill_form(self)
     upload_to_vbms(form_path)
   end
@@ -105,7 +107,10 @@ class SavedClaim::DependencyClaim < SavedClaim
   def partitioned_686_674_params
     dependent_data = parsed_form
 
-    college_student_data = dependent_data['dependents_application'].extract!(*STUDENT_ATTENDING_COLLEGE_KEYS)
+    keys = STUDENT_ATTENDING_COLLEGE_KEYS.map { |i| i }
+    keys << 'veteran_contact_information' << 'household_income'
+
+    college_student_data = { 'dependents_application' => dependent_data['dependents_application'].extract!(*keys) }
 
     { college_student_data: college_student_data, dependent_data: dependent_data }
   end

--- a/app/services/bgs/dependent_service.rb
+++ b/app/services/bgs/dependent_service.rb
@@ -17,7 +17,12 @@ module BGS
 
       BGS::SubmitForm686cJob.perform_async(@user.uuid, claim.id, vet_info.to_686c_form_hash) if claim.submittable_686?
       BGS::SubmitForm674Job.perform_async(@user.uuid, claim.id, vet_info.to_686c_form_hash) if claim.submittable_674?
-      VBMS::SubmitDependentsPdfJob.perform_async(claim.id, vet_info.to_686c_form_hash)
+      VBMS::SubmitDependentsPdfJob.perform_async(
+        saved_claim_id: claim.id,
+        va_file_number_with_payload: vet_info.to_686c_form_hash,
+        submittable_686: claim.submittable_686?,
+        submittable_674: claim.submittable_674?
+      )
     rescue => e
       report_error(e)
     end

--- a/app/workers/bgs/submit_form674_job.rb
+++ b/app/workers/bgs/submit_form674_job.rb
@@ -25,6 +25,8 @@ module BGS
     def valid_claim_data(saved_claim_id, vet_info)
       claim = SavedClaim::DependencyClaim.find(saved_claim_id)
 
+      claim.add_veteran_info(vet_info)
+
       raise Invalid674Claim unless claim.valid?(:run_686_form_jobs)
 
       claim.formatted_674_data(vet_info)

--- a/app/workers/vbms/submit_dependents_pdf_job.rb
+++ b/app/workers/vbms/submit_dependents_pdf_job.rb
@@ -7,7 +7,7 @@ module VBMS
     include SentryLogging
 
     # Generates PDF for 686c form and uploads to VBMS
-    def perform(saved_claim_id, va_file_number_with_payload)
+    def perform(saved_claim_id, va_file_number_with_payload, submittable_686, submittable_674)
       claim = SavedClaim::DependencyClaim.find(saved_claim_id)
       claim.add_veteran_info(va_file_number_with_payload)
 
@@ -17,7 +17,8 @@ module VBMS
         claim.upload_to_vbms("tmp#{attachment.file_url}")
       end
 
-      claim.upload_pdf
+      claim.upload_pdf('686C-674') if submittable_686
+      claim.upload_pdf('21-674') if submittable_674
     rescue => e
       send_error_to_sentry(e, claim&.id)
     end

--- a/app/workers/vbms/submit_dependents_pdf_job.rb
+++ b/app/workers/vbms/submit_dependents_pdf_job.rb
@@ -7,7 +7,7 @@ module VBMS
     include SentryLogging
 
     # Generates PDF for 686c form and uploads to VBMS
-    def perform(saved_claim_id, va_file_number_with_payload, submittable_686, submittable_674)
+    def perform(saved_claim_id:, va_file_number_with_payload:, submittable_686:, submittable_674:)
       claim = SavedClaim::DependencyClaim.find(saved_claim_id)
       claim.add_veteran_info(va_file_number_with_payload)
 

--- a/app/workers/vbms/submit_dependents_pdf_job.rb
+++ b/app/workers/vbms/submit_dependents_pdf_job.rb
@@ -17,8 +17,7 @@ module VBMS
         claim.upload_to_vbms("tmp#{attachment.file_url}")
       end
 
-      claim.upload_pdf('686C-674') if submittable_686
-      claim.upload_pdf('21-674') if submittable_674
+      generate_pdf(claim, submittable_686, submittable_674)
     rescue => e
       send_error_to_sentry(e, claim&.id)
     end
@@ -33,6 +32,11 @@ module VBMS
         },
         { team: 'vfs-ebenefits' }
       )
+    end
+
+    def generate_pdf(claim, submittable_686, submittable_674)
+      claim.upload_pdf('686C-674') if submittable_686
+      claim.upload_pdf('21-674') if submittable_674
     end
   end
 end

--- a/spec/factories/dependency_claim.rb
+++ b/spec/factories/dependency_claim.rb
@@ -89,7 +89,40 @@ FactoryBot.define do
               ssn: '370947143',
               birth_date: '2010-03-03'
             }
-          ]
+          ],
+          student_name_and_ssn: {
+            full_name: {
+              first: 'Juan',
+              last: 'Barrett'
+            },
+            ssn: '333224444',
+            birth_date: '2001-10-06'
+          },
+          student_address_marriage_tuition: {
+            address: {
+              country_name: 'USA',
+              address_line1: '1900 W Olney Ave.',
+              city: 'Philadelphia',
+              state_code: 'PA',
+              zip_code: '19141'
+            },
+            was_married: false,
+            tuition_is_paid_by_gov_agency: false
+          },
+          program_information: {
+            student_is_enrolled_full_time: true
+          },
+          school_information: {
+            name: 'University of Pennsylvania',
+            address: {
+              country_name: 'USA',
+              address_line1: '4201 Henry Ave',
+              city: 'Philadelphia',
+              state_code: 'PA',
+              zip_code: '19144'
+            }
+          },
+          student_did_attend_school_last_term: false
         }
       }.to_json
     }

--- a/spec/models/saved_claim/dependency_claim_spec.rb
+++ b/spec/models/saved_claim/dependency_claim_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe SavedClaim::DependencyClaim do
       )
 
       dependency_claim.add_veteran_info(va_file_number_with_payload)
-      dependency_claim.upload_pdf
+      dependency_claim.upload_pdf('686C-674')
     end
 
     it 'uploads to vbms' do
       expect_any_instance_of(ClaimsApi::VBMSUploader).to receive(:upload!)
 
       dependency_claim.add_veteran_info(va_file_number_with_payload)
-      dependency_claim.upload_pdf
+      dependency_claim.upload_pdf('686C-674')
     end
   end
 
@@ -52,7 +52,8 @@ RSpec.describe SavedClaim::DependencyClaim do
       claim = described_class.new(form: all_flows_payload.to_json)
 
       formatted_data = claim.formatted_674_data(va_file_number_with_payload)
-      expect(formatted_data).to include(:student_name_and_ssn)
+      expect(formatted_data).to include(:dependents_application)
+      expect(formatted_data[:dependents_application]).to include(:student_name_and_ssn)
     end
   end
 

--- a/spec/services/bgs/dependent_service_spec.rb
+++ b/spec/services/bgs/dependent_service_spec.rb
@@ -45,10 +45,15 @@ RSpec.describe BGS::DependentService do
     it 'fires PDF job' do
       VCR.use_cassette('bgs/dependent_service/submit_686c_form') do
         service = BGS::DependentService.new(user)
-        allow(claim).to receive(:submittable_686?)
-        allow(claim).to receive(:submittable_674?)
+        allow(claim).to receive(:submittable_686?).and_return(true)
+        allow(claim).to receive(:submittable_674?).and_return(false)
 
-        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(claim.id, vet_info)
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
+          saved_claim_id: claim.id,
+          va_file_number_with_payload: vet_info,
+          submittable_686: true,
+          submittable_674: false
+        )
 
         service.submit_686c_form(claim)
       end

--- a/spec/workers/vbms/submit_dependents_pdf_job_spec.rb
+++ b/spec/workers/vbms/submit_dependents_pdf_job_spec.rb
@@ -25,7 +25,12 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
           vet_info
         )
 
-        described_class.new.perform(dependency_claim.id, vet_info, true, false)
+        described_class.new.perform(
+          saved_claim_id: dependency_claim.id,
+          va_file_number_with_payload: vet_info,
+          submittable_686: true,
+          submittable_674: false
+        )
       end
     end
 
@@ -35,7 +40,12 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
           vet_info
         )
 
-        described_class.new.perform(dependency_claim.id, vet_info, false, true)
+        described_class.new.perform(
+          saved_claim_id: dependency_claim.id,
+          va_file_number_with_payload: vet_info,
+          submittable_686: false,
+          submittable_674: true
+        )
       end
     end
 
@@ -48,7 +58,12 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
           nil
         )
 
-        job.perform('non-existant-claim', vet_info, true, false)
+        job.perform(
+          saved_claim_id: 'non-existant-claim',
+          va_file_number_with_payload: vet_info,
+          submittable_686: true,
+          submittable_674: false
+        )
       end
 
       it 'raises an error if there is nothing in the dependents_application is empty' do
@@ -60,11 +75,21 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
         )
 
         vet_info['veteran_information'].delete('ssn')
-        job.perform(invalid_dependency_claim.id, vet_info, true, false)
+        job.perform(
+          saved_claim_id: invalid_dependency_claim.id,
+          va_file_number_with_payload: vet_info,
+          submittable_686: true,
+          submittable_674: false
+        )
       end
 
       it 'returns false' do
-        job = described_class.new.perform('f', vet_info, true, false)
+        job = described_class.new.perform(
+          saved_claim_id: 'f',
+          va_file_number_with_payload: vet_info,
+          submittable_686: true,
+          submittable_674: false
+        )
 
         expect(job).to eq(false)
       end

--- a/spec/workers/vbms/submit_dependents_pdf_job_spec.rb
+++ b/spec/workers/vbms/submit_dependents_pdf_job_spec.rb
@@ -19,13 +19,23 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
   end
 
   describe '#perform' do
-    context 'with a valid submission' do
-      it 'creates a PDF' do
+    context 'with a valid 686 submission' do
+      it 'creates a 686 PDF' do
         expect_any_instance_of(SavedClaim::DependencyClaim).to receive(:add_veteran_info).with(
           vet_info
         )
 
         described_class.new.perform(dependency_claim.id, vet_info, true, false)
+      end
+    end
+
+    context 'with a valid 674 submission' do
+      it 'creates a 674 PDF' do
+        expect_any_instance_of(SavedClaim::DependencyClaim).to receive(:add_veteran_info).with(
+          vet_info
+        )
+
+        described_class.new.perform(dependency_claim.id, vet_info, false, true)
       end
     end
 

--- a/spec/workers/vbms/submit_dependents_pdf_job_spec.rb
+++ b/spec/workers/vbms/submit_dependents_pdf_job_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
           vet_info
         )
 
-        described_class.new.perform(dependency_claim.id, vet_info)
+        described_class.new.perform(dependency_claim.id, vet_info, true, false)
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
           nil
         )
 
-        job.perform('non-existant-claim', vet_info)
+        job.perform('non-existant-claim', vet_info, true, false)
       end
 
       it 'raises an error if there is nothing in the dependents_application is empty' do
@@ -50,11 +50,11 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
         )
 
         vet_info['veteran_information'].delete('ssn')
-        job.perform(invalid_dependency_claim.id, vet_info)
+        job.perform(invalid_dependency_claim.id, vet_info, true, false)
       end
 
       it 'returns false' do
-        job = described_class.new.perform('f', vet_info)
+        job = described_class.new.perform('f', vet_info, true, false)
 
         expect(job).to eq(false)
       end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
When a dependency claim is submitted on VA.gov, one of the options is to submit a VA Form 674.  This PR adds the functionality of generating a 674 PDF and uploading it to VBMS when the form is submitted by the user.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#17517

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
The code to generate and submit a 686 PDF was already in place, this PR just adds the additional functionality of also generating a 674 PDF.  No additional logging or settings were needed.
<!-- Please describe testing done to verify the changes or any testing planned. -->
## Testing
- [x] Local testing
- [x] Specs updated
- [x] Staging testing planned