### PR TITLE
BGS 686 Set Child Married Indicator

### DIFF
--- a/app/models/bgs_dependents/child_marriage.rb
+++ b/app/models/bgs_dependents/child_marriage.rb
@@ -10,7 +10,8 @@ module BGSDependents
       {
         'event_date': @child_marriage['date_married'],
         'ssn': @child_marriage['ssn'],
-        'birth_date': @child_marriage['birth_date']
+        'birth_date': @child_marriage['birth_date'],
+        'ever_married_ind': 'Y'
       }.merge(@child_marriage['full_name']).with_indifferent_access
     end
   end

--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -27,7 +27,7 @@ class SavedClaim::DependencyClaim < SavedClaim
     report_stepchild_not_in_household
     report_marriage_of_child_under18
     child_marriage
-    not_attending_school
+    report_child18_or_older_is_not_attending_school
     add_spouse
   ].freeze
 

--- a/lib/bgs/children.rb
+++ b/lib/bgs/children.rb
@@ -98,7 +98,8 @@ module BGS
         'Other',
         {
           'event_date': formatted_info['event_date'],
-          'type': event_type
+          'type': event_type,
+          'child_prevly_married_ind': formatted_info['ever_married_ind'],
         }
       )
     end

--- a/lib/bgs/children.rb
+++ b/lib/bgs/children.rb
@@ -99,7 +99,7 @@ module BGS
         {
           'event_date': formatted_info['event_date'],
           'type': event_type,
-          'child_prevly_married_ind': formatted_info['ever_married_ind'],
+          'child_prevly_married_ind': formatted_info['ever_married_ind']
         }
       )
     end

--- a/lib/bgs/children.rb
+++ b/lib/bgs/children.rb
@@ -95,7 +95,7 @@ module BGS
       @children << child_event.serialize_dependent_result(
         participant,
         'Child',
-        'Other',
+        'Biological',
         {
           'event_date': formatted_info['event_date'],
           'type': event_type,

--- a/spec/lib/bgs/children_spec.rb
+++ b/spec/lib/bgs/children_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe BGS::Children do
         expect(children[:dependents]).to include(
           a_hash_including(
             event_date: '1977-02-01',
-            family_relationship_type_name: 'Other',
+            family_relationship_type_name: 'Biological',
             participant_relationship_type_name: 'Child',
             type: 'child_marriage'
           )
@@ -123,7 +123,7 @@ RSpec.describe BGS::Children do
         expect(children[:dependents]).to include(
           a_hash_including(
             participant_relationship_type_name: 'Child',
-            family_relationship_type_name: 'Other',
+            family_relationship_type_name: 'Biological',
             event_date: '2019-03-03',
             type: 'not_attending_school'
           )

--- a/spec/models/bgs_dependents/child_marriage_spec.rb
+++ b/spec/models/bgs_dependents/child_marriage_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe BGSDependents::ChildMarriage do
       'last' => 'Johnson',
       'suffix' => 'Sr.',
       'ssn' => '555612341',
-      'birth_date' => '2020-01-01'
+      'birth_date' => '2020-01-01',
+      'ever_married_ind' => 'Y'
     }
   end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
During testing of the 686 (Dependency Claims), we discovered that when reporting the marriage of a child under 18, the child previously married indicator must be set to Y and the relationship type must be set to Biological.  This PR is a fix to update those flags accordingly.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#17810
department-of-veterans-affairs/va.gov-team#12425

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
No additional settings or configuration have been added.  The dependency application process is already in place, this PR is just updating a couple flags for a specific workflow.
<!-- Please describe testing done to verify the changes or any testing planned. -->
## Testing
- [x] Local testing
- [x] Specs updated
- [x] Staging testing planned