### PR TITLE
S-I-P Bug - Approach 1: Manually "olivebranch" the Metadata Field for Save-In-Progress Data

### DIFF
--- a/app/controllers/v0/in_progress_forms_controller.rb
+++ b/app/controllers/v0/in_progress_forms_controller.rb
@@ -13,15 +13,15 @@ module V0
       form    = InProgressForm.form_for_user(form_id, @current_user)
 
       if form
-        render json: form.data_and_metadata
+        render json: form.data_and_camelized_metadata
       else
-        render json: FormProfile.for(form_id: form_id, user: @current_user).prefill
+        render json: FormProfile.for(form_id: form_id, user: @current_user).camelized_prefill
       end
     end
 
     def update
       form = InProgressForm.where(form_id: params[:id], user_uuid: @current_user.uuid).first_or_initialize
-      form.update!(form_data: params[:form_data], metadata: params[:metadata])
+      form.update! form_data: form_data, metadata: metadata
       render json: form
     end
 
@@ -31,6 +31,16 @@ module V0
 
       form.destroy
       render json: form
+    end
+
+    private
+
+    def form_data
+      params[:form_data] || params[:formData]
+    end
+
+    def metadata
+      OliveBranch::Transformations.transform params[:metadata], &:underscore
     end
   end
 end

--- a/app/controllers/v0/in_progress_forms_controller.rb
+++ b/app/controllers/v0/in_progress_forms_controller.rb
@@ -40,7 +40,7 @@ module V0
     end
 
     def metadata
-      OliveBranch::Transformations.transform params[:metadata], &:underscore
+      OliveBranch::Transformations.transform params[:metadata], :underscore.to_proc
     end
   end
 end

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -192,6 +192,13 @@ class FormProfile
     { form_data: form_data, metadata: metadata }
   end
 
+  def camelized_prefill
+    OliveBranch::Transformations.transform(
+      prefill,
+      OliveBranch::Transformations.method(:camelize)
+    )
+  end
+
   private
 
   def initialize_military_information

--- a/app/models/in_progress_form.rb
+++ b/app/models/in_progress_form.rb
@@ -36,6 +36,13 @@ class InProgressForm < ApplicationRecord
     }
   end
 
+  def data_and_camelized_metadata
+    {
+      form_data: JSON.parse(form_data),
+      metadata: camelized_metadata
+    }
+  end
+
   def metadata
     data = super || {}
     last_accessed = updated_at || Time.current
@@ -43,6 +50,13 @@ class InProgressForm < ApplicationRecord
       'expires_at' => expires_at.to_i || (last_accessed + expires_after).to_i,
       'last_updated' => updated_at.to_i,
       'in_progress_form_id' => id
+    )
+  end
+
+  def camelized_metadata
+    OliveBranch::Transformations.transform(
+      metadata,
+      OliveBranch::Transformations.method(:camelize)
     )
   end
 

--- a/app/serializers/in_progress_form_serializer.rb
+++ b/app/serializers/in_progress_form_serializer.rb
@@ -2,4 +2,8 @@
 
 class InProgressFormSerializer < ActiveModel::Serializer
   attributes :form_id, :created_at, :updated_at, :metadata
+
+  def metadata
+    object.camelized_metadata
+  end
 end

--- a/spec/request/in_progress_forms_request_spec.rb
+++ b/spec/request/in_progress_forms_request_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe V0::InProgressFormsController, type: :request do
 
           expect(response).to have_http_status(:ok)
           expect(JSON.parse(response.body)).to eq({
-            'form_data' => JSON.parse(in_progress_form.form_data),
-            'metadata' => in_progress_form.camelized_metadata
-          })
+                                                    'form_data' => JSON.parse(in_progress_form.form_data),
+                                                    'metadata' => in_progress_form.camelized_metadata
+                                                  })
         end
 
         context 'with the x key inflection header set' do

--- a/spec/request/in_progress_forms_request_spec.rb
+++ b/spec/request/in_progress_forms_request_spec.rb
@@ -77,10 +77,10 @@ RSpec.describe V0::InProgressFormsController, type: :request do
           get v0_in_progress_form_url(in_progress_form.form_id), params: nil
 
           expect(response).to have_http_status(:ok)
-          expect(response.body).to eq({
+          expect(JSON.parse(response.body)).to eq({
             'form_data' => JSON.parse(in_progress_form.form_data),
-            'metadata' => in_progress_form.metadata
-          }.to_json)
+            'metadata' => in_progress_form.camelized_metadata
+          })
         end
 
         context 'with the x key inflection header set' do


### PR DESCRIPTION
The FE is going to switch to only sometimes sending the inflection header for save-in-progress routes --that is, the FE will sometimes opt-out of [OliveBranch](https://github.com/vigetlabs/olive_branch) when using save-in-progress routes.

## Why?
form_data sometimes has fancy keys that do not survive olivebranch's
`camelCase` ➡️ `snake_case` ➡️ back to `camelCase`
(or `snake_case` ➡️ `camelCase` ➡️ back to `snake_case`)

example:
```
irb(main):001:0> "Hello there, Sam-I-Am!".underscore.camelize(:lower).underscore
=> "hello there, sam_i_am!"
```

(Sometimes sentences with spaces and punctuation end up being keys in the json (checkboxes).)

Because the BE does not operate on form_data --it acts as a passive store-- it's (hopefully) safe to cut out olivebranch for SIP.

From the FE, it won't look like a change:

we're going from:
```
FE sends camelCase
     \
      \ tranformation!
       \
        `--> Database stores snake_case
            /
           / transformation!
          /
camel <--'
```
to:
```
FE sends camelCase
     \
      \ no tranformation
       \
        `--> Database stores camelCase
            /
           / no transformation
          /
camel <--'
```
## The Catch!

Both the FE and BE operate on the metadata field, and both are expecting it to be in their own case.

Therefore, even when the inflection header is not sent, the metadata field must be transformed as if [OliveBranch](https://github.com/department-of-veterans-affairs/vets-api/pull/61) operated on it.
