### PR TITLE
API-3265: [logic] Special Issues - Add special issues persistence for established claim

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -23,6 +23,7 @@ module ClaimsApi
             auth_headers: auth_headers,
             form_data: form_attributes,
             flashes: flashes,
+            special_issues: special_issues_per_disability,
             source: source_name
           )
           unless auto_claim.id

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -26,6 +26,7 @@ module ClaimsApi
             auth_headers: auth_headers,
             form_data: form_attributes,
             flashes: flashes,
+            special_issues: special_issues_per_disability,
             source: source_name
           )
           unless auto_claim.id

--- a/modules/claims_api/spec/fixtures/form_526_json_api.json
+++ b/modules/claims_api/spec/fixtures/form_526_json_api.json
@@ -28,7 +28,8 @@
             {
               "name": "PTSD personal trauma",
               "disabilityActionType": "SECONDARY",
-              "serviceRelevance": "Caused by a service-connected disability\\nLengthy description"
+              "serviceRelevance": "Caused by a service-connected disability\\nLengthy description",
+              "specialIssues": ["Radiation", "Emergency Care – CH17 Determination"]
             }
           ]
         }

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -75,6 +75,19 @@ RSpec.describe 'Disability Claims ', type: :request do
       end
     end
 
+    it 'sets the special issues' do
+      with_okta_user(scopes) do |auth_header|
+        VCR.use_cassette('evss/claims/claims') do
+          post path, params: data, headers: headers.merge(auth_header)
+          token = JSON.parse(response.body)['data']['attributes']['token']
+          aec = ClaimsApi::AutoEstablishedClaim.find(token)
+          expect(aec.special_issues).to eq([{ 'code' => 9999,
+                                              'name' => 'PTSD (post traumatic stress disorder)',
+                                              'special_issues' => %w[SSR RDN ECCD] }])
+        end
+      end
+    end
+
     it 'builds the auth headers' do
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('evss/claims/claims') do

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Disability Claims ', type: :request do
           aec = ClaimsApi::AutoEstablishedClaim.find(token)
           expect(aec.special_issues).to eq([{ 'code' => 9999,
                                               'name' => 'PTSD (post traumatic stress disorder)',
-                                              'special_issues' => %w[SSR RDN ECCD] }])
+                                              'special_issues' => %w[FDC PTSD/2 RDN ECCD] }])
         end
       end
     end


### PR DESCRIPTION
## Description of change
Stores special issues for a particular claim long-term.

## Original issue(s)
https://vajira.max.gov/browse/API-3265

## Things to know about this PR
Ensured existing specs still worked and added spec for this particular functionality.