### PR TITLE
15330 removing ppms v1 clients and round trip feature flags

### DIFF
--- a/app/models/ppms/provider_facility.rb
+++ b/app/models/ppms/provider_facility.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'facilities/ppms/v0/client'
 require 'facilities/ppms/v1/client'
 require 'lighthouse/facilities/client'
 
@@ -31,24 +30,6 @@ class PPMS::ProviderFacility < Common::Base
   private
 
   def ppms_api_results
-    if Flipper.enabled?(:facility_locator_ppms_use_v1_client)
-      ppms_api_results_v1
-    else
-      ppms_api_results_v0
-    end
-  end
-
-  def ppms_api_results_v0
-    Facilities::PPMS::V0::Client.new.pos_locator(ppms_params.with_indifferent_access).collect do |result|
-      provider = PPMS::Provider.new(
-        result.attributes.transform_keys { |k| k.to_s.snakecase.to_sym }
-      )
-      provider.set_hexdigest_as_id!
-      provider
-    end.uniq(&:id).paginate(pagination_params)
-  end
-
-  def ppms_api_results_v1
     Facilities::PPMS::V1::Client.new.pos_locator(ppms_params.with_indifferent_access)
   end
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -60,12 +60,6 @@ features:
   facility_locator_ppms_legacy_urgent_care_to_pos_locator:
     actor_type: user
     description: force the legacy urgent care path to use the new POS locator
-  facility_locator_ppms_use_v1_client:
-    actor_type: user
-    description: Have the V1 API use the PPMS::V1::Client
-  facility_locator_ppms_skip_additional_round_trips:
-    actor_type: user
-    description: Have the PPMS::V1::Client skip the additional round trips to get the type
   facility_locator_ppms_forced_unique_id:
     actor_type: user
     description: Use an hexdigest for the ID on PPMS Place of Service Calls

--- a/spec/request/v1/facilities/ccp_request_spec.rb
+++ b/spec/request/v1/facilities/ccp_request_spec.rb
@@ -9,631 +9,428 @@ vcr_options = {
 }
 
 RSpec.describe 'Community Care Providers', type: :request, team: :facilities, vcr: vcr_options do
-  [[0, false], [1, false], [1, true]].each do |(client_version, skip_round_trips)|
-    context "Facilities::PPMS::V#{client_version}::Client, Skip Extra Round Trips [#{skip_round_trips}]" do
-      before do
-        Flipper.enable(:facility_locator_ppms_use_v1_client, client_version == 1)
-        Flipper.enable(:facility_locator_ppms_skip_additional_round_trips, skip_round_trips)
-      end
+  before do
+    Flipper.enable(:facility_locator_ppms_skip_additional_round_trips, true)
+  end
 
-      let(:sha256) do
-        if Flipper.enabled?(:facility_locator_ppms_skip_additional_round_trips)
-          'bd2b84cc5c0aa3676090eacde32e99c7d668388e5fc5440e3c582aef419fc398'
-        elsif Flipper.enabled?(:facility_locator_ppms_use_v1_client)
-          'bd2b84cc5c0aa3676090eacde32e99c7d668388e5fc5440e3c582aef419fc398'
-        else
-          'b15b6aeb98d75d1fe64450c412483f9e38d3245a875e071c13ccb6bf44415f4a'
-        end
-      end
+  let(:sha256) { 'bd2b84cc5c0aa3676090eacde32e99c7d668388e5fc5440e3c582aef419fc398' }
 
-      let(:params) do
-        case client_version
-        when 0
+  let(:params) do
+    {
+      latitude: 40.415217,
+      longitude: -74.057114,
+      radius: 200,
+      type: 'provider',
+      specialties: ['213E00000X']
+    }
+  end
+
+  describe '#index' do
+    context 'Missing Provider', vcr: vcr_options.merge(cassette_name: 'facilities/ppms/ppms_missing_provider') do
+      it 'gracefully handles ppms provider lookup failures' do
+        get '/v1/facilities/ccp', params: params
+
+        bod = JSON.parse(response.body)
+        expect(bod['data']).to include(
           {
-            address: '58 Leonard Ave, Leonardo, NJ 07737',
-            bbox: ['-75.91', '38.55', '-72.19', '42.27'],
-            type: 'provider',
-            specialties: ['213E00000X']
+            'id' => '1154383230',
+            'type' => 'provider',
+            'attributes' => {
+              'acc_new_patients' => 'true',
+              'address' => {
+                'street' => '176 RIVERSIDE AVE',
+                'city' => 'RED BANK',
+                'state' => 'NJ',
+                'zip' => '07701-1063'
+              },
+              'caresite_phone' => '732-219-6625',
+              'email' => nil,
+              'fax' => nil,
+              'gender' => 'Female',
+              'lat' => 40.35396,
+              'long' => -74.07492,
+              'name' => 'GESUALDI, AMY',
+              'phone' => nil,
+              'pos_codes' => nil,
+              'pref_contact' => nil,
+              'unique_id' => '1154383230'
+            },
+            'relationships' => {
+              'specialties' => {
+                'data' => []
+              }
+            }
           }
-        when 1
+        )
+      end
+    end
+
+    context 'type=provider' do
+      context 'specialties=261QU0200X' do
+        let(:params) do
           {
             latitude: 40.415217,
             longitude: -74.057114,
             radius: 200,
             type: 'provider',
-            specialties: ['213E00000X']
+            specialties: ['261QU0200X']
           }
         end
-      end
 
-      describe '#index' do
-        context 'Missing Provider', vcr: vcr_options.merge(cassette_name: 'facilities/ppms/ppms_missing_provider') do
-          it 'gracefully handles ppms provider lookup failures' do
-            get '/v1/facilities/ccp', params: params
-
-            bod = JSON.parse(response.body)
-            expect(bod['data']).to include(
-              {
-                'id' => '1154383230',
-                'type' => 'provider',
-                'attributes' => {
-                  'acc_new_patients' => 'true',
-                  'address' => {
-                    'street' => '176 RIVERSIDE AVE',
-                    'city' => 'RED BANK',
-                    'state' => 'NJ',
-                    'zip' => '07701-1063'
-                  },
-                  'caresite_phone' => '732-219-6625',
-                  'email' => nil,
-                  'fax' => nil,
-                  'gender' => 'Female',
-                  'lat' => 40.35396,
-                  'long' => -74.07492,
-                  'name' => 'GESUALDI, AMY',
-                  'phone' => nil,
-                  'pos_codes' => nil,
-                  'pref_contact' => nil,
-                  'unique_id' => '1154383230'
-                },
-                'relationships' => {
-                  'specialties' => {
-                    'data' => []
-                  }
-                }
-              }
-            )
-          end
-        end
-
-        context 'type=provider' do
-          context 'specialties=261QU0200X' do
-            let(:params) do
-              case client_version
-              when 0
-                {
-                  address: '58 Leonard Ave, Leonardo, NJ 07737',
-                  bbox: ['-75.91', '38.55', '-72.19', '42.27'],
-                  type: 'provider',
-                  specialties: ['261QU0200X']
-                }
-              when 1
-                {
-                  latitude: 40.415217,
-                  longitude: -74.057114,
-                  radius: 200,
-                  type: 'provider',
-                  specialties: ['261QU0200X']
-                }
-              end
-            end
-
-            it 'returns a results from the pos_locator' do
-              get '/v1/facilities/ccp', params: params
-
-              bod = JSON.parse(response.body)
-
-              sha256 = if Flipper.enabled?(:facility_locator_ppms_use_v1_client)
-                         'b09211e205d103edf949d2897dcbe489fb7bc3f2c73f203022b4d7b96e603d0d'
-                       else
-                         '263e81aab50e1c4ea77e84ff7130473f074036f0f01e86abe5ad4a1864c77cb9'
-                       end
-
-              expect(bod['data']).to include(
-                {
-                  'id' => sha256,
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '5024 5TH AVE',
-                      'city' => 'BROOKLYN',
-                      'state' => 'NY',
-                      'zip' => '11220-1909'
-                    },
-                    'caresite_phone' => '718-571-9251',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.644795,
-                    'long' => -74.011055,
-                    'name' => 'CITY MD URGENT CARE',
-                    'phone' => nil,
-                    'pos_codes' => '20',
-                    'pref_contact' => nil,
-                    'unique_id' => '1487993564'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                }
-              )
-              expect(response).to be_successful
-            end
-          end
-
-          it "sends a 'facilities.ppms.request.faraday' notification to any subscribers listening" do
-            allow(StatsD).to receive(:measure)
-
-            expect(StatsD).to receive(:measure).with(
-              'facilities.ppms.provider_locator',
-              kind_of(Numeric),
-              hash_including(
-                tags: ['facilities.ppms']
-              )
-            )
-
-            unless skip_round_trips
-              expect(StatsD).to receive(:measure).with(
-                'facilities.ppms.providers',
-                kind_of(Numeric),
-                hash_including(
-                  tags: ['facilities.ppms']
-                )
-              ).exactly(9).times
-            end
-
-            expect do
-              get '/v1/facilities/ccp', params: params
-            end.to instrument('facilities.ppms.request.faraday')
-          end
-
-          [
-            [1, 5, 6],
-            [2, 5, 11],
-            [3, 1, 4]
-          ].each do |(page, per_page, total_items)|
-            it "paginates ppms responses (page: #{page}, per_page: #{per_page}, total_items: #{total_items})" do
-              params_with_pagination = params.merge(
-                page: page.to_s,
-                per_page: per_page.to_s
-              )
-
-              case client_version
-              when 0
-                mock_client = instance_double('Facilities::PPMS::V0::Client')
-                expect(Facilities::PPMS::V0::Client).to receive(:new).and_return(mock_client)
-                expect(mock_client).to receive(:provider_locator).with(
-                  ActionController::Parameters.new(params_with_pagination).permit!
-                ).and_return(
-                  FactoryBot.build_list(:provider, total_items)
-                )
-                allow(mock_client).to receive(:provider_info).and_return(
-                  FactoryBot.build(:provider)
-                )
-              when 1
-                client = Facilities::PPMS::V1::Client.new
-                expect(Facilities::PPMS::V1::Client).to receive(:new).and_return(client)
-                expect(client).to receive(:provider_locator).and_return(
-                  Facilities::PPMS::V1::Response.new(
-                    FactoryBot.build_list(:ppms_provider, total_items).collect(&:attributes),
-                    params_with_pagination
-                  ).providers
-                )
-                allow(client).to receive(:provider_info).and_return(
-                  FactoryBot.build(:ppms_provider)
-                )
-              end
-
-              get '/v1/facilities/ccp', params: params_with_pagination
-              bod = JSON.parse(response.body)
-
-              prev_page = page == 1 ? nil : page - 1
-              expect(bod['meta']).to include(
-                'pagination' => {
-                  'current_page' => page,
-                  'prev_page' => prev_page,
-                  'next_page' => page + 1,
-                  'total_pages' => page + 1
-                }
-              )
-            end
-          end
-
-          it 'returns a results from the provider_locator' do
-            get '/v1/facilities/ccp', params: params
-
-            bod = JSON.parse(response.body)
-            if skip_round_trips
-              expect(bod['data']).to include(
-                {
-                  'id' => '1154383230',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'true',
-                    'address' => {
-                      'street' => '176 RIVERSIDE AVE',
-                      'city' => 'RED BANK',
-                      'state' => 'NJ',
-                      'zip' => '07701-1063'
-                    },
-                    'caresite_phone' => '732-219-6625',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'Female',
-                    'lat' => 40.35396,
-                    'long' => -74.07492,
-                    'name' => 'GESUALDI, AMY',
-                    'phone' => nil,
-                    'pos_codes' => nil,
-                    'pref_contact' => nil,
-                    'unique_id' => '1154383230'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                }
-              )
-              expect(bod['included']).to match([])
-            else
-              expect(bod['data']).to include(
-                {
-                  'id' => '1154383230',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'true',
-                    'address' => {
-                      'street' => '176 RIVERSIDE AVE',
-                      'city' => 'RED BANK',
-                      'state' => 'NJ',
-                      'zip' => '07701-1063'
-                    },
-                    'caresite_phone' => '732-219-6625',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'Female',
-                    'lat' => 40.35396,
-                    'long' => -74.07492,
-                    'name' => 'GESUALDI, AMY',
-                    'phone' => nil,
-                    'pos_codes' => nil,
-                    'pref_contact' => nil,
-                    'unique_id' => '1154383230'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => [
-                        {
-                          'id' => '213E00000X',
-                          'type' => 'specialty'
-                        }
-                      ]
-                    }
-                  }
-                }
-              )
-              expect(bod['included']).to include(
-                {
-                  'id' => '213E00000X',
-                  'type' => 'specialty',
-                  'attributes' => {
-                    'classification' => 'Podiatrist',
-                    'grouping' => 'Podiatric Medicine & Surgery Service Providers',
-                    'name' => 'Podiatrist',
-                    'specialization' => nil,
-                    'specialty_code' => '213E00000X',
-                    'specialty_description' => 'A podiatrist is a person qualified by a Doctor of Podiatric Medicine ' \
-                                               '(D.P.M.) degree, licensed by the state, and practicing within the ' \
-                                               'scope of that license. Podiatrists diagnose and treat foot diseases ' \
-                                               'and deformities. They perform medical, surgical and other operative ' \
-                                               'procedures, prescribe corrective devices and prescribe and ' \
-                                               'administer drugs and physical therapy.'
-                  }
-                }
-              )
-            end
-
-            expect(response).to be_successful
-          end
-        end
-
-        context 'type=pharmacy' do
-          let(:params) do
-            case client_version
-            when 0
-              {
-                address: '58 Leonard Ave, Leonardo, NJ 07737',
-                bbox: ['-75.91', '38.55', '-72.19', '42.27'],
-                type: 'pharmacy'
-              }
-            when 1
-              {
-                latitude: 40.415217,
-                longitude: -74.057114,
-                radius: 200,
-                type: 'pharmacy'
-              }
-            end
-          end
-
-          it 'returns results from the pos_locator' do
-            get '/v1/facilities/ccp', params: params
-
-            bod = JSON.parse(response.body)
-
-            if skip_round_trips
-
-              expect(bod['data'][0]).to match(
-                {
-                  'id' => '1225028293',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '2 BAYSHORE PLZ',
-                      'city' => 'ATLANTIC HIGHLANDS',
-                      'state' => 'NJ',
-                      'zip' => '07716'
-                    },
-                    'caresite_phone' => '732-291-2900',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.409114,
-                    'long' => -74.041849,
-                    'name' => 'BAYSHORE PHARMACY',
-                    'phone' => nil,
-                    'pos_codes' => nil,
-                    'pref_contact' => nil,
-                    'unique_id' => '1225028293'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                }
-              )
-
-              expect(bod['included']).to match([])
-
-            else
-
-              expect(bod['data'][0]).to match(
-                {
-                  'id' => '1225028293',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '2 BAYSHORE PLZ',
-                      'city' => 'ATLANTIC HIGHLANDS',
-                      'state' => 'NJ',
-                      'zip' => '07716'
-                    },
-                    'caresite_phone' => '732-291-2900',
-                    'email' => 'MANAGER.BAYSHOREPHARMACY@COMCAST.NET',
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.409114,
-                    'long' => -74.041849,
-                    'name' => 'BAYSHORE PHARMACY',
-                    'phone' => nil,
-                    'pos_codes' => nil,
-                    'pref_contact' => nil,
-                    'unique_id' => '1225028293'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => [
-                        {
-                          'id' => '3336C0003X',
-                          'type' => 'specialty'
-                        }
-                      ]
-                    }
-                  }
-                }
-              )
-
-              expect(bod['included'][0]).to match(
-                {
-                  'id' => '3336C0003X',
-                  'type' => 'specialty',
-                  'attributes' => {
-                    'classification' => 'Pharmacy',
-                    'grouping' => 'Suppliers',
-                    'name' => 'Pharmacy - Community/Retail Pharmacy',
-                    'specialization' => 'Community/Retail Pharmacy',
-                    'specialty_code' => '3336C0003X',
-                    'specialty_description' => 'A pharmacy where pharmacists store, prepare, and dispense medicinal ' \
-                      'preparations and/or prescriptions for a local patient population in accordance with federal ' \
-                      'and state law; counsel patients and caregivers (sometimes independent of the dispensing ' \
-                      'process); administer vaccinations; and provide other professional services associated with ' \
-                      'pharmaceutical care such as health screenings, consultative services with other health care ' \
-                      'providers, collaborative practice, disease state management, and education classes.'
-                  }
-                }
-              )
-
-            end
-            expect(response).to be_successful
-          end
-        end
-
-        context 'type=urgent_care' do
-          let(:params) do
-            case client_version
-            when 0
-              {
-                address: '58 Leonard Ave, Leonardo, NJ 07737',
-                bbox: ['-75.91', '38.55', '-72.19', '42.27'],
-                type: 'urgent_care'
-              }
-            when 1
-              {
-                latitude: 40.415217,
-                longitude: -74.057114,
-                radius: 200,
-                type: 'urgent_care'
-              }
-            end
-          end
-
-          it 'returns results from the pos_locator' do
-            get '/v1/facilities/ccp', params: params
-
-            bod = JSON.parse(response.body)
-
-            sha256 = if Flipper.enabled?(:facility_locator_ppms_use_v1_client)
-                       'b09211e205d103edf949d2897dcbe489fb7bc3f2c73f203022b4d7b96e603d0d'
-                     else
-                       '263e81aab50e1c4ea77e84ff7130473f074036f0f01e86abe5ad4a1864c77cb9'
-                     end
-
-            expect(bod['data']).to include(
-              {
-                'id' => sha256,
-                'type' => 'provider',
-                'attributes' => {
-                  'acc_new_patients' => 'false',
-                  'address' => {
-                    'street' => '5024 5TH AVE',
-                    'city' => 'BROOKLYN',
-                    'state' => 'NY',
-                    'zip' => '11220-1909'
-                  },
-                  'caresite_phone' => '718-571-9251',
-                  'email' => nil,
-                  'fax' => nil,
-                  'gender' => 'NotSpecified',
-                  'lat' => 40.644795,
-                  'long' => -74.011055,
-                  'name' => 'CITY MD URGENT CARE',
-                  'phone' => nil,
-                  'pos_codes' => '20',
-                  'pref_contact' => nil,
-                  'unique_id' => '1487993564'
-                },
-                'relationships' => {
-                  'specialties' => {
-                    'data' => []
-                  }
-                }
-              }
-            )
-
-            expect(response).to be_successful
-          end
-        end
-      end
-
-      describe '#show' do
-        it 'returns RecordNotFound if ppms has no record' do
-          pending('This needs an updated VCR tape with a request for a provider by id that isnt found')
-          get '/v1/facilities/ccp/ccp_0000000000'
+        it 'returns a results from the pos_locator' do
+          get '/v1/facilities/ccp', params: params
 
           bod = JSON.parse(response.body)
 
-          expect(bod['errors'].length).to be > 0
-          expect(bod['errors'][0]['title']).to eq('Record not found')
-        end
+          sha256 = 'b09211e205d103edf949d2897dcbe489fb7bc3f2c73f203022b4d7b96e603d0d'
 
-        it 'returns a provider with services' do
-          get '/v1/facilities/ccp/1225028293'
-
-          bod = JSON.parse(response.body)
-
-          expect(bod).to include(
-            'data' => {
-              'id' => '1225028293',
+          expect(bod['data']).to include(
+            {
+              'id' => sha256,
               'type' => 'provider',
               'attributes' => {
-                'acc_new_patients' => nil,
+                'acc_new_patients' => 'false',
                 'address' => {
-                  'street' => '2 BAYSHORE PLZ',
-                  'city' => 'ATLANTIC HIGHLANDS',
-                  'state' => 'NJ',
-                  'zip' => '07716'
+                  'street' => '5024 5TH AVE',
+                  'city' => 'BROOKLYN',
+                  'state' => 'NY',
+                  'zip' => '11220-1909'
                 },
-                'caresite_phone' => nil,
-                'email' => 'MANAGER.BAYSHOREPHARMACY@COMCAST.NET',
+                'caresite_phone' => '718-571-9251',
+                'email' => nil,
                 'fax' => nil,
-                'gender' => nil,
-                'lat' => 40.409114,
-                'long' => -74.041849,
-                'name' => 'BAYSHORE PHARMACY',
+                'gender' => 'NotSpecified',
+                'lat' => 40.644795,
+                'long' => -74.011055,
+                'name' => 'CITY MD URGENT CARE',
                 'phone' => nil,
-                'pos_codes' => nil,
+                'pos_codes' => '20',
                 'pref_contact' => nil,
-                'unique_id' => '1225028293'
+                'unique_id' => '1487993564'
               },
               'relationships' => {
                 'specialties' => {
-                  'data' => [
-                    {
-                      'id' => '3336C0003X',
-                      'type' => 'specialty'
-                    }
-                  ]
+                  'data' => []
                 }
               }
-            },
-            'included' => [
-              {
-                'id' => '3336C0003X',
-                'type' => 'specialty',
-                'attributes' => {
-                  'classification' => 'Pharmacy',
-                  'grouping' => 'Suppliers',
-                  'name' => 'Pharmacy - Community/Retail Pharmacy',
-                  'specialization' => 'Community/Retail Pharmacy',
-                  'specialty_code' => '3336C0003X',
-                  'specialty_description' => 'A pharmacy where pharmacists store, prepare, and dispense medicinal ' \
-                    'preparations and/or prescriptions for a local patient population in accordance with federal and ' \
-                    'state law; counsel patients and caregivers (sometimes independent of the dispensing process); ' \
-                    'administer vaccinations; and provide other professional services associated with pharmaceutical ' \
-                    'care such as health screenings, consultative services with other health care providers, ' \
-                    'collaborative practice, disease state management, and education classes.'
-                }
-              }
-            ]
+            }
           )
+          expect(response).to be_successful
         end
       end
 
-      describe '#specialties', vcr: vcr_options.merge(cassette_name: 'facilities/ppms/ppms_specialties') do
-        it 'returns a list of available specializations' do
-          get '/v1/facilities/ccp/specialties'
+      it "sends a 'facilities.ppms.request.faraday' notification to any subscribers listening" do
+        allow(StatsD).to receive(:measure)
 
+        expect(StatsD).to receive(:measure).with(
+          'facilities.ppms.provider_locator',
+          kind_of(Numeric),
+          hash_including(
+            tags: ['facilities.ppms']
+          )
+        )
+
+        expect do
+          get '/v1/facilities/ccp', params: params
+        end.to instrument('facilities.ppms.request.faraday')
+      end
+
+      [
+        [1, 5, 6],
+        [2, 5, 11],
+        [3, 1, 4]
+      ].each do |(page, per_page, total_items)|
+        it "paginates ppms responses (page: #{page}, per_page: #{per_page}, total_items: #{total_items})" do
+          params_with_pagination = params.merge(
+            page: page.to_s,
+            per_page: per_page.to_s
+          )
+
+          client = Facilities::PPMS::V1::Client.new
+          expect(Facilities::PPMS::V1::Client).to receive(:new).and_return(client)
+          expect(client).to receive(:provider_locator).and_return(
+            Facilities::PPMS::V1::Response.new(
+              FactoryBot.build_list(:ppms_provider, total_items).collect(&:attributes),
+              params_with_pagination
+            ).providers
+          )
+          allow(client).to receive(:provider_info).and_return(
+            FactoryBot.build(:ppms_provider)
+          )
+
+          get '/v1/facilities/ccp', params: params_with_pagination
           bod = JSON.parse(response.body)
 
-          expect(bod['data'][0..1]).to match(
-            [{
-              'id' => '101Y00000X',
-              'type' => 'specialty',
-              'attributes' => {
-                'classification' => 'Counselor',
-                'grouping' => 'Behavioral Health & Social Service Providers',
-                'name' => 'Counselor',
-                'specialization' => nil,
-                'specialty_code' => '101Y00000X',
-                'specialty_description' => 'A provider who is trained and educated in the performance of behavior ' \
-             'health services through interpersonal communications and analysis. ' \
-             'Training and education at the specialty level usually requires a ' \
-             'master\'s degree and clinical experience and supervision for licensure ' \
-             'or certification.'
-              }
-            },
-             {
-               'id' => '101YA0400X',
-               'type' => 'specialty',
-               'attributes' => {
-                 'classification' => 'Counselor',
-                 'grouping' => 'Behavioral Health & Social Service Providers',
-                 'name' => 'Counselor - Addiction (Substance Use Disorder)',
-                 'specialization' => 'Addiction (Substance Use Disorder)',
-                 'specialty_code' => '101YA0400X',
-                 'specialty_description' => 'Definition to come...'
-               }
-             }]
+          prev_page = page == 1 ? nil : page - 1
+          expect(bod['meta']).to include(
+            'pagination' => {
+              'current_page' => page,
+              'prev_page' => prev_page,
+              'next_page' => page + 1,
+              'total_pages' => page + 1
+            }
           )
         end
       end
+
+      it 'returns a results from the provider_locator' do
+        get '/v1/facilities/ccp', params: params
+
+        bod = JSON.parse(response.body)
+        expect(bod['data']).to include(
+          {
+            'id' => '1154383230',
+            'type' => 'provider',
+            'attributes' => {
+              'acc_new_patients' => 'true',
+              'address' => {
+                'street' => '176 RIVERSIDE AVE',
+                'city' => 'RED BANK',
+                'state' => 'NJ',
+                'zip' => '07701-1063'
+              },
+              'caresite_phone' => '732-219-6625',
+              'email' => nil,
+              'fax' => nil,
+              'gender' => 'Female',
+              'lat' => 40.35396,
+              'long' => -74.07492,
+              'name' => 'GESUALDI, AMY',
+              'phone' => nil,
+              'pos_codes' => nil,
+              'pref_contact' => nil,
+              'unique_id' => '1154383230'
+            },
+            'relationships' => {
+              'specialties' => {
+                'data' => []
+              }
+            }
+          }
+        )
+        expect(bod['included']).to match([])
+
+        expect(response).to be_successful
+      end
+    end
+
+    context 'type=pharmacy' do
+      let(:params) do
+        {
+          latitude: 40.415217,
+          longitude: -74.057114,
+          radius: 200,
+          type: 'pharmacy'
+        }
+      end
+
+      it 'returns results from the pos_locator' do
+        get '/v1/facilities/ccp', params: params
+
+        bod = JSON.parse(response.body)
+
+        expect(bod['data'][0]).to match(
+          {
+            'id' => '1225028293',
+            'type' => 'provider',
+            'attributes' => {
+              'acc_new_patients' => 'false',
+              'address' => {
+                'street' => '2 BAYSHORE PLZ',
+                'city' => 'ATLANTIC HIGHLANDS',
+                'state' => 'NJ',
+                'zip' => '07716'
+              },
+              'caresite_phone' => '732-291-2900',
+              'email' => nil,
+              'fax' => nil,
+              'gender' => 'NotSpecified',
+              'lat' => 40.409114,
+              'long' => -74.041849,
+              'name' => 'BAYSHORE PHARMACY',
+              'phone' => nil,
+              'pos_codes' => nil,
+              'pref_contact' => nil,
+              'unique_id' => '1225028293'
+            },
+            'relationships' => {
+              'specialties' => {
+                'data' => []
+              }
+            }
+          }
+        )
+
+        expect(bod['included']).to match([])
+
+        expect(response).to be_successful
+      end
+    end
+
+    context 'type=urgent_care' do
+      let(:params) do
+        {
+          latitude: 40.415217,
+          longitude: -74.057114,
+          radius: 200,
+          type: 'urgent_care'
+        }
+      end
+
+      it 'returns results from the pos_locator' do
+        get '/v1/facilities/ccp', params: params
+
+        bod = JSON.parse(response.body)
+
+        sha256 = 'b09211e205d103edf949d2897dcbe489fb7bc3f2c73f203022b4d7b96e603d0d'
+
+        expect(bod['data']).to include(
+          {
+            'id' => sha256,
+            'type' => 'provider',
+            'attributes' => {
+              'acc_new_patients' => 'false',
+              'address' => {
+                'street' => '5024 5TH AVE',
+                'city' => 'BROOKLYN',
+                'state' => 'NY',
+                'zip' => '11220-1909'
+              },
+              'caresite_phone' => '718-571-9251',
+              'email' => nil,
+              'fax' => nil,
+              'gender' => 'NotSpecified',
+              'lat' => 40.644795,
+              'long' => -74.011055,
+              'name' => 'CITY MD URGENT CARE',
+              'phone' => nil,
+              'pos_codes' => '20',
+              'pref_contact' => nil,
+              'unique_id' => '1487993564'
+            },
+            'relationships' => {
+              'specialties' => {
+                'data' => []
+              }
+            }
+          }
+        )
+
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe '#show' do
+    it 'returns RecordNotFound if ppms has no record' do
+      pending('This needs an updated VCR tape with a request for a provider by id that isnt found')
+      get '/v1/facilities/ccp/ccp_0000000000'
+
+      bod = JSON.parse(response.body)
+
+      expect(bod['errors'].length).to be > 0
+      expect(bod['errors'][0]['title']).to eq('Record not found')
+    end
+
+    it 'returns a provider with services' do
+      get '/v1/facilities/ccp/1225028293'
+
+      bod = JSON.parse(response.body)
+
+      expect(bod).to include(
+        'data' => {
+          'id' => '1225028293',
+          'type' => 'provider',
+          'attributes' => {
+            'acc_new_patients' => nil,
+            'address' => {
+              'street' => '2 BAYSHORE PLZ',
+              'city' => 'ATLANTIC HIGHLANDS',
+              'state' => 'NJ',
+              'zip' => '07716'
+            },
+            'caresite_phone' => nil,
+            'email' => 'MANAGER.BAYSHOREPHARMACY@COMCAST.NET',
+            'fax' => nil,
+            'gender' => nil,
+            'lat' => 40.409114,
+            'long' => -74.041849,
+            'name' => 'BAYSHORE PHARMACY',
+            'phone' => nil,
+            'pos_codes' => nil,
+            'pref_contact' => nil,
+            'unique_id' => '1225028293'
+          },
+          'relationships' => {
+            'specialties' => {
+              'data' => [
+                {
+                  'id' => '3336C0003X',
+                  'type' => 'specialty'
+                }
+              ]
+            }
+          }
+        },
+        'included' => [
+          {
+            'id' => '3336C0003X',
+            'type' => 'specialty',
+            'attributes' => {
+              'classification' => 'Pharmacy',
+              'grouping' => 'Suppliers',
+              'name' => 'Pharmacy - Community/Retail Pharmacy',
+              'specialization' => 'Community/Retail Pharmacy',
+              'specialty_code' => '3336C0003X',
+              'specialty_description' => 'A pharmacy where pharmacists store, prepare, and dispense medicinal ' \
+                'preparations and/or prescriptions for a local patient population in accordance with federal and ' \
+                'state law; counsel patients and caregivers (sometimes independent of the dispensing process); ' \
+                'administer vaccinations; and provide other professional services associated with pharmaceutical ' \
+                'care such as health screenings, consultative services with other health care providers, ' \
+                'collaborative practice, disease state management, and education classes.'
+            }
+          }
+        ]
+      )
+    end
+  end
+
+  describe '#specialties', vcr: vcr_options.merge(cassette_name: 'facilities/ppms/ppms_specialties') do
+    it 'returns a list of available specializations' do
+      get '/v1/facilities/ccp/specialties'
+
+      bod = JSON.parse(response.body)
+
+      expect(bod['data'][0..1]).to match(
+        [{
+          'id' => '101Y00000X',
+          'type' => 'specialty',
+          'attributes' => {
+            'classification' => 'Counselor',
+            'grouping' => 'Behavioral Health & Social Service Providers',
+            'name' => 'Counselor',
+            'specialization' => nil,
+            'specialty_code' => '101Y00000X',
+            'specialty_description' => 'A provider who is trained and educated in the performance of behavior ' \
+         'health services through interpersonal communications and analysis. ' \
+         'Training and education at the specialty level usually requires a ' \
+         'master\'s degree and clinical experience and supervision for licensure ' \
+         'or certification.'
+          }
+        },
+         {
+           'id' => '101YA0400X',
+           'type' => 'specialty',
+           'attributes' => {
+             'classification' => 'Counselor',
+             'grouping' => 'Behavioral Health & Social Service Providers',
+             'name' => 'Counselor - Addiction (Substance Use Disorder)',
+             'specialization' => 'Addiction (Substance Use Disorder)',
+             'specialty_code' => '101YA0400X',
+             'specialty_description' => 'Definition to come...'
+           }
+         }]
+      )
     end
   end
 end

--- a/spec/request/v1/facilities/va_ccp_request_spec.rb
+++ b/spec/request/v1/facilities/va_ccp_request_spec.rb
@@ -9,573 +9,559 @@ vcr_options = {
 }
 
 RSpec.describe 'VA and Community Care Mashup', type: :request, team: :facilities, vcr: vcr_options do
-  [0, 1].each do |client_version|
-    context "Facilities::PPMS::V#{client_version}::Client" do
-      before do
-        Flipper.enable(:facility_locator_ppms_use_v1_client, client_version == 1)
-      end
+  context "Facilities::PPMS::V1::Client" do
 
-      let(:params) do
-        case client_version
-        when 0
-          {
-            address: '58 Leonard Ave, Leonardo, NJ 07737',
-            bbox: ['-75.91', '38.55', '-72.19', '42.27'],
-            type: 'provider'
-          }
-        when 1
-          {
-            bbox: ['-75.91', '38.55', '-72.19', '42.27'],
-            latitude: 40.415217,
-            longitude: -74.057114,
-            radius: 200,
-            type: 'provider'
-          }
-        end
-      end
+    let(:params) do
+      {
+        bbox: ['-75.91', '38.55', '-72.19', '42.27'],
+        latitude: 40.415217,
+        longitude: -74.057114,
+        radius: 200,
+        type: 'provider'
+      }
+    end
 
-      describe '#va_ccp/urgent_care' do
-        let(:path) { '/v1/facilities/va_ccp/urgent_care' }
+    describe '#va_ccp/urgent_care' do
+      let(:path) { '/v1/facilities/va_ccp/urgent_care' }
 
-        it "sends a 'facilities.ppms.request.faraday' notification to any subscribers listening" do
-          allow(StatsD).to receive(:measure)
+      it "sends a 'facilities.ppms.request.faraday' notification to any subscribers listening" do
+        allow(StatsD).to receive(:measure)
 
-          expect(StatsD).to receive(:measure).with(
-            'facilities.ppms.place_of_service_locator',
-            kind_of(Numeric),
-            hash_including(tags: ['facilities.ppms'])
-          )
+        expect(StatsD).to receive(:measure).with(
+          'facilities.ppms.place_of_service_locator',
+          kind_of(Numeric),
+          hash_including(tags: ['facilities.ppms'])
+        )
 
-          expect do
-            get path, params: params
-          end.to instrument('facilities.ppms.request.faraday')
-        end
-
-        it "sends a 'lighthouse.facilities.request.faraday' notification to any subscribers listening" do
-          allow(StatsD).to receive(:measure)
-
-          expect(StatsD).to receive(:measure).with(
-            'facilities.lighthouse',
-            kind_of(Numeric),
-            hash_including(tags: ['facilities.lighthouse'])
-          )
-
-          expect do
-            get path, params: params
-          end.to instrument('lighthouse.facilities.request.faraday')
-        end
-
-        it 'returns results from the pos_locator' do
-          allow(SecureRandom).to receive(:uuid).and_return('927d31eb-11fd-43c2-ac29-11c1a4128819')
-
+        expect do
           get path, params: params
+        end.to instrument('facilities.ppms.request.faraday')
+      end
 
-          bod = JSON.parse(response.body)
+      it "sends a 'lighthouse.facilities.request.faraday' notification to any subscribers listening" do
+        allow(StatsD).to receive(:measure)
 
-          expect(bod).to match(
-            {
-              'data' => [
-                {
-                  'id' => '927d31eb-11fd-43c2-ac29-11c1a4128819',
-                  'type' => 'provider_facility',
-                  'relationships' => {
-                    'providers' => {
-                      'data' => [
-                        {
-                          'id' => 'b09211e205d103edf949d2897dcbe489fb7bc3f2c73f203022b4d7b96e603d0d',
-                          'type' => 'provider'
-                        },
-                        {
-                          'id' => '4fd8291ae0bb51e568eb29d215ed5a784f9171b9f98f9963a706a5fc387a24c5',
-                          'type' => 'provider'
-                        },
-                        {
-                          'id' => 'a0cfafe8986a6893bfc651244ce6e9fee21dfd3e7c4b82c33062d31281b8989c',
-                          'type' => 'provider'
-                        },
-                        {
-                          'id' => '30f247acf7bd6635760a6398043bf0235030e8299aad5390a210f24a3b4684c4',
-                          'type' => 'provider'
-                        },
-                        {
-                          'id' => '73f57df2aeda3424246aa1526d91a4eb2e27a6828bb646898a77e87b88b2bab9',
-                          'type' => 'provider'
-                        },
-                        {
-                          'id' => 'dfa50f5b6bf7a5ffc36f11f636ef8d51ee1303c102c4fd9c6925ca1c2c433fa7',
-                          'type' => 'provider'
-                        },
-                        {
-                          'id' => 'a9e664cb35c5705a371962fca74ea7c2f6b277aa75446673b8795b3afe7f29a1',
-                          'type' => 'provider'
-                        },
-                        {
-                          'id' => 'a01a12227953e3b4e538e1ad1eea8a49c8f789ca587e849c13894529553e49b5',
-                          'type' => 'provider'
-                        },
-                        {
-                          'id' => 'f6c97daea4f94f7e5c3ed73840ec3f61832da018c2d5e43a884c297dd94019f1',
-                          'type' => 'provider'
-                        },
-                        {
-                          'id' => '9a90ec56691c18bfe3a05fa99e44a3a8299700a07b02c1da65aefdaea1d9987c',
-                          'type' => 'provider'
-                        }
-                      ]
-                    },
-                    'facilities' => {
-                      'data' => [
-                        {
-                          'id' => 'vha_561',
-                          'type' => 'facility'
-                        }
-                      ]
-                    }
-                  }
-                }
-              ],
-              'included' => [
-                {
-                  'id' => 'vha_561',
-                  'type' => 'facility',
-                  'attributes' => {
-                    'access' => {
-                      'health' => [
-                        {
-                          'service' => 'Audiology',
-                          'new' => 39.456,
-                          'established' => 32.118421
-                        },
-                        {
-                          'service' => 'Cardiology',
-                          'new' => 27.711538,
-                          'established' => 20.4
-                        },
-                        {
-                          'service' => 'Dermatology',
-                          'new' => 19.785714,
-                          'established' => 13.75
-                        },
-                        {
-                          'service' => 'Gastroenterology',
-                          'new' => 22.470588,
-                          'established' => 16.355555
-                        },
-                        {
-                          'service' => 'Gynecology',
-                          'new' => 22.962962,
-                          'established' => 5.612903
-                        },
-                        {
-                          'service' => 'MentalHealthCare',
-                          'new' => 3.964285,
-                          'established' => 1.37902
-                        },
-                        {
-                          'service' => 'Ophthalmology',
-                          'new' => 8.25,
-                          'established' => 18.841726
-                        },
-                        {
-                          'service' => 'Optometry',
-                          'new' => 33.75,
-                          'established' => 21.683168
-                        },
-                        {
-                          'service' => 'Orthopedics',
-                          'new' => 11.133333,
-                          'established' => 1.142857
-                        },
-                        {
-                          'service' => 'PrimaryCare',
-                          'new' => 19.391304,
-                          'established' => 18.299295
-                        },
-                        {
-                          'service' => 'SpecialtyCare',
-                          'new' => 22.659012,
-                          'established' => 16.878493
-                        },
-                        {
-                          'service' => 'Urology',
-                          'new' => 26.1875,
-                          'established' => 2.166666
-                        }
-                      ],
-                      'effective_date' => '2020-11-30'
-                    },
-                    'active_status' => 'A',
-                    'address' => {
-                      'mailing' => {
+        expect(StatsD).to receive(:measure).with(
+          'facilities.lighthouse',
+          kind_of(Numeric),
+          hash_including(tags: ['facilities.lighthouse'])
+        )
+
+        expect do
+          get path, params: params
+        end.to instrument('lighthouse.facilities.request.faraday')
+      end
+
+      it 'returns results from the pos_locator' do
+        allow(SecureRandom).to receive(:uuid).and_return('927d31eb-11fd-43c2-ac29-11c1a4128819')
+
+        get path, params: params
+
+        bod = JSON.parse(response.body)
+
+        expect(bod).to match(
+          {
+            'data' => [
+              {
+                'id' => '927d31eb-11fd-43c2-ac29-11c1a4128819',
+                'type' => 'provider_facility',
+                'relationships' => {
+                  'providers' => {
+                    'data' => [
+                      {
+                        'id' => 'b09211e205d103edf949d2897dcbe489fb7bc3f2c73f203022b4d7b96e603d0d',
+                        'type' => 'provider'
                       },
-                      'physical' => {
-                        'zip' => '07018-1023',
-                        'city' => 'East Orange',
-                        'state' => 'NJ',
-                        'address_1' => '385 Tremont Avenue',
-                        'address_2' => nil,
-                        'address_3' => nil
+                      {
+                        'id' => '4fd8291ae0bb51e568eb29d215ed5a784f9171b9f98f9963a706a5fc387a24c5',
+                        'type' => 'provider'
+                      },
+                      {
+                        'id' => 'a0cfafe8986a6893bfc651244ce6e9fee21dfd3e7c4b82c33062d31281b8989c',
+                        'type' => 'provider'
+                      },
+                      {
+                        'id' => '30f247acf7bd6635760a6398043bf0235030e8299aad5390a210f24a3b4684c4',
+                        'type' => 'provider'
+                      },
+                      {
+                        'id' => '73f57df2aeda3424246aa1526d91a4eb2e27a6828bb646898a77e87b88b2bab9',
+                        'type' => 'provider'
+                      },
+                      {
+                        'id' => 'dfa50f5b6bf7a5ffc36f11f636ef8d51ee1303c102c4fd9c6925ca1c2c433fa7',
+                        'type' => 'provider'
+                      },
+                      {
+                        'id' => 'a9e664cb35c5705a371962fca74ea7c2f6b277aa75446673b8795b3afe7f29a1',
+                        'type' => 'provider'
+                      },
+                      {
+                        'id' => 'a01a12227953e3b4e538e1ad1eea8a49c8f789ca587e849c13894529553e49b5',
+                        'type' => 'provider'
+                      },
+                      {
+                        'id' => 'f6c97daea4f94f7e5c3ed73840ec3f61832da018c2d5e43a884c297dd94019f1',
+                        'type' => 'provider'
+                      },
+                      {
+                        'id' => '9a90ec56691c18bfe3a05fa99e44a3a8299700a07b02c1da65aefdaea1d9987c',
+                        'type' => 'provider'
                       }
-                    },
-                    'classification' => 'VA Medical Center (VAMC)',
-                    'facility_type' => 'va_health_facility',
-                    'feedback' => {
-                      'health' => {
-                        'primary_care_urgent' => 0.7400000095367432,
-                        'primary_care_routine' => 0.7699999809265137,
-                        'specialty_care_urgent' => 0.800000011920929,
-                        'specialty_care_routine' => 0.8999999761581421
-                      },
-                      'effective_date' => '2020-04-16'
-                    },
-                    'hours' => {
-                      'friday' => '24/7',
-                      'monday' => '24/7',
-                      'sunday' => '24/7',
-                      'tuesday' => '24/7',
-                      'saturday' => '24/7',
-                      'thursday' => '24/7',
-                      'wednesday' => '24/7'
-                    },
-                    'id' => 'vha_561',
-                    'lat' => 40.75380161,
-                    'long' => -74.23432989,
-                    'mobile' => false,
-                    'name' => 'East Orange VA Medical Center',
-                    'operating_status' => {
-                      'code' => 'NORMAL'
-                    },
-                    'phone' => {
-                      'fax' => '973-676-4226',
-                      'main' => '973-676-1000',
-                      'pharmacy' => '800-480-5590',
-                      'after_hours' => '973-676-1000',
-                      'patient_advocate' => '973-676-1000 x3399',
-                      'mental_health_clinic' => '973-676-1000 x 1421',
-                      'enrollment_coordinator' => '973-676-1000 x3044'
-                    },
-                    'services' => {
-                      'other' => [],
-                      'health' => %w[
-                        Audiology
-                        Cardiology
-                        DentalServices
-                        Dermatology
-                        EmergencyCare
-                        Gastroenterology
-                        Gynecology
-                        MentalHealthCare
-                        Nutrition
-                        Ophthalmology
-                        Optometry
-                        Orthopedics
-                        Podiatry
-                        PrimaryCare
-                        SpecialtyCare
-                        UrgentCare
-                        Urology
-                      ],
-                      'last_updated' => '2020-11-30'
-                    },
-                    'unique_id' => '561',
-                    'visn' => '2',
-                    'website' => 'https://www.newjersey.va.gov/locations/directions.asp'
-                  }
-                },
-                {
-                  'id' => 'b09211e205d103edf949d2897dcbe489fb7bc3f2c73f203022b4d7b96e603d0d',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '5024 5TH AVE',
-                      'city' => 'BROOKLYN',
-                      'state' => 'NY',
-                      'zip' => '11220-1909'
-                    },
-                    'caresite_phone' => '718-571-9251',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.644795,
-                    'long' => -74.011055,
-                    'name' => 'CITY MD URGENT CARE',
-                    'phone' => nil,
-                    'pos_codes' => '20',
-                    'pref_contact' => nil,
-                    'unique_id' => '1487993564'
+                    ]
                   },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                },
-                {
-                  'id' => '4fd8291ae0bb51e568eb29d215ed5a784f9171b9f98f9963a706a5fc387a24c5',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '2175 86TH ST',
-                      'city' => 'BROOKLYN',
-                      'state' => 'NY',
-                      'zip' => '11214-3205'
-                    },
-                    'caresite_phone' => '646-828-6401',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.602322,
-                    'long' => -73.993869,
-                    'name' => 'CITY MD URGENT CARE',
-                    'phone' => nil,
-                    'pos_codes' => '20',
-                    'pref_contact' => nil,
-                    'unique_id' => '1487993564'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                },
-                {
-                  'id' => 'a0cfafe8986a6893bfc651244ce6e9fee21dfd3e7c4b82c33062d31281b8989c',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '418 5TH AVE # 420',
-                      'city' => 'BROOKLYN',
-                      'state' => 'NY',
-                      'zip' => '11215-3316'
-                    },
-                    'caresite_phone' => '718-965-2273',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.6698417,
-                    'long' => -73.98545,
-                    'name' => 'CITY MD URGENT CARE',
-                    'phone' => nil,
-                    'pos_codes' => '20',
-                    'pref_contact' => nil,
-                    'unique_id' => '1487993564'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                },
-                {
-                  'id' => '30f247acf7bd6635760a6398043bf0235030e8299aad5390a210f24a3b4684c4',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '712 BRIGHTON BEACH AVE',
-                      'city' => 'BROOKLYN',
-                      'state' => 'NY',
-                      'zip' => '11235-6412'
-                    },
-                    'caresite_phone' => '718-571-9291',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.5776963,
-                    'long' => -73.960225,
-                    'name' => 'CITY MD URGENT CARE',
-                    'phone' => nil,
-                    'pos_codes' => '20',
-                    'pref_contact' => nil,
-                    'unique_id' => '1487993564'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                },
-                {
-                  'id' => '73f57df2aeda3424246aa1526d91a4eb2e27a6828bb646898a77e87b88b2bab9',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '1305 KINGS HWY',
-                      'city' => 'BROOKLYN',
-                      'state' => 'NY',
-                      'zip' => '11229-1903'
-                    },
-                    'caresite_phone' => '718-280-5172',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.608378,
-                    'long' => -73.959851,
-                    'name' => 'CITY MD URGENT CARE',
-                    'phone' => nil,
-                    'pos_codes' => '20',
-                    'pref_contact' => nil,
-                    'unique_id' => '1487993564'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                },
-                {
-                  'id' => 'dfa50f5b6bf7a5ffc36f11f636ef8d51ee1303c102c4fd9c6925ca1c2c433fa7',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '874 FLATBUSH AVE',
-                      'city' => 'BROOKLYN',
-                      'state' => 'NY',
-                      'zip' => '11226-3102'
-                    },
-                    'caresite_phone' => '718-571-9372',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.650747,
-                    'long' => -73.959134,
-                    'name' => 'CITY MD URGENT CARE',
-                    'phone' => nil,
-                    'pos_codes' => '20',
-                    'pref_contact' => nil,
-                    'unique_id' => '1487993564'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                },
-                {
-                  'id' => 'a9e664cb35c5705a371962fca74ea7c2f6b277aa75446673b8795b3afe7f29a1',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '288 FLATBUSH AVE',
-                      'city' => 'BROOKLYN',
-                      'state' => 'NY',
-                      'zip' => '11217-2812'
-                    },
-                    'caresite_phone' => '718-656-1290',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.678175,
-                    'long' => -73.97373,
-                    'name' => 'CITY MD URGENT CARE',
-                    'phone' => nil,
-                    'pos_codes' => '20',
-                    'pref_contact' => nil,
-                    'unique_id' => '1487993564'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                },
-                {
-                  'id' => 'a01a12227953e3b4e538e1ad1eea8a49c8f789ca587e849c13894529553e49b5',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '2125 NOSTRAND AVE',
-                      'city' => 'BROOKLYN',
-                      'state' => 'NY',
-                      'zip' => '11210-3001'
-                    },
-                    'caresite_phone' => '718-489-3557',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.633455,
-                    'long' => -73.947402,
-                    'name' => 'CITY MD URGENT CARE',
-                    'phone' => nil,
-                    'pos_codes' => '20',
-                    'pref_contact' => nil,
-                    'unique_id' => '1487993564'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                },
-                {
-                  'id' => 'f6c97daea4f94f7e5c3ed73840ec3f61832da018c2d5e43a884c297dd94019f1',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'true',
-                    'address' => {
-                      'street' => '256 UTICA AVE',
-                      'city' => 'BROOKLYN',
-                      'state' => 'NY',
-                      'zip' => '11213-4029'
-                    },
-                    'caresite_phone' => '718-240-2644',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.669966,
-                    'long' => -73.931422,
-                    'name' => 'CITY MD URGENT CARE',
-                    'phone' => nil,
-                    'pos_codes' => '20',
-                    'pref_contact' => nil,
-                    'unique_id' => '1326229022'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
-                  }
-                },
-                {
-                  'id' => '9a90ec56691c18bfe3a05fa99e44a3a8299700a07b02c1da65aefdaea1d9987c',
-                  'type' => 'provider',
-                  'attributes' => {
-                    'acc_new_patients' => 'false',
-                    'address' => {
-                      'street' => '256 UTICA AVE',
-                      'city' => 'BROOKLYN',
-                      'state' => 'NY',
-                      'zip' => '11213-4029'
-                    },
-                    'caresite_phone' => '718-571-9355',
-                    'email' => nil,
-                    'fax' => nil,
-                    'gender' => 'NotSpecified',
-                    'lat' => 40.669966,
-                    'long' => -73.931422,
-                    'name' => 'CITY MD URGENT CARE',
-                    'phone' => nil,
-                    'pos_codes' => '20',
-                    'pref_contact' => nil,
-                    'unique_id' => '1487993564'
-                  },
-                  'relationships' => {
-                    'specialties' => {
-                      'data' => []
-                    }
+                  'facilities' => {
+                    'data' => [
+                      {
+                        'id' => 'vha_561',
+                        'type' => 'facility'
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          )
-        end
+              }
+            ],
+            'included' => [
+              {
+                'id' => 'vha_561',
+                'type' => 'facility',
+                'attributes' => {
+                  'access' => {
+                    'health' => [
+                      {
+                        'service' => 'Audiology',
+                        'new' => 39.456,
+                        'established' => 32.118421
+                      },
+                      {
+                        'service' => 'Cardiology',
+                        'new' => 27.711538,
+                        'established' => 20.4
+                      },
+                      {
+                        'service' => 'Dermatology',
+                        'new' => 19.785714,
+                        'established' => 13.75
+                      },
+                      {
+                        'service' => 'Gastroenterology',
+                        'new' => 22.470588,
+                        'established' => 16.355555
+                      },
+                      {
+                        'service' => 'Gynecology',
+                        'new' => 22.962962,
+                        'established' => 5.612903
+                      },
+                      {
+                        'service' => 'MentalHealthCare',
+                        'new' => 3.964285,
+                        'established' => 1.37902
+                      },
+                      {
+                        'service' => 'Ophthalmology',
+                        'new' => 8.25,
+                        'established' => 18.841726
+                      },
+                      {
+                        'service' => 'Optometry',
+                        'new' => 33.75,
+                        'established' => 21.683168
+                      },
+                      {
+                        'service' => 'Orthopedics',
+                        'new' => 11.133333,
+                        'established' => 1.142857
+                      },
+                      {
+                        'service' => 'PrimaryCare',
+                        'new' => 19.391304,
+                        'established' => 18.299295
+                      },
+                      {
+                        'service' => 'SpecialtyCare',
+                        'new' => 22.659012,
+                        'established' => 16.878493
+                      },
+                      {
+                        'service' => 'Urology',
+                        'new' => 26.1875,
+                        'established' => 2.166666
+                      }
+                    ],
+                    'effective_date' => '2020-11-30'
+                  },
+                  'active_status' => 'A',
+                  'address' => {
+                    'mailing' => {
+                    },
+                    'physical' => {
+                      'zip' => '07018-1023',
+                      'city' => 'East Orange',
+                      'state' => 'NJ',
+                      'address_1' => '385 Tremont Avenue',
+                      'address_2' => nil,
+                      'address_3' => nil
+                    }
+                  },
+                  'classification' => 'VA Medical Center (VAMC)',
+                  'facility_type' => 'va_health_facility',
+                  'feedback' => {
+                    'health' => {
+                      'primary_care_urgent' => 0.7400000095367432,
+                      'primary_care_routine' => 0.7699999809265137,
+                      'specialty_care_urgent' => 0.800000011920929,
+                      'specialty_care_routine' => 0.8999999761581421
+                    },
+                    'effective_date' => '2020-04-16'
+                  },
+                  'hours' => {
+                    'friday' => '24/7',
+                    'monday' => '24/7',
+                    'sunday' => '24/7',
+                    'tuesday' => '24/7',
+                    'saturday' => '24/7',
+                    'thursday' => '24/7',
+                    'wednesday' => '24/7'
+                  },
+                  'id' => 'vha_561',
+                  'lat' => 40.75380161,
+                  'long' => -74.23432989,
+                  'mobile' => false,
+                  'name' => 'East Orange VA Medical Center',
+                  'operating_status' => {
+                    'code' => 'NORMAL'
+                  },
+                  'phone' => {
+                    'fax' => '973-676-4226',
+                    'main' => '973-676-1000',
+                    'pharmacy' => '800-480-5590',
+                    'after_hours' => '973-676-1000',
+                    'patient_advocate' => '973-676-1000 x3399',
+                    'mental_health_clinic' => '973-676-1000 x 1421',
+                    'enrollment_coordinator' => '973-676-1000 x3044'
+                  },
+                  'services' => {
+                    'other' => [],
+                    'health' => %w[
+                      Audiology
+                      Cardiology
+                      DentalServices
+                      Dermatology
+                      EmergencyCare
+                      Gastroenterology
+                      Gynecology
+                      MentalHealthCare
+                      Nutrition
+                      Ophthalmology
+                      Optometry
+                      Orthopedics
+                      Podiatry
+                      PrimaryCare
+                      SpecialtyCare
+                      UrgentCare
+                      Urology
+                    ],
+                    'last_updated' => '2020-11-30'
+                  },
+                  'unique_id' => '561',
+                  'visn' => '2',
+                  'website' => 'https://www.newjersey.va.gov/locations/directions.asp'
+                }
+              },
+              {
+                'id' => 'b09211e205d103edf949d2897dcbe489fb7bc3f2c73f203022b4d7b96e603d0d',
+                'type' => 'provider',
+                'attributes' => {
+                  'acc_new_patients' => 'false',
+                  'address' => {
+                    'street' => '5024 5TH AVE',
+                    'city' => 'BROOKLYN',
+                    'state' => 'NY',
+                    'zip' => '11220-1909'
+                  },
+                  'caresite_phone' => '718-571-9251',
+                  'email' => nil,
+                  'fax' => nil,
+                  'gender' => 'NotSpecified',
+                  'lat' => 40.644795,
+                  'long' => -74.011055,
+                  'name' => 'CITY MD URGENT CARE',
+                  'phone' => nil,
+                  'pos_codes' => '20',
+                  'pref_contact' => nil,
+                  'unique_id' => '1487993564'
+                },
+                'relationships' => {
+                  'specialties' => {
+                    'data' => []
+                  }
+                }
+              },
+              {
+                'id' => '4fd8291ae0bb51e568eb29d215ed5a784f9171b9f98f9963a706a5fc387a24c5',
+                'type' => 'provider',
+                'attributes' => {
+                  'acc_new_patients' => 'false',
+                  'address' => {
+                    'street' => '2175 86TH ST',
+                    'city' => 'BROOKLYN',
+                    'state' => 'NY',
+                    'zip' => '11214-3205'
+                  },
+                  'caresite_phone' => '646-828-6401',
+                  'email' => nil,
+                  'fax' => nil,
+                  'gender' => 'NotSpecified',
+                  'lat' => 40.602322,
+                  'long' => -73.993869,
+                  'name' => 'CITY MD URGENT CARE',
+                  'phone' => nil,
+                  'pos_codes' => '20',
+                  'pref_contact' => nil,
+                  'unique_id' => '1487993564'
+                },
+                'relationships' => {
+                  'specialties' => {
+                    'data' => []
+                  }
+                }
+              },
+              {
+                'id' => 'a0cfafe8986a6893bfc651244ce6e9fee21dfd3e7c4b82c33062d31281b8989c',
+                'type' => 'provider',
+                'attributes' => {
+                  'acc_new_patients' => 'false',
+                  'address' => {
+                    'street' => '418 5TH AVE # 420',
+                    'city' => 'BROOKLYN',
+                    'state' => 'NY',
+                    'zip' => '11215-3316'
+                  },
+                  'caresite_phone' => '718-965-2273',
+                  'email' => nil,
+                  'fax' => nil,
+                  'gender' => 'NotSpecified',
+                  'lat' => 40.6698417,
+                  'long' => -73.98545,
+                  'name' => 'CITY MD URGENT CARE',
+                  'phone' => nil,
+                  'pos_codes' => '20',
+                  'pref_contact' => nil,
+                  'unique_id' => '1487993564'
+                },
+                'relationships' => {
+                  'specialties' => {
+                    'data' => []
+                  }
+                }
+              },
+              {
+                'id' => '30f247acf7bd6635760a6398043bf0235030e8299aad5390a210f24a3b4684c4',
+                'type' => 'provider',
+                'attributes' => {
+                  'acc_new_patients' => 'false',
+                  'address' => {
+                    'street' => '712 BRIGHTON BEACH AVE',
+                    'city' => 'BROOKLYN',
+                    'state' => 'NY',
+                    'zip' => '11235-6412'
+                  },
+                  'caresite_phone' => '718-571-9291',
+                  'email' => nil,
+                  'fax' => nil,
+                  'gender' => 'NotSpecified',
+                  'lat' => 40.5776963,
+                  'long' => -73.960225,
+                  'name' => 'CITY MD URGENT CARE',
+                  'phone' => nil,
+                  'pos_codes' => '20',
+                  'pref_contact' => nil,
+                  'unique_id' => '1487993564'
+                },
+                'relationships' => {
+                  'specialties' => {
+                    'data' => []
+                  }
+                }
+              },
+              {
+                'id' => '73f57df2aeda3424246aa1526d91a4eb2e27a6828bb646898a77e87b88b2bab9',
+                'type' => 'provider',
+                'attributes' => {
+                  'acc_new_patients' => 'false',
+                  'address' => {
+                    'street' => '1305 KINGS HWY',
+                    'city' => 'BROOKLYN',
+                    'state' => 'NY',
+                    'zip' => '11229-1903'
+                  },
+                  'caresite_phone' => '718-280-5172',
+                  'email' => nil,
+                  'fax' => nil,
+                  'gender' => 'NotSpecified',
+                  'lat' => 40.608378,
+                  'long' => -73.959851,
+                  'name' => 'CITY MD URGENT CARE',
+                  'phone' => nil,
+                  'pos_codes' => '20',
+                  'pref_contact' => nil,
+                  'unique_id' => '1487993564'
+                },
+                'relationships' => {
+                  'specialties' => {
+                    'data' => []
+                  }
+                }
+              },
+              {
+                'id' => 'dfa50f5b6bf7a5ffc36f11f636ef8d51ee1303c102c4fd9c6925ca1c2c433fa7',
+                'type' => 'provider',
+                'attributes' => {
+                  'acc_new_patients' => 'false',
+                  'address' => {
+                    'street' => '874 FLATBUSH AVE',
+                    'city' => 'BROOKLYN',
+                    'state' => 'NY',
+                    'zip' => '11226-3102'
+                  },
+                  'caresite_phone' => '718-571-9372',
+                  'email' => nil,
+                  'fax' => nil,
+                  'gender' => 'NotSpecified',
+                  'lat' => 40.650747,
+                  'long' => -73.959134,
+                  'name' => 'CITY MD URGENT CARE',
+                  'phone' => nil,
+                  'pos_codes' => '20',
+                  'pref_contact' => nil,
+                  'unique_id' => '1487993564'
+                },
+                'relationships' => {
+                  'specialties' => {
+                    'data' => []
+                  }
+                }
+              },
+              {
+                'id' => 'a9e664cb35c5705a371962fca74ea7c2f6b277aa75446673b8795b3afe7f29a1',
+                'type' => 'provider',
+                'attributes' => {
+                  'acc_new_patients' => 'false',
+                  'address' => {
+                    'street' => '288 FLATBUSH AVE',
+                    'city' => 'BROOKLYN',
+                    'state' => 'NY',
+                    'zip' => '11217-2812'
+                  },
+                  'caresite_phone' => '718-656-1290',
+                  'email' => nil,
+                  'fax' => nil,
+                  'gender' => 'NotSpecified',
+                  'lat' => 40.678175,
+                  'long' => -73.97373,
+                  'name' => 'CITY MD URGENT CARE',
+                  'phone' => nil,
+                  'pos_codes' => '20',
+                  'pref_contact' => nil,
+                  'unique_id' => '1487993564'
+                },
+                'relationships' => {
+                  'specialties' => {
+                    'data' => []
+                  }
+                }
+              },
+              {
+                'id' => 'a01a12227953e3b4e538e1ad1eea8a49c8f789ca587e849c13894529553e49b5',
+                'type' => 'provider',
+                'attributes' => {
+                  'acc_new_patients' => 'false',
+                  'address' => {
+                    'street' => '2125 NOSTRAND AVE',
+                    'city' => 'BROOKLYN',
+                    'state' => 'NY',
+                    'zip' => '11210-3001'
+                  },
+                  'caresite_phone' => '718-489-3557',
+                  'email' => nil,
+                  'fax' => nil,
+                  'gender' => 'NotSpecified',
+                  'lat' => 40.633455,
+                  'long' => -73.947402,
+                  'name' => 'CITY MD URGENT CARE',
+                  'phone' => nil,
+                  'pos_codes' => '20',
+                  'pref_contact' => nil,
+                  'unique_id' => '1487993564'
+                },
+                'relationships' => {
+                  'specialties' => {
+                    'data' => []
+                  }
+                }
+              },
+              {
+                'id' => 'f6c97daea4f94f7e5c3ed73840ec3f61832da018c2d5e43a884c297dd94019f1',
+                'type' => 'provider',
+                'attributes' => {
+                  'acc_new_patients' => 'true',
+                  'address' => {
+                    'street' => '256 UTICA AVE',
+                    'city' => 'BROOKLYN',
+                    'state' => 'NY',
+                    'zip' => '11213-4029'
+                  },
+                  'caresite_phone' => '718-240-2644',
+                  'email' => nil,
+                  'fax' => nil,
+                  'gender' => 'NotSpecified',
+                  'lat' => 40.669966,
+                  'long' => -73.931422,
+                  'name' => 'CITY MD URGENT CARE',
+                  'phone' => nil,
+                  'pos_codes' => '20',
+                  'pref_contact' => nil,
+                  'unique_id' => '1326229022'
+                },
+                'relationships' => {
+                  'specialties' => {
+                    'data' => []
+                  }
+                }
+              },
+              {
+                'id' => '9a90ec56691c18bfe3a05fa99e44a3a8299700a07b02c1da65aefdaea1d9987c',
+                'type' => 'provider',
+                'attributes' => {
+                  'acc_new_patients' => 'false',
+                  'address' => {
+                    'street' => '256 UTICA AVE',
+                    'city' => 'BROOKLYN',
+                    'state' => 'NY',
+                    'zip' => '11213-4029'
+                  },
+                  'caresite_phone' => '718-571-9355',
+                  'email' => nil,
+                  'fax' => nil,
+                  'gender' => 'NotSpecified',
+                  'lat' => 40.669966,
+                  'long' => -73.931422,
+                  'name' => 'CITY MD URGENT CARE',
+                  'phone' => nil,
+                  'pos_codes' => '20',
+                  'pref_contact' => nil,
+                  'unique_id' => '1487993564'
+                },
+                'relationships' => {
+                  'specialties' => {
+                    'data' => []
+                  }
+                }
+              }
+            ]
+          }
+        )
       end
     end
   end

--- a/spec/request/v1/facilities/va_ccp_request_spec.rb
+++ b/spec/request/v1/facilities/va_ccp_request_spec.rb
@@ -9,8 +9,7 @@ vcr_options = {
 }
 
 RSpec.describe 'VA and Community Care Mashup', type: :request, team: :facilities, vcr: vcr_options do
-  context "Facilities::PPMS::V1::Client" do
-
+  context 'Facilities::PPMS::V1::Client' do
     let(:params) do
       {
         bbox: ['-75.91', '38.55', '-72.19', '42.27'],

--- a/spec/service_consumers/provider_states_for/facilities.rb
+++ b/spec/service_consumers/provider_states_for/facilities.rb
@@ -7,7 +7,6 @@ Pact.provider_states_for 'Facility Locator' do
   }
   provider_state 'ccp data exists' do
     set_up do
-      Flipper.enable(:facility_locator_ppms_use_v1_client, true)
       VCR.insert_cassette('facilities/ppms/ppms', vcr_options)
     end
 
@@ -18,7 +17,6 @@ Pact.provider_states_for 'Facility Locator' do
 
   provider_state 'mashup urgent care data exists' do
     set_up do
-      Flipper.enable(:facility_locator_ppms_use_v1_client, true)
       VCR.insert_cassette('facilities/va/ppms_and_lighthouse', vcr_options)
     end
 
@@ -29,7 +27,6 @@ Pact.provider_states_for 'Facility Locator' do
 
   provider_state 'va data exists' do
     set_up do
-      Flipper.enable(:facility_locator_ppms_use_v1_client, true)
       VCR.insert_cassette('/lighthouse/facilities', vcr_options)
     end
 
@@ -40,7 +37,6 @@ Pact.provider_states_for 'Facility Locator' do
 
   provider_state 'ccp specialties data exists' do
     set_up do
-      Flipper.enable(:facility_locator_ppms_use_v1_client, true)
       VCR.insert_cassette('facilities/ppms/ppms', vcr_options)
     end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
We are happy with how the new feature flags are working and the significant performance increase in response times.
removing the ppms v1 client flag and the skip round trip flags and associated code

## Original issue(s)
department-of-veterans-affairs/va.gov-team#15330

## Things to know about this PR
### Removing the Following feature flags
* `facility_locator_ppms_use_v1_client`
* `facility_locator_ppms_skip_additional_round_trips`
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
