### PR TITLE
Refactor deprecated code

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -92,7 +92,7 @@ module AppealsApi
 
     scope :received_or_processing, -> { where status: RECEIVED_OR_PROCESSING }
     scope :completed, -> { where status: COMPLETE_STATUSES }
-    scope :has_pii, -> { where.not encrypted_form_data: nil, encrypted_auth_headers: nil }
+    scope :has_pii, -> { where.not(encrypted_form_data: nil).or(where.not(encrypted_auth_headers: nil)) }
     scope :has_not_been_updated_in_a_week, -> { where 'updated_at < ?', 1.week.ago }
     scope :ready_to_have_pii_expunged, -> { has_pii.completed.has_not_been_updated_in_a_week }
 

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -135,7 +135,7 @@ module AppealsApi
 
     scope :received_or_processing, -> { where status: RECEIVED_OR_PROCESSING }
     scope :completed, -> { where status: COMPLETE_STATUSES }
-    scope :has_pii, -> { where.not encrypted_form_data: nil, encrypted_auth_headers: nil }
+    scope :has_pii, -> { where.not(encrypted_form_data: nil).or(where.not(encrypted_auth_headers: nil)) }
     scope :has_not_been_updated_in_a_week, -> { where 'updated_at < ?', 1.week.ago }
     scope :ready_to_have_pii_expunged, -> { has_pii.completed.has_not_been_updated_in_a_week }
 


### PR DESCRIPTION
## Description of change
The appeals_api test suite was reporting deprecation errors when run.

- update `where.not` when querying multiple attributes 

## Original issue(s)
https://vajira.max.gov/browse/API-4168