### PR TITLE
API-3267: Special Issues - Update the claim establisher job to check for special issues

### DIFF
--- a/modules/claims_api/app/workers/claims_api/claim_establisher.rb
+++ b/modules/claims_api/app/workers/claims_api/claim_establisher.rb
@@ -16,14 +16,14 @@ module ClaimsApi
 
       form_data = auto_claim.to_internal
       auth_headers = auto_claim.auth_headers
-      flashes = auto_claim.flashes
 
       response = service(auth_headers).submit_form526(form_data)
       auto_claim.evss_id = response.claim_id
       auto_claim.status = ClaimsApi::AutoEstablishedClaim::ESTABLISHED
       auto_claim.save
 
-      queue_flash_updater(auth_headers, flashes, auto_claim_id) if flashes.present?
+      queue_flash_updater(auth_headers, auto_claim.flashes, auto_claim_id)
+      queue_special_issues_updater(auth_headers, auto_claim.special_issues, auto_claim)
     rescue ::EVSS::DisabilityCompensationForm::ServiceException => e
       auto_claim.status = ClaimsApi::AutoEstablishedClaim::ERRORED
       auto_claim.evss_response = e.messages
@@ -38,7 +38,24 @@ module ClaimsApi
 
     private
 
+    def queue_special_issues_updater(auth_headers, special_issues_per_disability, auto_claim)
+      return if special_issues_per_disability.blank?
+
+      special_issues_per_disability.each do |disability|
+        contention_id = {
+          claim_id: auto_claim.evss_id,
+          code: disability['code'],
+          name: disability['name']
+        }
+        ClaimsApi::SpecialIssueUpdater.perform_async(bgs_user(auth_headers),
+                                                     contention_id,
+                                                     disability['special_issues'])
+      end
+    end
+
     def queue_flash_updater(auth_headers, flashes, auto_claim_id)
+      return if flashes.blank?
+
       ClaimsApi::FlashUpdater.perform_async(bgs_user(auth_headers), flashes, auto_claim_id: auto_claim_id)
     end
 

--- a/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
+++ b/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
@@ -124,10 +124,10 @@ module ClaimsApi
     #
     # @return [Boolean] true if matches, false if not
     def matches_contention?(contention_id, contention)
-      return false if contention[:clm_id] != contention_id[:claim_id]
-      return true if contention_id[:code].present? && contention[:clsfcn_id] == contention_id[:code]
+      return false if contention[:clm_id] != contention_id[:claim_id].to_s
+      return true if contention_id[:code].present? && contention[:clsfcn_id] == contention_id[:code].to_s
 
-      contention_id[:code].blank? && contention_id[:name] == contention[:clmnt_txt]
+      contention_id[:code].blank? && contention_id[:name].to_s == contention[:clmnt_txt]
     end
 
     # Ensure contention_id provided is a valid starting structure

--- a/modules/claims_api/spec/factories/auto_established_claims.rb
+++ b/modules/claims_api/spec/factories/auto_established_claims.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'claims_api/special_issue_mapper'
+
 FactoryBot.define do
   factory :auto_established_claim, class: 'ClaimsApi::AutoEstablishedClaim' do
     id { SecureRandom.uuid }
@@ -12,6 +14,16 @@ FactoryBot.define do
       json['data']['attributes']
     end
     flashes { form_data.dig('veteran', 'flashes') }
+    special_issues do
+      if form_data['disabilities'].present? && form_data['disabilities'].first['specialIssues'].present?
+        mapper = ClaimsApi::SpecialIssueMapper.new
+        [{ code: form_data['disabilities'].first['diagnosticCode'],
+           name: form_data['disabilities'].first['name'],
+           special_issues: form_data['disabilities'].first['specialIssues'].map { |si| mapper.code_from_name(si) } }]
+      else
+        []
+      end
+    end
 
     trait :status_established do
       status { 'established' }

--- a/modules/claims_api/spec/fixtures/form_526_json_api.json
+++ b/modules/claims_api/spec/fixtures/form_526_json_api.json
@@ -23,6 +23,7 @@
           "diagnosticCode": 9999,
           "disabilityActionType": "NEW",
           "name": "PTSD (post traumatic stress disorder)",
+          "specialIssues": ["Fully Developed Claim", "PTSD/2"],
           "secondaryDisabilities": [
             {
               "name": "PTSD personal trauma",


### PR DESCRIPTION
## Description of change
Kicks off special issue updater job if special issues are found on the claim submission.
Also ensures the equality checks within the special issue updater job doesn't have issues with some items being strings and others being integers.

## Original issue(s)
https://vajira.max.gov/browse/API-3267

## Things to know about this PR
Updated a fixture to ensure this new code section gets executed within existing specs.
