### PR TITLE
API-3274: Special Issues - Set up logging to capture what we need

### DIFF
--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -12,6 +12,7 @@ module ClaimsApi
                                          marshal: true,
                                          marshaler: JsonMarshal::Marshaller)
 
+    after_create :log_special_issues
     after_create :log_flashes
 
     has_many :supporting_documents, dependent: :destroy
@@ -89,6 +90,12 @@ module ClaimsApi
 
     def log_flashes
       Rails.logger.info("ClaimsApi: Claim[#{id}] contains the following flashes - #{flashes}") if flashes.present?
+    end
+
+    def log_special_issues
+      return if special_issues.blank?
+
+      Rails.logger.info("ClaimsApi: Claim[#{id}] contains the following special issues - #{special_issues}")
     end
 
     def remove_encrypted_fields

--- a/modules/claims_api/spec/factories/auto_established_claims.rb
+++ b/modules/claims_api/spec/factories/auto_established_claims.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'claims_api/special_issue_mapper'
+
 FactoryBot.define do
   factory :auto_established_claim, class: 'ClaimsApi::AutoEstablishedClaim' do
     id { SecureRandom.uuid }
@@ -12,6 +14,16 @@ FactoryBot.define do
       json['data']['attributes']
     end
     flashes { form_data.dig('veteran', 'flashes') }
+    special_issues do
+      if form_data['disabilities'].present? && form_data['disabilities'].first['specialIssues'].present?
+        mapper = ClaimsApi::SpecialIssueMapper.new
+        [{ code: form_data['disabilities'].first['diagnosticCode'],
+           name: form_data['disabilities'].first['name'],
+           special_issues: form_data['disabilities'].first['specialIssues'].map { |si| mapper.code_from_name(si) } }]
+      else
+        []
+      end
+    end
 
     trait :status_established do
       status { 'established' }

--- a/modules/claims_api/spec/fixtures/form_526_json_api.json
+++ b/modules/claims_api/spec/fixtures/form_526_json_api.json
@@ -23,6 +23,7 @@
           "diagnosticCode": 9999,
           "disabilityActionType": "NEW",
           "name": "PTSD (post traumatic stress disorder)",
+          "specialIssues": ["Fully Developed Claim", "PTSD/2"],
           "secondaryDisabilities": [
             {
               "name": "PTSD personal trauma",

--- a/modules/claims_api/spec/models/auto_establish_claim_spec.rb
+++ b/modules/claims_api/spec/models/auto_establish_claim_spec.rb
@@ -14,9 +14,11 @@ RSpec.describe ClaimsApi::AutoEstablishedClaim, type: :model do
     end
   end
 
-  it 'writes flashes to log on create' do
+  it 'writes flashes and special issues to log on create' do
     expect(Rails.logger).to receive(:info)
       .with(/ClaimsApi: Claim\[.+\] contains the following flashes - \["Hardship", "Homeless"\]/)
+    expect(Rails.logger).to receive(:info)
+      .with(/ClaimsApi: Claim\[.+\] contains the following special issues - \[.*FDC.*PTSD\/2.*\]/)
     pending_record
   end
 

--- a/modules/claims_api/spec/models/auto_establish_claim_spec.rb
+++ b/modules/claims_api/spec/models/auto_establish_claim_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ClaimsApi::AutoEstablishedClaim, type: :model do
     expect(Rails.logger).to receive(:info)
       .with(/ClaimsApi: Claim\[.+\] contains the following flashes - \["Hardship", "Homeless"\]/)
     expect(Rails.logger).to receive(:info)
-      .with(/ClaimsApi: Claim\[.+\] contains the following special issues - \[.*FDC.*PTSD\/2.*\]/)
+      .with(%r{ClaimsApi: Claim\[.+\] contains the following special issues - \[.*FDC.*PTSD/2.*\]})
     pending_record
   end
 


### PR DESCRIPTION
## Description of change
Writes special issues to log when an ClaimsApi::AutoEstablishedClaim record is created, for tracking purposes.

## Original issue(s)
https://vajira.max.gov/browse/API-3274

## Things to know about this PR
spec