### PR TITLE
Fix DetailedSchemaErrors

### DIFF
--- a/lib/common/exceptions/detailed_schema_errors.rb
+++ b/lib/common/exceptions/detailed_schema_errors.rb
@@ -52,7 +52,7 @@ module Common
       end
 
       def length(error)
-        data = i18n_interpolated :length
+        data = i18n_interpolated :length, detail: { value: error['data'] }
         data[:meta] ||= {}
         data[:meta].merge! max_length: error['schema']['maxLength'] if error['schema']['maxLength']
         data[:meta].merge! min_length: error['schema']['minLength'] if error['schema']['minLength']
@@ -62,7 +62,7 @@ module Common
       alias minlength length
 
       def range(error)
-        data = i18n_interpolated :range
+        data = i18n_interpolated :range, detail: { value: error['data'] }
         data[:meta] ||= {}
         data[:meta].merge! maximum: error['schema']['maximum'] if error['schema']['maximum']
         data[:meta].merge! minimum: error['schema']['minimum'] if error['schema']['minimum']

--- a/modules/appeals_api/config/schemas/200996_headers.json
+++ b/modules/appeals_api/config/schemas/200996_headers.json
@@ -36,7 +36,7 @@
         {
           "type": "string",
           "maxLength": 12,
-          "$comment": "can be whitespace, to accomodate those with 1 legal name"
+          "$comment": "can be whitespace, to accommodate those with 1 legal name"
         }
       ]
     },

--- a/spec/fixtures/json/detailed_schema_errors_schema.json
+++ b/spec/fixtures/json/detailed_schema_errors_schema.json
@@ -33,7 +33,8 @@
     },
     "email": {
       "type": "string",
-      "pattern": ".@."
+      "pattern": ".@.",
+      "minLength": 3
     },
     "gender": {
       "type": "string",


### PR DESCRIPTION
## Description of change
Fixes errors of DetailedSchemaErrors where translations were not receiving the proper interpolated values to display as expected.

Before: `:detail => "'%{value}' did not fit within the defined length limits"`
After: `:detail => "'Ed' did not fit within the defined length limits"`