### PR TITLE
Add source field to NOD and HLR

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_31_033748) do
+ActiveRecord::Schema.define(version: 2021_01_05_174800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_12_31_033748) do
     t.datetime "updated_at", null: false
     t.string "code"
     t.string "detail"
+    t.string "source"
   end
 
   create_table "appeals_api_notice_of_disagreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_05_174800) do
+ActiveRecord::Schema.define(version: 2021_01_05_181435) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2021_01_05_174800) do
     t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
+    t.string "source"
   end
 
   create_table "async_transactions", id: :serial, force: :cascade do |t|

--- a/modules/appeals_api/db/migrate/20210105174800_add_source_to_hlr.rb
+++ b/modules/appeals_api/db/migrate/20210105174800_add_source_to_hlr.rb
@@ -1,0 +1,5 @@
+class AddSourceToHlr < ActiveRecord::Migration[6.0]
+  def change
+    add_column :appeals_api_higher_level_reviews, :source, :string
+  end
+end

--- a/modules/appeals_api/db/migrate/20210105181435_add_source_to_nod.rb
+++ b/modules/appeals_api/db/migrate/20210105181435_add_source_to_nod.rb
@@ -1,0 +1,5 @@
+class AddSourceToNod < ActiveRecord::Migration[6.0]
+  def change
+    add_column :appeals_api_notice_of_disagreements, :source, :string
+  end
+end


### PR DESCRIPTION
This PR is part of [API-4180](https://vajira.max.gov/browse/API-4180).


## Description of change
To allow for metrics to be better reported we need to add a `source` field to both the NoticeOfDisagreement and HigherLevelReview models.