### PR TITLE
[HOTFIX] PROD Issue - Debts Portal

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -68,7 +68,7 @@ dmc:
   client_secret: "secret"
   mock_debts: false
   mock_fsr: false
-  url: "https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465"
+  url: "https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465/api/v1/digital-services/"
 
 fsr:
   prefill: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -68,7 +68,8 @@ dmc:
   client_secret: "secret"
   mock_debts: false
   mock_fsr: false
-  url: "https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465/api/v1/digital-services/"
+  url: https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465/api/v1/digital-services/
+  debts_endpoint: debt-letter/get
 
 fsr:
   prefill: true

--- a/lib/debt_management_center/debts_configuration.rb
+++ b/lib/debt_management_center/debts_configuration.rb
@@ -14,7 +14,7 @@ module DebtManagementCenter
     end
 
     def base_path
-      "#{Settings.dmc.url}/api/v1/digital-services/"
+      Settings.dmc.url
     end
 
     def connection

--- a/lib/debt_management_center/debts_service.rb
+++ b/lib/debt_management_center/debts_service.rb
@@ -45,7 +45,9 @@ module DebtManagementCenter
 
     def init_debts
       with_monitoring_and_error_handling do
-        DebtManagementCenter::DebtsResponse.new(perform(:post, Settings.dmc.debts_endpoint, fileNumber: @file_number).body).debts
+        DebtManagementCenter::DebtsResponse.new(
+          perform(:post, Settings.dmc.debts_endpoint, fileNumber: @file_number).body
+        ).debts
       end
     end
 

--- a/lib/debt_management_center/debts_service.rb
+++ b/lib/debt_management_center/debts_service.rb
@@ -45,7 +45,7 @@ module DebtManagementCenter
 
     def init_debts
       with_monitoring_and_error_handling do
-        DebtManagementCenter::DebtsResponse.new(perform(:post, 'debt-letter/get', fileNumber: @file_number).body).debts
+        DebtManagementCenter::DebtsResponse.new(perform(:post, Settings.dmc.debts_endpoint, fileNumber: @file_number).body).debts
       end
     end
 

--- a/lib/debt_management_center/financial_status_report_configuration.rb
+++ b/lib/debt_management_center/financial_status_report_configuration.rb
@@ -14,7 +14,7 @@ module DebtManagementCenter
     end
 
     def base_path
-      "#{Settings.dmc.url}/api/v1/digital-services/"
+      Settings.dmc.url
     end
 
     def connection

--- a/spec/lib/debt_management_center/debts_service_spec.rb
+++ b/spec/lib/debt_management_center/debts_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe DebtManagementCenter::DebtsService do
             )
             expect(Raven).to receive(:tags_context).once.with(external_service: described_class.to_s.underscore)
             expect(Raven).to receive(:extra_context).once.with(
-              url: "#{Settings.dmc.url}/api/v1/digital-services/",
+              url: Settings.dmc.url,
               message: 'the server responded with status 400',
               body: { 'message' => 'Bad request' }
             )


### PR DESCRIPTION
## Description of change
Debts Portal is currently using the wrong URL in production, will need to be changed over to the old style URL. Changed format to facilitate this change easier, as lower envs and prod will be using different style URLs for the time being.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/18135
