### PR TITLE
added update to statsd_pulugin url filtering and updated rspecs

### DIFF
--- a/lib/breakers/statsd_plugin.rb
+++ b/lib/breakers/statsd_plugin.rb
@@ -48,17 +48,21 @@ module Breakers
       okta_users = %r{(?<user_path>api\/v1\/users\/)\w*}
       r = %r{
         (?<first_slash>\/)
-        (#{okta_users}
-        |#{digit}
-        |#{contact_id}
-        |#{uuids}
-        |#{institution_ids}
-        |#{provider_ids})
+        (#{okta_users} |#{digit} |#{contact_id} |#{uuids} |#{institution_ids} |#{provider_ids})
         (?<ending_slash>\/|$)
       }x
 
-      path.gsub(r) do
+      # replace  ids sent in the endpoint with 'xxx'
+      rslt = path.gsub(r) do
         "#{$LAST_MATCH_INFO[:first_slash]}#{$LAST_MATCH_INFO[:user_path]}xxx#{$LAST_MATCH_INFO[:ending_slash]}"
+      end
+
+      # for endpoints of type '/cce/v1/patients/xxx/eligibility/<specialty>' replace <specialty> with zzz to provide
+      # better grouping in grafana
+      if rslt =~ %r{/cce/v1/patients/xxx/eligibility/}
+        "#{$LAST_MATCH_INFO}zzz"
+      else
+        rslt
       end
     end
   end

--- a/spec/lib/breakers/statsd_plugin_spec.rb
+++ b/spec/lib/breakers/statsd_plugin_spec.rb
@@ -62,6 +62,9 @@ describe Breakers::StatsdPlugin do
 
         request.url = URI(test_host + '/api/v1/users/00u2i1p2u2m3l7FYb712/grants')
         expect(subject.get_tags(request)).to include('endpoint:/api/v1/users/xxx/grants')
+
+        request.url = URI(test_host + '/cce/v1/patients/1012845331V153043/eligibility/Podiatry')
+        expect(subject.get_tags(request)).to include('endpoint:/cce/v1/patients/xxx/eligibility/zzz')
       end
     end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This work is to provide more clarity around the VAOS Latency graph. Currently the graph displays individual urls for each service related to eligibility service calls (e.g. /cce/v1/patients/xxx/eligibility/Nutrition, /cce/v1/patients/xxx/eligibility/Optometry, /cce/v1/patients/xxx/eligibility/Audiology, etc...), this level of detail is unnecessary and detracts from the overall readability of the graph. 

To resolve this, the service portion (e.g. Nutrition, Optometry, Audiology, etc...) will use a mask (zzz) instead, allowing all associated urls to roll-up under /cce/v1/patients/xxx/eligibility/zzz


## Original issue(s)
department-of-veterans-affairs/va.gov-team#18128

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->


