### PR TITLE
Consolidate hlr/nod central mail status logic into concern

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -11,6 +11,12 @@ module AppealsApi
       date < Time.zone.today
     end
 
+    def self.date_from_string(string)
+      string.match(/\d{4}-\d{2}-\d{2}/) && Date.parse(string)
+    rescue ArgumentError
+      nil
+    end
+
     attr_encrypted(:form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
     attr_encrypted(:auth_headers, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
 

--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -7,10 +7,9 @@ module AppealsApi
   class HigherLevelReview < ApplicationRecord
     include CentralMailStatus
 
-    class << self
-      def past?(date)
-        date < Time.zone.today
-      end
+    def self.past?(date)
+      date < Time.zone.today
+    end
 
     attr_encrypted(:form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
     attr_encrypted(:auth_headers, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)

--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -5,88 +5,15 @@ require 'common/exceptions'
 
 module AppealsApi
   class HigherLevelReview < ApplicationRecord
-    include SentryLogging
+    include CentralMailStatus
 
     class << self
-      def refresh_statuses_using_central_mail!(higher_level_reviews)
-        return if higher_level_reviews.empty?
-
-        response = CentralMail::Service.new.status(higher_level_reviews.pluck(:id))
-        unless response.success?
-          log_bad_central_mail_response(response)
-          raise Common::Exceptions::BadGateway
-        end
-
-        central_mail_status_objects = parse_central_mail_response(response).select { |s| s.id.present? }
-        ActiveRecord::Base.transaction do
-          central_mail_status_objects.each do |obj|
-            higher_level_reviews.find { |h| h.id == obj.id }
-                                .update_status_using_central_mail_status!(obj.status, obj.error_message)
-          end
-        end
-      end
-
-      def log_unknown_central_mail_status(status)
-        log_message_to_sentry('Unknown status value from Central Mail API', :warning, status: status)
-      end
-
-      def date_from_string(string)
-        string.match(/\d{4}-\d{2}-\d{2}/) && Date.parse(string)
-      rescue ArgumentError
-        nil
-      end
-
       def past?(date)
         date < Time.zone.today
       end
 
-      private
-
-      def parse_central_mail_response(response)
-        JSON.parse(response.body).flatten.map do |hash|
-          Struct.new(:id, :status, :error_message).new(*hash.values_at('uuid', 'status', 'errorMessage'))
-        end
-      end
-
-      def log_bad_central_mail_response(resp)
-        log_message_to_sentry('Error getting status from Central Mail', :warning, status: resp.status, body: resp.body)
-      end
-    end
-
     attr_encrypted(:form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
     attr_encrypted(:auth_headers, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
-
-    STATUSES = %w[pending submitting submitted processing error uploaded received success expired].freeze
-
-    validates :status, inclusion: { 'in': STATUSES }
-
-    CENTRAL_MAIL_STATUS_TO_HLR_ATTRIBUTES = lambda do
-      hash = Hash.new { |_, _| raise ArgumentError, 'Unknown Central Mail status' }
-      hash['Received'] = { status: 'received' }
-      hash['In Process'] = { status: 'processing' }
-      hash['Processing Success'] = hash['In Process']
-      hash['Success'] = { status: 'success' }
-      hash['Error'] = { status: 'error', code: 'DOC202' }
-      hash['Processing Error'] = hash['Error']
-      hash
-    end.call.freeze
-    # ensure that statuses in map are valid statuses
-    raise unless CENTRAL_MAIL_STATUS_TO_HLR_ATTRIBUTES.values.all? do |attributes|
-      [:status, 'status'].all? do |status|
-        !attributes.key?(status) || attributes[status].in?(STATUSES)
-      end
-    end
-
-    CENTRAL_MAIL_ERROR_STATUSES = ['Error', 'Processing Error'].freeze
-    raise unless CENTRAL_MAIL_ERROR_STATUSES - CENTRAL_MAIL_STATUS_TO_HLR_ATTRIBUTES.keys == []
-
-    RECEIVED_OR_PROCESSING = %w[received processing].freeze
-    raise unless RECEIVED_OR_PROCESSING - STATUSES == []
-
-    COMPLETE_STATUSES = %w[success error].freeze
-    raise unless COMPLETE_STATUSES - STATUSES == []
-
-    scope :received_or_processing, -> { where status: RECEIVED_OR_PROCESSING }
 
     INFORMAL_CONFERENCE_REP_NAME_AND_PHONE_NUMBER_MAX_LENGTH = 100
     NO_ADDRESS_PROVIDED_SENTENCE = 'USE ADDRESS ON FILE'
@@ -103,20 +30,6 @@ module AppealsApi
       :contestable_issue_dates_are_valid_dates,
       if: proc { |a| a.form_data.present? }
     )
-
-    def update_status_using_central_mail_status!(status, error_message = nil)
-      begin
-        attributes = CENTRAL_MAIL_STATUS_TO_HLR_ATTRIBUTES[status] || {}
-      rescue ArgumentError
-        self.class.log_unknown_central_mail_status(status)
-        raise Common::Exceptions::BadGateway, detail: 'Unknown processing status'
-      end
-      if status.in?(CENTRAL_MAIL_ERROR_STATUSES) && error_message
-        attributes = attributes.merge(detail: "Downstream status: #{error_message}")
-      end
-
-      update! attributes
-    end
 
     # 1. VETERAN'S NAME
     def first_name

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -11,48 +11,11 @@ module AppealsApi
       MultiJson.load File.read Rails.root.join('modules', 'appeals_api', 'config', 'schemas', "#{filename}.json")
     end
 
-      # a json schemer error is a hash with this shape:
-      #
-      # {
-      #   "type": "required",
-      #   "details": {
-      #     "missing_keys": ["addressLine1"]
-      #   },
-      #   "data_pointer": "/data/attributes/veteran/address",
-      #   "data": {
-      #     "addressLine2": "Suite #1200",
-      #     "addressLine3": "Box 4",
-      #     "city": "New York",
-      #     "countryName": "United States",
-      #     "stateCode": "NY",
-      #     "zipCode5": "30012",
-      #     "internationalPostalCode": "1"
-      #   },
-      #   "schema_pointer": "/definitions/nodCreateAddress",
-      #   "schema": {
-      #     "type": "object",
-      #     "additionalProperties": false,
-      #     "properties": {
-      #       "addressLine1": {"type": "string"},
-      #       "addressLine2": {"type": "string"},
-      #       "addressLine3": {"type": "string"},
-      #       "city": {"type": "string"},
-      #       "stateCode": {"$ref": "#/definitions/nodCreateStateCode"},
-      #       "countryName": {"type": "string"},
-      #       "zipCode5": {"type": "string", "pattern": "^[0-9]{5}$"},
-      #       "internationalPostalCode": {"type": "string"}
-      #     },
-      #     "required": [
-      #       "addressLine1",
-      #       "city",
-      #       "countryName",
-      #       "zipCode5"
-      #     ]
-      #   },
-      #   "root_schema": {
-      #     ... # entire schema
-      #   }
-      # }
+    def self.date_from_string(string)
+      string.match(/\d{4}-\d{2}-\d{2}/) && Date.parse(string)
+    rescue ArgumentError
+      nil
+    end
 
     attr_encrypted(:form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
     attr_encrypted(:auth_headers, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -7,10 +7,9 @@ module AppealsApi
   class NoticeOfDisagreement < ApplicationRecord
     include CentralMailStatus
 
-    class << self
-      def load_json_schema(filename)
-        MultiJson.load File.read Rails.root.join('modules', 'appeals_api', 'config', 'schemas', "#{filename}.json")
-      end
+    def self.load_json_schema(filename)
+      MultiJson.load File.read Rails.root.join('modules', 'appeals_api', 'config', 'schemas', "#{filename}.json")
+    end
 
       # a json schemer error is a hash with this shape:
       #

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -5,37 +5,9 @@ require 'common/exceptions'
 
 module AppealsApi
   class NoticeOfDisagreement < ApplicationRecord
-    include SentryLogging
+    include CentralMailStatus
 
     class << self
-      def refresh_statuses_using_central_mail!(notice_of_disagreement)
-        return if notice_of_disagreement.empty?
-
-        response = CentralMail::Service.new.status(notice_of_disagreement.pluck(:id))
-        unless response.success?
-          log_bad_central_mail_response(response)
-          raise Common::Exceptions::BadGateway
-        end
-
-        central_mail_status_objects = parse_central_mail_response(response).select { |s| s.id.present? }
-        ActiveRecord::Base.transaction do
-          central_mail_status_objects.each do |obj|
-            notice_of_disagreement.find { |h| h.id == obj.id }
-                                  .update_status_using_central_mail_status!(obj.status, obj.error_message)
-          end
-        end
-      end
-
-      def log_unknown_central_mail_status(status)
-        log_message_to_sentry('Unknown status value from Central Mail API', :warning, status: status)
-      end
-
-      def date_from_string(string)
-        string.match(/\d{4}-\d{2}-\d{2}/) && Date.parse(string)
-      rescue ArgumentError
-        nil
-      end
-
       def load_json_schema(filename)
         MultiJson.load File.read Rails.root.join('modules', 'appeals_api', 'config', 'schemas', "#{filename}.json")
       end
@@ -83,69 +55,10 @@ module AppealsApi
       #   }
       # }
 
-      private
-
-      def parse_central_mail_response(response)
-        JSON.parse(response.body).flatten.map do |hash|
-          Struct.new(:id, :status, :error_message).new(*hash.values_at('uuid', 'status', 'errorMessage'))
-        end
-      end
-
-      def log_bad_central_mail_response(resp)
-        log_message_to_sentry('Error getting status from Central Mail', :warning, status: resp.status, body: resp.body)
-      end
-    end
-
     attr_encrypted(:form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
     attr_encrypted(:auth_headers, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
 
-    STATUSES = %w[pending submitting submitted processing error uploaded received success expired].freeze
-
-    validates :status, inclusion: { 'in': STATUSES }
-
-    CENTRAL_MAIL_STATUS_TO_NOD_ATTRIBUTES = lambda do
-      hash = Hash.new { |_, _| raise ArgumentError, 'Unknown Central Mail status' }
-      hash['Received'] = { status: 'received' }
-      hash['In Process'] = { status: 'processing' }
-      hash['Processing Success'] = hash['In Process']
-      hash['Success'] = { status: 'success' }
-      hash['Error'] = { status: 'error', code: 'DOC202' }
-      hash['Processing Error'] = hash['Error']
-      hash
-    end.call.freeze
-    # ensure that statuses in map are valid statuses
-    raise unless CENTRAL_MAIL_STATUS_TO_NOD_ATTRIBUTES.values.all? do |attributes|
-      [:status, 'status'].all? do |status|
-        !attributes.key?(status) || attributes[status].in?(STATUSES)
-      end
-    end
-
-    CENTRAL_MAIL_ERROR_STATUSES = ['Error', 'Processing Error'].freeze
-    raise unless CENTRAL_MAIL_ERROR_STATUSES - CENTRAL_MAIL_STATUS_TO_NOD_ATTRIBUTES.keys == []
-
-    RECEIVED_OR_PROCESSING = %w[received processing].freeze
-    raise unless RECEIVED_OR_PROCESSING - STATUSES == []
-
-    COMPLETE_STATUSES = %w[success error].freeze
-    raise unless COMPLETE_STATUSES - STATUSES == []
-
-    scope :received_or_processing, -> { where status: RECEIVED_OR_PROCESSING }
-
     validate :validate_hearing_type_selection
-
-    def update_status_using_central_mail_status!(status, error_message = nil)
-      begin
-        attributes = CENTRAL_MAIL_STATUS_TO_NOD_ATTRIBUTES[status] || {}
-      rescue ArgumentError
-        self.class.log_unknown_central_mail_status(status)
-        raise Common::Exceptions::BadGateway, detail: 'Unknown processing status'
-      end
-      if status.in?(CENTRAL_MAIL_ERROR_STATUSES) && error_message
-        attributes = attributes.merge(detail: "Downstream status: #{error_message}")
-      end
-
-      update! attributes
-    end
 
     def veteran_first_name
       header_field_as_string 'X-VA-Veteran-First-Name'

--- a/modules/appeals_api/app/models/concerns/appeals_api/central_mail_status.rb
+++ b/modules/appeals_api/app/models/concerns/appeals_api/central_mail_status.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  module CentralMailStatus
+    extend ActiveSupport::Concern
+
+    include SentryLogging
+
+    included do
+      scope :received_or_processing, -> { where status: RECEIVED_OR_PROCESSING }
+
+      STATUSES = %w[pending submitting submitted processing error uploaded received success expired].freeze
+
+      validates :status, inclusion: { 'in': STATUSES }
+
+      CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES = lambda do
+        hash = Hash.new { |_, _| raise ArgumentError, 'Unknown Central Mail status' }
+        hash['Received'] = { status: 'received' }
+        hash['In Process'] = { status: 'processing' }
+        hash['Processing Success'] = hash['In Process']
+        hash['Success'] = { status: 'success' }
+        hash['Error'] = { status: 'error', code: 'DOC202' }
+        hash['Processing Error'] = hash['Error']
+        hash
+      end.call.freeze
+
+      raise "One or more CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES values is invalid" unless status_attributes_valid?
+
+      CENTRAL_MAIL_ERROR_STATUSES = ['Error', 'Processing Error'].freeze
+      raise "One or more CENTRAL_MAIL_ERROR_STATUSES is invalid" unless error_statuses_valid?
+
+      RECEIVED_OR_PROCESSING = %w[received processing].freeze
+      raise "One or more RECEIVED_OR_PROCESSING stats invalid" unless statuses_valid?(RECEIVED_OR_PROCESSING)
+
+      COMPLETE_STATUSES = %w[success error].freeze
+      raise "One or more COMPLETE_STATUSES is invalid" unless statuses_valid?(COMPLETE_STATUSES)
+
+      def update_status_using_central_mail_status!(status, error_message = nil)
+        begin
+          attributes = CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES[status] || {}
+        rescue ArgumentError
+          # TODO: test logging
+          log_message_to_sentry('Unknown status value from Central Mail API', :warning, status: status)
+          raise Common::Exceptions::BadGateway, detail: 'Unknown processing status'
+        end
+        if status.in?(CENTRAL_MAIL_ERROR_STATUSES) && error_message
+          attributes = attributes.merge(detail: "Downstream status: #{error_message}")
+        end
+
+        update! attributes
+      end
+    end
+
+    class_methods do
+      def refresh_statuses_using_central_mail!(appeals)
+        return if appeals.empty?
+
+        response = CentralMail::Service.new.status(appeals.pluck(:id))
+
+        unless response.success?
+          # TODO: need better solution & Need to test
+          appeals[0].log_message_to_sentry('Error getting status from Central Mail', :warning, status: response.status, body: response.body)
+          raise Common::Exceptions::BadGateway
+        end
+
+        central_mail_status_objects = parse_central_mail_response(response).select { |struct| struct.id.present? }
+        ActiveRecord::Base.transaction do
+          central_mail_status_objects.each do |obj|
+            appeals.find { |h| h.id == obj.id }
+                   .update_status_using_central_mail_status!(obj.status, obj.error_message)
+          end
+        end
+      end
+
+      def date_from_string(string)
+        string.match(/\d{4}-\d{2}-\d{2}/) && Date.parse(string)
+      rescue ArgumentError
+        nil
+      end
+
+      private
+
+      def parse_central_mail_response(response)
+        JSON.parse(response.body).flatten.map do |hash|
+          Struct.new(:id, :status, :error_message).new(*hash.values_at('uuid', 'status', 'errorMessage'))
+        end
+      end
+
+      def status_attributes_valid?
+        CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES.values.all? do |attributes|
+          [:status, 'status'].all? do |status|
+            !attributes.key?(status) || attributes[status].in?(STATUSES)
+          end
+        end
+      end
+
+      def error_statuses_valid?
+        CENTRAL_MAIL_ERROR_STATUSES.all? do |error_status|
+          CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES.keys.include?(error_status)
+        end
+      end
+
+      def statuses_valid?(statuses)
+        statuses.all? { |status| STATUSES.include?(status) }
+      end
+    end
+  end
+end

--- a/modules/appeals_api/app/models/concerns/appeals_api/central_mail_status.rb
+++ b/modules/appeals_api/app/models/concerns/appeals_api/central_mail_status.rb
@@ -69,7 +69,7 @@ module AppealsApi
           attributes = CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES[status] || {}
         rescue ArgumentError
           log_message_to_sentry('Unknown status value from Central Mail API', :warning, status: status)
-          raise Common::Exceptions::BadGateway, detail: 'Unknown processing status'
+          raise Common::Exceptions::BadGateway
         end
 
         if status.in?(CENTRAL_MAIL_ERROR_STATUSES) && error_message

--- a/modules/appeals_api/app/models/concerns/appeals_api/central_mail_status.rb
+++ b/modules/appeals_api/app/models/concerns/appeals_api/central_mail_status.rb
@@ -78,28 +78,6 @@ module AppealsApi
         update! attributes
       end
     end
-
-    # the following three validations are called in tests to ensure that the statuses above are written correctly
-    def status_attributes_valid?
-      # check to ensure the subject file has the correct statuses coded
-      CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES.values.all? do |attributes|
-        [:status, 'status'].all? do |status|
-          !attributes.key?(status) || attributes[status].in?(STATUSES)
-        end
-      end
-    end
-
-    def error_statuses_valid?
-      # check to ensure the subject file has the correct statuses coded
-      CENTRAL_MAIL_ERROR_STATUSES.all? do |error_status|
-        CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES.keys.include?(error_status)
-      end
-    end
-
-    def statuses_valid?
-      # check to ensure the subject file has the correct statuses coded
-      [*RECEIVED_OR_PROCESSING, *COMPLETE_STATUSES].all? { |status| STATUSES.include?(status) }
-    end
     # rubocop:enable Metrics/BlockLength
   end
 end

--- a/modules/appeals_api/app/models/concerns/appeals_api/central_mail_status.rb
+++ b/modules/appeals_api/app/models/concerns/appeals_api/central_mail_status.rb
@@ -6,59 +6,14 @@ module AppealsApi
 
     include SentryLogging
 
-    included do
-      scope :received_or_processing, -> { where status: RECEIVED_OR_PROCESSING }
-
-      STATUSES = %w[pending submitting submitted processing error uploaded received success expired].freeze
-
-      validates :status, inclusion: { 'in': STATUSES }
-
-      CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES = lambda do
-        hash = Hash.new { |_, _| raise ArgumentError, 'Unknown Central Mail status' }
-        hash['Received'] = { status: 'received' }
-        hash['In Process'] = { status: 'processing' }
-        hash['Processing Success'] = hash['In Process']
-        hash['Success'] = { status: 'success' }
-        hash['Error'] = { status: 'error', code: 'DOC202' }
-        hash['Processing Error'] = hash['Error']
-        hash
-      end.call.freeze
-
-      raise "One or more CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES values is invalid" unless status_attributes_valid?
-
-      CENTRAL_MAIL_ERROR_STATUSES = ['Error', 'Processing Error'].freeze
-      raise "One or more CENTRAL_MAIL_ERROR_STATUSES is invalid" unless error_statuses_valid?
-
-      RECEIVED_OR_PROCESSING = %w[received processing].freeze
-      raise "One or more RECEIVED_OR_PROCESSING stats invalid" unless statuses_valid?(RECEIVED_OR_PROCESSING)
-
-      COMPLETE_STATUSES = %w[success error].freeze
-      raise "One or more COMPLETE_STATUSES is invalid" unless statuses_valid?(COMPLETE_STATUSES)
-
-      def update_status_using_central_mail_status!(status, error_message = nil)
-        begin
-          attributes = CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES[status] || {}
-        rescue ArgumentError
-          # TODO: test logging
-          log_message_to_sentry('Unknown status value from Central Mail API', :warning, status: status)
-          raise Common::Exceptions::BadGateway, detail: 'Unknown processing status'
-        end
-        if status.in?(CENTRAL_MAIL_ERROR_STATUSES) && error_message
-          attributes = attributes.merge(detail: "Downstream status: #{error_message}")
-        end
-
-        update! attributes
-      end
-    end
-
     class_methods do
       def refresh_statuses_using_central_mail!(appeals)
+
         return if appeals.empty?
 
         response = CentralMail::Service.new.status(appeals.pluck(:id))
 
         unless response.success?
-          # TODO: need better solution & Need to test
           appeals[0].log_message_to_sentry('Error getting status from Central Mail', :warning, status: response.status, body: response.body)
           raise Common::Exceptions::BadGateway
         end
@@ -85,23 +40,43 @@ module AppealsApi
           Struct.new(:id, :status, :error_message).new(*hash.values_at('uuid', 'status', 'errorMessage'))
         end
       end
+    end
 
-      def status_attributes_valid?
-        CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES.values.all? do |attributes|
-          [:status, 'status'].all? do |status|
-            !attributes.key?(status) || attributes[status].in?(STATUSES)
-          end
+    included do
+      scope :received_or_processing, -> { where status: RECEIVED_OR_PROCESSING }
+
+      STATUSES = %w[pending submitting submitted processing error uploaded received success expired].freeze
+
+      validates :status, inclusion: { 'in': STATUSES }
+
+      CENTRAL_MAIL_ERROR_STATUSES = ['Error', 'Processing Error'].freeze
+      RECEIVED_OR_PROCESSING = %w[received processing].freeze
+      COMPLETE_STATUSES = %w[success error].freeze
+
+      CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES = lambda do
+        hash = Hash.new { |_, _| raise ArgumentError, 'Unknown Central Mail status' }
+        hash['Received'] = { status: 'received' }
+        hash['In Process'] = { status: 'processing' }
+        hash['Processing Success'] = hash['In Process']
+        hash['Success'] = { status: 'success' }
+        hash['Error'] = { status: 'error', code: 'DOC202' }
+        hash['Processing Error'] = hash['Error']
+        hash
+      end.call.freeze
+
+      def update_status_using_central_mail_status!(status, error_message = nil)
+        begin
+          attributes = CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES[status] || {}
+        rescue ArgumentError
+          log_message_to_sentry('Unknown status value from Central Mail API', :warning, status: status)
+          raise Common::Exceptions::BadGateway, detail: 'Unknown processing status'
         end
-      end
 
-      def error_statuses_valid?
-        CENTRAL_MAIL_ERROR_STATUSES.all? do |error_status|
-          CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES.keys.include?(error_status)
+        if status.in?(CENTRAL_MAIL_ERROR_STATUSES) && error_message
+          attributes = attributes.merge(detail: "Downstream status: #{error_message}")
         end
-      end
 
-      def statuses_valid?(statuses)
-        statuses.all? { |status| STATUSES.include?(status) }
+        update! attributes
       end
     end
   end

--- a/modules/appeals_api/spec/models/concerns/appeals_api/central_mail_status_spec.rb
+++ b/modules/appeals_api/spec/models/concerns/appeals_api/central_mail_status_spec.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-# require Rails.root.join('spec', 'lib', 'sentry_logging_spec_helper.rb')
 
 describe AppealsApi::CentralMailStatus, type: :concern do
-  # include_examples 'a sentry logger'
-
   let(:client_stub) { instance_double('CentralMail::Service') }
   let(:faraday_response) { instance_double('Faraday::Response') }
   let!(:upload) { create(:notice_of_disagreement) }
@@ -16,67 +13,76 @@ describe AppealsApi::CentralMailStatus, type: :concern do
        "lastUpdated": '2018-04-25 00:02:39' }]
   end
 
-  # let(:error_element) do
-  #   [{ "uuid": 'ignored',
-  #      "status": 'Error',
-  #      "errorMessage": 'Very bad',
-  #      "lastUpdated": '2018-04-25 00:02:39' }]
-  # end
+  before do
+    allow(CentralMail::Service).to receive(:new) { client_stub }
+    allow(client_stub).to receive(:status).and_return(faraday_response)
+  end
 
   describe ".refresh_statuses_using_central_mail!" do
     context "when there are no appeals to update" do
       it "returns nil" do
-        appeals = []
-        expect(AppealsApi::HigherLevelReview.refresh_statuses_using_central_mail!(appeals)).to be_nil
+        expect(AppealsApi::HigherLevelReview.refresh_statuses_using_central_mail!([])).to be_nil
       end
     end
 
     context "when central mail response is unsuccessful" do
-      it "raises an exception" do
-        expect(CentralMail::Service).to receive(:new) { client_stub }
-        expect(client_stub).to receive(:status).and_return(faraday_response)
-        expect(faraday_response).to receive(:success?).and_return(false)
-        in_process_element[0]['uuid'] = upload.id
-        expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
-        expect(faraday_response).to receive(:status).at_least(:once).and_return([in_process_element].flatten[0][:status])
+      before do
+        allow(faraday_response).to receive(:success?).and_return(false)
+        allow(faraday_response).to receive(:body)
+        allow(faraday_response).to receive(:status)
+        allow(upload).to receive(:log_message_to_sentry)
+      end
 
-        appeals = [upload]
-        expect { AppealsApi::HigherLevelReview.refresh_statuses_using_central_mail!(appeals) }.to raise_error(Common::Exceptions::BadGateway)
-        # expect(upload).to receive(:log_message_to_sentry)
+      it "raises an exception" do
+        expect {
+          AppealsApi::HigherLevelReview.refresh_statuses_using_central_mail!([upload])
+        }.to raise_error(Common::Exceptions::BadGateway)
+      end
+
+      it "logs to Sentry" do
+        begin
+          AppealsApi::HigherLevelReview.refresh_statuses_using_central_mail!([upload])
+        rescue Common::Exceptions::BadGateway
+          expect(upload).to have_received(:log_message_to_sentry)
+        end
       end
     end
 
     context "when central mail response is successful" do
+      before do
+        allow(faraday_response).to receive(:success?).and_return(true)
+        in_process_element[0]['uuid'] = upload.id
+        allow(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
+        allow(upload).to receive(:log_message_to_sentry)
+      end
+
       context "when #update_status_using_central_mail_status!' is called" do
         it "updates the appeal's attributes" do
-          expect(CentralMail::Service).to receive(:new) { client_stub }
-          expect(client_stub).to receive(:status).and_return(faraday_response)
-          expect(faraday_response).to receive(:success?).and_return(true)
-          in_process_element[0]['uuid'] = upload.id
-          expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
-
           with_settings(Settings.modules_appeals_api, higher_level_review_updater_enabled: true) do
-            appeals = [upload]
-            AppealsApi::HigherLevelReview.refresh_statuses_using_central_mail!(appeals)
-            upload.reload
+            AppealsApi::HigherLevelReview.refresh_statuses_using_central_mail!([upload])
             expect(upload.status).to eq('processing')
           end
         end
 
         context "when unknown status passed from central mail" do
-          it "raises an error" do
-            expect { upload.update_status_using_central_mail_status!(status: "pumpkins") }.to raise_error(Common::Exceptions::BadGateway)
+          it "raises an exception" do
+            expect {
+              upload.update_status_using_central_mail_status!(status: "pumpkins")
+            }.to raise_error(Common::Exceptions::BadGateway)
           end
 
           it "logs to Sentry" do
-
+            begin
+              upload.update_status_using_central_mail_status!(status: "pumpkins")
+            rescue Common::Exceptions::BadGateway
+              expect(upload).to have_received(:log_message_to_sentry)
+            end
           end
         end
 
         context "when appeal object contains an error message" do
           it "updates appeal details to include error message" do
             upload.update_status_using_central_mail_status!('Error', 'You did a bad')
-            upload.reload
             expect(upload.status).to eq('error')
             expect(upload.detail).to eq('Downstream status: You did a bad')
           end
@@ -85,7 +91,7 @@ describe AppealsApi::CentralMailStatus, type: :concern do
     end
   end
 
-  context "verifying our status structures" do
+  context "when verifying model status structures" do
     it "fails if one or more CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES keys or values is mismatched" do
       expect(status_attributes_valid?).to be true
     end
@@ -100,7 +106,7 @@ describe AppealsApi::CentralMailStatus, type: :concern do
   end
 
   def status_attributes_valid?
-    # TODO: need better solution for the constants here
+    # TODO: need better solution for the constants here?
     subject::CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES.values.all? do |attributes|
       [:status, 'status'].all? do |status|
         !attributes.key?(status) || attributes[status].in?(subject::STATUSES)
@@ -109,14 +115,14 @@ describe AppealsApi::CentralMailStatus, type: :concern do
   end
 
   def error_statuses_valid?
-    # TODO: need better solution for the constants here
+    # TODO: need better solution for the constants here?
     subject::CENTRAL_MAIL_ERROR_STATUSES.all? do |error_status|
       subject::CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES.keys.include?(error_status)
     end
   end
 
   def statuses_valid?
-    # TODO: need better solution for the constants here
+    # TODO: need better solution for the constants here?
     [*subject::RECEIVED_OR_PROCESSING, *subject::COMPLETE_STATUSES].all? { |status| subject::STATUSES.include?(status) }
   end
 end

--- a/modules/appeals_api/spec/models/concerns/appeals_api/central_mail_status_spec.rb
+++ b/modules/appeals_api/spec/models/concerns/appeals_api/central_mail_status_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+# require Rails.root.join('spec', 'lib', 'sentry_logging_spec_helper.rb')
+
+describe AppealsApi::CentralMailStatus, type: :concern do
+  # include_examples 'a sentry logger'
+
+  let(:client_stub) { instance_double('CentralMail::Service') }
+  let(:faraday_response) { instance_double('Faraday::Response') }
+  let!(:upload) { create(:notice_of_disagreement) }
+  let(:in_process_element) do
+    [{ "uuid": 'ignored',
+       "status": 'In Process',
+       "errorMessage": '',
+       "lastUpdated": '2018-04-25 00:02:39' }]
+  end
+
+  # let(:error_element) do
+  #   [{ "uuid": 'ignored',
+  #      "status": 'Error',
+  #      "errorMessage": 'Very bad',
+  #      "lastUpdated": '2018-04-25 00:02:39' }]
+  # end
+
+  describe ".refresh_statuses_using_central_mail!" do
+    context "when there are no appeals to update" do
+      it "returns nil" do
+        appeals = []
+        expect(AppealsApi::HigherLevelReview.refresh_statuses_using_central_mail!(appeals)).to be_nil
+      end
+    end
+
+    context "when central mail response is unsuccessful" do
+      it "raises an exception" do
+        expect(CentralMail::Service).to receive(:new) { client_stub }
+        expect(client_stub).to receive(:status).and_return(faraday_response)
+        expect(faraday_response).to receive(:success?).and_return(false)
+        in_process_element[0]['uuid'] = upload.id
+        expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
+        expect(faraday_response).to receive(:status).at_least(:once).and_return([in_process_element].flatten[0][:status])
+
+        appeals = [upload]
+        expect { AppealsApi::HigherLevelReview.refresh_statuses_using_central_mail!(appeals) }.to raise_error(Common::Exceptions::BadGateway)
+        # expect(upload).to receive(:log_message_to_sentry)
+      end
+    end
+
+    context "when central mail response is successful" do
+      context "when #update_status_using_central_mail_status!' is called" do
+        it "updates the appeal's attributes" do
+          expect(CentralMail::Service).to receive(:new) { client_stub }
+          expect(client_stub).to receive(:status).and_return(faraday_response)
+          expect(faraday_response).to receive(:success?).and_return(true)
+          in_process_element[0]['uuid'] = upload.id
+          expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
+
+          with_settings(Settings.modules_appeals_api, higher_level_review_updater_enabled: true) do
+            appeals = [upload]
+            AppealsApi::HigherLevelReview.refresh_statuses_using_central_mail!(appeals)
+            upload.reload
+            expect(upload.status).to eq('processing')
+          end
+        end
+
+        context "when unknown status passed from central mail" do
+          it "raises an error" do
+            expect { upload.update_status_using_central_mail_status!(status: "pumpkins") }.to raise_error(Common::Exceptions::BadGateway)
+          end
+
+          it "logs to Sentry" do
+
+          end
+        end
+
+        context "when appeal object contains an error message" do
+          it "updates appeal details to include error message" do
+            upload.update_status_using_central_mail_status!('Error', 'You did a bad')
+            upload.reload
+            expect(upload.status).to eq('error')
+            expect(upload.detail).to eq('Downstream status: You did a bad')
+          end
+        end
+      end
+    end
+  end
+
+  context "verifying our status structures" do
+    it "fails if one or more CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES keys or values is mismatched" do
+      expect(status_attributes_valid?).to be true
+    end
+
+    it "fails if error statuses is mismatched" do
+      expect(error_statuses_valid?).to be true
+    end
+
+    it "fails if remaining statuses is mismatched" do
+      expect(statuses_valid?).to be true
+    end
+  end
+
+  def status_attributes_valid?
+    # TODO: need better solution for the constants here
+    subject::CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES.values.all? do |attributes|
+      [:status, 'status'].all? do |status|
+        !attributes.key?(status) || attributes[status].in?(subject::STATUSES)
+      end
+    end
+  end
+
+  def error_statuses_valid?
+    # TODO: need better solution for the constants here
+    subject::CENTRAL_MAIL_ERROR_STATUSES.all? do |error_status|
+      subject::CENTRAL_MAIL_STATUS_TO_APPEAL_ATTRIBUTES.keys.include?(error_status)
+    end
+  end
+
+  def statuses_valid?
+    # TODO: need better solution for the constants here
+    [*subject::RECEIVED_OR_PROCESSING, *subject::COMPLETE_STATUSES].all? { |status| subject::STATUSES.include?(status) }
+  end
+end


### PR DESCRIPTION
## Description of change
Both HLR and NOD models contain identical code, controlling the updating of instance statuses to match the status returned from central mail. We want to consolidate this code into a shared concern. 

## Original issue(s)
https://vajira.max.gov/browse/API-4219

## Things to know about this PR
Refactoring validations (see raises) into tests