### PR TITLE
API-4263: 404 "Claim not found" error on PUT to /526 after successful POST

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_disability_compensation_controller.rb
@@ -10,30 +10,6 @@ module ClaimsApi
     STATSD_VALIDATION_FAIL_KEY = 'api.claims_api.526.validation_fail'
     STATSD_VALIDATION_FAIL_TYPE_KEY = 'api.claims_api.526.validation_fail_type'
 
-    before_action :validate_documents_content_type, only: %i[upload_form_526]
-    before_action :validate_documents_page_size, only: %i[upload_form_526]
-
-    def upload_form_526
-      pending_claim = ClaimsApi::AutoEstablishedClaim.pending?(params[:id])
-
-      if pending_claim && (pending_claim.form_data['autoCestPDFGenerationDisabled'] == true)
-        pending_claim.set_file_data!(documents.first, params[:doc_type])
-        pending_claim.save!
-
-        ClaimsApi::ClaimUploader.perform_async(pending_claim.id)
-
-        render json: pending_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
-      elsif pending_claim && (pending_claim.form_data['autoCestPDFGenerationDisabled'] == false)
-        # rubocop:disable Layout/LineLength
-        render json: { status: 422, message: 'Claim submission requires that the "autoCestPDFGenerationDisabled" field must be set to "true" in order to allow a 526 PDF to be uploaded' }.to_json, status: :unprocessable_entity
-        # rubocop:enable Layout/LineLength
-      else
-        render json: { status: 404, message: 'Claim not found' }.to_json, status: :not_found
-      end
-    rescue => e
-      render json: unprocessable_response(e), status: :unprocessable_entity
-    end
-
     # rubocop:disable Metrics/MethodLength
     def validate_form_526
       service = EVSS::DisabilityCompensationForm::Service.new(auth_headers)

--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -13,8 +13,8 @@ module ClaimsApi
 
         skip_before_action(:authenticate)
         before_action :validate_json_schema, only: %i[submit_form_526 validate_form_526]
-        before_action :validate_documents_content_type, only: %i[upload_supporting_documents]
-        before_action :validate_documents_page_size, only: %i[upload_supporting_documents]
+        before_action :validate_documents_content_type, only: %i[upload_supporting_documents upload_form_526]
+        before_action :validate_documents_page_size, only: %i[upload_supporting_documents upload_form_526]
         skip_before_action :validate_json_format, only: %i[upload_supporting_documents]
 
         def submit_form_526
@@ -33,6 +33,27 @@ module ClaimsApi
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
 
           render json: auto_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
+        end
+
+        def upload_form_526
+          pending_claim = ClaimsApi::AutoEstablishedClaim.pending?(params[:id])
+
+          if pending_claim && (pending_claim.form_data['autoCestPDFGenerationDisabled'] == true)
+            pending_claim.set_file_data!(documents.first, params[:doc_type])
+            pending_claim.save!
+
+            ClaimsApi::ClaimUploader.perform_async(pending_claim.id)
+
+            render json: pending_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
+          elsif pending_claim && (pending_claim.form_data['autoCestPDFGenerationDisabled'] == false)
+            # rubocop:disable Layout/LineLength
+            render json: { status: 422, message: 'Claim submission requires that the "autoCestPDFGenerationDisabled" field must be set to "true" in order to allow a 526 PDF to be uploaded' }.to_json, status: :unprocessable_entity
+            # rubocop:enable Layout/LineLength
+          else
+            render json: { status: 404, message: 'Claim not found' }.to_json, status: :not_found
+          end
+        rescue => e
+          render json: unprocessable_response(e), status: :unprocessable_entity
         end
 
         def upload_supporting_documents

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -15,8 +15,8 @@ module ClaimsApi
         before_action { permit_scopes %w[claim.write] }
         before_action :validate_json_schema, only: %i[submit_form_526 validate_form_526]
         before_action :validate_initial_claim, only: %i[submit_form_526 validate_form_526]
-        before_action :validate_documents_content_type, only: %i[upload_supporting_documents]
-        before_action :validate_documents_page_size, only: %i[upload_supporting_documents]
+        before_action :validate_documents_content_type, only: %i[upload_supporting_documents upload_form_526]
+        before_action :validate_documents_page_size, only: %i[upload_supporting_documents upload_form_526]
         before_action :find_claim, only: %i[upload_supporting_documents]
         skip_before_action :validate_json_format, only: %i[upload_supporting_documents]
 
@@ -33,9 +33,33 @@ module ClaimsApi
             auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5, source: source_name)
           end
 
-          ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
+          unless form_attributes['autoCestPDFGenerationDisabled'] == true
+            ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)
+          end
 
           render json: auto_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
+        end
+
+        def upload_form_526
+          pending_claim = ClaimsApi::AutoEstablishedClaim.pending?(params[:id])
+
+          if pending_claim && (pending_claim.form_data['autoCestPDFGenerationDisabled'] == true)
+            pending_claim.set_file_data!(documents.first, params[:doc_type])
+            pending_claim.save!
+
+            ClaimsApi::ClaimEstablisher.perform_async(pending_claim.id)
+            ClaimsApi::ClaimUploader.perform_async(pending_claim.id)
+
+            render json: pending_claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
+          elsif pending_claim && (pending_claim.form_data['autoCestPDFGenerationDisabled'] == false)
+            # rubocop:disable Layout/LineLength
+            render json: { status: 422, message: 'Claim submission requires that the "autoCestPDFGenerationDisabled" field must be set to "true" in order to allow a 526 PDF to be uploaded' }.to_json, status: :unprocessable_entity
+            # rubocop:enable Layout/LineLength
+          else
+            render json: { status: 404, message: 'Claim not found' }.to_json, status: :not_found
+          end
+        rescue => e
+          render json: unprocessable_response(e), status: :unprocessable_entity
         end
 
         def upload_supporting_documents

--- a/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
@@ -67,6 +67,9 @@ module ClaimsApi
               Takes in JSON, returns UUID for submission. Asynchronously auto-establishes claim and generates a PDF for VBMS.
               Can accept document binary PDF or base64 string as part of a multi-part payload (as `attachment1`, `attachment2`, etc.).
               **If you are filing an original claim, and the filer is not the veteran** (the oauth token is not the veteran’s), see [PUT /forms/526/{id}](#operations-Disability-upload526Attachment).
+
+              * Claim establishment is handled asynchronously. See [GET /claims/{id}](#operations-Claims-findClaimById) to check status of submission.
+              * Claim establishment does not start if autoCestPDFGenerationDisabled is set to true. [PUT /forms/526/{id}](#operations-Disability-upload526Attachment) is required to begin establishing the claim.
             X
           )
           key :operationId, 'post526Claim'

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -21,7 +21,14 @@ RSpec.describe 'Disability Claims ', type: :request do
   end
 
   describe '#526' do
-    let(:data) { File.read(Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'form_526_json_api.json')) }
+    let(:auto_cest_pdf_generation_disabled) { false }
+    let(:data) do
+      temp = File.read(Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'form_526_json_api.json'))
+      temp = JSON.parse(temp)
+      temp['data']['attributes']['autoCestPDFGenerationDisabled'] = auto_cest_pdf_generation_disabled
+
+      temp.to_json
+    end
     let(:path) { '/services/claims/v1/forms/526' }
     let(:schema) { File.read(Rails.root.join('modules', 'claims_api', 'config', 'schemas', '526.json')) }
 
@@ -44,11 +51,27 @@ RSpec.describe 'Disability Claims ', type: :request do
       end
     end
 
-    it 'creates the sidekick job' do
-      with_okta_user(scopes) do |auth_header|
-        VCR.use_cassette('evss/claims/claims') do
-          expect(ClaimsApi::ClaimEstablisher).to receive(:perform_async)
-          post path, params: data, headers: headers.merge(auth_header)
+    context 'when autoCestPDFGenerationDisabled is false' do
+      let(:auto_cest_pdf_generation_disabled) { false }
+
+      it 'creates the sidekick job' do
+        with_okta_user(scopes) do |auth_header|
+          VCR.use_cassette('evss/claims/claims') do
+            expect(ClaimsApi::ClaimEstablisher).to receive(:perform_async)
+            post path, params: data, headers: headers.merge(auth_header)
+          end
+        end
+      end
+    end
+
+    context 'when autoCestPDFGenerationDisabled is true' do
+      let(:auto_cest_pdf_generation_disabled) { true }
+
+      it 'creates the sidekick job' do
+        with_okta_user(scopes) do |auth_header|
+          VCR.use_cassette('evss/claims/claims') do
+            post path, params: data, headers: headers.merge(auth_header)
+          end
         end
       end
     end


### PR DESCRIPTION
## Description of change
No longer runs the ClaimEstablisher background job on POST submission if autoCestPDFGenerationDisabled is set to true. In this case, a 526 pdf form is required to be sent in through the PUT endpoint before the claim can be established.

Note: This only applies to v1. 

## Original issue(s)
https://vajira.max.gov/browse/API-4263

## Things to know about this PR
Updated existing broken specs and added new to handle this new workflow.
Added a bit of clarification to the developer portal documentation around both these changes and the fact that 526 POST submission is an asynchronous process.