### PR TITLE
Fix quote mismatch in OneRecord description

### DIFF
--- a/modules/apps_api/lib/apps_api/directory_application_creator.rb
+++ b/modules/apps_api/lib/apps_api/directory_application_creator.rb
@@ -94,8 +94,8 @@ module AppsApi
           "Your Health, Your Life, Your OneRecord.\n\n"\
           'OneRecord is an app that enables you to build a consolidated medical record of your full health history. '\
           'Whether you have medical records from your time in active duty, your treatment at VA facilities, '\
-          "or from doctors and hospitals outside of the military system, '\
-          'secure your medical records in one place — your OneRecord.\n\n"\
+          'or from doctors and hospitals outside of the military system, '\
+          "secure your medical records in one place — your OneRecord.\n\n"\
           'Available on IOS, Android, and on the web at www.onerecord.com'
         app.privacy_url = 'https://onerecord.com/privacy'
         app.tos_url = 'https://onerecord.com/terms'


### PR DESCRIPTION
## Description of change
This PR updates the OneRecord app description and fixes mismatched quotation marks.

## Original issue(s)
https://vajira.max.gov/browse/API-4086

## Things to know about this PR
- updated app description, locally tested
