### PR TITLE
Update Swagger docs to reflect schema minItems for included

### DIFF
--- a/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
@@ -48,6 +48,15 @@ module AppealsApi::V1
               end
             end
           end
+
+          property :included do
+            key :type, :array
+            key :minItems, 1
+
+            items do
+              key :'$ref', :contestableIssue
+            end
+          end
         end
 
         schema :nodCreateResponse do


### PR DESCRIPTION
## Description of change
Update `included` key in nodCreateOptions for swagger documentation to reflect schema minItems.

## Original issue(s)
[4239](https://vajira.max.gov/browse/API-4239)

