### PR TITLE
API-4231: Benefits Claims- GET request for specific claim resulting in valid response

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -46,10 +46,13 @@ module ClaimsApi
         fetch_errored(claim)
       elsif claim && claim.evss_id.nil?
         render json: claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
-      else
+      elsif /^\d{2,20}$/.match?(params[:id])
         evss_claim = claims_service.update_from_remote(claim.try(:evss_id) || params[:id])
         # Note: source doesn't seem to be accessible within a remote evss_claim
         render json: evss_claim, serializer: ClaimsApi::ClaimDetailSerializer
+      else
+        render json: { errors: [{ status: 404, detail: 'Claim not found' }] },
+               status: :not_found
       end
     end
 

--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -39,6 +39,8 @@ module ClaimsApi
 
     private
 
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def find_claim
       claim = ClaimsApi::AutoEstablishedClaim.find_by(id: params[:id], source: source_name)
 
@@ -55,6 +57,8 @@ module ClaimsApi
                status: :not_found
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     def fetch_errored(claim)
       if claim.evss_response&.any?

--- a/modules/claims_api/spec/requests/v0/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/claims_request_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
     end
 
     context 'with an auto established claim' do
+      let(:evss_claim_id) { 600_118_851 }
       let(:auto_established_claim_id) { 'd5536c5c-0465-4038-a368-1a9d9daf65c9' }
       let(:wesley_ford_headers) do
         {
@@ -131,14 +132,14 @@ RSpec.describe 'EVSS Claims management', type: :request do
         create(:auto_established_claim,
                source: 'TestConsumer',
                auth_headers: { some: 'data' },
-               evss_id: 600_118_851,
+               evss_id: evss_claim_id,
                id: auto_established_claim_id)
       end
 
       it 'shows a single Claim through it', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         VCR.use_cassette('evss/claims/claim') do
           get(
-            "/services/claims/v0/claims/#{auto_established_claim_id}",
+            "/services/claims/v0/claims/#{evss_claim_id}",
             params: nil,
             headers: wesley_ford_headers
           )
@@ -149,7 +150,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
       it 'shows a single Claim through it when camel-inflected', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         VCR.use_cassette('evss/claims/claim') do
           get(
-            "/services/claims/v0/claims/#{auto_established_claim_id}",
+            "/services/claims/v0/claims/#{evss_claim_id}",
             params: nil,
             headers: wesley_ford_headers.merge(camel_inflection_header)
           )

--- a/modules/claims_api/spec/requests/v1/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/claims_request_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
                  id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
           VCR.use_cassette('evss/claims/claim') do
             get(
-              '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
+              '/services/claims/v1/claims/600118851',
               params: nil, headers: request_headers.merge(auth_header)
             )
             expect(response).to match_response_schema('claims_api/claim')
@@ -100,7 +100,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
                  id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
           VCR.use_cassette('evss/claims/claim') do
             get(
-              '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
+              '/services/claims/v1/claims/600118851',
               params: nil, headers: request_headers_camel.merge(auth_header)
             )
             expect(response).to match_camelized_response_schema('claims_api/claim')
@@ -121,7 +121,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
             .and_raise(StandardError.new('no claim found'))
           VCR.use_cassette('evss/claims/claim') do
             get(
-              '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
+              '/services/claims/v1/claims/600118851',
               params: nil, headers: request_headers.merge(auth_header)
             )
             expect(response.code.to_i).to eq(404)
@@ -184,7 +184,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
           allow(BGS::PowerOfAttorneyVerifier).to receive(:new) { verifier_stub }
           allow(verifier_stub).to receive(:verify)
           headers = request_headers.merge(auth_header)
-          get '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9', params: nil, headers: headers
+          get '/services/claims/v1/claims/600118851', params: nil, headers: headers
           expect(response.status).to eq(200)
         end
       end


### PR DESCRIPTION
## Description of change
Ensures environments with mocked EVSS has some sort of resemblance to how production behaves if an invalid identifier is passed in to the "get claim by id" endpoint.

## Original issue(s)
https://vajira.max.gov/browse/API-4231

## Things to know about this PR
Fixed broken specs.
Tested manually hitting the endpoint locally.