### PR TITLE
API-4074 Fix NOD header data retrieval

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -148,19 +148,27 @@ module AppealsApi
     end
 
     def veteran_first_name
-      header_field_as_string 'X-VA-First-Name'
+      header_field_as_string 'X-VA-Veteran-First-Name'
     end
 
     def veteran_last_name
-      header_field_as_string 'X-VA-Last-Name'
+      header_field_as_string 'X-VA-Veteran-Last-Name'
     end
 
     def ssn
-      header_field_as_string 'X-VA-SSN'
+      header_field_as_string 'X-VA-Veteran-SSN'
     end
 
     def file_number
-      header_field_as_string 'X-VA-File-Number'
+      header_field_as_string 'X-VA-Veteran-File-Number'
+    end
+
+    def consumer_name
+      header_field_as_string 'X-Consumer-Username'
+    end
+
+    def consumer_id
+      header_field_as_string 'X-Consumer-ID'
     end
 
     def veteran_homeless_state
@@ -169,14 +177,6 @@ module AppealsApi
 
     def veteran_representative
       form_data&.dig('data', 'attributes', 'veteran', 'representativesName')
-    end
-
-    def consumer_name
-      auth_headers&.dig('X-Consumer-Username')
-    end
-
-    def consumer_id
-      auth_headers&.dig('X-Consumer-ID')
     end
 
     def board_review_option

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -87,7 +87,27 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
     end
   end
 
+  describe '#veteran_first_name' do
+    it { expect(notice_of_disagreement.veteran_first_name).to eq 'Jane' }
+  end
+
+  describe '#veteran_last_name' do
+    it { expect(notice_of_disagreement.veteran_last_name).to eq 'Doe' }
+  end
+
+  describe '#ssn' do
+    it { expect(notice_of_disagreement.ssn).to eq '123456789' }
+  end
+
+  describe '#file_number' do
+    it { expect(notice_of_disagreement.file_number).to eq '987654321' }
+  end
+
   describe '#consumer_name' do
-    it { expect(notice_of_disagreement.consumer_name).to eq('va.gov') }
+    it { expect(notice_of_disagreement.consumer_name).to eq 'va.gov' }
+  end
+
+  describe '#consumer_id' do
+    it { expect(notice_of_disagreement.consumer_id).to eq 'some-guid' }
   end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Temporarily use ZIP `00000` to ensure we only need the zip (and not more of the address) to pass properly into centralmail.

## Original issue(s)
https://vajira.max.gov/browse/API-4074
