### PR TITLE
API-4074 Temporarily use 0s for centralmail zip

### DIFF
--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
@@ -34,7 +34,7 @@ module AppealsApi
         'veteranFirstName' => notice_of_disagreement.veteran_first_name,
         'veteranLastName' => notice_of_disagreement.veteran_last_name,
         'fileNumber' => notice_of_disagreement.file_number.presence || notice_of_disagreement.ssn,
-        'zipCode' => '', # TODO: temporarily an empty string until we take in address info
+        'zipCode' => '00000', # TODO: temporarily 0's until we take in address info
         'source' => "Appeals-NOD-#{notice_of_disagreement.consumer_name}",
         'uuid' => notice_of_disagreement.id,
         'hashV' => Digest::SHA256.file(pdf_path).hexdigest,


### PR DESCRIPTION
## Description of change
CentralMail requires a 5-digit zipcode in its metadata or else it will error. Supply it with 0's for now.

## Original issue(s)
https://vajira.max.gov/browse/API-4074
