### PR TITLE
Api 4180 - appeals_api report email

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -156,6 +156,7 @@ decision_review:
 
 # Settings for modules/appeals_api
 modules_appeals_api:
+  report_enabled: false
   higher_level_review_updater_enabled: true
   notice_of_disagreement_updater_enabled: true
   schema_dir: config/schemas

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -126,6 +126,11 @@ AppealsApi::HigherLevelReviewCleanUpWeekOldPii:
   class: AppealsApi::HigherLevelReviewCleanUpWeekOldPii
   description: "Remove PII of HigherLevelReviews that have 1) reached one of the 'completed' statuses and 2) are a week old"
 
+AppealsApi::DecisionReviewReportJob:
+  cron: "0 0 * * MON-FRI America/New_York"
+  class: AppealsApi::DecisionReviewReportJob
+  description: "Daily report of appeals submissions"
+
 TransactionalEmailAnalyticsJob:
   cron: "0 1 * * * America/New_York"
   description: "posts Transactional email (HCA Failure and Direct Deposit Update) sends and failures to Google Analytics"

--- a/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
+++ b/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'appeals_api/decision_review_report'
+
+module AppealsApi
+  class DecisionReviewMailer < ApplicationMailer
+    RECIPIENTS = %w[
+      example@va.gov
+    ].freeze
+
+    def build(date_from:, date_to:)
+      @report = DecisionReviewReport.new(from: date_from, to: date_to)
+
+      template = File.read(path)
+      body = ERB.new(template).result(binding)
+
+      mail(
+        to: RECIPIENTS,
+        subject: 'Decision Review API report',
+        content_type: 'text/html',
+        body: body
+      )
+    end
+
+    private
+
+    def path
+      AppealsApi::Engine.root.join(
+        'app',
+        'views',
+        'appeals_api',
+        'decision_review_mailer',
+        'mailer.html.erb'
+      )
+    end
+  end
+end

--- a/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
+++ b/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
@@ -6,6 +6,11 @@ module AppealsApi
   class DecisionReviewMailer < ApplicationMailer
     RECIPIENTS = %w[
       premal.shah@va.gov
+      kelly@adhocteam.us
+      laura.trager@adhocteam.us
+      drew.fisher@adhocteam.us
+      jack.schuss@oddball.io
+      nathan.wright@oddball.io
     ].freeze
 
     def build(date_from:, date_to:)

--- a/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
+++ b/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
@@ -5,7 +5,7 @@ require 'appeals_api/decision_review_report'
 module AppealsApi
   class DecisionReviewMailer < ApplicationMailer
     RECIPIENTS = %w[
-      example@va.gov
+      premal.shah@va.gov
     ].freeze
 
     def build(date_from:, date_to:)

--- a/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
+++ b/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <style>
+      body {
+        font-family: sans-serif;
+        font-size: smaller;
+      }
+      table {
+        border-collapse: collapse;
+      }
+      table tr th, table tr td {
+        border: 1px solid #d3d3d3;
+        padding: 10px;
+      }
+      table tr th {
+        padding: 5px 10px;
+        white-space: nowrap;
+        color: #808080;
+        font-size: smaller;
+        text-transform: uppercase;
+        font-weight: normal;
+        text-align: left;
+      }
+      table tr td {
+        padding: 5px 10px;
+        vertical-align: top;
+      }
+      table tr td.right-align {
+        text-align: right;
+      }
+      h2 {
+        margin: 30px 0 2px;
+      }
+      h2 span.title {
+        color: #808080;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>Decision Review Report from <%= @report.from %> -- <%= @report.to %> </h1>
+
+    <h2><span class="title">Number of successful submissions by Appeal type</span></h2>
+    <table>
+      <thead>
+        <tr>
+            <th>Type</th>
+            <th>Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>HLR</td>
+          <td class="right-align"><%= @report.successful_hlr_count %></td>
+        </tr>
+        <tr>
+          <td>NOD</td>
+          <td class="right-align"><%= @report.successful_nod_count %></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2><span class="title">Errors</span></h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Type</th>
+          <th>GUID</th>
+          <th>Consumer</th>
+          <th>Status</th>
+          <th>Code</th>
+          <th>Created At</th>
+          <th>Updated At</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @report.hlr_with_errors.each do |hlr| %>
+          <tr>
+            <td>HLR</td>
+            <td class="right-align"><%= hlr.id %></td>
+            <td class="right-align"><%= hlr.source %></td>
+            <td class="right-align"><%= hlr.status %></td>
+            <td class="right-align"><%= hlr.code %></td>
+            <td class="right-align"><%= hlr.created_at %></td>
+            <td class="right-align"><%= hlr.updated_at %></td>
+          </tr>
+        <% end %>
+        <% @report.nod_with_errors.each do |nod| %>
+          <tr>
+            <td>NOD</td>
+            <td class="right-align"><%= nod.id %></td>
+            <td class="right-align"><%= nod.source %></td>
+            <td class="right-align"><%= nod.status %></td>
+            <td class="right-align"><%= nod.code %></td>
+            <td class="right-align"><%= nod.created_at %></td>
+            <td class="right-align"><%= nod.updated_at %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+  </body>
+</html>

--- a/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
+++ b/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
@@ -71,6 +71,7 @@
           <th>Consumer</th>
           <th>Status</th>
           <th>Code</th>
+          <th>Detail</th>
           <th>Created At</th>
           <th>Updated At</th>
         </tr>
@@ -83,6 +84,7 @@
             <td class="right-align"><%= hlr.source %></td>
             <td class="right-align"><%= hlr.status %></td>
             <td class="right-align"><%= hlr.code %></td>
+            <td class="right-align"><%= hlr.detail %></td>
             <td class="right-align"><%= hlr.created_at %></td>
             <td class="right-align"><%= hlr.updated_at %></td>
           </tr>
@@ -94,6 +96,7 @@
             <td class="right-align"><%= nod.source %></td>
             <td class="right-align"><%= nod.status %></td>
             <td class="right-align"><%= nod.code %></td>
+            <td class="right-align"><%= nod.detail %></td>
             <td class="right-align"><%= nod.created_at %></td>
             <td class="right-align"><%= nod.updated_at %></td>
           </tr>

--- a/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
+++ b/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
@@ -42,27 +42,25 @@
   <body>
     <h1>Decision Review Report from <%= @report.from %> -- <%= @report.to %> </h1>
 
-    <h2><span class="title">Number of successful submissions by Appeal type</span></h2>
+    <h2><span class="title">HLR submissions by status and count</span></h2>
     <table>
       <thead>
         <tr>
-            <th>Type</th>
+            <th>Status</th>
             <th>Count</th>
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <td>HLR</td>
-          <td class="right-align"><%= @report.successful_hlr_count %></td>
-        </tr>
-        <tr>
-          <td>NOD</td>
-          <td class="right-align"><%= @report.successful_nod_count %></td>
-        </tr>
+        <% @report.hlr_by_status_and_count.each do |status, count| %>
+          <tr>
+            <td class="right-align"><%= status %></td>
+            <td class="right-align"><%= count %></td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
 
-    <h2><span class="title">Errors</span></h2>
+    <h2><span class="title">HLR Errors</span></h2>
     <table>
       <thead>
         <tr>
@@ -89,6 +87,45 @@
             <td class="right-align"><%= hlr.updated_at %></td>
           </tr>
         <% end %>
+      </tbody>
+    </table>
+
+    <br />
+    <hr />
+
+    <h2><span class="title">NOD submissions by status and count</span></h2>
+    <table>
+      <thead>
+        <tr>
+            <th>Status</th>
+            <th>Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @report.nod_by_status_and_count.each do |status, count| %>
+          <tr>
+            <td class="right-align"><%= status %></td>
+            <td class="right-align"><%= count %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <h2><span class="title">NOD Errors</span></h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Type</th>
+          <th>GUID</th>
+          <th>Consumer</th>
+          <th>Status</th>
+          <th>Code</th>
+          <th>Detail</th>
+          <th>Created At</th>
+          <th>Updated At</th>
+        </tr>
+      </thead>
+      <tbody>
         <% @report.nod_with_errors.each do |nod| %>
           <tr>
             <td>NOD</td>

--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_job.rb
@@ -7,10 +7,12 @@ module AppealsApi
     include Sidekiq::Worker
 
     def perform
-      to = Time.zone.now
-      from = to.monday? ? 7.days.ago : 1.day.ago
+      if Settings.modules_appeals_api.report_enabled
+        to = Time.zone.now
+        from = to.monday? ? 7.days.ago : 1.day.ago
 
-      DecisionReviewMailer.build(date_from: from, date_to: to).deliver_now
+        DecisionReviewMailer.build(date_from: from, date_to: to).deliver_now
+      end
     end
   end
 end

--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+
+module AppealsApi
+  class DecisionReviewReportJob
+    include Sidekiq::Worker
+
+    def perform
+      to = Time.zone.now
+      from = to.monday? ? 7.days.ago : 1.day.ago
+
+      DecisionReviewMailer.build(date_from: from, date_to: to).deliver_now
+    end
+  end
+end

--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_job.rb
@@ -9,7 +9,7 @@ module AppealsApi
     def perform
       if Settings.modules_appeals_api.report_enabled
         to = Time.zone.now
-        from = to.monday? ? 7.days.ago : 1.day.ago
+        from = 1.day.ago.utc
 
         DecisionReviewMailer.build(date_from: from, date_to: to).deliver_now
       end

--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_job.rb
@@ -6,11 +6,8 @@ module AppealsApi
   class DecisionReviewReportJob
     include Sidekiq::Worker
 
-    def perform
+    def perform(to: Time.zone.now, from: (to.monday? ? 3.days.ago : 1.day.ago))
       if Settings.modules_appeals_api.report_enabled
-        to = Time.zone.now
-        from = 1.day.ago.utc
-
         DecisionReviewMailer.build(date_from: from, date_to: to).deliver_now
       end
     end

--- a/modules/appeals_api/lib/appeals_api/decision_review_report.rb
+++ b/modules/appeals_api/lib/appeals_api/decision_review_report.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  class DecisionReviewReport
+    attr_reader :from, :to
+
+    def initialize(from:, to:)
+      @from = from
+      @to = to
+    end
+
+    def successful_hlr_count
+      HigherLevelReview.where(created_at: from..to, status: 'success').count
+    end
+
+    def hlr_with_errors
+      HigherLevelReview.where(created_at: from..to, status: 'error')
+    end
+
+    def successful_nod_count
+      NoticeOfDisagreement.where(created_at: from..to, status: 'success').count
+    end
+
+    def nod_with_errors
+      NoticeOfDisagreement.where(created_at: from..to, status: 'error')
+    end
+  end
+end

--- a/modules/appeals_api/lib/appeals_api/decision_review_report.rb
+++ b/modules/appeals_api/lib/appeals_api/decision_review_report.rb
@@ -9,20 +9,33 @@ module AppealsApi
       @to = to
     end
 
-    def successful_hlr_count
-      HigherLevelReview.where(created_at: from..to, status: 'success').count
+    def hlr_by_status_and_count
+      group_records(HigherLevelReview)
     end
 
     def hlr_with_errors
       HigherLevelReview.where(created_at: from..to, status: 'error')
     end
 
-    def successful_nod_count
-      NoticeOfDisagreement.where(created_at: from..to, status: 'success').count
+    def nod_by_status_and_count
+      group_records(NoticeOfDisagreement)
     end
 
     def nod_with_errors
       NoticeOfDisagreement.where(created_at: from..to, status: 'error')
+    end
+
+    private
+
+    def group_records(record_type)
+      statuses = record_type::STATUSES.sort.index_with { |_| 0 }
+
+      record_type
+        .where(created_at: from..to)
+        .group_by(&:status)
+        .each { |status, record_list| statuses[status] = record_list.size }
+
+      statuses
     end
   end
 end

--- a/modules/appeals_api/spec/factories/higher_level_reviews.rb
+++ b/modules/appeals_api/spec/factories/higher_level_reviews.rb
@@ -9,6 +9,9 @@ FactoryBot.define do
     form_data do
       JSON.parse File.read "#{::Rails.root}/modules/appeals_api/spec/fixtures/valid_200996.json"
     end
+    trait :status_error do
+      status { 'error' }
+    end
     trait :status_received do
       status { 'received' }
     end

--- a/modules/appeals_api/spec/factories/notice_of_disagreements.rb
+++ b/modules/appeals_api/spec/factories/notice_of_disagreements.rb
@@ -9,6 +9,9 @@ FactoryBot.define do
     form_data do
       JSON.parse File.read "#{::Rails.root}/modules/appeals_api/spec/fixtures/valid_10182.json"
     end
+    trait :status_error do
+      status { 'error' }
+    end
     trait :status_received do
       status { 'received' }
     end

--- a/modules/appeals_api/spec/lib/decision_review_report_spec.rb
+++ b/modules/appeals_api/spec/lib/decision_review_report_spec.rb
@@ -7,22 +7,26 @@ describe AppealsApi::DecisionReviewReport do
   it 'can correctly calculate hlrs' do
     create :higher_level_review, created_at: 1.week.ago, status: 'success'
     create :higher_level_review, status: 'success'
+    create :higher_level_review, status: 'success'
+
     errored_hlr = create :higher_level_review, :status_error
 
     subject = described_class.new(from: 5.days.ago, to: Time.now.utc)
 
-    expect(subject.successful_hlr_count).to eq(1)
+    expect(subject.successful_hlr_count).to eq(2)
     expect(subject.hlr_with_errors).to eq([errored_hlr])
   end
 
   it 'can correctly calculate nods' do
     create :notice_of_disagreement, created_at: 1.week.ago, status: 'success'
     create :notice_of_disagreement, status: 'success'
+    create :notice_of_disagreement, status: 'success'
+
     errored_nod = create :notice_of_disagreement, :status_error
 
     subject = described_class.new(from: 5.days.ago, to: Time.now.utc)
 
-    expect(subject.successful_nod_count).to eq(1)
+    expect(subject.successful_nod_count).to eq(2)
     expect(subject.nod_with_errors).to eq([errored_nod])
   end
 end

--- a/modules/appeals_api/spec/lib/decision_review_report_spec.rb
+++ b/modules/appeals_api/spec/lib/decision_review_report_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'appeals_api/decision_review_report'
+
+describe AppealsApi::DecisionReviewReport do
+  it 'can correctly calculate hlrs' do
+    create :higher_level_review, created_at: 1.week.ago, status: 'success'
+    create :higher_level_review, status: 'success'
+    errored_hlr = create :higher_level_review, :status_error
+
+    subject = described_class.new(from: 5.days.ago, to: Time.now.utc)
+
+    expect(subject.successful_hlr_count).to eq(1)
+    expect(subject.hlr_with_errors).to eq([errored_hlr])
+  end
+
+  it 'can correctly calculate nods' do
+    create :notice_of_disagreement, created_at: 1.week.ago, status: 'success'
+    create :notice_of_disagreement, status: 'success'
+    errored_nod = create :notice_of_disagreement, :status_error
+
+    subject = described_class.new(from: 5.days.ago, to: Time.now.utc)
+
+    expect(subject.successful_nod_count).to eq(1)
+    expect(subject.nod_with_errors).to eq([errored_nod])
+  end
+end

--- a/modules/appeals_api/spec/lib/decision_review_report_spec.rb
+++ b/modules/appeals_api/spec/lib/decision_review_report_spec.rb
@@ -4,16 +4,30 @@ require 'rails_helper'
 require 'appeals_api/decision_review_report'
 
 describe AppealsApi::DecisionReviewReport do
+  # rubocop:disable Layout/FirstHashElementIndentation
   it 'can correctly calculate hlrs' do
+    create :higher_level_review, status: 'processing'
+    create :higher_level_review, status: 'processing'
+    create :higher_level_review, status: 'processing'
+
     create :higher_level_review, created_at: 1.week.ago, status: 'success'
     create :higher_level_review, status: 'success'
     create :higher_level_review, status: 'success'
 
     errored_hlr = create :higher_level_review, :status_error
-
     subject = described_class.new(from: 5.days.ago, to: Time.now.utc)
 
-    expect(subject.successful_hlr_count).to eq(2)
+    expect(subject.hlr_by_status_and_count).to eq({
+      'error' => 1,
+      'expired' => 0,
+      'pending' => 0,
+      'processing' => 3,
+      'received' => 0,
+      'submitted' => 0,
+      'submitting' => 0,
+      'success' => 2,
+      'uploaded' => 0
+    })
     expect(subject.hlr_with_errors).to eq([errored_hlr])
   end
 
@@ -26,7 +40,18 @@ describe AppealsApi::DecisionReviewReport do
 
     subject = described_class.new(from: 5.days.ago, to: Time.now.utc)
 
-    expect(subject.successful_nod_count).to eq(2)
+    expect(subject.nod_by_status_and_count).to eq({
+      'error' => 1,
+      'expired' => 0,
+      'pending' => 0,
+      'processing' => 0,
+      'received' => 0,
+      'submitted' => 0,
+      'submitting' => 0,
+      'success' => 2,
+      'uploaded' => 0
+    })
     expect(subject.nod_with_errors).to eq([errored_nod])
   end
+  # rubocop:enable Layout/FirstHashElementIndentation
 end

--- a/modules/appeals_api/spec/mailers/decision_review_report_mailer_spec.rb
+++ b/modules/appeals_api/spec/mailers/decision_review_report_mailer_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe AppealsApi::DecisionReviewMailer, type: [:mailer] do
       expect(subject.to).to eq(
         %w[
           premal.shah@va.gov
+          kelly@adhocteam.us
+          laura.trager@adhocteam.us
+          drew.fisher@adhocteam.us
+          jack.schuss@oddball.io
+          nathan.wright@oddball.io
         ]
       )
     end

--- a/modules/appeals_api/spec/mailers/decision_review_report_mailer_spec.rb
+++ b/modules/appeals_api/spec/mailers/decision_review_report_mailer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AppealsApi::DecisionReviewMailer, type: [:mailer] do
     it 'sends to the right people' do
       expect(subject.to).to eq(
         %w[
-          example@va.gov
+          premal.shah@va.gov
         ]
       )
     end

--- a/modules/appeals_api/spec/mailers/decision_review_report_mailer_spec.rb
+++ b/modules/appeals_api/spec/mailers/decision_review_report_mailer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AppealsApi::DecisionReviewMailer, type: [:mailer] do
+  describe '#build' do
+    subject do
+      described_class.build(date_from: 7.days.ago, date_to: Time.zone.now).deliver_now
+    end
+
+    it 'sends the email' do
+      expect(subject.subject).to eq('Decision Review API report')
+    end
+
+    it 'sends to the right people' do
+      expect(subject.to).to eq(
+        %w[
+          example@va.gov
+        ]
+      )
+    end
+  end
+end

--- a/modules/appeals_api/spec/workers/decision_review_report_spec.rb
+++ b/modules/appeals_api/spec/workers/decision_review_report_spec.rb
@@ -8,7 +8,7 @@ describe AppealsApi::DecisionReviewReportJob, type: :job do
       with_settings(Settings.modules_appeals_api, report_enabled: true) do
         Timecop.freeze
         date_to = Time.zone.now
-        date_from = date_to.monday? ? 7.days.ago : 1.day.ago
+        date_from = date_to.monday? ? 3.days.ago : 1.day.ago
 
         expect(AppealsApi::DecisionReviewMailer).to receive(:build).once.with(
           date_from: date_from,

--- a/modules/appeals_api/spec/workers/decision_review_report_spec.rb
+++ b/modules/appeals_api/spec/workers/decision_review_report_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AppealsApi::DecisionReviewReportJob, type: :job do
+  describe '#perform' do
+    it 'sends mail' do
+      Timecop.freeze
+      date_to = Time.zone.now
+      date_from = date_to.monday? ? 7.days.ago : 1.day.ago
+
+      expect(AppealsApi::DecisionReviewMailer).to receive(:build).once.with(
+        date_from: date_from,
+        date_to: date_to
+      ).and_return(double.tap do |mailer|
+        expect(mailer).to receive(:deliver_now).once
+      end)
+
+      described_class.new.perform
+
+      Timecop.return
+    end
+  end
+end

--- a/modules/appeals_api/spec/workers/decision_review_report_spec.rb
+++ b/modules/appeals_api/spec/workers/decision_review_report_spec.rb
@@ -5,20 +5,22 @@ require 'rails_helper'
 describe AppealsApi::DecisionReviewReportJob, type: :job do
   describe '#perform' do
     it 'sends mail' do
-      Timecop.freeze
-      date_to = Time.zone.now
-      date_from = date_to.monday? ? 7.days.ago : 1.day.ago
+      with_settings(Settings.modules_appeals_api, report_enabled: true) do
+        Timecop.freeze
+        date_to = Time.zone.now
+        date_from = date_to.monday? ? 7.days.ago : 1.day.ago
 
-      expect(AppealsApi::DecisionReviewMailer).to receive(:build).once.with(
-        date_from: date_from,
-        date_to: date_to
-      ).and_return(double.tap do |mailer|
-        expect(mailer).to receive(:deliver_now).once
-      end)
+        expect(AppealsApi::DecisionReviewMailer).to receive(:build).once.with(
+          date_from: date_from,
+          date_to: date_to
+        ).and_return(double.tap do |mailer|
+          expect(mailer).to receive(:deliver_now).once
+        end)
 
-      described_class.new.perform
+        described_class.new.perform
 
-      Timecop.return
+        Timecop.return
+      end
     end
   end
 end

--- a/spec/mailers/previews/appeals_api_decision_review_preview.rb
+++ b/spec/mailers/previews/appeals_api_decision_review_preview.rb
@@ -6,6 +6,6 @@ class AppealsApiDecisionReviewPreview < ActionMailer::Preview
     from = 1.week.ago.utc
     to = Time.zone.now
 
-    AppealsApi::DecisionReviewMailer.build(from: from, to: to)
+    AppealsApi::DecisionReviewMailer.build(date_from: from, date_to: to)
   end
 end

--- a/spec/mailers/previews/appeals_api_decision_review_preview.rb
+++ b/spec/mailers/previews/appeals_api_decision_review_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AppealsApiDecisionReviewPreview < ActionMailer::Preview
+  # Preview this email at http://localhost:3000/rails/mailers/appeals_api/decision_review/report
+  def build
+    from = 1.week.ago.utc
+    to = Time.zone.now
+
+    AppealsApi::DecisionReviewMailer.build(from: from, to: to)
+  end
+end

--- a/spec/mailers/previews/appeals_api_decision_review_preview.rb
+++ b/spec/mailers/previews/appeals_api_decision_review_preview.rb
@@ -3,8 +3,8 @@
 class AppealsApiDecisionReviewPreview < ActionMailer::Preview
   # Preview this email at http://localhost:3000/rails/mailers/appeals_api/decision_review/report
   def build
-    from = 1.week.ago.utc
     to = Time.zone.now
+    from = 1.day.ago.utc
 
     AppealsApi::DecisionReviewMailer.build(date_from: from, date_to: to)
   end

--- a/spec/mailers/previews/appeals_api_decision_review_preview.rb
+++ b/spec/mailers/previews/appeals_api_decision_review_preview.rb
@@ -4,7 +4,7 @@ class AppealsApiDecisionReviewPreview < ActionMailer::Preview
   # Preview this email at http://localhost:3000/rails/mailers/appeals_api/decision_review/report
   def build
     to = Time.zone.now
-    from = 1.day.ago.utc
+    from = Time.at(0).utc
 
     AppealsApi::DecisionReviewMailer.build(date_from: from, date_to: to)
   end


### PR DESCRIPTION
This PR addresses [API-4180](https://vajira.max.gov/browse/API-4180)

## Description of change
Initial implementation of email report for HLR and NODs.

### Some questions
- How often should this report go out? (will need to update sidekiq scheduler)
- Who all should be included?
- Should the report be turned on (via the `settings.yml`) by default?
