### PR TITLE
Fix mobile user's work and mobile phone numbers being flipped in profile response

### DIFF
--- a/modules/mobile/app/serializers/mobile/v0/user_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/user_serializer.rb
@@ -64,8 +64,8 @@ module Mobile
           residential_address: filter_keys(user.vet360_contact_info&.residential_address, ADDRESS_KEYS),
           mailing_address: filter_keys(user.vet360_contact_info&.mailing_address, ADDRESS_KEYS),
           home_phone_number: filter_keys(user.vet360_contact_info&.home_phone, PHONE_KEYS),
-          mobile_phone_number: filter_keys(user.vet360_contact_info&.work_phone, PHONE_KEYS),
-          work_phone_number: filter_keys(user.vet360_contact_info&.mobile_phone, PHONE_KEYS),
+          mobile_phone_number: filter_keys(user.vet360_contact_info&.mobile_phone, PHONE_KEYS),
+          work_phone_number: filter_keys(user.vet360_contact_info&.work_phone, PHONE_KEYS),
           fax_number: filter_keys(user.vet360_contact_info&.fax_number, PHONE_KEYS)
         }
       end

--- a/modules/mobile/spec/request/user_request_spec.rb
+++ b/modules/mobile/spec/request/user_request_spec.rb
@@ -107,12 +107,12 @@ RSpec.describe 'user', type: :request do
       it 'includes a mobile phone number' do
         expect(attributes['profile']['mobilePhoneNumber']).to include(
           {
-            'id' => 791,
+            'id' => 790,
             'areaCode' => '303',
             'countryCode' => '1',
             'extension' => nil,
             'phoneNumber' => '5551234',
-            'phoneType' => 'WORK'
+            'phoneType' => 'MOBILE'
           }
         )
       end
@@ -120,12 +120,12 @@ RSpec.describe 'user', type: :request do
       it 'includes a work phone number' do
         expect(attributes['profile']['workPhoneNumber']).to include(
           {
-            'id' => 790,
+            'id' => 791,
             'areaCode' => '303',
             'countryCode' => '1',
             'extension' => nil,
             'phoneNumber' => '5551234',
-            'phoneType' => 'MOBILE'
+            'phoneType' => 'WORK'
           }
         )
       end


### PR DESCRIPTION
## Description of change
In the serializer for the mobile user profile the work number shows the mobile number and vice versa.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18296
