### PR TITLE
API-4074 Add zipcode into NOD schema

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -187,6 +187,10 @@ module AppealsApi
       form_data&.dig('data', 'attributes', 'hearingTypePreference')
     end
 
+    def zip_code_5
+      form_data&.dig('data', 'attributes', 'veteran', 'address', 'zipCode5')
+    end
+
     private
 
     def validate_hearing_type_selection

--- a/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
@@ -43,6 +43,8 @@ module AppealsApi::V1
                     key :type, :string
                     key :description, '5-digit zipcode. Use "00000" if Veteran is outside the United States'
                     key :example, '20001'
+                    key :maxLength, 5
+                    key :minLength, 5
                   end
                 end
               end

--- a/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
@@ -26,12 +26,24 @@ module AppealsApi::V1
               property :veteran do
                 key :type, :object
                 key :description, 'Veteran Object being submitted in appeal'
-                key :required, %i[homeless]
+                key :required, %i[homeless address]
 
                 property :homeless do
                   key :type, :boolean
                   key :example, false
                   key :description, 'Flag if Veteran is homeless'
+                end
+
+                property :address do
+                  key :type, :object
+                  key :description, 'Address of the Veteran'
+                  key :required, %i[zipCode5]
+
+                  property :zipCode5 do
+                    key :type, :string
+                    key :description, '5-digit zipcode. Use "00000" if Veteran is outside the United States'
+                    key :example, '20001'
+                  end
                 end
               end
 

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
@@ -34,7 +34,7 @@ module AppealsApi
         'veteranFirstName' => notice_of_disagreement.veteran_first_name,
         'veteranLastName' => notice_of_disagreement.veteran_last_name,
         'fileNumber' => notice_of_disagreement.file_number.presence || notice_of_disagreement.ssn,
-        'zipCode' => '00000', # TODO: temporarily 0's until we take in address info
+        'zipCode' => notice_of_disagreement.zip_code_5,
         'source' => "Appeals-NOD-#{notice_of_disagreement.consumer_name}",
         'uuid' => notice_of_disagreement.id,
         'hashV' => Digest::SHA256.file(pdf_path).hexdigest,

--- a/modules/appeals_api/config/schemas/10182.json
+++ b/modules/appeals_api/config/schemas/10182.json
@@ -46,9 +46,18 @@
       "additionalProperties": false,
       "properties": {
         "homeless":            { "type": "boolean" },
-        "representativesName": { "type": "string", "maxLength": 120 }
+        "representativesName": { "type": "string", "maxLength": 120 },
+        "address": { "$ref": "#/definitions/nodCreateAddress" }
       },
-      "required": [ "homeless" ]
+      "required": [ "homeless", "address" ]
+    },
+
+
+    "nodCreateAddress": {
+      "type": "object",
+      "properties": { "zipCode5": { "type": "string", "pattern": "^[0-9]{5}$" } },
+      "additionalProperties": false,
+      "required": [ "zipCode5" ]
     },
 
 

--- a/modules/appeals_api/config/schemas/10182.json
+++ b/modules/appeals_api/config/schemas/10182.json
@@ -55,7 +55,7 @@
 
     "nodCreateAddress": {
       "type": "object",
-      "properties": { "zipCode5": { "type": "string", "pattern": "^[0-9]{5}$" } },
+      "properties": { "zipCode5": { "type": "string", "pattern": "^[0-9]{5}$", "minLength": 5, "maxLength": 5 } },
       "additionalProperties": false,
       "required": [ "zipCode5" ]
     },

--- a/modules/appeals_api/spec/fixtures/invalid_10182.json
+++ b/modules/appeals_api/spec/fixtures/invalid_10182.json
@@ -4,6 +4,7 @@
     "attributes": {
       "veteran": {
         "homeless": false,
+        "address": { "zipCode5":  "66002" },
         "representativesName": "Tony Danza"
       },
       "boardReviewOption": "hearing",

--- a/modules/appeals_api/spec/fixtures/valid_10182.json
+++ b/modules/appeals_api/spec/fixtures/valid_10182.json
@@ -4,6 +4,7 @@
     "attributes": {
       "veteran": {
         "homeless": false,
+        "address": { "zipCode5": "66002" },
         "representativesName": "Tony Danza"
       },
       "boardReviewOption": "hearing",

--- a/modules/appeals_api/spec/fixtures/valid_10182_minimum.json
+++ b/modules/appeals_api/spec/fixtures/valid_10182_minimum.json
@@ -3,7 +3,8 @@
     "type": "noticeOfDisagreement",
     "attributes": {
       "veteran": {
-        "homeless": false
+        "homeless": false,
+        "address": { "zipCode5":  "66002" }
       },
       "boardReviewOption": "evidence_submission",
       "timezone": "America/Chicago",

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -110,4 +110,8 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
   describe '#consumer_id' do
     it { expect(notice_of_disagreement.consumer_id).to eq 'some-guid' }
   end
+
+  describe '#zip_code_5' do
+    it { expect(notice_of_disagreement.zip_code_5).to eq '66002' }
+  end
 end

--- a/modules/appeals_api/spec/support/pdf_matcher.rb
+++ b/modules/appeals_api/spec/support/pdf_matcher.rb
@@ -4,9 +4,16 @@ require 'rspec/expectations'
 
 RSpec::Matchers.define :match_pdf do |expected|
   match do |actual|
-    actual_text = PDF::Reader.new(actual).pages.map(&:text)
-    expected_text = PDF::Reader.new(expected).pages.map(&:text)
-    actual_text == expected_text
+    actual_reader = PDF::Reader.new(actual)
+    actual_pages = actual_reader.pages.size
+    actual_text = actual_reader.pages.map(&:text)
+
+    expected_reader = PDF::Reader.new(expected)
+    expected_pages = expected_reader.pages.size
+    expected_text = expected_reader.pages.map(&:text)
+
+    # Check both page count and text content in case there are extraneous blank pages
+    actual_pages == expected_pages && actual_text == expected_text
   end
   failure_message do |actual|
     "expected that content of #{actual} matches content of #{expected}"


### PR DESCRIPTION
## Description of change
We require a zip code to talk to CentralMail, so this change makes `data.attributes.veteran.address.zipCode5` a required part of the NOD create form data.

Note: HLR is already requiring this, so the precedent has already been set.

## Original issue(s)
https://vajira.max.gov/browse/API-4074