### PR TITLE
VBADocuments uses VBA inflection

### DIFF
--- a/modules/vba_documents/app/controllers/vba_documents/docs/v0/api_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/docs/v0/api_controller.rb
@@ -13,16 +13,16 @@ module VBADocuments
         include Swagger::Blocks
 
         SWAGGERED_CLASSES = [
-          VbaDocuments::V0::ControllerSwagger,
-          VbaDocuments::DocumentUpload::StatusReportSwagger,
-          VbaDocuments::DocumentUpload::StatusGuidListSwagger,
-          VbaDocuments::DocumentUpload::FailureSwagger,
-          VbaDocuments::DocumentUpload::MetadataSwagger,
-          VbaDocuments::DocumentUpload::StatusAttributesSwagger,
-          VbaDocuments::DocumentUpload::StatusSwagger,
-          VbaDocuments::DocumentUpload::SubmissionSwagger,
-          VbaDocuments::V0::SecuritySchemeSwagger,
-          VbaDocuments::V0::SwaggerRoot
+          VBADocuments::V0::ControllerSwagger,
+          VBADocuments::DocumentUpload::StatusReportSwagger,
+          VBADocuments::DocumentUpload::StatusGuidListSwagger,
+          VBADocuments::DocumentUpload::FailureSwagger,
+          VBADocuments::DocumentUpload::MetadataSwagger,
+          VBADocuments::DocumentUpload::StatusAttributesSwagger,
+          VBADocuments::DocumentUpload::StatusSwagger,
+          VBADocuments::DocumentUpload::SubmissionSwagger,
+          VBADocuments::V0::SecuritySchemeSwagger,
+          VBADocuments::V0::SwaggerRoot
         ].freeze
 
         def index

--- a/modules/vba_documents/app/controllers/vba_documents/docs/v1/api_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/docs/v1/api_controller.rb
@@ -15,19 +15,19 @@ module VBADocuments
         include Swagger::Blocks
 
         SWAGGERED_CLASSES = [
-          VbaDocuments::V1::ControllerSwagger,
-          VbaDocuments::V1::ErrorModelSwagger,
-          VbaDocuments::DocumentUpload::StatusReportSwagger,
-          VbaDocuments::DocumentUpload::StatusGuidListSwagger,
-          VbaDocuments::DocumentUpload::FailureSwagger,
-          VbaDocuments::DocumentUpload::MetadataSwagger,
-          VbaDocuments::DocumentUpload::V1::StatusAttributesSwagger,
-          VbaDocuments::DocumentUpload::V1::PdfUploadAttributesSwagger,
-          VbaDocuments::DocumentUpload::V1::PdfDimensionAttributesSwagger,
-          VbaDocuments::DocumentUpload::StatusSwagger,
-          VbaDocuments::DocumentUpload::SubmissionSwagger,
-          VbaDocuments::V1::SecuritySchemeSwagger,
-          VbaDocuments::V1::SwaggerRoot
+          VBADocuments::V1::ControllerSwagger,
+          VBADocuments::V1::ErrorModelSwagger,
+          VBADocuments::DocumentUpload::StatusReportSwagger,
+          VBADocuments::DocumentUpload::StatusGuidListSwagger,
+          VBADocuments::DocumentUpload::FailureSwagger,
+          VBADocuments::DocumentUpload::MetadataSwagger,
+          VBADocuments::DocumentUpload::V1::StatusAttributesSwagger,
+          VBADocuments::DocumentUpload::V1::PdfUploadAttributesSwagger,
+          VBADocuments::DocumentUpload::V1::PdfDimensionAttributesSwagger,
+          VBADocuments::DocumentUpload::StatusSwagger,
+          VBADocuments::DocumentUpload::SubmissionSwagger,
+          VBADocuments::V1::SecuritySchemeSwagger,
+          VBADocuments::V1::SwaggerRoot
         ].freeze
 
         def index

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/failure_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/failure_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module DocumentUpload
     class FailureSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/metadata_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/metadata_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module DocumentUpload
     class MetadataSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/status_attributes_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/status_attributes_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module DocumentUpload
     class StatusAttributesSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/status_guid_list_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/status_guid_list_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module DocumentUpload
     class StatusGuidListSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/status_report_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/status_report_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module DocumentUpload
     class StatusReportSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/status_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/status_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module DocumentUpload
     class StatusSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/submission_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/submission_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module DocumentUpload
     class SubmissionSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/v1/pdf_dimension_attributes_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/v1/pdf_dimension_attributes_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module DocumentUpload
     module V1
       class PdfDimensionAttributesSwagger

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/v1/pdf_upload_attributes_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/v1/pdf_upload_attributes_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module DocumentUpload
     module V1
       class PdfUploadAttributesSwagger

--- a/modules/vba_documents/app/swagger/vba_documents/document_upload/v1/status_attributes_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/document_upload/v1/status_attributes_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module DocumentUpload
     module V1
       class StatusAttributesSwagger

--- a/modules/vba_documents/app/swagger/vba_documents/v0/controller_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v0/controller_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module V0
     class ControllerSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/v0/security_scheme_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v0/security_scheme_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module V0
     class SecuritySchemeSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/v0/swagger_root.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v0/swagger_root.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module V0
     class SwaggerRoot
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/v1/controller_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v1/controller_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module V1
     class ControllerSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/v1/error_model_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v1/error_model_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module V1
     class ErrorModelSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/v1/security_scheme_swagger.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v1/security_scheme_swagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module V1
     class SecuritySchemeSwagger
       include Swagger::Blocks

--- a/modules/vba_documents/app/swagger/vba_documents/v1/swagger_root.rb
+++ b/modules/vba_documents/app/swagger/vba_documents/v1/swagger_root.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module VbaDocuments
+module VBADocuments
   module V1
     class SwaggerRoot
       include Swagger::Blocks


### PR DESCRIPTION
VbaDocuments occurs in the VBADocuments swagger classes and should be changed to respect the inflectiono

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18283
