### PR TITLE
adding in rack attack for covid-vaccine

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -29,6 +29,10 @@ class Rack::Attack
     req.ip if req.path == '/v0/evss_claims_async'
   end
 
+  throttle('covid_vaccine', limit: 4, period: 5.minutes) do |req|
+    req.ip if req.path.starts_with?('/covid_vaccine/v0') && (req.post? || req.put?)
+  end
+
   # Source: https://github.com/kickstarter/rack-attack#x-ratelimit-headers-for-well-behaved-clients
   Rack::Attack.throttled_response = lambda do |env|
     rate_limit = env['rack.attack.match_data']

--- a/spec/middleware/rack/attack_spec.rb
+++ b/spec/middleware/rack/attack_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Rack::Attack do
 
   describe 'covid_vaccine' do
     let(:headers) { { 'REMOTE_ADDR' => '1.2.3.4' } }
-    
+
     it 'limits requests for any post and put endpoints to 4 in 5 minutes' do
       post '/covid_vaccine/v0/registration', headers: headers
       expect(last_response.status).not_to eq(429)

--- a/spec/middleware/rack/attack_spec.rb
+++ b/spec/middleware/rack/attack_spec.rb
@@ -32,6 +32,24 @@ RSpec.describe Rack::Attack do
     end
   end
 
+  describe 'covid_vaccine' do
+    let(:headers) { { 'REMOTE_ADDR' => '1.2.3.4' } }
+    
+    it 'limits requests for any post and put endpoints to 4 in 5 minutes' do
+      post '/covid_vaccine/v0/registration', headers: headers
+      expect(last_response.status).not_to eq(429)
+      put '/covid_vaccine/v0/registration/opt_out', headers: headers
+      expect(last_response.status).not_to eq(429)
+      put '/covid_vaccine/v0/registration/opt_in', headers: headers
+      expect(last_response.status).not_to eq(429)
+      put '/covid_vaccine/v0/registration/unauthenticated', headers: headers
+      expect(last_response.status).not_to eq(429)
+
+      put '/covid_vaccine/v0/registration/opt_out', headers: headers
+      expect(last_response.status).to eq(429)
+    end
+  end
+
   describe 'vic rate-limits', run_at: 'Thu, 26 Dec 2015 15:54:20 GMT' do
     let(:headers) { { 'REMOTE_ADDR' => '1.2.3.4' } }
 


### PR DESCRIPTION
## Description of change
Adds RackAttack rate-limiting to all POST and PUT covid-vaccine endpoints. 

Of the following routes:

```
    get 'registration', to: 'registration#show'
    post 'registration', to: 'registration#create'
    post 'registration/unauthenticated', to: 'registration#create'
    put 'registration/opt_out', to: 'registration#opt_out'
    put 'registration/opt_in', to: 'registration#opt_in'
```

the last 4 will be grouped into a single bucket, such that any POST or PUT requests to ANY of those endpoints will be considered part of the same bucket, and limited to only 4 of either variant within a 5 minute time period for a given IP address. For more details see the rspec example.
