### PR TITLE
create commit message for module success metric tracking

### DIFF
--- a/lib/generators/module/module_generator.rb
+++ b/lib/generators/module/module_generator.rb
@@ -69,8 +69,10 @@ class ModuleGenerator < Rails::Generators::NamedBase
   end
 
   def create_commit_message
-    git add: '.'
-    git commit: "-a -m 'Initial commit of module structure *KEEP THIS COMMIT MESSAGE*'"
+    if Dir.exist?("modules/#{file_name}")
+      git add: '.'
+      git commit: "-a -m 'Initial commit of module structure *KEEP THIS COMMIT MESSAGE*'"
+    end
   end
 
   # :nocov:

--- a/lib/generators/module/module_generator.rb
+++ b/lib/generators/module/module_generator.rb
@@ -67,6 +67,12 @@ class ModuleGenerator < Rails::Generators::NamedBase
     puts "\u{1F64C} new module generated at ./modules/#{file_name}\n\n"
     puts "\n"
   end
+
+  def create_commit_message
+    git add: '.'
+    git commit: "-a -m 'Initial commit of module structure *KEEP THIS COMMIT MESSAGE*'"
+  end
+
   # :nocov:
   # rubocop:enable Rails/Output
 end


### PR DESCRIPTION
## Description of change
This adds a specific commit message for the module generator when creating a new module in vets-api. The commit message will be used/searched via Github as a success metric to track developer usage.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18348
