### PR TITLE
API-4354: Discover and document response when POA active endpoint is used by someone that is not POA

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
@@ -382,7 +382,11 @@ module ClaimsApi
       swagger_path '/forms/2122/active' do
         operation :get do
           key :summary, 'Check active power of attorney status'
-          key :description, 'Returns last active JSON payload.'
+          key :description,
+              <<~X
+                Returns last active JSON payload.
+                * Any authenticated user can view any individual's active, and previous, POA.
+              X
           key :operationId, 'getActive2122Poa'
           key :tags, [
             'Power of Attorney'


### PR DESCRIPTION
## Description of change
Add note around eased authentication around active POA endpoint.

## Original issue(s)
https://vajira.max.gov/browse/API-4354

## Things to know about this PR
Viewed through local developer portal.