### PR TITLE
API-4284 Adding a sidekiq debugging flag

### DIFF
--- a/rakelib/docker_debugging.rake
+++ b/rakelib/docker_debugging.rake
@@ -26,10 +26,8 @@ namespace :docker_debugging do
       if s.enable_sidekiq
         puts 'Sidekiq debugging is enabled'
         command += ',job=0'
-        sh command
-      else
-        sh command
       end
+        sh command
     end
   end
 end

--- a/rakelib/docker_debugging.rake
+++ b/rakelib/docker_debugging.rake
@@ -27,7 +27,7 @@ namespace :docker_debugging do
         puts 'Sidekiq debugging is enabled'
         command += ',job=0'
       end
-        sh command
+      sh command
     end
   end
 end

--- a/rakelib/docker_debugging.rake
+++ b/rakelib/docker_debugging.rake
@@ -3,6 +3,7 @@
 $stdout.sync = true
 namespace :docker_debugging do
   desc 'Setup environment for debugging in docker'
+  command = 'foreman start -m all=1,clamd=0,freshclam=0'
   task setup: :environment do |_task|
     if Settings.docker_debugging
       raise 'This rake task runs in development mode only!' unless Rails.env.development?
@@ -22,7 +23,13 @@ namespace :docker_debugging do
         Rake::Task['db:schema:load'].invoke
         puts 'All dun!'
       end
-      sh 'foreman start -m all=1,clamd=0,freshclam=0'
+      if s.enable_sidekiq
+        puts 'Sidekiq debugging is enabled'
+        command += ',job=0'
+        sh command
+      else
+        sh command
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Adding a sidekiq debugging flag. If true, appends job=0 to foreman command.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#API-4284

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* No
* Is there a feature flag? What is it?
* No
* Is there some Sentry logging that was added? What alerts are relevant?
* No
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* No
* Are there Swagger docs that were updated?
* No
* Is there any PII concerns or questions?
* No
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Local testing was done in Docker. Verified that setting flag enables or disables Sidekiq as intended.