### PR TITLE
18427 BGS Awards Lookup Fix

### DIFF
--- a/app/services/bgs/awards_service.rb
+++ b/app/services/bgs/awards_service.rb
@@ -11,9 +11,8 @@ module BGS
     # @return [Hash]
     #
     def get_awards
-      response = @service.awards.find_award_by_participant_id(@user.participant_id, @user.ssn)
-      response = @service.awards.find_award_by_ssn(@user.ssn) if response.nil?
-      response
+      @service.awards.find_award_by_participant_id(@user.participant_id, @user.ssn) ||
+        @service.awards.find_award_by_ssn(@user.ssn)
     rescue => e
       report_error(e)
     end

--- a/app/services/bgs/awards_service.rb
+++ b/app/services/bgs/awards_service.rb
@@ -11,7 +11,9 @@ module BGS
     # @return [Hash]
     #
     def get_awards
-      @service.awards.find_award_by_participant_id(@user.participant_id, @user.ssn)
+      response = @service.awards.find_award_by_participant_id(@user.participant_id, @user.ssn)
+      response = @service.awards.find_award_by_ssn(@user.ssn) if response.nil?
+      response
     rescue => e
       report_error(e)
     end


### PR DESCRIPTION
## Description of change
Lookup fails sometimes when looking up award amounts via participant id. Secondary look up within the `get_awards` method added to attempt the look up via SSN if first lookup fails.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18427

## Things to know about this PR
Tested and verified locally using both BGS calls and mock data.
