### PR TITLE
Get lighthouse access_token

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -590,6 +590,15 @@ hqva_mobile:
   key_path: /srv/vets-api/secret/health-quest.key
   development_key_path: modules/health_quest/config/rsa/sandbox_rsa
   timeout: 15
+  lighthouse:
+    url: "https://sandbox-api.va.gov"
+    host: "sandbox-api.va.gov"
+    aud_claim_url: "https://deptva-eval.okta.com/oauth2/aus8x27nv4g4BS01v2p7"
+    claim_common_id: "0oa9gvwf5mvxcX3zH2p7"
+    redis_session_prefix: "healthquest_lighthouse"
+    mock: false
+    key_path: /srv/vets-api/secret/health-quest.lighthouse.key
+    local_key_path: modules/health_quest/config/rsa/sandbox_rsa
 
 lighthouse:
   api_key: fake_key

--- a/modules/health_quest/app/services/health_quest/lighthouse/claims_token.rb
+++ b/modules/health_quest/app/services/health_quest/lighthouse/claims_token.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module Lighthouse
+    ##
+    # An object responsible for handling JWT claims used for Lighthouse authentication
+    #
+    class ClaimsToken
+      EXPIRATION_DURATION = 15
+      SIGNING_ALGORITHM = 'RS512'
+      TOKEN_PATH = '/v1/token'
+
+      ##
+      # Builds a Lighthouse::ClaimsToken instance
+      #
+      # @return [Lighthouse::ClaimsToken] an instance of this class
+      #
+      def self.build
+        new
+      end
+
+      ##
+      # Sign the claims JWT using a private key and algorithm
+      #
+      # @return [String]
+      #
+      def sign_assertion
+        JWT.encode(claims, rsa_key, signing_algorithm)
+      end
+
+      private
+
+      def claims
+        {
+          aud: aud,
+          iss: iss,
+          sub: sub,
+          jti: random_uuid,
+          iat: issued_at_time,
+          exp: expires_at_time
+        }
+      end
+
+      def rsa_key
+        @rsa_key ||= OpenSSL::PKey::RSA.new(File.read(private_key_path))
+      end
+
+      def aud
+        "#{lighthouse.aud_claim_url}#{TOKEN_PATH}"
+      end
+
+      def iss
+        lighthouse.claim_common_id
+      end
+
+      def sub
+        lighthouse.claim_common_id
+      end
+
+      def random_uuid
+        @random_uuid ||= SecureRandom.uuid
+      end
+
+      def issued_at_time
+        @issued_at_time ||= Time.zone.now.to_i
+      end
+
+      def expires_at_time
+        @expires_at_time ||= EXPIRATION_DURATION.minutes.from_now.to_i
+      end
+
+      def signing_algorithm
+        SIGNING_ALGORITHM
+      end
+
+      def private_key_path
+        Rails.env.development? || Rails.env.test? ? lighthouse.local_key_path : lighthouse.key_path
+      end
+
+      def lighthouse
+        Settings.hqva_mobile.lighthouse
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/lighthouse/redis_handler.rb
+++ b/modules/health_quest/app/services/health_quest/lighthouse/redis_handler.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module Lighthouse
+    ##
+    # An object responsible for facilitating communication between Lighthouse::Session and redis
+    #
+    # @!attribute session_id
+    #   @return [String]
+    # @!attribute session_store
+    #   @return [Lighthouse::SessionStore]
+    # @!attribute token
+    #   @return [Lighthouse::Token]
+    class RedisHandler
+      attr_reader :session_id, :session_store
+      attr_accessor :token
+
+      ##
+      # Builds a Lighthouse::RedisHandler instance from a session_id and session_store
+      #
+      # @param session_id [String] the users unique id for creating a token in redis.
+      # @param session_store [SessionStore] an object for calling redis functions.
+      #
+      # @return [Lighthouse::RedisHandler] an instance of this class
+      #
+      def self.build(session_id: nil, session_store: SessionStore)
+        new(session_id, session_store)
+      end
+
+      def initialize(session_id, session_store)
+        @session_id = session_id
+        @session_store = session_store
+      end
+
+      ##
+      # Gets the active session from redis for by the given lighthouse session_id
+      #
+      # @return [HealthQuest::SessionStore]
+      #
+      def get
+        session_store.find(session_id)
+      end
+
+      ##
+      # Saves the session in redis from the newly obtained lighthouse access_token
+      #
+      # @return [HealthQuest::SessionStore]
+      #
+      def save
+        hash = {
+          account_uuid: session_id,
+          token: token&.access_token,
+          unix_created_at: token&.created_at
+        }
+
+        session_store.new(hash).tap do |ss|
+          ss.save
+          ss.expire(token&.ttl_duration)
+        end
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/lighthouse/request.rb
+++ b/modules/health_quest/app/services/health_quest/lighthouse/request.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+Faraday::Response.register_middleware health_quest_errors: HealthQuest::Middleware::Response::Errors
+Faraday::Middleware.register_middleware health_quest_logging: HealthQuest::Middleware::HealthQuestLogging
+
+module HealthQuest
+  module Lighthouse
+    ##
+    # An object responsible for making HTTP calls to the Lighthouse service
+    #
+    class Request
+      ##
+      # Builds a Lighthouse::Request instance from a user
+      #
+      # @return [Lighthouse::Request] an instance of this class
+      #
+      def self.build
+        new
+      end
+
+      ##
+      # make a HTTP POST call to the lighthouse in order to obtain an access_token
+      #
+      # @param path [String] the path to POST to
+      # @param params [String] URI.encode_www_form parameters
+      #
+      # @return [Faraday::Response]
+      #
+      def post(path, params)
+        connection.post(path) { |req| req.body = params }
+      end
+
+      private
+
+      def connection
+        Faraday.new(url: url, headers: headers) do |conn|
+          conn.response :health_quest_errors
+          conn.use :health_quest_logging
+          conn.adapter Faraday.default_adapter
+        end
+      end
+
+      def url
+        Settings.hqva_mobile.lighthouse.url
+      end
+
+      def headers
+        {
+          'Host' => Settings.hqva_mobile.lighthouse.host,
+          'Content-Type' => 'application/x-www-form-urlencoded'
+        }
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/lighthouse/session.rb
+++ b/modules/health_quest/app/services/health_quest/lighthouse/session.rb
@@ -38,7 +38,7 @@ module HealthQuest
       ##
       # Gets the active session from redis for the logged in user
       # or creates a new one in redis by first obtaining
-      # an access_token from lighthouse
+      # an access_token from Lighthouse
       #
       # @return [HealthQuest::SessionStore]
       #
@@ -49,20 +49,36 @@ module HealthQuest
         establish_lighthouse_session
       end
 
-      private
-
+      ##
+      # Gets the active session from redis for the logged in user
+      #
+      # @return [HealthQuest::SessionStore]
+      #
       def session_from_redis
         redis_handler.get
       end
 
+      ##
+      # Makes the call to `lighthouse_access_token` and saves the token
+      # to a SessionStore in Redis
+      #
+      # @return [HealthQuest::SessionStore]
+      #
       def establish_lighthouse_session
         redis_handler.token = lighthouse_access_token
         redis_handler.save
       end
 
+      ##
+      # Fetches a new access_token from Lighthouse for the logged in user
+      #
+      # @return [HealthQuest::SessionStore]
+      #
       def lighthouse_access_token
         token.fetch
       end
+
+      private
 
       def session_id
         @build_session_id ||= "#{lighthouse_prefix}_#{account_uuid}"

--- a/modules/health_quest/app/services/health_quest/lighthouse/session.rb
+++ b/modules/health_quest/app/services/health_quest/lighthouse/session.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module Lighthouse
+    ##
+    # An object responsible for establishing a session between the vets-api and
+    # the Lighthouse so that PGD resources can be fetched and created.
+    #
+    # @!attribute user
+    #   @return [User]
+    # @!attribute id
+    #   @return [String]
+    # @!attribute redis_handler
+    #   @return [Lighthouse::RedisHandler]
+    # @!attribute token
+    #   @return [Lighthouse::Token]
+    class Session
+      attr_reader :user, :id, :redis_handler, :token
+
+      ##
+      # Builds a Lighthouse::Session instance from a given User
+      #
+      # @param user [User] the currently logged in user
+      #
+      # @return [Lighthouse::Session] an instance of this class
+      #
+      def self.build(user)
+        new(user: user)
+      end
+
+      def initialize(user:, redis_handler: RedisHandler)
+        @user = user
+        @token = Token.build(user: user)
+        @id = session_id
+        @redis_handler = redis_handler.build(session_id: id)
+      end
+
+      ##
+      # Gets the active session from redis for the logged in user
+      # or creates a new one in redis by first obtaining
+      # an access_token from lighthouse
+      #
+      # @return [HealthQuest::SessionStore]
+      #
+      def retrieve
+        session = session_from_redis
+        return session if session.present?
+
+        establish_lighthouse_session
+      end
+
+      private
+
+      def session_from_redis
+        redis_handler.get
+      end
+
+      def establish_lighthouse_session
+        redis_handler.token = lighthouse_access_token
+        redis_handler.save
+      end
+
+      def lighthouse_access_token
+        token.fetch
+      end
+
+      def session_id
+        @build_session_id ||= "#{lighthouse_prefix}_#{account_uuid}"
+      end
+
+      def lighthouse_prefix
+        Settings.hqva_mobile.lighthouse.lighthouse_prefix
+      end
+
+      def account_uuid
+        user&.account_uuid
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/lighthouse/token.rb
+++ b/modules/health_quest/app/services/health_quest/lighthouse/token.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module Lighthouse
+    ##
+    # An object responsible for fetching and building access_tokens
+    # from the Lighthouse for the Lighthouse::Session object.
+    #
+    # @!attribute user
+    #   @return [User]
+    # @!attribute request
+    #   @return [Lighthouse::Request]
+    # @!attribute claims_token
+    #   @return [Lighthouse::ClaimsToken]
+    # @!attribute access_token
+    #   @return [String]
+    # @!attribute decoded_token
+    #   @return [Hash]
+    class Token
+      attr_reader :user, :request, :claims_token
+      attr_accessor :access_token, :decoded_token
+
+      ##
+      # Builds a Lighthouse::Token instance from a user
+      #
+      # @param user [User] the current user
+      #
+      # @return [Lighthouse::Token] an instance of this class
+      #
+      def self.build(user:)
+        new(user)
+      end
+
+      def initialize(user)
+        @user = user
+        @request = Request.build
+        @claims_token = ClaimsToken.build.sign_assertion
+      end
+
+      ##
+      # Return a token instance that was built using the access_token data
+      # from the response obtained by calling the Lighthouse with a certain
+      # set of parameters
+      #
+      # @return [Lighthouse::Token]
+      #
+      def fetch
+        response = request.post('/oauth2/pgd/v1/token', post_params)
+
+        self.access_token = JSON.parse(response.body).fetch('access_token')
+        self.decoded_token = JWT.decode(access_token, nil, false).first
+        self
+      end
+
+      ##
+      # Return a integer representing the time the Token instance was created at
+      #
+      # @return [Integer]
+      #
+      def created_at
+        @created_at ||= Time.zone.now.utc.to_i
+      end
+
+      ##
+      # Return the duration for which the saved redis session is valid
+      #
+      # @return [Integer]
+      #
+      def ttl_duration
+        exp = decoded_token.fetch('exp')
+        Time.zone.at(exp).utc.to_i - Time.zone.now.utc.to_i - 5
+      end
+
+      private
+
+      def post_params
+        hash = {
+          grant_type: 'client_credentials',
+          client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+          client_assertion: claims_token,
+          scope: 'launch/patient patient/Patient.read',
+          launch: user&.icn
+        }
+
+        URI.encode_www_form(hash)
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/fhir_client.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/fhir_client.rb
@@ -4,7 +4,7 @@ module HealthQuest
   module PatientGeneratedData
     module FHIRClient
       def url
-        "#{Settings.hqva_mobile.url}/smart-pgd-fhir/v1"
+        "#{Settings.hqva_mobile.lighthouse.url}/smart-pgd-fhir/v1"
       end
 
       def client

--- a/modules/health_quest/spec/services/lighthouse/claims_token_spec.rb
+++ b/modules/health_quest/spec/services/lighthouse/claims_token_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::Lighthouse::ClaimsToken do
+  subject { described_class }
+
+  describe 'constants' do
+    it 'has an EXPIRATION_DURATION of 15' do
+      expect(subject::EXPIRATION_DURATION).to eq(15)
+    end
+
+    it 'has a SIGNING_ALGORITHM of RS512' do
+      expect(subject::SIGNING_ALGORITHM).to eq('RS512')
+    end
+
+    it 'has a TOKEN_PATH of /v1/token' do
+      expect(subject::TOKEN_PATH).to eq('/v1/token')
+    end
+  end
+
+  describe '.build' do
+    it 'returns an instance of ClaimsToken' do
+      expect(subject.build).to be_an_instance_of(HealthQuest::Lighthouse::ClaimsToken)
+    end
+  end
+
+  describe '#sign_assertion' do
+    it 'is a String' do
+      expect(subject.build.sign_assertion).to be_a(String)
+    end
+
+    it 'decoded jwt token has a set of keys' do
+      signed_claims = subject.build.sign_assertion
+
+      expect(JWT.decode(signed_claims, nil, false).first.keys.sort).to eq(%w[aud exp iat iss jti sub])
+    end
+  end
+end

--- a/modules/health_quest/spec/services/lighthouse/redis_handler_spec.rb
+++ b/modules/health_quest/spec/services/lighthouse/redis_handler_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::Lighthouse::RedisHandler do
+  subject { described_class }
+
+  let(:session_store) { double('HealthQuest::SessionStore') }
+  let(:redis_handler) { subject.build(session_id: '123', session_store: HealthQuest::SessionStore) }
+  let(:token) { double('Token', access_token: '123', created_at: 1234, ttl_duration: 5647) }
+
+  describe 'attributes' do
+    it 'responds to session_id' do
+      expect(redis_handler.respond_to?(:session_id)).to be(true)
+    end
+
+    it 'responds to session_store' do
+      expect(redis_handler.respond_to?(:session_store)).to be(true)
+    end
+
+    it 'responds to token' do
+      expect(redis_handler.respond_to?(:token)).to be(true)
+    end
+  end
+
+  describe '.build' do
+    it 'returns an instance of RedisHandler' do
+      expect(subject.build).to be_an_instance_of(HealthQuest::Lighthouse::RedisHandler)
+    end
+  end
+
+  describe '#get' do
+    context 'when session exists' do
+      it 'returns an instance of SessionStore' do
+        allow(HealthQuest::SessionStore).to receive(:find).with(anything).and_return(session_store)
+
+        expect(subject.build.get).to eq(session_store)
+      end
+    end
+
+    context 'when session does not exist' do
+      it 'returns nil' do
+        allow(HealthQuest::SessionStore).to receive(:find).with(anything).and_return(nil)
+
+        expect(subject.build.get).to eq(nil)
+      end
+    end
+  end
+
+  describe '#save' do
+    it 'saves and returns a SessionStore' do
+      redis_handler.token = token
+
+      expect(redis_handler.save).to be_an_instance_of(HealthQuest::SessionStore)
+    end
+  end
+end

--- a/modules/health_quest/spec/services/lighthouse/request_spec.rb
+++ b/modules/health_quest/spec/services/lighthouse/request_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::Lighthouse::Request do
+  subject { described_class }
+
+  describe '.build' do
+    it 'returns an instance of Request' do
+      expect(subject.build).to be_an_instance_of(HealthQuest::Lighthouse::Request)
+    end
+  end
+
+  describe '#post' do
+    it 'returns a Faraday::Response' do
+      allow_any_instance_of(Faraday::Connection).to receive(:post).and_return(Faraday::Response.new)
+
+      expect(subject.build.post('', '')).to be_an_instance_of(Faraday::Response)
+    end
+  end
+end

--- a/modules/health_quest/spec/services/lighthouse/session_spec.rb
+++ b/modules/health_quest/spec/services/lighthouse/session_spec.rb
@@ -53,4 +53,44 @@ describe HealthQuest::Lighthouse::Session do
       end
     end
   end
+
+  describe '#session_from_redis' do
+    let(:session_store) { double('HealthQuest::SessionStore') }
+
+    context 'when session exists' do
+      it 'returns an instance of SessionStore' do
+        allow(HealthQuest::SessionStore).to receive(:find).with(anything).and_return(session_store)
+
+        expect(subject.build(user).session_from_redis).to eq(session_store)
+      end
+    end
+
+    context 'when session does not exist' do
+      it 'returns nil' do
+        allow(HealthQuest::SessionStore).to receive(:find).with(anything).and_return(nil)
+
+        expect(subject.build(user).session_from_redis).to eq(nil)
+      end
+    end
+  end
+
+  describe '#lighthouse_access_token' do
+    let(:token) { HealthQuest::Lighthouse::Token.build(user: user) }
+
+    it 'returns a Token instance' do
+      allow_any_instance_of(HealthQuest::Lighthouse::Token).to receive(:fetch).and_return(token)
+
+      expect(subject.build(user).lighthouse_access_token).to eq(token)
+    end
+  end
+
+  describe '#establish_lighthouse_session' do
+    let(:token) { double('Token', access_token: '123', decoded_token: '34568', created_at: 1234, ttl_duration: 5647) }
+
+    it 'returns a session store' do
+      allow_any_instance_of(subject).to receive(:lighthouse_access_token).and_return(token)
+
+      expect(subject.build(user).establish_lighthouse_session).to be_a(HealthQuest::SessionStore)
+    end
+  end
 end

--- a/modules/health_quest/spec/services/lighthouse/session_spec.rb
+++ b/modules/health_quest/spec/services/lighthouse/session_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::Lighthouse::Session do
+  subject { described_class }
+
+  let(:user) { double('User', account_uuid: 'abc123', icn: '1008596379V859838') }
+
+  describe 'attributes' do
+    let(:session) { subject.build(user) }
+
+    it 'responds to user' do
+      expect(session.respond_to?(:user)).to be(true)
+    end
+
+    it 'responds to id' do
+      expect(session.respond_to?(:id)).to be(true)
+    end
+
+    it 'responds to redis_handler' do
+      expect(session.respond_to?(:redis_handler)).to be(true)
+    end
+
+    it 'responds to token' do
+      expect(session.respond_to?(:token)).to be(true)
+    end
+  end
+
+  describe '.build' do
+    it 'returns an instance of Session' do
+      expect(subject.build(user)).to be_an_instance_of(HealthQuest::Lighthouse::Session)
+    end
+  end
+
+  describe '#retrieve' do
+    let(:session_store) { double('HealthQuest::SessionStore') }
+
+    context 'when session exists' do
+      it 'returns existing session' do
+        allow_any_instance_of(subject).to receive(:session_from_redis).and_return('existing_session_123')
+
+        expect(subject.build(user).retrieve).to eq('existing_session_123')
+      end
+    end
+
+    context 'when session does not exist' do
+      it 'returns a new session' do
+        allow_any_instance_of(subject).to receive(:session_from_redis).and_return(nil)
+        allow_any_instance_of(subject).to receive(:establish_lighthouse_session).and_return(session_store)
+
+        expect(subject.build(user).retrieve).to eq(session_store)
+      end
+    end
+  end
+end

--- a/modules/health_quest/spec/services/lighthouse/token_spec.rb
+++ b/modules/health_quest/spec/services/lighthouse/token_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::Lighthouse::Token do
+  subject { described_class }
+
+  let(:user) { double('User', account_uuid: 'abc123', icn: '1008596379V859838') }
+  let(:token) { subject.build(user: user) }
+
+  describe 'attributes' do
+    it 'responds to user' do
+      expect(token.respond_to?(:user)).to be(true)
+    end
+
+    it 'responds to request' do
+      expect(token.respond_to?(:request)).to be(true)
+    end
+
+    it 'responds to claims_token' do
+      expect(token.respond_to?(:claims_token)).to be(true)
+    end
+
+    it 'responds to access_token' do
+      expect(token.respond_to?(:access_token)).to be(true)
+    end
+
+    it 'responds to decoded_token' do
+      expect(token.respond_to?(:decoded_token)).to be(true)
+    end
+  end
+
+  describe '.build' do
+    it 'returns an instance of Token' do
+      expect(token).to be_an_instance_of(HealthQuest::Lighthouse::Token)
+    end
+  end
+
+  describe '#fetch' do
+    let(:sample_access_token) do
+      'eyJraWQiOiJRMFZKbEt0TU9rYUxXTEtxdXhsTllHQzFRLWMtblQzYjRWVlJLaXB4TThzIiwiYWxnIj' \
+        'oiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULjVTcDV4QnNZQzdXQU1MU2ZOR3JETlFmS0JQaHpWaW' \
+        'VwQ1NYbHhPODBKV1kiLCJpc3MiOiJodHRwczovL2RlcHR2YS1ldmFsLm9rdGEuY29tL29hdXRoMi9hdX' \
+        'M4eDI3bnY0ZzRCUzAxdjJwNyIsImF1ZCI6Imh0dHBzOi8vc2FuZGJveC1hcGkudmEuZ292L3NlcnZpY2V' \
+        'zL3BnZCIsImlhdCI6MTYxMDExODk3NywiZXhwIjoxNjEwMTE5Mjc3LCJjaWQiOiIwb2E5Z3Z3ZjVtdnhj' \
+        'WDN6SDJwNyIsInNjcCI6WyJwYXRpZW50L1BhdGllbnQucmVhZCIsImxhdW5jaC9wYXRpZW50Il0sInN1Yi' \
+        'I6IjBvYTlndndmNW12eGNYM3pIMnA3In0.Z_1xLenmVFZwqkboOGB8xdRvoiWmn1kFaPDBklOz2vRncuKX' \
+        'HFuiHqsULMM9Jr4IimSyhhSX26A0AQZj5F1LcS4I1N_CeJEiCzCr4ZuihUd6HFeP5g3wbtLekrPWL697vVX' \
+        'itUytDpcaWlUTTtW1pzfNKFVyb-m5Z3votzqLPp9tV_DdhnkbwnEuAFKp-lIkOfBfZtB7_Orv55xunvNeY6R' \
+        '-j-DjMgjNn7Xmn3-h_PXi9doVwp5KOdoTD3fX9t4EZy0zRFgN3zz5DahVmBEq65Sy9KLzmu_CL9wF2CEqgQz' \
+        '4rOGK0j6RcoezpJwuABi61a3WOGMJx6kT3eytuzA-UA'
+    end
+    let(:faraday_response) { double('Faraday::Response', body: { 'access_token' => sample_access_token }.to_json) }
+
+    it 'returns an instance of Token' do
+      allow_any_instance_of(HealthQuest::Lighthouse::Request).to receive(:post)
+        .with(anything, anything).and_return(faraday_response)
+
+      expect(token.fetch).to be_an_instance_of(subject)
+    end
+  end
+
+  describe '#created_at' do
+    it 'is an Integer' do
+      expect(token.created_at).to be_a(Integer)
+    end
+  end
+
+  describe '#ttl_duration' do
+    it 'is an Integer' do
+      token.decoded_token = { 'exp' => 5.minutes.from_now.utc.to_i }
+
+      expect(token.ttl_duration).to be_a(Integer)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Provide the ability for the Health Quest module to request an access_token from Lighthouse so that the vets-api can use it to procure FHIR resources from that service for a signed-in user
- First, we check to see if a lighthouse session exists in Redis. If it does we return it back so that the user can access FHIR resources from the lighthouse.
- If the lighthouse session does not exist, then we make an HTTP POST call to the lighthouse service to obtain an access_token. This is then stored in Redis as a SessionStore and then returned back to the user so that they can use it during subsequent calls to the lighthouse.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#17904

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- There are additions to `settings.yml` and the values will vary by environment.
- The entire feature is on a Flipper: in_progress_form_custom_expiration.

<!-- Please describe testing done to verify the changes or any testing planned. -->
- RSpec tests written and passing.
- Manually obtained an access_token from Lighthouse by running the code under a break point.