### PR TITLE
API-4406: Proper 400 response if pdf provided is invalid

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/document_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/document_validations.rb
@@ -23,6 +23,8 @@ module ClaimsApi
       def document_page_size_errors
         @document_page_size_errors ||= documents.reduce([]) do |cur, doc|
           valid_page_size?(doc) ? cur : cur << json_api_page_size_error(doc)
+        rescue
+          cur << json_api_validation_error(doc)
         end
       end
 
@@ -38,6 +40,14 @@ module ClaimsApi
         ['application/pdf', 'text/plain', 'application/octet-stream'].include?(document.content_type) && extension.downcase == 'pdf'
       end
       # rubocop:enable Layout/LineLength
+
+      def json_api_validation_error(document)
+        {
+          status: 400,
+          source: document.original_filename,
+          detail: "#{document.original_filename} is invalid"
+        }
+      end
 
       def json_api_page_size_error(document)
         {


### PR DESCRIPTION
## Description of change
Noticed we were returning a 500 if an invalid pdf is provided. Changed to be a 400 with brief explanation that the pdf provided is invalid:
```
{
    "errors": [
        {
            "status": 400,
            "source": "temp_upload_1610564138.pdf",
            "detail": "temp_upload_1610564138.pdf is invalid"
        }
    ]
}
```

## Original issue(s)
semi-related to https://vajira.max.gov/browse/API-4406

## Things to know about this PR
Test locallly