### PR TITLE
Improve claim submission error response if issues in record creation

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -27,7 +27,12 @@ module ClaimsApi
             source: source_name
           )
           unless auto_claim.id
-            auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5, source: source_name)
+            existing_auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5, source: source_name)
+            auto_claim = existing_auto_claim if existing_auto_claim.present?
+          end
+
+          if auto_claim.errors.present?
+            raise Common::Exceptions::UnprocessableEntity.new(detail: auto_claim.errors.messages.to_s)
           end
 
           ClaimsApi::ClaimEstablisher.perform_async(auto_claim.id)

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -30,7 +30,12 @@ module ClaimsApi
             source: source_name
           )
           unless auto_claim.id
-            auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5, source: source_name)
+            existing_auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5, source: source_name)
+            auto_claim = existing_auto_claim if existing_auto_claim.present?
+          end
+
+          if auto_claim.errors.present?
+            raise Common::Exceptions::UnprocessableEntity.new(detail: auto_claim.errors.messages.to_s)
           end
 
           unless form_attributes['autoCestPDFGenerationDisabled'] == true


### PR DESCRIPTION
## Description of change
Added logic to return a 422 with the relevant error message if a claim submission creation fails for whatever reason.

## Original issue(s)
semi-related to https://vajira.max.gov/browse/API-3273

## Things to know about this PR
Tested locally and ensured all existing specs still pass.