### PR TITLE
Added controller methods, model validation, and tests

### DIFF
--- a/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
+++ b/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
@@ -7,6 +7,8 @@ module AppsApi
   module V0
     class DirectoryController < ApplicationController
       skip_before_action(:authenticate)
+      before_action :set_directory_application, only: %i[show update destroy]
+      before_action :verify_auth, only: %i[create update destroy]
 
       def index
         render json: {
@@ -15,10 +17,40 @@ module AppsApi
       end
 
       def show
-        app = DirectoryApplication.find_by(name: params[:id])
         render json: {
-          data: app
+          data: @directory_application
         }
+      end
+
+      def create
+        @directory_application = DirectoryApplication.new(directory_application_params)
+
+        if @directory_application.save
+          render json: {
+            data: @directory_application
+          }, status: :ok
+        else
+          render json: {
+            data: @directory_application.errors
+          }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @directory_application.update(directory_application_params)
+          render json: {
+            data: @directory_application
+          }, status: :ok
+        else
+          render json: {
+            data: @directory_application.errors
+          }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @directory_application.destroy
+        head :ok
       end
 
       def scopes
@@ -33,6 +65,24 @@ module AppsApi
         end
         end
       end
+      private
+
+      def verify_auth
+        # put this secret in settings.local.yml
+        head :unauthorized unless request.authorization == Settings.directory.secret
+      end
+
+      def set_directory_application
+        @directory_application = DirectoryApplication.find_by(name: params[:id])
+      end
+
+      def directory_application_params
+        params.require(:directory_application).permit(
+          :name, :logo_url, :app_type, :app_url, :description, :privacy_url,
+          :tos_url, { service_categories: [] }, { platforms: [] }
+        )
+      end
+
     end
   end
 end

--- a/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
+++ b/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
@@ -65,6 +65,7 @@ module AppsApi
         end
         end
       end
+
       private
 
       def verify_auth
@@ -82,7 +83,6 @@ module AppsApi
           :tos_url, { service_categories: [] }, { platforms: [] }
         )
       end
-
     end
   end
 end

--- a/modules/apps_api/app/models/directory_application.rb
+++ b/modules/apps_api/app/models/directory_application.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class DirectoryApplication < ApplicationRecord
-  validates :name, :logo_url, :app_type, :service_categories, :platforms,
+  validates :name, uniqueness: true
+  validates :logo_url, :app_type, :service_categories, :platforms,
             :app_url, :description, :privacy_url, :tos_url, presence: true
 end

--- a/modules/apps_api/config/routes.rb
+++ b/modules/apps_api/config/routes.rb
@@ -9,7 +9,7 @@ AppsApi::Engine.routes.draw do
     scope_default = { category: 'unknown_category' }
     get 'directory/scopes/:category', to: 'directory#scopes', defaults: scope_default
     get 'directory/scopes', to: 'directory#scopes', defaults: scope_default
-    resources 'directory', only: %i[index show]
+    resources 'directory'
   end
   namespace :docs do
     namespace :v0 do

--- a/modules/apps_api/config/routes.rb
+++ b/modules/apps_api/config/routes.rb
@@ -11,6 +11,7 @@ AppsApi::Engine.routes.draw do
     get 'directory/scopes', to: 'directory#scopes', defaults: scope_default
     resources 'directory'
   end
+
   namespace :docs do
     namespace :v0 do
       get 'api', to: 'api#index'

--- a/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
+++ b/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
@@ -61,11 +61,12 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
            params: { id: 'testing', directory_application: valid_params },
            headers: valid_headers
 
-      put '/services/apps/v0/directory',
+      put '/services/apps/v0/directory/testing',
           params: { id: 'testing', directory_application: valid_params },
           headers: valid_headers
       body = JSON.parse(response.body)
       expect(body.length).to be(1)
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -95,6 +96,14 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
       post '/services/apps/v0/directory',
            params: { id: 'testing', directory_application: valid_params },
            headers: valid_headers
+      expect(response).to have_http_status(:ok)
+    end
+    it 'has :unprocessable_entity when given invalid params' do
+      post '/services/apps/v0/directory',
+           params: { id: 'testing', directory_application: invalid_params },
+           headers: valid_headers
+      expect(response).to have_http_status(:unprocessable_entity)
+
     end
   end
 

--- a/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
+++ b/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
@@ -103,7 +103,6 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
            params: { id: 'testing', directory_application: invalid_params },
            headers: valid_headers
       expect(response).to have_http_status(:unprocessable_entity)
-
     end
   end
 

--- a/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
+++ b/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
@@ -3,6 +3,37 @@
 require 'rails_helper'
 
 RSpec.describe 'Application Directory Endpoint', type: :request do
+  let(:valid_headers) do
+    { 'Authorization' => Settings.directory.secret }
+  end
+  let(:invalid_headers) do
+    { 'Authorization' => 'somethingwrong' }
+  end
+  let(:valid_params) do
+    {
+      "name": 'testing',
+      "logo_url": 'www.example.com/image2',
+      "service_categories": ['Health'],
+      "app_type": 'Third-Party-OAuth',
+      "platforms": ['iOS'],
+      "app_url": 'www.example.com',
+      "description": 'This is the testing description',
+      "privacy_url": 'www.example.com/privacy',
+      "tos_url": 'www.example.com/tos'
+    }
+  end
+  let(:invalid_params) do
+    {
+      # missing required variables
+      "name": 'testing',
+      "platforms": ['iOS'],
+      "app_url": 'www.example.com',
+      "description": 'This is the testing description',
+      "privacy_url": 'www.example.com/privacy',
+      "tos_url": 'www.example.com/tos'
+    }
+  end
+
   describe '#get /services/apps/v0/directory' do
     it 'returns a populated list of applications' do
       get '/services/apps/v0/directory'
@@ -24,9 +55,52 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
     end
   end
 
+  describe '#put /services/apps/v0/directory/:name' do
+    it 'updates the app' do
+      post '/services/apps/v0/directory',
+           params: { id: 'testing', directory_application: valid_params },
+           headers: valid_headers
+
+      put '/services/apps/v0/directory',
+          params: { id: 'testing', directory_application: valid_params },
+          headers: valid_headers
+      body = JSON.parse(response.body)
+      expect(body.length).to be(1)
+    end
+  end
+
+  describe '#destroy /services/apps/v0/directory/:name' do
+    it 'returns unauthorized if the header is invalid' do
+      post '/services/apps/v0/directory',
+           params: { id: 'testing', directory_application: valid_params },
+           headers: valid_headers
+      delete '/services/apps/v0/directory/testing',
+             params: { id: 'testing' },
+             headers: invalid_headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+    it 'deletes the app' do
+      post '/services/apps/v0/directory',
+           params: { id: 'testing', directory_application: valid_params },
+           headers: valid_headers
+      delete '/services/apps/v0/directory/testing',
+             params: { id: 'testing' },
+             headers: valid_headers
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe '#create /services/apps/v0/directory' do
+    it 'creates the app' do
+      post '/services/apps/v0/directory',
+           params: { id: 'testing', directory_application: valid_params },
+           headers: valid_headers
+    end
+  end
+
   describe '#get /services/apps/v0/directory/scopes/:category' do
     it 'returns a populated list of health scopes' do
-      VCR.use_cassette('okta/health-scopes') do
+      VCR.use_cassette('okta/health-scopes', match_requests_on: %i[method path]) do
         get '/services/apps/v0/directory/scopes/Health'
         body = JSON.parse(response.body)
         expect(response).to have_http_status(:success)
@@ -35,7 +109,7 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
       end
     end
     it 'returns a populated list of benefits scopes' do
-      VCR.use_cassette('okta/benefits-scopes') do
+      VCR.use_cassette('okta/benefits-scopes', match_requests_on: %i[method path]) do
         get '/services/apps/v0/directory/scopes/Benefits'
         body = JSON.parse(response.body)
         expect(response).to have_http_status(:success)
@@ -44,7 +118,7 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
       end
     end
     it 'returns a populated list of verification scopes' do
-      VCR.use_cassette('okta/verification-scopes') do
+      VCR.use_cassette('okta/verification-scopes', match_requests_on: %i[method path]) do
         get '/services/apps/v0/directory/scopes/Verification'
         body = JSON.parse(response.body)
         expect(response).to have_http_status(:success)
@@ -53,13 +127,13 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
       end
     end
     it 'returns an empty list when given an unknown category' do
-      VCR.use_cassette('okta/verification-scopes') do
+      VCR.use_cassette('okta/verification-scopes', match_requests_on: %i[method path]) do
         get '/services/apps/v0/directory/scopes/unknown_category'
         expect(response).to have_http_status(:no_content)
       end
     end
     it '204s when given a null category' do
-      VCR.use_cassette('okta/verification-scopes') do
+      VCR.use_cassette('okta/verification-scopes', match_requests_on: %i[method path]) do
         get '/services/apps/v0/directory/scopes'
         expect(response).to have_http_status(:no_content)
       end

--- a/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
+++ b/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 require_relative '../../../app/controllers/apps_api/v0/directory_controller.rb'
 
 RSpec.describe 'Application Directory Endpoint', type: :request do
-  let(:valid_headers) do
-    { 'Authorization' => 'blah' }
-  end
   let(:auth_string) { 'blah' }
+  let(:valid_headers) do
+    { 'Authorization' => auth_string }
+  end
   let(:invalid_headers) do
     { 'Authorization' => 'somethingwrong' }
   end
@@ -36,6 +36,10 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
     }
   end
 
+  before do
+    allow(Settings.directory).to receive(:secret).and_return(auth_string)
+  end
+
   describe '#get /services/apps/v0/directory' do
     it 'returns a populated list of applications' do
       get '/services/apps/v0/directory'
@@ -58,12 +62,7 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
   end
 
   describe '#put /services/apps/v0/directory/:name' do
-    before do
-      allow(Settings.directory).to receive(:secret).and_return(auth_string)
-    end
-
     it 'updates the app' do
-      allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
            params: { id: 'testing', directory_application: valid_params },
            headers: valid_headers
@@ -78,12 +77,7 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
   end
 
   describe '#destroy /services/apps/v0/directory/:name' do
-    before do
-      allow(Settings.directory).to receive(:secret).and_return(auth_string)
-    end
-
     it 'returns unauthorized if the header is invalid' do
-      allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
            params: { id: 'testing', directory_application: valid_params },
            headers: valid_headers
@@ -93,7 +87,6 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
     it 'deletes the app' do
-      allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
            params: { id: 'testing', directory_application: valid_params },
            headers: valid_headers
@@ -105,19 +98,13 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
   end
 
   describe '#create /services/apps/v0/directory' do
-    before do
-      allow(Settings.directory).to receive(:secret).and_return(auth_string)
-    end
-
     it 'creates the app' do
-      allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
            params: { id: 'testing', directory_application: valid_params },
            headers: valid_headers
       expect(response).to have_http_status(:ok)
     end
     it 'has :unprocessable_entity when given invalid params' do
-      allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
            params: { id: 'testing', directory_application: invalid_params },
            headers: valid_headers

--- a/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
+++ b/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
   let(:valid_headers) do
     { 'Authorization' => 'blah' }
   end
+  let(:auth_string) { 'blah' }
   let(:invalid_headers) do
     { 'Authorization' => 'somethingwrong' }
   end
@@ -57,6 +58,10 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
   end
 
   describe '#put /services/apps/v0/directory/:name' do
+    before do
+      allow(Settings.directory).to receive(:secret).and_return(auth_string)
+    end
+
     it 'updates the app' do
       allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
@@ -73,6 +78,10 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
   end
 
   describe '#destroy /services/apps/v0/directory/:name' do
+    before do
+      allow(Settings.directory).to receive(:secret).and_return(auth_string)
+    end
+
     it 'returns unauthorized if the header is invalid' do
       allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
@@ -96,6 +105,10 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
   end
 
   describe '#create /services/apps/v0/directory' do
+    before do
+      allow(Settings.directory).to receive(:secret).and_return(auth_string)
+    end
+
     it 'creates the app' do
       allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',

--- a/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
+++ b/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../../../app/controllers/apps_api/v0/directory_controller.rb'
 
 RSpec.describe 'Application Directory Endpoint', type: :request do
   let(:valid_headers) do
-    { 'Authorization' => Settings.directory.secret }
+    { 'Authorization' => 'blah' }
   end
   let(:invalid_headers) do
     { 'Authorization' => 'somethingwrong' }
@@ -57,6 +58,7 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
 
   describe '#put /services/apps/v0/directory/:name' do
     it 'updates the app' do
+      allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
            params: { id: 'testing', directory_application: valid_params },
            headers: valid_headers
@@ -72,6 +74,7 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
 
   describe '#destroy /services/apps/v0/directory/:name' do
     it 'returns unauthorized if the header is invalid' do
+      allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
            params: { id: 'testing', directory_application: valid_params },
            headers: valid_headers
@@ -81,6 +84,7 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
     it 'deletes the app' do
+      allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
            params: { id: 'testing', directory_application: valid_params },
            headers: valid_headers
@@ -93,12 +97,14 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
 
   describe '#create /services/apps/v0/directory' do
     it 'creates the app' do
+      allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
            params: { id: 'testing', directory_application: valid_params },
            headers: valid_headers
       expect(response).to have_http_status(:ok)
     end
     it 'has :unprocessable_entity when given invalid params' do
+      allow(Settings.directory).to receive(:secret).and_return('blah')
       post '/services/apps/v0/directory',
            params: { id: 'testing', directory_application: invalid_params },
            headers: valid_headers


### PR DESCRIPTION
## Description of change
Added `#create` `#update` and `#destroy` to `DirectoryController`. The endpoints added all require a correct Authorization header stored in credstash and are only intended for internal use when managing the Application Directory.

## Original issue(s)
https://vajira.max.gov/secure/RapidBoard.jspa?rapidView=777&view=detail&selectedIssue=API-4055

## Things to know about this PR
Sentry logging to be added later. 

<!-- Please describe testing done to verify the changes or any testing planned. -->
Tests have been included and code coverage is above the required `%`.