### PR TITLE
Prevent snake_casing For Update and Destroy Response (InProgressFormsController)

### DIFF
--- a/app/controllers/v0/in_progress_forms_controller.rb
+++ b/app/controllers/v0/in_progress_forms_controller.rb
@@ -24,7 +24,7 @@ module V0
     def update
       form = InProgressForm.where(form_id: params[:id], user_uuid: @current_user.uuid).first_or_initialize
       form.update!(form_data: params[:form_data] || params[:formData], metadata: params[:metadata])
-      render json: form
+      render json: form, key_transform: :unaltered
     end
 
     def destroy
@@ -32,7 +32,7 @@ module V0
       raise Common::Exceptions::RecordNotFound, params[:id] if form.blank?
 
       form.destroy
-      render json: form
+      render json: form, key_transform: :unaltered
     end
 
     private

--- a/spec/request/in_progress_forms_request_spec.rb
+++ b/spec/request/in_progress_forms_request_spec.rb
@@ -275,12 +275,14 @@ RSpec.describe V0::InProgressFormsController, type: :request do
         context 'when the user is not loa3' do
           let(:user) { loa1_user }
 
-          it 'returns a 200' do
+          it 'returns a 200 with camelCases JSON' do
             put v0_in_progress_form_url(new_form.form_id), params: {
               form_data: new_form.form_data,
               metadata: new_form.metadata
             }.to_json, headers: { 'CONTENT_TYPE' => 'application/json' }
             expect(response).to have_http_status(:ok)
+            expect(JSON.parse(response.body)['data']['attributes'].keys)
+              .to contain_exactly('formId', 'createdAt', 'updatedAt', 'metadata')
           end
         end
 
@@ -336,9 +338,11 @@ RSpec.describe V0::InProgressFormsController, type: :request do
       context 'when the user is not loa3' do
         let(:user) { loa1_user }
 
-        it 'returns a 200' do
+        it 'returns a 200 with camelCase JSON' do
           delete v0_in_progress_form_url(in_progress_form.form_id), params: nil
           expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)['data']['attributes'].keys)
+            .to contain_exactly('formId', 'createdAt', 'updatedAt', 'metadata')
         end
       end
 


### PR DESCRIPTION
the `#update` and `#destroy` renders should use `key_transform: :unaltered` just like `#index`