### PR TITLE
Address 500's for when payments are empty

### DIFF
--- a/app/serializers/vet_payment_history_serializer.rb
+++ b/app/serializers/vet_payment_history_serializer.rb
@@ -14,7 +14,7 @@ class VetPaymentHistorySerializer < ActiveModel::Serializer
     @formatted_payments = []
     @returned_payments = []
 
-    process_all_payments(object[:payments][:payment]) if object[:payments].present?
+    process_all_payments(object[:payments][:payment]) if object.dig('payments', 'payment').present?
     super
   end
 

--- a/app/serializers/vet_payment_history_serializer.rb
+++ b/app/serializers/vet_payment_history_serializer.rb
@@ -14,7 +14,7 @@ class VetPaymentHistorySerializer < ActiveModel::Serializer
     @formatted_payments = []
     @returned_payments = []
 
-    process_all_payments(object[:payments][:payment]) if object.dig('payments', 'payment').present?
+    process_all_payments(object[:payments][:payment]) if object.dig(:payments, :payment).present?
     super
   end
 

--- a/app/services/bgs/payment_service.rb
+++ b/app/services/bgs/payment_service.rb
@@ -21,7 +21,7 @@ module BGS
     private
 
     def empty_response
-      { payments: [], return_payments: [] }
+      { payments: {payment: []}}
     end
   end
 end

--- a/app/services/bgs/payment_service.rb
+++ b/app/services/bgs/payment_service.rb
@@ -9,7 +9,6 @@ module BGS
         '00', # payee code
         person[:ssn_nbr]
       )
-
       return empty_response if response[:payments].nil?
 
       response
@@ -21,7 +20,7 @@ module BGS
     private
 
     def empty_response
-      { payments: {payment: []}}
+      { payments: { payment: [] } }
     end
   end
 end

--- a/spec/controllers/v0/profile/payment_history_controller_spec.rb
+++ b/spec/controllers/v0/profile/payment_history_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe V0::Profile::PaymentHistoryController, type: :controller do
           expect(response.code).to eq('200')
           expect(response).to have_http_status(:ok)
           # not using "eq" for these counts in case additional payments are added for this user
+
           expect(JSON.parse(response.body)['data']['attributes']['payments'].count).to be >= 47
           expect(JSON.parse(response.body)['data']['attributes']['return_payments'].count).to be >= 0
         end

--- a/spec/services/bgs/payment_service_spec.rb
+++ b/spec/services/bgs/payment_service_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe BGS::PaymentService do
         person_hash[:ptcpnt_id] = '000000000'
 
         response = BGS::PaymentService.new(user).payment_history(person_hash)
-        expect(response).to include({ payments: [], return_payments: [] })
+
+        expect(response).to include({ payments: { payment: [] } })
       end
     end
 


### PR DESCRIPTION
## Description of change
We recently launched view payments functionality 🥳 which allows vets to see their payment and return payment history.

We were alerted to rare 500 errors occurrences where we were calling `[]` on nil.
![image](https://user-images.githubusercontent.com/4297274/104632964-725baf00-566c-11eb-9f8d-c006d4058ed4.png)

This PR checks for the `payment` hash so we don not call it on `nil`. It also adjusts the empty default payload that we had set in the service.

What changed in the empty default payload/Why was it not right in the beginning? The short answer is I'm not sure. Throughout the development of this feature, we had to stumble through a few services to find the one that was _just_ right; the service that had everything we wanted. I think we had set the empty payload according to one of those services and then once we got to the one we're using now, never updated the empty default to reflect what the service actually returns.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18440

## Things to know about this PR
* Are there additions to a `settings.yml` file? Do they vary by environment?
  * Negative
* Is there a feature flag? What is it?
  * No FF
* Is there some Sentry logging that was added? What alerts are relevant?
  * Not added in this PR
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
  * no
* Are there Swagger docs that were updated?
  * no
* Is there any PII concerns or questions?
  * no concerns

<!-- Please describe testing done to verify the changes or any testing planned. -->
