### PR TITLE
Tweak module generator file insert

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -345,6 +345,8 @@ Rails.application.routes.draw do
     mount VeteranConfirmation::Engine, at: '/veteran_confirmation'
   end
 
+  # Modules
+	mount TesterTest::Engine, at: '/tester_test'
   mount HealthQuest::Engine, at: '/health_quest'
   mount VAOS::Engine, at: '/vaos'
   mount CovidResearch::Engine, at: '/covid-research'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -346,7 +346,6 @@ Rails.application.routes.draw do
   end
 
   # Modules
-	mount TesterTest::Engine, at: '/tester_test'
   mount HealthQuest::Engine, at: '/health_quest'
   mount VAOS::Engine, at: '/vaos'
   mount CovidResearch::Engine, at: '/covid-research'

--- a/lib/generators/module/module_generator.rb
+++ b/lib/generators/module/module_generator.rb
@@ -59,7 +59,8 @@ class ModuleGenerator < Rails::Generators::NamedBase
 
     # insert into main app gemfile
     insert_into_file 'Gemfile', "\tgem '#{file_name}'\n", after: "path 'modules' do\n"
-    route "mount #{file_name.camelize}::Engine, at: '/#{file_name}'"
+
+    insert_into_file 'config/routes.rb', "\tmount #{file_name.camelize}::Engine, at: '/#{file_name}'\n", after: "# Modules\n"
 
     run 'bundle install'
 

--- a/lib/generators/module/module_generator.rb
+++ b/lib/generators/module/module_generator.rb
@@ -50,15 +50,18 @@ class ModuleGenerator < Rails::Generators::NamedBase
   # :nocov:
   def update_and_install
     # spec helper add group
-    insert_into_file 'spec/spec_helper.rb', "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
+    insert_into_file 'spec/spec_helper.rb',
+    "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
 
     # simplecov add group
-    insert_into_file 'spec/simplecov_helper.rb', "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
+    insert_into_file 'spec/simplecov_helper.rb',
+    "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
 
     # insert into main app gemfile
     insert_into_file 'Gemfile', "\tgem '#{file_name}'\n", after: "path 'modules' do\n"
 
-    insert_into_file 'config/routes.rb', "\tmount #{file_name.camelize}::Engine, at: '/#{file_name}'\n", after: "# Modules\n"
+    insert_into_file 'config/routes.rb',
+    "\tmount #{file_name.camelize}::Engine, at: '/#{file_name}'\n", after: "# Modules\n"
 
     run 'bundle install'
 

--- a/lib/generators/module/module_generator.rb
+++ b/lib/generators/module/module_generator.rb
@@ -50,12 +50,10 @@ class ModuleGenerator < Rails::Generators::NamedBase
   # :nocov:
   def update_and_install
     # spec helper add group
-    insert_into_file 'spec/spec_helper.rb', "\tadd_group '#{file_name.camelize}',
-      'modules/#{file_name}/'\n", after: "# Modules\n"
+    insert_into_file 'spec/spec_helper.rb', "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
 
     # simplecov add group
-    insert_into_file 'spec/simplecov_helper.rb', "\tadd_group '#{file_name.camelize}',
-      'modules/#{file_name}/'\n", after: "# Modules\n"
+    insert_into_file 'spec/simplecov_helper.rb', "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
 
     # insert into main app gemfile
     insert_into_file 'Gemfile', "\tgem '#{file_name}'\n", after: "path 'modules' do\n"

--- a/lib/generators/module/module_generator.rb
+++ b/lib/generators/module/module_generator.rb
@@ -51,17 +51,17 @@ class ModuleGenerator < Rails::Generators::NamedBase
   def update_and_install
     # spec helper add group
     insert_into_file 'spec/spec_helper.rb',
-    "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
+                     "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
 
     # simplecov add group
     insert_into_file 'spec/simplecov_helper.rb',
-    "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
+                     "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
 
     # insert into main app gemfile
     insert_into_file 'Gemfile', "\tgem '#{file_name}'\n", after: "path 'modules' do\n"
 
     insert_into_file 'config/routes.rb',
-    "\tmount #{file_name.camelize}::Engine, at: '/#{file_name}'\n", after: "# Modules\n"
+                     "\tmount #{file_name.camelize}::Engine, at: '/#{file_name}'\n", after: "# Modules\n"
 
     run 'bundle install'
 

--- a/lib/generators/module/module_generator.rb
+++ b/lib/generators/module/module_generator.rb
@@ -50,12 +50,12 @@ class ModuleGenerator < Rails::Generators::NamedBase
   # :nocov:
   def update_and_install
     # spec helper add group
-    insert_into_file 'spec/spec_helper.rb',
-                     "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
+    insert_into_file 'spec/spec_helper.rb', "\tadd_group '#{file_name.camelize}',
+                     'modules/#{file_name}/'\n", after: "# Modules\n"
 
     # simplecov add group
-    insert_into_file 'spec/simplecov_helper.rb',
-                     "\tadd_group '#{file_name.camelize}', 'modules/#{file_name}/'\n", after: "# Modules\n"
+    insert_into_file 'spec/simplecov_helper.rb', "\tadd_group '#{file_name.camelize}',
+                     'modules/#{file_name}/'\n", after: "# Modules\n"
 
     # insert into main app gemfile
     insert_into_file 'Gemfile', "\tgem '#{file_name}'\n", after: "path 'modules' do\n"


### PR DESCRIPTION
## Description of change
This PR updates the formatting for the lines of code that are inserted into the routes, spec_helper and simplecov_helper when invoking the module generator. The location of where the generator inserted into the routes file was incorrect. The code was updated to use the insert_into_file helper instead of the route helper. The simplecov and spec helper lines were multiline and are now updated to remove the newline character to match the preferred formatting. 

## Testing
- [x] Tested locally


