### PR TITLE
14853 mobile GET appointments fixes

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
@@ -21,7 +21,9 @@ module Mobile
       private
 
       def appointments_with_facilities(va_appointments, facility_ids)
-        facilities = facilities_service.get_facilities(ids: facility_ids.to_a.map { |id| "vha_#{id}" })
+        facilities = facilities_service.get_facilities(
+          ids: facility_ids.to_a.map { |id| "vha_#{id}" }.join(',')
+        )
         facilities_by_id = facilities.index_by(&:id)
         va_appointments.map do |appointment|
           facility = facilities_by_id["vha_#{appointment.facility_id}"]
@@ -65,15 +67,15 @@ module Mobile
       end
 
       def start_date
-        DateTime.parse(params[:start_date])
-      rescue ArgumentError
-        raise Common::Exceptions::InvalidFieldValue.new('start_date', params[:start_date])
+        DateTime.parse(params[:startDate])
+      rescue ArgumentError, TypeError
+        raise Common::Exceptions::InvalidFieldValue.new('startDate', params[:startDate])
       end
 
       def end_date
-        DateTime.parse(params[:end_date])
-      rescue ArgumentError
-        raise Common::Exceptions::InvalidFieldValue.new('end_date', params[:end_date])
+        DateTime.parse(params[:endDate])
+      rescue ArgumentError, TypeError
+        raise Common::Exceptions::InvalidFieldValue.new('endDate', params[:endDate])
       end
     end
   end

--- a/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
@@ -7,18 +7,36 @@ module Mobile
   module V0
     class AppointmentsController < ApplicationController
       def index
-        responses = appointments_service.get_appointments(start_date, end_date)
-        va_appointments, facility_ids = va_adapter.parse(responses[:va].body)
-        cc_appointments = cc_adapter.parse(responses[:cc].body)
+        responses, errors = appointments_service.get_appointments(start_date, end_date)
 
-        va_appointments = appointments_with_facilities(va_appointments, facility_ids) if va_appointments.size.positive?
+        va_appointments = []
+        cc_appointments = []
+        options = {
+          meta: {
+            errors: nil
+          }
+        }
+
+        va_appointments = parse_va_appointments(responses[:va].body) unless errors[:va]
+        cc_appointments = cc_adapter.parse(responses[:cc].body) unless errors[:cc]
 
         appointments = (va_appointments + cc_appointments).sort_by(&:start_date_utc)
 
-        render json: Mobile::V0::AppointmentSerializer.new(appointments)
+        errors = errors.values.compact
+        raise Common::Exceptions::BackendServiceException, 'VAOS_502' if errors.size == 2
+
+        options[:meta][:errors] = errors if errors.size.positive?
+
+        render json: Mobile::V0::AppointmentSerializer.new(appointments, options)
       end
 
       private
+
+      def parse_va_appointments(appointments_from_response)
+        appointments, facility_ids = va_adapter.parse(appointments_from_response)
+        appointments = appointments_with_facilities(appointments, facility_ids) if appointments.size.positive?
+        appointments
+      end
 
       def appointments_with_facilities(va_appointments, facility_ids)
         facilities = facilities_service.get_facilities(

--- a/modules/mobile/app/services/mobile/v0/appointments/service.rb
+++ b/modules/mobile/app/services/mobile/v0/appointments/service.rb
@@ -36,13 +36,8 @@ module Mobile
             responses[:va], errors[:va] = get(va_url, params)
           end
 
-          if errors.values.any? { |e| !e.nil? }
-            Rails.logger.error('mobile get va appointments call failed') if errors[:va]
-            Rails.logger.error('mobile get community care appointments call failed') if errors[:cc]
-            raise Common::Exceptions::BackendServiceException, 'VAOS_502'
-          end
-
-          responses
+          StatsD.increment('mobile.appointments.get_appointments.success')
+          [responses, errors]
         end
 
         private
@@ -50,8 +45,10 @@ module Mobile
         def get(url, params)
           response = config.parallel_connection.get(url, params, headers)
           [response, nil]
+        rescue VAOS::Exceptions::BackendServiceException => e
+          vaos_error(e, url)
         rescue => e
-          [nil, e]
+          internal_error(e, url)
         end
 
         def config
@@ -69,6 +66,38 @@ module Mobile
         def cc_url
           '/var/VeteranAppointmentRequestService/v4/rest/direct-scheduling' \
             "/patient/ICN/#{@user.icn}/booked-cc-appointments"
+        end
+
+        def internal_error(e, url)
+          Rails.logger.error(
+            'mobile appointments internal exception',
+            { url: url, error: e.message, backtrace: e.backtrace }
+          )
+          error = {
+            status: '500',
+            source: url == va_url ? 'VA Service' : 'Community Care Service',
+            title: 'Internal Server Error',
+            detail: e.message
+          }
+
+          StatsD.increment('mobile.appointments.get_appointments.failure')
+          [nil, error]
+        end
+
+        def vaos_error(e, url)
+          Rails.logger.error(
+            'mobile appointments backend service exception',
+            { url: url, error: e.message, backtrace: e.backtrace }
+          )
+          error = {
+            status: '502',
+            source: url == va_url ? 'VA Service' : 'Community Care Service',
+            title: 'Backend Service Exception',
+            detail: e.response_values[:detail]
+          }
+
+          StatsD.increment('mobile.appointments.get_appointments.failure')
+          [nil, error]
         end
       end
     end

--- a/modules/mobile/app/services/mobile/v0/appointments/service.rb
+++ b/modules/mobile/app/services/mobile/v0/appointments/service.rb
@@ -55,10 +55,6 @@ module Mobile
           Mobile::V0::Appointments::Configuration.instance
         end
 
-        def responses_ok?(responses)
-          responses[:cc]&.status == 200 && responses[:va]&.status == 200
-        end
-
         def va_url
           "/appointments/v1/patients/#{@user.icn}/appointments"
         end

--- a/modules/mobile/config/initializers/statsd.rb
+++ b/modules/mobile/config/initializers/statsd.rb
@@ -9,9 +9,5 @@ Mobile::ApplicationController.statsd_count_success :authenticate, 'mobile.authen
 StatsD.increment('mobile.authentication.success', 0)
 StatsD.increment('mobile.authentication.failure', 0)
 
-Mobile::V0::Appointments::Service.extend StatsD::Instrument
-Mobile::V0::Appointments::Service.statsd_count_success :get_appointments,
-                                                       'mobile.appointments.service.get_appointments'
-
 StatsD.increment('mobile.appointments.get_appointments.success', 0)
 StatsD.increment('mobile.appointments.get_appointments.failure', 0)

--- a/modules/mobile/spec/request/appointments_request_spec.rb
+++ b/modules/mobile/spec/request/appointments_request_spec.rb
@@ -22,20 +22,20 @@ RSpec.describe 'appointments', type: :request do
     end
 
     after(:all) { VCR.configure { |c| c.cassette_library_dir = @original_cassette_dir } }
-    
+
     context 'with a missing params' do
       it 'returns a bad request error' do
         get '/mobile/v0/appointments', headers: iam_headers, params: nil
-        
+
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body).to eq(
           {
-            "errors" => [
+            'errors' => [
               {
-                "title" => "Invalid field value",
-                "detail" => "\"\" is not a valid value for \"startDate\"",
-                "code" => "103",
-                "status" => "400"
+                'title' => 'Invalid field value',
+                'detail' => '"" is not a valid value for "startDate"',
+                'code' => '103',
+                'status' => '400'
               }
             ]
           }
@@ -44,23 +44,22 @@ RSpec.describe 'appointments', type: :request do
     end
 
     context 'with an invalid date in params' do
-  
       let(:start_date) { 42 }
       let(:end_date) { (Time.now.utc + 3.months).iso8601 }
       let(:params) { { startDate: start_date, endDate: end_date } }
-      
+
       it 'returns a bad request error' do
         get '/mobile/v0/appointments', headers: iam_headers, params: params
-    
+
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body).to eq(
           {
-            "errors" => [
+            'errors' => [
               {
-                "title" => "Invalid field value",
-                "detail" => "\"42\" is not a valid value for \"startDate\"",
-                "code" => "103",
-                "status" => "400"
+                'title' => 'Invalid field value',
+                'detail' => '"42" is not a valid value for "startDate"',
+                'code' => '103',
+                'status' => '400'
               }
             ]
           }
@@ -68,110 +67,173 @@ RSpec.describe 'appointments', type: :request do
       end
     end
 
-    context 'with a user has mixed upcoming appointments' do
-      before do
-        VCR.use_cassette('appointments/get_facilities', match_requests_on: %i[method uri]) do
+    context 'with valid params' do
+      let(:start_date) { Time.now.utc.iso8601 }
+      let(:end_date) { (Time.now.utc + 3.months).iso8601 }
+      let(:params) { { startDate: start_date, endDate: end_date } }
+
+      context 'with a user has mixed upcoming appointments' do
+        before do
+          VCR.use_cassette('appointments/get_facilities', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('appointments/get_cc_appointments', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('appointments/get_appointments', match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: iam_headers, params: params
+              end
+            end
+          end
+        end
+
+        let(:first_appointment) { response.parsed_body['data'].first['attributes'] }
+        let(:last_appointment) { response.parsed_body['data'].last['attributes'] }
+
+        it 'returns an ok response' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'matches the expected schema' do
+          expect(response.body).to match_json_schema('appointments')
+        end
+
+        it 'sorts the appointments by startDateUtc ascending' do
+          expect(first_appointment['startDateUtc']).to be < last_appointment['startDateUtc']
+        end
+
+        it 'includes the expected properties for a VA appointment' do
+          va_appointment = response.parsed_body['data'].filter { |a| a['attributes']['appointmentType'] == 'VA' }.first
+          expect(va_appointment).to include(
+            {
+              'type' => 'appointment',
+              'attributes' => {
+                'appointmentType' => 'VA',
+                'comment' => nil,
+                'facilityId' => '442',
+                'healthcareService' => 'CHY PC KILPATRICK',
+                'location' => {
+                  'name' => 'CHEYENNE VAMC',
+                  'address' => {
+                    'street' => '2360 East Pershing Boulevard',
+                    'city' => 'Cheyenne',
+                    'state' => 'WY',
+                    'zipCode' => '82001-5356'
+                  },
+                  'lat' => 41.148027,
+                  'long' => -104.7862575,
+                  'phone' => {
+                    'areaCode' => nil,
+                    'number' => nil,
+                    'extension' => nil
+                  },
+                  'url' => nil,
+                  'code' => nil
+                },
+                'minutesDuration' => 20,
+                'startDateLocal' => '2020-11-03T09:00:00.000-07:00',
+                'startDateUtc' => '2020-11-03T16:00:00.000+00:00',
+                'status' => 'BOOKED'
+              }
+            }
+          )
+        end
+
+        it 'includes the expected properties for a CC appointment' do
+          cc_appointment = response.parsed_body['data'].filter do |a|
+            a['attributes']['appointmentType'] == 'COMMUNITY_CARE'
+          end.first
+
+          expect(cc_appointment).to include(
+            {
+              'type' => 'appointment',
+              'attributes' => {
+                'appointmentType' => 'COMMUNITY_CARE',
+                'comment' => 'Test',
+                'facilityId' => nil,
+                'healthcareService' => 'AP',
+                'location' => {
+                  'name' => 'AP',
+                  'address' => {
+                    'street' => '2345, Oak Crest Cir',
+                    'city' => 'Aldie',
+                    'state' => 'VA',
+                    'zipCode' => '20106'
+                  },
+                  'lat' => nil,
+                  'long' => nil,
+                  'phone' => {
+                    'areaCode' => nil,
+                    'number' => nil,
+                    'extension' => nil
+                  },
+                  'url' => nil,
+                  'code' => nil
+                },
+                'minutesDuration' => 60,
+                'startDateLocal' => '2020-01-10T13:00:00.000-05:00',
+                'startDateUtc' => '2020-01-10T18:00:00.000Z',
+                'status' => 'BOOKED'
+              }
+            }
+          )
+        end
+      end
+
+      context 'when va appointments succeeds but cc appointments fail' do
+        before do
+          VCR.use_cassette('appointments/get_facilities', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('appointments/get_cc_appointments_500', match_requests_on: %i[method uri]) do
+              VCR.use_cassette('appointments/get_appointments', match_requests_on: %i[method uri]) do
+                get '/mobile/v0/appointments', headers: iam_headers, params: params
+              end
+            end
+          end
+        end
+
+        it 'returns an ok response' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'has va appointments' do
+          expect(response.parsed_body['data'].size).to eq(8)
+        end
+
+        it 'matches the expected schema' do
+          expect(response.body).to match_json_schema('appointments')
+        end
+      end
+
+      context 'when cc appointments succeeds but va appointments fail' do
+        before do
           VCR.use_cassette('appointments/get_cc_appointments', match_requests_on: %i[method uri]) do
-            VCR.use_cassette('appointments/get_appointments', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('appointments/get_appointments_500', match_requests_on: %i[method uri]) do
               get '/mobile/v0/appointments', headers: iam_headers, params: params
             end
           end
         end
+
+        it 'returns an ok response' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'has va appointments' do
+          expect(response.parsed_body['data'].size).to eq(101)
+        end
+
+        it 'matches the expected schema' do
+          expect(response.body).to match_json_schema('appointments')
+        end
       end
 
-      let(:start_date) { Time.now.utc.iso8601 }
-      let(:end_date) { (Time.now.utc + 3.months).iso8601 }
-      let(:params) { { startDate: start_date, endDate: end_date } }
-      let(:first_appointment) { response.parsed_body['data'].first['attributes'] }
-      let(:last_appointment) { response.parsed_body['data'].last['attributes'] }
+      context 'when both fail' do
+        before do
+          VCR.use_cassette('appointments/get_appointments_500', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('appointments/get_cc_appointments_500', match_requests_on: %i[method uri]) do
+              get '/mobile/v0/appointments', headers: iam_headers, params: params
+            end
+          end
+        end
 
-      it 'returns an ok response' do
-        expect(response).to have_http_status(:ok)
-      end
-
-      it 'matches the expected schema' do
-        expect(response.body).to match_json_schema('appointments')
-      end
-
-      it 'sorts the appointments by startDateUtc ascending' do
-        expect(first_appointment['startDateUtc']).to be < last_appointment['startDateUtc']
-      end
-
-      it 'includes the expected properties for a VA appointment' do
-        va_appointment = response.parsed_body['data'].filter { |a| a['attributes']['appointmentType'] == 'VA' }.first
-        expect(va_appointment).to include(
-          {
-            'type' => 'appointment',
-            'attributes' => {
-              'appointmentType' => 'VA',
-              'comment' => nil,
-              'facilityId' => '442',
-              'healthcareService' => 'CHY PC KILPATRICK',
-              'location' => {
-                'name' => 'CHEYENNE VAMC',
-                'address' => {
-                  'street' => '2360 East Pershing Boulevard',
-                  'city' => 'Cheyenne',
-                  'state' => 'WY',
-                  'zipCode' => '82001-5356'
-                },
-                'lat' => 41.148027,
-                'long' => -104.7862575,
-                'phone' => {
-                  'areaCode' => nil,
-                  'number' => nil,
-                  'extension' => nil
-                },
-                'url' => nil,
-                'code' => nil
-              },
-              'minutesDuration' => 20,
-              'startDateLocal' => '2020-11-03T09:00:00.000-07:00',
-              'startDateUtc' => '2020-11-03T16:00:00.000+00:00',
-              'status' => 'BOOKED'
-            }
-          }
-        )
-      end
-
-      it 'includes the expected properties for a CC appointment' do
-        cc_appointment = response.parsed_body['data'].filter do |a|
-          a['attributes']['appointmentType'] == 'COMMUNITY_CARE'
-        end.first
-
-        expect(cc_appointment).to include(
-          {
-            'type' => 'appointment',
-            'attributes' => {
-              'appointmentType' => 'COMMUNITY_CARE',
-              'comment' => 'Test',
-              'facilityId' => nil,
-              'healthcareService' => 'AP',
-              'location' => {
-                'name' => 'AP',
-                'address' => {
-                  'street' => '2345, Oak Crest Cir',
-                  'city' => 'Aldie',
-                  'state' => 'VA',
-                  'zipCode' => '20106'
-                },
-                'lat' => nil,
-                'long' => nil,
-                'phone' => {
-                  'areaCode' => nil,
-                  'number' => nil,
-                  'extension' => nil
-                },
-                'url' => nil,
-                'code' => nil
-              },
-              'minutesDuration' => 60,
-              'startDateLocal' => '2020-01-10T13:00:00.000-05:00',
-              'startDateUtc' => '2020-01-10T18:00:00.000Z',
-              'status' => 'BOOKED'
-            }
-          }
-        )
+        it 'returns a 502 response' do
+          expect(response).to have_http_status(:bad_gateway)
+        end
       end
     end
   end

--- a/modules/mobile/spec/services/appointments_service_spec.rb
+++ b/modules/mobile/spec/services/appointments_service_spec.rb
@@ -141,7 +141,9 @@ describe Mobile::V0::Appointments::Service do
 
     context 'when service calls fails due to an internal error' do
       it 'logs an internal error' do
-        allow(Mobile::V0::Appointments::Configuration.instance.parallel_connection).to receive(:get).and_raise(JSON::ParserError)
+        allow(Mobile::V0::Appointments::Configuration.instance.parallel_connection)
+          .to receive(:get)
+          .and_raise(JSON::ParserError)
         expect(Rails.logger).to receive(:error).with(
           'mobile appointments internal exception', any_args
         ).twice

--- a/modules/mobile/spec/services/appointments_service_spec.rb
+++ b/modules/mobile/spec/services/appointments_service_spec.rb
@@ -138,5 +138,15 @@ describe Mobile::V0::Appointments::Service do
         end
       end
     end
+
+    context 'when service calls fails due to an internal error' do
+      it 'logs an internal error' do
+        allow(Mobile::V0::Appointments::Configuration.instance.parallel_connection).to receive(:get).and_raise(JSON::ParserError)
+        expect(Rails.logger).to receive(:error).with(
+          'mobile appointments internal exception', any_args
+        ).twice
+        service.get_appointments(start_date, end_date)
+      end
+    end
   end
 end

--- a/modules/mobile/spec/services/appointments_service_spec.rb
+++ b/modules/mobile/spec/services/appointments_service_spec.rb
@@ -81,23 +81,9 @@ describe Mobile::V0::Appointments::Service do
       end
 
       it 'increments the VAOS and Mobile success metrics' do
-        expect(StatsD).to receive(:increment).once.with(
-          'api.external_http_request.VAOS.success',
-          1,
-          { tags: [
-            'endpoint:/appointments/v1/patients/xxx/appointments',
-            'method:get'
-          ] }
-        )
-        expect(StatsD).to receive(:increment).once.with(
-          'api.external_http_request.VAOS.success',
-          1,
-          { tags: [
-            'endpoint:/var/VeteranAppointmentRequestService/v4/rest'\
-'/direct-scheduling/patient/ICN/xxx/booked-cc-appointments',
-            'method:get'
-          ] }
-        )
+        expect(StatsD).to receive(:increment).with(
+          'api.external_http_request.VAOS.success', any_args
+        ).twice
         expect(StatsD).to receive(:increment).once.with(
           'mobile.appointments.get_appointments.success'
         )

--- a/modules/mobile/spec/support/vcr_cassettes/appointments/get_facilities.yml
+++ b/modules/mobile/spec/support/vcr_cassettes/appointments/get_facilities.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://sandbox-api.va.gov/services/va_facilities/v0/facilities?ids%5B%5D=vha_442
+      uri: https://sandbox-api.va.gov/services/va_facilities/v0/facilities?ids=vha_442
       body:
         encoding: US-ASCII
         string: ''


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Fixes a couple issues found during appointments staging integration testing. 

- Fixes missing or invalid startDate and endDate params handling
- Fixes the params format in the cal to the facilities API that retrives VA location data 

Also updates the endpoint to still return some appointments if one of the VA or Community Care appointment services is down.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14853
