### PR TITLE
M1 Mac Docker Support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -590,7 +590,7 @@ GEM
       ruby-rc4
       ttfunk
     pg (1.2.3)
-    pg_query (1.2.0)
+    pg_query (1.3.0)
     pghero (2.7.3)
       activerecord (>= 5)
     prawn (2.2.2)


### PR DESCRIPTION
Running `make up` previously failed on M1 Macs running Docker. This update to pg_query fixes it.