### PR TITLE
686 Dependency Claim Address Fix

### DIFF
--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -107,9 +107,7 @@ class SavedClaim::DependencyClaim < SavedClaim
   def partitioned_686_674_params
     dependent_data = parsed_form
 
-    keys = (STUDENT_ATTENDING_COLLEGE_KEYS.dup << %w[veteran_contact_information household_income]).flatten
-
-    college_student_data = { 'dependents_application' => dependent_data['dependents_application'].extract!(*keys) }
+    college_student_data = dependent_data['dependents_application'].extract!(*STUDENT_ATTENDING_COLLEGE_KEYS)
 
     { college_student_data: college_student_data, dependent_data: dependent_data }
   end

--- a/spec/models/saved_claim/dependency_claim_spec.rb
+++ b/spec/models/saved_claim/dependency_claim_spec.rb
@@ -52,8 +52,7 @@ RSpec.describe SavedClaim::DependencyClaim do
       claim = described_class.new(form: all_flows_payload.to_json)
 
       formatted_data = claim.formatted_674_data(va_file_number_with_payload)
-      expect(formatted_data).to include(:dependents_application)
-      expect(formatted_data[:dependents_application]).to include(:student_name_and_ssn)
+      expect(formatted_data).to include(:student_name_and_ssn)
     end
   end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
When submitting a 686c (Dependency Application) the Veteran's address is not being passed properly.  This PR is a fix to ensure the address gets passed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18672

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is a quick fix/revert so no additional settings or logging has been added.
<!-- Please describe testing done to verify the changes or any testing planned. -->
## Testing
- [x] Local testing
- [x] Updated specs
- [x] Staging testing planned