### PR TITLE
point BGS at Rails.logger so it doesn't ouput during tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,9 +42,9 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/bgs-ext.git
-  revision: 4da926722554116a116b4e02763cad9d104b72bd
+  revision: a440c6ea6349f98839118ebe29f0aeade72898f1
   specs:
-    bgs_ext (0.18.0)
+    bgs_ext (0.19.0)
       httpclient
       nokogiri (>= 1.8.5)
       savon (~> 2.12)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -176,3 +176,7 @@ RSpec.configure do |config|
     FileUtils.rm_rf(Dir[Rails.root.join('spec', 'support', "uploads#{ENV['TEST_ENV_NUMBER']}")]) if Rails.env.test?
   end
 end
+
+BGS.configure do |config|
+  config.logger = Rails.logger
+end


### PR DESCRIPTION
When there's a logger provided to BGS it won't output to console (which makes test output hard to read).