### PR TITLE
API-4491 Move report recipients to settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -163,6 +163,12 @@ modules_appeals_api:
   notice_of_disagreement_pii_expunge_enabled: true
   notice_of_disagreement_updater_enabled: true
   report_enabled: false
+  report_recipients:
+    - drew.fisher@adhocteam.us
+    - jack.schuss@oddball.io
+    - kelly@adhocteam.us
+    - laura.trager@adhocteam.us
+    - nathan.wright@oddball.io
   schema_dir: config/schemas
 
 vre_counseling:

--- a/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
+++ b/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
@@ -4,15 +4,6 @@ require 'appeals_api/decision_review_report'
 
 module AppealsApi
   class DecisionReviewMailer < ApplicationMailer
-    RECIPIENTS = %w[
-      premal.shah@va.gov
-      kelly@adhocteam.us
-      laura.trager@adhocteam.us
-      drew.fisher@adhocteam.us
-      jack.schuss@oddball.io
-      nathan.wright@oddball.io
-    ].freeze
-
     def build(date_from:, date_to:)
       @report = DecisionReviewReport.new(from: date_from, to: date_to)
 
@@ -20,7 +11,7 @@ module AppealsApi
       body = ERB.new(template).result(binding)
 
       mail(
-        to: RECIPIENTS,
+        to: Settings.modules_appeals_api.report_recipients,
         subject: 'Decision Review API report',
         content_type: 'text/html',
         body: body

--- a/modules/appeals_api/spec/mailers/decision_review_report_mailer_spec.rb
+++ b/modules/appeals_api/spec/mailers/decision_review_report_mailer_spec.rb
@@ -13,9 +13,8 @@ RSpec.describe AppealsApi::DecisionReviewMailer, type: [:mailer] do
     end
 
     it 'sends to the right people' do
-      expect(subject.to).to eq(
+      expect(subject.to).to match_array(
         %w[
-          premal.shah@va.gov
           kelly@adhocteam.us
           laura.trager@adhocteam.us
           drew.fisher@adhocteam.us


### PR DESCRIPTION
## Description of change
Moves decision review report email recipients from a constant to Settings. This allows the list to be changed per environment.

## Original issue(s)
https://vajira.max.gov/browse/API-4491

## Things to know about this PR
A corresponding PR for updating the settings in devops is here: https://github.com/department-of-veterans-affairs/devops/pull/8384
<!-- Please describe testing done to verify the changes or any testing planned. -->
