### PR TITLE
Add privacy policy url to profile/connected_applications response

### DIFF
--- a/app/models/okta_redis/app.rb
+++ b/app/models/okta_redis/app.rb
@@ -23,6 +23,12 @@ module OktaRedis
       okta_response.body['_links']['logo'].last['href']
     end
 
+    def privacy_url
+      app_name = okta_response.body['label']
+      app_data = DirectoryApplication.find_by(name: app_name)
+      app_data.privacy_url
+    end
+
     # rubocop:disable Rails/FindEach
     def fetch_grants
       raise 'Requires user set!' unless @user

--- a/app/models/okta_redis/app.rb
+++ b/app/models/okta_redis/app.rb
@@ -29,7 +29,7 @@ module OktaRedis
       if app_data
         app_data.privacy_url
       else
-        'None Available'
+        ''
       end
     end
 

--- a/app/models/okta_redis/app.rb
+++ b/app/models/okta_redis/app.rb
@@ -26,7 +26,11 @@ module OktaRedis
     def privacy_url
       app_name = okta_response.body['label']
       app_data = DirectoryApplication.find_by(name: app_name)
-      app_data.privacy_url
+      if app_data
+        app_data.privacy_url
+      else
+        'None Available'
+      end
     end
 
     # rubocop:disable Rails/FindEach

--- a/app/serializers/okta_app_serializer.rb
+++ b/app/serializers/okta_app_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OktaAppSerializer < ActiveModel::Serializer
-  attributes :id, :title, :logo, :grants
+  attributes :id, :title, :logo, :privacy_url, :grants
 
   def grants
     object.grants.map do |grant|

--- a/app/swagger/swagger/schemas/connected_applications.rb
+++ b/app/swagger/swagger/schemas/connected_applications.rb
@@ -15,6 +15,7 @@ module Swagger
               property :title, type: :string
               property :created, type: :string
               property :logo, type: :string
+              property :privacy_url, type: :string
               property :grants, type: :array do
                 items do
                   property :id, type: :string

--- a/modules/apps_api/app/models/directory_application.rb
+++ b/modules/apps_api/app/models/directory_application.rb
@@ -3,5 +3,4 @@
 class DirectoryApplication < ApplicationRecord
   validates :name, :logo_url, :app_type, :service_categories, :platforms,
             :app_url, :description, :privacy_url, :tos_url, presence: true
-  attr_reader :privacy_url
 end

--- a/modules/apps_api/app/models/directory_application.rb
+++ b/modules/apps_api/app/models/directory_application.rb
@@ -3,4 +3,5 @@
 class DirectoryApplication < ApplicationRecord
   validates :name, :logo_url, :app_type, :service_categories, :platforms,
             :app_url, :description, :privacy_url, :tos_url, presence: true
+  attr_reader :privacy_url
 end


### PR DESCRIPTION
## Description of change

This PR adds a privacy url property to the `profile/connected_applications` response object. This property is needed to update the third party app disconnect copy.


## Original issue(s)

[Ticket](https://vajira.max.gov/browse/API-4003)

## Things to know about this PR

[Discussion in vets-website PR](https://github.com/department-of-veterans-affairs/vets-website/pull/15653)
