### PR TITLE
18312: Add State Search Feature Flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -374,3 +374,8 @@ features:
     enable_in_development: true
     description: >
       Enable frontend application and cta for Search Representative application
+  gibct_state_search:
+    actor_type: user
+    enable_in_development: true
+    description: >
+       Include state abbreviation when searching on comparison tool 


### PR DESCRIPTION
## Description
As a developer, I need to create a feature flag for including state abbreviations in search so that the functionality can be toggled on or off until it's ready for production.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/18312)

## Testing done
Testing passes locallly

## Screenshots
<img width="956" alt="Screen Shot 2021-01-19 at 10 47 47 AM" src="https://user-images.githubusercontent.com/48804834/105058154-e9fe5500-5a43-11eb-8b99-f980fba81f86.png">

## Acceptance criteria
- [x] The Feature Flag gibct_state_search is available to be used for the state abbreviation search enhancements.
- [x] The Feature Flag description is: "Include state abbreviation when searching on comparison tool"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
