### PR TITLE
Don't require backend review for mobile only changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,8 @@ spec/support/*/vaos/                 @department-of-veterans-affairs/vfs-vaos @d
 lib/bgs @department-of-veterans-affairs/vfs-ebenefits @department-of-veterans-affairs/backend-review-group
 spec/bgs @department-of-veterans-affairs/vfs-ebenefits @department-of-veterans-affairs/backend-review-group
 
-modules/mobile/                      @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/backend-review-group
-spec/support/*/mobile/               @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/backend-review-group
+modules/mobile/                      @department-of-veterans-affairs/mobile-api-team
+spec/support/*/mobile/               @department-of-veterans-affairs/mobile-api-team
 
 # authentication
 app/controllers/*/sessions_controller.rb @department-of-veterans-affairs/vsp-identity


### PR DESCRIPTION
According to Github's [CODEOWNERS Syntax](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax) docs, backend-review-group will be required unless only the `modules/mobile` and `spec/support/*/mobile/` have been changed:

```
# Order is important; the last matching pattern takes the most
# precedence. When someone opens a pull request that only
# modifies JS files, only @js-owner and not the global
# owner(s) will be requested for a review.
*.js    @js-owner
```