### PR TITLE
Add search_gov click tracking endpoint

### DIFF
--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -162,6 +162,7 @@ module V0
       Swagger::Requests::Prescriptions::Trackings,
       Swagger::Requests::Profile,
       Swagger::Requests::Search,
+      Swagger::Requests::SearchClickTracking,
       Swagger::Requests::TermsAndConditions,
       Swagger::Requests::UploadSupportingEvidence,
       Swagger::Requests::User,

--- a/app/controllers/v0/search_click_tracking_controller.rb
+++ b/app/controllers/v0/search_click_tracking_controller.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'search_click_tracking/service'
+
+module V0
+  class SearchClickTrackingController < ApplicationController
+    include ActionView::Helpers::SanitizeHelper
+
+    skip_before_action :authenticate
+    skip_before_action :verify_authenticity_token
+
+    # Sends click tracking data to search.gov analytics, based on the passed url,
+    # query, position, client_ip, and user_agent.
+    #
+    def create
+      response = SearchClickTracking::Service.new(url, query, position, user_agent, client_ip).track_click
+      if response.success?
+        render nothing: true, status: 204
+      else
+        render json: response.body, status: 400
+      end
+    end
+
+    private
+
+    def click_params
+      params.permit(:url, :query, :position, :client_ip, :user_agent)
+    end
+
+    # Returns a sanitized, permitted version of the passed url params.
+    #
+    # @return [String]
+    # @see https://api.rubyonrails.org/v4.2/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize
+    #
+    def url
+      sanitize click_params['url']
+    end
+
+    # Returns a sanitized, permitted version of the passed query params.
+    #
+    # @return [String]
+    # @see https://api.rubyonrails.org/v4.2/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize
+    #
+    def query
+      sanitize click_params['query']
+    end
+
+    # Returns a sanitized, permitted version of the passed position params.
+    #
+    # @return [String]
+    # @see https://api.rubyonrails.org/v4.2/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize
+    #
+    def position
+      sanitize click_params['position']
+    end
+
+    # Returns a sanitized, permitted version of the passed client_ip params.
+    #
+    # @return [String]
+    # @see https://api.rubyonrails.org/v4.2/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize
+    #
+    def client_ip
+      sanitize click_params['client_ip']
+    end
+
+    # Returns a sanitized, permitted version of the passed user_agent params.
+    #
+    # @return [String]
+    # @see https://api.rubyonrails.org/v4.2/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize
+    #
+    def user_agent
+      sanitize click_params['user_agent']
+    end
+  end
+end

--- a/app/swagger/swagger/requests/search_click_tracking.rb
+++ b/app/swagger/swagger/requests/search_click_tracking.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# rubocop:disable Layout/LineLength
+module Swagger
+  module Requests
+    class SearchClickTracking
+      include Swagger::Blocks
+
+      swagger_path '/v0/search_click_tracking/?client_ip={client_ip}&position={position}&query={query}&url={url}&user_agent={user_agent}' do
+        operation :post do
+          key :description, 'Sends a Click Tracking event to Search.gov analytics'
+          key :operationId, 'sendClickTrackingData'
+          key :tags, %w[
+            search_click_tracking
+          ]
+
+          parameter do
+            key :name, 'url'
+            key :in, :path
+            key :description, 'the url of the link that was clicked'
+            key :required, true
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'query'
+            key :in, :path
+            key :description, 'the search query used to generate results'
+            key :required, true
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'position'
+            key :in, :path
+            key :description, 'The position/rank of the result on your search results page. Was it the first result or the second?'
+            key :required, true
+            key :type, :integer
+          end
+
+          parameter do
+            key :name, 'client_ip'
+            key :in, :path
+            key :description, 'the IP address of the user who clicked'
+            key :required, true
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'user_agent'
+            key :in, :path
+            key :description, 'the user agent of the user who clicked'
+            key :required, true
+            key :type, :string
+          end
+
+          response 204 do
+            key :description, 'Empty Response'
+          end
+
+          response 400 do
+            key :description, 'Error Occurred'
+            schema do
+              key :'$ref', :Errors
+            end
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Layout/LineLength

--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -30,6 +30,7 @@ require 'preneeds/configuration'
 require 'rx/configuration'
 require 'sm/configuration'
 require 'search/configuration'
+require 'search_click_tracking/configuration'
 require 'okta/configuration'
 require 'vet360/contact_information/configuration'
 require 'iam_ssoe_oauth/configuration'
@@ -70,6 +71,7 @@ services = [
   SM::Configuration.instance.breakers_service,
   Vet360::ContactInformation::Configuration.instance.breakers_service,
   Search::Configuration.instance.breakers_service,
+  SearchClickTracking::Configuration.instance.breakers_service,
   Okta::Configuration.instance.breakers_service,
   VAOS::Configuration.instance.breakers_service,
   IAMSSOeOAuth::Configuration.instance.breakers_service,

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -12,6 +12,7 @@ require 'saml/responses/base'
 require 'saml/user'
 require 'stats_d_metric'
 require 'search/service'
+require 'search_click_tracking/service'
 require 'vet360/exceptions/parser'
 require 'vet360/service'
 require 'va_notify/service'
@@ -131,6 +132,9 @@ StatsD.increment(SentryJob::STATSD_ERROR_KEY, 0)
 
 # init Search
 StatsD.increment("#{Search::Service::STATSD_KEY_PREFIX}.exceptions", 0, tags: ['exception:429'])
+
+# init SearchClickTracking
+StatsD.increment("#{SearchClickTracking::Service::STATSD_KEY_PREFIX}.exceptions", 0, tags: ['exception:400'])
 
 # init Form1010cg
 StatsD.increment(Form1010cg::Auditor.metrics.submission.attempt, 0)

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -577,6 +577,12 @@ en:
         code: 'SEARCH_429'
         detail: 'Exceeded Search.gov rate limit'
         status: 429
+      SEARCH_CLICK_TRACKING_400:
+        <<: *external_defaults
+        title: Bad Request
+        code: 'SEARCH_CLICK_TRACKING_400'
+        detail: 'Missing query parameter'
+        status: 400
       VAOS_409A:
         <<: *external_defaults
         title: Conflict

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,6 +256,7 @@ Rails.application.routes.draw do
     end
 
     resources :search, only: :index
+    resources :search_click_tracking, only: :create
 
     get 'forms', to: 'forms#index'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -497,6 +497,14 @@ search:
   mock_search: true
   url: https://search.usa.gov/api/v2
 
+  # Settings for search-click-tracking
+search_click_tracking:
+  access_key: SEARCH_GOV_ACCESS_KEY
+  affiliate: va
+  module_code: I14Y
+  mock: false
+  url: https://api.gsa.gov/technology/searchgov/v2
+
 flipper:
   admin_user_emails:
     - adewitt@thoughtworks.com

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -26,18 +26,15 @@ saml_ssoe:
   cert_path: spec/support/certificates/ruby-saml.crt
   key_path: spec/support/certificates/ruby-saml.key
 
-
 edu:
   prefill: true
   sftp:
     relative_path: 'spool_files'
 
-
 pension_burial:
   prefill: true
   sftp:
     relative_path: 'VETSGOV_PENSION'
-
 
 hca:
   prefill: true
@@ -64,6 +61,12 @@ search:
   access_key: TESTKEY
   affiliate: va
   url: https://search.usa.gov/api/v2
+
+search_click_tracking:
+  access_key: TESTKEY
+  affiliate: va
+  module_code: I14Y
+  url: https://api.gsa.gov/technology/searchgov/v2
 
 vba_documents:
   enable_download_endpoint: true

--- a/lib/search_click_tracking/configuration.rb
+++ b/lib/search_click_tracking/configuration.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'common/client/configuration/rest'
+
+module SearchClickTracking
+  class Configuration < Common::Client::Configuration::REST
+    self.read_timeout = 30
+
+    def base_path
+      "#{Settings.search_click_tracking.url}/clicks/"
+    end
+
+    def service_name
+      'SearchClickTracking'
+    end
+  end
+end

--- a/lib/search_click_tracking/service.rb
+++ b/lib/search_click_tracking/service.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'uri'
+require 'common/client/base'
+require 'common/client/concerns/monitoring'
+require 'common/client/errors'
+require 'search_click_tracking/configuration'
+
+module SearchClickTracking
+  # This class builds a wrapper around Search.gov web results API. Creating a new instance of class
+  # will and calling #results will return a ResultsResponse upon success or an exception upon failure.
+  #
+  # @see https://search.usa.gov/sites/7378/api_instructions
+  #
+  class Service < Common::Client::Base
+    include Common::Client::Concerns::Monitoring
+
+    STATSD_KEY_PREFIX = 'api.search_click_tracking'
+
+    configuration SearchClickTracking::Configuration
+
+    attr_reader :url
+    attr_reader :query
+    attr_reader :position
+    attr_reader :client_ip
+    attr_reader :user_agent
+
+    def initialize(url, query, position, user_agent, client_ip = request.remote_ip)
+      @url = url
+      @query = query
+      @position = position
+      @client_ip = client_ip
+      @user_agent = user_agent
+    end
+
+    # POSTs click tracking query param data to search.gov
+    #
+    def track_click
+      with_monitoring do
+        Faraday.post(url_with_params, '')
+      end
+    rescue => e
+      e
+    end
+
+    private
+
+    def url_with_params
+      "#{track_click_url}?#{query_params}"
+    end
+
+    def track_click_url
+      config.base_path
+    end
+
+    # Required params [affiliate, access_key, module_code, url, query, position, client_ip, user_agent]
+    #
+    # @see https://search.usa.gov/sites/7378/api_instructions
+    #
+    def query_params
+      URI.encode_www_form(
+        {
+          affiliate: affiliate,
+          access_key: access_key,
+          module_code: module_code,
+          url: url,
+          query: query,
+          position: position,
+          client_ip: client_ip,
+          user_agent: user_agent
+        }
+      )
+    end
+
+    def affiliate
+      Settings.search_click_tracking.affiliate
+    end
+
+    def access_key
+      Settings.search_click_tracking.access_key
+    end
+
+    def module_code
+      Settings.search_click_tracking.module_code
+    end
+  end
+end

--- a/lib/statsd_middleware.rb
+++ b/lib/statsd_middleware.rb
@@ -54,6 +54,7 @@ class StatsdMiddleware
     questionnaire
     resources-and-support
     search
+    search-click-tracking
     static-pages
     terms-and-conditions
     vaos

--- a/spec/lib/search_click_tracking/configuration_spec.rb
+++ b/spec/lib/search_click_tracking/configuration_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SearchClickTracking::Configuration do
+  describe '#service_name' do
+    it 'has the expected service name' do
+      expect(described_class.instance.service_name).to eq('SearchClickTracking')
+    end
+  end
+end

--- a/spec/lib/search_click_tracking/service_spec.rb
+++ b/spec/lib/search_click_tracking/service_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+# require 'search_click_tracking/service'
+
+describe SearchClickTracking::Service do
+  subject { described_class.new(url, query, position, user_agent, client_ip) }
+
+  before do
+    allow_any_instance_of(described_class).to receive(:access_key).and_return('TESTKEY')
+  end
+
+  let(:client_ip) { 'testIP' }
+  let(:user_agent) { 'testUserAgent' }
+  let(:position) { '0' }
+  let(:url) { 'https://www.testurl.com' }
+
+  describe '#track_click' do
+    context 'when successful' do
+      let(:query) { 'testQuery' }
+
+      it 'returns a status of 200' do
+        VCR.use_cassette('search_click_tracking/success', VCR::MATCH_EVERYTHING) do
+          response = subject.track_click
+          expect(response.status).to eq 200
+        end
+      end
+
+      it 'returns an empty body' do
+        VCR.use_cassette('search_click_tracking/success', VCR::MATCH_EVERYTHING) do
+          response = subject.track_click
+          expect(response.body).to eq ''
+        end
+      end
+    end
+
+    context 'with a missing parameter' do
+      let(:query) { '' }
+
+      it 'returns a status of 400', :aggregate_failures do
+        VCR.use_cassette('search_click_tracking/missing_parameter', VCR::MATCH_EVERYTHING) do
+          response = subject.track_click
+          expect(response.status).to eq(400)
+          expect(response.body).to eq "[\"Query can\'t be blank\"]"
+        end
+      end
+    end
+  end
+end

--- a/spec/request/search_click_tracking_request_spec.rb
+++ b/spec/request/search_click_tracking_request_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/error_details'
+require 'uri'
+
+describe 'search_click_tracking', type: :request do
+  include ErrorDetails
+
+  describe 'POST /v0/search_click_tracking' do
+    context 'on a successfull post request' do
+      let(:query_params) do
+        URI.encode_www_form(
+          {
+            client_ip: 'testIP',
+            position: 0,
+            query: 'testQuery',
+            url: 'https://www.testurl.com',
+            user_agent: 'testUserAgent'
+          }
+        )
+      end
+
+      it 'returns a response of 204 No Content', :aggregate_failures do
+        VCR.use_cassette('search_click_tracking/success') do
+          post "/v0/search_click_tracking/?#{query_params}"
+          expect(response).to have_http_status(:no_content)
+          expect(response.body).to eq ''
+        end
+      end
+    end
+
+    context 'with a missing parameter' do
+      let(:query_params) do
+        URI.encode_www_form(
+          {
+            client_ip: 'testIP',
+            position: 0,
+            query: '',
+            url: 'https://www.testurl.com',
+            user_agent: 'testUserAgent'
+          }
+        )
+      end
+
+      it 'returns a 400', :aggregate_failures do
+        VCR.use_cassette('search_click_tracking/missing_parameter') do
+          post "/v0/search_click_tracking/?#{query_params}"
+          expect(response).to have_http_status(:bad_request)
+        end
+      end
+    end
+  end
+end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -2679,6 +2679,30 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
       end
     end
 
+    describe 'search click tracking' do
+      context 'when successful' do
+        # rubocop:disable Layout/LineLength
+        let(:params) { { 'client_ip' => 'testIP', 'position' => 0, 'query' => 'testQuery', 'url' => 'https%3A%2F%2Fwww.testurl.com', 'user_agent' => 'testUserAgent' } }
+
+        it 'sends data as query params' do
+          VCR.use_cassette('search_click_tracking/success') do
+            expect(subject).to validate(:post, '/v0/search_click_tracking/?client_ip={client_ip}&position={position}&query={query}&url={url}&user_agent={user_agent}', 204, params)
+          end
+        end
+      end
+
+      context 'with an empty search query' do
+        let(:params) { { 'client_ip' => 'testIP', 'position' => 0, 'query' => '', 'url' => 'https%3A%2F%2Fwww.testurl.com', 'user_agent' => 'testUserAgent' } }
+
+        it 'returns a 400 with error details' do
+          VCR.use_cassette('search_click_tracking/missing_parameter') do
+            expect(subject).to validate(:post, '/v0/search_click_tracking/?client_ip={client_ip}&position={position}&query={query}&url={url}&user_agent={user_agent}', 400, params)
+          end
+          # rubocop:enable Layout/LineLength
+        end
+      end
+    end
+
     describe 'notifications' do
       let(:notification_subject) { Notification::FORM_10_10EZ }
 

--- a/spec/support/vcr_cassettes/search_click_tracking/missing_parameter.yml
+++ b/spec/support/vcr_cassettes/search_click_tracking/missing_parameter.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.gsa.gov/technology/searchgov/v2/clicks/?access_key=TESTKEY&affiliate=va&client_ip=testIP&module_code=I14Y&position=0&query=&url=https://www.testurl.com&user_agent=testUserAgent
+      body:
+        encoding: UTF-8
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v0.17.0
+        Content-Type:
+          - application/x-www-form-urlencoded
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 400
+        message: Bad Request
+      headers:
+        Date:
+          - Wed, 20 Jan 2021 17:42:13 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "24"
+        Connection:
+          - keep-alive
+        X-Ratelimit-Limit:
+          - "1000"
+        X-Ratelimit-Remaining:
+          - "995"
+        Cache-Control:
+          - no-cache
+        Referrer-Policy:
+          - strict-origin-when-cross-origin
+        Status:
+          - 400 Bad Request
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubdomains; preload
+          - max-age=31536000; preload
+        Vary:
+          - Origin
+        Via:
+          - 1.1 proxy5.us-east-1.prod.infr.search.usa.gov:8443, https/1.1 api-umbrella
+            (ApacheTrafficServer [cMs f ])
+        X-Content-Type-Options:
+          - nosniff
+        X-Download-Options:
+          - noopen
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Request-Id:
+          - dc2a5526-6743-4589-a354-89f9307cf7c3
+        X-Xss-Protection:
+          - 1; mode=block
+        Age:
+          - "0"
+        X-Cache:
+          - MISS
+      body:
+        encoding: UTF-8
+        string: '["Query can''t be blank"]'
+    recorded_at: Wed, 20 Jan 2021 17:42:13 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/search_click_tracking/success.yml
+++ b/spec/support/vcr_cassettes/search_click_tracking/success.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.gsa.gov/technology/searchgov/v2/clicks/?access_key=TESTKEY&affiliate=va&client_ip=testIP&module_code=I14Y&position=0&query=testQuery&url=https://www.testurl.com&user_agent=testUserAgent
+      body:
+        encoding: UTF-8
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v0.17.0
+        Content-Type:
+          - application/x-www-form-urlencoded
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Wed, 20 Jan 2021 17:42:13 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - "0"
+        Connection:
+          - keep-alive
+        X-Ratelimit-Limit:
+          - "1000"
+        X-Ratelimit-Remaining:
+          - "994"
+        Cache-Control:
+          - no-cache
+        Referrer-Policy:
+          - strict-origin-when-cross-origin
+        Status:
+          - 200 OK
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubdomains; preload
+          - max-age=31536000; preload
+        Vary:
+          - Origin
+        Via:
+          - 1.1 proxy1.us-east-1.prod.infr.search.usa.gov:8443, https/1.1 api-umbrella
+            (ApacheTrafficServer [cMsSf ])
+        X-Content-Type-Options:
+          - nosniff
+        X-Download-Options:
+          - noopen
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Request-Id:
+          - a0934f65-a83e-44a6-b2ac-33deeedbd672
+        X-Xss-Protection:
+          - 1; mode=block
+        Age:
+          - "0"
+        X-Cache:
+          - MISS
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Wed, 20 Jan 2021 17:42:13 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Description of change
This change adds an endpoint to access search.gov's click tracking api

## Original issue(s)
department-of-veterans-affairs/va.gov-team#16367

## Things to know about this PR
This POST request is unique in that it sends all information as query params rather than as part of the body
