### PR TITLE
Update swagger/schema for max contestable issues

### DIFF
--- a/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
@@ -66,6 +66,7 @@ module AppealsApi::V1
           property :included do
             key :type, :array
             key :minItems, 1
+            key :maxItems, 100
 
             items do
               key :'$ref', :contestableIssue

--- a/modules/appeals_api/config/schemas/10182.json
+++ b/modules/appeals_api/config/schemas/10182.json
@@ -65,6 +65,7 @@
       "type": "array",
       "items": { "$ref": "#/definitions/nodCreateContestableIssue" },
       "minItems": 1,
+      "maxItems": 100,
       "uniqueItems": true
     },
 


### PR DESCRIPTION
## Description of change
This change updates the JSON Schema for Notice of Disagreement to accept a max of included contestable issues.

It also updates the swagger documentation to reflect the change. 

The additional acceptance criteria listed in the ticket was handled by the NOD refactor outlined in [4306](https://vajira.max.gov/browse/API-4306)

## Original issue(s)
[4240](https://vajira.max.gov/browse/API-4240)

