### PR TITLE
Cris.shupp/api 4088 forms api db rake

### DIFF
--- a/modules/va_forms/app/workers/va_forms/form_reloader.rb
+++ b/modules/va_forms/app/workers/va_forms/form_reloader.rb
@@ -25,52 +25,6 @@ module VAForms
         next
       end
     end
-    # load('./modules/va_forms/app/workers/va_forms/form_reloader.rb')
-    def perform_curl
-      query = File.read(Rails.root.join('modules', 'va_forms', 'config', 'graphql_query.txt'))
-      body = { query: query }
-
-      curl_command2 = <<CURL_COMMAND
-curl -i -X POST -k -u  api:drupal8 --proxy "socks5h://host.docker.internal:2001" -d '{"query":"{\n  nodeQuery(limit: 1000, offset: 0, filter: {conditions: [{field: \"type\", value: [\"va_form\"]}]}) {\n    entities {\n      ... on NodePage {\n        fieldRelatedLinks {\n          entity {\n            parentFieldName\n          }\n        }\n      }\n      ...vaForm\n    }\n  }\n}\nfragment vaForm on NodeVaForm {\n  entityBundle\n  entityId\n  entityPublished\n  entityUrl {\n    path\n  }\n  entityTranslations {\n    entityCreated\n    entityLabel\n    entityId\n    entityChanged\n    entityBundle\n    entityType\n    entityUuid\n  }\n  entityRevisions {\n    entities {\n      entityChanged\n      ... on NodeVaForm {\n        fieldVaFormName\n      }\n    }\n  }\n  title\n  status\n  revisionLog\n  fieldVaFormDeleted\n  fieldVaFormDeletedDate {\n    value\n  }\n  langcode {\n    value\n  }\n  title\n  fieldVaFormName\n  fieldVaFormTitle\n  fieldVaFormType\n  fieldVaFormUrl {\n    uri\n  }\n  fieldVaFormUsage {\n    value\n    format\n    processed\n  }\n  fieldVaFormNumber\n  fieldVaFormToolIntro\n  fieldVaFormToolUrl {\n    uri\n    title\n    options\n  }\n  fieldBenefitCategories {\n    targetId\n    entity {\n      entityLabel\n      ... on NodeLandingPage {\n        fieldHomePageHubLabel\n      }\n    }\n  }\n  fieldVaFormRevisionDate {\n    value\n    date\n  }\n  fieldVaFormIssueDate {\n    value\n    date\n  }\n  fieldVaFormNumPages\n\n  fieldVaFormLinkTeasers {\n    entity {\n      entityLabel\n      parentFieldName\n      ... on ParagraphLinkTeaser {\n        entityId\n    \t\tfieldLink {\n          url {\n            path\n          }\n          title\n          options\n        }\n        fieldLinkSummary\n      }\n    }\n  }\n  fieldVaFormRelatedForms {\n    entity {\n      ... on NodeVaForm {\n        fieldVaFormNumber\n      }\n    }\n  }\n  changed\n  status\n}","variables":null,"operationName":null}' https://dev.cms.va.gov/graphql
-CURL_COMMAND
-      curl_command2 = curl_command2.chomp
-
-      curl_command = <<CURL_COMMAND
-curl -i -X POST -k -u  api:drupal8 --proxy "socks5h://host.docker.internal:2001" -d '#{body.to_json}' https://dev.cms.va.gov/graphql
-CURL_COMMAND
-      results, error, exit_code = nil
-      puts "starting..."
-      Open3.popen3(curl_command) {|stdin, stdout, stderr, wait_thr|
-        results = stdout.read
-        error = stderr.read
-        exit_code = wait_thr.value
-      }
-      puts "Result is:"
-      puts results[0..2000] rescue "nada"
-      results =~ /(\{\"data.*)/m
-      data = $1
-      puts 'data is:'
-      puts data
-      puts '-----------------'
-      puts "error is:"
-      puts error
-      puts '-----------------'
-      puts "exit is:"
-      puts exit_code
-      puts '-----------------'
-      #puts curl_command
-      # return
-      puts "parsing data"
-      forms_data = JSON.parse(data)
-      puts "parsing data -- dun!"
-      forms_data.dig('data', 'nodeQuery', 'entities').each do |form|
-        build_and_save_form(form)
-      rescue => e
-        puts "#{form['fieldVaFormNumber']} failed to import into forms database"
-        puts e.message
-        next
-      end
-    end
 
     def connection
       basic_auth_class = Faraday::Request::BasicAuthentication

--- a/modules/va_forms/lib/tasks/va_forms.rake
+++ b/modules/va_forms/lib/tasks/va_forms.rake
@@ -4,4 +4,9 @@ namespace :va_forms do
   task fetch_latest: :environment do
     VAForms::FormReloader.new.perform
   end
+
+  task fetch_latest_curl: :environment do
+    VAForms::FormReloader.new.perform_curl
+  end
+
 end

--- a/modules/va_forms/lib/tasks/va_forms.rake
+++ b/modules/va_forms/lib/tasks/va_forms.rake
@@ -1,12 +1,53 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace :va_forms do
+  QUERY = File.read(Rails.root.join('modules', 'va_forms', 'config', 'graphql_query.txt'))
+  SOCKS_URL = Settings.docker_debugging&.socks_url ? Settings.docker_debugging.socks_url : 'socks://localhost:2001'
+  FORMS_URL = Settings.va_forms.drupal_url
+  CURL_COMMAND = <<~CURL_COMMAND
+    curl -i -X POST -k -u  api:drupal8 --proxy "#{SOCKS_URL}" -d '#{{ query: QUERY }.to_json}' #{FORMS_URL}/graphql
+  CURL_COMMAND
+
+  # rubocop:disable Metrics/MethodLength
+  # for some strange reason within docker faraday fails over socks.
+  def fetch_all_forms
+    results, error, exit_code = nil
+    puts "starting fetch from #{FORMS_URL}..."
+    Open3.popen3(CURL_COMMAND) do |_stdin, stdout, stderr, wait_thr|
+      results = stdout.read
+      error = stderr.read
+      exit_code = wait_thr.value
+    end
+    results =~ /(\{\"data.*)/m
+    data = Regexp.last_match(1)
+    unless exit_code.success?
+      puts "Failed to fetch data from #{FORMS_URL}\n #{error}"
+      return
+    end
+    puts 'Parsing data.'
+    forms_data = JSON.parse(data)
+    puts 'Populating database, this takes time.'
+    num_rows = 0
+    forms_data.dig('data', 'nodeQuery', 'entities').each do |form|
+      VAForms::FormReloader.new.build_and_save_form(form)
+      num_rows += 1
+      puts "#{num_rows} completed" if (num_rows % 10).zero?
+    rescue => e
+      puts "#{form['fieldVaFormNumber']} failed to import into forms database"
+      puts e.message
+      next
+    end
+    puts "#{num_rows} added/updated in the database!"
+  end
+  # rubocop:enable Metrics/MethodLength
+
   task fetch_latest: :environment do
     VAForms::FormReloader.new.perform
   end
 
   task fetch_latest_curl: :environment do
-    VAForms::FormReloader.new.perform_curl
+    fetch_all_forms
   end
-
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
For those of us running within docker
This rake task
rake va_forms:fetch_latest

fails to run over socks on the host machine (Faraday bombs out).
Adding in a curl based approach for populating our forms db.

rake va_forms:fetch_latest_curl

## Original issue(s)
https://vajira.max.gov/browse/API-4088
## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
