### PR TITLE
Fix 686 Submission PDF Job

### DIFF
--- a/app/services/bgs/dependent_service.rb
+++ b/app/services/bgs/dependent_service.rb
@@ -18,10 +18,10 @@ module BGS
       BGS::SubmitForm686cJob.perform_async(@user.uuid, claim.id, vet_info.to_686c_form_hash) if claim.submittable_686?
       BGS::SubmitForm674Job.perform_async(@user.uuid, claim.id, vet_info.to_686c_form_hash) if claim.submittable_674?
       VBMS::SubmitDependentsPdfJob.perform_async(
-        saved_claim_id: claim.id,
-        va_file_number_with_payload: vet_info.to_686c_form_hash,
-        submittable_686: claim.submittable_686?,
-        submittable_674: claim.submittable_674?
+        claim.id,
+        vet_info.to_686c_form_hash,
+        claim.submittable_686?,
+        claim.submittable_674?
       )
     rescue => e
       report_error(e)

--- a/app/workers/vbms/submit_dependents_pdf_job.rb
+++ b/app/workers/vbms/submit_dependents_pdf_job.rb
@@ -7,7 +7,7 @@ module VBMS
     include SentryLogging
 
     # Generates PDF for 686c form and uploads to VBMS
-    def perform(saved_claim_id:, va_file_number_with_payload:, submittable_686:, submittable_674:)
+    def perform(saved_claim_id, va_file_number_with_payload, submittable_686, submittable_674)
       claim = SavedClaim::DependencyClaim.find(saved_claim_id)
       claim.add_veteran_info(va_file_number_with_payload)
 

--- a/spec/services/bgs/dependent_service_spec.rb
+++ b/spec/services/bgs/dependent_service_spec.rb
@@ -48,12 +48,7 @@ RSpec.describe BGS::DependentService do
         allow(claim).to receive(:submittable_686?).and_return(true)
         allow(claim).to receive(:submittable_674?).and_return(false)
 
-        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(
-          saved_claim_id: claim.id,
-          va_file_number_with_payload: vet_info,
-          submittable_686: true,
-          submittable_674: false
-        )
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(claim.id, vet_info, true, false)
 
         service.submit_686c_form(claim)
       end

--- a/spec/workers/vbms/submit_dependents_pdf_job_spec.rb
+++ b/spec/workers/vbms/submit_dependents_pdf_job_spec.rb
@@ -25,12 +25,7 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
           vet_info
         )
 
-        described_class.new.perform(
-          saved_claim_id: dependency_claim.id,
-          va_file_number_with_payload: vet_info,
-          submittable_686: true,
-          submittable_674: false
-        )
+        described_class.new.perform(dependency_claim.id, vet_info, true, false)
       end
     end
 
@@ -40,12 +35,7 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
           vet_info
         )
 
-        described_class.new.perform(
-          saved_claim_id: dependency_claim.id,
-          va_file_number_with_payload: vet_info,
-          submittable_686: false,
-          submittable_674: true
-        )
+        described_class.new.perform(dependency_claim.id, vet_info, false, true)
       end
     end
 
@@ -58,12 +48,7 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
           nil
         )
 
-        job.perform(
-          saved_claim_id: 'non-existant-claim',
-          va_file_number_with_payload: vet_info,
-          submittable_686: true,
-          submittable_674: false
-        )
+        job.perform('non-existant-claim', vet_info, true, false)
       end
 
       it 'raises an error if there is nothing in the dependents_application is empty' do
@@ -75,21 +60,11 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
         )
 
         vet_info['veteran_information'].delete('ssn')
-        job.perform(
-          saved_claim_id: invalid_dependency_claim.id,
-          va_file_number_with_payload: vet_info,
-          submittable_686: true,
-          submittable_674: false
-        )
+        job.perform(invalid_dependency_claim.id, vet_info, true, false)
       end
 
       it 'returns false' do
-        job = described_class.new.perform(
-          saved_claim_id: 'f',
-          va_file_number_with_payload: vet_info,
-          submittable_686: true,
-          submittable_674: false
-        )
+        job = described_class.new.perform('f', vet_info, true, false)
 
         expect(job).to eq(false)
       end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
During testing, it was discovered that the PDF submission job for the 686/674 was failing.  Apparently, Sidekiq does not support keyword arguments.  This PR is a fix to change the arguments so that the PDF job gets kicked off successfully.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18789

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is a tiny PR fix to change the arguments and no longer use keyword arguments.  No additional logging or settings have been added.
<!-- Please describe testing done to verify the changes or any testing planned. -->
## Testing
- [x] Local testing
- [x] Updated specs
- [x] Staging testing planned
