### PR TITLE
API-4589: Record not saving in sandbox after claim establishment through EVSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Vets API
-
+ 
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Vets API
- 
+
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -33,7 +33,7 @@ module ClaimsApi
 
     before_validation :set_md5
     after_validation :remove_encrypted_fields, on: [:update]
-    validates :md5, uniqueness: true
+    validates :md5, uniqueness: true, on: :create
 
     EVSS_CLAIM_ATTRIBUTES.each do |attribute|
       define_method attribute do

--- a/modules/claims_api/app/workers/claims_api/claim_establisher.rb
+++ b/modules/claims_api/app/workers/claims_api/claim_establisher.rb
@@ -20,7 +20,7 @@ module ClaimsApi
       response = service(auth_headers).submit_form526(form_data)
       auto_claim.evss_id = response.claim_id
       auto_claim.status = ClaimsApi::AutoEstablishedClaim::ESTABLISHED
-      auto_claim.save
+      auto_claim.save!
 
       queue_flash_updater(auth_headers, auto_claim.flashes, auto_claim_id)
       queue_special_issues_updater(auth_headers, auto_claim.special_issues, auto_claim)
@@ -61,13 +61,9 @@ module ClaimsApi
 
     def service(auth_headers)
       if Settings.claims_api.disability_claims_mock_override && !auth_headers['Mock-Override']
-        ClaimsApi::DisabilityCompensation::MockOverrideService.new(
-          auth_headers
-        )
+        ClaimsApi::DisabilityCompensation::MockOverrideService.new(auth_headers)
       else
-        EVSS::DisabilityCompensationForm::Service.new(
-          auth_headers
-        )
+        EVSS::DisabilityCompensationForm::Service.new(auth_headers)
       end
     end
 


### PR DESCRIPTION
## Description of change
After working through this, im not 100% sure why this is working correctly in production now, but it definitely is somehow.
When i run through the internals of the ClaimEstablisher job in sandbox it fails to save because of the `uniqueness` validation on the record's md5. That md5 will always be the same at that point in the logic, because it is generated from the record's `auth_headers` and `form_data` which are unchanged at that point.

Even weirder is that calling `save` once more, after the initial save fails, succeeds (all in sandbox i should reiterate). I'm not sure why this is the case...

Hopefully this change makes overall sense for this logic (and also seems to resolve sandbox as a nice side-effect). It essentially only validates the uniqueness of the md5 on create, not update. 

## Original issue(s)
https://vajira.max.gov/browse/API-4589

## Things to know about this PR
Tested manually in sandbox environment.
Existing spec tests still pass.