### PR TITLE
API-4405: Validate flash sent to BGS was successfully added to Veteran

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Vets API
-
+ 
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Vets API
- 
+
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/modules/claims_api/app/workers/claims_api/flash_updater.rb
+++ b/modules/claims_api/app/workers/claims_api/flash_updater.rb
@@ -15,14 +15,27 @@ module ClaimsApi
         # Note: Assumption that duplicate flashes are ignored when submitted
         service.add_flash(file_number: user.ssn, flash_name: flash_name)
       rescue BGS::ShareError, BGS::PublicError => e
-        if auto_claim_id.present?
-          auto_claim = ClaimsApi::AutoEstablishedClaim.find(auto_claim_id)
-          auto_claim.bgs_flash_responses = [] if auto_claim.bgs_flash_responses.blank?
-          auto_claim.bgs_flash_responses = auto_claim.bgs_flash_responses + [{ key: e.code, text: e.message }]
-          auto_claim.save
-        end
-        log_exception_to_sentry(e)
+        persist_exception(e, auto_claim_id: auto_claim_id)
       end
+
+      assigned_flashes = service.find_assigned_flashes(user.ssn)[:flashes]
+      flashes.each do |flash_name|
+        assigned_flash = assigned_flashes.find { |af| af[:flash_name] == flash_name }
+        if assigned_flash.blank?
+          e = StandardError.new("Failed to assign '#{flash_name}' to Veteran")
+          persist_exception(e, auto_claim_id: auto_claim_id, message: { text: e.message })
+        end
+      end
+    end
+
+    def persist_exception(e, auto_claim_id: nil, message: { key: e.code, text: e.message })
+      if auto_claim_id.present?
+        auto_claim = ClaimsApi::AutoEstablishedClaim.find(auto_claim_id)
+        auto_claim.bgs_flash_responses = [] if auto_claim.bgs_flash_responses.blank?
+        auto_claim.bgs_flash_responses = auto_claim.bgs_flash_responses + [message]
+        auto_claim.save
+      end
+      log_exception_to_sentry(e)
     end
 
     def bgs_service(user)

--- a/modules/claims_api/spec/workers/flash_updater_spec.rb
+++ b/modules/claims_api/spec/workers/flash_updater_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe ClaimsApi::FlashUpdater, type: :job do
   let(:user) { FactoryBot.create(:evss_user, :loa3) }
   let(:flashes) { %w[Homeless POW] }
   let(:claim) { create(:auto_established_claim) }
+  let(:assigned_flashes) do
+    { flashes: flashes.map { |flash| { assigned_indicator: nil, flash_name: flash, flash_type: nil } } }
+  end
 
   it 'submits successfully without claim id' do
     expect do
@@ -30,6 +33,8 @@ RSpec.describe ClaimsApi::FlashUpdater, type: :job do
       expect_any_instance_of(BGS::ClaimantWebService)
         .to receive(:add_flash).with(file_number: user.ssn, flash_name: flash_name)
     end
+    expect_any_instance_of(BGS::ClaimantWebService)
+      .to receive(:find_assigned_flashes).with(user.ssn).and_return(assigned_flashes)
 
     subject.new.perform(user, flashes)
   end
@@ -44,6 +49,8 @@ RSpec.describe ClaimsApi::FlashUpdater, type: :job do
           .to receive(:add_flash).with(file_number: user.ssn, flash_name: flash_name)
       end
     end
+    expect_any_instance_of(BGS::ClaimantWebService)
+      .to receive(:find_assigned_flashes).with(user.ssn).and_return(assigned_flashes)
 
     subject.new.perform(user, flashes, auto_claim_id: claim.id)
   end
@@ -53,6 +60,8 @@ RSpec.describe ClaimsApi::FlashUpdater, type: :job do
       expect_any_instance_of(BGS::ClaimantWebService).to receive(:add_flash)
         .with(file_number: user.ssn, flash_name: flash_name).and_raise(BGS::ShareError.new('failed', 500))
     end
+    expect_any_instance_of(BGS::ClaimantWebService)
+      .to receive(:find_assigned_flashes).with(user.ssn).and_return(assigned_flashes)
 
     subject.new.perform(user, flashes, auto_claim_id: claim.id)
     expect(ClaimsApi::AutoEstablishedClaim.find(claim.id).bgs_flash_responses.count).to eq(flashes.count)

--- a/modules/claims_api/spec/workers/flash_updater_spec.rb
+++ b/modules/claims_api/spec/workers/flash_updater_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe ClaimsApi::FlashUpdater, type: :job do
         .with(file_number: user.ssn, flash_name: flash_name).and_raise(BGS::ShareError.new('failed', 500))
     end
     expect_any_instance_of(BGS::ClaimantWebService)
-      .to receive(:find_assigned_flashes).with(user.ssn).and_return(assigned_flashes)
+      .to receive(:find_assigned_flashes).with(user.ssn).and_return({ flashes: [] })
 
     subject.new.perform(user, flashes, auto_claim_id: claim.id)
-    expect(ClaimsApi::AutoEstablishedClaim.find(claim.id).bgs_flash_responses.count).to eq(flashes.count)
+    expect(ClaimsApi::AutoEstablishedClaim.find(claim.id).bgs_flash_responses.count).to eq(flashes.count * 2)
   end
 end


### PR DESCRIPTION
## Description of change
Calls BGS after adding all flashes to a Veteran and verifies flashes have been added successfully.
Stores a message in the bgs_flash_responses if a flash the job was supposed to add is not found to be assigned to the Veteran.

## Original issue(s)
https://vajira.max.gov/browse/API-4405

## Things to know about this PR
Existing and new specs
