### PR TITLE
API-4615 Add environment to report email

### DIFF
--- a/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
+++ b/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
@@ -12,7 +12,7 @@ module AppealsApi
 
       mail(
         to: Settings.modules_appeals_api.report_recipients,
-        subject: 'Decision Review API report',
+        subject: "Decision Review API report (#{Rails.env.titleize})",
         content_type: 'text/html',
         body: body
       )

--- a/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
+++ b/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
@@ -40,7 +40,7 @@
   </head>
 
   <body>
-    <h1>Decision Review Report from <%= @report.from %> -- <%= @report.to %> </h1>
+    <h1><%= Rails.env.titleize %> Decision Review Report from <%= @report.from %> -- <%= @report.to %> </h1>
 
     <h2><span class="title">HLR submissions by status and count</span></h2>
     <table>

--- a/modules/appeals_api/spec/mailers/decision_review_report_mailer_spec.rb
+++ b/modules/appeals_api/spec/mailers/decision_review_report_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AppealsApi::DecisionReviewMailer, type: [:mailer] do
     end
 
     it 'sends the email' do
-      expect(subject.subject).to eq('Decision Review API report')
+      expect(subject.subject).to eq('Decision Review API report (Test)')
     end
 
     it 'sends to the right people' do

--- a/spec/mailers/previews/appeals_api_decision_review_preview.rb
+++ b/spec/mailers/previews/appeals_api_decision_review_preview.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AppealsApiDecisionReviewPreview < ActionMailer::Preview
-  # Preview this email at http://localhost:3000/rails/mailers/appeals_api/decision_review/report
+  # Preview this email at http://localhost:3000/rails/mailers/appeals_api_decision_review
   def build
     to = Time.zone.now
     from = Time.at(0).utc


### PR DESCRIPTION
## Description of change
Adds environment name to the reporting email in both the email subject & body.

## Original issue(s)
https://vajira.max.gov/browse/API-4615