### PR TITLE
Add feature flag to hide Sign-in button for Covid Vaccine app

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -34,6 +34,11 @@ features:
     actor_type: user
     description: >
       Toggles the availability of the call-to-action prompt (cta) on "va.gov/health-care/covid-19-vaccine/" leading to the frontend form on va.gov for the covid-19 vaccine sign-up
+  covid_vaccine_registration_frontend_hide_auth:
+    actor_type: user
+    description: >
+      Toggles the availability of the sign-in button on the covid-19 vaccine sign-up form on va.gov. 
+      Note: When this is enabled, the 'Sign in' button will be hidden
   covid_vaccine_registration:
     actor_type: user
     description: >
@@ -373,7 +378,7 @@ features:
     actor_type: user
     enable_in_development: true
     description: >
-       Update OMB # and expiration dates for forms   
+      Update OMB # and expiration dates for forms
   in_progress_form_custom_expiration:
     actor_type: user
     enable_in_development: true
@@ -388,4 +393,4 @@ features:
     actor_type: user
     enable_in_development: true
     description: >
-       Include state abbreviation when searching on comparison tool 
+      Include state abbreviation when searching on comparison tool


### PR DESCRIPTION
## Description of change
This PR just adds a feature flag for the Covid Vaccine app that allows the sign-in button to be hidden.
Related vets-website PR: https://github.com/department-of-veterans-affairs/vets-website/pull/15758


## Things to know about this PR
Not much more to add.  

<!-- Please describe testing done to verify the changes or any testing planned. -->
I have tested the feature flag functionality locally, and implemented a Cypress test for the FE 