### PR TITLE
API-4400 Remove participant ID from responses for Claims Endpoints

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -153,7 +153,7 @@ module ClaimsApi
       vet.mpi_record?
       vet.gender = header('X-VA-Gender') || vet.mpi.profile&.gender if with_gender
       vet.edipi = header('X-VA-EDIPI') || vet.mpi.profile&.edipi
-      vet.participant_id = header('X-VA-PID') || vet.mpi.profile&.participant_id
+      vet.participant_id = vet.mpi.profile&.participant_id
       vet
     end
 

--- a/modules/claims_api/app/models/claims_api/power_of_attorney.rb
+++ b/modules/claims_api/app/models/claims_api/power_of_attorney.rb
@@ -98,11 +98,7 @@ module ClaimsApi
     end
 
     def representative
-      form_data.merge(participant_id: nil)
-    end
-
-    def veteran
-      { participant_id: nil }
+      form_data
     end
 
     def previous_poa

--- a/modules/claims_api/app/serializers/claims_api/power_of_attorney_serializer.rb
+++ b/modules/claims_api/app/serializers/claims_api/power_of_attorney_serializer.rb
@@ -2,6 +2,6 @@
 
 module ClaimsApi
   class PowerOfAttorneySerializer < ActiveModel::Serializer
-    attributes :status, :date_request_accepted, :representative, :veteran, :previous_poa
+    attributes :status, :date_request_accepted, :representative, :previous_poa
   end
 end

--- a/modules/claims_api/app/swagger/claims_api/forms/form_2122_response_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_2122_response_swagger.rb
@@ -312,7 +312,6 @@ with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as
                 key :example, 'Doe'
                 key :description, 'Power of Attorney representative last name submitted for Veteran'
               end
-
             end
 
             property :previous_poa do

--- a/modules/claims_api/app/swagger/claims_api/forms/form_2122_response_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_2122_response_swagger.rb
@@ -313,22 +313,6 @@ with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as
                 key :description, 'Power of Attorney representative last name submitted for Veteran'
               end
 
-              property :participant_id do
-                key :type, :string
-                key :example, '987654'
-                key :description, 'Participant ID for veteran representative'
-              end
-            end
-
-            property :veteran do
-              key :type, :object
-              key :description, 'Information about Veteran'
-
-              property :participant_id do
-                key :type, :string
-                key :example, '14567'
-                key :description, 'Participant ID for veteran'
-              end
             end
 
             property :previous_poa do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->
Removes Participant ID from any public facing responses. We don't currently require it, and all the lookups for it are internal, so there's no need to expose it at this time

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
https://vajira.max.gov/browse/API-4400

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
