### PR TITLE
Add missing method - fixes failing specs

### DIFF
--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v1/structure.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v1/structure.rb
@@ -84,6 +84,10 @@ module AppealsApi
           @additional_pages_pdf
         end
 
+        def final_page_adjustments
+          # no-op
+        end
+
         def form_title
           '200996'
         end


### PR DESCRIPTION
## Description of change
Adds missing `final_page_adjustments` method to the HLR PDF Structure

## Analysis
PRs #5703 and #5754 were created separately and each had passed CI and review.

#5730 added the `final_page_adjustment` method but #5754 was not aware of the need to include it in its own code. Had tests been re-run between merging either PR, the issue would have been caught. Since both were already green, however, they were merged in and caused the issue after the fact.

Luckily the timing worked in our favor and #5754 was merged after the final deploy time on Fri, Jan 21 so won't cause issues on production over the weekend.