### PR TITLE
API-4568: Don't replace GUID with EVSS Claim ID

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -46,10 +46,13 @@ module ClaimsApi
 
       if claim && claim.status == 'errored'
         fetch_errored(claim)
-      elsif claim && claim.evss_id.nil?
+      elsif claim && claim.evss_id.blank?
         render json: claim, serializer: ClaimsApi::AutoEstablishedClaimSerializer
+      elsif claim && claim.evss_id.present?
+        evss_claim = claims_service.update_from_remote(claim.evss_id)
+        render json: evss_claim, serializer: ClaimsApi::ClaimDetailSerializer, uuid: claim.id
       elsif /^\d{2,20}$/.match?(params[:id])
-        evss_claim = claims_service.update_from_remote(claim.try(:evss_id) || params[:id])
+        evss_claim = claims_service.update_from_remote(params[:id])
         # Note: source doesn't seem to be accessible within a remote evss_claim
         render json: evss_claim, serializer: ClaimsApi::ClaimDetailSerializer
       else

--- a/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/disability_compensation_controller.rb
@@ -70,7 +70,7 @@ module ClaimsApi
             ClaimsApi::ClaimUploader.perform_async(claim_document.id)
           end
 
-          render json: claim, serializer: ClaimsApi::ClaimDetailSerializer
+          render json: claim, serializer: ClaimsApi::ClaimDetailSerializer, uuid: claim.id
         end
 
         def validate_form_526

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -75,7 +75,7 @@ module ClaimsApi
             ClaimsApi::ClaimUploader.perform_async(claim_document.id)
           end
 
-          render json: @claim, serializer: ClaimsApi::ClaimDetailSerializer
+          render json: @claim, serializer: ClaimsApi::ClaimDetailSerializer, uuid: claim.id
         end
 
         def validate_form_526

--- a/modules/claims_api/app/serializers/claims_api/auto_established_claim_serializer.rb
+++ b/modules/claims_api/app/serializers/claims_api/auto_established_claim_serializer.rb
@@ -7,7 +7,7 @@ module ClaimsApi
     type :claims_api_claim
 
     def id
-      object&.evss_id || object&.id
+      object&.id
     end
   end
 end

--- a/modules/claims_api/app/serializers/claims_api/claim_detail_serializer.rb
+++ b/modules/claims_api/app/serializers/claims_api/claim_detail_serializer.rb
@@ -8,6 +8,10 @@ module ClaimsApi
     attribute :supporting_documents
     type :claims_api_claim
 
+    def id
+      @instance_options[:uuid] || object&.evss_id
+    end
+
     def supporting_documents
       object.supporting_documents.map do |document|
         {

--- a/modules/claims_api/spec/requests/v1/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/claims_request_spec.rb
@@ -73,37 +73,61 @@ RSpec.describe 'EVSS Claims management', type: :request do
     end
 
     context 'when source matches' do
-      it 'shows a single Claim through auto established claims', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
-        with_okta_user(scopes) do |auth_header|
-          create(:auto_established_claim,
-                 source: 'abraham lincoln',
-                 auth_headers: { some: 'data' },
-                 evss_id: 600_118_851,
-                 id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
-          VCR.use_cassette('evss/claims/claim') do
-            get(
-              '/services/claims/v1/claims/600118851',
-              params: nil, headers: request_headers.merge(auth_header)
-            )
-            expect(response).to match_response_schema('claims_api/claim')
+      context 'when evss_id is provided' do
+        it 'shows a single Claim through auto established claims', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+          with_okta_user(scopes) do |auth_header|
+            create(:auto_established_claim,
+                   source: 'abraham lincoln',
+                   auth_headers: { some: 'data' },
+                   evss_id: 600_118_851,
+                   id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
+            VCR.use_cassette('evss/claims/claim') do
+              get(
+                '/services/claims/v1/claims/600118851',
+                params: nil, headers: request_headers.merge(auth_header)
+              )
+              expect(response).to match_response_schema('claims_api/claim')
+              expect(JSON.parse(response.body)['data']['id']).to eq('600118851')
+            end
+          end
+        end
+
+        it 'shows a single Claim through auto established claims when camel-inflected',
+           run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+          with_okta_user(scopes) do |auth_header|
+            create(:auto_established_claim,
+                   source: 'abraham lincoln',
+                   auth_headers: { some: 'data' },
+                   evss_id: 600_118_851,
+                   id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
+            VCR.use_cassette('evss/claims/claim') do
+              get(
+                '/services/claims/v1/claims/600118851',
+                params: nil, headers: request_headers_camel.merge(auth_header)
+              )
+              expect(response).to match_camelized_response_schema('claims_api/claim')
+              expect(JSON.parse(response.body)['data']['id']).to eq('600118851')
+            end
           end
         end
       end
 
-      it 'shows a single Claim through auto established claims when camel-inflected',
-         run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
-        with_okta_user(scopes) do |auth_header|
-          create(:auto_established_claim,
-                 source: 'abraham lincoln',
-                 auth_headers: { some: 'data' },
-                 evss_id: 600_118_851,
-                 id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
-          VCR.use_cassette('evss/claims/claim') do
-            get(
-              '/services/claims/v1/claims/600118851',
-              params: nil, headers: request_headers_camel.merge(auth_header)
-            )
-            expect(response).to match_camelized_response_schema('claims_api/claim')
+      context 'when uuid is provided' do
+        it 'shows a single Claim through auto established claims', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+          with_okta_user(scopes) do |auth_header|
+            create(:auto_established_claim,
+                   source: 'abraham lincoln',
+                   auth_headers: { some: 'data' },
+                   evss_id: 600_118_851,
+                   id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
+            VCR.use_cassette('evss/claims/claim') do
+              get(
+                '/services/claims/v1/claims/d5536c5c-0465-4038-a368-1a9d9daf65c9',
+                params: nil, headers: request_headers.merge(auth_header)
+              )
+              expect(response).to match_response_schema('claims_api/claim')
+              expect(JSON.parse(response.body)['data']['id']).to eq('d5536c5c-0465-4038-a368-1a9d9daf65c9')
+            end
           end
         end
       end


### PR DESCRIPTION
## Description of change
Always return our database uuid for the id value in every claim response.
The only time the evss_id will be used is if the user provides an evss_id (in the case where the particular claim may not have been submitted through our api).

## Original issue(s)
https://vajira.max.gov/browse/API-4568

## Things to know about this PR
Tested locally.
Updated and add specs.