### PR TITLE
Cleanup after moving to lighthouse PGD

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -637,6 +637,7 @@ hqva_mobile:
   timeout: 15
   lighthouse:
     url: "https://sandbox-api.va.gov"
+    pgd_path: "/services/pgd/v0/r4"
     host: "sandbox-api.va.gov"
     aud_claim_url: "https://deptva-eval.okta.com/oauth2/aus8x27nv4g4BS01v2p7"
     claim_common_id: "0oa9gvwf5mvxcX3zH2p7"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -101,6 +101,7 @@ hqva_mobile:
   timeout: 15
   lighthouse:
     url: "https://sandbox-api.va.gov"
+    pgd_path: "/services/pgd/v0/r4"
     host: "sandbox-api.va.gov"
     aud_claim_url: "https://deptva-eval.okta.com/oauth2/aus8x27nv4g4BS01v2p7"
     claim_common_id: "0oa9gvwf5mvxcX3zH2p7"

--- a/modules/health_quest/app/services/health_quest/lighthouse/token.rb
+++ b/modules/health_quest/app/services/health_quest/lighthouse/token.rb
@@ -78,7 +78,7 @@ module HealthQuest
           grant_type: 'client_credentials',
           client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
           client_assertion: claims_token,
-          scope: 'launch/patient patient/Patient.read',
+          scope: 'launch/patient patient/Patient.read patient/Questionnaire.read patient/QuestionnaireResponse.read',
           launch: user&.icn
         }
 

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/fhir_client.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/fhir_client.rb
@@ -4,23 +4,25 @@ module HealthQuest
   module PatientGeneratedData
     module FHIRClient
       def url
-        "#{Settings.hqva_mobile.lighthouse.url}/smart-pgd-fhir/v1"
+        "#{lighthouse.url}#{lighthouse.pgd_path}"
       end
 
       def client
         FHIR::Client.new(url).tap do |client|
           client.use_r4
           client.default_json
-          client.additional_headers = headers&.merge(accept_headers)
+          client.additional_headers = headers
         end
-      end
-
-      def accept_headers
-        { 'Accept' => 'application/json+fhir' }
       end
 
       def headers
         raise NotImplementedError "#{self.class} should have implemented headers ..."
+      end
+
+      private
+
+      def lighthouse
+        Settings.hqva_mobile.lighthouse
       end
     end
   end

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/fhir_headers.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/fhir_headers.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module PatientGeneratedData
+    module FHIRHeaders
+      def auth_header
+        {
+          'Authorization' => "Bearer #{access_token}"
+        }
+      end
+
+      def content_type_header
+        {
+          'Content-Type' => 'application/fhir+json'
+        }
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/patient/factory.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/patient/factory.rb
@@ -7,7 +7,7 @@ module HealthQuest
       # A service object for isolating dependencies from any implementing service or controller.
       #
       # @!attribute session_service
-      #   @return [HealthQuest::SessionService]
+      #   @return [HealthQuest::Lighthouse::Session]
       # @!attribute user
       #   @return [User]
       # @!attribute map_query
@@ -27,8 +27,8 @@ module HealthQuest
 
         def initialize(user)
           @user = user
-          @session_service = HealthQuest::SessionService.new(user)
-          @map_query = PatientGeneratedData::Patient::MapQuery.build(session_service.headers)
+          @session_service = HealthQuest::Lighthouse::Session.build(user)
+          @map_query = PatientGeneratedData::Patient::MapQuery.build(session_service.retrieve)
         end
 
         ##

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/patient/map_query.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/patient/map_query.rb
@@ -6,25 +6,29 @@ module HealthQuest
       ##
       # A service object for querying the PGD for Patient resources.
       #
+      # @!attribute access_token
+      #   @return [String]
       # @!attribute headers
       #   @return [Hash]
       class MapQuery
         include PatientGeneratedData::FHIRClient
+        include PatientGeneratedData::FHIRHeaders
 
-        attr_reader :headers
+        attr_reader :access_token, :headers
 
         ##
-        # Builds a PatientGeneratedData::Patient::MapQuery instance from a given hash of headers.
+        # Builds a PatientGeneratedData::Patient::MapQuery instance from a redis session.
         #
-        # @param headers [Hash] the set of headers.
+        # @param session_store [HealthQuest::SessionStore] the users redis session.
         # @return [PatientGeneratedData::Patient::MapQuery] an instance of this class
         #
-        def self.build(headers)
-          new(headers)
+        def self.build(session_store)
+          new(session_store)
         end
 
-        def initialize(headers)
-          @headers = headers
+        def initialize(session_store)
+          @access_token = session_store.token
+          @headers = auth_header
         end
 
         ##
@@ -44,8 +48,9 @@ module HealthQuest
         # @return [FHIR::Patient::ClientReply] an instance of ClientReply
         #
         def create(user)
-          patient = Resource.manufacture(user).prepare
+          headers.merge!(content_type_header)
 
+          patient = Resource.manufacture(user).prepare
           client.create(patient)
         end
 

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/factory.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/factory.rb
@@ -9,7 +9,7 @@ module HealthQuest
       # A service object for isolating dependencies from the questionnaire controller.
       #
       # @!attribute session_service
-      #   @return [HealthQuest::SessionService]
+      #   @return [HealthQuest::Lighthouse::Session]
       # @!attribute user
       #   @return [User]
       # @!attribute map_query
@@ -31,8 +31,8 @@ module HealthQuest
 
         def initialize(user)
           @user = user
-          @session_service = HealthQuest::SessionService.new(user)
-          @map_query = PatientGeneratedData::Questionnaire::MapQuery.build(session_service.headers)
+          @session_service = HealthQuest::Lighthouse::Session.build(user)
+          @map_query = PatientGeneratedData::Questionnaire::MapQuery.build(session_service.retrieve)
           @options_builder = OptionsBuilder
         end
 

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/map_query.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/map_query.rb
@@ -6,25 +6,29 @@ module HealthQuest
       ##
       # A service object for querying the PGD for Questionnaire Response resources.
       #
+      # @!attribute access_token
+      #   @return [String]
       # @!attribute headers
       #   @return [Hash]
       class MapQuery
         include PatientGeneratedData::FHIRClient
+        include PatientGeneratedData::FHIRHeaders
 
-        attr_reader :headers
+        attr_reader :access_token, :headers
 
         ##
-        # Builds a PatientGeneratedData::Questionnaire::MapQuery instance from a given hash of headers.
+        # Builds a PatientGeneratedData::Questionnaire::MapQuery instance from a redis session.
         #
-        # @param headers [Hash] the set of headers.
+        # @param session_store [HealthQuest::SessionStore] the users redis session.
         # @return [PatientGeneratedData::Questionnaire::MapQuery] an instance of this class
         #
-        def self.build(headers)
-          new(headers)
+        def self.build(session_store)
+          new(session_store)
         end
 
-        def initialize(headers)
-          @headers = headers
+        def initialize(session_store)
+          @access_token = session_store.token
+          @headers = auth_header
         end
 
         ##

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/factory.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/factory.rb
@@ -7,7 +7,7 @@ module HealthQuest
       # A service object for isolating dependencies from the questionnaire_responses controller.
       #
       # @!attribute session_service
-      #   @return [HealthQuest::SessionService]
+      #   @return [HealthQuest::Lighthouse::Session]
       # @!attribute user
       #   @return [User]
       # @!attribute map_query
@@ -29,8 +29,8 @@ module HealthQuest
 
         def initialize(user)
           @user = user
-          @session_service = HealthQuest::SessionService.new(user)
-          @map_query = PatientGeneratedData::QuestionnaireResponse::MapQuery.build(session_service.headers)
+          @session_service = HealthQuest::Lighthouse::Session.build(user)
+          @map_query = PatientGeneratedData::QuestionnaireResponse::MapQuery.build(session_service.retrieve)
           @options_builder = OptionsBuilder
         end
 
@@ -63,9 +63,7 @@ module HealthQuest
         # @return [FHIR::Patient::ClientReply] an instance of ClientReply
         #
         def create(data)
-          questionnaire_response = Resource.manufacture(data, user).prepare
-
-          map_query.create(questionnaire_response)
+          map_query.create(data, user)
         end
       end
     end

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/map_query.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/map_query.rb
@@ -6,25 +6,29 @@ module HealthQuest
       ##
       # A service object for querying the PGD for Questionnaire Response resources.
       #
+      # @!attribute access_token
+      #   @return [String]
       # @!attribute headers
       #   @return [Hash]
       class MapQuery
         include PatientGeneratedData::FHIRClient
+        include PatientGeneratedData::FHIRHeaders
 
-        attr_reader :headers
+        attr_reader :access_token, :headers
 
         ##
-        # Builds a PatientGeneratedData::QuestionnaireResponse::MapQuery instance from a given hash of headers.
+        # Builds a PatientGeneratedData::QuestionnaireResponse::MapQuery instance from a redis session.
         #
-        # @param headers [Hash] the set of headers.
+        # @param session_store [HealthQuest::SessionStore] the users redis session.
         # @return [PatientGeneratedData::QuestionnaireResponse::MapQuery] an instance of this class
         #
-        def self.build(headers)
-          new(headers)
+        def self.build(session_store)
+          new(session_store)
         end
 
-        def initialize(headers)
-          @headers = headers
+        def initialize(session_store)
+          @access_token = session_store.token
+          @headers = auth_header
         end
 
         ##
@@ -51,10 +55,14 @@ module HealthQuest
         # Create a QuestionnaireResponse resource from the logged in user.
         #
         # @param data [Hash] questionnaire answers and appointment data hash.
+        # @param user [User] the current user.
         # @return [FHIR::Patient::ClientReply] an instance of ClientReply
         #
-        def create(data) # rubocop:disable Rails/Delegate
-          client.create(data)
+        def create(data, user)
+          headers.merge!(content_type_header)
+
+          questionnaire_response = Resource.manufacture(data, user).prepare
+          client.create(questionnaire_response)
         end
 
         ##

--- a/modules/health_quest/spec/request/patients_request_spec.rb
+++ b/modules/health_quest/spec/request/patients_request_spec.rb
@@ -28,15 +28,14 @@ RSpec.describe 'health_quest patients', type: :request do
 
     context 'health quest user' do
       let(:current_user) { build(:user, :health_quest) }
-      let(:headers) { { 'Accept' => 'application/json+fhir' } }
-      let(:session_service) { double('HealthQuest::SessionService', user: current_user, headers: headers) }
+      let(:session_store) { double('SessionStore', token: '123abc') }
       let(:client_reply) do
         double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Patient' } })
       end
 
       before do
         sign_in_as(current_user)
-        allow(HealthQuest::SessionService).to receive(:new).with(anything).and_return(session_service)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
         allow_any_instance_of(HealthQuest::PatientGeneratedData::Patient::MapQuery)
           .to receive(:get).with(anything).and_return(client_reply)
       end
@@ -72,15 +71,14 @@ RSpec.describe 'health_quest patients', type: :request do
 
     context 'health quest user' do
       let(:current_user) { build(:user, :health_quest) }
-      let(:headers) { { 'Accept' => 'application/json+fhir' } }
-      let(:session_service) { double('HealthQuest::SessionService', user: current_user, headers: headers) }
+      let(:session_store) { double('SessionStore', token: '123abc') }
       let(:client_reply) do
         double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Patient' } })
       end
 
       before do
         sign_in_as(current_user)
-        allow(HealthQuest::SessionService).to receive(:new).with(anything).and_return(session_service)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
         allow_any_instance_of(HealthQuest::PatientGeneratedData::Patient::MapQuery)
           .to receive(:create).with(anything).and_return(client_reply)
       end

--- a/modules/health_quest/spec/request/questionnaire_responses_request_spec.rb
+++ b/modules/health_quest/spec/request/questionnaire_responses_request_spec.rb
@@ -29,16 +29,15 @@ RSpec.describe 'health_quest questionnaire_responses', type: :request do
 
     context 'health quest user' do
       let(:current_user) { build(:user, :health_quest) }
-      let(:headers) { { 'Accept' => 'application/json+fhir' } }
       let(:id) { 'faae134c-9c7b-49d7-8161-10e314da4de1' }
-      let(:session_service) { double('HealthQuest::SessionService', user: current_user, headers: headers) }
+      let(:session_store) { double('SessionStore', token: '123abc') }
       let(:client_reply) do
         double('FHIR::ClientReply', response: { body: { 'resourceType' => 'QuestionnaireResponse' } })
       end
 
       before do
         sign_in_as(current_user)
-        allow(HealthQuest::SessionService).to receive(:new).with(anything).and_return(session_service)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
         allow_any_instance_of(HealthQuest::PatientGeneratedData::QuestionnaireResponse::MapQuery)
           .to receive(:get).with(anything).and_return(client_reply)
       end
@@ -74,13 +73,12 @@ RSpec.describe 'health_quest questionnaire_responses', type: :request do
 
     context 'health quest user' do
       let(:current_user) { build(:user, :health_quest) }
-      let(:headers) { { 'Accept' => 'application/json+fhir' } }
-      let(:session_service) { double('HealthQuest::SessionService', user: current_user, headers: headers) }
+      let(:session_store) { double('SessionStore', token: '123abc') }
       let(:client_reply) { double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Bundle' } }) }
 
       before do
         sign_in_as(current_user)
-        allow(HealthQuest::SessionService).to receive(:new).with(anything).and_return(session_service)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
         allow_any_instance_of(HealthQuest::PatientGeneratedData::QuestionnaireResponse::MapQuery)
           .to receive(:search).with(anything).and_return(client_reply)
       end

--- a/modules/health_quest/spec/request/questionnaires_request_spec.rb
+++ b/modules/health_quest/spec/request/questionnaires_request_spec.rb
@@ -29,16 +29,15 @@ RSpec.describe 'health_quest questionnaires', type: :request do
 
     context 'health quest user' do
       let(:current_user) { build(:user, :health_quest) }
-      let(:headers) { { 'Accept' => 'application/json+fhir' } }
       let(:id) { 'faae134c-9c7b-49d7-8161-10e314da4de1' }
-      let(:session_service) { double('HealthQuest::SessionService', user: current_user, headers: headers) }
+      let(:session_store) { double('SessionStore', token: '123abc') }
       let(:client_reply) do
         double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Questionnaire' } })
       end
 
       before do
         sign_in_as(current_user)
-        allow(HealthQuest::SessionService).to receive(:new).with(anything).and_return(session_service)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
         allow_any_instance_of(HealthQuest::PatientGeneratedData::Questionnaire::MapQuery)
           .to receive(:get).with(anything).and_return(client_reply)
       end
@@ -74,13 +73,12 @@ RSpec.describe 'health_quest questionnaires', type: :request do
 
     context 'health quest user' do
       let(:current_user) { build(:user, :health_quest) }
-      let(:headers) { { 'Accept' => 'application/json+fhir' } }
-      let(:session_service) { double('HealthQuest::SessionService', user: current_user, headers: headers) }
+      let(:session_store) { double('SessionStore', token: '123abc') }
       let(:client_reply) { double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Bundle' } }) }
 
       before do
         sign_in_as(current_user)
-        allow(HealthQuest::SessionService).to receive(:new).with(anything).and_return(session_service)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
         allow_any_instance_of(HealthQuest::PatientGeneratedData::Questionnaire::MapQuery)
           .to receive(:search).with(anything).and_return(client_reply)
       end

--- a/modules/health_quest/spec/services/patient_generated_data/fhir_client_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/fhir_client_spec.rb
@@ -5,12 +5,6 @@ require 'rails_helper'
 describe HealthQuest::PatientGeneratedData::FHIRClient do
   include HealthQuest::PatientGeneratedData::FHIRClient
 
-  describe '#accept_headers' do
-    it 'has default Accept header' do
-      expect(accept_headers).to eq({ 'Accept' => 'application/json+fhir' })
-    end
-  end
-
   describe '#headers' do
     it 'raises NotImplementedError' do
       expect { headers }.to raise_error(NoMethodError, /NotImplementedError/)
@@ -27,7 +21,7 @@ describe HealthQuest::PatientGeneratedData::FHIRClient do
 
   describe '#url' do
     it 'has a pgd path' do
-      expect(url).to match('/smart-pgd-fhir/v1')
+      expect(url).to match(Settings.hqva_mobile.lighthouse.pgd_path)
     end
   end
 end

--- a/modules/health_quest/spec/services/patient_generated_data/fhir_headers_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/fhir_headers_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::PatientGeneratedData::FHIRHeaders do
+  include HealthQuest::PatientGeneratedData::FHIRHeaders
+
+  describe '#auth_header' do
+    let(:access_token) { '123abc' }
+
+    it 'has an auth_header key/val' do
+      expect(auth_header).to eq({ 'Authorization' => 'Bearer 123abc' })
+    end
+  end
+
+  describe '#content_type_header' do
+    it 'has a content_type_header key/val' do
+      expect(content_type_header).to eq({ 'Content-Type' => 'application/fhir+json' })
+    end
+  end
+end

--- a/modules/health_quest/spec/services/patient_generated_data/patient/factory_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/patient/factory_spec.rb
@@ -5,32 +5,30 @@ require 'rails_helper'
 describe HealthQuest::PatientGeneratedData::Patient::Factory do
   subject { described_class }
 
-  let(:headers) { { 'Accept' => 'application/json+fhir' } }
   let(:user) { double('User', icn: '1008596379V859838') }
-  let(:session_service) { double('HealthQuest::SessionService', use: user, headers: headers) }
+  let(:session_store) { double('SessionStore', token: '123abc') }
+  let(:session_service) { double('HealthQuest::Lighthouse::Session', user: user, retrieve: session_store) }
   let(:client_reply) { double('FHIR::ClientReply') }
 
-  describe '#get_patient' do
-    before do
-      allow(HealthQuest::SessionService).to receive(:new).with(user).and_return(session_service)
+  before do
+    allow(HealthQuest::Lighthouse::Session).to receive(:build).with(user).and_return(session_service)
+  end
+
+  describe '#get' do
+    it 'returns a ClientReply' do
+      allow_any_instance_of(HealthQuest::PatientGeneratedData::Patient::MapQuery)
+        .to receive(:get).with(user.icn).and_return(client_reply)
+
+      expect(subject.new(user).get).to eq(client_reply)
     end
+  end
 
-    describe '#get' do
-      it 'returns a ClientReply' do
-        allow_any_instance_of(HealthQuest::PatientGeneratedData::Patient::MapQuery)
-          .to receive(:get).with(user.icn).and_return(client_reply)
+  describe '#create' do
+    it 'returns a ClientReply' do
+      allow_any_instance_of(HealthQuest::PatientGeneratedData::Patient::MapQuery)
+        .to receive(:create).with(user).and_return(client_reply)
 
-        expect(subject.new(user).get).to eq(client_reply)
-      end
-    end
-
-    describe '#create' do
-      it 'returns a ClientReply' do
-        allow_any_instance_of(HealthQuest::PatientGeneratedData::Patient::MapQuery)
-          .to receive(:create).with(user).and_return(client_reply)
-
-        expect(subject.new(user).create).to eq(client_reply)
-      end
+      expect(subject.new(user).create).to eq(client_reply)
     end
   end
 end

--- a/modules/health_quest/spec/services/patient_generated_data/patient/map_query_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/patient/map_query_spec.rb
@@ -5,29 +5,33 @@ require 'rails_helper'
 describe HealthQuest::PatientGeneratedData::Patient::MapQuery do
   subject { described_class }
 
-  let(:headers) { { 'Accept' => 'application/json+fhir' } }
+  let(:session_store) { double('SessionStore', token: '123abc') }
 
   describe 'included modules' do
     it 'includes PatientGeneratedData::FHIRClient' do
       expect(subject.ancestors).to include(HealthQuest::PatientGeneratedData::FHIRClient)
     end
+
+    it 'includes PatientGeneratedData::FHIRHeaders' do
+      expect(subject.ancestors).to include(HealthQuest::PatientGeneratedData::FHIRHeaders)
+    end
   end
 
   describe '.build' do
     it 'returns an instance of MapQuery' do
-      expect(subject.build(headers)).to be_an_instance_of(subject)
+      expect(subject.build(session_store)).to be_an_instance_of(subject)
     end
   end
 
   describe 'object initialization' do
     it 'has a headers attribute' do
-      expect(subject.new({}).respond_to?(:headers)).to eq(true)
+      expect(subject.new(session_store).respond_to?(:headers)).to eq(true)
     end
   end
 
   describe '#fhir_model' do
     it 'is a FHIR::Patient class' do
-      expect(subject.new({}).fhir_model).to eq(FHIR::Patient)
+      expect(subject.new(session_store).fhir_model).to eq(FHIR::Patient)
     end
   end
 
@@ -42,7 +46,16 @@ describe HealthQuest::PatientGeneratedData::Patient::MapQuery do
       it 'returns an instance of Reply' do
         expect(client).to receive(:read).with(FHIR::Patient, '123').exactly(1).time
 
-        subject.build(headers).get('123')
+        subject.build(session_store).get('123')
+      end
+
+      it 'has request headers' do
+        allow(client).to receive(:read).with(FHIR::Patient, '123').and_return(anything)
+
+        map_query = subject.build(session_store)
+        map_query.get('123')
+
+        expect(map_query.headers).to eq({ 'Authorization' => 'Bearer 123abc' })
       end
     end
   end
@@ -59,7 +72,19 @@ describe HealthQuest::PatientGeneratedData::Patient::MapQuery do
     it 'returns an instance of Reply' do
       expect(client).to receive(:create).with(patient).exactly(1).time
 
-      subject.build(headers).create(user)
+      subject.build(session_store).create(user)
+    end
+
+    it 'has request headers' do
+      request_headers =
+        { 'Authorization' => 'Bearer 123abc', 'Content-Type' => 'application/fhir+json' }
+
+      allow(client).to receive(:create).with(patient).and_return(anything)
+
+      map_query = subject.build(session_store)
+      map_query.create(user)
+
+      expect(map_query.headers).to eq(request_headers)
     end
   end
 end

--- a/modules/health_quest/spec/services/patient_generated_data/questionnaire/factory_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/questionnaire/factory_spec.rb
@@ -5,13 +5,13 @@ require 'rails_helper'
 describe HealthQuest::PatientGeneratedData::Questionnaire::Factory do
   subject { described_class }
 
-  let(:headers) { { 'Accept' => 'application/json+fhir' } }
   let(:user) { double('User', icn: '1008596379V859838') }
-  let(:session_service) { double('HealthQuest::SessionService', user: user, headers: headers) }
+  let(:session_store) { double('SessionStore', token: '123abc') }
+  let(:session_service) { double('HealthQuest::Lighthouse::Session', user: user, retrieve: session_store) }
   let(:client_reply) { double('FHIR::ClientReply') }
 
   before do
-    allow(HealthQuest::SessionService).to receive(:new).with(user).and_return(session_service)
+    allow(HealthQuest::Lighthouse::Session).to receive(:build).with(user).and_return(session_service)
   end
 
   describe 'object initialization' do

--- a/modules/health_quest/spec/services/patient_generated_data/questionnaire_response/factory_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/questionnaire_response/factory_spec.rb
@@ -5,13 +5,13 @@ require 'rails_helper'
 describe HealthQuest::PatientGeneratedData::QuestionnaireResponse::Factory do
   subject { described_class }
 
-  let(:headers) { { 'Accept' => 'application/json+fhir' } }
   let(:user) { double('User', icn: '1008596379V859838') }
-  let(:session_service) { double('HealthQuest::SessionService', user: user, headers: headers) }
+  let(:session_store) { double('SessionStore', token: '123abc') }
+  let(:session_service) { double('HealthQuest::Lighthouse::Session', user: user, retrieve: session_store) }
   let(:client_reply) { double('FHIR::ClientReply') }
 
   before do
-    allow(HealthQuest::SessionService).to receive(:new).with(user).and_return(session_service)
+    allow(HealthQuest::Lighthouse::Session).to receive(:build).with(user).and_return(session_service)
   end
 
   describe 'object initialization' do
@@ -63,7 +63,7 @@ describe HealthQuest::PatientGeneratedData::QuestionnaireResponse::Factory do
 
     it 'returns a ClientReply' do
       allow_any_instance_of(HealthQuest::PatientGeneratedData::QuestionnaireResponse::MapQuery)
-        .to receive(:create).with(anything).and_return(client_reply)
+        .to receive(:create).with(anything, anything).and_return(client_reply)
 
       expect(subject.new(user).create(data)).to eq(client_reply)
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

- This PR adds a `pgd_path` to the settings.yml file so that PGD services in the health-quest module can now "talk" to the Lighthouse PGD server in the sandbox environment.
- Refactoring the code and the tests so that the health-quest services use the access_token obtained from the Lighthouse PGD to query for FHIR resources from the Lighthouse PGD FHIR server(the sandbox only).

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18921

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- Adding `pgd_path` variable to `settings.yml`. Appropriate values will be added for development and staging environments.
-  Feature flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- RSpec tests written and passing.