### PR TITLE
Add 'lob' to CentralMail upload

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -72,6 +72,10 @@ module AppealsApi
       form_data&.dig('data', 'attributes', 'veteran', 'address', 'zipCode5')
     end
 
+    def lob
+      'BVA'
+    end
+
     private
 
     def validate_hearing_type_selection

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
@@ -32,7 +32,8 @@ module AppealsApi
         'numberAttachments' => 0,
         'receiveDt' => notice_of_disagreement.created_at.strftime('%Y-%m-%d %H:%M:%S'),
         'numberPages' => PdfInfo::Metadata.read(pdf_path).pages,
-        'docType' => '10182'
+        'docType' => '10182',
+        'lob' => notice_of_disagreement.lob
       }
       body = { 'metadata' => metadata.to_json, 'document' => to_faraday_upload(pdf_path, '10182-document.pdf') }
       process_response(CentralMail::Service.new.upload(body), notice_of_disagreement)

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -114,4 +114,8 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
   describe '#zip_code_5' do
     it { expect(notice_of_disagreement.zip_code_5).to eq '66002' }
   end
+
+  describe '#lob' do
+    it { expect(notice_of_disagreement.lob).to eq 'BVA' }
+  end
 end

--- a/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe AppealsApi::NoticeOfDisagreementPdfSubmitJob, type: :job do
     expect(capture_body).to have_key('document')
     metadata = JSON.parse(capture_body['metadata'])
     expect(metadata['uuid']).to eq(notice_of_disagreement.id)
+    expect(metadata['lob']).to eq(notice_of_disagreement.lob)
     updated = AppealsApi::NoticeOfDisagreement.find(notice_of_disagreement.id)
     expect(updated.status).to eq('submitted')
   end
@@ -52,6 +53,7 @@ RSpec.describe AppealsApi::NoticeOfDisagreementPdfSubmitJob, type: :job do
     expect(capture_body).to have_key('document')
     metadata = JSON.parse(capture_body['metadata'])
     expect(metadata['uuid']).to eq(notice_of_disagreement.id)
+    expect(metadata['lob']).to eq(notice_of_disagreement.lob)
     updated = AppealsApi::NoticeOfDisagreement.find(notice_of_disagreement.id)
     expect(updated.status).to eq('error')
     expect(updated.code).to eq('DOC104')


### PR DESCRIPTION
[API-3817](https://vajira.max.gov/browse/API-3817)

This ticket sends the NOD line of business with parameter 'lob' to CentralMail uploading, using the NOD value of 'BVA', in order to route the 10182 correctly.

