### PR TITLE
Adding VSA/BAM1 Ownership of Form526 Rake Task

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,8 @@ spec/bgs @department-of-veterans-affairs/vfs-ebenefits @department-of-veterans-a
 modules/mobile/                      @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/backend-review-group
 spec/support/*/mobile/               @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/backend-review-group
 
-rakelib/form526.rake @annaswims @edmangimelli @department-of-veterans-affairs/backend-review-group
+rakelib/form526.rake @department-of-veterans-affairs/vsa-bam-1-backend @department-of-veterans-affairs/backend-review-group
+
 
 # authentication
 app/controllers/*/sessions_controller.rb @department-of-veterans-affairs/vsp-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@ spec/bgs @department-of-veterans-affairs/vfs-ebenefits @department-of-veterans-a
 modules/mobile/                      @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/backend-review-group
 spec/support/*/mobile/               @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/backend-review-group
 
-rakelib/form526.rake @annaswims @edmangimelli
+rakelib/form526.rake @annaswims @edmangimelli @department-of-veterans-affairs/backend-review-group
 
 # authentication
 app/controllers/*/sessions_controller.rb @department-of-veterans-affairs/vsp-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,6 @@ spec/support/*/mobile/               @department-of-veterans-affairs/mobile-api-
 
 rakelib/form526.rake @department-of-veterans-affairs/vsa-bam-1-backend @department-of-veterans-affairs/backend-review-group
 
-
 # authentication
 app/controllers/*/sessions_controller.rb @department-of-veterans-affairs/vsp-identity
 app/models/account.rb @department-of-veterans-affairs/vsp-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,8 @@ spec/bgs @department-of-veterans-affairs/vfs-ebenefits @department-of-veterans-a
 modules/mobile/                      @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/backend-review-group
 spec/support/*/mobile/               @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/backend-review-group
 
+rakelib/form526.rake @annaswims @edmangimelli
+
 # authentication
 app/controllers/*/sessions_controller.rb @department-of-veterans-affairs/vsp-identity
 app/models/account.rb @department-of-veterans-affairs/vsp-identity


### PR DESCRIPTION
The Form526 Rake Task is just helper code for Benefits & Memorials 1 Team --largely stats and reporting stuff (some migration stuff). I propose that _BAM Team_ owns it for reviewing purposes.
