### PR TITLE
Fixing 686 Pension Eligibility Question

### DIFF
--- a/app/models/bgs_dependents/vnp_benefit_claim.rb
+++ b/app/models/bgs_dependents/vnp_benefit_claim.rb
@@ -42,7 +42,8 @@ module BGSDependents
         pgm_type_cd: benefit_claim_record[:program_type_code],
         ptcpnt_clmant_id: vnp_benefit_claim_record[:participant_claimant_id],
         status_type_cd: benefit_claim_record[:status_type_code],
-        svc_type_cd: 'CP'
+        svc_type_cd: 'CP',
+        net_worth_over_limit_ind: @veteran[:net_worth_over_limit_ind]
       }.merge
     end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
During integration testing with BGS, it was discovered that one of the values we are passing for a pension eligibility question was not being saved on their side.  After some debugging, they realized that it was being overwritten.  This PR is a quick fix to add the `netWorthOverLimitInd` field to the `vnpBnftClaimUpdate` call so that it doesn't get overwritten during the update.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19003

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is a minor fix so no new settings or logging have been added.
<!-- Please describe testing done to verify the changes or any testing planned. -->
## Testing
- [x] Local testing
- [x] Staging testing planned