### PR TITLE
API-4076 - Change max length of nod issue

### DIFF
--- a/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
@@ -264,7 +264,7 @@ module AppealsApi::V1
               key :type, :string
               key :example, 'tinnitus'
               key :example, 'the type of issue being contested'
-              key :maxLength, 368
+              key :maxLength, 255
             end
 
             property :decisionDate do

--- a/modules/appeals_api/config/schemas/10182.json
+++ b/modules/appeals_api/config/schemas/10182.json
@@ -85,7 +85,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "issue":                     { "$ref": "#/definitions/nodCreateNonBlankString", "maxLength": 368 },
+        "issue":                     { "$ref": "#/definitions/nodCreateNonBlankString", "maxLength": 255 },
         "decisionDate":              { "$ref": "#/definitions/nodCreateDate" },
         "decisionIssueId":           { "type": "integer" },
         "ratingIssueReferenceId":    { "type": "string" },


### PR DESCRIPTION
## Description of change
This PR updates our NOD contestable issues `issue` field to be 255 chars (in both the docs and the schema). This is based on Caseflow's Contention class that truncates at 255 bytes (https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/contention.rb).

## Original issue(s)
https://vajira.max.gov/browse/API-4076