### PR TITLE
Rename Vet360Redis to VAProfileRedis

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -310,7 +310,7 @@ RSpec/ScatteredLet:
     - 'spec/lib/sentry/processor/log_as_warning_processor_spec.rb'
     - 'spec/mailers/spool_submissions_report_mailer_spec.rb'
     - 'spec/models/form_profile_spec.rb'
-    - 'spec/models/vet360_redis/contact_information_spec.rb'
+    - 'spec/models/va_profile_redis/contact_information_spec.rb'
     - 'spec/request/health_care_applications_request_spec.rb'
     - 'spec/request/health_records_request_spec.rb'
     - 'spec/request/http_method_not_allowed_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -69,7 +69,7 @@ RSpec/EmptyLineAfterExample:
 RSpec/RepeatedExampleGroupBody:
   Exclude:
     - 'spec/lib/pdf_fill/forms/common_ptsd_spec.rb'
-    - 'spec/models/vet360_redis/contact_information_spec.rb'
+    - 'spec/models/va_profile_redis/contact_information_spec.rb'
 
 # Offense count: 20
 RSpec/RepeatedExampleGroupDescription:

--- a/app/controllers/concerns/vet360/writeable.rb
+++ b/app/controllers/concerns/vet360/writeable.rb
@@ -26,7 +26,7 @@ module Vet360
     end
 
     def invalidate_cache
-      Vet360Redis::Cache.invalidate(@current_user)
+      VaProfileRedis::Cache.invalidate(@current_user)
     end
 
     private

--- a/app/controllers/concerns/vet360/writeable.rb
+++ b/app/controllers/concerns/vet360/writeable.rb
@@ -26,7 +26,7 @@ module Vet360
     end
 
     def invalidate_cache
-      VaProfileRedis::Cache.invalidate(@current_user)
+      VAProfileRedis::Cache.invalidate(@current_user)
     end
 
     private

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -277,7 +277,7 @@ class FormProfile
 
     @vet360_contact_info_retrieved = true
     if Settings.vet360.prefill && user.vet360_id.present?
-      @vet360_contact_info = VaProfileRedis::ContactInformation.for_user(user)
+      @vet360_contact_info = VAProfileRedis::ContactInformation.for_user(user)
     end
     @vet360_contact_info
   end

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -277,7 +277,7 @@ class FormProfile
 
     @vet360_contact_info_retrieved = true
     if Settings.vet360.prefill && user.vet360_id.present?
-      @vet360_contact_info = Vet360Redis::ContactInformation.for_user(user)
+      @vet360_contact_info = VaProfileRedis::ContactInformation.for_user(user)
     end
     @vet360_contact_info
   end

--- a/app/models/form_profiles/va_686c674.rb
+++ b/app/models/form_profiles/va_686c674.rb
@@ -34,7 +34,7 @@ class FormProfiles::VA686c674 < FormProfile
   private
 
   def prefill_form_address
-    mailing_address = Vet360Redis::ContactInformation.for_user(user).mailing_address if user.vet360_id.present?
+    mailing_address = VaProfileRedis::ContactInformation.for_user(user).mailing_address if user.vet360_id.present?
     return if mailing_address.blank?
 
     @form_address = FormAddress.new(

--- a/app/models/form_profiles/va_686c674.rb
+++ b/app/models/form_profiles/va_686c674.rb
@@ -34,7 +34,7 @@ class FormProfiles::VA686c674 < FormProfile
   private
 
   def prefill_form_address
-    mailing_address = VaProfileRedis::ContactInformation.for_user(user).mailing_address if user.vet360_id.present?
+    mailing_address = VAProfileRedis::ContactInformation.for_user(user).mailing_address if user.vet360_id.present?
     return if mailing_address.blank?
 
     @form_address = FormAddress.new(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -279,7 +279,7 @@ class User < Common::RedisStore
   def vet360_contact_info
     return nil unless Settings.vet360.contact_information.enabled && vet360_id.present?
 
-    @vet360_contact_info ||= Vet360Redis::ContactInformation.for_user(self)
+    @vet360_contact_info ||= VaProfileRedis::ContactInformation.for_user(self)
   end
 
   def all_emails

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -279,7 +279,7 @@ class User < Common::RedisStore
   def vet360_contact_info
     return nil unless Settings.vet360.contact_information.enabled && vet360_id.present?
 
-    @vet360_contact_info ||= VaProfileRedis::ContactInformation.for_user(self)
+    @vet360_contact_info ||= VAProfileRedis::ContactInformation.for_user(self)
   end
 
   def all_emails

--- a/app/models/va_profile_redis/cache.rb
+++ b/app/models/va_profile_redis/cache.rb
@@ -2,11 +2,11 @@
 
 require 'sentry_logging'
 
-module VaProfileRedis
+module VAProfileRedis
   class Cache
     include SentryLogging
 
-    # Invalidates the cache set in VaProfileRedis::ContactInformation through
+    # Invalidates the cache set in VAProfileRedis::ContactInformation through
     # our Common::RedisStore#destroy method.
     #
     # @param user [User] The current user

--- a/app/models/va_profile_redis/cache.rb
+++ b/app/models/va_profile_redis/cache.rb
@@ -2,11 +2,11 @@
 
 require 'sentry_logging'
 
-module Vet360Redis
+module VaProfileRedis
   class Cache
     include SentryLogging
 
-    # Invalidates the cache set in Vet360Redis::ContactInformation through
+    # Invalidates the cache set in VaProfileRedis::ContactInformation through
     # our Common::RedisStore#destroy method.
     #
     # @param user [User] The current user

--- a/app/models/va_profile_redis/cache.rb
+++ b/app/models/va_profile_redis/cache.rb
@@ -17,7 +17,7 @@ module VAProfileRedis
       if contact_info.present?
         contact_info.destroy
       else
-        new.log_message_to_sentry('Vet360: Cannot invalidate a nil response cache', :info)
+        new.log_message_to_sentry('VA Profile: Cannot invalidate a nil response cache', :info)
       end
     end
   end

--- a/app/models/va_profile_redis/contact_information.rb
+++ b/app/models/va_profile_redis/contact_information.rb
@@ -20,7 +20,7 @@ module VAProfileRedis
 
     # Redis settings for ttl and namespacing reside in config/redis.yml
     #
-    redis_config_key :vet360_contact_info_response
+    redis_config_key :va_profile_contact_info_response
 
     # @return [User] the user being queried in Vet360
     #

--- a/app/models/va_profile_redis/contact_information.rb
+++ b/app/models/va_profile_redis/contact_information.rb
@@ -8,7 +8,7 @@ require 'vet360/models/permission'
 require 'common/models/redis_store'
 require 'common/models/concerns/cache_aside'
 
-module Vet360Redis
+module VaProfileRedis
   # Facade for Vet360::ContactInformation::Service. The user_serializer delegates
   # to this class through the User model.
   #
@@ -153,7 +153,7 @@ module Vet360Redis
     end
 
     # This method allows us to populate the local instance of a
-    # Vet360Redis::ContactInformation object with the uuid necessary
+    # VaProfileRedis::ContactInformation object with the uuid necessary
     # to perform subsequent actions on the key such as deletion.
     def populate_from_redis
       response_from_redis_or_service

--- a/app/models/va_profile_redis/contact_information.rb
+++ b/app/models/va_profile_redis/contact_information.rb
@@ -8,7 +8,7 @@ require 'vet360/models/permission'
 require 'common/models/redis_store'
 require 'common/models/concerns/cache_aside'
 
-module VaProfileRedis
+module VAProfileRedis
   # Facade for Vet360::ContactInformation::Service. The user_serializer delegates
   # to this class through the User model.
   #
@@ -153,7 +153,7 @@ module VaProfileRedis
     end
 
     # This method allows us to populate the local instance of a
-    # VaProfileRedis::ContactInformation object with the uuid necessary
+    # VAProfileRedis::ContactInformation object with the uuid necessary
     # to perform subsequent actions on the key such as deletion.
     def populate_from_redis
       response_from_redis_or_service

--- a/app/models/va_profile_redis/contact_information.rb
+++ b/app/models/va_profile_redis/contact_information.rb
@@ -22,7 +22,7 @@ module VAProfileRedis
     #
     redis_config_key :va_profile_contact_info_response
 
-    # @return [User] the user being queried in Vet360
+    # @return [User] the user being queried in VA Profile
     #
     attr_accessor :user
 
@@ -34,7 +34,7 @@ module VAProfileRedis
       contact_info
     end
 
-    # Returns the user's email model. In Vet360, a user can only have one
+    # Returns the user's email model. In VA Profile, a user can only have one
     # email address.
     #
     # @return [Vet360::Models::Email] The user's one email address model
@@ -45,7 +45,7 @@ module VAProfileRedis
       value_for('emails')&.first
     end
 
-    # Returns the user's residence. In Vet360, a user can only have one
+    # Returns the user's residence. In VA Profile, a user can only have one
     # residence address.
     #
     # @return [Vet360::Models::Address] The user's one residential address model
@@ -56,7 +56,7 @@ module VAProfileRedis
       dig_out('addresses', 'address_pou', Vet360::Models::Address::RESIDENCE)
     end
 
-    # Returns the user's mailing address. In Vet360, a user can only have one
+    # Returns the user's mailing address. In VA Profile, a user can only have one
     # mailing address.
     #
     # @return [Vet360::Models::Address] The user's one mailing address model
@@ -67,7 +67,7 @@ module VAProfileRedis
       dig_out('addresses', 'address_pou', Vet360::Models::Address::CORRESPONDENCE)
     end
 
-    # Returns the user's home phone. In Vet360, a user can only have one
+    # Returns the user's home phone. In VA Profile, a user can only have one
     # home phone.
     #
     # @return [Vet360::Models::Telephone] The user's one home phone model
@@ -78,7 +78,7 @@ module VAProfileRedis
       dig_out('telephones', 'phone_type', Vet360::Models::Telephone::HOME)
     end
 
-    # Returns the user's mobile phone. In Vet360, a user can only have one
+    # Returns the user's mobile phone. In VA Profile, a user can only have one
     # mobile phone.
     #
     # @return [Vet360::Models::Telephone] The user's one mobile phone model
@@ -89,7 +89,7 @@ module VAProfileRedis
       dig_out('telephones', 'phone_type', Vet360::Models::Telephone::MOBILE)
     end
 
-    # Returns the user's work phone. In Vet360, a user can only have one
+    # Returns the user's work phone. In VA Profile, a user can only have one
     # work phone.
     #
     # @return [Vet360::Models::Telephone] The user's one work phone model
@@ -100,7 +100,7 @@ module VAProfileRedis
       dig_out('telephones', 'phone_type', Vet360::Models::Telephone::WORK)
     end
 
-    # Returns the user's temporary phone. In Vet360, a user can only have one
+    # Returns the user's temporary phone. In VA Profile, a user can only have one
     # temporary phone.
     #
     # @return [Vet360::Models::Telephone] The user's one temporary phone model
@@ -111,7 +111,7 @@ module VAProfileRedis
       dig_out('telephones', 'phone_type', Vet360::Models::Telephone::TEMPORARY)
     end
 
-    # Returns the user's fax number. In Vet360, a user can only have one
+    # Returns the user's fax number. In VA Profile, a user can only have one
     # fax number.
     #
     # @return [Vet360::Models::Telephone] The user's one fax number model
@@ -122,7 +122,7 @@ module VAProfileRedis
       dig_out('telephones', 'phone_type', Vet360::Models::Telephone::FAX)
     end
 
-    # Returns the user's text permission. In Vet360, a user can only have one
+    # Returns the user's text permission. In VA Profile, a user can only have one
     # text permission.
     #
     # @return [Vet360::Models::Permission] The user's one text permission model

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -69,12 +69,9 @@ development: &defaults
   pciu_address_dependencies:
     namespace: pciu-address-dependencies
     each_ttl: 604800
-  vet360_contact_info_response:
-    namespace: vet360-contact-info-response
+  va_profile_contact_info_response:
+    namespace: va-profile-contact-info-response
     each_ttl: 3600 # 1 hour
-  vet360_reference_data_response:
-    namespace: vet360-reference-data-response
-    each_ttl: 86400
   intent_to_file_response:
     namespace: intent-to-file-response
     each_ttl: 86400

--- a/spec/lib/common/models/concerns/cache_aside_spec.rb
+++ b/spec/lib/common/models/concerns/cache_aside_spec.rb
@@ -19,12 +19,12 @@ describe Common::CacheAside do
     end
 
     it 'sets the attributes needed to perform redis actions', :aggregate_failures do
-      instance1 = VaProfileRedis::ContactInformation.for_user(user)
+      instance1 = VAProfileRedis::ContactInformation.for_user(user)
       instance1.do_cached_with(key: 'test') { person_response }
       expect(instance1.attributes[:uuid]).not_to be(nil)
       expect(instance1.attributes[:response]).not_to be(nil)
 
-      instance2 = VaProfileRedis::ContactInformation.for_user(user)
+      instance2 = VAProfileRedis::ContactInformation.for_user(user)
       instance2.do_cached_with(key: 'test') { raise 'value was not cached!' }
       expect(instance2.attributes[:uuid]).not_to be(nil)
       expect(instance2.attributes[:response]).not_to be(nil)

--- a/spec/lib/common/models/concerns/cache_aside_spec.rb
+++ b/spec/lib/common/models/concerns/cache_aside_spec.rb
@@ -19,12 +19,12 @@ describe Common::CacheAside do
     end
 
     it 'sets the attributes needed to perform redis actions', :aggregate_failures do
-      instance1 = Vet360Redis::ContactInformation.for_user(user)
+      instance1 = VaProfileRedis::ContactInformation.for_user(user)
       instance1.do_cached_with(key: 'test') { person_response }
       expect(instance1.attributes[:uuid]).not_to be(nil)
       expect(instance1.attributes[:response]).not_to be(nil)
 
-      instance2 = Vet360Redis::ContactInformation.for_user(user)
+      instance2 = VaProfileRedis::ContactInformation.for_user(user)
       instance2.do_cached_with(key: 'test') { raise 'value was not cached!' }
       expect(instance2.attributes[:uuid]).not_to be(nil)
       expect(instance2.attributes[:response]).not_to be(nil)

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -1108,7 +1108,8 @@ RSpec.describe FormProfile, type: :model do
             before do
               Settings.vet360.prefill = true
               expected_veteran_info = v21_526_ez_expected['veteran']
-              expected_veteran_info['emailAddress'] = VAProfileRedis::ContactInformation.for_user(user).email.email_address
+              expected_veteran_info['emailAddress'] =
+                VAProfileRedis::ContactInformation.for_user(user).email.email_address
               expected_veteran_info['primaryPhone'] = '3035551234'
             end
 

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -937,7 +937,7 @@ RSpec.describe FormProfile, type: :model do
           stub_methods_for_emis_data
           Settings.vet360.prefill = true
 
-          v22_1990_expected['email'] = VaProfileRedis::ContactInformation.for_user(user).email.email_address
+          v22_1990_expected['email'] = VAProfileRedis::ContactInformation.for_user(user).email.email_address
           v22_1990_expected['homePhone'] = '3035551234'
           v22_1990_expected['mobilePhone'] = '3035551234'
           v22_1990_expected['veteranAddress'] = {
@@ -1108,7 +1108,7 @@ RSpec.describe FormProfile, type: :model do
             before do
               Settings.vet360.prefill = true
               expected_veteran_info = v21_526_ez_expected['veteran']
-              expected_veteran_info['emailAddress'] = VaProfileRedis::ContactInformation.for_user(user).email.email_address
+              expected_veteran_info['emailAddress'] = VAProfileRedis::ContactInformation.for_user(user).email.email_address
               expected_veteran_info['primaryPhone'] = '3035551234'
             end
 

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -937,7 +937,7 @@ RSpec.describe FormProfile, type: :model do
           stub_methods_for_emis_data
           Settings.vet360.prefill = true
 
-          v22_1990_expected['email'] = Vet360Redis::ContactInformation.for_user(user).email.email_address
+          v22_1990_expected['email'] = VaProfileRedis::ContactInformation.for_user(user).email.email_address
           v22_1990_expected['homePhone'] = '3035551234'
           v22_1990_expected['mobilePhone'] = '3035551234'
           v22_1990_expected['veteranAddress'] = {
@@ -1108,7 +1108,7 @@ RSpec.describe FormProfile, type: :model do
             before do
               Settings.vet360.prefill = true
               expected_veteran_info = v21_526_ez_expected['veteran']
-              expected_veteran_info['emailAddress'] = Vet360Redis::ContactInformation.for_user(user).email.email_address
+              expected_veteran_info['emailAddress'] = VaProfileRedis::ContactInformation.for_user(user).email.email_address
               expected_veteran_info['primaryPhone'] = '3035551234'
             end
 

--- a/spec/models/va_profile_redis/cache_spec.rb
+++ b/spec/models/va_profile_redis/cache_spec.rb
@@ -8,7 +8,7 @@ describe VAProfileRedis::Cache do
 
   describe '.invalidate' do
     context 'when user.vet360_contact_info is present' do
-      it 'invalidates the vet360-contact-info-response cache' do
+      it 'invalidates the va-profile-contact-info-response cache' do
         contact_info.cache(user.uuid, 'cache data')
 
         expect_any_instance_of(Common::RedisStore).to receive(:destroy)

--- a/spec/models/va_profile_redis/cache_spec.rb
+++ b/spec/models/va_profile_redis/cache_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe Vet360Redis::Cache do
+describe VaProfileRedis::Cache do
   let(:user) { build :user, :loa3 }
-  let(:contact_info) { Vet360Redis::ContactInformation.for_user(user) }
+  let(:contact_info) { VaProfileRedis::ContactInformation.for_user(user) }
 
   describe '.invalidate' do
     context 'when user.vet360_contact_info is present' do
@@ -13,7 +13,7 @@ describe Vet360Redis::Cache do
 
         expect_any_instance_of(Common::RedisStore).to receive(:destroy)
 
-        Vet360Redis::Cache.invalidate(user)
+        VaProfileRedis::Cache.invalidate(user)
       end
     end
 
@@ -25,13 +25,13 @@ describe Vet360Redis::Cache do
       it 'does not call #destroy' do
         expect_any_instance_of(Common::RedisStore).not_to receive(:destroy)
 
-        Vet360Redis::Cache.invalidate(user)
+        VaProfileRedis::Cache.invalidate(user)
       end
 
       it 'logs to sentry' do
         expect_any_instance_of(described_class).to receive(:log_message_to_sentry).once
 
-        Vet360Redis::Cache.invalidate(user)
+        VaProfileRedis::Cache.invalidate(user)
       end
     end
   end

--- a/spec/models/va_profile_redis/cache_spec.rb
+++ b/spec/models/va_profile_redis/cache_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe VaProfileRedis::Cache do
+describe VAProfileRedis::Cache do
   let(:user) { build :user, :loa3 }
-  let(:contact_info) { VaProfileRedis::ContactInformation.for_user(user) }
+  let(:contact_info) { VAProfileRedis::ContactInformation.for_user(user) }
 
   describe '.invalidate' do
     context 'when user.vet360_contact_info is present' do
@@ -13,7 +13,7 @@ describe VaProfileRedis::Cache do
 
         expect_any_instance_of(Common::RedisStore).to receive(:destroy)
 
-        VaProfileRedis::Cache.invalidate(user)
+        VAProfileRedis::Cache.invalidate(user)
       end
     end
 
@@ -25,13 +25,13 @@ describe VaProfileRedis::Cache do
       it 'does not call #destroy' do
         expect_any_instance_of(Common::RedisStore).not_to receive(:destroy)
 
-        VaProfileRedis::Cache.invalidate(user)
+        VAProfileRedis::Cache.invalidate(user)
       end
 
       it 'logs to sentry' do
         expect_any_instance_of(described_class).to receive(:log_message_to_sentry).once
 
-        VaProfileRedis::Cache.invalidate(user)
+        VAProfileRedis::Cache.invalidate(user)
       end
     end
   end

--- a/spec/models/va_profile_redis/contact_information_spec.rb
+++ b/spec/models/va_profile_redis/contact_information_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe Vet360Redis::ContactInformation do
+describe VaProfileRedis::ContactInformation do
   let(:user) { build :user, :loa3 }
-  let(:contact_info) { Vet360Redis::ContactInformation.for_user(user) }
+  let(:contact_info) { VaProfileRedis::ContactInformation.for_user(user) }
   let(:person) { build :person, telephones: telephones, permissions: permissions }
   let(:telephones) do
     [
@@ -56,9 +56,9 @@ describe Vet360Redis::ContactInformation do
 
       it 'makes a new request' do
         expect(contact_info.email).to eq(nil)
-        Vet360Redis::Cache.invalidate(user)
+        VaProfileRedis::Cache.invalidate(user)
 
-        expect(Vet360Redis::ContactInformation.for_user(user).email).to eq(nil)
+        expect(VaProfileRedis::ContactInformation.for_user(user).email).to eq(nil)
       end
     end
   end

--- a/spec/models/va_profile_redis/contact_information_spec.rb
+++ b/spec/models/va_profile_redis/contact_information_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe VaProfileRedis::ContactInformation do
+describe VAProfileRedis::ContactInformation do
   let(:user) { build :user, :loa3 }
-  let(:contact_info) { VaProfileRedis::ContactInformation.for_user(user) }
+  let(:contact_info) { VAProfileRedis::ContactInformation.for_user(user) }
   let(:person) { build :person, telephones: telephones, permissions: permissions }
   let(:telephones) do
     [
@@ -56,9 +56,9 @@ describe VaProfileRedis::ContactInformation do
 
       it 'makes a new request' do
         expect(contact_info.email).to eq(nil)
-        VaProfileRedis::Cache.invalidate(user)
+        VAProfileRedis::Cache.invalidate(user)
 
-        expect(VaProfileRedis::ContactInformation.for_user(user).email).to eq(nil)
+        expect(VAProfileRedis::ContactInformation.for_user(user).email).to eq(nil)
       end
     end
   end

--- a/spec/models/va_profile_redis/contact_information_spec.rb
+++ b/spec/models/va_profile_redis/contact_information_spec.rb
@@ -4,6 +4,11 @@ require 'rails_helper'
 
 describe VAProfileRedis::ContactInformation do
   let(:user) { build :user, :loa3 }
+  let(:person_response) do
+    raw_response = OpenStruct.new(status: 200, body: { 'bio' => person.to_hash })
+
+    Vet360::ContactInformation::PersonResponse.from(raw_response)
+  end
   let(:contact_info) { VAProfileRedis::ContactInformation.for_user(user) }
   let(:person) { build :person, telephones: telephones, permissions: permissions }
   let(:telephones) do
@@ -23,12 +28,6 @@ describe VAProfileRedis::ContactInformation do
 
   before do
     allow(Vet360::Models::Person).to receive(:build_from).and_return(person)
-  end
-
-  let(:person_response) do
-    raw_response = OpenStruct.new(status: 200, body: { 'bio' => person.to_hash })
-
-    Vet360::ContactInformation::PersonResponse.from(raw_response)
   end
 
   context 'with a 404 from get_person', skip_vet360: true do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
rename `Vet360Redis` to `VAProfileRedis`
vet360 name is no longer in use and they want us to rename all references of vet360 to va_profile
all existing Vet360Redis caches will be invalidated, but it should just fetch data again and there shouldn't be any problems
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/19201

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
tested with unit tests
<!-- Please describe testing done to verify the changes or any testing planned. -->
