### PR TITLE
Log Failed HLR-related Requests to the PII Log

### DIFF
--- a/app/controllers/appeals_base_controller.rb
+++ b/app/controllers/appeals_base_controller.rb
@@ -5,14 +5,8 @@ require 'decision_review/service'
 
 class AppealsBaseController < ApplicationController
   include ActionController::Serialization
+  include FailedRequestLoggable
   before_action { authorize :appeals, :access? }
-
-  class << self
-    def exception_hash(exception)
-      %i[message backtrace key response_values original_status original_body]
-        .reduce({}) { |hash, key| hash.merge({ key => exception.try(key) }) }
-    end
-  end
 
   private
 
@@ -49,32 +43,5 @@ class AppealsBaseController < ApplicationController
       request_body_class_name: request.try(:body).class.name,
       request_body_string: request.try(:body).try(:string)
     }
-  end
-
-  def current_user_hash
-    hash = {}
-
-    %i[first_name last_name birls_id icn edipi mhv_correlation_id participant_id vet360_id ssn]
-      .each { |key| hash[key] = @current_user.try(key) }
-
-    hash[:assurance_level] = begin
-                               @current_user.loa[:current]
-                             rescue
-                               nil
-                             end
-
-    hash[:birth_date] = begin
-                          @current_user.va_profile.birth_date.to_date.iso8601
-                        rescue
-                          nil
-                        end
-    hash
-  end
-
-  def log_exception_to_personal_information_log(exception, error_class:, data: {})
-    PersonalInformationLog.create!(
-      error_class: error_class,
-      data: { user: current_user_hash, error: self.class.exception_hash(exception) }.merge(data)
-    )
   end
 end

--- a/app/controllers/appeals_base_controller.rb
+++ b/app/controllers/appeals_base_controller.rb
@@ -9,14 +9,8 @@ class AppealsBaseController < ApplicationController
 
   class << self
     def exception_hash(exception)
-      %i[
-        message
-        backtrace
-        key
-        response_values
-        original_status
-        original_body
-      ].reduce({}) { |hash, key| hash.merge({ key => exception.try(key) }) }
+      %i[message backtrace key response_values original_status original_body]
+        .reduce({}) { |hash, key| hash.merge({ key => exception.try(key) }) }
     end
   end
 
@@ -60,19 +54,15 @@ class AppealsBaseController < ApplicationController
   def current_user_hash
     hash = {}
 
-    %i[
-      first_name
-      last_name
-      birls_id
-      icn
-      edipi
-      mhv_correlation_id
-      participant_id
-      vet360_id
-      ssn
-    ].each { |key| hash[key] = @current_user.try(key) }
+    %i[first_name last_name birls_id icn edipi mhv_correlation_id participant_id vet360_id ssn]
+      .each { |key| hash[key] = @current_user.try(key) }
 
-    hash[:assurance_level] = @current_user.try(:loa)&.dig(:current)&.to_s
+    hash[:assurance_level] = begin
+                               @current_user.loa[:current]
+                             rescue
+                               nil
+                             end
+
     hash[:birth_date] = begin
                           @current_user.va_profile.birth_date.to_date.iso8601
                         rescue

--- a/app/controllers/appeals_base_controller.rb
+++ b/app/controllers/appeals_base_controller.rb
@@ -74,10 +74,7 @@ class AppealsBaseController < ApplicationController
   def log_exception_to_personal_information_log(exception, error_class:, data: {})
     PersonalInformationLog.create!(
       error_class: error_class,
-      data: {
-        user: current_user_hash,
-        error: self.class.exception_hash(exception)
-      }.merge(data)
+      data: { user: current_user_hash, error: self.class.exception_hash(exception) }.merge(data)
     )
   end
 end

--- a/app/controllers/appeals_base_controller.rb
+++ b/app/controllers/appeals_base_controller.rb
@@ -7,6 +7,19 @@ class AppealsBaseController < ApplicationController
   include ActionController::Serialization
   before_action { authorize :appeals, :access? }
 
+  class << self
+    def exception_hash(exception)
+      %i[
+        message
+        backtrace
+        key
+        response_values
+        original_status
+        original_body
+      ].reduce({}) { |hash, key| hash.merge({ key => exception.try(key) }) }
+    end
+  end
+
   private
 
   def appeals_service
@@ -35,5 +48,46 @@ class AppealsBaseController < ApplicationController
 
   def request_body_is_not_a_hash_error
     DecisionReview::ServiceException.new key: 'DR_REQUEST_BODY_IS_NOT_A_HASH'
+  end
+
+  def request_body_debug_data
+    {
+      request_body_class_name: request.try(:body).class.name,
+      request_body_string: request.try(:body).try(:string)
+    }
+  end
+
+  def current_user_hash
+    hash = {}
+
+    %i[
+      first_name
+      last_name
+      birls_id
+      icn
+      edipi
+      mhv_correlation_id
+      participant_id
+      vet360_id
+      ssn
+    ].each { |key| hash[key] = @current_user.try(key) }
+
+    hash[:assurance_level] = @current_user.try(:loa)&.dig(:current)&.to_s
+    hash[:birth_date] = begin
+                          @current_user.va_profile.birth_date.to_date.iso8601
+                        rescue
+                          nil
+                        end
+    hash
+  end
+
+  def log_exception_to_personal_information_log(exception, error_class:, data: {})
+    PersonalInformationLog.create!(
+      error_class: error_class,
+      data: {
+        user: current_user_hash,
+        error: self.class.exception_hash(exception)
+      }.merge(data)
+    )
   end
 end

--- a/app/controllers/concerns/failed_request_loggable.rb
+++ b/app/controllers/concerns/failed_request_loggable.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module FailedRequestLoggable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def exception_hash(exception)
+      %i[message backtrace key response_values original_status original_body]
+        .reduce({}) { |hash, key| hash.merge({ key => exception.try(key) }) }
+    end
+  end
+
+  private
+
+  def current_user_hash
+    hash = {}
+
+    %i[first_name last_name birls_id icn edipi mhv_correlation_id participant_id vet360_id ssn]
+      .each { |key| hash[key] = @current_user.try(key) }
+
+    hash[:assurance_level] = begin
+                               @current_user.loa[:current]
+                             rescue
+                               nil
+                             end
+
+    hash[:birth_date] = begin
+                          @current_user.va_profile.birth_date.to_date.iso8601
+                        rescue
+                          nil
+                        end
+    hash
+  end
+
+  def log_exception_to_personal_information_log(exception, error_class:, data: {})
+    PersonalInformationLog.create!(
+      error_class: error_class,
+      data: { user: current_user_hash, error: self.class.exception_hash(exception) }.merge(data)
+    )
+  end
+end

--- a/app/controllers/concerns/failed_request_loggable.rb
+++ b/app/controllers/concerns/failed_request_loggable.rb
@@ -32,10 +32,13 @@ module FailedRequestLoggable
     hash
   end
 
-  def log_exception_to_personal_information_log(exception, error_class:, data: {})
-    PersonalInformationLog.create!(
-      error_class: error_class,
-      data: { user: current_user_hash, error: self.class.exception_hash(exception) }.merge(data)
-    )
+  def log_exception_to_personal_information_log(exception, error_class:, **additional_data)
+    data = {
+      user: current_user_hash,
+      error: self.class.exception_hash(exception)
+    }
+    data[:additional_data] = additional_data if additional_data.present?
+
+    PersonalInformationLog.create! error_class: error_class, data: data
   end
 end

--- a/app/controllers/v0/higher_level_reviews/contestable_issues_controller.rb
+++ b/app/controllers/v0/higher_level_reviews/contestable_issues_controller.rb
@@ -7,6 +7,13 @@ module V0
         render json: decision_review_service
           .get_higher_level_review_contestable_issues(user: current_user, benefit_type: params[:benefit_type])
           .body
+      rescue => e
+        log_exception_to_personal_information_log(
+          e,
+          error_class: "#{self.class.name}#index exception",
+          data: { request_data: { benefit_type: params[:benefit_type] } }
+        )
+        raise
       end
     end
   end

--- a/app/controllers/v0/higher_level_reviews/contestable_issues_controller.rb
+++ b/app/controllers/v0/higher_level_reviews/contestable_issues_controller.rb
@@ -11,7 +11,7 @@ module V0
         log_exception_to_personal_information_log(
           e,
           error_class: "#{self.class.name}#index exception",
-          data: { request_data: { benefit_type: params[:benefit_type] } }
+          benefit_type: params[:benefit_type]
         )
         raise
       end

--- a/app/controllers/v0/higher_level_reviews_controller.rb
+++ b/app/controllers/v0/higher_level_reviews_controller.rb
@@ -5,11 +5,7 @@ module V0
     def show
       render json: decision_review_service.get_higher_level_review(params[:id]).body
     rescue => e
-      log_exception_to_personal_information_log(
-        e,
-        error_class: "#{self.class.name}#show exception",
-        data: { request_data: { id: params[:id] } }
-      )
+      log_exception_to_personal_information_log e, error_class: "#{self.class.name}#show exception", id: params[:id]
       raise
     end
 
@@ -18,17 +14,13 @@ module V0
         .create_higher_level_review(request_body: request_body_hash, user: current_user)
         .body
     rescue => e
-      request_data = begin
-                       { body: request_body_hash }
-                     rescue
-                       request_body_debug_data
-                     end
+      request = begin
+                  { body: request_body_hash }
+                rescue
+                  request_body_debug_data
+                end
 
-      log_exception_to_personal_information_log(
-        e,
-        error_class: "#{self.class.name}#create exception",
-        data: { request_data: request_data }
-      )
+      log_exception_to_personal_information_log e, error_class: "#{self.class.name}#create exception", request: request
       raise
     end
   end

--- a/app/controllers/v0/higher_level_reviews_controller.rb
+++ b/app/controllers/v0/higher_level_reviews_controller.rb
@@ -4,12 +4,32 @@ module V0
   class HigherLevelReviewsController < AppealsBaseController
     def show
       render json: decision_review_service.get_higher_level_review(params[:id]).body
+    rescue => e
+      log_exception_to_personal_information_log(
+        e,
+        error_class: "#{self.class.name}#show exception",
+        data: { request_data: { id: params[:id] } }
+      )
+      raise
     end
 
     def create
       render json: decision_review_service
         .create_higher_level_review(request_body: request_body_hash, user: current_user)
         .body
+    rescue => e
+      request_data = begin
+                       { body: request_body_hash }
+                     rescue
+                       request_body_debug_data
+                     end
+
+      log_exception_to_personal_information_log(
+        e,
+        error_class: "#{self.class.name}#create exception",
+        data: { request_data: request_data }
+      )
+      raise
     end
   end
 end

--- a/spec/request/v0/higher_level_reviews_controller_request_spec.rb
+++ b/spec/request/v0/higher_level_reviews_controller_request_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe V0::HigherLevelReviewsController, type: :request do
         ].each { |key| expect(pil.data['user'][key]).to be_truthy }
         %w[message backtrace key response_values original_status original_body]
           .each { |key| expect(pil.data['error'][key]).to be_truthy }
-        expect(pil.data['request_data']['body']).not_to be_empty
+        expect(pil.data['additional_data']['request']['body']).not_to be_empty
       end
     end
   end

--- a/spec/request/v0/higher_level_reviews_controller_request_spec.rb
+++ b/spec/request/v0/higher_level_reviews_controller_request_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe V0::HigherLevelReviewsController, type: :request do
         subject
         expect(personal_information_logs.count).to be 1
         pil = personal_information_logs.first
-        expect(pil.data['user']).to be_a Hash
-        expect(pil.data['user']).not_to be_empty
-        expect(pil.data['error']).to be_a Hash
-        expect(pil.data['error']).not_to be_empty
-        expect(pil.data['request_data']).to be_a Hash
-        expect(pil.data['request_data']['body']).to be_a Hash
+        %w[
+          first_name last_name birls_id icn edipi mhv_correlation_id
+          participant_id vet360_id ssn assurance_level birth_date
+        ].each { |key| expect(pil.data['user'][key]).to be_truthy }
+        %w[message backtrace key response_values original_status original_body]
+          .each { |key| expect(pil.data['error'][key]).to be_truthy }
         expect(pil.data['request_data']['body']).not_to be_empty
       end
     end

--- a/spec/request/v0/higher_level_reviews_controller_request_spec.rb
+++ b/spec/request/v0/higher_level_reviews_controller_request_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/controller_spec_helper'
+
+RSpec.describe V0::HigherLevelReviewsController, type: :request do
+  context 'with a user' do
+    let(:user) { build(:user, :loa3) }
+    let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+    before { sign_in_as(user) }
+
+    describe '#create' do
+      def personal_information_logs
+        PersonalInformationLog.where(
+          error_class: 'V0::HigherLevelReviewsController#create exception'
+        )
+      end
+
+      subject do
+        post '/v0/higher_level_reviews',
+             params: VetsJsonSchema::EXAMPLES.fetch('HLR-CREATE-REQUEST-BODY').to_json,
+             headers: headers
+      end
+
+      it 'creates an HLR' do
+        VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-200') do
+          subject
+          expect(response).to be_successful
+        end
+      end
+
+      it 'adds to the PersonalInformationLog when an exception is thrown' do
+        VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-422') do
+          expect(personal_information_logs.count).to be 0
+          subject
+          expect(personal_information_logs.count).to be 1
+          pil = personal_information_logs.first
+          expect(pil.data['user']).to be_a Hash
+          expect(pil.data['user']).not_to be_empty
+          expect(pil.data['error']).to be_a Hash
+          expect(pil.data['error']).not_to be_empty
+          expect(pil.data['request_data']).to be_a Hash
+          expect(pil.data['request_data']['body']).to be_a Hash
+          expect(pil.data['request_data']['body']).not_to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/request/v0/higher_level_reviews_controller_request_spec.rb
+++ b/spec/request/v0/higher_level_reviews_controller_request_spec.rb
@@ -4,46 +4,44 @@ require 'rails_helper'
 require 'support/controller_spec_helper'
 
 RSpec.describe V0::HigherLevelReviewsController, type: :request do
-  context 'with a user' do
-    let(:user) { build(:user, :loa3) }
-    let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+  let(:user) { build(:user, :loa3) }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
 
-    before { sign_in_as(user) }
+  before { sign_in_as(user) }
 
-    describe '#create' do
-      def personal_information_logs
-        PersonalInformationLog.where(
-          error_class: 'V0::HigherLevelReviewsController#create exception'
-        )
+  describe '#create' do
+    def personal_information_logs
+      PersonalInformationLog.where(
+        error_class: 'V0::HigherLevelReviewsController#create exception'
+      )
+    end
+
+    subject do
+      post '/v0/higher_level_reviews',
+           params: VetsJsonSchema::EXAMPLES.fetch('HLR-CREATE-REQUEST-BODY').to_json,
+           headers: headers
+    end
+
+    it 'creates an HLR' do
+      VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-200') do
+        subject
+        expect(response).to be_successful
       end
+    end
 
-      subject do
-        post '/v0/higher_level_reviews',
-             params: VetsJsonSchema::EXAMPLES.fetch('HLR-CREATE-REQUEST-BODY').to_json,
-             headers: headers
-      end
-
-      it 'creates an HLR' do
-        VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-200') do
-          subject
-          expect(response).to be_successful
-        end
-      end
-
-      it 'adds to the PersonalInformationLog when an exception is thrown' do
-        VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-422') do
-          expect(personal_information_logs.count).to be 0
-          subject
-          expect(personal_information_logs.count).to be 1
-          pil = personal_information_logs.first
-          expect(pil.data['user']).to be_a Hash
-          expect(pil.data['user']).not_to be_empty
-          expect(pil.data['error']).to be_a Hash
-          expect(pil.data['error']).not_to be_empty
-          expect(pil.data['request_data']).to be_a Hash
-          expect(pil.data['request_data']['body']).to be_a Hash
-          expect(pil.data['request_data']['body']).not_to be_empty
-        end
+    it 'adds to the PersonalInformationLog when an exception is thrown' do
+      VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-422') do
+        expect(personal_information_logs.count).to be 0
+        subject
+        expect(personal_information_logs.count).to be 1
+        pil = personal_information_logs.first
+        expect(pil.data['user']).to be_a Hash
+        expect(pil.data['user']).not_to be_empty
+        expect(pil.data['error']).to be_a Hash
+        expect(pil.data['error']).not_to be_empty
+        expect(pil.data['request_data']).to be_a Hash
+        expect(pil.data['request_data']['body']).to be_a Hash
+        expect(pil.data['request_data']['body']).not_to be_empty
       end
     end
   end

--- a/spec/request/v0/higher_level_reviews_controller_request_spec.rb
+++ b/spec/request/v0/higher_level_reviews_controller_request_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe V0::HigherLevelReviewsController, type: :request do
 
   describe '#create' do
     def personal_information_logs
-      PersonalInformationLog.where(
-        error_class: 'V0::HigherLevelReviewsController#create exception'
-      )
+      PersonalInformationLog.where error_class: 'V0::HigherLevelReviewsController#create exception'
     end
 
     subject do


### PR DESCRIPTION
from [the ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/19143)
>Currently we aren't capturing the complete request data anywhere when an HLR request fails. Now that we've soft launched, let's capture the complete request data in the PersonalInformationLog (which gets cleared every 2 weeks) for failures so that we can better debug failed requests.