### PR TITLE
GET questionnaire_responses by appointment_id

### DIFF
--- a/modules/health_quest/app/controllers/health_quest/v0/questionnaire_responses_controller.rb
+++ b/modules/health_quest/app/controllers/health_quest/v0/questionnaire_responses_controller.rb
@@ -4,7 +4,7 @@ module HealthQuest
   module V0
     class QuestionnaireResponsesController < HealthQuest::V0::BaseController
       def index
-        render json: factory.search(params[:filters]).response[:body]
+        render json: factory.search(request.query_parameters).response[:body]
       end
 
       def show

--- a/modules/health_quest/app/controllers/health_quest/v0/questionnaires_controller.rb
+++ b/modules/health_quest/app/controllers/health_quest/v0/questionnaires_controller.rb
@@ -4,7 +4,7 @@ module HealthQuest
   module V0
     class QuestionnairesController < HealthQuest::V0::BaseController
       def index
-        render json: factory.search(params[:filters]).response[:body]
+        render json: factory.search(request.query_parameters).response[:body]
       end
 
       def show

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/options_builder.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/options_builder.rb
@@ -34,11 +34,28 @@ module HealthQuest
       # @return [Hash]
       #
       def to_hash
-        if appointment_id.present?
-          { subject: subject_reference }
-        else
-          { author: user.icn }
-        end
+        name = filters.delete(:resource_name)
+        query_param = filters.keys.pop
+
+        registry[name.to_sym][query_param.to_sym]
+      end
+
+      ##
+      # The registry which holds the return value for `to_hash`.
+      #
+      # @return [Hash]
+      #
+      def registry
+        {
+          questionnaire_response: {
+            appointment_id: { _tag: appointment_reference },
+            patient: { subject: user.icn },
+            authored: { authored: resource_created_date }
+          },
+          questionnaire: {
+            use_context: { 'context-type-value': context_type_value }
+          }
+        }
       end
 
       ##
@@ -46,17 +63,42 @@ module HealthQuest
       #
       # @return [String]
       #
-      def subject_reference
-        "#{Settings.hqva_mobile.url}/appointments/v1/patients/#{user.icn}/Appointment/#{appointment_id}"
+      def appointment_reference
+        @appointment_reference ||=
+          "#{lighthouse.url}#{lighthouse.pgd_path}/NamingSystem/va-appointment-identifier|#{appointment_id}"
       end
 
       ##
-      # Get the appointment id from the filters that were passed into the controller action.
+      # Get the appointment id from the filters.
       #
       # @return [String]
       #
       def appointment_id
         @appointment_id ||= filters&.fetch(:appointment_id, nil)
+      end
+
+      ##
+      # Get the authored date from the filters.
+      #
+      # @return [String]
+      #
+      def resource_created_date
+        @resource_created_date ||= filters&.fetch(:authored, nil)
+      end
+
+      ##
+      # Get the use context values from the filters.
+      #
+      # @return [String]
+      #
+      def context_type_value
+        '' # blank temp value
+      end
+
+      private
+
+      def lighthouse
+        Settings.hqva_mobile.lighthouse
       end
     end
   end

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/factory.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/factory.rb
@@ -39,12 +39,13 @@ module HealthQuest
         ##
         # Gets Questionnaires from a given set of options
         #
-        # @param filters [PatientGeneratedData::OptionsBuilder] a set of query options
+        # @param filters [Hash] a set of query options
         # @return [FHIR::Questionnaire::ClientReply] an instance of ClientReply
         #
-        def search(filters)
-          with_options = options_builder.manufacture(user, filters).to_hash
+        def search(filters = {})
+          filters.merge!(resource_name)
 
+          with_options = options_builder.manufacture(user, filters).to_hash
           map_query.search(with_options)
         end
 
@@ -56,6 +57,15 @@ module HealthQuest
         #
         def get(id) # rubocop:disable Rails/Delegate
           map_query.get(id)
+        end
+
+        ##
+        # Builds the key/value pair for identifying the resource
+        #
+        # @return [Hash] a key value pair
+        #
+        def resource_name
+          { resource_name: 'questionnaire' }
         end
       end
     end

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/map_query.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/map_query.rb
@@ -37,7 +37,7 @@ module HealthQuest
         # @param options [Hash] the search options.
         # @return [FHIR::Questionnaire::Bundle] an instance of Bundle
         #
-        def search(options = {})
+        def search(options)
           client.search(fhir_model, search_options(options))
         end
 

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/factory.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/factory.rb
@@ -47,12 +47,13 @@ module HealthQuest
         ##
         # Gets Questionnaire Responses from a given set of OptionsBuilder
         #
-        # @param filters [PatientGeneratedData::QuestionnaireResponse::OptionsBuilder] the set of query options.
+        # @param filters [Hash] the set of query options.
         # @return [FHIR::QuestionnaireResponse::ClientReply] an instance of ClientReply
         #
-        def search(filters)
-          with_options = options_builder.manufacture(user, filters).to_hash
+        def search(filters = {})
+          filters.merge!(resource_name)
 
+          with_options = options_builder.manufacture(user, filters).to_hash
           map_query.search(with_options)
         end
 
@@ -64,6 +65,15 @@ module HealthQuest
         #
         def create(data)
           map_query.create(data, user)
+        end
+
+        ##
+        # Builds the key/value pair for identifying the resource
+        #
+        # @return [Hash] a key value pair
+        #
+        def resource_name
+          { resource_name: 'questionnaire_response' }
         end
       end
     end

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/map_query.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/map_query.rb
@@ -37,7 +37,7 @@ module HealthQuest
         # @param options [Hash] the search options.
         # @return [FHIR::QuestionnaireResponse::Bundle] an instance of Bundle
         #
-        def search(options = {})
+        def search(options)
           client.search(fhir_model, search_options(options))
         end
 

--- a/modules/health_quest/spec/request/questionnaire_responses_request_spec.rb
+++ b/modules/health_quest/spec/request/questionnaire_responses_request_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'health_quest questionnaire_responses', type: :request do
       end
 
       it 'returns a FHIR bundle' do
-        get '/health_quest/v0/questionnaire_responses'
+        get '/health_quest/v0/questionnaire_responses?patient=123dfgh'
 
         expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Bundle' })
       end

--- a/modules/health_quest/spec/request/questionnaires_request_spec.rb
+++ b/modules/health_quest/spec/request/questionnaires_request_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'health_quest questionnaires', type: :request do
       end
 
       it 'returns a FHIR bundle' do
-        get '/health_quest/v0/questionnaires'
+        get '/health_quest/v0/questionnaires?use_context=123'
 
         expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Bundle' })
       end

--- a/modules/health_quest/spec/services/patient_generated_data/options_builder_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/options_builder_spec.rb
@@ -6,16 +6,22 @@ describe HealthQuest::PatientGeneratedData::OptionsBuilder do
   subject { described_class }
 
   let(:user) { double('User', icn: '1008596379V859838') }
-  let(:filters) { {}.with_indifferent_access }
   let(:options_builder) { subject.manufacture(user, filters) }
+  let(:qr_filter) { { resource_name: 'questionnaire_response' } }
+  let(:q_filter) { { resource_name: 'questionnaire' } }
+  let(:lighthouse) { Settings.hqva_mobile.lighthouse }
 
   describe '.manufacture' do
+    let(:filters) { {}.with_indifferent_access }
+
     it 'returns an OptionsBuilder instance' do
       expect(subject.manufacture(nil, nil)).to be_an_instance_of(subject)
     end
   end
 
   describe 'object attributes' do
+    let(:filters) { {}.with_indifferent_access }
+
     it 'responds to set attributes' do
       expect(options_builder.respond_to?(:user)).to eq(true)
       expect(options_builder.respond_to?(:filters)).to eq(true)
@@ -23,35 +29,95 @@ describe HealthQuest::PatientGeneratedData::OptionsBuilder do
   end
 
   describe '#appointment_id' do
-    let(:filters) { { appointment_id: '123' }.with_indifferent_access }
+    let(:filters) { qr_filter.merge!(appointment_id: '123').with_indifferent_access }
 
     it 'has an appointment_id' do
       expect(options_builder.appointment_id).to eq('123')
     end
   end
 
-  describe '#subject_reference' do
-    let(:filters) { { appointment_id: '123' }.with_indifferent_access }
+  describe '#resource_created_date' do
+    let(:filters) { qr_filter.merge!(authored: '2021-12-26').with_indifferent_access }
+
+    it 'has a resource_created_date' do
+      expect(options_builder.resource_created_date).to eq('2021-12-26')
+    end
+  end
+
+  describe '#context_type_value' do
+    let(:filters) { q_filter.with_indifferent_access }
+
+    it 'has a context_type_value' do
+      expect(options_builder.context_type_value).to eq('')
+    end
+  end
+
+  describe '#appointment_reference' do
+    let(:filters) { qr_filter.merge!(appointment_id: '123').with_indifferent_access }
 
     it 'has an appointment reference link' do
-      expect(options_builder.subject_reference)
-        .to eq("#{Settings.hqva_mobile.url}/appointments/v1/patients/1008596379V859838/Appointment/123")
+      expect(options_builder.appointment_reference)
+        .to eq("#{lighthouse.url}#{lighthouse.pgd_path}/NamingSystem/va-appointment-identifier|123")
+    end
+  end
+
+  describe '#registry' do
+    context 'when resource is questionnaire_response' do
+      let(:filters) { qr_filter.merge!(appointment_id: '123').with_indifferent_access }
+
+      it 'has relevant keys' do
+        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys)
+          .to eq(%i[appointment_id patient authored])
+      end
+    end
+
+    context 'when resource is questionnaire' do
+      let(:filters) { q_filter.merge!(use_context: '123').with_indifferent_access }
+
+      it 'has relevant keys' do
+        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[use_context])
+      end
     end
   end
 
   describe '#to_hash' do
-    context 'without filters' do
-      it 'has a user option' do
-        expect(options_builder.to_hash).to eq({ author: '1008596379V859838' })
+    context 'when resource is questionnaire_response' do
+      context 'when appointment_id' do
+        let(:filters) { qr_filter.merge!(appointment_id: '123').with_indifferent_access }
+
+        it 'returns a _tag hash' do
+          expect(options_builder.to_hash)
+            .to eq({ _tag: 'https://sandbox-api.va.gov/services/pgd/v0/r4/NamingSystem/va-appointment-identifier|123' })
+        end
+      end
+
+      context 'when patient' do
+        let(:filters) { qr_filter.merge!(patient: '1008596379V859838').with_indifferent_access }
+
+        it 'returns a subject hash' do
+          expect(options_builder.to_hash)
+            .to eq({ subject: '1008596379V859838' })
+        end
+      end
+
+      context 'when authored' do
+        let(:filters) { qr_filter.merge!(authored: '2021-12-26').with_indifferent_access }
+
+        it 'returns an authored hash' do
+          expect(options_builder.to_hash)
+            .to eq({ authored: '2021-12-26' })
+        end
       end
     end
 
-    context 'with appointment_id filter' do
-      let(:filters) { { appointment_id: '123' }.with_indifferent_access }
+    context 'when resource is questionnaire' do
+      context 'when use_context' do
+        let(:filters) { q_filter.merge!(use_context: '').with_indifferent_access }
 
-      it 'has a subject option' do
-        expect(options_builder.to_hash)
-          .to eq({ subject: "#{Settings.hqva_mobile.url}/appointments/v1/patients/1008596379V859838/Appointment/123" })
+        it 'returns an use_context hash' do
+          expect(options_builder.to_hash)
+            .to eq({ 'context-type-value': '' })
+        end
       end
     end
   end

--- a/modules/health_quest/spec/services/patient_generated_data/questionnaire/factory_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/questionnaire/factory_spec.rb
@@ -31,13 +31,13 @@ describe HealthQuest::PatientGeneratedData::Questionnaire::Factory do
   end
 
   describe '#search' do
-    let(:filters) { { appointment_id: nil }.with_indifferent_access }
+    let(:filters) { { resource_name: 'questionnaire', appointment_id: nil }.with_indifferent_access }
     let(:options_builder) { HealthQuest::PatientGeneratedData::OptionsBuilder.manufacture(user, filters) }
 
     it 'returns a ClientReply' do
       allow_any_instance_of(FHIR::Client).to receive(:search).with(anything, anything).and_return(client_reply)
 
-      expect(subject.new(user).search(options_builder.to_hash)).to eq(client_reply)
+      expect(subject.new(user).search(filters)).to eq(client_reply)
     end
   end
 

--- a/modules/health_quest/spec/services/patient_generated_data/questionnaire_response/factory_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/questionnaire_response/factory_spec.rb
@@ -31,7 +31,7 @@ describe HealthQuest::PatientGeneratedData::QuestionnaireResponse::Factory do
   end
 
   describe '#search' do
-    let(:filters) { { appointment_id: nil }.with_indifferent_access }
+    let(:filters) { { resource_name: 'questionnaire_response', appointment_id: nil }.with_indifferent_access }
     let(:options_builder) { HealthQuest::PatientGeneratedData::OptionsBuilder.manufacture(user, filters) }
 
     it 'returns a ClientReply' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- GET Questionnaire Responses from the Lighthouse PGD by a given appointment ID
- Refactoring the `options_builder.rb` and related rspec tests so that filters can be scoped by QuestionnaireResponse and Questionnaire resources respectively.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#17207

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests written and test suite passing.