### PR TITLE
remove require_dependency from app directory

### DIFF
--- a/app/models/emis_redis/model.rb
+++ b/app/models/emis_redis/model.rb
@@ -2,7 +2,6 @@
 
 require 'common/models/redis_store'
 require 'common/models/concerns/cache_aside'
-require_dependency 'emis/responses'
 require 'emis/military_information_service_v2'
 
 module EMISRedis

--- a/app/models/okta_redis/grants.rb
+++ b/app/models/okta_redis/grants.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-# We need to ensure that the response class is defined before we ask Common::RedisStore.find to
-# deserialize one.
-require_dependency 'okta/response'
-
 module OktaRedis
   class Grants < Model
     CLASS_NAME = 'GrantsService'


### PR DESCRIPTION
`require_dependency` is obsoleted by zeitwerk.  More PRs will come for modules directories.

## Description of change
"All these problems are solved in zeitwerk mode, it just works as expected, and require_dependency should not be used anymore, it is no longer needed." https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#ruby-constant-lookup-compliance

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14688