### PR TITLE
put back submitting status

### DIFF
--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -14,6 +14,7 @@ module AppealsApi
     def perform(higher_level_review, retries = 0)
       @retries = retries
       stamped_pdf = AppealsApi::PdfConstruction::Generator.new(higher_level_review).generate
+      higher_level_review.update!(status: 'submitting')
       upload_to_central_mail(higher_level_review, stamped_pdf)
       File.delete(stamped_pdf) if File.exist?(stamped_pdf)
     end


### PR DESCRIPTION
The pre-submitted status  for the HLR PDF - "submitting" was accidentally removed during a Refactor. This puts it back.