### PR TITLE
submit ID instead of object to PDF Submit Job

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews_controller.rb
@@ -22,7 +22,7 @@ class AppealsApi::V1::DecisionReviews::HigherLevelReviewsController < AppealsApi
 
   def create
     @higher_level_review.save
-    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review)
+    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id)
     render_higher_level_review
   end
 

--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -11,7 +11,8 @@ module AppealsApi
     include Sidekiq::Worker
     include CentralMail::Utilities
 
-    def perform(higher_level_review, retries = 0)
+    def perform(higher_level_review_id, retries = 0)
+      higher_level_review = AppealsApi::HigherLevelReview.find(higher_level_review_id)
       @retries = retries
       stamped_pdf = AppealsApi::PdfConstruction::Generator.new(higher_level_review).generate
       higher_level_review.update!(status: 'submitting')

--- a/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
       capture_body = arg
       faraday_response
     }
-    described_class.new.perform(higher_level_review)
+    described_class.new.perform(higher_level_review.id)
     expect(capture_body).to be_a(Hash)
     expect(capture_body).to have_key('metadata')
     expect(capture_body).to have_key('document')
@@ -46,7 +46,7 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
       capture_body = arg
       faraday_response
     }
-    described_class.new.perform(higher_level_review)
+    described_class.new.perform(higher_level_review.id)
     expect(capture_body).to be_a(Hash)
     expect(capture_body).to have_key('metadata')
     expect(capture_body).to have_key('document')
@@ -68,7 +68,7 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
     it 'queues another job to retry the request' do
       expect(client_stub).to receive(:upload) { |_arg| faraday_response }
       Timecop.freeze(Time.zone.now)
-      described_class.new.perform(higher_level_review)
+      described_class.new.perform(higher_level_review.id)
       expect(described_class.jobs.last['at']).to eq(30.minutes.from_now.to_f)
       Timecop.return
     end


### PR DESCRIPTION
When calling perform_async using sidekiq, the parameter passed in gets serialized to JSON in order to put it on the redis queue. This causes a NoMethodError, because the resulting object is a string.

```
"error_message\":\"undefined method `pdf_structure' for \\\"#<AppealsApi::HigherLevelReview:0x000055b485ed1ce8>\\\":String\",\"error_class\":\"NoMethodError\",\
```

https://vajira.max.gov/browse/API-4762