### PR TITLE
Add _iv column to education_stem_automated_decisions table

### DIFF
--- a/db/migrate/20210128150813_add_column_to_education_stem_automated_decisions.rb
+++ b/db/migrate/20210128150813_add_column_to_education_stem_automated_decisions.rb
@@ -1,0 +1,5 @@
+class AddColumnToEducationStemAutomatedDecisions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :education_stem_automated_decisions, :encrypted_auth_headers_json_iv, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_21_161138) do
+ActiveRecord::Schema.define(version: 2021_01_28_150813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -274,6 +274,7 @@ ActiveRecord::Schema.define(version: 2021_01_21_161138) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "poa"
     t.string "encrypted_auth_headers_json"
+    t.string "encrypted_auth_headers_json_iv"
     t.index ["education_benefits_claim_id"], name: "index_education_stem_automated_decisions_on_claim_id"
     t.index ["user_uuid"], name: "index_education_stem_automated_decisions_on_user_uuid"
   end


### PR DESCRIPTION
## Description of change
Added the `encrypted_auth_headers_json_iv` column to the `education_stem_automated_decisions` table because the `_iv` column is required for the encrypted field to function correctly.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18622

## Things to know about this PR
- Tested locally and QA reviewed.
- Used in https://github.com/department-of-veterans-affairs/vets-api/pull/5793