### PR TITLE
Changed typo in DirectoryController

### DIFF
--- a/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
+++ b/modules/apps_api/app/controllers/apps_api/v0/directory_controller.rb
@@ -70,7 +70,7 @@ module AppsApi
 
       def verify_auth
         # put this secret in settings.local.yml
-        head :unauthorized unless request.authorization == Settings.directory.secret
+        head :unauthorized unless request.authorization == Settings.directory.key
       end
 
       def set_directory_application

--- a/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
+++ b/modules/apps_api/spec/requests/v0/application_directory_request_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Application Directory Endpoint', type: :request do
   end
 
   before do
-    allow(Settings.directory).to receive(:secret).and_return(auth_string)
+    allow(Settings.directory).to receive(:key).and_return(auth_string)
   end
 
   describe '#get /services/apps/v0/directory' do


### PR DESCRIPTION
Signed-off-by: Braden Shipley <bradenrshipley@gmail.com>

## Description of change
This is a small hotfix to use the correct value of `Settings.directory.key` instead of `Settings.directory.secret` inside the `directory_controller`. This typo wormed its way through past PRs due to my `Settings.local.yml` having `key` instead of `secret`.

## Original issue(s)
Slack thread where this typo was found: https://dsva.slack.com/archives/CBU0KDSB1/p1611861312392800

## Things to know about this PR
The `credstash` calls that reference this value  in the devops repo are correct and do not need to be updated.

<!-- Please describe testing done to verify the changes or any testing planned. -->
Value of secret checked inside credstash and inside the Rails Console of the `vets-api` dev environment.
