### PR TITLE
Api 4695/update healthcheck to include central mail

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
   config.action_view.cache_template_loading = true
 
   # Do not eager load code on boot. This avoids loading your whole application

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = false
+  config.cache_classes = true
   config.action_view.cache_template_loading = true
 
   # Do not eager load code on boot. This avoids loading your whole application

--- a/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
@@ -54,7 +54,7 @@ module AppealsApi
 
       render json: {
         description: 'Appeals API upstream health check',
-        status: health_checker.services_are_healthy? ? 'UP' : 'DOWN',
+        status: health_checker.appeals_services_are_healthy? ? 'UP' : 'DOWN',
         time: time,
         details: {
           name: 'All upstream services',
@@ -62,7 +62,7 @@ module AppealsApi
                               upstream_service_details(service, health_checker, time)
                             end
         }
-      }, status: health_checker.services_are_healthy? ? 200 : 503
+      }, status: health_checker.appeals_services_are_healthy? ? 200 : 503
     end
 
     def decision_reviews_upstream_healthcheck

--- a/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
@@ -48,7 +48,7 @@ module AppealsApi
       }
     end
 
-    def upstream_healthcheck
+    def appeals_status_upstream_healthcheck
       health_checker = AppealsApi::HealthChecker.new
       time = Time.zone.now.to_formatted_s(:iso8601)
 
@@ -58,11 +58,28 @@ module AppealsApi
         time: time,
         details: {
           name: 'All upstream services',
-          upstreamServices: AppealsApi::HealthChecker::SERVICES.map do |service|
+          upstreamServices: AppealsApi::HealthChecker::APPEALS_SERVICES.map do |service|
                               upstream_service_details(service, health_checker, time)
                             end
         }
       }, status: health_checker.services_are_healthy? ? 200 : 503
+    end
+
+    def decision_reviews_upstream_healthcheck
+      health_checker = AppealsApi::HealthChecker.new
+      time = Time.zone.now.to_formatted_s(:iso8601)
+
+      render json: {
+        description: 'Appeals API upstream health check',
+        status: health_checker.decision_reviews_services_are_healthy? ? 'UP' : 'DOWN',
+        time: time,
+        details: {
+          name: 'All upstream services',
+          upstreamServices: AppealsApi::HealthChecker::DECISION_REVIEWS_SERVICES.map do |service|
+                              upstream_service_details(service, health_checker, time)
+                            end
+        }
+      }, status: health_checker.decision_reviews_services_are_healthy? ? 200 : 503
     end
 
     private

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -5,8 +5,8 @@ AppealsApi::Engine.routes.draw do
   match '/decision_reviews/metadata', to: 'metadata#decision_reviews', via: [:get]
   match '/v0/healthcheck', to: 'metadata#healthcheck', via: [:get]
   match '/v1/healthcheck', to: 'metadata#healthcheck', via: [:get]
-  match '/v0/upstream_healthcheck', to: 'metadata#upstream_healthcheck', via: [:get]
-  match '/v1/upstream_healthcheck', to: 'metadata#upstream_healthcheck', via: [:get]
+  match '/v0/upstream_healthcheck', to: 'metadata#appeals_status_upstream_healthcheck', via: [:get]
+  match '/v1/upstream_healthcheck', to: 'metadata#decision_reviews_upstream_healthcheck', via: [:get]
   match '/v0/appeals', to: 'v0/appeals#index', via: [:get]
 
   namespace :v1, defaults: { format: 'json' } do

--- a/modules/appeals_api/spec/requests/metadata_request_spec.rb
+++ b/modules/appeals_api/spec/requests/metadata_request_spec.rb
@@ -105,6 +105,8 @@ RSpec.describe 'Appeals Metadata Endpoint', type: :request do
     context 'v1' do
       it 'returns correct response and status when healthy' do
         VCR.use_cassette('caseflow/health-check') do
+          allow(CentralMail::Service).to receive(:current_breaker_outage?).and_return(false)
+
           get '/services/appeals/v1/upstream_healthcheck'
           expect(response).to have_http_status(:ok)
 
@@ -117,7 +119,7 @@ RSpec.describe 'Appeals Metadata Endpoint', type: :request do
           expect(details['name']).to eq('All upstream services')
 
           upstream_service = details['upstreamServices'].first
-          expect(details['upstreamServices'].size).to eq(1)
+          expect(details['upstreamServices'].size).to eq(2)
           expect(upstream_service['description']).to eq('Caseflow')
           expect(upstream_service['status']).to eq('UP')
           expect(upstream_service['details']['name']).to eq('Caseflow')
@@ -129,6 +131,8 @@ RSpec.describe 'Appeals Metadata Endpoint', type: :request do
 
       it 'returns correct status when caseflow is not healthy' do
         VCR.use_cassette('caseflow/health-check-down') do
+          allow(CentralMail::Service).to receive(:current_breaker_outage?).and_return(false)
+
           get '/services/appeals/v1/upstream_healthcheck'
           expect(response).to have_http_status(:service_unavailable)
 
@@ -141,12 +145,64 @@ RSpec.describe 'Appeals Metadata Endpoint', type: :request do
           expect(details['name']).to eq('All upstream services')
 
           upstream_service = details['upstreamServices'].first
-          expect(details['upstreamServices'].size).to eq(1)
+          expect(details['upstreamServices'].size).to eq(2)
           expect(upstream_service['description']).to eq('Caseflow')
           expect(upstream_service['status']).to eq('DOWN')
           expect(upstream_service['details']['name']).to eq('Caseflow')
           expect(upstream_service['details']['statusCode']).to eq(503)
           expect(upstream_service['details']['status']).to eq('Unavailable')
+          expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
+        end
+      end
+
+      it 'returns the correct status when CentralMail is not healthy' do
+        VCR.use_cassette('caseflow/health-check') do
+          allow(CentralMail::Service).to receive(:current_breaker_outage?).and_return(true)
+
+          get '/services/appeals/v1/upstream_healthcheck'
+          expect(response).to have_http_status(:service_unavailable)
+
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['description']).to eq('Appeals API upstream health check')
+          expect(parsed_response['status']).to eq('DOWN')
+          expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+
+          details = parsed_response['details']
+          expect(details['name']).to eq('All upstream services')
+
+          upstream_service = details['upstreamServices'].last
+          expect(details['upstreamServices'].size).to eq(2)
+          expect(upstream_service['description']).to eq('Central Mail')
+          expect(upstream_service['status']).to eq('DOWN')
+          expect(upstream_service['details']['name']).to eq('Central Mail')
+          expect(upstream_service['details']['statusCode']).to eq(503)
+          expect(upstream_service['details']['status']).to eq('Unavailable')
+          expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
+        end
+      end
+
+      it 'returns correct status when CentralMail is healthy' do
+        VCR.use_cassette('caseflow/health-check') do
+          allow(CentralMail::Service).to receive(:current_breaker_outage?).and_return(false)
+
+          get '/services/appeals/v1/upstream_healthcheck'
+          expect(response).to have_http_status(:ok)
+
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['description']).to eq('Appeals API upstream health check')
+          expect(parsed_response['status']).to eq('UP')
+          expect(parsed_response['time']).to eq('2020-09-21T00:00:00Z')
+
+          details = parsed_response['details']
+          expect(details['name']).to eq('All upstream services')
+
+          upstream_service = details['upstreamServices'].last
+          expect(details['upstreamServices'].size).to eq(2)
+          expect(upstream_service['description']).to eq('Central Mail')
+          expect(upstream_service['status']).to eq('UP')
+          expect(upstream_service['details']['name']).to eq('Central Mail')
+          expect(upstream_service['details']['statusCode']).to eq(200)
+          expect(upstream_service['details']['status']).to eq('OK')
           expect(upstream_service['details']['time']).to eq('2020-09-21T00:00:00Z')
         end
       end

--- a/modules/appeals_api/spec/requests/metadata_request_spec.rb
+++ b/modules/appeals_api/spec/requests/metadata_request_spec.rb
@@ -103,7 +103,6 @@ RSpec.describe 'Appeals Metadata Endpoint', type: :request do
     end
 
     context 'v1' do
-
       it 'checks the status of both services individually' do
         VCR.use_cassette('caseflow/health-check') do
           allow(CentralMail::Service).to receive(:current_breaker_outage?).and_return(true)


### PR DESCRIPTION
[4695](https://vajira.max.gov/browse/API-4695)

This PR adjusts the HealthChecker for AppealsAPI to accommodate multiple upstream services for different versions of our API.

