### PR TITLE
Setting Appropriate Doc Type for Form 674

### DIFF
--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -38,7 +38,7 @@ class SavedClaim::DependencyClaim < SavedClaim
     self.form_id = form_id
 
     form_path = PdfFill::Filler.fill_form(self)
-    upload_to_vbms(form_path, doc_type)
+    upload_to_vbms(path: form_path, doc_type: doc_type)
   end
 
   def add_veteran_info(va_file_number_with_payload)
@@ -92,7 +92,7 @@ class SavedClaim::DependencyClaim < SavedClaim
     end
   end
 
-  def upload_to_vbms(path, doc_type: '148')
+  def upload_to_vbms(path:, doc_type: '148')
     uploader = ClaimsApi::VBMSUploader.new(
       filepath: path,
       file_number: parsed_form['veteran_information']['ssn'],

--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -34,11 +34,11 @@ class SavedClaim::DependencyClaim < SavedClaim
   validate :validate_686_form_data, on: :run_686_form_jobs
   validate :address_exists
 
-  def upload_pdf(form_id)
+  def upload_pdf(form_id, doc_type: '148')
     self.form_id = form_id
 
     form_path = PdfFill::Filler.fill_form(self)
-    upload_to_vbms(form_path)
+    upload_to_vbms(form_path, doc_type)
   end
 
   def add_veteran_info(va_file_number_with_payload)

--- a/app/workers/vbms/submit_dependents_pdf_job.rb
+++ b/app/workers/vbms/submit_dependents_pdf_job.rb
@@ -36,7 +36,7 @@ module VBMS
 
     def generate_pdf(claim, submittable_686, submittable_674)
       claim.upload_pdf('686C-674') if submittable_686
-      claim.upload_pdf('21-674') if submittable_674
+      claim.upload_pdf('21-674', doc_type: '143') if submittable_674
     end
   end
 end

--- a/spec/models/saved_claim/dependency_claim_spec.rb
+++ b/spec/models/saved_claim/dependency_claim_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe SavedClaim::DependencyClaim do
   describe '#format_and_uplad_pdf' do
     it 'calls upload to vbms' do
       expect_any_instance_of(described_class).to receive(:upload_to_vbms).with(
-        a_string_starting_with('tmp/pdfs/686C-674_')
+        {
+          path: a_string_starting_with('tmp/pdfs/686C-674_'),
+          doc_type: '148'
+        }
       )
 
       dependency_claim.add_veteran_info(va_file_number_with_payload)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
When submitting a 674 (VA Form 21-674b), we generate a PDF and send it to VBMS but currently we are using the incorrect document type. We need to set the document type that corresponds to the 674 form, instead of using the default doc type.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19089

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is a minor fix so no new settings or logging have been added.
<!-- Please describe testing done to verify the changes or any testing planned. -->
## Testing
- [x] Local testing
- [x] Updated specs
- [x] Staging testing planned