### PR TITLE
[5763] Refactoring user birth_date so that MPI or va_profile referenc…

### DIFF
--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -4,6 +4,7 @@ require 'evss/gi_bill_status/external_service_unavailable'
 require 'evss/gi_bill_status/gi_bill_status_response'
 require 'evss/gi_bill_status/outside_working_hours'
 require 'evss/gi_bill_status/service'
+require 'formatters/date_formatter'
 
 module V0
   class Post911GIBillStatusesController < ApplicationController
@@ -78,14 +79,8 @@ module V0
         participant_id: user.participant_id,
         vet360_id: user.vet360_id,
         ssn: user.ssn,
-        birth_date: birth_date_formatted(user.birth_date)
+        birth_date: Formatters::DateFormatter.format_date(user.birth_date, :datetime_iso8601)
       }.to_json
-    end
-
-    def birth_date_formatted(birth_date)
-      return unless birth_date
-
-      DateTime.parse(birth_date).iso8601
     end
 
     def skip_sentry_exception_types

--- a/app/controllers/v0/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v0/post911_gi_bill_statuses_controller.rb
@@ -78,14 +78,14 @@ module V0
         participant_id: user.participant_id,
         vet360_id: user.vet360_id,
         ssn: user.ssn,
-        birth_date: iso8601_birth_date(user)
+        birth_date: birth_date_formatted(user.birth_date)
       }.to_json
     end
 
-    def iso8601_birth_date(user)
-      return nil unless user&.va_profile&.birth_date
+    def birth_date_formatted(birth_date)
+      return unless birth_date
 
-      Time.parse(user.va_profile.birth_date).iso8601
+      DateTime.parse(birth_date).iso8601
     end
 
     def skip_sentry_exception_types

--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -20,7 +20,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
         'pid' => user.participant_id,
         'edipi' => user.edipi,
         'vet360ID' => user.vet360_id,
-        'dob' => parsed_date(user.birth_date)
+        'dob' => user.birth_date
       }
     ).except!('vaFileNumber')
 
@@ -64,11 +64,5 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     file_number.presence
   rescue
     nil
-  end
-
-  def parsed_date(date)
-    date.strftime('%Y-%m-%d')
-  rescue
-    date
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,8 +89,21 @@ class User < Common::RedisStore
     identity.gender || (mhv_icn.present? ? mpi&.profile&.gender : nil)
   end
 
+  # Returns a Date string in iso8601 format, eg. '{year}-{month}-{day}'
   def birth_date
-    identity.birth_date || (mhv_icn.present? ? mpi&.profile&.birth_date&.to_date&.to_s : nil)
+    birth_date = nil
+
+    if identity.birth_date
+      birth_date =  identity.birth_date
+    elsif mhv_icn.present?
+      birth_date =  mpi_profile_birth_date
+    end
+    if birth_date.nil?
+      Rails.logger.info "[User] Cannot find birth date for User with uuid: #{uuid}"
+      return nil
+    end
+
+    Date.parse(birth_date.to_s).iso8601
   end
 
   def zip
@@ -335,6 +348,31 @@ class User < Common::RedisStore
   end
 
   private
+
+  def mpi_profile
+    if mpi.nil?
+      Rails.logger.info "[User] Cannot find MPI record for User with uuid: #{uuid}"
+      return nil
+    end
+
+    if mpi.profile.nil?
+      Rails.logger.info "[User] Cannot find MPI profile record for User with uuid: #{uuid}"
+      return nil
+    end
+
+    mpi.profile
+  end
+
+  def mpi_profile_birth_date
+    return unless mpi_profile
+
+    if mpi_profile.birth_date.nil?
+      Rails.logger.info "[User] Cannot find birth date from MPI profile for User with uuid: #{uuid}"
+      return nil
+    end
+
+    mpi_profile.birth_date
+  end
 
   def pciu
     @pciu ||= EVSS::PCIU::Service.new self if loa3? && edipi.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ require 'evss/pciu/service'
 require 'mpi/messages/find_profile_message'
 require 'mpi/service'
 require 'saml/user'
+require 'formatters/date_formatter'
 
 class User < Common::RedisStore
   include BetaSwitch
@@ -103,7 +104,7 @@ class User < Common::RedisStore
       return nil
     end
 
-    Date.parse(birth_date.to_s).iso8601
+    Formatters::DateFormatter.format_date(birth_date)
   end
 
   def zip
@@ -350,21 +351,13 @@ class User < Common::RedisStore
   private
 
   def mpi_profile
-    if mpi.nil?
-      Rails.logger.info "[User] Cannot find MPI record for User with uuid: #{uuid}"
-      return nil
-    end
-
-    if mpi.profile.nil?
-      Rails.logger.info "[User] Cannot find MPI profile record for User with uuid: #{uuid}"
-      return nil
-    end
+    return nil unless mpi
 
     mpi.profile
   end
 
   def mpi_profile_birth_date
-    return unless mpi_profile
+    return nil unless mpi_profile
 
     if mpi_profile.birth_date.nil?
       Rails.logger.info "[User] Cannot find birth date from MPI profile for User with uuid: #{uuid}"

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# These entries represent the possible formats for a Date for a to_s call
+Date::DATE_FORMATS[:iso8601] = '%Y-%m-%d'
+Date::DATE_FORMATS[:number_iso8601] = '%Y%m%d'
+Date::DATE_FORMATS[:datetime_iso8601] = '%FT%T%:z'
+Date::DATE_FORMATS[:month_day_year] = '%b %d, %Y'

--- a/lib/evss/auth_headers.rb
+++ b/lib/evss/auth_headers.rb
@@ -26,7 +26,7 @@ module EVSS
         'va_eauth_birlsfilenumber' => @user.birls_id,
         'va_eauth_pid' => @user.participant_id,
         'va_eauth_pnid' => @user.ssn,
-        'va_eauth_birthdate' => iso8601_birth_date,
+        'va_eauth_birthdate' => birth_date_formatted(@user.birth_date),
         'va_eauth_authorization' => eauth_json,
         'va_eauth_authenticationauthority' => 'eauth',
         'va_eauth_service_transaction_id' => @transaction_id
@@ -54,9 +54,15 @@ module EVSS
           edi: @user.edipi,
           firstName: @user.first_name,
           lastName: @user.last_name,
-          birthDate: iso8601_birth_date
+          birthDate: birth_date_formatted(@user.birth_date)
         }
       }.to_json
+    end
+
+    def birth_date_formatted(birth_date)
+      return unless birth_date
+
+      DateTime.parse(birth_date).iso8601
     end
   end
 end

--- a/lib/evss/auth_headers.rb
+++ b/lib/evss/auth_headers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'evss/base_headers'
+require 'formatters/date_formatter'
 
 module EVSS
   class AuthHeaders < EVSS::BaseHeaders
@@ -26,7 +27,7 @@ module EVSS
         'va_eauth_birlsfilenumber' => @user.birls_id,
         'va_eauth_pid' => @user.participant_id,
         'va_eauth_pnid' => @user.ssn,
-        'va_eauth_birthdate' => birth_date_formatted(@user.birth_date),
+        'va_eauth_birthdate' => Formatters::DateFormatter.format_date(@user.birth_date, :datetime_iso8601),
         'va_eauth_authorization' => eauth_json,
         'va_eauth_authenticationauthority' => 'eauth',
         'va_eauth_service_transaction_id' => @transaction_id
@@ -54,15 +55,9 @@ module EVSS
           edi: @user.edipi,
           firstName: @user.first_name,
           lastName: @user.last_name,
-          birthDate: birth_date_formatted(@user.birth_date)
+          birthDate: Formatters::DateFormatter.format_date(@user.birth_date, :datetime_iso8601)
         }
       }.to_json
-    end
-
-    def birth_date_formatted(birth_date)
-      return unless birth_date
-
-      DateTime.parse(birth_date).iso8601
     end
   end
 end

--- a/lib/evss/base_headers.rb
+++ b/lib/evss/base_headers.rb
@@ -6,15 +6,5 @@ module EVSS
       # user may be either ClaimsApi::Veteran or User model
       @user = user
     end
-
-    private
-
-    def iso8601_birth_date
-      birth_date = @user&.va_profile&.birth_date
-      birth_date = @user.identity.birth_date if !birth_date && @user.is_a?(User)
-      return nil unless birth_date
-
-      DateTime.parse(birth_date).iso8601
-    end
   end
 end

--- a/lib/evss/disability_compensation_auth_headers.rb
+++ b/lib/evss/disability_compensation_auth_headers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'evss/base_headers'
+require 'formatters/date_formatter'
 
 module EVSS
   class DisabilityCompensationAuthHeaders < EVSS::BaseHeaders
@@ -23,16 +24,10 @@ module EVSS
           edi: @user.edipi,
           firstName: @user.first_name,
           lastName: @user.last_name,
-          birthDate: birth_date_formatted(@user.birth_date),
+          birthDate: Formatters::DateFormatter.format_date(@user.birth_date, :datetime_iso8601),
           gender: gender
         }
       }.to_json
-    end
-
-    def birth_date_formatted(birth_date)
-      return unless birth_date
-
-      DateTime.parse(birth_date).iso8601
     end
 
     def gender

--- a/lib/evss/disability_compensation_auth_headers.rb
+++ b/lib/evss/disability_compensation_auth_headers.rb
@@ -23,10 +23,16 @@ module EVSS
           edi: @user.edipi,
           firstName: @user.first_name,
           lastName: @user.last_name,
-          birthDate: iso8601_birth_date,
+          birthDate: birth_date_formatted(@user.birth_date),
           gender: gender
         }
       }.to_json
+    end
+
+    def birth_date_formatted(birth_date)
+      return unless birth_date
+
+      DateTime.parse(birth_date).iso8601
     end
 
     def gender

--- a/lib/formatters/date_formatter.rb
+++ b/lib/formatters/date_formatter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Given a date to format, in either a Date/Time object, or a String representing a Date,
+# additionally an optional symbol from config/initializers/date_formats.rb to specifically
+# format. Default is  Date object :iso8601, or '2020-01-31'
+module Formatters
+  class DateFormatter
+    def self.format_date(date_to_format, format = :iso8601)
+      return if date_to_format.nil?
+
+      begin
+        Date.parse(date_to_format.to_s).to_s(format)
+      rescue ArgumentError
+        Rails.logger.error "[Formatters/DateFormatter] Cannot parse given date: #{date_to_format}"
+        nil
+      end
+    end
+  end
+end

--- a/lib/mdot/client.rb
+++ b/lib/mdot/client.rb
@@ -74,13 +74,9 @@ module MDOT
         VA_VETERAN_MIDDLE_NAME: @user.middle_name,
         VA_VETERAN_LAST_NAME: @user.last_name,
         VA_VETERAN_ID: @user.ssn.last(4),
-        VA_VETERAN_BIRTH_DATE: format_birthdate(@user.birth_date),
+        VA_VETERAN_BIRTH_DATE: @user.birth_date,
         VA_ICN: @user.icn
       }
-    end
-
-    def format_birthdate(date)
-      Date.parse(date).strftime('%Y-%m-%d')
     end
 
     def submission_headers

--- a/lib/mpi/messages/add_person_message.rb
+++ b/lib/mpi/messages/add_person_message.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'socket'
+require 'formatters/date_formatter'
 
 module MPI
   module Messages
@@ -44,17 +45,11 @@ module MPI
           'edipi' => user.edipi,
           'first_name' => user.first_name,
           'last_name' => user.last_name,
-          'date_of_birth' => parsed_date(user.birth_date),
+          'date_of_birth' => Formatters::DateFormatter.format_date(user.birth_date, :number_iso8601),
           'ssn' => user.ssn,
           'current_datetime' => current_time.strftime('%Y-%m-%d %H:%M:%S'),
           'ip_address' => ip_address
         }
-      end
-
-      def parsed_date(date)
-        return unless date
-
-        date.to_date.strftime('%Y%m%d')
       end
     end
   end

--- a/lib/mpi/messages/add_person_message.rb
+++ b/lib/mpi/messages/add_person_message.rb
@@ -44,11 +44,17 @@ module MPI
           'edipi' => user.edipi,
           'first_name' => user.first_name,
           'last_name' => user.last_name,
-          'date_of_birth' => Date.parse(user.birth_date).strftime('%Y%m%d'),
+          'date_of_birth' => parsed_date(user.birth_date),
           'ssn' => user.ssn,
           'current_datetime' => current_time.strftime('%Y-%m-%d %H:%M:%S'),
           'ip_address' => ip_address
         }
+      end
+
+      def parsed_date(date)
+        return unless date
+
+        date.to_date.strftime('%Y%m%d')
       end
     end
   end

--- a/modules/health_quest/app/services/health_quest/jwt_wrapper.rb
+++ b/modules/health_quest/app/services/health_quest/jwt_wrapper.rb
@@ -34,8 +34,8 @@ module HealthQuest
         sst: 1.minute.ago.to_i + 50,
         version: VERSION,
         gender: gender,
-        dob: dob,
-        dateOfBirth: dob,
+        dob: birth_date,
+        dateOfBirth: birth_date,
         edipid: edipi,
         ssn: ssn
       }
@@ -65,8 +65,8 @@ module HealthQuest
       end
     end
 
-    def dob
-      user.mpi&.profile&.birth_date
+    def birth_date
+      user.birth_date
     end
 
     def edipi

--- a/modules/vaos/app/models/vaos/appointment_request_form.rb
+++ b/modules/vaos/app/models/vaos/appointment_request_form.rb
@@ -84,7 +84,7 @@ module VAOS
         display_name: "#{last_name}, #{first_name}",
         first_name: first_name,
         last_name: last_name,
-        date_of_birth: dob,
+        date_of_birth: birth_date,
         patient_identifier: {
           unique_id: edipi
         },
@@ -140,10 +140,10 @@ module VAOS
       @user.mpi&.profile&.family_name
     end
 
-    def dob
-      Date.parse(@user.mpi.profile.birth_date).strftime('%b %d, %Y')
-    rescue
-      ''
+    def birth_date
+      return unless @user.birth_date
+
+      @user.birth_date.to_date.strftime('%b %d, %Y')
     end
 
     def edipi

--- a/modules/vaos/app/models/vaos/appointment_request_form.rb
+++ b/modules/vaos/app/models/vaos/appointment_request_form.rb
@@ -3,6 +3,7 @@
 require 'active_model'
 require 'common/models/form'
 require 'common/exceptions'
+require 'formatters/date_formatter'
 
 module VAOS
   class AppointmentRequestForm < Common::Form
@@ -141,9 +142,7 @@ module VAOS
     end
 
     def birth_date
-      return unless @user.birth_date
-
-      @user.birth_date.to_date.strftime('%b %d, %Y')
+      Formatters::DateFormatter.format_date(@user.birth_date, :month_day_year)
     end
 
     def edipi

--- a/modules/vaos/app/services/vaos/jwt_wrapper.rb
+++ b/modules/vaos/app/services/vaos/jwt_wrapper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'formatters/date_formatter'
+
 module VAOS
   class JwtWrapper
     VERSION = 2.1
@@ -66,9 +68,7 @@ module VAOS
     end
 
     def parsed_date
-      return unless user.birth_date
-
-      user.birth_date.to_date.strftime('%Y%m%d')
+      Formatters::DateFormatter.format_date(user.birth_date, :number_iso8601)
     end
 
     def edipi

--- a/modules/vaos/app/services/vaos/jwt_wrapper.rb
+++ b/modules/vaos/app/services/vaos/jwt_wrapper.rb
@@ -34,8 +34,8 @@ module VAOS
         sst: 1.minute.ago.to_i + 50,
         version: VERSION,
         gender: gender,
-        dob: dob,
-        dateOfBirth: dob,
+        dob: parsed_date,
+        dateOfBirth: parsed_date,
         edipid: edipi,
         ssn: ssn
       }
@@ -65,8 +65,10 @@ module VAOS
       end
     end
 
-    def dob
-      user.mpi&.profile&.birth_date
+    def parsed_date
+      return unless user.birth_date
+
+      user.birth_date.to_date.strftime('%Y%m%d')
     end
 
     def edipi

--- a/spec/lib/formatters/date_formatter_spec.rb
+++ b/spec/lib/formatters/date_formatter_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'formatters/date_formatter'
+
+describe Formatters::DateFormatter do
+  describe '.format_date' do
+    subject { described_class.format_date(date, date_format) }
+
+    let(:date) { '30-1-2020' }
+    let(:date_format) { :iso8601 }
+
+    context 'when input date is nil' do
+      let(:date) { nil }
+
+      it 'returns nil' do
+        expect(subject).to be nil
+      end
+    end
+
+    context 'when input date is an arbitrary value that is not a date' do
+      let(:date) { 'banana' }
+      let(:expected_log) { "[Formatters/DateFormatter] Cannot parse given date: #{date}" }
+
+      it 'logs to the Rails Logger error buffer' do
+        expect(Rails.logger).to receive(:error).with(expected_log)
+        subject
+      end
+
+      it 'returns nil' do
+        expect(subject).to be nil
+      end
+    end
+
+    context 'when input date is a date object' do
+      let(:date) { Date.parse('30-1-2020') }
+
+      context 'and default format is given' do
+        let(:date_format) { :iso8601 }
+        let(:expected_formatted_date) { '2020-01-30' }
+
+        it 'returns a string that represents a date parsed to iso8601 format' do
+          expect(subject).to eq(expected_formatted_date)
+        end
+      end
+
+      context 'and number_iso98601 format is given' do
+        let(:date_format) { :number_iso8601 }
+        let(:expected_formatted_date) { '20200130' }
+
+        it 'returns a string that represents a date parsed to iso8601 with numbers only' do
+          expect(subject).to eq(expected_formatted_date)
+        end
+      end
+
+      context 'and datetime_iso8601 format is given' do
+        let(:date_format) { :datetime_iso8601 }
+        let(:expected_formatted_date) { '2020-01-30T00:00:00+00:00' }
+
+        it 'returns a string that represents a date parsed to iso8601 with full datetime granularity' do
+          expect(subject).to eq(expected_formatted_date)
+        end
+      end
+
+      context 'and month_day_year format is given' do
+        let(:date_format) { :month_day_year }
+        let(:expected_formatted_date) { 'Jan 30, 2020' }
+
+        it 'returns a string that represents a date parsed to a Month Date, Year format' do
+          expect(subject).to eq(expected_formatted_date)
+        end
+      end
+    end
+
+    context 'when input date is a string object that represents a date' do
+      let(:date) { '30-1-2020' }
+
+      context 'and default format is given' do
+        let(:date_format) { :iso8601 }
+        let(:expected_formatted_date) { '2020-01-30' }
+
+        it 'returns a string that represents a date parsed to iso8601 format' do
+          expect(subject).to eq(expected_formatted_date)
+        end
+      end
+
+      context 'and number_iso98601 format is given' do
+        let(:date_format) { :number_iso8601 }
+        let(:expected_formatted_date) { '20200130' }
+
+        it 'returns a string that represents a date parsed to iso8601 with numbers only' do
+          expect(subject).to eq(expected_formatted_date)
+        end
+      end
+
+      context 'and datetime_iso8601 format is given' do
+        let(:date_format) { :datetime_iso8601 }
+        let(:expected_formatted_date) { '2020-01-30T00:00:00+00:00' }
+
+        it 'returns a string that represents a date parsed to iso8601 with full datetime granularity' do
+          expect(subject).to eq(expected_formatted_date)
+        end
+      end
+
+      context 'and month_day_year format is given' do
+        let(:date_format) { :month_day_year }
+        let(:expected_formatted_date) { 'Jan 30, 2020' }
+
+        it 'returns a string that represents a date parsed to a Month Date, Year format' do
+          expect(subject).to eq(expected_formatted_date)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -332,8 +332,8 @@ RSpec.describe User, type: :model do
           expect(user.gender).to be(user.identity.gender)
         end
 
-        it 'fetches birth_date from IDENTITY' do
-          expect(user.birth_date).to be(user.identity.birth_date)
+        it 'fetches properly parsed birth_date from IDENTITY' do
+          expect(user.birth_date).to eq(Date.parse(user.identity.birth_date).iso8601)
         end
 
         it 'fetches zip from IDENTITY' do
@@ -400,8 +400,8 @@ RSpec.describe User, type: :model do
           expect(user.gender).to be(user.va_profile.gender)
         end
 
-        it 'fetches birth_date from MVI' do
-          expect(user.birth_date).to eq(user.va_profile.birth_date.to_date.to_s)
+        it 'fetches properly parsed birth_date from MVI' do
+          expect(user.birth_date).to eq(Date.parse(user.va_profile.birth_date).iso8601)
         end
 
         it 'fetches zip from MVI' do
@@ -470,8 +470,8 @@ RSpec.describe User, type: :model do
           expect(user.gender).to be(user.identity.gender)
         end
 
-        it 'fetches birth_date from IDENTITY' do
-          expect(user.birth_date).to be(user.identity.birth_date)
+        it 'fetches properly parsed birth_date from IDENTITY' do
+          expect(user.birth_date).to eq(Date.parse(user.identity.birth_date).iso8601)
         end
 
         it 'fetches zip from IDENTITY' do
@@ -700,6 +700,57 @@ RSpec.describe User, type: :model do
 
         expect(account.class).to eq Account
         expect(account.idme_uuid).to eq user.uuid
+      end
+    end
+  end
+
+  describe '#birth_date' do
+    let(:user) { subject }
+
+    context 'when birth_date attribute is available on the UserIdentity object' do
+      it 'returns iso8601 parsed date from the UserIdentity birth_date attribute' do
+        expect(user.birth_date).to eq Date.parse(user.identity.birth_date.to_s).iso8601
+      end
+    end
+
+    context 'when birth_date attribute is not available on the UserIdentity object' do
+      before do
+        allow(user.identity).to receive(:birth_date).and_return nil
+      end
+
+      context 'and mhv_icn attribute is available on the UserIdentity object' do
+        let(:user) { described_class.new(build(:user, :mhv, mhv_icn: 'some-mhv-icn')) }
+
+        context 'and MPI Profile birth date does not exist' do
+          before do
+            allow(user.mpi.profile).to receive(:birth_date).and_return nil
+          end
+
+          it 'returns nil' do
+            expect(user.birth_date).to eq nil
+          end
+        end
+
+        context 'and MPI Profile birth date does exist' do
+          it 'returns iso8601 parsed date from the MPI Profile birth_date attribute' do
+            expect(user.birth_date).to eq Date.parse(user.mpi.profile.birth_date.to_s).iso8601
+          end
+        end
+      end
+
+      context 'when birth_date attribute cannot be retrieved from UserIdentity or MPI object' do
+        before do
+          allow(user.identity).to receive(:birth_date).and_return nil
+        end
+
+        it 'logs a cannot find birth date message to Rails logger' do
+          expect(Rails.logger).to receive(:info).with "[User] Cannot find birth date for User with uuid: #{user.uuid}"
+          user.birth_date
+        end
+
+        it 'returns nil' do
+          expect(user.birth_date).to eq nil
+        end
       end
     end
   end


### PR DESCRIPTION
…es stay within the User class

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR refactors the User `birth_date` attribute so that other classes will no longer have to decide whether to choose from the `MPI` birth_date, or the `UserIdentity` birth_date from the authentication payload. This keeps that logic within the User class

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/5763

## Things to know about this PR
There technically shouldn't be any Production changes with this refactor, although, since many places are no longer specifically deciding whether to pull the birth_date from UserIdentity or MPI, it's possible this may lead to an issue if a service was specifically expecting it to come from one or the other. I don't think this should be the case, but it's something we can watch out for

<!-- Please describe testing done to verify the changes or any testing planned. -->
To test this:
- Ran specs
- Logged in with SSOe user and confirmed that `birth_date` can be inspected on the user. To do this, set a breakpoint in `app/controllers/v1/sessions_controller.rb`, line 58, after `user_login`, and try `@current_user.birth_date`. Can also inspect `@current_user.identity.birth_date` and `@current_user.mpi.profile.birth_date` to make sure the values match
