### PR TITLE
add manage dependents toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -394,3 +394,8 @@ features:
     enable_in_development: true
     description: >
       Include state abbreviation when searching on comparison tool
+  dependents_management:
+    actor_type: user
+    enable_in_development: true
+    description: >
+      Manage dependent removal from view dependent page


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

This pull request adds a new feature toggle that will allow the view dependents page to house an in development application for directly managing dependents instead of feeding users into the 686 form flow.

## Screenshots
<img width="1015" alt="Screen Shot 2021-02-01 at 11 53 10 AM" src="https://user-images.githubusercontent.com/15097156/106491216-a1538c80-6484-11eb-8009-0341173954eb.png">


## Original issue(s)
department-of-veterans-affairs/va.gov-team#17564

