### PR TITLE
replace CombinePdf with pdftk#cat

### DIFF
--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/generator.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/generator.rb
@@ -28,7 +28,6 @@ module AppealsApi
       attr_accessor :appeal, :structure
 
       def fill_unique_form_fields
-        pdftk = PdfForms.new(Settings.binaries.pdftk)
         form_fill_path = "/tmp/#{appeal.id}-tmp"
 
         pdftk.fill_form(
@@ -58,7 +57,6 @@ module AppealsApi
       def finalize_pages
         return @all_pages_path unless structure.final_page_adjustments
 
-        pdftk = PdfForms.new(Settings.binaries.pdftk)
         adjusted_pages_path = "/tmp/#{appeal.id}-rebuilt-pages-tmp.pdf"
         pdftk.cat({ @all_pages_path => structure.final_page_adjustments }, adjusted_pages_path)
         adjusted_pages_path
@@ -90,10 +88,14 @@ module AppealsApi
 
       def combine_form_fill_and_additional_pages(additional_pages_added_path)
         path = "/tmp/#{appeal.id}-completed-unstamped-tmp.pdf"
-        unstamped_completed_pdf = CombinePDF.load(@form_fill_path) << CombinePDF.load(additional_pages_added_path)
-        unstamped_completed_pdf.save(path)
+
+        pdftk.cat(@form_fill_path, additional_pages_added_path, path)
 
         path
+      end
+
+      def pdftk
+        @pdftk ||= PdfForms.new(Settings.binaries.pdftk)
       end
 
       def pdf_template_path


### PR DESCRIPTION
[API-4720](https://vajira.max.gov/browse/API-4720)

CombinePDF currently displays a warning if it's receiving a null object.

The

`appeals_api/spec/services/appeals_api/pdf_construction/generator_spec.rb`
file generates a whole bunch of warnings when we try to use CombinePDF during the routine PDF generation.

The goal is to keep the functionality we currently have while adjusting the tests to handle the null object that CombinePDF is struggling with.

Couldn't connect reference for {:is_reference_only=>true, :indirect_generation_number=>0, :indirect_reference_id=>396, :referenced_object=>nil}

Since CombinePdf is working as expected with these errors, using pdftk in favor of CombinePdf... makes sense.
