### PR TITLE
WIP - raise exception if no access token is returned by salesforce

### DIFF
--- a/lib/salesforce/service.rb
+++ b/lib/salesforce/service.rb
@@ -31,10 +31,17 @@ module Salesforce
     end
 
     def get_oauth_token
-      body = with_monitoring { request(:post, '', oauth_params).body }
-      Raven.extra_context(oauth_response_body: body)
+      response = nil
+      with_monitoring do
+        response = request(:post, '', oauth_params)
 
-      body['access_token']
+        if response.body['access_token'].nil? do
+          Raven.extra_context(oauth_token_response: response)
+          raise 'No salesforce access token returned!'
+        end
+      end
+
+      response.body['access_token']
     end
 
     def get_client


### PR DESCRIPTION
## Description of change
Raise an exception if no oauth token is returned by salesforce. This helps raise an exception earlier in the process (and producing a clearer error message) before attempting to instantiate a `Restforce` client.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/19331

## Testing
rspecs only.
