### PR TITLE
PPMS provider_id is not unique

### DIFF
--- a/lib/facilities/ppms/v1/response.rb
+++ b/lib/facilities/ppms/v1/response.rb
@@ -25,7 +25,9 @@ module Facilities
 
         def providers
           providers = body[offset, per_page].map do |attr|
-            ::PPMS::Provider.new(attr)
+            provider = ::PPMS::Provider.new(attr)
+            provider.set_hexdigest_as_id!
+            provider
           end.uniq(&:id)
 
           paginate_response(providers)

--- a/spec/lib/facilities/ppms/v1/client_spec.rb
+++ b/spec/lib/facilities/ppms/v1/client_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Facilities::PPMS::V1::Client, team: :facilities, vcr: vcr_options
   describe '#provider_locator' do
     it 'returns a list of providers' do
       r = Facilities::PPMS::V1::Client.new.provider_locator(params.merge(specialties: ['213E00000X']))
-      expect(r.length).to be 9
+      expect(r.length).to be 10
       expect(r[0]).to have_attributes(
         acc_new_patients: 'true',
         address_city: 'RED BANK',

--- a/spec/request/v1/facilities/ccp_request_spec.rb
+++ b/spec/request/v1/facilities/ccp_request_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Community Care Providers', type: :request, team: :facilities, vc
         bod = JSON.parse(response.body)
         expect(bod['data']).to include(
           {
-            'id' => '1154383230',
+            'id' => '6d4644e7db7491635849b23e20078f74cfcd2d0aeee6a77aca921f5540d03f33',
             'type' => 'provider',
             'attributes' => {
               'acc_new_patients' => 'true',
@@ -173,7 +173,7 @@ RSpec.describe 'Community Care Providers', type: :request, team: :facilities, vc
         bod = JSON.parse(response.body)
         expect(bod['data']).to include(
           {
-            'id' => '1154383230',
+            'id' => '6d4644e7db7491635849b23e20078f74cfcd2d0aeee6a77aca921f5540d03f33',
             'type' => 'provider',
             'attributes' => {
               'acc_new_patients' => 'true',
@@ -219,7 +219,7 @@ RSpec.describe 'Community Care Providers', type: :request, team: :facilities, vc
 
         expect(bod['data'][0]).to match(
           {
-            'id' => '1225028293',
+            'id' => '1a2ec66b370936eccc980db2fcf4b094fc61a5329aea49744d538f6a9bab2569',
             'type' => 'provider',
             'attributes' => {
               'acc_new_patients' => 'false',


### PR DESCRIPTION
we are now deduping providers the same way we dedupe places of service.

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
PPMS results provide a `uniqueId` this isn't a uniqueId and several providers at different locations use the same unique id...
we are now deduping providers the same way we dedupe Places of Service....

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19045

## Things to know about this PR
* This makes the ID useless for looking up specific providers (ie details page) but we don't do that anymore.

<!-- Please describe testing done to verify the changes or any testing planned. -->
