### PR TITLE
Update Appeal status if error throws during PDF submit job

### DIFF
--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -20,8 +20,8 @@ module AppealsApi
         higher_level_review.update!(status: 'submitting')
         upload_to_central_mail(higher_level_review, stamped_pdf)
         File.delete(stamped_pdf) if File.exist?(stamped_pdf)
-      rescue
-        higher_level_review.update!(status: 'error')
+      rescue => e
+        higher_level_review.update!(status: 'error', code: e.class.to_s, detail: e.message)
         raise
       end
     end

--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -13,11 +13,17 @@ module AppealsApi
 
     def perform(higher_level_review_id, retries = 0)
       higher_level_review = AppealsApi::HigherLevelReview.find(higher_level_review_id)
-      @retries = retries
-      stamped_pdf = AppealsApi::PdfConstruction::Generator.new(higher_level_review).generate
-      higher_level_review.update!(status: 'submitting')
-      upload_to_central_mail(higher_level_review, stamped_pdf)
-      File.delete(stamped_pdf) if File.exist?(stamped_pdf)
+
+      begin
+        @retries = retries
+        stamped_pdf = AppealsApi::PdfConstruction::Generator.new(higher_level_review).generate
+        higher_level_review.update!(status: 'submitting')
+        upload_to_central_mail(higher_level_review, stamped_pdf)
+        File.delete(stamped_pdf) if File.exist?(stamped_pdf)
+      rescue
+        higher_level_review.update!(status: 'error')
+        raise
+      end
     end
 
     def upload_to_central_mail(higher_level_review, pdf_path)

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
@@ -20,8 +20,9 @@ module AppealsApi
         stamped_pdf = PdfConstruction::Generator.new(notice_of_disagreement).generate
         upload_to_central_mail(notice_of_disagreement, stamped_pdf)
         File.delete(stamped_pdf) if File.exist?(stamped_pdf)
-      rescue
-        notice_of_disagreement.update!(status: 'error')
+      rescue => e
+        notice_of_disagreement.update!(status: 'error', code: e.class.to_s, detail: e.message)
+        raise
       end
     end
 

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
@@ -14,10 +14,15 @@ module AppealsApi
     def perform(id, retries = 0)
       @retries = retries
       notice_of_disagreement = NoticeOfDisagreement.find(id)
-      notice_of_disagreement.update!(status: 'submitting')
-      stamped_pdf = PdfConstruction::Generator.new(notice_of_disagreement).generate
-      upload_to_central_mail(notice_of_disagreement, stamped_pdf)
-      File.delete(stamped_pdf) if File.exist?(stamped_pdf)
+
+      begin
+        notice_of_disagreement.update!(status: 'submitting')
+        stamped_pdf = PdfConstruction::Generator.new(notice_of_disagreement).generate
+        upload_to_central_mail(notice_of_disagreement, stamped_pdf)
+        File.delete(stamped_pdf) if File.exist?(stamped_pdf)
+      rescue
+        notice_of_disagreement.update!(status: 'error')
+      end
     end
 
     def upload_to_central_mail(notice_of_disagreement, pdf_path)

--- a/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
@@ -74,6 +74,19 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
     end
   end
 
+  context 'an error throws' do
+    it 'updates the HLR status to reflect the error' do
+      submit_job_worker = described_class.new
+      allow(submit_job_worker).to receive(:upload_to_central_mail).and_raise
+
+      begin
+        submit_job_worker.perform(higher_level_review.id)
+      rescue
+        expect(higher_level_review.reload.status).to eq('error')
+      end
+    end
+  end
+
   private
 
   def create_higher_level_review

--- a/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
@@ -77,12 +77,14 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
   context 'an error throws' do
     it 'updates the HLR status to reflect the error' do
       submit_job_worker = described_class.new
-      allow(submit_job_worker).to receive(:upload_to_central_mail).and_raise
+      allow(submit_job_worker).to receive(:upload_to_central_mail).and_raise(RuntimeError, 'runtime error!')
 
       begin
         submit_job_worker.perform(higher_level_review.id)
       rescue
         expect(higher_level_review.reload.status).to eq('error')
+        expect(higher_level_review.reload.code).to eq('RuntimeError')
+        expect(higher_level_review.reload.detail).to eq('runtime error!')
       end
     end
   end

--- a/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
@@ -79,12 +79,14 @@ RSpec.describe AppealsApi::NoticeOfDisagreementPdfSubmitJob, type: :job do
   context 'an error throws' do
     it 'updates the NOD status to reflect the error' do
       submit_job_worker = described_class.new
-      allow(submit_job_worker).to receive(:upload_to_central_mail).and_raise
+      allow(submit_job_worker).to receive(:upload_to_central_mail).and_raise(RuntimeError, 'runtime error!')
 
       begin
         submit_job_worker.perform(notice_of_disagreement.id)
       rescue
         expect(notice_of_disagreement.reload.status).to eq('error')
+        expect(notice_of_disagreement.reload.code).to eq('RuntimeError')
+        expect(notice_of_disagreement.reload.detail).to eq('runtime error!')
       end
     end
   end

--- a/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
@@ -75,4 +75,17 @@ RSpec.describe AppealsApi::NoticeOfDisagreementPdfSubmitJob, type: :job do
       Timecop.return
     end
   end
+
+  context 'an error throws' do
+    it 'updates the NOD status to reflect the error' do
+      submit_job_worker = described_class.new
+      allow(submit_job_worker).to receive(:upload_to_central_mail).and_raise
+
+      begin
+        submit_job_worker.perform(notice_of_disagreement.id)
+      rescue
+        expect(notice_of_disagreement.reload.status).to eq('error')
+      end
+    end
+  end
 end


### PR DESCRIPTION
[API-4763](https://vajira.max.gov/browse/API-4763)

We're not currently changing the status of an appeal unless the error thrown is an Upload error from Central Mail.

This changes the error handling pattern to capture _any_ error during the PDF submission, and update it's status accordingly.