### PR TITLE
17551: Removal of stem_applicant_email feature flag

### DIFF
--- a/app/workers/education_form/send_school_certifying_officials_email.rb
+++ b/app/workers/education_form/send_school_certifying_officials_email.rb
@@ -89,9 +89,7 @@ module EducationForm
       if emails.any?
         StatsD.increment("#{stats_key}.success")
         SchoolCertifyingOfficialsMailer.build(@claim.open_struct_form, emails, nil).deliver_now
-        if Flipper.enabled?(:stem_applicant_email, @user)
-          StemApplicantScoMailer.build(@claim.open_struct_form, nil).deliver_now
-        end
+        StemApplicantScoMailer.build(@claim.open_struct_form, nil).deliver_nowf
         @claim.email_sent(true)
       else
         StatsD.increment("#{stats_key}.failure")

--- a/app/workers/education_form/send_school_certifying_officials_email.rb
+++ b/app/workers/education_form/send_school_certifying_officials_email.rb
@@ -89,7 +89,7 @@ module EducationForm
       if emails.any?
         StatsD.increment("#{stats_key}.success")
         SchoolCertifyingOfficialsMailer.build(@claim.open_struct_form, emails, nil).deliver_now
-        StemApplicantScoMailer.build(@claim.open_struct_form, nil).deliver_nowf
+        StemApplicantScoMailer.build(@claim.open_struct_form, nil).deliver_now
         @claim.email_sent(true)
       else
         StatsD.increment("#{stats_key}.failure")

--- a/config/features.yml
+++ b/config/features.yml
@@ -369,11 +369,6 @@ features:
     enable_in_development: true
     description: >
       Add automated decision to 10203 application workflow
-  stem_applicant_email:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enable/disable SCO applicant email per environment
   edu_form_omb_and_expiration:
     actor_type: user
     enable_in_development: true

--- a/spec/jobs/education_form/send_school_certifying_officials_email_spec.rb
+++ b/spec/jobs/education_form/send_school_certifying_officials_email_spec.rb
@@ -112,8 +112,6 @@ RSpec.describe EducationForm::SendSchoolCertifyingOfficialsEmail, type: :model, 
 
     context 'when all conditions are met' do
       before do
-        allow(Flipper).to receive(:enabled?).with(:stem_applicant_email, anything).and_return(true)
-
         gi_bill_status = build(:gi_bill_status_response)
         allow_any_instance_of(EVSS::GiBillStatus::Service).to receive(:get_gi_bill_status)
           .and_return(gi_bill_status)


### PR DESCRIPTION
## Description of change
As a developer, I need to remove the stem_applicant_email feature flag toggle so that it is no longer configurable, and the new functionality is permanent.

## Original issue(s)
[Originating Issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/17551)


## Acceptance Criteria
- [x] The feature flag stem_applicant_email is removed.
- [x] The feature flag is not displayed here: https://[environment]-api.va.gov/flipper/features.
