### PR TITLE
Breakers should consider 500 range errors outages

### DIFF
--- a/lib/common/client/configuration/base.rb
+++ b/lib/common/client/configuration/base.rb
@@ -103,6 +103,8 @@ module Common
               (500..599).cover?(exception.response_values[:status])
             elsif exception.is_a?(Common::Client::Errors::HTTPError)
               (500..599).cover?(exception.status)
+            elsif exception.is_a?(Faraday::ClientError)
+              (500..599).cover?(exception.response[:status])
             else
               false
             end

--- a/lib/common/client/configuration/base.rb
+++ b/lib/common/client/configuration/base.rb
@@ -109,9 +109,8 @@ module Common
               (500..599).cover?(exception.response_values[:status])
             elsif exception.is_a?(Common::Client::Errors::HTTPError)
               (500..599).cover?(exception.status)
-            elsif exception.is_a?(Faraday::ClientError) || exception.is_a?(Faraday::ServerError)
-              # we're not yet using Faraday > 1.0, but when we do, 500 errors will be a ServerError
-              # before then they will be Faraday::ClientError
+            elsif exception.is_a?(Faraday::ClientError)
+              # we're not yet using Faraday > 1.0, but when we do, 500 errors will be Faraday::ServerError
               (500..599).cover?(exception.response[:status])
             else
               false

--- a/lib/common/client/configuration/base.rb
+++ b/lib/common/client/configuration/base.rb
@@ -92,13 +92,19 @@ module Common
         def breakers_service
           return @service if defined?(@service)
 
+          @service = create_new_breakers_service(breakers_matcher, breakers_exception_handler)
+        end
+
+        def breakers_matcher
           base_uri = URI.parse(base_path)
-          matcher = proc do |request_env|
+          proc do |request_env|
             request_env.url.host == base_uri.host && request_env.url.port == base_uri.port &&
               request_env.url.path =~ /^#{base_uri.path}/
           end
+        end
 
-          exception_handler = proc do |exception|
+        def breakers_exception_handler
+          proc do |exception|
             if exception.is_a?(Common::Exceptions::BackendServiceException)
               (500..599).cover?(exception.response_values[:status])
             elsif exception.is_a?(Common::Client::Errors::HTTPError)
@@ -109,8 +115,6 @@ module Common
               false
             end
           end
-
-          @service = create_new_breakers_service(matcher, exception_handler)
         end
 
         def create_new_breakers_service(matcher, exception_handler)

--- a/lib/common/client/configuration/base.rb
+++ b/lib/common/client/configuration/base.rb
@@ -109,7 +109,9 @@ module Common
               (500..599).cover?(exception.response_values[:status])
             elsif exception.is_a?(Common::Client::Errors::HTTPError)
               (500..599).cover?(exception.status)
-            elsif exception.is_a?(Faraday::ClientError)
+            elsif exception.is_a?(Faraday::ClientError) || exception.is_a?(Faraday::ServerError)
+              # we're not yet using Faraday > 1.0, but when we do, 500 errors will be a ServerError
+              # before then they will be Faraday::ClientError
               (500..599).cover?(exception.response[:status])
             else
               false

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -94,7 +94,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
       end
     end
 
-
     context 'with a 503 error' do
       it 'runs the retryable_error_handler and raises a ServiceUnavailableException' do
         expect_any_instance_of(EVSS::DisabilityCompensationForm::Service).to receive(:submit_form526).and_raise(

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
       subject.perform_async(submission.id)
       expect_any_instance_of(EVSS::DisabilityCompensationForm::Metrics).to receive(:increment_retryable).once
       expect(Form526JobStatus).to receive(:upsert).twice
-      expect(Rails.logger).to receive(:error).once
       expect { described_class.drain }.to raise_error(error_class)
     end
 
@@ -95,12 +94,13 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
       end
     end
 
+
     context 'with a 503 error' do
       it 'runs the retryable_error_handler and raises a ServiceUnavailableException' do
         expect_any_instance_of(EVSS::DisabilityCompensationForm::Service).to receive(:submit_form526).and_raise(
           EVSS::DisabilityCompensationForm::ServiceUnavailableException
         )
-
+        expect(Rails.logger).to receive(:error).once
         expect_retryable_error(EVSS::DisabilityCompensationForm::ServiceUnavailableException)
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
     context 'with a breakers outage' do
       it 'runs the retryable_error_handler and raises a gateway timeout' do
         EVSS::DisabilityCompensationForm::Configuration.instance.breakers_service.begin_forced_outage!
-
+        expect(Rails.logger).to receive(:error).once
         expect_retryable_error(Breakers::OutageException)
       end
     end
@@ -138,6 +138,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
     context 'with an upstream service error' do
       it 'sets the transaction to "retrying"' do
         VCR.use_cassette('evss/disability_compensation_form/submit_500_with_err_msg') do
+          expect(Rails.logger).to receive(:error).twice
           expect_retryable_error(EVSS::DisabilityCompensationForm::ServiceException)
         end
       end
@@ -146,6 +147,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
     context 'with an upstream bad gateway' do
       it 'sets the transaction to "retrying"' do
         VCR.use_cassette('evss/disability_compensation_form/submit_502') do
+          expect(Rails.logger).to receive(:error).twice
           expect_retryable_error(Common::Exceptions::BackendServiceException)
         end
       end
@@ -154,6 +156,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
     context 'with an upstream service unavailable' do
       it 'sets the transaction to "retrying"' do
         VCR.use_cassette('evss/disability_compensation_form/submit_503') do
+          expect(Rails.logger).to receive(:error).twice
           expect_retryable_error(EVSS::DisabilityCompensationForm::ServiceUnavailableException)
         end
       end

--- a/spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
         EVSS::DisabilityCompensationForm::Configuration.instance.breakers_service.begin_forced_outage!
         expect(Rails.logger).to receive(:error).once
         expect_retryable_error(Breakers::OutageException)
+        EVSS::DisabilityCompensationForm::Configuration.instance.breakers_service.end_forced_outage!
       end
     end
 

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -771,11 +771,11 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
         VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
           expect(subject).to validate(:get, '/v0/disability_compensation_form/rated_disabilities', 200, headers)
         end
-        VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_500') do
-          expect(subject).to validate(:get, '/v0/disability_compensation_form/rated_disabilities', 502, headers)
-        end
         VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_400') do
           expect(subject).to validate(:get, '/v0/disability_compensation_form/rated_disabilities', 400, headers)
+        end
+        VCR.use_cassette('evss/disability_compensation_form/rated_disabilities_500') do
+          expect(subject).to validate(:get, '/v0/disability_compensation_form/rated_disabilities', 502, headers)
         end
       end
 


### PR DESCRIPTION
## Description of change
When we get a 500 range response Faraday raises `Faraday::ClientError`. [ It seems like breakers intends](https://github.com/department-of-veterans-affairs/breakers/blob/master/lib/breakers/uptime_middleware.rb#L58) to count any response in the 500-range, but [rescue block](https://github.com/department-of-veterans-affairs/breakers/blob/master/lib/breakers/uptime_middleware.rb#L85) doesn't include  `Faraday::ClientError`

we found this when [EVSS 500 errors in sentry ](http://sentry.vfs.va.gov/organizations/vsp/issues/466/?project=3&query=is%3Aunresolved+500&statsPeriod=14d) weren't being counted as errors in the [Backend service report](http://grafana.vfs.va.gov/d/000000050/backend-service-report?orgId=1)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19394

## Things to know about this PR
There will likely be more external service alerts as things that have been erroring all along get counted as errors.

This might make a big difference in VSP's SLO dashboard. 