### PR TITLE
Update Proc State Type Code for 686

### DIFF
--- a/lib/bgs/service.rb
+++ b/lib/bgs/service.rb
@@ -140,7 +140,7 @@ module BGS
 
     def update_manual_proc(proc_id)
       service.vnp_proc_v2.vnp_proc_update(
-        { vnp_proc_id: proc_id, vnp_proc_state_type_cd: 'MANUAL', vnp_proc_type_cd: 'DEPCHG' }.merge(bgs_auth)
+        { vnp_proc_id: proc_id, vnp_proc_state_type_cd: 'MANUAL_VAGOV', vnp_proc_type_cd: 'DEPCHG' }.merge(bgs_auth)
       )
     rescue => e
       notify_of_service_exception(e, __method__)

--- a/lib/bgs/service.rb
+++ b/lib/bgs/service.rb
@@ -140,7 +140,7 @@ module BGS
 
     def update_manual_proc(proc_id)
       service.vnp_proc_v2.vnp_proc_update(
-        { vnp_proc_id: proc_id, vnp_proc_state_type_cd: 'Manual', vnp_proc_type_cd: 'DEPCHG' }.merge(bgs_auth)
+        { vnp_proc_id: proc_id, vnp_proc_state_type_cd: 'MANUAL_VAGOV', vnp_proc_type_cd: 'DEPCHG' }.merge(bgs_auth)
       )
     rescue => e
       notify_of_service_exception(e, __method__)

--- a/lib/bgs/service.rb
+++ b/lib/bgs/service.rb
@@ -140,7 +140,7 @@ module BGS
 
     def update_manual_proc(proc_id)
       service.vnp_proc_v2.vnp_proc_update(
-        { vnp_proc_id: proc_id, vnp_proc_state_type_cd: 'MANUAL_VAGOV', vnp_proc_type_cd: 'DEPCHG' }.merge(bgs_auth)
+        { vnp_proc_id: proc_id, vnp_proc_state_type_cd: 'MANUAL', vnp_proc_type_cd: 'DEPCHG' }.merge(bgs_auth)
       )
     rescue => e
       notify_of_service_exception(e, __method__)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
During 686 testing, BGS asked us to update the proc state type from `Manual` to `MANUAL_VAGOV` so they can see that VA.gov is the application that is setting the claim to manual. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19087

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is a very tiny PR that just changes one value, so no additional logging or configurations have been added.
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] Local testing
- [x] Staging testing planned