### PR TITLE
Add a date range filter to mobile Community Care appointments

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
@@ -20,6 +20,12 @@ module Mobile
         va_appointments = parse_va_appointments(responses[:va].body) unless errors[:va]
         cc_appointments = cc_adapter.parse(responses[:cc].body) unless errors[:cc]
 
+        # There's currently a bug in the underlying Community Care service
+        # where data ranges are not being respected
+        cc_appointments.select! do |appointment|
+          appointment.start_date_utc.between?(start_date, end_date)
+        end
+
         appointments = (va_appointments + cc_appointments).sort_by(&:start_date_utc)
 
         errors = errors.values.compact

--- a/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
@@ -21,7 +21,7 @@ module Mobile
         cc_appointments = cc_adapter.parse(responses[:cc].body) unless errors[:cc]
 
         # There's currently a bug in the underlying Community Care service
-        # where data ranges are not being respected
+        # where date ranges are not being respected
         cc_appointments.select! do |appointment|
           appointment.start_date_utc.between?(start_date, end_date)
         end

--- a/modules/mobile/spec/request/appointments_request_spec.rb
+++ b/modules/mobile/spec/request/appointments_request_spec.rb
@@ -143,33 +143,34 @@ RSpec.describe 'appointments', type: :request do
 
           expect(cc_appointment).to include(
             {
+              'id' => '8a48912a6c2409b9016c4e4ef7ae018b',
               'type' => 'appointment',
               'attributes' => {
                 'appointmentType' => 'COMMUNITY_CARE',
-                'comment' => 'Test',
+                'comment' => '',
                 'facilityId' => nil,
-                'healthcareService' => 'AP',
+                'healthcareService' => 'rtt',
                 'location' => {
-                  'name' => 'AP',
+                  'name' => 'rtt',
                   'address' => {
-                    'street' => '2345, Oak Crest Cir',
-                    'city' => 'Aldie',
-                    'state' => 'VA',
-                    'zipCode' => '20106'
+                    'street' => 'test drive',
+                    'city' => 'clraksburg',
+                    'state' => 'MD',
+                    'zipCode' => '00000'
                   },
                   'lat' => nil,
                   'long' => nil,
                   'phone' => {
-                    'areaCode' => '999',
-                    'number' => '999-9999',
+                    'areaCode' => '301',
+                    'number' => '916-1212',
                     'extension' => nil
                   },
                   'url' => nil,
                   'code' => nil
                 },
                 'minutesDuration' => 60,
-                'startDateLocal' => '2020-01-10T13:00:00.000-05:00',
-                'startDateUtc' => '2020-01-10T18:00:00.000Z',
+                'startDateLocal' => '2020-11-01T22:30:00.000-05:00',
+                'startDateUtc' => '2020-11-02T03:30:00.000Z',
                 'status' => 'BOOKED',
                 'timeZone' => 'America/New_York'
               }
@@ -216,7 +217,7 @@ RSpec.describe 'appointments', type: :request do
         end
 
         it 'has va appointments' do
-          expect(response.parsed_body['data'].size).to eq(101)
+          expect(response.parsed_body['data'].size).to eq(33)
         end
 
         it 'matches the expected schema' do


### PR DESCRIPTION
## Description of change
This is actually a bug in the upstream VAOS service but there's no timeline for them to fix it. This patch in our middleware will filter out any appointments not within the date range passed to out API endpoint.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19361
