### PR TITLE
Remove TODOs, tickets created

### DIFF
--- a/modules/appeals_api/config/schemas/200996.json
+++ b/modules/appeals_api/config/schemas/200996.json
@@ -147,8 +147,7 @@
         "emailAddressText": {
           "type": "string",
           "pattern": ".@.",
-          "maxLength": 44,
-          "$comment": "TODO: use draft 7 feature [format: idn-email] or [format: email] over pattern (when there is broader support)"
+          "maxLength": 44
         },
         "timezone": {
           "type": "string",

--- a/modules/appeals_api/lib/appeals_api/form_schemas.rb
+++ b/modules/appeals_api/lib/appeals_api/form_schemas.rb
@@ -4,9 +4,6 @@ require 'json_schema/form_schemas'
 
 module AppealsApi
   class FormSchemas < JsonSchema::FormSchemas
-    # TODO: Use Common::Exceptions::DetailedSchemaErrors for more robust errors.
-    # HigherLevelReviewsController currently uses JsonSchema::JsonApiMissingAttribute, NOD uses DetailedSchemaErrors
-    # HLR will need to wait for a new version to be able to switch to DetailedSchemaErrors
     def initialize(error_type = JsonSchema::JsonApiMissingAttribute)
       @error_type = error_type
     end


### PR DESCRIPTION
This PR removes TODO comments in our code, with corresponding tickets to apportion out the work.

[4821](https://vajira.max.gov/browse/API-4821)
[4822](https://vajira.max.gov/browse/API-4822)