### PR TITLE
Add NODSerializer spec to have parity with HLR

### DIFF
--- a/modules/appeals_api/spec/serializers/higher_level_review_serializer_spec.rb
+++ b/modules/appeals_api/spec/serializers/higher_level_review_serializer_spec.rb
@@ -4,36 +4,47 @@ require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::HigherLevelReviewSerializer do
-  it('serializes') do
-    hlr = create(:higher_level_review)
+  let(:higher_level_review) { create(:higher_level_review) }
+  let(:rendered_hash) { described_class.new(higher_level_review).serializable_hash }
 
-    rendered_hash = described_class.new(hlr).serializable_hash
+  it 'serializes the HLR properly' do
+    expect(rendered_hash).to eq(
+      {
+        data: {
+          type: :higherLevelReview,
+          id: higher_level_review.id,
+          attributes: {
+            status: higher_level_review.status,
+            createdAt: higher_level_review.created_at,
+            updatedAt: higher_level_review.updated_at,
+            formData: higher_level_review.form_data
+          }
+        }
+      }
+    )
+  end
 
+  it 'has the correct top level keys' do
     expect(rendered_hash.keys.count).to be 1
     expect(rendered_hash).to have_key :data
+  end
+
+  it 'has the correct data keys' do
     expect(rendered_hash[:data].keys.count).to be 3
     expect(rendered_hash[:data]).to have_key :type
     expect(rendered_hash[:data]).to have_key :id
     expect(rendered_hash[:data]).to have_key :attributes
+  end
+
+  it 'has the correct attribute keys' do
     expect(rendered_hash[:data][:attributes].keys.count).to be 4
     expect(rendered_hash[:data][:attributes]).to have_key :status
     expect(rendered_hash[:data][:attributes]).to have_key :createdAt
     expect(rendered_hash[:data][:attributes]).to have_key :updatedAt
     expect(rendered_hash[:data][:attributes]).to have_key :formData
+  end
+
+  it 'has the correct type' do
     expect(rendered_hash[:data][:type]).to eq :higherLevelReview
-    expect(rendered_hash).to eq(
-      {
-        data: {
-          type: :higherLevelReview,
-          id: hlr.id,
-          attributes: {
-            status: hlr.status,
-            createdAt: hlr.created_at,
-            updatedAt: hlr.updated_at,
-            formData: hlr.form_data
-          }
-        }
-      }
-    )
   end
 end

--- a/modules/appeals_api/spec/serializers/notice_of_disagreement_serializer_spec.rb
+++ b/modules/appeals_api/spec/serializers/notice_of_disagreement_serializer_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')

--- a/modules/appeals_api/spec/serializers/notice_of_disagreement_serializer_spec.rb
+++ b/modules/appeals_api/spec/serializers/notice_of_disagreement_serializer_spec.rb
@@ -4,23 +4,10 @@ require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::NoticeOfDisagreementSerializer do
+  let(:notice_of_disagreement) { create(:notice_of_disagreement) }
+  let(:rendered_hash) { described_class.new(notice_of_disagreement).serializable_hash }
+
   it 'serializes the NOD properly' do
-    notice_of_disagreement = create(:notice_of_disagreement)
-
-    rendered_hash = described_class.new(notice_of_disagreement).serializable_hash
-
-    expect(rendered_hash.keys.count).to be 1
-    expect(rendered_hash).to have_key :data
-    expect(rendered_hash[:data].keys.count).to be 3
-    expect(rendered_hash[:data]).to have_key :type
-    expect(rendered_hash[:data]).to have_key :id
-    expect(rendered_hash[:data]).to have_key :attributes
-    expect(rendered_hash[:data][:attributes].keys.count).to be 4
-    expect(rendered_hash[:data][:attributes]).to have_key :status
-    expect(rendered_hash[:data][:attributes]).to have_key :createdAt
-    expect(rendered_hash[:data][:attributes]).to have_key :updatedAt
-    expect(rendered_hash[:data][:attributes]).to have_key :formData
-    expect(rendered_hash[:data][:type]).to eq :noticeOfDisagreement
     expect(rendered_hash).to eq(
       {
         data: {
@@ -35,5 +22,29 @@ describe AppealsApi::NoticeOfDisagreementSerializer do
         }
       }
     )
+  end
+
+  it 'has the correct top level keys' do
+    expect(rendered_hash.keys.count).to be 1
+    expect(rendered_hash).to have_key :data
+  end
+
+  it 'has the correct data keys' do
+    expect(rendered_hash[:data].keys.count).to be 3
+    expect(rendered_hash[:data]).to have_key :type
+    expect(rendered_hash[:data]).to have_key :id
+    expect(rendered_hash[:data]).to have_key :attributes
+  end
+
+  it 'has the correct attribute keys' do
+    expect(rendered_hash[:data][:attributes].keys.count).to be 4
+    expect(rendered_hash[:data][:attributes]).to have_key :status
+    expect(rendered_hash[:data][:attributes]).to have_key :createdAt
+    expect(rendered_hash[:data][:attributes]).to have_key :updatedAt
+    expect(rendered_hash[:data][:attributes]).to have_key :formData
+  end
+
+  it 'has the correct type' do
+    expect(rendered_hash[:data][:type]).to eq :noticeOfDisagreement
   end
 end

--- a/modules/appeals_api/spec/serializers/notice_of_disagreement_serializer_spec.rb
+++ b/modules/appeals_api/spec/serializers/notice_of_disagreement_serializer_spec.rb
@@ -1,0 +1,38 @@
+
+require 'rails_helper'
+require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
+
+describe AppealsApi::NoticeOfDisagreementSerializer do
+  it 'serializes the NOD properly' do
+    notice_of_disagreement = create(:notice_of_disagreement)
+
+    rendered_hash = described_class.new(notice_of_disagreement).serializable_hash
+
+    expect(rendered_hash.keys.count).to be 1
+    expect(rendered_hash).to have_key :data
+    expect(rendered_hash[:data].keys.count).to be 3
+    expect(rendered_hash[:data]).to have_key :type
+    expect(rendered_hash[:data]).to have_key :id
+    expect(rendered_hash[:data]).to have_key :attributes
+    expect(rendered_hash[:data][:attributes].keys.count).to be 4
+    expect(rendered_hash[:data][:attributes]).to have_key :status
+    expect(rendered_hash[:data][:attributes]).to have_key :createdAt
+    expect(rendered_hash[:data][:attributes]).to have_key :updatedAt
+    expect(rendered_hash[:data][:attributes]).to have_key :formData
+    expect(rendered_hash[:data][:type]).to eq :noticeOfDisagreement
+    expect(rendered_hash).to eq(
+      {
+        data: {
+          type: :noticeOfDisagreement,
+          id: notice_of_disagreement.id,
+          attributes: {
+            status: notice_of_disagreement.status,
+            createdAt: notice_of_disagreement.created_at,
+            updatedAt: notice_of_disagreement.updated_at,
+            formData: notice_of_disagreement.form_data
+          }
+        }
+      }
+    )
+  end
+end


### PR DESCRIPTION
This PR adds a spec for NODSerializer, to maintain parity between HLR/NOD. Currently HLR serializer is being tested, NOD is not.

[4704](https://vajira.max.gov/browse/API-4704)