### PR TITLE
Appeals api - weekly appeals report

### DIFF
--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -120,10 +120,15 @@ VBADocuments::RunUnsuccessfulSubmissions:
   class: VBADocuments::RunUnsuccessfulSubmissions
   description: "Run VBADocuments::UploadProcessor for submissions that are stuck in uploaded status"
 
-AppealsApi::DecisionReviewReportJob:
+AppealsApi::DecisionReviewReportDaily:
   cron: "0 0 * * MON-FRI America/New_York"
-  class: AppealsApi::DecisionReviewReportJob
+  class: AppealsApi::DecisionReviewReportDaily
   description: "Daily report of appeals submissions"
+
+AppealsApi::DecisionReviewReportWeekly:
+  cron: "0 0 * * MON America/New_York"
+  class: AppealsApi::DecisionReviewReportWeekly
+  description: "Weekly report of appeals submissions"
 
 AppealsApi::HigherLevelReviewCleanUpWeekOldPii:
   every: ['24h', first_in: '45m']

--- a/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
+++ b/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
@@ -4,15 +4,17 @@ require 'appeals_api/decision_review_report'
 
 module AppealsApi
   class DecisionReviewMailer < ApplicationMailer
-    def build(date_from:, date_to:)
+    def build(date_from:, date_to:, friendly_duration: '')
       @report = DecisionReviewReport.new(from: date_from, to: date_to)
+      @friendly_duration = friendly_duration
+      @friendly_env = (Settings.vsp_environment || Rails.env).titleize
 
       template = File.read(path)
       body = ERB.new(template).result(binding)
 
       mail(
         to: Settings.modules_appeals_api.report_recipients,
-        subject: "Decision Review API report (#{(Settings.vsp_environment || Rails.env).titleize})",
+        subject: "#{@friendly_duration} Decision Review API report (#{@friendly_env})",
         content_type: 'text/html',
         body: body
       )

--- a/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
+++ b/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
@@ -40,7 +40,7 @@
   </head>
 
   <body>
-    <h1><%= (Settings.vsp_environment || Rails.env).titleize %> Decision Review Report from <%= @report.from %> -- <%= @report.to %> </h1>
+    <h1><%= @friendly_duration %> <%= @friendly_env %> Decision Review Report from <%= @report.from %> -- <%= @report.to %> </h1>
 
     <h2><span class="title">HLR submissions by status and count</span></h2>
     <table>

--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_daily.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_daily.rb
@@ -3,12 +3,12 @@
 require 'sidekiq'
 
 module AppealsApi
-  class DecisionReviewReportJob
+  class DecisionReviewReportDaily
     include Sidekiq::Worker
 
     def perform(to: Time.zone.now, from: (to.monday? ? 3.days.ago : 1.day.ago))
       if Settings.modules_appeals_api.report_enabled
-        DecisionReviewMailer.build(date_from: from, date_to: to).deliver_now
+        DecisionReviewMailer.build(date_from: from, date_to: to, friendly_duration: 'Daily').deliver_now
       end
     end
   end

--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_weekly.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_weekly.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+
+module AppealsApi
+  class DecisionReviewReportWeekly
+    include Sidekiq::Worker
+
+    def perform(to: Time.zone.now, from: 1.week.ago)
+      if Settings.modules_appeals_api.report_enabled
+        DecisionReviewMailer.build(date_from: from, date_to: to, friendly_duration: 'Weekly').deliver_now
+      end
+    end
+  end
+end

--- a/modules/appeals_api/spec/mailers/decision_review_mailer_spec.rb
+++ b/modules/appeals_api/spec/mailers/decision_review_mailer_spec.rb
@@ -5,12 +5,12 @@ require 'rails_helper'
 RSpec.describe AppealsApi::DecisionReviewMailer, type: [:mailer] do
   describe '#build' do
     subject do
-      described_class.build(date_from: 7.days.ago, date_to: Time.zone.now).deliver_now
+      described_class.build(date_from: 7.days.ago, date_to: Time.zone.now, friendly_duration: 'duration').deliver_now
     end
 
     it 'sends the email' do
       with_settings(Settings, vsp_environment: 'spartacus') do
-        expect(subject.subject).to eq 'Decision Review API report (Spartacus)'
+        expect(subject.subject).to eq 'duration Decision Review API report (Spartacus)'
       end
     end
 

--- a/modules/appeals_api/spec/workers/decision_review_report_weekly_spec.rb
+++ b/modules/appeals_api/spec/workers/decision_review_report_weekly_spec.rb
@@ -2,18 +2,18 @@
 
 require 'rails_helper'
 
-describe AppealsApi::DecisionReviewReportDaily, type: :job do
+describe AppealsApi::DecisionReviewReportWeekly, type: :job do
   describe '#perform' do
     it 'sends mail' do
       with_settings(Settings.modules_appeals_api, report_enabled: true) do
         Timecop.freeze
         date_to = Time.zone.now
-        date_from = date_to.monday? ? 3.days.ago : 1.day.ago
+        date_from = 1.week.ago
 
         expect(AppealsApi::DecisionReviewMailer).to receive(:build).once.with(
           date_from: date_from,
           date_to: date_to,
-          friendly_duration: 'Daily'
+          friendly_duration: 'Weekly'
         ).and_return(double.tap do |mailer|
           expect(mailer).to receive(:deliver_now).once
         end)


### PR DESCRIPTION
## Description of change
This PR adds a weekly report (same format/data points as the current daily email with the exception of adding `Daily`/`Weekly` to the subject and title) for reporting stats and errors on HLR and NOD. It renames the current daily email job to better differentiate between the daily and weekly email.

## Original issue(s)
https://vajira.max.gov/browse/API-4807