### PR TITLE
Remove double value of 'POW' in 526 specialIssues enum array

### DIFF
--- a/modules/claims_api/config/schemas/526.json
+++ b/modules/claims_api/config/schemas/526.json
@@ -28,7 +28,6 @@
         "enum": [
           "ALS",
           "HEPC",
-          "POW",
           "PTSD/1",
           "PTSD/2",
           "PTSD/3",


### PR DESCRIPTION
Linter caught this double value, removing one of them.
