### PR TITLE
evss no longer sends 500 for address error

### DIFF
--- a/lib/evss/letters/service.rb
+++ b/lib/evss/letters/service.rb
@@ -56,7 +56,7 @@ module EVSS
       def handle_error(error)
         Raven.tags_context(team: 'benefits-memorial-1') # tag sentry logs with team name
         if (error.is_a?(Common::Client::Errors::ClientError) && error.status != 403 && error.body.is_a?(Hash)) ||
-          error.is_a?(EVSS::ErrorMiddleware::EVSSError)
+           error.is_a?(EVSS::ErrorMiddleware::EVSSError)
           begin
             log_edipi if invalid_address_error?(error)
           ensure

--- a/lib/evss/letters/service.rb
+++ b/lib/evss/letters/service.rb
@@ -55,7 +55,8 @@ module EVSS
 
       def handle_error(error)
         Raven.tags_context(team: 'benefits-memorial-1') # tag sentry logs with team name
-        if error.is_a?(Common::Client::Errors::ClientError) && error.status != 403 && error.body.is_a?(Hash)
+        if (error.is_a?(Common::Client::Errors::ClientError) && error.status != 403 && error.body.is_a?(Hash)) ||
+          error.is_a?(EVSS::ErrorMiddleware::EVSSError)
           begin
             log_edipi if invalid_address_error?(error)
           ensure

--- a/spec/support/vcr_cassettes/evss/letters/letters_invalid_address.yml
+++ b/spec/support/vcr_cassettes/evss/letters/letters_invalid_address.yml
@@ -39,7 +39,7 @@ http_interactions:
       - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"272111863","edi":"9294277224","firstName":"abraham","lastName":"lincoln"}}'
   response:
     status:
-      code: 500
+      code: 200
       message: OK
     headers:
       Date:


### PR DESCRIPTION
## Description of change
Starting in april 2020,  EVSS stopped sending http 500 for validation errors. So, we need to rescue slightly differently.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#7701
department-of-veterans-affairs/va.gov-team#7816

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
