### PR TITLE
Questionnaire Manager invoke patient service

### DIFF
--- a/modules/health_quest/app/controllers/health_quest/v0/questionnaire_manager_controller.rb
+++ b/modules/health_quest/app/controllers/health_quest/v0/questionnaire_manager_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module V0
+    class QuestionnaireManagerController < HealthQuest::V0::BaseController
+      def index
+        data = factory.all
+
+        render json: data
+      end
+
+      private
+
+      def factory
+        @factory ||= QuestionnaireManager::Factory.manufacture(current_user)
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
+++ b/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module QuestionnaireManager
+    ##
+    # A service object for isolating dependencies from the questionnaire_manager controller.
+    # An aggregator which collects and combines data from the health_quest services, those which
+    # interact with appointments and patient generated data in particular
+    #
+    # @!attribute aggregated_data
+    #   @return [Hash]
+    # @!attribute patient
+    #   @return [FHIR::Patient]
+    # @!attribute patient_service
+    #   @return [PatientGeneratedData::Patient::Factory]
+    # @!attribute user
+    #   @return [User]
+    class Factory
+      attr_reader :aggregated_data,
+                  :patient,
+                  :patient_service,
+                  :user
+
+      def self.manufacture(user)
+        new(user)
+      end
+
+      def initialize(user)
+        @aggregated_data = default_response
+        @user = user
+        @patient_service = PatientGeneratedData::Patient::Factory.manufacture(user)
+      end
+
+      ##
+      # Interacts with and invokes functionality on the PGD and appointment health_quest services.
+      # Invokes the `compose` method in the end to stitch all the data together for the controller
+      #
+      # @return [Hash] an aggregated hash
+      #
+      def all
+        @patient = get_patient.resource
+        return default_response if patient.blank?
+
+        compose
+      end
+
+      ##
+      # Gets a patient resource from the PGD
+      #
+      # @return [FHIR::Patient::ClientReply] an instance of ClientReply
+      #
+      def get_patient
+        @get_patient ||= patient_service.get
+      end
+
+      ##
+      # Builds the final aggregated data structure after the PGD and appointment
+      # health_quest services are called
+      #
+      # @return [Hash] a combined hash containing appointment, questionnaire_response,
+      # questionnaire and SIP data
+      #
+      def compose
+        { data: 'WIP' }
+      end
+
+      private
+
+      def default_response
+        { data: [] }
+      end
+    end
+  end
+end

--- a/modules/health_quest/config/routes.rb
+++ b/modules/health_quest/config/routes.rb
@@ -8,6 +8,7 @@ HealthQuest::Engine.routes.draw do
     resources :questionnaires, only: %i[index show]
     resources :questionnaire_responses, only: %i[index show create]
 
+    get 'questionnaire_manager', to: 'questionnaire_manager#index'
     get 'signed_in_patient', to: 'patients#signed_in_patient'
     get 'apidocs', to: 'apidocs#index'
   end

--- a/modules/health_quest/spec/request/questionnaire_manager_request_spec.rb
+++ b/modules/health_quest/spec/request/questionnaire_manager_request_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'health_quest questionnaire_manager', type: :request do
+  let(:access_denied_message) { 'You do not have access to the health quest service' }
+  let(:questionnaires_id) { '32' }
+  let(:default_client_reply) { double('FHIR::ClientReply') }
+
+  describe 'GET questionnaire_manager' do
+    context 'loa1 user' do
+      before do
+        sign_in_as(current_user)
+      end
+
+      let(:current_user) { build(:user, :loa1) }
+
+      it 'has forbidden status' do
+        get '/health_quest/v0/questionnaire_manager'
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'has access denied message' do
+        get '/health_quest/v0/questionnaire_manager'
+
+        expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
+      end
+    end
+
+    context 'health quest user' do
+      let(:current_user) { build(:user, :health_quest) }
+      let(:id) { 'faae134c-9c7b-49d7-8161-10e314da4de1' }
+      let(:session_store) { double('SessionStore', token: '123abc') }
+      let(:client_reply) do
+        double('FHIR::ClientReply', response: { body: { 'data' => [] } }, resource: default_client_reply)
+      end
+
+      before do
+        sign_in_as(current_user)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
+        allow_any_instance_of(HealthQuest::PatientGeneratedData::Patient::MapQuery)
+          .to receive(:get).with(anything).and_return(client_reply)
+      end
+
+      it 'returns a WIP response' do
+        get '/health_quest/v0/questionnaire_manager'
+
+        expect(JSON.parse(response.body)).to eq({ 'data' => 'WIP' })
+      end
+    end
+  end
+end

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::QuestionnaireManager::Factory do
+  subject { described_class }
+
+  let(:user) { double('User', icn: '1008596379V859838') }
+  let(:session_store) { double('SessionStore', token: '123abc') }
+  let(:session_service) { double('HealthQuest::Lighthouse::Session', user: user, retrieve: session_store) }
+  let(:client_reply) { double('FHIR::ClientReply') }
+
+  before do
+    allow(HealthQuest::Lighthouse::Session).to receive(:build).with(user).and_return(session_service)
+  end
+
+  describe 'object initialization' do
+    let(:factory) { described_class.manufacture(user) }
+
+    it 'responds to attributes' do
+      expect(factory.respond_to?(:aggregated_data)).to eq(true)
+      expect(factory.respond_to?(:patient)).to eq(true)
+      expect(factory.respond_to?(:patient_service)).to eq(true)
+      expect(factory.respond_to?(:user)).to eq(true)
+    end
+  end
+
+  describe '.manufacture' do
+    it 'returns an instance of the described class' do
+      expect(described_class.manufacture(user)).to be_an_instance_of(described_class)
+    end
+  end
+
+  describe '#all' do
+    let(:patient) { double('FHIR::Patient') }
+
+    context 'when patient does not exist' do
+      let(:client_reply) { double('FHIR::ClientReply', resource: nil) }
+
+      it 'returns a default hash' do
+        hash = { data: [] }
+        allow_any_instance_of(HealthQuest::PatientGeneratedData::Patient::MapQuery)
+          .to receive(:get).with(user.icn).and_return(client_reply)
+
+        expect(described_class.manufacture(user).all).to eq(hash)
+      end
+    end
+
+    context 'when patient exists' do
+      let(:client_reply) { double('FHIR::ClientReply', resource: patient) }
+
+      it 'returns a WIP hash' do
+        hash = { data: 'WIP' }
+        allow_any_instance_of(HealthQuest::PatientGeneratedData::Patient::MapQuery)
+          .to receive(:get).with(user.icn).and_return(client_reply)
+
+        expect(described_class.manufacture(user).all).to eq(hash)
+      end
+    end
+  end
+
+  describe '#get_patient' do
+    it 'returns a FHIR::ClientReply' do
+      allow_any_instance_of(HealthQuest::PatientGeneratedData::Patient::MapQuery)
+        .to receive(:get).with(user.icn).and_return(client_reply)
+
+      expect(described_class.manufacture(user).get_patient).to eq(client_reply)
+    end
+  end
+
+  describe '#compose' do
+    it 'returns a WIP hash' do
+      hash = { data: 'WIP' }
+
+      expect(described_class.manufacture(user).compose).to eq(hash)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- This PR establishes the QuestionnaireManager module which will ultimately return an aggregated data structure for the FE UI to consume
- This PR creates the basic structure of the questionnaire manager module and tests and invokes the Patient service
- The final response to the `/health_quest/v0/questionnaire_manager` route will be built over several PRs
- This PR invokes the Patient service only and returns a "Placeholder" hash for now
## Original issue(s)
department-of-veterans-affairs/va.gov-team#19015

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- Feature flip: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests passing