### PR TITLE
remove two of VAOS flat facility feature flags

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -145,16 +145,6 @@ features:
     enable_in_development: true
     description: >
       Enables Express Care request flow in VAOS
-  va_online_scheduling_flat_facility_page:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables the new VA facility choice page with a flat list
-  va_online_scheduling_flat_facility_page_sacramento:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables the new VA facility choice page with a flat list for users registered to Sacramento (612)
   va_online_scheduling_provider_selection:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
Remove the flat facility feature flag because the VAOS application no longer calls on the flat facility flag names. 


