### PR TITLE
Minor Tweaks to Form526 Reports Rake Task

### DIFF
--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -103,7 +103,7 @@ namespace :form526 do
         print_header: -> { puts ROW[:order].map { |key| ROW[:headers][key] }.join(separator) },
         print_hr: -> { puts },
         print_row: redact_participant_id ? print_row_with_redacted_participant_id : print_row,
-        print_total: ->(header, total) { puts "#{header.strip}#{separator}#{total}" },
+        print_total: ->(header, total) { puts "#{header.to_s.strip}#{separator}#{total}" },
         ignore_submission: ->(submission) { submission.bdd? ? false : submission.id },
         submissions: Form526Submission.where('created_at >= ?', start_date.to_date.beginning_of_day),
         success_failure_totals_header_string: '* Job Success/Failure counts *'

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -79,7 +79,7 @@ namespace :form526 do
         print_header: -> { print_row.call(**ROW[:headers]) },
         print_hr: -> { puts '------------------------------------------------------------' },
         print_row: print_row,
-        print_total: ->(header, total) { puts format("%-20s#{separator}%s", header, total) },
+        print_total: ->(header, total) { puts format("%-20s#{separator}%s", "#{header}:", total) },
         ignore_submission: ->(_) { false },
         submissions: Form526Submission.where(created_at: [start_date.beginning_of_day..end_date.end_of_day]),
         success_failure_totals_header_string: "* Job Success/Failure counts between #{start_date} - #{end_date} *"
@@ -91,7 +91,9 @@ namespace :form526 do
 
       redact_participant_id = true
       separator = ','
-      print_row = ->(**fields) { puts ROW[:order].map { |key| fields[key].inspect }.join(separator) }
+      print_row = lambda do |**fields|
+        puts ROW[:order].map { |key| fields[key].try(:iso8601) || fields[key].inspect }.join(separator)
+      end
       print_row_with_redacted_participant_id = lambda do |**fields|
         print_row.call(**fields.merge(p_id: '*****' + fields[:p_id].to_s[5..]))
       end
@@ -101,7 +103,7 @@ namespace :form526 do
         print_header: -> { puts ROW[:order].map { |key| ROW[:headers][key] }.join(separator) },
         print_hr: -> { puts },
         print_row: redact_participant_id ? print_row_with_redacted_participant_id : print_row,
-        print_total: ->(header, total) { puts "#{header}#{separator}#{total}" },
+        print_total: ->(header, total) { puts "#{header.strip}#{separator}#{total}" },
         ignore_submission: ->(submission) { submission.bdd? ? false : submission.id },
         submissions: Form526Submission.where('created_at >= ?', start_date.to_date.beginning_of_day),
         success_failure_totals_header_string: '* Job Success/Failure counts *'
@@ -190,23 +192,23 @@ namespace :form526 do
 
     options.print_hr.call
     puts options.success_failure_totals_header_string
-    options.print_total.call('Total Jobs: ', total_jobs)
-    options.print_total.call('Successful Jobs: ', success_jobs_count)
-    options.print_total.call('Failed Jobs: ', fail_jobs)
+    options.print_total.call('Total Jobs', total_jobs)
+    options.print_total.call('Successful Jobs', success_jobs_count)
+    options.print_total.call('Failed Jobs', fail_jobs)
     options.print_total.call('User Success Rate', user_success_rate)
 
     options.print_hr.call
-    options.print_total.call('Total Users Submitted: ', total_users_submitting)
-    options.print_total.call('Total Users Submitted Successfully: ', total_successful_users_submitting)
+    options.print_total.call('Total Users Submitted', total_users_submitting)
+    options.print_total.call('Total Users Submitted Successfully', total_successful_users_submitting)
     options.print_total.call('User Success rate', user_success_rate)
 
     options.print_hr.call
     puts '* Failure Counts for form526 Submission Job (not including uploads/cleanup/etc...) *'
-    options.print_total.call('Outage Failures: ', outage_errors)
-    options.print_total.call('Other Failures: ', other_errors)
+    options.print_total.call('Outage Failures', outage_errors)
+    options.print_total.call('Other Failures', other_errors)
     puts 'Ancillary Job Errors:'
     ancillary_job_errors.each do |class_name, error_count|
-      options.print_total.call "    #{class_name}:", error_count
+      options.print_total.call "    #{class_name}", error_count
     end
 
     options.print_hr.call


### PR DESCRIPTION
Cleans up `print_total` function for BDD mode (removes colon and space). Switch to using ISO8601 styles dates for CSV output (to ensure that dates are lexicographically sortable and don't contain commas).