### PR TITLE
remove toggle :allow_online_10_10cg_submissions

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -337,10 +337,6 @@ features:
     enable_in_development: true
     description: >
       Enables type ahead search functionality
-  allow_online_10_10cg_submissions:
-    actor_type: cookie_id
-    description: >
-      Allows (unauthenticated) users to submit a 10-10CG through VA.gov. When disabled, this will redirect visitors from the form's page to the home page (va.gov).
   async_10_10_cg_attachments:
     actor_type: cookie_id
     description: >


### PR DESCRIPTION
Fixes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/19395

## Description of change
Removing the `allow_online_10_10cg_submissions` feature toggle since it's no longer in use.

## Things to know about this PR
All references to this feature flip, in the UI, were removed in this pr: https://github.com/department-of-veterans-affairs/vets-website/pull/15625
