### PR TITLE
Prevent Country Code Lookup When There's No Address Info (VA 21P530 Form Profile)

### DIFF
--- a/app/models/form_profiles/va_21p530.rb
+++ b/app/models/form_profiles/va_21p530.rb
@@ -14,7 +14,9 @@ class FormProfiles::VA21p530 < FormProfile
   def prefill
     @identity_information = initialize_identity_information
     @contact_information = initialize_contact_information
-    @contact_information.address.country = convert_to_iso2(@contact_information.address.country)
+    if @contact_information&.address&.country.present?
+      @contact_information.address.country = convert_to_iso2(@contact_information.address.country)
+    end
     @military_information = initialize_military_information
     mappings = self.class.mappings_for_form(form_id)
 

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -1140,6 +1140,27 @@ RSpec.describe FormProfile, type: :model do
       it 'returns the va profile mapped to the burial form' do
         expect_prefilled('21P-530')
       end
+
+      context 'without address' do
+        let(:v21_p_530_expected) do
+          {
+            'claimantFullName' => {
+              'first' => user.first_name&.capitalize,
+              'last' => user.last_name&.capitalize,
+              'suffix' => user.va_profile[:suffix]
+            }
+          }
+        end
+
+        before do
+          allow_any_instance_of(FormProfiles::VA21p530)
+            .to receive(:initialize_contact_information).and_return(FormContactInformation.new)
+        end
+
+        it "doesn't throw an exception" do
+          expect_prefilled('21P-530')
+        end
+      end
     end
 
     context 'with a higher level review form' do


### PR DESCRIPTION
Fixes `undefined method 'country' for nil:NilClass`
([sentry](http://sentry.vfs.va.gov/organizations/vsp/issues/17590/?query=is%3Aunresolved+InProgressFormsController&statsPeriod=14d))
(not sure which team this form belongs to)