### PR TITLE
Exhausted metrics for disability compensation

### DIFF
--- a/app/workers/evss/disability_compensation_form/submit_form526_cleanup.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form526_cleanup.rb
@@ -8,6 +8,13 @@ module EVSS
       include Sidekiq::Worker
       STATSD_KEY_PREFIX = 'worker.evss.submit_form526_cleanup'
 
+      # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
+      # :nocov:
+      sidekiq_retries_exhausted do |msg, _ex|
+        job_exhausted(msg, STATSD_KEY_PREFIX)
+      end
+      # :nocov:
+
       # Cleans up a 526 submission by removing its {InProgressForm} and deleting the
       # active Intent to File record (via EVSS)
       #

--- a/app/workers/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/workers/evss/disability_compensation_form/submit_uploads.rb
@@ -8,6 +8,13 @@ module EVSS
       # retry for one day
       sidekiq_options retry: 14
 
+      # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
+      # :nocov:
+      sidekiq_retries_exhausted do |msg, _ex|
+        job_exhausted(msg, STATSD_KEY_PREFIX)
+      end
+      # :nocov:
+
       # Recursively submits a file in a new instance of this job for each upload in the uploads list
       #
       # @param submission_id [Integer] The {Form526Submission} id

--- a/app/workers/evss/disability_compensation_form/upload_bdd_instructions.rb
+++ b/app/workers/evss/disability_compensation_form/upload_bdd_instructions.rb
@@ -8,6 +8,13 @@ module EVSS
       # retry for one day
       sidekiq_options retry: 14
 
+      # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
+      # :nocov:
+      sidekiq_retries_exhausted do |msg, _ex|
+        job_exhausted(msg, STATSD_KEY_PREFIX)
+      end
+      # :nocov:
+
       # Submits a BDD instruction PDF in to EVSS
       #
       # @param submission_id [Integer] The {Form526Submission} id

--- a/lib/evss/error_middleware.rb
+++ b/lib/evss/error_middleware.rb
@@ -33,10 +33,8 @@ module EVSS
       when 200
         if env.response_headers['content-type'].downcase.include?('xml')
           handle_xml_body(env)
-        else
-          if resp['success'] == false || resp['messages']&.find { |m| m['severity'] =~ /fatal|error/i }
-            raise EVSSError.new(resp['messages'], resp['messages'], resp)
-          end
+        elsif resp['success'] == false || resp['messages']&.find { |m| m['severity'] =~ /fatal|error/i }
+          raise EVSSError.new(resp['messages'], resp['messages'], resp)
         end
       when 503, 504
         raise EVSSBackendServiceError.new("EVSS#{status}", { status: status }, status, resp)

--- a/lib/evss/error_middleware.rb
+++ b/lib/evss/error_middleware.rb
@@ -27,20 +27,18 @@ module EVSS
 
     def on_complete(env)
       status = env[:status]
-
+      resp = env.body
+      Raven.extra_context(body: resp)
       case status
       when 200
         if env.response_headers['content-type'].downcase.include?('xml')
           handle_xml_body(env)
         else
-          resp = env.body
-
           if resp['success'] == false || resp['messages']&.find { |m| m['severity'] =~ /fatal|error/i }
             raise EVSSError.new(resp['messages'], resp['messages'], resp)
           end
         end
       when 503, 504
-        resp = env.body
         raise EVSSBackendServiceError.new("EVSS#{status}", { status: status }, status, resp)
       end
     end

--- a/spec/lib/evss/error_middleware_spec.rb
+++ b/spec/lib/evss/error_middleware_spec.rb
@@ -35,7 +35,7 @@ describe EVSS::ErrorMiddleware do
         </messages>
       </submit686Request>
       XML
-    )
+    ).twice
 
     expect do
       described_class.new.on_complete(env)


### PR DESCRIPTION
## Description of change
Ensure that we are sending job exhausted metrics for Form526-related workers.
Also, add response body to sentry for EVSS errors.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19568

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
