### PR TITLE
Add sentry tag for each app

### DIFF
--- a/app/controllers/concerns/sentry_controller_logging.rb
+++ b/app/controllers/concerns/sentry_controller_logging.rb
@@ -36,6 +36,7 @@ module SentryControllerLogging
       else
         tags[:sign_in_method] = 'not-signed-in'
       end
+      tags[:source_app] = request.headers['Source-App-Name'] if request.headers['Source-App-Name']
     end
   end
 end

--- a/app/controllers/concerns/sentry_controller_logging.rb
+++ b/app/controllers/concerns/sentry_controller_logging.rb
@@ -36,7 +36,9 @@ module SentryControllerLogging
       else
         tags[:sign_in_method] = 'not-signed-in'
       end
-      tags[:source_app] = request.headers['Source-App-Name'] if request.headers['Source-App-Name']
+      if request.headers['Source-App-Name']
+        tags[:source_app] = request.headers['Source-App-Name']
+      end
     end
   end
 end

--- a/app/controllers/concerns/sentry_controller_logging.rb
+++ b/app/controllers/concerns/sentry_controller_logging.rb
@@ -36,9 +36,7 @@ module SentryControllerLogging
       else
         tags[:sign_in_method] = 'not-signed-in'
       end
-      if request.headers['Source-App-Name']
-        tags[:source_app] = request.headers['Source-App-Name']
-      end
+      tags[:source_app] = request.headers['Source-App-Name'] if request.headers['Source-App-Name']
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -239,7 +239,8 @@ RSpec.describe ApplicationController, type: :controller do
       # if current user is nil it means user is not signed in.
       expect(Raven).to receive(:tags_context).once.with(
         controller_name: 'anonymous',
-        sign_in_method: 'not-signed-in'
+        sign_in_method: 'not-signed-in',
+        source_app: 'my_testing'
       )
       expect(Raven).to receive(:tags_context).once.with(
         error: 'mhv_session'
@@ -247,6 +248,7 @@ RSpec.describe ApplicationController, type: :controller do
       # since user is not signed in this shouldnt get called.
       expect(Raven).not_to receive(:user_context)
       expect(Raven).to receive(:capture_exception).once
+      request.headers['Source-App-Name'] = 'my_testing'
       with_settings(Settings.sentry, dsn: 'T') do
         get :client_connection_failed
       end

--- a/spec/lib/sidekiq/error_tag_spec.rb
+++ b/spec/lib/sidekiq/error_tag_spec.rb
@@ -13,13 +13,10 @@ describe Sidekiq::ErrorTag do
   end
 
   before do
-    allow_any_instance_of(ApplicationController).to receive(:request).and_return(
-      OpenStruct.new(
-        uuid: '123',
-        remote_ip: '99.99.99.99',
-        user_agent: 'banana'
-      )
-    )
+    req = ActionDispatch::TestRequest.create('HTTP_USER_AGENT' => 'banana', 'REMOTE_ADDR' => '99.99.99.99')
+    req.request_id = '123'
+    allow_any_instance_of(ApplicationController).to receive(:request).and_return(req)
+
     ApplicationController.new.send(:set_tags_and_extra_context)
   end
 


### PR DESCRIPTION
## Description of change
Add a sentry tag with the front end app name for all reqests that have the  `Source-App-Name` header.  The Source-App-Name header should be present for all apps because of our [frontend to backend mapping stats](http://grafana.vfs.va.gov/d/zGS4XzkMk/backend-to-frontend-app-mapping?orgId=1)

I did an end to (almost) end test by making a call from vets-website, to vets-api and verifying that the tag was present in the sidekiq job to create a sentry issue. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#7249
