### PR TITLE
Add support for const keyword to DetailedSchemaErrors

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -208,6 +208,12 @@ en:
           detail: "'%{value}' is not an available option"
           code: 141
           status: 422
+        const:
+          <<: *defaults
+          title: Invalid value
+          detail: "'%{value}' does not match the provided const"
+          code: 148
+          status: 422
         length:
           <<: *defaults
           title: Invalid length

--- a/lib/common/exceptions/detailed_schema_errors.rb
+++ b/lib/common/exceptions/detailed_schema_errors.rb
@@ -51,6 +51,13 @@ module Common
         data
       end
 
+      def const(error)
+        data = i18n_interpolated :const, detail: { value: error['data'] }
+        data[:meta] ||= {}
+        data.merge! meta: { required_value: error.dig('schema', 'const') }
+        data
+      end
+
       def length(error)
         data = i18n_interpolated :length, detail: { value: error['data'] }
         data[:meta] ||= {}

--- a/spec/fixtures/json/detailed_schema_errors_schema.json
+++ b/spec/fixtures/json/detailed_schema_errors_schema.json
@@ -12,11 +12,12 @@
         "married": { "$ref": "#/definitions/married" },
         "email": { "$ref": "#/definitions/email" },
         "gender": { "$ref": "#/definitions/gender" },
+        "favoriteFood": { "$ref": "#/definitions/favoriteFood" },
         "location": { "$ref": "#/definitions/location" },
         "favoriteFruits": { "$ref":  "#/definitions/favoriteFruits" },
         "requiredField": { "$ref": "#/definitions/requiredField" }
       },
-      "required": ["name", "age", "married", "email", "gender", "location", "requiredField"]
+      "required": ["name", "age", "married", "email", "gender", "favoriteFood", "location", "requiredField"]
     },
     "name": {
       "type": "string",
@@ -43,6 +44,10 @@
         "female",
         "undisclosed"
       ]
+    },
+    "favoriteFood": {
+      "type": "string",
+      "const": "pizza"
     },
     "location": {
       "type": "object",

--- a/spec/lib/common/exceptions/detailed_schema_errors_spec.rb
+++ b/spec/lib/common/exceptions/detailed_schema_errors_spec.rb
@@ -23,6 +23,7 @@ describe Common::Exceptions::DetailedSchemaErrors do
       'gender' => 'male',
       'location' => { 'latitude' => 38.9013369,
                       'longitude' => -77.0316181 },
+      'favoriteFood' => 'pizza',
       'requiredField' => 'exists' }
   end
   let(:pointer) { subject[:source][:pointer] }
@@ -126,6 +127,15 @@ describe Common::Exceptions::DetailedSchemaErrors do
       expect(subject[:title]).to eq 'Invalid option'
       expect(subject[:detail]).to eq "'#{data['gender']}' is not an available option"
       expect(subject[:meta][:available_options]).to match_array %w[male female undisclosed]
+    end
+  end
+
+  context 'const' do
+    it 'has title, detail, and meta' do
+      data['favoriteFood'] = Faker::Lorem.sentence
+      expect(subject[:title]).to eq 'Invalid value'
+      expect(subject[:detail]).to eq "'#{data['favoriteFood']}' does not match the provided const"
+      expect(subject[:meta][:required_value]).to eq('pizza')
     end
   end
 


### PR DESCRIPTION
## Description of change
This PR adds support for the `const` keyword, as seen [here](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.1.3) to the `DetailedSchemaErrors` class.

## Original issue(s)
[API-4864](https://vajira.max.gov/browse/API-4864)
