### PR TITLE
Move model validation for address

### DIFF
--- a/modules/appeals_api/config/schemas/10182.json
+++ b/modules/appeals_api/config/schemas/10182.json
@@ -40,18 +40,19 @@
       "required": [ "boardReviewOption", "socOptIn" ]
     },
 
-
     "nodCreateVeteran": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "homeless":            { "type": "boolean" },
-        "address":             { "$ref": "#/definitions/nodCreateAddress", "minLength": 5, "maxLength": 165 },
+        "address":             { "$ref": "#/definitions/nodCreateAddress" },
         "phone":               { "$ref": "#/definitions/nodCreatePhone" },
         "emailAddressText":    { "$ref": "#/definitions/nodCreateEmail", "minLength": 5, "maxLength": 120 },
         "representativesName": { "type": "string", "maxLength": 120 }
       },
-      "required": [ "homeless", "phone", "emailAddressText" ]
+      "required": ["homeless",  "phone", "emailAddressText"],
+      "if": { "properties": { "homeless": { "const":  false } } },
+      "then": { "required":  ["address"] }
     },
 
 

--- a/modules/appeals_api/spec/fixtures/invalid_10182.json
+++ b/modules/appeals_api/spec/fixtures/invalid_10182.json
@@ -4,23 +4,6 @@
     "attributes": {
       "veteran": {
         "homeless": false,
-        "address": {
-          "addressLine1": "123 Main St",
-          "addressLine2": "Suite #1200",
-          "addressLine3": "Box 4",
-          "city": "New York",
-          "countryName": "United States",
-          "stateCode": "NY",
-          "zipCode5": "30012",
-          "internationalPostalCode": "1"
-        },
-        "phone": {
-          "countryCode": "6",
-          "areaCode": "555",
-          "phoneNumber": "8001111",
-          "phoneNumberExt": "2"
-        },
-        "emailAddressText": "user@example.com",
         "representativesName": "Tony Danza"
       },
       "boardReviewOption": "hearing",

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -23,83 +23,47 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
   end
 
   # rubocop:disable Layout/LineLength
-  describe 'validations' do
-    describe '#validate_address' do
-      context 'when homeless is true' do
+  describe '#validate_hearing_type_selection' do
+    context "when board review option 'hearing' selected" do
+      context 'when hearing type provided' do
         before do
-          notice_of_disagreement.form_data['data']['attributes']['veteran']['homeless'] = true
-          notice_of_disagreement.form_data['data']['attributes']['veteran'].delete('address')
           notice_of_disagreement.valid?
         end
 
-        it { expect(notice_of_disagreement.errors.count).to be 0 }
+        it 'does not throw an error' do
+          expect(notice_of_disagreement.errors.count).to be 0
+        end
       end
 
-      context 'when homeless is false' do
-        before { notice_of_disagreement.form_data['data']['attributes']['veteran']['homeless'] = false }
-
-        context 'when address is provided' do
-          it { expect(notice_of_disagreement.errors.count).to be 0 }
+      context 'when hearing type missing' do
+        before do
+          form_data['data']['attributes'].delete('hearingTypePreference')
+          notice_of_disagreement.valid?
         end
 
-        context 'when address is not provided' do
-          before do
-            notice_of_disagreement.form_data['data']['attributes']['veteran'].delete('address')
-            notice_of_disagreement.valid?
-          end
-
-          it 'throws and error' do
-            expect(notice_of_disagreement.errors.count).to be 1
-            expect(notice_of_disagreement.errors.full_messages.first).to eq(
-              "Form data If not homeless, address must be provided: '/data/attributes/veteran/address'"
-            )
-          end
+        it 'throws an error' do
+          expect(notice_of_disagreement.errors.count).to be 1
+          expect(notice_of_disagreement.errors[:'/data/attributes/hearingTypePreference'][0][:detail]).to eq(
+            "If '/data/attributes/boardReviewOption' 'hearing' is selected, '/data/attributes/hearingTypePreference' must also be present"
+          )
         end
       end
     end
 
-    describe '#validate_hearing_type_selection' do
-      context "when board review option 'hearing' selected" do
-        context 'when hearing type provided' do
-          before do
-            notice_of_disagreement.valid?
-          end
+    context "when board review option 'direct_review' or 'evidence_submission' is selected" do
+      let(:form_data) { fixture_as_json 'valid_10182_minimum.json' }
 
-          it 'does not throw an error' do
-            expect(notice_of_disagreement.errors.count).to be 0
-          end
+      context 'when hearing type provided' do
+        before do
+          notice_of_disagreement.form_data['data']['attributes']['hearingTypePreference'] = 'video_conference'
+          notice_of_disagreement.valid?
         end
 
-        context 'when hearing type missing' do
-          before do
-            form_data['data']['attributes'].delete('hearingTypePreference')
-            notice_of_disagreement.valid?
-          end
-
-          it 'throws an error' do
-            expect(notice_of_disagreement.errors.count).to be 1
-            expect(notice_of_disagreement.errors[:'/data/attributes/hearingTypePreference'][0][:detail]).to eq(
-              "If '/data/attributes/boardReviewOption' 'hearing' is selected, '/data/attributes/hearingTypePreference' must also be present"
-            )
-          end
-        end
-      end
-
-      context "when board review option 'direct_review' or 'evidence_submission' is selected" do
-        let(:form_data) { fixture_as_json 'valid_10182_minimum.json' }
-
-        context 'when hearing type provided' do
-          before do
-            notice_of_disagreement.form_data['data']['attributes']['hearingTypePreference'] = 'video_conference'
-            notice_of_disagreement.valid?
-          end
-
-          it 'throws an error' do
-            expect(notice_of_disagreement.errors.count).to be 1
-            expect(notice_of_disagreement.errors[:'/data/attributes/hearingTypePreference'][0][:detail]).to eq(
-              "If '/data/attributes/boardReviewOption' 'direct_review' or 'evidence_submission' is selected, '/data/attributes/hearingTypePreference' must not be selected"
-            )
-          end
+        it 'throws an error' do
+          expect(notice_of_disagreement.errors.count).to be 1
+          expect(notice_of_disagreement.errors[:'/data/attributes/hearingTypePreference'][0][:detail]).to eq(
+            "If '/data/attributes/boardReviewOption' 'direct_review' or 'evidence_submission' is selected, '/data/attributes/hearingTypePreference' must not be selected"
+          )
         end
       end
     end

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
@@ -69,9 +69,9 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController, type:
       end
 
       it 'returns error objects in JSON API 1.0 ErrorObject format' do
-        expected_keys = %w[code detail links meta sentry_type source status title]
-        expect(parsed['errors'].first.keys).to match_array(expected_keys)
-        expect(parsed['errors'][0]['source']['pointer']).to eq '/data/attributes/hearingTypePreference'
+        expected_keys = %w[code detail meta source status title]
+        expect(parsed['errors'].first.keys).to include(*expected_keys)
+        expect(parsed['errors'][0]['source']['pointer']).to eq '/data/attributes/veteran'
       end
     end
 
@@ -111,4 +111,21 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController, type:
       expect(parsed['errors']).not_to be_empty
     end
   end
+
+  # rubocop:disable Layout/LineLength
+  describe '#render_model_errors' do
+    let(:path) { base_path 'notice_of_disagreements' }
+    let(:data) { JSON.parse(@minimum_valid_data) }
+
+    it 'returns model errors in JSON API 1.0 ErrorObject format' do
+      data['data']['attributes']['boardReviewOption'] = 'hearing'
+
+      post(path, params: data.to_json, headers: @headers)
+
+      expect(response.status).to eq(422)
+      expect(parsed['errors'][0]['source']['pointer']).to eq('/data/attributes/hearingTypePreference')
+      expect(parsed['errors'][0]['detail']).to eq("If '/data/attributes/boardReviewOption' 'hearing' is selected, '/data/attributes/hearingTypePreference' must also be present")
+    end
+  end
+  # rubocop:enable Layout/LineLength
 end

--- a/spec/fixtures/json/detailed_schema_errors_schema.json
+++ b/spec/fixtures/json/detailed_schema_errors_schema.json
@@ -14,11 +14,15 @@
         "email": { "$ref": "#/definitions/email" },
         "gender": { "$ref": "#/definitions/gender" },
         "favoriteFood": { "$ref": "#/definitions/favoriteFood" },
+        "hungry?": { "$ref": "#/definitions/hungry?" },
+        "dessert": { "$ref": "#/definitions/dessert" },
         "location": { "$ref": "#/definitions/location" },
         "favoriteFruits": { "$ref":  "#/definitions/favoriteFruits" },
         "requiredField": { "$ref": "#/definitions/requiredField" }
       },
-      "required": ["name", "age", "married", "pattern", "email", "gender", "favoriteFood", "location", "requiredField"]
+      "required": ["name", "age", "married", "pattern", "email", "gender", "favoriteFood", "hungry?", "location", "requiredField"],
+      "if": { "properties": { "hungry?": { "const":  true } } },
+      "then": { "required":  ["dessert"] }
     },
     "name": {
       "type": "string",
@@ -52,6 +56,17 @@
     "favoriteFood": {
       "type": "string",
       "const": "pizza"
+    },
+    "hungry?": {
+      "type": "boolean"
+    },
+    "dessert": {
+      "type": "string",
+      "enum": [
+        "cheesecake",
+        "snickerdoodles",
+        "cream puff"
+      ]
     },
     "location": {
       "type": "object",

--- a/spec/lib/common/exceptions/detailed_schema_errors_spec.rb
+++ b/spec/lib/common/exceptions/detailed_schema_errors_spec.rb
@@ -25,6 +25,7 @@ describe Common::Exceptions::DetailedSchemaErrors do
       'location' => { 'latitude' => 38.9013369,
                       'longitude' => -77.0316181 },
       'favoriteFood' => 'pizza',
+      'hungry?' => false,
       'requiredField' => 'exists' }
   end
   let(:pointer) { subject[:source][:pointer] }
@@ -221,6 +222,15 @@ describe Common::Exceptions::DetailedSchemaErrors do
       expect(error[:title]).to eq 'Validation error'
       expect(error[:code]).to eq '100'
       expect(error[:source][:pointer]).to eq '/married'
+    end
+  end
+
+  context 'respects conditional fields' do
+    it do
+      data['hungry?'] = true
+      expect(subject[:title]).to eq 'Missing required fields'
+      expect(subject[:detail]).to eq 'One or more expected fields were not found'
+      expect(subject[:meta][:missing_fields]).to eq ['dessert']
     end
   end
 end


### PR DESCRIPTION
## Description of change
A Veteran's address is dependent on whether they are experiencing homelessness
We were validating this on the model
This PR moves the validation from the model to json schema.

## Ticket
https://vajira.max.gov/browse/API-4816

## Testing
Test removed from model spec and added to detailed_schema_errors_spec