### PR TITLE
Handle VA appointment errors that include a partial response

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/community_care_appointments.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/community_care_appointments.rb
@@ -22,6 +22,7 @@ module Mobile
         #
         def parse(appointments)
           appointments_list = appointments[:booked_appointment_collections].first[:booked_cc_appointments]
+          return [] if appointments_list.size.zero?
 
           appointments_list.map do |appointment_hash|
             location = location(

--- a/modules/mobile/app/models/mobile/v0/adapters/va_appointments.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/va_appointments.rb
@@ -66,6 +66,8 @@ module Mobile
         def parse(appointments)
           facilities = Set.new
           appointments_list = appointments.dig(:data, :appointment_list)
+          return [nil, nil] if appointments_list.size.zero?
+
           appointments = appointments_list.map do |appointment_hash|
             build_appointment_model(appointment_hash, facilities)
           end

--- a/modules/mobile/app/services/mobile/v0/appointments/proxy.rb
+++ b/modules/mobile/app/services/mobile/v0/appointments/proxy.rb
@@ -35,6 +35,8 @@ module Mobile
 
         def va_appointments_with_facilities(appointments_from_response)
           appointments, facility_ids = va_appointments_adapter.parse(appointments_from_response)
+          return [] if appointments.nil?
+
           get_appointment_facilities(appointments, facility_ids) if appointments.size.positive?
         end
 

--- a/modules/mobile/spec/request/appointments_request_spec.rb
+++ b/modules/mobile/spec/request/appointments_request_spec.rb
@@ -243,6 +243,24 @@ RSpec.describe 'appointments', type: :request do
           expect(response).to have_http_status(:bad_gateway)
         end
       end
+
+      context 'when the VA endpoint returns a partial response with an error' do
+        before do
+          VCR.use_cassette('appointments/get_appointments_200_with_error', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('appointments/get_cc_appointments', match_requests_on: %i[method uri]) do
+              get '/mobile/v0/appointments', headers: iam_headers, params: params
+            end
+          end
+        end
+
+        it 'returns a 200 response' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'has the right CC count' do
+          expect(response.parsed_body['data'].size).to eq(33)
+        end
+      end
     end
   end
 end

--- a/modules/mobile/spec/support/vcr_cassettes/appointments/get_appointments_200_with_error.yml
+++ b/modules/mobile/spec/support/vcr_cassettes/appointments/get_appointments_200_with_error.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/appointments/v1/patients/24811694708759028/appointments?endDate=2021-02-01T10:30:00Z&pageSize=0&startDate=2020-11-01T10:30:00Z&useCache=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - eyJhbGciOiJSUzUxMiJ9.eyJsYXN0TmFtZSI6Ik1vcnJpc29uIiwic3ViIjoiMTAxMjg0NTMzMVYxNTMwNDMiLCJhdXRoZW50aWNhdGVkIjp0cnVlLCJhdXRoZW50aWNhdGlvbkF1dGhvcml0eSI6Imdvdi52YS52YW9zIiwiaWRUeXBlIjoiSUNOIiwiZ2VuZGVyIjoiRkVNQUxFIiwiaXNzIjoiZ292LnZhLnZhbWYudXNlcnNlcnZpY2UudjEiLCJ2YW1mLmF1dGgucmVzb3VyY2VzIjpbIl4uKihcLyk_c2l0ZVtzXT9cLyhkZm4tKT85ODRcL3BhdGllbnRbc10_XC81NTIxNjEwNTBcL2FwcG9pbnRtZW50cyhcLy4qKT8kIiwiXi4qKFwvKT9zaXRlW3NdP1wvKGRmbi0pPzk4M1wvcGF0aWVudFtzXT9cLzcyMTY2OTFcL2FwcG9pbnRtZW50cyhcLy4qKT8kIiwiXi4qKFwvKT9wYXRpZW50W3NdP1wvKElDTlwvKT8xMDEyODQ1MzMxVjE1MzA0MyhcLy4qKT8kIl0sImRhdGVPZkJpcnRoIjoiMTk1MzA0MDEiLCJ2ZXJzaW9uIjoyLjEsImVkaXBpZCI6IjEyNTk4OTc5NzgiLCJ2aXN0YUlkcyI6W3sicGF0aWVudElkIjoiNTUyMTYxMDUwIiwic2l0ZUlkIjoiOTg0In0seyJwYXRpZW50SWQiOiI3MjE2NjkxIiwic2l0ZUlkIjoiOTgzIn1dLCJzc24iOiI3OTYwNjE5NzYiLCJmaXJzdE5hbWUiOiJKdWR5Iiwic3RhZmZEaXNjbGFpbWVyQWNjZXB0ZWQiOnRydWUsIm5iZiI6MTU5MTEyNDk2MCwic3N0IjoxNTkxMTI1MTM5LCJwYXRpZW50Ijp7ImZpcnN0TmFtZSI6Ikp1ZHkiLCJsYXN0TmFtZSI6Ik1vcnJpc29uIiwiZ2VuZGVyIjoiRkVNQUxFIiwiaWNuIjoiMTAxMjg0NTMzMVYxNTMwNDMiLCJkb2IiOiIxOTUzLTA0LTAxIiwiZGF0ZU9mQmlydGgiOiIxOTUzLTA0LTAxIiwic3NuIjoiNzk2MDYxOTc2In0sImRvYiI6IjE5NTMwNDAxIiwidmFtZi5hdXRoLnJvbGVzIjpbInZldGVyYW4iXSwicmlnaHRPZkFjY2Vzc0FjY2VwdGVkIjp0cnVlLCJleHAiOjE1OTExMjYwNDAsImp0aSI6ImI0NDg3YTZjLTRmN2YtNDcxMS05Y2NiLWE4YmJlM2UwZGUyMSIsImxvYSI6Mn0.eDaxQUJo6T8sk-13GSoNh3gK5c5MLRYOzFMHSw2wtt0EC-YJBZwhjY1uuvKBpZrrZm7pjhzNs-5cfXJJ2N2VM5rCyq4_xucyb6DKyB61WYtdECqeMZvovdUdLCgd9I_FkkJ3-4tyO5C0HwLJUNYOWKVgpsfZOeldD2jb-aCA9rki7EtGncIImhjuBjKkqLgsPCRz9W9Rf-9g0HhZvux_6u0cyVavxqBuT-isRbD-IHn4NQpGupYIAXaMhkHWFJWJPclLtsCvUd3wKPGO6PWpx-JtGMqggu_BLcub0_BTQ3IvlZrzuOg2hf9Dp-2pa4XNLuQVHRYZ9DYW_R3YvDliZA
+      X-Request-Id:
+      - 01bc1d5d-14a7-46cc-9171-4b8bc2a81d54
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 01 Nov 2020 10:30:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4481'
+      Server:
+      - openresty
+      X-B3-Parentspanid:
+      - f1c3bd9bc5185a25
+      X-Vamf-Version:
+      - 1.16.0
+      X-B3-Traceid:
+      - 7e62bc60b16d5963
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - 8f21c0b
+      X-B3-Sampled:
+      - '0'
+      X-Vamf-Timestamp:
+      - '2020-05-13T14:48:04+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      X-B3-Spanid:
+      - c9b7274078a4eead
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+        	"errors": [
+        		{
+        			"code": 500,
+        			"source": "987 ",
+        			"summary": "Could not get appointments from VistA Scheduling Service (1f74ae36-dd76-4cd3-9a22-4802b0e83b36) "
+        		}
+        	],
+        	"data": {
+        		"result": {
+        			"partial": true
+        		},
+        		"appointment_list": [
+
+        		],
+        		"num_appointments": 0
+        	}
+        }
+      http_version: null
+  recorded_at: Mon, 01 Nov 2020 10:30:00 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
The underlying VAOS VistA Scheduling Service can throw an error but have VAOS still return an empty result. Adds a VCR cassette and a spec for this case.

## Original issue(s)
N/A

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
