### PR TITLE
19333: Add user to 10203 report

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -435,6 +435,7 @@ reports:
       - Ricardo.DaSilva@va.gov
       - shay.norton@va.gov
       - tammy.hurley1@va.gov
+      - robert.shinners@va.gov
     staging_emails:
       - Brian.Grubb@va.gov
       - Darrell.Neel@va.gov

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -433,9 +433,9 @@ reports:
       - lihan@adhocteam.us
       - Lucas.Tickner@va.gov
       - Ricardo.DaSilva@va.gov
+      - robert.shinners@va.gov
       - shay.norton@va.gov
       - tammy.hurley1@va.gov
-      - robert.shinners@va.gov
     staging_emails:
       - Brian.Grubb@va.gov
       - Darrell.Neel@va.gov

--- a/spec/mailers/spool10203_submissions_report_mailer_spec.rb
+++ b/spec/mailers/spool10203_submissions_report_mailer_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe Spool10203SubmissionsReportMailer, type: %i[mailer aws_helpers] d
             robert.shinners@va.gov
             shay.norton@va.gov
             tammy.hurley1@va.gov
-            
           ]
         )
       end

--- a/spec/mailers/spool10203_submissions_report_mailer_spec.rb
+++ b/spec/mailers/spool10203_submissions_report_mailer_spec.rb
@@ -67,8 +67,10 @@ RSpec.describe Spool10203SubmissionsReportMailer, type: %i[mailer aws_helpers] d
             lihan@adhocteam.us
             Lucas.Tickner@va.gov
             Ricardo.DaSilva@va.gov
+            robert.shinners@va.gov
             shay.norton@va.gov
             tammy.hurley1@va.gov
+            
           ]
         )
       end


### PR DESCRIPTION
## Description of change
As an Education Services team member, I need reporting done on the number of 10203 submissions and denials each day, so that I can monitor the number of automated denials vs the total number of submissions.

## Acceptance Criteria
- [x] A daily report is sent out that contains the 10203 and 10203 DNY spool file submissions from the previous day.
a. robert.shinners@va.gov is included in the production report distribution

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/19333
