### PR TITLE
Questionnaire Manager get SIP data

### DIFF
--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe HealthQuest::QuestionnaireManager::Factory do
   subject { described_class }
 
-  let(:user) { double('User', icn: '1008596379V859838', account_uuid: 'abc123') }
+  let(:user) { double('User', icn: '1008596379V859838', account_uuid: 'abc123', uuid: '789defg') }
   let(:session_store) { double('SessionStore', token: '123abc') }
   let(:session_service) { double('HealthQuest::Lighthouse::Session', user: user, retrieve: session_store) }
   let(:client_reply) { double('FHIR::ClientReply') }
@@ -22,8 +22,12 @@ describe HealthQuest::QuestionnaireManager::Factory do
       expect(factory.respond_to?(:appointments)).to eq(true)
       expect(factory.respond_to?(:aggregated_data)).to eq(true)
       expect(factory.respond_to?(:patient)).to eq(true)
+      expect(factory.respond_to?(:questionnaires)).to eq(true)
+      expect(factory.respond_to?(:save_in_progress)).to eq(true)
       expect(factory.respond_to?(:appointment_service)).to eq(true)
       expect(factory.respond_to?(:patient_service)).to eq(true)
+      expect(factory.respond_to?(:questionnaire_service)).to eq(true)
+      expect(factory.respond_to?(:sip_model)).to eq(true)
       expect(factory.respond_to?(:transformer)).to eq(true)
       expect(factory.respond_to?(:user)).to eq(true)
     end
@@ -106,7 +110,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       end
     end
 
-    context 'when patient and appointment and questionnaires and questionnaire_responses exist' do
+    context 'when patient and appointment and questionnaires and questionnaire_responses and sip data exist' do
       let(:fhir_data) { double('FHIR::Bundle', entry: [{}, {}]) }
       let(:appointments) { { data: [{}, {}] } }
       let(:fhir_patient) { double('FHIR::Patient') }
@@ -124,6 +128,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
         allow_any_instance_of(subject).to receive(:get_questionnaires).and_return(questionnaire_client_reply)
         allow_any_instance_of(subject)
           .to receive(:get_questionnaire_responses).and_return(questionnaire_response_client_reply)
+        allow_any_instance_of(subject).to receive(:get_save_in_progress).and_return([{}])
       end
 
       it 'returns a WIP hash' do
@@ -174,6 +179,12 @@ describe HealthQuest::QuestionnaireManager::Factory do
       allow_any_instance_of(HealthQuest::AppointmentService).to receive(:get_appointments).and_return(appointments)
 
       expect(described_class.manufacture(user).get_appointments).to eq(appointments)
+    end
+  end
+
+  describe '#get_save_in_progress' do
+    it 'returns an empty array when user does not exist' do
+      expect(described_class.manufacture(user).get_save_in_progress).to eq([])
     end
   end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- This PR invokes the health-quest QuestionnaireResponse service via the QuestionnaireManager module and retrieves SIP(save in progress) data for the user/form from the vets-api PostgreSQL database.
- The final response to the /health_quest/v0/questionnaire_manager route will be built out in the next two PRs.
- This PR returns a placeholder hash { data: 'WIP' } as the success response when the above route is called.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19015

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- Feature flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [X] RSpec tests passing