### PR TITLE
add person_types to SSOe parsing

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -127,6 +127,7 @@ class User < Common::RedisStore
   delegate :idme_uuid, to: :identity, allow_nil: true
   delegate :dslogon_edipi, to: :identity, allow_nil: true
   delegate :common_name, to: :identity, allow_nil: true
+  delegate :person_types, to: :identity, allow_nil: true
 
   # mpi attributes
   delegate :icn_with_aaid, to: :mpi

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -11,7 +11,7 @@ module SAML
       include SentryLogging
       SERIALIZABLE_ATTRIBUTES = %i[email first_name middle_name last_name common_name zip gender ssn birth_date
                                    uuid idme_uuid sec_id mhv_icn mhv_correlation_id mhv_account_type
-                                   dslogon_edipi loa sign_in multifactor participant_id birls_id icn].freeze
+                                   dslogon_edipi loa sign_in multifactor participant_id birls_id icn person_types].freeze
       INBOUND_AUTHN_CONTEXT = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password'
 
       attr_reader :attributes, :authn_context, :warnings
@@ -80,6 +80,11 @@ module SAML
         safe_attr('va_eauth_emailaddress')
       end
 
+      # Returns an array beause a person can have multipe types.
+      def person_types
+        safe_attr('va_eauth_persontype')&.split("|")
+      end
+
       ### Identifiers
       def uuid
         raise Common::Exceptions::InvalidResource, @attributes unless idme_uuid || sec_id
@@ -125,6 +130,10 @@ module SAML
 
       def dslogon_edipi
         safe_attr('va_eauth_dodedipnid')&.split(',')&.first
+      end
+
+      def sponsor_dod_epi_pn_id
+        safe_attr('va_eauth_sponsordodedipnid')&.split(',')&.first
       end
 
       # va_eauth_credentialassurancelevel is supposed to roll up the

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -11,7 +11,8 @@ module SAML
       include SentryLogging
       SERIALIZABLE_ATTRIBUTES = %i[email first_name middle_name last_name common_name zip gender ssn birth_date
                                    uuid idme_uuid sec_id mhv_icn mhv_correlation_id mhv_account_type
-                                   dslogon_edipi loa sign_in multifactor participant_id birls_id icn person_types].freeze
+                                   dslogon_edipi loa sign_in multifactor participant_id birls_id icn
+                                   person_types].freeze
       INBOUND_AUTHN_CONTEXT = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password'
 
       attr_reader :attributes, :authn_context, :warnings
@@ -82,7 +83,7 @@ module SAML
 
       # Returns an array beause a person can have multipe types.
       def person_types
-        safe_attr('va_eauth_persontype')&.split("|")
+        safe_attr('va_eauth_persontype')&.split('|')
       end
 
       ### Identifiers

--- a/spec/factories/saml_attributes.rb
+++ b/spec/factories/saml_attributes.rb
@@ -697,7 +697,7 @@ FactoryBot.define do
        '1306e31273604dd4a12aa67609a63bfe^PN^200VIDM^USDVA^A|'\
        '796123607^AN^200CORP^USVBA^']
     }
-    va_eauth_persontype { ['PAT'] }
+    va_eauth_persontype { ['PAT|VET'] }
     va_eauth_multifactor { ['true'] }
     va_eauth_street1 { ['811 Vermont Ave NW'] }
     va_eauth_mhv_ien { ['14384899'] }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,6 +28,7 @@ FactoryBot.define do
       search_token { nil }
       icn_with_aaid { nil }
       common_name { nil }
+      person_types { [] }
 
       sign_in do
         {

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -118,7 +118,8 @@ RSpec.describe SAML::User do
           participant_id: nil,
           birls_id: nil,
           icn: nil,
-          common_name: nil
+          common_name: nil,
+          person_types: nil
         )
       end
 
@@ -157,7 +158,8 @@ RSpec.describe SAML::User do
           participant_id: nil,
           birls_id: nil,
           icn: nil,
-          common_name: nil
+          common_name: nil,
+          person_types: nil
         )
       end
 
@@ -194,7 +196,8 @@ RSpec.describe SAML::User do
           participant_id: nil,
           birls_id: nil,
           icn: '1008830476V316605',
-          common_name: 'vets.gov.user+262@example.com'
+          common_name: 'vets.gov.user+262@example.com',
+          person_types: nil
         )
       end
 
@@ -233,7 +236,8 @@ RSpec.describe SAML::User do
           birls_id: nil,
           icn: nil,
           multifactor: multifactor,
-          common_name: nil
+          common_name: nil,
+          person_types: nil
         )
       end
 
@@ -274,7 +278,8 @@ RSpec.describe SAML::User do
           birls_id: nil,
           icn: '1013183292V131165',
           multifactor: multifactor,
-          common_name: 'alexmac_0@example.com'
+          common_name: 'alexmac_0@example.com',
+          person_types: nil
         )
       end
     end
@@ -313,7 +318,8 @@ RSpec.describe SAML::User do
           icn: nil,
           participant_id: nil,
           multifactor: true,
-          common_name: nil
+          common_name: nil,
+          person_types: nil
         )
       end
 
@@ -355,7 +361,8 @@ RSpec.describe SAML::User do
           birls_id: nil,
           icn: '1012853550V207686',
           multifactor: multifactor,
-          common_name: 'k+tristan@example.com'
+          common_name: 'k+tristan@example.com',
+          person_types: nil
         )
       end
     end
@@ -398,7 +405,8 @@ RSpec.describe SAML::User do
           birls_id: nil,
           icn: nil,
           multifactor: multifactor,
-          common_name: 'k+tristan@example.com'
+          common_name: 'k+tristan@example.com',
+          person_types: nil          
         )
       end
     end
@@ -677,7 +685,8 @@ RSpec.describe SAML::User do
           participant_id: nil,
           birls_id: nil,
           icn: nil,
-          multifactor: multifactor
+          multifactor: multifactor,
+          person_types: nil
         )
       end
     end
@@ -715,7 +724,8 @@ RSpec.describe SAML::User do
           birls_id: nil,
           icn: '1013173963V366678',
           multifactor: false,
-          common_name: 'iam.tester@example.com'
+          common_name: 'iam.tester@example.com',
+          person_types: nil
         )
       end
 
@@ -758,7 +768,8 @@ RSpec.describe SAML::User do
           birls_id: '796123607',
           icn: '1012740600V714187',
           multifactor: multifactor,
-          common_name: 'dslogon10923109@gmail.com'
+          common_name: 'dslogon10923109@gmail.com',
+          person_types: ['PAT', 'VET']
         )
       end
     end
@@ -800,7 +811,8 @@ RSpec.describe SAML::User do
           birls_id: '796123607',
           icn: '1012740600V714187',
           multifactor: multifactor,
-          common_name: 'dslogon10923109@gmail.com'
+          common_name: 'dslogon10923109@gmail.com',
+          person_types: ['PAT', 'VET']
         )
       end
     end
@@ -859,7 +871,8 @@ RSpec.describe SAML::User do
           birls_id: nil,
           icn: '1012779219V964737',
           multifactor: multifactor,
-          common_name: 'SOFIA MCKIBBENS'
+          common_name: 'SOFIA MCKIBBENS',
+          person_types: nil
         )
       end
 
@@ -911,7 +924,8 @@ RSpec.describe SAML::User do
           birls_id: nil,
           icn: '1013062086V794840',
           multifactor: multifactor,
-          common_name: 'mhvzack@mhv.va.gov'
+          common_name: 'mhvzack@mhv.va.gov',
+          person_types: nil
         )
       end
     end
@@ -952,7 +966,8 @@ RSpec.describe SAML::User do
           birls_id: '666271151',
           icn: '1012827134V054550',
           multifactor: multifactor,
-          common_name: 'vets.gov.user+262@gmail.com'
+          common_name: 'vets.gov.user+262@gmail.com',
+          person_types: nil          
         )
       end
     end

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -406,7 +406,7 @@ RSpec.describe SAML::User do
           icn: nil,
           multifactor: multifactor,
           common_name: 'k+tristan@example.com',
-          person_types: nil          
+          person_types: nil
         )
       end
     end
@@ -769,7 +769,7 @@ RSpec.describe SAML::User do
           icn: '1012740600V714187',
           multifactor: multifactor,
           common_name: 'dslogon10923109@gmail.com',
-          person_types: ['PAT', 'VET']
+          person_types: %w[PAT VET]
         )
       end
     end
@@ -812,7 +812,7 @@ RSpec.describe SAML::User do
           icn: '1012740600V714187',
           multifactor: multifactor,
           common_name: 'dslogon10923109@gmail.com',
-          person_types: ['PAT', 'VET']
+          person_types: %w[PAT VET]
         )
       end
     end
@@ -967,7 +967,7 @@ RSpec.describe SAML::User do
           icn: '1012827134V054550',
           multifactor: multifactor,
           common_name: 'vets.gov.user+262@gmail.com',
-          person_types: nil          
+          person_types: nil
         )
       end
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change

Add parsing person_type from SSOe for use in User roles.

## Original issue(s)

https://app.zenhub.com/workspaces/vsp-identity-5f5bab705a94c9001ba33734/issues/department-of-veterans-affairs/va.gov-team/19600

## Things to know about this PR