### PR TITLE
Fix DetailedSchemaErrors when running individually

### DIFF
--- a/spec/lib/common/exceptions/detailed_schema_errors_spec.rb
+++ b/spec/lib/common/exceptions/detailed_schema_errors_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 require 'common/exceptions/detailed_schema_errors'
 
 describe Common::Exceptions::DetailedSchemaErrors do


### PR DESCRIPTION
## Description of change
Spec would fail when run on its own, but pass when in a collection. Using `rails_helper` instead of `spec_helper` included the missing pieces needed to run the spec file on its own.