### PR TITLE
19015 concurrent pgd and api calls

### DIFF
--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -10,6 +10,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
   let(:session_service) { double('HealthQuest::Lighthouse::Session', user: user, retrieve: session_store) }
   let(:client_reply) { double('FHIR::ClientReply') }
   let(:default_appointments) { { data: [] } }
+  let(:appointments) { { data: [{}, {}] } }
 
   before do
     allow(HealthQuest::Lighthouse::Session).to receive(:build).with(user).and_return(session_service)
@@ -40,12 +41,41 @@ describe HealthQuest::QuestionnaireManager::Factory do
   end
 
   describe '#all' do
-    context 'when patient does not exist' do
-      let(:client_reply) { double('FHIR::ClientReply', resource: nil) }
+    let(:fhir_data) { double('FHIR::Bundle', entry: [{}, {}]) }
+    let(:questionnaire_response_client_reply) do
+      double('FHIR::ClientReply', resource: fhir_questionnaire_response_bundle)
+    end
+    let(:fhir_questionnaire_response_bundle) { fhir_data }
+    let(:questionnaire_client_reply) { double('FHIR::ClientReply', resource: fhir_questionnaire_bundle) }
+
+    before do
+      allow_any_instance_of(subject).to receive(:get_patient).and_return(client_reply)
+      allow_any_instance_of(subject).to receive(:get_appointments).and_return(appointments)
+      allow_any_instance_of(subject).to receive(:get_save_in_progress).and_return([{}])
+      allow_any_instance_of(subject)
+        .to receive(:get_questionnaire_responses).and_return(questionnaire_response_client_reply)
+      allow_any_instance_of(subject).to receive(:get_questionnaires).and_return(questionnaire_client_reply)
+    end
+
+    context 'when appointment does not exist' do
+      let(:questionnaire_response_client_reply) { nil }
+      let(:questionnaire_client_reply) { nil }
+      let(:fhir_questionnaire_response_bundle) { nil }
 
       before do
-        allow_any_instance_of(subject).to receive(:get_patient).and_return(client_reply)
+        allow_any_instance_of(subject).to receive(:get_appointments).and_return(default_appointments)
       end
+
+      it 'returns a default hash' do
+        hash = { data: [] }
+
+        expect(described_class.manufacture(user).all).to eq(hash)
+      end
+    end
+
+    context 'when appointments and questionnaires and questionnaire_responses and sip and no patient' do
+      let(:client_reply) { double('FHIR::ClientReply', resource: nil) }
+      let(:fhir_questionnaire_bundle) { fhir_data }
 
       it 'returns a default hash' do
         hash = { data: [] }
@@ -61,40 +91,10 @@ describe HealthQuest::QuestionnaireManager::Factory do
       end
     end
 
-    context 'when patient and no appointments' do
-      let(:fhir_patient) { double('FHIR::Patient') }
-      let(:client_reply) { double('FHIR::ClientReply', resource: fhir_patient) }
-
-      before do
-        allow_any_instance_of(subject).to receive(:get_appointments).and_return(default_appointments)
-        allow_any_instance_of(subject).to receive(:get_patient).and_return(client_reply)
-      end
-
-      it 'returns a default hash' do
-        hash = { data: [] }
-
-        expect(described_class.manufacture(user).all).to eq(hash)
-      end
-
-      it 'has a FHIR::Patient patient' do
-        factory = described_class.manufacture(user)
-        factory.all
-
-        expect(factory.patient).to eq(fhir_patient)
-      end
-    end
-
-    context 'when patient and appointments and no questionnaires' do
-      let(:appointments) { { data: [{}, {}] } }
+    context 'when appointments and patient and questionnaire_responses and sip and no questionnaires' do
       let(:fhir_patient) { double('FHIR::Patient') }
       let(:client_reply) { double('FHIR::ClientReply', resource: fhir_patient) }
       let(:questionnaire_client_reply) { double('FHIR::ClientReply', resource: double('FHIR::ClientReply', entry: [])) }
-
-      before do
-        allow_any_instance_of(subject).to receive(:get_appointments).and_return(appointments)
-        allow_any_instance_of(subject).to receive(:get_patient).and_return(client_reply)
-        allow_any_instance_of(subject).to receive(:get_questionnaires).and_return(questionnaire_client_reply)
-      end
 
       it 'returns a default hash' do
         hash = { data: [] }
@@ -111,25 +111,9 @@ describe HealthQuest::QuestionnaireManager::Factory do
     end
 
     context 'when patient and appointment and questionnaires and questionnaire_responses and sip data exist' do
-      let(:fhir_data) { double('FHIR::Bundle', entry: [{}, {}]) }
-      let(:appointments) { { data: [{}, {}] } }
       let(:fhir_patient) { double('FHIR::Patient') }
-      let(:fhir_questionnaire_bundle) { fhir_data }
-      let(:fhir_questionnaire_response_bundle) { fhir_data }
       let(:client_reply) { double('FHIR::ClientReply', resource: fhir_patient) }
-      let(:questionnaire_client_reply) { double('FHIR::ClientReply', resource: fhir_questionnaire_bundle) }
-      let(:questionnaire_response_client_reply) do
-        double('FHIR::ClientReply', resource: fhir_questionnaire_response_bundle)
-      end
-
-      before do
-        allow_any_instance_of(subject).to receive(:get_appointments).and_return(appointments)
-        allow_any_instance_of(subject).to receive(:get_patient).and_return(client_reply)
-        allow_any_instance_of(subject).to receive(:get_questionnaires).and_return(questionnaire_client_reply)
-        allow_any_instance_of(subject)
-          .to receive(:get_questionnaire_responses).and_return(questionnaire_response_client_reply)
-        allow_any_instance_of(subject).to receive(:get_save_in_progress).and_return([{}])
-      end
+      let(:fhir_questionnaire_bundle) { fhir_data }
 
       it 'returns a WIP hash' do
         hash = { data: 'WIP' }
@@ -173,8 +157,6 @@ describe HealthQuest::QuestionnaireManager::Factory do
   end
 
   describe '#get_appointments' do
-    let(:appointments) { { data: [{}, {}] } }
-
     it 'returns a FHIR::ClientReply' do
       allow_any_instance_of(HealthQuest::AppointmentService).to receive(:get_appointments).and_return(appointments)
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Obtain patient, questionnaire, questionnaire_response, and save_in_progress data in a multi-threaded fashion and cut down on the number of sequential http requests that we make to the PGD and vets-api; Helps cut down lag and improves overall performance.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19015

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- Feature flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [X] RSpec tests passing