### PR TITLE
Update HLR schema to check email against JSON API email spec

### DIFF
--- a/modules/appeals_api/config/schemas/200996.json
+++ b/modules/appeals_api/config/schemas/200996.json
@@ -146,7 +146,7 @@
         "phone":   { "$ref": "#/definitions/hlrCreatePhone" },
         "emailAddressText": {
           "type": "string",
-          "pattern": ".@.",
+          "format": "email",
           "maxLength": 44
         },
         "timezone": {


### PR DESCRIPTION
## Description of change
This PR updates our HLR schema to check supplied emails against the JSON schema draft 7 email format.

## Original issue(s)
https://vajira.max.gov/browse/API-4822