### PR TITLE
add code for engine factory initializer

### DIFF
--- a/lib/generators/module/templates/lib/namespace/engine.rb.erb
+++ b/lib/generators/module/templates/lib/namespace/engine.rb.erb
@@ -4,5 +4,9 @@ module <%= class_name %>
   class Engine < ::Rails::Engine
     isolate_namespace <%= class_name %>
     config.generators.api_only = true
+	
+    initializer 'model_core.factories', after: 'factory_bot.set_factory_paths' do
+      FactoryBot.definition_file_paths << File.expand_path('../../spec/factories', __dir__) if defined?(FactoryBot)
+    end
   end
 end


### PR DESCRIPTION

## Description of change
It was brought up in the #vsp-tools-be channel that some initialization code needs to be added to the module generator engine template to load factories automatically when running specs. This PR adds the code and the changes are confirmed as working when invoking the generator. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19647


