### PR TITLE
10203 STEM Automated Decision - additional null check

### DIFF
--- a/app/workers/education_form/process10203_submissions.rb
+++ b/app/workers/education_form/process10203_submissions.rb
@@ -80,6 +80,7 @@ module EducationForm
     # Retrieve EVSS gi_bill_status data for a user
     def get_gi_bill_status(auth_headers)
       return {} if auth_headers.nil?
+
       service = EVSS::GiBillStatus::Service.new(nil, auth_headers)
       service.get_gi_bill_status(auth_headers)
     rescue => e
@@ -90,6 +91,7 @@ module EducationForm
     # Retrieve poa status fromEVSS VSOSearch for a user
     def get_user_poa_status(auth_headers)
       return nil if auth_headers.nil?
+
       service = EVSS::VSOSearch::Service.new(nil, auth_headers)
       service.get_current_info(auth_headers)['userPoaInfoAvailable']
     rescue => e

--- a/app/workers/education_form/process10203_submissions.rb
+++ b/app/workers/education_form/process10203_submissions.rb
@@ -79,6 +79,7 @@ module EducationForm
 
     # Retrieve EVSS gi_bill_status data for a user
     def get_gi_bill_status(auth_headers)
+      return {} if auth_headers.nil?
       service = EVSS::GiBillStatus::Service.new(nil, auth_headers)
       service.get_gi_bill_status(auth_headers)
     rescue => e
@@ -88,6 +89,7 @@ module EducationForm
 
     # Retrieve poa status fromEVSS VSOSearch for a user
     def get_user_poa_status(auth_headers)
+      return nil if auth_headers.nil?
       service = EVSS::VSOSearch::Service.new(nil, auth_headers)
       service.get_current_info(auth_headers)['userPoaInfoAvailable']
     rescue => e


### PR DESCRIPTION
## Description of change
Added a null check to the process10203_submissions job because have records in staging without `auth_headers` (this won't be true in prod)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18622

## Things to know about this PR
- Tested locally and QA reviewed
- The STEM automated decision functionality is behind the stem_automated_decision feature flag.
