### PR TITLE
18732 - removed message text length validation, and removed unnecessary tests

### DIFF
--- a/modules/vaos/app/models/vaos/message_form.rb
+++ b/modules/vaos/app/models/vaos/message_form.rb
@@ -48,7 +48,7 @@ module VAOS
     end
     # rubocop:enable Naming/PredicateName
 
-    validates :message_text, length: { minimum: 1, maximum: 100 }
+    validates :message_text, presence: true
 
     def params
       raise Common::Exceptions::ValidationErrors, self unless valid?

--- a/modules/vaos/spec/models/message_form_spec.rb
+++ b/modules/vaos/spec/models/message_form_spec.rb
@@ -17,17 +17,6 @@ describe VAOS::MessageForm, type: :model do
     it 'raises a Common::Exceptions::ValidationErrors when trying to fetch coerced params' do
       expect { subject.params }.to raise_error(Common::Exceptions::ValidationErrors)
     end
-
-    context 'message_text length > 100' do
-      subject do
-        described_class.new(user, request_id, message_text: Faker::Lorem.characters(number: 101))
-      end
-
-      it 'raises a custom error message' do
-        expect(subject).not_to be_valid
-        expect(subject.errors.full_messages).to eq(['Message text is too long (maximum is 100 characters)'])
-      end
-    end
   end
 
   describe 'valid object' do

--- a/modules/vaos/spec/request/messages_request_spec.rb
+++ b/modules/vaos/spec/request/messages_request_spec.rb
@@ -102,19 +102,6 @@ RSpec.describe 'vaos appointment request messages', type: :request do
       end
 
       context 'with access and invalid message' do
-        let(:request_body) { { message_text: Faker::Lorem.characters(number: 101) } }
-
-        it 'returns a validation error', :skip_mvi do
-          post "/vaos/v0/appointment_requests/#{request_id}/messages", params: request_body
-
-          expect(response).to have_http_status(:unprocessable_entity)
-          expect(response.body).to be_a(String)
-          expect(JSON.parse(response.body)['errors'].first['detail'])
-            .to eq('message-text - is too long (maximum is 100 characters)')
-        end
-      end
-
-      context 'with access and invalid message' do
         let(:request_body) { { message_text: '' } }
 
         it 'returns a validation error', :skip_mvi do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
We removed validation for `message_text` in `appointment_request` model and instead made it a required field.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Tests were updated to reflect this change
