### PR TITLE
Add new flag for operationalHoursSpecialInstructions on FL

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -52,7 +52,7 @@ features:
     enable_in_development: true
     description: >
       Enables The New My VA Dashboard 2.0
-  facility_locator_show_operational_hours_special_instruction:
+  facility_locator_show_operational_hours_special_instructions:
     actor_type: user
     enable_in_development: true
     description: Display new field operationalHoursSpecialInstructions for VA facilities

--- a/config/features.yml
+++ b/config/features.yml
@@ -52,6 +52,10 @@ features:
     enable_in_development: true
     description: >
       Enables The New My VA Dashboard 2.0
+  facility_locator_show_operational_hours_special_instruction:
+    actor_type: user
+    enable_in_development: true
+    description: Display new field operationalHoursSpecialInstructions for VA facilities
   facility_locator_show_community_cares:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Description of change

Flag to display new field operationalHoursSpecialInstructions for VA facilities

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/19615

## Front end support

https://github.com/department-of-veterans-affairs/vets-website/pull/16004/files
