### PR TITLE
[API-4737] - Add missing statuses to "ClaimsShow" Swagger schema

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/claims/claims_response_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/claims/claims_response_swagger.rb
@@ -299,10 +299,12 @@ module ClaimsApi
               key :description, 'Current status of the claim'
               key :enum, [
                 '"Claim received"',
+                '"Complete"',
                 '"Initial review"',
+                '"Errored"',
                 '"Evidence gathering, review, and decision"',
-                '"Preparation for notification"',
-                '"Complete"'
+                '"Pending"',
+                '"Preparation for notification"'
               ]
             end
           end

--- a/modules/claims_api/app/swagger/claims_api/claims/claims_response_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/claims/claims_response_swagger.rb
@@ -301,10 +301,10 @@ module ClaimsApi
                 '"Claim received"',
                 '"Complete"',
                 '"Initial review"',
-                '"Errored"',
                 '"Evidence gathering, review, and decision"',
-                '"Pending"',
-                '"Preparation for notification"'
+                '"Preparation for notification"',
+                '"errored"',
+                '"pending"'
               ]
             end
           end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Adds the following statuses to the `ClaimsShow` Swagger schema ::
- `pending`
- `errored`

## Original issue(s)
[API-4737](https://vajira.max.gov/browse/API-4737)

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
The JSON output from http://localhost:3000/services/claims/docs/v1/api will now include the two new statuses.

<!-- Please describe testing done to verify the changes or any testing planned. -->
