### PR TITLE
[5905] Removing unnecessary icn delegate function now that we specifi…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,7 +129,6 @@ class User < Common::RedisStore
   delegate :common_name, to: :identity, allow_nil: true
 
   # mpi attributes
-  delegate :icn, to: :mpi
   delegate :icn_with_aaid, to: :mpi
   delegate :vet360_id, to: :mpi
   delegate :search_token, to: :mpi


### PR DESCRIPTION
…cally define the function in the User model


## Description of change
This simply removes a function (`icn`) that was delegated to the `MPI` object in the `User` model, we already specifically define that function in `user.rb`, so this change should not have impact on behavior or with specs.

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/5905

## Things to know about this PR
- Should be no production change
- Test by setting a breakpoint in `app/controllers/v1/sessions_controller.rb`, line `130` (should be in `user_login`, right after `UserSessionForm` is created)
- Begin login process with ID.me
- Breakpoint will hit with the initial `LOA1` login, `continue` to the next `LOA3` authentication
- Confirm that `@current_user.icn` returns the value on the SAML Payload
