### PR TITLE
Update NOD statuses

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -26,6 +26,18 @@ module AppealsApi
       if: proc { |a| a.form_data.present? }
     )
 
+    def submitting!
+      update!(status: 'submitting')
+    end
+
+    def submitted!
+      update!(status: 'submitted')
+    end
+
+    def error!(code:, detail:)
+      update!(status: 'error', code: code, detail: detail)
+    end
+
     def pdf_structure(version)
       Object.const_get(
         "AppealsApi::PdfConstruction::NoticeOfDisagreement::#{version.upcase}::Structure"

--- a/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
@@ -8,7 +8,7 @@ module AppealsApi::V1
       swagger_component do
         schema :nodStatus do
           key :type, :string
-          key :enum, AppealsApi::CentralMailStatus::STATUSES
+          key :enum, %i[pending submitting submitted error]
           key :example, 'submitted'
         end
 

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
@@ -16,12 +16,12 @@ module AppealsApi
       notice_of_disagreement = NoticeOfDisagreement.find(id)
 
       begin
-        notice_of_disagreement.update!(status: 'submitting')
+        notice_of_disagreement.submitting!
         stamped_pdf = PdfConstruction::Generator.new(notice_of_disagreement).generate
         upload_to_central_mail(notice_of_disagreement, stamped_pdf)
         File.delete(stamped_pdf) if File.exist?(stamped_pdf)
       rescue => e
-        notice_of_disagreement.update!(status: 'error', code: e.class.to_s, detail: e.message)
+        notice_of_disagreement.error!(code: e.class.to_s, detail: e.message)
         raise
       end
     end
@@ -51,7 +51,7 @@ module AppealsApi
 
     def process_response(response, notice_of_disagreement)
       if response.success? || response.body.match?(NON_FAILING_ERROR_REGEX)
-        notice_of_disagreement.update!(status: 'submitted')
+        notice_of_disagreement.submitted!
       else
         map_error(response.status, response.body, AppealsApi::UploadError)
       end

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -22,6 +22,28 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
     end
   end
 
+  describe 'status updates' do
+    it '#submitting!' do
+      notice_of_disagreement.submitting!
+
+      expect(notice_of_disagreement.status).to eq('submitting')
+    end
+
+    it '#submitted!' do
+      notice_of_disagreement.submitted!
+
+      expect(notice_of_disagreement.status).to eq('submitted')
+    end
+
+    it '#error!' do
+      notice_of_disagreement.error!(code: 'error code', detail: 'error detail')
+
+      expect(notice_of_disagreement.status).to eq('error')
+      expect(notice_of_disagreement.code).to eq('error code')
+      expect(notice_of_disagreement.detail).to eq('error detail')
+    end
+  end
+
   # rubocop:disable Layout/LineLength
   describe 'validations' do
     describe '#validate_address' do

--- a/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
@@ -79,13 +79,12 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
       submit_job_worker = described_class.new
       allow(submit_job_worker).to receive(:upload_to_central_mail).and_raise(RuntimeError, 'runtime error!')
 
-      begin
+      expect do
         submit_job_worker.perform(higher_level_review.id)
-      rescue
-        expect(higher_level_review.reload.status).to eq('error')
-        expect(higher_level_review.reload.code).to eq('RuntimeError')
-        expect(higher_level_review.reload.detail).to eq('runtime error!')
-      end
+      end.to raise_error(RuntimeError, 'runtime error!')
+
+      higher_level_review.reload
+      expect(higher_level_review.status).to eq('error')
     end
   end
 

--- a/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
@@ -81,13 +81,12 @@ RSpec.describe AppealsApi::NoticeOfDisagreementPdfSubmitJob, type: :job do
       submit_job_worker = described_class.new
       allow(submit_job_worker).to receive(:upload_to_central_mail).and_raise(RuntimeError, 'runtime error!')
 
-      begin
+      expect do
         submit_job_worker.perform(notice_of_disagreement.id)
-      rescue
-        expect(notice_of_disagreement.reload.status).to eq('error')
-        expect(notice_of_disagreement.reload.code).to eq('RuntimeError')
-        expect(notice_of_disagreement.reload.detail).to eq('runtime error!')
-      end
+      end.to raise_error(RuntimeError, 'runtime error!')
+
+      notice_of_disagreement.reload
+      expect(notice_of_disagreement.status).to eq('error')
     end
   end
 end


### PR DESCRIPTION
## Description of change
This PR does several things:
- Updates the swagger docs to only show statuses that we actually use.
- It moves the logic for updating NOD status to the model itself.
- Updates the HLR and NOD pdf submit job specs to be a little more robust.

We still need to update the docs to describe each of the statuses and how they relate to each other.

## Original issue(s)
https://vajira.max.gov/browse/API-4960

