### PR TITLE
API-4733: 2122 status schema is missing a possible status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Vets API
 
-
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Vets API
 
+
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/modules/claims_api/app/swagger/claims_api/forms/form_2122_response_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_2122_response_swagger.rb
@@ -283,9 +283,10 @@ with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as
             property :status do
               key :type, :string
               key :example, 'submitted'
-              key :description, 'Says if the power of attorney is pending, updated or errored'
+              key :description, 'Says if the power of attorney is pending, submitted, updated or errored'
               key :enum, %w[
                 pending
+                submitted
                 updated
                 errored
               ]


### PR DESCRIPTION
## Description of change
Update possible status values for 2122 response schema in documentation.

## Original issue(s)
https://vajira.max.gov/browse/API-4733

## Things to know about this PR
Viewed in developer portal locally.