### PR TITLE
API-2275: Clarify Wording on Claims API headers documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Vets API
 
-
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Vets API
 
+
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/modules/claims_api/app/swagger/claims_api/v0/claims_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/claims_controller_swagger.rb
@@ -28,7 +28,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :example, '123121234'
             key :required, true
             key :type, :string
@@ -37,7 +37,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :example, 'John'
             key :required, true
             key :type, :string
@@ -46,7 +46,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :example, 'Doe'
             key :required, true
             key :type, :string
@@ -55,7 +55,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :example, '1954-12-15'
             key :required, true
             key :type, :string
@@ -64,7 +64,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -133,7 +133,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :example, '123121234'
             key :required, true
             key :type, :string
@@ -142,7 +142,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :example, 'John'
             key :required, true
             key :type, :string
@@ -151,7 +151,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :example, 'Doe'
             key :required, true
             key :type, :string
@@ -160,7 +160,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :example, '1954-12-15'
             key :required, true
             key :type, :string
@@ -169,7 +169,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v0/form_0966_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_0966_controller_swagger.rb
@@ -80,7 +80,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -88,7 +88,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -96,7 +96,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -104,7 +104,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
             key :type, :string
           end
@@ -112,7 +112,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -235,7 +235,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -243,7 +243,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -251,7 +251,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -259,7 +259,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
             key :type, :string
           end
@@ -267,7 +267,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -69,7 +69,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -77,7 +77,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -85,7 +85,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -93,7 +93,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
             key :type, :string
           end
@@ -101,7 +101,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -195,7 +195,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -203,7 +203,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -211,7 +211,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -219,7 +219,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
             key :type, :string
           end
@@ -227,7 +227,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -302,7 +302,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -310,7 +310,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -318,7 +318,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -326,7 +326,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
             key :type, :string
           end
@@ -334,7 +334,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -403,7 +403,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -411,7 +411,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -419,7 +419,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -427,7 +427,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -435,7 +435,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -495,7 +495,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -503,7 +503,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -511,7 +511,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -519,7 +519,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -527,7 +527,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v0/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_526_controller_swagger.rb
@@ -70,7 +70,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -78,7 +78,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -86,7 +86,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -94,7 +94,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
             key :type, :string
           end
@@ -102,7 +102,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -191,7 +191,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -199,7 +199,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -207,7 +207,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -215,7 +215,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
             key :type, :string
           end
@@ -223,7 +223,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -295,7 +295,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -303,7 +303,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -311,7 +311,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -319,7 +319,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
             key :type, :string
           end
@@ -327,7 +327,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -449,7 +449,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -457,7 +457,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -465,7 +465,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -473,7 +473,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
             key :type, :string
           end
@@ -481,7 +481,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v1/claims_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/claims_controller_swagger.rb
@@ -29,7 +29,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -37,7 +37,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -45,7 +45,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -53,7 +53,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -61,7 +61,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -124,7 +124,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -132,7 +132,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -140,7 +140,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -148,7 +148,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -156,7 +156,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
@@ -75,7 +75,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -83,7 +83,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -91,7 +91,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -99,7 +99,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -107,7 +107,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -202,7 +202,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -210,7 +210,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -218,7 +218,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -226,7 +226,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -234,7 +234,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
@@ -72,7 +72,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -80,7 +80,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -88,7 +88,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -96,7 +96,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -104,7 +104,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -185,7 +185,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -193,7 +193,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -201,7 +201,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -209,7 +209,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -217,7 +217,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -283,7 +283,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -291,7 +291,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -299,7 +299,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -307,7 +307,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -315,7 +315,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -399,7 +399,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -407,7 +407,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -415,7 +415,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -423,7 +423,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -431,7 +431,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -491,7 +491,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -499,7 +499,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -507,7 +507,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -515,7 +515,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -523,7 +523,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
@@ -84,7 +84,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -92,7 +92,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -100,7 +100,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -108,7 +108,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -116,7 +116,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -218,7 +218,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -226,7 +226,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -234,7 +234,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -242,7 +242,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -250,7 +250,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -317,7 +317,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -325,7 +325,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -333,7 +333,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, true
             key :type, :string
           end
@@ -341,7 +341,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
             key :type, :string
           end
@@ -349,7 +349,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -466,7 +466,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-SSN'
             key :in, :header
-            key :description, 'SSN of Veteran to fetch'
+            key :description, 'SSN of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -474,7 +474,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-First-Name'
             key :in, :header
-            key :description, 'First Name of Veteran to fetch'
+            key :description, 'First Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -482,7 +482,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Last-Name'
             key :in, :header
-            key :description, 'Last Name of Veteran to fetch'
+            key :description, 'Last Name of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -490,7 +490,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-Birth-Date'
             key :in, :header
-            key :description, 'Date of Birth of Veteran to fetch in iso8601 format'
+            key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, false
             key :type, :string
           end
@@ -498,7 +498,7 @@ module ClaimsApi
           parameter do
             key :name, 'X-VA-EDIPI'
             key :in, :header
-            key :description, 'EDIPI Number of Veteran to fetch'
+            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end


### PR DESCRIPTION
## Description of change
There was confusion around the verbiage of "to fetch" for headers descriptions in a non-GET endpoint.
This has been changed to "being represented" to hopefully clear up any confusion.

## Original issue(s)
https://vajira.max.gov/browse/API-2275

## Things to know about this PR
Viewed in the developer portal locally.