### PR TITLE
Refactor zipCode5 for zeros if homeless and no address

### DIFF
--- a/lib/common/exceptions/detailed_schema_errors.rb
+++ b/lib/common/exceptions/detailed_schema_errors.rb
@@ -92,8 +92,7 @@ module Common
       end
 
       def schema(_error)
-        data = i18n_interpolated :schema
-        data
+        i18n_interpolated :schema
       end
 
       def array_items(error)

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -97,7 +97,8 @@ module AppealsApi
     end
 
     def zip_code_5
-      form_data&.dig('data', 'attributes', 'veteran', 'address', 'zipCode5')
+      # schema already validated address presence if not homeless
+      veteran_contact_info&.dig('address', 'zipCode5') || '00000'
     end
 
     def lob

--- a/modules/appeals_api/config/schemas/10182.json
+++ b/modules/appeals_api/config/schemas/10182.json
@@ -40,6 +40,7 @@
       "required": [ "boardReviewOption", "socOptIn" ]
     },
 
+
     "nodCreateVeteran": {
       "type": "object",
       "additionalProperties": false,

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -110,7 +110,21 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
   end
 
   describe '#zip_code_5' do
-    it { expect(notice_of_disagreement.zip_code_5).to eq '30012' }
+    context 'when address present' do
+      it { expect(notice_of_disagreement.zip_code_5).to eq '30012' }
+    end
+
+    context 'when homeless and no address' do
+      before do
+        veteran_data = default_form_data['data']['attributes']['veteran']
+        veteran_data['homeless'] = true
+        veteran_data.delete('address')
+      end
+
+      it do
+        expect(notice_of_disagreement.zip_code_5).to eq '00000'
+      end
+    end
   end
 
   describe '#lob' do

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
@@ -71,6 +71,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController, type:
       it 'returns error objects in JSON API 1.0 ErrorObject format' do
         expected_keys = %w[code detail meta source status title]
         expect(parsed['errors'].first.keys).to include(*expected_keys)
+        expect(parsed['errors'][0]['meta']['missing_fields']).to eq ['address']
         expect(parsed['errors'][0]['source']['pointer']).to eq '/data/attributes/veteran'
       end
     end


### PR DESCRIPTION
## Description of change
If a veteran is experiencing homelessness, including an address is optional. However, CentralMail requires a 5-digit zip code from our request. We've refactored so that `zipCode5 => 00000` is sent via the request in cases of homelessness with no address. 

## Original issue(s)
https://vajira.max.gov/browse/API-4832

## Testing
`zipCode5 formatting` tested in model spec
`address presence if not experiencing homelessness` tested in controller spec