### PR TITLE
added pagerduty for health care questionnaire

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -578,6 +578,7 @@ maintenance:
     vet360: PHVOGQ1
     vetext_vaccine: P9PG8HG
     vic: P7LW3MS
+    hcq: PWGA814
   aws:
     access_key_id: ~
     bucket: ~


### PR DESCRIPTION
## Description of change
Adding a new PagerDuty service for the Health Care Questionnaire. Following the directions provided [here](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/platform/tools/downtime-notifications/)

Our app is not in production yet, so no users should be affected. 

## Original issue(s)
[Github Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/18237)

