### PR TITLE
Updates facilities factory to use string class reference to avoid class loading issue

### DIFF
--- a/spec/factories/lighthouse/facilities/lighthouse_facility.rb
+++ b/spec/factories/lighthouse/facilities/lighthouse_facility.rb
@@ -3,7 +3,7 @@
 require 'lighthouse/facilities/facility'
 
 FactoryBot.define do
-  factory :lighthouse_facility, class: Lighthouse::Facilities::Facility do
+  factory :lighthouse_facility, class: 'Lighthouse::Facilities::Facility' do
     # vha_648A4
     transient do
       access do


### PR DESCRIPTION
## Description of change
A random thing I ran into, that probably only affects development?

I was getting a ruby class loading error when invoking a mobile API endpoint, related to Lighthouse::Facilities::Facility, and backtracing to the Lighthouse Facilities FactoryBot file. 

Our various rails engines (such as modules/mobile) append to the FactoryBot definition file paths, and this is seemingly causing an attempt to load classes referenced in factories.
(see for example modules/mobile/lib/mobile/engine.rb)
But for whatever reason the class (Lighthouse::Facilities::Facility) referenced in this factory was not  findable from the engine and was causing the classloading error. 

Changing this reference to a string (which is valid for FactoryBot) seems to clear up the issue. Maybe we should be doing that  across the board in factories? I don't know, but this is the only one that's caused me an issue.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR


<!-- Please describe testing done to verify the changes or any testing planned. -->
