### PR TITLE
Allow Specifying a Date Range For BDD Stats Mode (form526 rake task)

### DIFF
--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -11,6 +11,10 @@ namespace :form526 do
       rake form526:submissions[]
     BDD stats mode:
       rake form526:submissions[bdd]
+      rake form526:submissions[bdd,2021-02-11] # this date and beyond
+      rake form526:submissions[2021-02-11,bdd] # "
+      rake form526:submissions[bdd,2021-02-10,2021-02-11] # restricted to date range (inclusive)
+      rake form526:submissions[2021-02-10,2021-02-11,bdd] # "
   HEREDOC
   task :submissions, %i[first second] => [:environment] do |_, args|
     # rubocop:disable Style/FormatStringToken
@@ -87,7 +91,8 @@ namespace :form526 do
     end
 
     def bdd_stats_mode(args)
-      return nil unless args[:first]&.downcase&.include? 'bdd'
+      start_date, end_date = bdd_stats_mode_dates_from_args args
+      return nil unless start_date
 
       redact_participant_id = true
       separator = ','
@@ -97,7 +102,6 @@ namespace :form526 do
       print_row_with_redacted_participant_id = lambda do |**fields|
         print_row.call(**fields.merge(p_id: '*****' + fields[:p_id].to_s[5..]))
       end
-      start_date = '2020-11-01'
 
       OPTIONS_STRUCT.new(
         print_header: -> { puts ROW[:order].map { |key| ROW[:headers][key] }.join(separator) },
@@ -105,9 +109,19 @@ namespace :form526 do
         print_row: redact_participant_id ? print_row_with_redacted_participant_id : print_row,
         print_total: ->(header, total) { puts "#{header.to_s.strip}#{separator}#{total}" },
         ignore_submission: ->(submission) { submission.bdd? ? false : submission.id },
-        submissions: Form526Submission.where('created_at >= ?', start_date.to_date.beginning_of_day),
+        submissions: Form526Submission.where(created_at: [start_date.beginning_of_day..end_date.end_of_day]),
         success_failure_totals_header_string: '* Job Success/Failure counts *'
       )
+    end
+
+    def bdd_stats_mode_dates_from_args(args)
+      args_array = args.values_at :first, :second, :third
+      return [] unless bdd_flag_present? args_array
+
+      dates = dates_from_array args_array
+      start_date = dates.first || '2020-11-01'.to_date
+      end_date = dates.second || Time.zone.now.utc + 1.day
+      [start_date, end_date]
     end
 
     def missing_dates_as_zero(hash_with_date_keys)
@@ -136,6 +150,23 @@ namespace :form526 do
 
     def tomorrow(date_string)
       to_date_string date_string.to_date.tomorrow
+    end
+
+    def bdd_flag_present?(array)
+      array.any? { |value| value&.to_s&.downcase&.include? 'bdd' }
+    end
+
+    def dates_from_array(array)
+      dates = []
+      array.each do |value|
+        date = begin
+          value.to_date
+               rescue
+                 nil
+        end
+        dates << date if date
+      end
+      dates
     end
 
     options = bdd_stats_mode(args) || date_range_mode(args)

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -16,7 +16,7 @@ namespace :form526 do
       rake form526:submissions[bdd,2021-02-10,2021-02-11] # restricted to date range (inclusive)
       rake form526:submissions[2021-02-10,2021-02-11,bdd] # "
   HEREDOC
-  task :submissions, %i[first second] => [:environment] do |_, args|
+  task :submissions, %i[first second third] => [:environment] do |_, args|
     # rubocop:disable Style/FormatStringToken
     # This forces string token formatting. Our examples don't match
     # what this style is enforcing

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -160,10 +160,10 @@ namespace :form526 do
       dates = []
       array.each do |value|
         date = begin
-          value.to_date
+                 value.to_date
                rescue
                  nil
-        end
+               end
         dates << date if date
       end
       dates


### PR DESCRIPTION
Running BDD stats is very slow as it must decrypt many submissions.

### Acceptance Criteria

- [x] Allow specifying a date range when pulling BDD stats, allowing someone to pull stats only for the dates they need. *(I end up running this once or twice a week, and I keep the stats for all the previous months. This way I can pull stats just for the days I don't have.)*