### PR TITLE
Add BIRLS ID Accessor Methods (Form526Submission)

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -39,6 +39,7 @@ class Form526Submission < ApplicationRecord
   FORM_4142 = 'form4142'
   FORM_0781 = 'form0781'
   FORM_8940 = 'form8940'
+  BIRLS_KEY = 'va_eauth_birlsfilenumber'
 
   # Kicks off a 526 submit workflow batch. The first step in a submission workflow is to submit
   # an increase only or all claims form. Once the first job succeeds the batch will callback and run
@@ -86,6 +87,21 @@ class Form526Submission < ApplicationRecord
   #
   def auth_headers
     @auth_headers_hash ||= JSON.parse(auth_headers_json)
+  end
+
+  def birls_id!
+    auth_headers[BIRLS_KEY]
+  end
+
+  def birls_id
+    birls_id! if auth_headers_json
+  end
+
+  def birls_id=(value)
+    headers = JSON.parse auth_headers_json
+    headers[BIRLS_KEY] = value
+    self.auth_headers_json = headers.to_json
+    @auth_headers_hash = nil # reset cache
   end
 
   # The workflow batch success handler

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -98,7 +98,7 @@ class Form526Submission < ApplicationRecord
   end
 
   def birls_id=(value)
-    headers = JSON.parse auth_headers_json
+    headers = JSON.parse(auth_headers_json) || {}
     headers[BIRLS_KEY] = value
     self.auth_headers_json = headers.to_json
     @auth_headers_hash = nil # reset cache

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -81,6 +81,46 @@ RSpec.describe Form526Submission do
     end
   end
 
+  describe '#birls_id!' do
+    it 'returns the BIRLS ID' do
+      expect(subject.birls_id!).to eq(auth_headers[described_class::BIRLS_KEY])
+    end
+
+    context 'auth_headers is nil' do
+      it 'throws an exception' do
+        subject.auth_headers_json = nil
+        expect { subject.birls_id! }.to raise_error TypeError
+      end
+    end
+
+    context 'auth_headers is unparseable' do
+      it 'throws an exception' do
+        subject.auth_headers_json = 'hi!'
+        expect { subject.birls_id! }.to raise_error JSON::ParserError
+      end
+    end
+  end
+
+  describe '#birls_id' do
+    it 'returns the BIRLS ID' do
+      expect(subject.birls_id).to eq(auth_headers[described_class::BIRLS_KEY])
+    end
+
+    context 'auth_headers is nil' do
+      it 'returns nil' do
+        subject.auth_headers_json = nil
+        expect(subject.birls_id).to be_nil
+      end
+    end
+
+    context 'auth_headers is unparseable' do
+      it 'throws an exception' do
+        subject.auth_headers_json = 'hi!'
+        expect { subject.birls_id }.to raise_error JSON::ParserError
+      end
+    end
+  end
+
   describe '#perform_ancillary_jobs_handler' do
     let(:status) { OpenStruct.new(parent_bid: SecureRandom.hex(8)) }
 

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -121,6 +121,29 @@ RSpec.describe Form526Submission do
     end
   end
 
+  describe '#birls_id=' do
+    let(:birls_id) { 1 }
+
+    it 'sets the BIRLS ID' do
+      subject.birls_id = birls_id
+      expect(subject.birls_id).to eq(birls_id)
+    end
+
+    context 'auth_headers is nil' do
+      it 'throws an exception' do
+        subject.auth_headers_json = nil
+        expect { subject.birls_id = birls_id }.to raise_error TypeError
+      end
+    end
+
+    context 'auth_headers is unparseable' do
+      it 'throws an exception' do
+        subject.auth_headers_json = 'hi!'
+        expect { subject.birls_id = birls_id }.to raise_error JSON::ParserError
+      end
+    end
+  end
+
   describe '#perform_ancillary_jobs_handler' do
     let(:status) { OpenStruct.new(parent_bid: SecureRandom.hex(8)) }
 


### PR DESCRIPTION
Working with (getting/setting) the BIRLS ID for a Form526Submission is difficult as it's stored as a field in `auth_headers_json`. (We will be manipulating the BIRLS ID more in [an upcoming PR.](https://github.com/department-of-veterans-affairs/vets-api/pull/5245/))

### Acceptance Criteria
- [x] Add accessor methods for BIRLS ID (Form526Submission)