### PR TITLE
adds 'standard' as ignored_column in preparation for removal

### DIFF
--- a/modules/test_user_dashboard/app/models/test_user_dashboard/tud_account.rb
+++ b/modules/test_user_dashboard/app/models/test_user_dashboard/tud_account.rb
@@ -2,6 +2,8 @@
 
 module TestUserDashboard
   class TudAccount < ApplicationRecord
+    self.ignored_columns = ['standard']
+
     ID_PROVIDERS = %w[id_me dslogon mhv].freeze
 
     validates :first_name, :last_name, :email, :gender, presence: true


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Update to remove `standard` colum from `tud_accounts` table as we are dropping the standard vs. custom tud_accounts feature from the TUD MVP

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/17208

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
