### PR TITLE
Questionnaire Manager must return aggregated data

### DIFF
--- a/modules/health_quest/app/services/health_quest/questionnaire_manager/transformer.rb
+++ b/modules/health_quest/app/services/health_quest/questionnaire_manager/transformer.rb
@@ -4,44 +4,167 @@ module HealthQuest
   module QuestionnaireManager
     ##
     # An object for mixing and blending data for the QuestionnaireManager::Factory
+    # The method implementations are intentionally imperative as to make the data
+    # blending process transparent and highlight the design considerations taken
+    # to reduce time complexity.
     #
+    # @!attribute appointments
+    #   @return [Array]
+    # @!attribute questionnaires
+    #   @return [Array]
+    # @!attribute questionnaire_responses
+    #   @return [Array]
+    # @!attribute save_in_progress
+    #   @return [Array]
+    # @!attribute hashed_questionnaires
+    #   @return [Hash]
+    # @!attribute hashed_questionnaire_responses
+    #   @return [Hash]
+    # @!attribute hashed_save_in_progress
+    #   @return [Hash]
     class Transformer
-      USE_CONTEXT_DELIMITER = ','
+      IN_PROGRESS_STATUS = 'in-progress'
+      QR_APPOINTMENT_ID_MATCHER = /([I2\-a-zA-Z0-9]+)\z/i.freeze
+      SIP_APPOINTMENT_ID_MATCHER = /HC-QSTNR_([I2\-a-zA-Z0-9]+)_/i.freeze
+      SIP_QUESTIONNAIRE_ID_MATCHER = /_([a-f0-9-]+)\z/i.freeze
+
+      attr_reader :appointments,
+                  :questionnaires,
+                  :questionnaire_responses,
+                  :save_in_progress,
+                  :hashed_questionnaires,
+                  :hashed_questionnaire_responses,
+                  :hashed_save_in_progress
 
       ##
       # Builds a HealthQuest::QuestionnaireManager::Transformer instance
       #
+      # @param user [Hash] the set of data to be used to construct the Questionnaire Manager data.
       # @return [HealthQuest::QuestionnaireManager::Transformer] an instance of this class
       #
-      def self.build
-        new
+      def self.manufacture(opts = {})
+        new(opts)
+      end
+
+      def initialize(opts)
+        @appointments = opts[:appointments]
+        @questionnaires = opts[:questionnaires]
+        @questionnaire_responses = opts[:questionnaire_responses]
+        @save_in_progress = opts[:save_in_progress]
+        @hashed_questionnaires = questionnaires_with_facility_clinic_id
+        @hashed_questionnaire_responses = questionnaire_responses_with_appointment_id
+        @hashed_save_in_progress = sip_with_appointment_id
       end
 
       ##
-      # Builds the final aggregated data structure after the PGD and appointment
-      # health_quest services are passed in as key/value arguments
+      # Builds the final aggregated data structure from a set of optimized data structures:
+      # `appointments`, `hashed_questionnaires`, `hashed_questionnaire_responses`,
+      # and `hashed_save_in_progress`.
       #
       # @return [Hash] a combined hash containing appointment, questionnaire_response,
       # questionnaire and SIP data
       #
-      def combine(_opts)
-        { data: 'WIP' }
-      end
+      def combine # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        questionnaire_manager_data =
+          appointments_with_questionnaires.each_with_object([]) do |item, accumulator|
+            appointment_id = item[:appointment][:id]
+            qr_responses = hashed_questionnaire_responses[appointment_id]
+            sip_responses = hashed_save_in_progress[appointment_id]
 
-      ##
-      # Builds the UseContext string from a list of Appointments
-      #
-      # @return [String] a context-type-value built using facility and clinic IDs
-      #
-      def get_use_context(appointments)
-        use_context_array =
-          appointments.each_with_object([]) do |apt, accumulator|
-            item = "venue$#{apt.facility_id}/#{apt.clinic_id}"
+            return { data: appointments_with_questionnaires } if qr_responses.blank? && sip_responses.blank?
+
+            appointment_questionnaires =
+              item[:questionnaire].each_with_object({}) do |appointment_questionnaire, acc|
+                questionnaire_id = appointment_questionnaire[:id]
+                acc[questionnaire_id] = appointment_questionnaire
+              end
+
+            qr_responses&.each do |qr|
+              questionnaire_id = qr.resource.id
+              questionnaire = appointment_questionnaires[questionnaire_id]
+              next if questionnaire.blank?
+
+              questionnaire[:questionnaire_response].store(:id, qr.resource.id)
+              questionnaire[:questionnaire_response].store(:status, qr.resource.status)
+              questionnaire[:questionnaire_response].store(:submitted_on, qr.resource.authored)
+            end
+
+            sip_responses&.each do |sip|
+              sip_questionnaire_id = sip.form_id.match(SIP_QUESTIONNAIRE_ID_MATCHER)[1]
+              questionnaire = appointment_questionnaires[sip_questionnaire_id]
+              next if questionnaire.blank?
+
+              questionnaire[:questionnaire_response].store(:status, IN_PROGRESS_STATUS)
+            end
 
             accumulator << item
           end
 
-        use_context_array.join(USE_CONTEXT_DELIMITER)
+        { data: questionnaire_manager_data }
+      end
+
+      private
+
+      def appointments_with_questionnaires
+        @appointments_with_questionnaires ||=
+          appointments.each_with_object([]) do |appointment, accumulator|
+            context_key = "#{appointment.facility_id}/#{appointment.clinic_id}"
+
+            next unless hashed_questionnaires.key?(context_key)
+
+            questionnaires =
+              hashed_questionnaires[context_key].map do |quest|
+                { id: quest.resource.id, title: quest.resource.title, questionnaire_response: {} }
+              end
+            appointment_questionnaire = { appointment: appointment.to_h, questionnaire: questionnaires }
+
+            accumulator << appointment_questionnaire
+          end
+      end
+
+      def sip_with_appointment_id
+        @sip_with_appointment_id ||=
+          save_in_progress.each_with_object({}) do |sip, accumulator|
+            appointment_id = sip.form_id.match(SIP_APPOINTMENT_ID_MATCHER)[1]
+
+            if accumulator.key?(appointment_id)
+              accumulator[appointment_id] << sip
+            else
+              accumulator[appointment_id] = [sip]
+            end
+          end
+      end
+
+      def questionnaires_with_facility_clinic_id
+        @questionnaires_with_facility_clinic_id ||=
+          questionnaires.each_with_object({}) do |questionnaire, accumulator|
+            questionnaire_hash = questionnaire.to_hash
+            use_contexts = questionnaire_hash['resource']['useContext']
+            value_codeable_concepts = use_contexts.map { |c| c['valueCodeableConcept']['coding'] }.flatten
+            codes = value_codeable_concepts.map { |vcc| vcc['code'] }
+
+            codes.each do |code|
+              if accumulator.key?(code)
+                accumulator[code] << questionnaire
+              else
+                accumulator[code] = [questionnaire]
+              end
+            end
+          end
+      end
+
+      def questionnaire_responses_with_appointment_id
+        @questionnaire_responses_with_appointment_id ||=
+          questionnaire_responses.each_with_object({}) do |questionnaire_response, accumulator|
+            appointment_reference = questionnaire_response.subject.reference
+            appointment_id = appointment_reference.match(QR_APPOINTMENT_ID_MATCHER)[1]
+
+            if accumulator.key?(appointment_id)
+              accumulator[appointment_id] << questionnaire_response
+            else
+              accumulator[appointment_id] = [questionnaire_response]
+            end
+          end
       end
     end
   end

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -109,17 +109,20 @@ describe HealthQuest::QuestionnaireManager::Factory do
         expect(factory.patient).to eq(fhir_patient)
       end
     end
+  end
 
-    context 'when patient and appointment and questionnaires and questionnaire_responses and sip data exist' do
-      let(:fhir_patient) { double('FHIR::Patient') }
-      let(:client_reply) { double('FHIR::ClientReply', resource: fhir_patient) }
-      let(:fhir_questionnaire_bundle) { fhir_data }
+  describe '#get_use_context' do
+    let(:data) do
+      [
+        double('Appointments', facility_id: '123', clinic_id: '54679'),
+        double('Appointments', facility_id: '789', clinic_id: '98741')
+      ]
+    end
 
-      it 'returns a WIP hash' do
-        hash = { data: 'WIP' }
+    it 'returns a formatted use-context string' do
+      allow_any_instance_of(described_class).to receive(:appointments).and_return(data)
 
-        expect(described_class.manufacture(user).all).to eq(hash)
-      end
+      expect(described_class.manufacture(user).get_use_context).to eq('venue$123/54679,venue$789/98741')
     end
   end
 
@@ -138,8 +141,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
     it 'returns a FHIR::ClientReply' do
       allow_any_instance_of(HealthQuest::PatientGeneratedData::Questionnaire::MapQuery)
         .to receive(:search).with(anything).and_return(client_reply)
-      allow_any_instance_of(HealthQuest::QuestionnaireManager::Transformer)
-        .to receive(:get_use_context).with(anything).and_return('venue$583/12345')
+      allow_any_instance_of(described_class).to receive(:get_use_context).and_return('venue$583/12345')
 
       expect(described_class.manufacture(user).get_questionnaires).to eq(client_reply)
     end
@@ -167,14 +169,6 @@ describe HealthQuest::QuestionnaireManager::Factory do
   describe '#get_save_in_progress' do
     it 'returns an empty array when user does not exist' do
       expect(described_class.manufacture(user).get_save_in_progress).to eq([])
-    end
-  end
-
-  describe '#compose' do
-    it 'returns a WIP hash' do
-      hash = { data: 'WIP' }
-
-      expect(described_class.manufacture(user).compose).to eq(hash)
     end
   end
 end

--- a/modules/health_quest/spec/services/questionnaire_manager/transformer_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/transformer_spec.rb
@@ -5,31 +5,441 @@ require 'rails_helper'
 describe HealthQuest::QuestionnaireManager::Transformer do
   subject { described_class }
 
-  let(:wip_hash) { { data: 'WIP' } }
+  describe '.manufacture' do
+    before do
+      allow_any_instance_of(subject).to receive(:questionnaires_with_facility_clinic_id).and_return({})
+      allow_any_instance_of(subject).to receive(:questionnaire_responses_with_appointment_id).and_return({})
+      allow_any_instance_of(subject).to receive(:sip_with_appointment_id).and_return({})
+    end
 
-  describe '.build' do
     it 'is an instance of the subject' do
-      expect(subject.build).to be_an_instance_of(described_class)
+      expect(subject.manufacture({})).to be_an_instance_of(described_class)
+    end
+  end
+
+  describe 'constants' do
+    before do
+      allow_any_instance_of(subject).to receive(:questionnaires_with_facility_clinic_id).and_return({})
+      allow_any_instance_of(subject).to receive(:questionnaire_responses_with_appointment_id).and_return({})
+      allow_any_instance_of(subject).to receive(:sip_with_appointment_id).and_return({})
+    end
+
+    it 'has a IN_PROGRESS_STATUS' do
+      expect(subject::IN_PROGRESS_STATUS).to eq('in-progress')
+    end
+
+    it 'has a QR_APPOINTMENT_ID_MATCHER' do
+      expect(subject::QR_APPOINTMENT_ID_MATCHER).to eq(/([I2\-a-zA-Z0-9]+)\z/i)
+    end
+
+    it 'has a SIP_APPOINTMENT_ID_MATCHER' do
+      expect(subject::SIP_APPOINTMENT_ID_MATCHER).to eq(/HC-QSTNR_([I2\-a-zA-Z0-9]+)_/i)
+    end
+
+    it 'has a SIP_QUESTIONNAIRE_ID_MATCHER' do
+      expect(subject::SIP_QUESTIONNAIRE_ID_MATCHER).to eq(/_([a-f0-9-]+)\z/i)
+    end
+  end
+
+  describe 'attributes' do
+    before do
+      allow_any_instance_of(subject).to receive(:questionnaires_with_facility_clinic_id).and_return({})
+      allow_any_instance_of(subject).to receive(:questionnaire_responses_with_appointment_id).and_return({})
+      allow_any_instance_of(subject).to receive(:sip_with_appointment_id).and_return({})
+    end
+
+    it 'responds to appointments' do
+      expect(subject.manufacture({}).respond_to?(:appointments)).to be(true)
+    end
+
+    it 'responds to questionnaires' do
+      expect(subject.manufacture({}).respond_to?(:questionnaires)).to be(true)
+    end
+
+    it 'responds to questionnaire_responses' do
+      expect(subject.manufacture({}).respond_to?(:questionnaire_responses)).to be(true)
+    end
+
+    it 'responds to save_in_progress' do
+      expect(subject.manufacture({}).respond_to?(:save_in_progress)).to be(true)
+    end
+
+    it 'responds to hashed_questionnaires' do
+      expect(subject.manufacture({}).respond_to?(:hashed_questionnaires)).to be(true)
+    end
+
+    it 'responds to hashed_questionnaire_responses' do
+      expect(subject.manufacture({}).respond_to?(:hashed_questionnaire_responses)).to be(true)
+    end
+
+    it 'responds to hashed_save_in_progress' do
+      expect(subject.manufacture({}).respond_to?(:hashed_save_in_progress)).to be(true)
+    end
+  end
+
+  describe '#hashed_save_in_progress' do
+    let(:sip_data) do
+      [
+        OpenStruct.new(
+          id: 1,
+          form_id: 'HC-QSTNR_I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000_abc-123-def-455'
+        ),
+        OpenStruct.new(
+          id: 2,
+          form_id: 'HC-QSTNR_I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000_ccc-123-ddd-455'
+        )
+      ]
+    end
+    let(:formatted_hash) do
+      {
+        'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000' => [
+          OpenStruct.new(
+            id: 1,
+            form_id: 'HC-QSTNR_I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000_abc-123-def-455'
+          ),
+          OpenStruct.new(
+            id: 2,
+            form_id: 'HC-QSTNR_I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000_ccc-123-ddd-455'
+          )
+        ]
+      }
+    end
+
+    before do
+      allow_any_instance_of(subject).to receive(:questionnaires_with_facility_clinic_id).and_return({})
+      allow_any_instance_of(subject).to receive(:questionnaire_responses_with_appointment_id).and_return({})
+    end
+
+    it 'returns a hash' do
+      expect(subject.manufacture(save_in_progress: sip_data).hashed_save_in_progress).to eq(formatted_hash)
+    end
+  end
+
+  describe '#hashed_questionnaire_responses' do
+    let(:questionnaire_responses_data) do
+      [
+        OpenStruct.new(
+          id: 1,
+          subject: OpenStruct.new(reference: 'Appointment/I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB')
+        ),
+        OpenStruct.new(
+          id: 2,
+          subject: OpenStruct.new(reference: 'Appointment/I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB')
+        )
+      ]
+    end
+    let(:formatted_hash) do
+      {
+        'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB' => [
+          OpenStruct.new(
+            id: 1,
+            subject: OpenStruct.new(reference: 'Appointment/I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB')
+          ),
+          OpenStruct.new(
+            id: 2,
+            subject: OpenStruct.new(reference: 'Appointment/I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB')
+          )
+        ]
+      }
+    end
+
+    before do
+      allow_any_instance_of(subject).to receive(:questionnaires_with_facility_clinic_id).and_return({})
+      allow_any_instance_of(subject).to receive(:sip_with_appointment_id).and_return({})
+    end
+
+    it 'returns a hash' do
+      expect(subject.manufacture(questionnaire_responses: questionnaire_responses_data).hashed_questionnaire_responses)
+        .to eq(formatted_hash)
+    end
+  end
+
+  describe '#hashed_questionnaires' do
+    let(:questionnaire_data) do
+      [
+        OpenStruct.new(
+          id: 1,
+          to_hash: { 'resource' => { 'useContext' => [{
+            'valueCodeableConcept' => { 'coding' => [{ 'code' => '123/45678' }] }
+          }] } }
+        ),
+        OpenStruct.new(
+          id: 2,
+          to_hash: { 'resource' => { 'useContext' => [{
+            'valueCodeableConcept' => { 'coding' => [{ 'code' => '123/45678' }] }
+          }] } }
+        )
+      ]
+    end
+    let(:formatted_hash) do
+      {
+        '123/45678' => [
+          OpenStruct.new(
+            id: 1,
+            to_hash: { 'resource' => { 'useContext' => [{
+              'valueCodeableConcept' => { 'coding' => [{ 'code' => '123/45678' }] }
+            }] } }
+          ),
+          OpenStruct.new(
+            id: 2,
+            to_hash: { 'resource' => { 'useContext' => [{
+              'valueCodeableConcept' => { 'coding' => [{ 'code' => '123/45678' }] }
+            }] } }
+          )
+        ]
+      }
+    end
+
+    before do
+      allow_any_instance_of(subject).to receive(:questionnaire_responses_with_appointment_id).and_return({})
+      allow_any_instance_of(subject).to receive(:sip_with_appointment_id).and_return({})
+    end
+
+    it 'returns a hash' do
+      expect(subject.manufacture(questionnaires: questionnaire_data).hashed_questionnaires).to eq(formatted_hash)
     end
   end
 
   describe '#combine' do
-    it 'returns combined data' do
-      # This will return a fully fleshed out hash with all the relevant data once the ticket is completed
-      expect(subject.build.combine(nil)).to eq(wip_hash)
-    end
-  end
-
-  describe '#get_use_context' do
     let(:data) do
       [
-        double('Appointments', facility_id: '123', clinic_id: '54679'),
-        double('Appointments', facility_id: '789', clinic_id: '98741')
+        double(
+          'Appointments',
+          id: 'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000',
+          facility_id: '534',
+          clinic_id: '12975',
+          to_h: { id: 'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000',
+                  attributes: { facility_id: '534', clinic_id: '12975' } }
+        ),
+        double(
+          'Appointments',
+          id: 'I2-DDRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000',
+          facility_id: '789',
+          clinic_id: '98741',
+          to_h: { id: 'I2-DDRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ000',
+                  attributes: { facility_id: '789', clinic_id: '98741' } }
+        )
       ]
     end
+    let(:questions_hash) do
+      {
+        '534/12975' => [
+          double('Questionnaire', resource: double('Resource', id: 'abc-123-def-455', title: 'Primary Care'))
+        ]
+      }
+    end
 
-    it 'returns a formatted use-context string' do
-      expect(subject.build.get_use_context(data)).to eq('venue$123/54679,venue$789/98741')
+    context 'when no sip and no questionnaire response data' do
+      let(:response) do
+        {
+          data: [
+            {
+              appointment: {
+                id: 'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000',
+                attributes: {
+                  facility_id: '534',
+                  clinic_id: '12975'
+                }
+              },
+              questionnaire: [
+                {
+                  id: 'abc-123-def-455',
+                  title: 'Primary Care',
+                  questionnaire_response: {}
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      before do
+        allow_any_instance_of(subject).to receive(:appointments).and_return(data)
+        allow_any_instance_of(subject).to receive(:questionnaires_with_facility_clinic_id).and_return(questions_hash)
+        allow_any_instance_of(subject).to receive(:questionnaire_responses_with_appointment_id).and_return({})
+        allow_any_instance_of(subject).to receive(:sip_with_appointment_id).and_return({})
+      end
+
+      it 'returns appointment with questionnaire and empty questionnaire response' do
+        expect(subject.manufacture({}).combine).to eq(response)
+      end
+    end
+
+    context 'when questionnaire response data and no sip' do
+      let(:questionnaire_response_hash) do
+        {
+          'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000' => [
+            double(
+              'QuestionnaireResponse',
+              resource: double('Resource', id: 'abc-123-def-455', status: 'completed', authored: '2021-02-01')
+            ),
+            double(
+              'QuestionnaireResponse',
+              resource: double('Resource', id: 'abc-321-kju-554', status: 'completed', authored: '2021-02-01')
+            )
+          ]
+        }
+      end
+      let(:response) do
+        {
+          data: [
+            {
+              appointment: {
+                id: 'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000',
+                attributes: {
+                  facility_id: '534',
+                  clinic_id: '12975'
+                }
+              },
+              questionnaire: [
+                {
+                  id: 'abc-123-def-455',
+                  title: 'Primary Care',
+                  questionnaire_response: {
+                    id: 'abc-123-def-455',
+                    status: 'completed',
+                    submitted_on: '2021-02-01'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      before do
+        allow_any_instance_of(subject).to receive(:appointments).and_return(data)
+        allow_any_instance_of(subject).to receive(:questionnaires_with_facility_clinic_id).and_return(questions_hash)
+        allow_any_instance_of(subject).to receive(:questionnaire_responses_with_appointment_id)
+          .and_return(questionnaire_response_hash)
+        allow_any_instance_of(subject).to receive(:sip_with_appointment_id).and_return({})
+      end
+
+      it 'returns appointment with questionnaire and matching questionnaire response' do
+        expect(subject.manufacture({}).combine).to eq(response)
+      end
+    end
+
+    context 'when sip and no questionnaire response data' do
+      let(:sip_hash) do
+        {
+          'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000' => [
+            double('SaveInProgress',
+                   form_id: 'HC-QSTNR_I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000_abc-123-def-455'),
+            double('SaveInProgress',
+                   form_id: 'HC-QSTNR_I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000_ccc-123-ddd-455')
+          ]
+        }
+      end
+      let(:response) do
+        {
+          data: [
+            {
+              appointment: {
+                id: 'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000',
+                attributes: {
+                  facility_id: '534',
+                  clinic_id: '12975'
+                }
+              },
+              questionnaire: [
+                {
+                  id: 'abc-123-def-455',
+                  title: 'Primary Care',
+                  questionnaire_response: {
+                    status: 'in-progress'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      before do
+        allow_any_instance_of(subject).to receive(:appointments).and_return(data)
+        allow_any_instance_of(subject).to receive(:questionnaires_with_facility_clinic_id).and_return(questions_hash)
+        allow_any_instance_of(subject).to receive(:questionnaire_responses_with_appointment_id).and_return({})
+        allow_any_instance_of(subject).to receive(:sip_with_appointment_id).and_return(sip_hash)
+      end
+
+      it 'returns appointment with questionnaire and matching questionnaire response' do
+        expect(subject.manufacture({}).combine).to eq(response)
+      end
+    end
+
+    context 'when questionnaire response and sip data' do
+      let(:questions_hash) do
+        {
+          '534/12975' => [
+            double('Questionnaire', resource: double('Resource', id: 'abc-123-def-455', title: 'Primary Care')),
+            double('Questionnaire', resource: double('Resource', id: 'ccc-123-ddd-455', title: 'Donut Intake'))
+          ]
+        }
+      end
+      let(:questionnaire_response_hash) do
+        {
+          'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000' => [
+            double(
+              'QuestionnaireResponse',
+              resource: double('Resource', id: 'abc-123-def-455', status: 'completed', authored: '2021-02-01')
+            )
+          ]
+        }
+      end
+      let(:sip_hash) do
+        {
+          'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000' => [
+            double('SaveInProgress',
+                   form_id: 'HC-QSTNR_I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000_ccc-123-ddd-455')
+          ]
+        }
+      end
+      let(:response) do
+        {
+          data: [
+            {
+              appointment: {
+                id: 'I2-SLRRT64GFGJAJGX62Q55NSQV44VEE4ZBB7U7YZQVVGKJGQ4653IQ0000',
+                attributes: {
+                  facility_id: '534',
+                  clinic_id: '12975'
+                }
+              },
+              questionnaire: [
+                {
+                  id: 'abc-123-def-455',
+                  title: 'Primary Care',
+                  questionnaire_response: {
+                    id: 'abc-123-def-455',
+                    status: 'completed',
+                    submitted_on: '2021-02-01'
+                  }
+                },
+                {
+                  id: 'ccc-123-ddd-455',
+                  title: 'Donut Intake',
+                  questionnaire_response: {
+                    status: 'in-progress'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      before do
+        allow_any_instance_of(subject).to receive(:appointments).and_return(data)
+        allow_any_instance_of(subject).to receive(:questionnaires_with_facility_clinic_id).and_return(questions_hash)
+        allow_any_instance_of(subject).to receive(:questionnaire_responses_with_appointment_id)
+          .and_return(questionnaire_response_hash)
+        allow_any_instance_of(subject).to receive(:sip_with_appointment_id).and_return(sip_hash)
+      end
+
+      it 'returns appointment with questionnaire and matching questionnaire response' do
+        expect(subject.manufacture({}).combine).to eq(response)
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Questionnaire Manager now returns an aggregated set of data when the `/health_quest/v0/questionnaire_manager` route is invoked.
- The `transformer.rb` class is a bit heavy on the data structure and algorithms implementation and is intentionally imperative in style and design. We can think about abstracting some of the code away into newer classes if necessary but I feel that having the computation heavy pieces in one area will make the code easier to read and understand.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#19015

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests have been written and are passing.