### PR TITLE
Updates IAM user model with MHV id, LOA fix

### DIFF
--- a/app/models/iam_user.rb
+++ b/app/models/iam_user.rb
@@ -16,9 +16,11 @@ class IAMUser < ::User
   attribute :iam_icn, String
   attribute :iam_edipi, String
   attribute :iam_sec_id, String
+  attribute :iam_mhv_id, String
 
   # MPI::Service uses 'mhv_icn' to query by icn rather than less accurate user traits
   alias mhv_icn iam_icn
+  alias mhv_correlation_id iam_mhv_id
 
   # Builds an user instance from a IAMUserIdentity
   #
@@ -52,6 +54,18 @@ class IAMUser < ::User
 
   def sec_id
     identity.iam_sec_id || va_profile&.sec_id
+  end
+
+  def mhv_account_type
+    MHVAccountTypeService.new(self).mhv_account_type
+  end
+
+  # This is not the correct way of determining VA patient status,
+  # but it works for authorizing access for existing MHV premium users
+  # If we are going to enable account creation/upgrade, then we'll need
+  # to  derive the list of facilities from the IAM introspection payload.
+  def va_patient?
+    mhv_correlation_id.present?
   end
 
   def set_expire

--- a/app/models/iam_user_identity.rb
+++ b/app/models/iam_user_identity.rb
@@ -66,7 +66,7 @@ class IAMUserIdentity < ::UserIdentity
 
   # Return a single mhv id from a possible comma-separated list value attribute
   def self.valid_mhv_id(id_from_profile)
-    # TODO: For now, log instances of duplicate MHV ID. 
+    # TODO: For now, log instances of duplicate MHV ID.
     # See issue #19971 for consideration of whether to reject access
     # to features using this identifier if this happens.
     mhv_ids = (id_from_profile == 'NOT_FOUND' ? nil : id_from_profile)

--- a/app/models/iam_user_identity.rb
+++ b/app/models/iam_user_identity.rb
@@ -13,6 +13,7 @@ class IAMUserIdentity < ::UserIdentity
   attribute :iam_icn, String
   attribute :iam_edipi, String
   attribute :iam_sec_id, String
+  attribute :iam_mhv_id, String
 
   # Builds an identity instance from the profile returned in the IAM introspect response
   #
@@ -29,6 +30,7 @@ class IAMUserIdentity < ::UserIdentity
       iam_icn: iam_profile[:fediam_mviicn],
       iam_edipi: iam_profile[:fediam_do_dedipn_id],
       iam_sec_id: iam_profile[:fediamsecid],
+      iam_mhv_id: valid_mhv_id(iam_profile[:fediam_mhv_ien]),
       last_name: iam_profile[:family_name],
       loa: { current: loa_level, highest: loa_level },
       middle_name: iam_profile[:middle_name]
@@ -52,4 +54,14 @@ class IAMUserIdentity < ::UserIdentity
   def uuid
     Digest::UUID.uuid_v5(@iam_sec_id, @iam_icn)
   end
+
+  # Return a single mhv id from a possible comma-separated list value attribute
+  def self.valid_mhv_id(id_from_profile)
+    # TODO: site login fails if multiple _different_ MHV IDs are present
+    # Should this code be doing the same? Or at least logging a warning?
+    # see lib/saml/user_attributes/ssoe.rb for example validation
+    id_from_profile&.split(',')&.first
+  end
+
+  private_class_method :valid_mhv_id
 end

--- a/app/models/iam_user_identity.rb
+++ b/app/models/iam_user_identity.rb
@@ -5,6 +5,9 @@
 # introspect endpoint.Adds IAM sourced versions of ICN, EDIPI, and SEC ID to pass to the IAMUser model.
 #
 class IAMUserIdentity < ::UserIdentity
+  PREMIUM_LOAS = [2, 3].freeze
+  UPGRADE_AUTH_TYPES = %w[DSL MHV].freeze
+
   redis_store REDIS_CONFIG[:iam_user_identity][:namespace]
   redis_ttl REDIS_CONFIG[:iam_user_identity][:each_ttl]
   redis_key :uuid
@@ -22,6 +25,8 @@ class IAMUserIdentity < ::UserIdentity
   #
   def self.build_from_iam_profile(iam_profile)
     loa_level = iam_profile[:fediamassur_level].to_i
+    iam_auth_n_type = iam_profile[:fediamauth_n_type]
+    loa_level = 3 if UPGRADE_AUTH_TYPES.include?(iam_auth_n_type) && PREMIUM_LOAS.include?(loa_level)
 
     identity = new(
       email: iam_profile[:email],

--- a/spec/factories/iam_introspection_responses.rb
+++ b/spec/factories/iam_introspection_responses.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :dslogon_level2_introspection_payload, class: Hash do
+    fediamtransaction_id { 'Yl5u1YecjH1qlWtGJxGjQtEJVpujROEotxY39gD2NTI=' }
+    fediam_is_delegate { 'false' }
+    fediam_birls_number { 'NOT_FOUND' }
+    birthdate { '1970-08-12' }
+    fediamss_issue_instant { '2021-02-12T17:42:40Z' }
+    fediam_mviicn { '1012666182V203559' }
+    fediam_street { '140 WHITEHAVEN CIR' }
+    fediamsecid { '0000027792' }
+    client_id { 'VAMobile' }
+    fediam_country { 'USA' }
+    fediam_gender { 'MALE' }
+    exp { 1_613_153_567 }
+    code_challenge { 'A0ZKRGWoD9TTNbO0j5mhDzV41jrLW-RbJZcAJsnjVTo' }
+    fediam_street1 { '140 WHITEHAVEN CIR' }
+    fediam_do_dedipn_id { '1005079124' }
+    fediam_gc_id { '1012666182V203559^NI^200M^USVHA^P|7187659^PI^987^USVHA^A|0000001012666182V203559000000^PI^200ESR^USVHA^A|0000001012666182V203559000000^PI^553^USVHA^A|600036159^PI^200CORP^USVBA^A|1005079124^NI^200NDZ^2.16.840.1.113883.3.42.10001.100001.13^A|0000027792^PN^200PROV^USDVA^A|14398876^PI^200MHS^USVHA^A|1005079124^NI^200DOD^USDOD^A|1411740^PI^200VETS^USDVA^A|85c50aa76934460c8736f687a6a30546^PN^200VIDM^USDVA^A|796121200^AN^200CORP^USVBA^' }
+    active { true }
+    fediamauth_n_type { 'DSL' }
+    fediamdmdc_authorization { '{"authorizationResponse":{"id":"796121200" }"idType":"SSN" }"lastName":"ANDERSON" }"firstName":"GREG" }"middleName":"A" }"cadencyName":"" }"deceased":false,"birthDate":"1933-04-05T08:00:00Z" }"gender":"MALE" }"edi":1005079124,"benefits":["21"],"personnels":[{"organization":"21" }"category":"RETIRED_MILITARY" }"serviceBranchClassification":"A" }"rank":"SSG"}],"status":"SPONSOR" }"personAssociatedSet":[{"id":"796121201" }"idType":"SSN" }"lastName":"WHITE" }"firstName":"CONNIE" }"middleName":"A" }"cadencyName":"" }"deceased":false,"birthDate":"1935-07-12T08:00:00Z" }"gender":"FEMALE" }"edi":1005079140,"associationReason":"SPOUSE" }"benefits":["21"],"personnels":[],"status":"DEPENDENT" }"relationshipTypes":["FAMILY"],"permissionTypes":["NON_CLINICAL"]}]}}' }
+    fediam_not_on_or_after { '2021-02-12T17:47:41Z' }
+    aud { 'VAMobile' }
+    fediam_mcid { 'WSSOE2102121242404971252931639' }
+    fediamidsource { 'ssoe' }
+    fediam_vaafi_proof_authority { 'DMDC' }
+    phone_number { '(333)444-5555' }
+    tokens_generated_by { 'OAuth AZN Code Flow' }
+    fediamissuer { 'https://sqa.eauth.va.gov/isam/sps/saml20idp/saml20' }
+    fediamproofing_auth { 'DMDC' }
+    fediam_authentication_method { 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password' }
+    fediamam_eai_xattr_session_lifetime { '1613155361' }
+    fediam_suffix { 'NOT_FOUND' }
+    sub { '0000027792' }
+    fediam_mhv_ien { '14398876' }
+    fediam_authentication_instant { '2021-02-12T17:42:41Z' }
+    token_type { 'bearer' }
+    fediam_common_name { 'GREG ANDERSON' }
+    fediam_sponsor_do_dedipn_id { '1005079124' }
+    scope { 'openid' }
+    fediam_npi { 'NOT_FOUND' }
+    fediam_postal_code { '80129-6676' }
+    fediam_vaafi_csp_id { '200DOD_1005079124' }
+    fediam_pn_id { '796121200' }
+    fediam_pn_id_type { 'SSN' }
+    iat { 1_613_151_767 }
+    email { 'veteran@gmail.asd' }
+    code_challenge_method { 'S256' }
+    given_name { 'GREG' }
+    middle_name { 'A' }
+    fediamassur_level { '2' }
+    fediam_not_before { '2021-02-12T17:37:41Z' }
+    fediam_prefix { 'NOT_FOUND' }
+    fediam_state { 'CO' }
+    fediam_city { 'HIGHLANDS RANCH' }
+    fediam_pid { '600036159' }
+    family_name { 'ANDERSON' }
+    username { '0000027792' }
+
+    initialize_with { attributes }
+  end
+
+  factory :mhv_premium_introspection_payload, class: Hash do
+    fediamtransaction_id { 'BO1rf1VBdAsPGVdNfyg5/1/Q6dV7CA6Dk+dPLg5o2M0=' }
+    fediam_is_delegate { 'false' }
+    fediam_birls_number { 'NOT_FOUND' }
+    birthdate { '1970-08-18' }
+    fediamss_issue_instant { '2021-02-12T18:01:17Z' }
+    fediam_mviicn { '1012853893V362415' }
+    fediam_street { 'NOT_FOUND' }
+    fediamsecid { '1012853893' }
+    client_id { 'VAMobile' }
+    fediam_country { 'NOT_FOUND' }
+    fediam_gender { 'MALE' }
+    exp { 1_613_154_684 }
+    code_challenge { 'foHWImw_789-f14zzYZj3AX6o-HBEVIbpAi3mvNeHOY' }
+    fediam_street1 { 'NOT_FOUND' }
+    fediam_do_dedipn_id { 'NOT_FOUND' }
+    fediam_gc_id { '1012853893V362415^NI^200M^USVHA^P|943574^PI^979^USVHA^A|20221^PI^200VETS^USDVA^A|da4ae1e5ef9d479084f66563457a2dc3^PN^200VIDM^USDVA^A|1012853893^PN^200PROV^USDVA^A|12403029^PI^200MH^USVHA^A|12403029^PI^200MHS^USVHA^A|438b7fbd26c5417ab57e0430e366c31d^PN^200VIDM^USDVA^A' }
+    active { true }
+    fediamauth_n_type { 'MHV' }
+    fediam_not_on_or_after { '2021-02-12T18:06:18Z' }
+    aud { 'VAMobile' }
+    fediam_mcid { 'WSSOE2102121301177192038357306' }
+    fediamidsource { 'ssoe' }
+    fediam_vaafi_proof_authority { 'FICAM' }
+    phone_number { 'NOT_FOUND' }
+    tokens_generated_by { 'OAuth AZN Code Flow' }
+    fediamissuer { 'https://sqa.eauth.va.gov/isam/sps/saml20idp/saml20' }
+    fediamproofing_auth { 'FICAM' }
+    fediam_authentication_method { 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password' }
+    fediamam_eai_xattr_session_lifetime { '1613156478' }
+    fediam_suffix { 'NOT_FOUND' }
+    sub { '1012853893' }
+    fediam_mhv_ien { '12403029' }
+    fediam_authentication_instant { '2021-02-12T18:01:18Z' }
+    token_type { 'bearer' }
+    fediam_common_name { 'easton1@mhv.va.gov' }
+    scope { 'openid' }
+    fediam_npi { 'NOT_FOUND' }
+    fediam_postal_code { 'NOT_FOUND' }
+    fediam_vaafi_csp_id { '200MH_12403029' }
+    fediam_pn_id { '666700746' }
+    fediam_pn_id_type { 'SSN' }
+    iat { 1_613_152_884 }
+    email { 'NOT_FOUND' }
+    code_challenge_method { 'S256' }
+    given_name { 'EASTON' }
+    middle_name { 'NOT_FOUND' }
+    fediamassur_level { '2' }
+    fediam_not_before { '2021-02-12T17:56:18Z' }
+    fediam_prefix { 'NOT_FOUND' }
+    fediam_state { 'NOT_FOUND' }
+    fediam_city { 'NOT_FOUND' }
+    fediam_pid { 'NOT_FOUND' }
+    family_name { 'GPTESTSYSSEVEN' }
+    username { '1012853893' }
+
+    initialize_with { attributes }
+  end
+end

--- a/spec/factories/iam_introspection_responses.rb
+++ b/spec/factories/iam_introspection_responses.rb
@@ -17,10 +17,25 @@ FactoryBot.define do
     code_challenge { 'A0ZKRGWoD9TTNbO0j5mhDzV41jrLW-RbJZcAJsnjVTo' }
     fediam_street1 { '140 WHITEHAVEN CIR' }
     fediam_do_dedipn_id { '1005079124' }
-    fediam_gc_id { '1012666182V203559^NI^200M^USVHA^P|7187659^PI^987^USVHA^A|0000001012666182V203559000000^PI^200ESR^USVHA^A|0000001012666182V203559000000^PI^553^USVHA^A|600036159^PI^200CORP^USVBA^A|1005079124^NI^200NDZ^2.16.840.1.113883.3.42.10001.100001.13^A|0000027792^PN^200PROV^USDVA^A|14398876^PI^200MHS^USVHA^A|1005079124^NI^200DOD^USDOD^A|1411740^PI^200VETS^USDVA^A|85c50aa76934460c8736f687a6a30546^PN^200VIDM^USDVA^A|796121200^AN^200CORP^USVBA^' }
+    fediam_gc_id {
+      '1012666182V203559^NI^200M^USVHA^P|7187659^PI^987^USVHA^A|0000001012666182V203559000000^PI^200ESR^USVHA^A|' \
+        '0000001012666182V203559000000^PI^553^USVHA^A|600036159^PI^200CORP^USVBA^A|' \
+        '1005079124^NI^200NDZ^2.16.840.1.113883.3.42.10001.100001.13^A|0000027792^PN^200PROV^USDVA^A|' \
+        '14398876^PI^200MHS^USVHA^A|1005079124^NI^200DOD^USDOD^A|1411740^PI^200VETS^USDVA^A|' \
+        '85c50aa76934460c8736f687a6a30546^PN^200VIDM^USDVA^A|796121200^AN^200CORP^USVBA^'
+    }
     active { true }
     fediamauth_n_type { 'DSL' }
-    fediamdmdc_authorization { '{"authorizationResponse":{"id":"796121200" }"idType":"SSN" }"lastName":"ANDERSON" }"firstName":"GREG" }"middleName":"A" }"cadencyName":"" }"deceased":false,"birthDate":"1933-04-05T08:00:00Z" }"gender":"MALE" }"edi":1005079124,"benefits":["21"],"personnels":[{"organization":"21" }"category":"RETIRED_MILITARY" }"serviceBranchClassification":"A" }"rank":"SSG"}],"status":"SPONSOR" }"personAssociatedSet":[{"id":"796121201" }"idType":"SSN" }"lastName":"WHITE" }"firstName":"CONNIE" }"middleName":"A" }"cadencyName":"" }"deceased":false,"birthDate":"1935-07-12T08:00:00Z" }"gender":"FEMALE" }"edi":1005079140,"associationReason":"SPOUSE" }"benefits":["21"],"personnels":[],"status":"DEPENDENT" }"relationshipTypes":["FAMILY"],"permissionTypes":["NON_CLINICAL"]}]}}' }
+    fediamdmdc_authorization {
+      '{"authorizationResponse":{"id":"796121200" }"idType":"SSN" }"lastName":"ANDERSON" }"firstName":"GREG" }' \
+      '"middleName":"A" }"cadencyName":"" }"deceased":false,"birthDate":"1933-04-05T08:00:00Z" }"gender":"MALE" }' \
+      '"edi":1005079124,"benefits":["21"],"personnels":[{"organization":"21" }"category":"RETIRED_MILITARY" }' \
+      '"serviceBranchClassification":"A" }"rank":"SSG"}],"status":"SPONSOR" }"personAssociatedSet":[' \
+      '{"id":"796121201" }"idType":"SSN" }"lastName":"WHITE" }"firstName":"CONNIE" }"middleName":"A" }' \
+      '"cadencyName":"" }"deceased":false,"birthDate":"1935-07-12T08:00:00Z" }"gender":"FEMALE" }' \
+      '"edi":1005079140,"associationReason":"SPOUSE" }"benefits":["21"],"personnels":[],"status":"DEPENDENT" }' \
+      '"relationshipTypes":["FAMILY"],"permissionTypes":["NON_CLINICAL"]}]}}'
+    }
     fediam_not_on_or_after { '2021-02-12T17:47:41Z' }
     aud { 'VAMobile' }
     fediam_mcid { 'WSSOE2102121242404971252931639' }
@@ -78,7 +93,11 @@ FactoryBot.define do
     code_challenge { 'foHWImw_789-f14zzYZj3AX6o-HBEVIbpAi3mvNeHOY' }
     fediam_street1 { 'NOT_FOUND' }
     fediam_do_dedipn_id { 'NOT_FOUND' }
-    fediam_gc_id { '1012853893V362415^NI^200M^USVHA^P|943574^PI^979^USVHA^A|20221^PI^200VETS^USDVA^A|da4ae1e5ef9d479084f66563457a2dc3^PN^200VIDM^USDVA^A|1012853893^PN^200PROV^USDVA^A|12403029^PI^200MH^USVHA^A|12403029^PI^200MHS^USVHA^A|438b7fbd26c5417ab57e0430e366c31d^PN^200VIDM^USDVA^A' }
+    fediam_gc_id {
+      '1012853893V362415^NI^200M^USVHA^P|943574^PI^979^USVHA^A|20221^PI^200VETS^USDVA^A|' \
+      'da4ae1e5ef9d479084f66563457a2dc3^PN^200VIDM^USDVA^A|1012853893^PN^200PROV^USDVA^A|' \
+      '12403029^PI^200MH^USVHA^A|12403029^PI^200MHS^USVHA^A|438b7fbd26c5417ab57e0430e366c31d^PN^200VIDM^USDVA^A'
+    }
     active { true }
     fediamauth_n_type { 'MHV' }
     fediam_not_on_or_after { '2021-02-12T18:06:18Z' }

--- a/spec/models/iam_user_identity_spec.rb
+++ b/spec/models/iam_user_identity_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IAMUserIdentity, type: :model do
+  let(:dslogon_attrs) { build(:dslogon_level2_introspection_payload) }
+  let(:mhv_attrs) { build(:mhv_premium_introspection_payload) }
+
+  context 'for a DSLogon user' do
+    it 'returns LOA3 for a premium assurance level' do
+      id = described_class.build_from_iam_profile(dslogon_attrs)
+      expect(id.loa[:current]).to eq(3)
+    end
+  end
+
+  context 'for an MHV user' do
+    it 'returns LOA3 for a premium assurance level' do
+      id = described_class.build_from_iam_profile(mhv_attrs)
+      expect(id.loa[:current]).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
Adds MHV identifier to IAM user identity payload, for use in invoking MHV APIs. 

Also fixes LOA interpretation to match VA.gov's, so that DSLogon or MHV assurance level 2 will be interpreted as LOA3 for authorization purposes.



## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR

<!-- Please describe testing done to verify the changes or any testing planned. -->
