### PR TITLE
Add mobile-specific SM backend integration profile

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -35,6 +35,9 @@ development: &defaults
   sm_store:
     namespace: sm-service
     each_ttl: 1200
+  sm_store_mobile:
+    namespace: sm-service-mobile
+    each_ttl: 1200
   mdot:
     namespace: mdot
     each_ttl: 1800
@@ -102,9 +105,6 @@ development: &defaults
   va_mobile_session_refresh_lock:
     namespace: va-mobile-session-refresh-lock
     each_ttl: 60
-  va_mobile_sm_store:
-    namespace: va-mobile-sm-service
-    each_ttl: 1200
   saml_request_tracker:
     namespace: saml_request_tracker
     each_ttl: 3600 # 1 hour

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -102,6 +102,9 @@ development: &defaults
   va_mobile_session_refresh_lock:
     namespace: va-mobile-session-refresh-lock
     each_ttl: 60
+  va_mobile_sm_store:
+    namespace: va-mobile-sm-service
+    each_ttl: 1200
   saml_request_tracker:
     namespace: saml_request_tracker
     each_ttl: 3600 # 1 hour

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -297,6 +297,11 @@ mhv:
   account:
     mock: false
 
+# Settings for alternate MHV integration for mobile app
+mhv_mobile:
+  sm:
+    app_token: fake-app-token
+
 # Settings for Master Veteran Index
 mvi:
   url: http://ps-dev.commserv.healthevet.va.gov:8110/psim_webservice/IdMWebService

--- a/modules/mobile/app/services/mobile/v0/messaging/client.rb
+++ b/modules/mobile/app/services/mobile/v0/messaging/client.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'common/client/base'
+require 'common/client/concerns/mhv_session_based_client'
+require 'sm/client'
+require 'mobile/v0/messaging/client_session'
+require 'mobile/v0/messaging/configuration'
+
+module Mobile
+  module V0
+    module Messaging
+      ##
+      # Class responsible for SM API interface operations
+      # Overrides configuration class member to use mobile-specific token
+      # Overrides client_session class member to use mobile-specific
+      #  session cache
+      #
+      class Client < SM::Client
+        configuration Mobile::V0::Messaging::Configuration
+        client_session Mobile::V0::Messaging::ClientSession
+      end
+    end
+  end
+end

--- a/modules/mobile/app/services/mobile/v0/messaging/client_session.rb
+++ b/modules/mobile/app/services/mobile/v0/messaging/client_session.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'common/client/session'
+
+module Mobile
+  module V0
+    module Messaging
+      class ClientSession < Common::Client::Session
+        redis_store REDIS_CONFIG[:va_mobile_sm_store][:namespace]
+        redis_ttl 900
+        redis_key :user_id
+      end
+    end
+  end
+end

--- a/modules/mobile/app/services/mobile/v0/messaging/client_session.rb
+++ b/modules/mobile/app/services/mobile/v0/messaging/client_session.rb
@@ -6,7 +6,7 @@ module Mobile
   module V0
     module Messaging
       class ClientSession < Common::Client::Session
-        redis_store REDIS_CONFIG[:va_mobile_sm_store][:namespace]
+        redis_store REDIS_CONFIG[:sm_store_mobile][:namespace]
         redis_ttl 900
         redis_key :user_id
       end

--- a/modules/mobile/app/services/mobile/v0/messaging/configuration.rb
+++ b/modules/mobile/app/services/mobile/v0/messaging/configuration.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'common/client/configuration/rest'
+require 'common/client/middleware/request/camelcase'
+require 'common/client/middleware/request/multipart_request'
+require 'common/client/middleware/response/json_parser'
+require 'common/client/middleware/response/raise_error'
+require 'common/client/middleware/response/mhv_errors'
+require 'common/client/middleware/response/snakecase'
+require 'sm/middleware/response/sm_parser'
+
+module Mobile
+  module V0
+    module Messaging
+      ##
+      # HTTP client configuration for {Mobile::V0::Messaging::Client},
+      # sets the app token
+      # For now the base_path and service_name are unchanged, i.e. this is
+      # a shared service with distinct app_token.
+      #
+      class Configuration < SM::Configuration
+        ##
+        # @return [String] Client token set in `settings.yml` via credstash
+        #
+        def app_token
+          Settings.mhv_mobile.sm.app_token
+        end
+      end
+    end
+  end
+end

--- a/modules/mobile/spec/services/messaging_client_spec.rb
+++ b/modules/mobile/spec/services/messaging_client_spec.rb
@@ -17,7 +17,7 @@ describe Mobile::V0::Messaging::Client do
 
     it 'uses alternate session store' do
       user_id = '10616687'
-      key = "#{REDIS_CONFIG[:va_mobile_sm_store][:namespace]}:#{user_id}"
+      key = "#{REDIS_CONFIG[:sm_store_mobile][:namespace]}:#{user_id}"
       with_settings(Settings.mhv_mobile.sm, app_token: 'TestToken') do
         stub_request(:get, /session/).with(headers: { 'appToken' => 'TestToken' })
                                      .to_return(status: 200, headers: { 'Token' => 'abcd1234z' })

--- a/modules/mobile/spec/services/messaging_client_spec.rb
+++ b/modules/mobile/spec/services/messaging_client_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Mobile::V0::Messaging::Client do
+  describe 'configuration override' do
+    it 'uses alternate app_token' do
+      with_settings(Settings.mhv_mobile.sm, app_token: 'TestToken') do
+        stub_request(:get, /session/).with(headers: { 'appToken' => 'TestToken' })
+                                     .to_return(status: 200, headers: { 'Token' => 'abcd1234z' })
+        svc = Mobile::V0::Messaging::Client.new(session: { user_id: '10616687' })
+        svc.authenticate
+        expect(a_request(:get, /session/).with(headers: { 'appToken' => 'TestToken' }))
+          .to have_been_made.once
+      end
+    end
+
+    it 'uses alternate session store' do
+      user_id = '10616687'
+      key = "#{REDIS_CONFIG[:va_mobile_sm_store][:namespace]}:#{user_id}"
+      with_settings(Settings.mhv_mobile.sm, app_token: 'TestToken') do
+        stub_request(:get, /session/).with(headers: { 'appToken' => 'TestToken' })
+                                     .to_return(status: 200, headers: { 'Token' => 'abcd1234z' })
+        svc = Mobile::V0::Messaging::Client.new(session: { user_id: user_id })
+        svc.authenticate
+        expect(Redis.new.get(key)).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Adds a  mobile-app-specific MHV profile - i.e. a unique appToken configuration, and a separate session store to avoid userid collisions. 

~Note this is based on top of https://github.com/department-of-veterans-affairs/vets-api/pull/5929 which I expect to get merged first.~ Merged

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
- Adds a new settings.yml element for the  new mobile-specific MHV appToken.  

Planned test: Invoke SM API with configured staging appToken and verify difference  in MHV account activity logs.
