### PR TITLE
Add missing \n to end of rewritten viewportPreset.js file

### DIFF
--- a/app/workers/cypress_viewport_updater/viewport_preset_js_file.rb
+++ b/app/workers/cypress_viewport_updater/viewport_preset_js_file.rb
@@ -23,7 +23,7 @@ module CypressViewportUpdater
         end
       end
 
-      self.updated_content = new_lines.join("\n")
+      self.updated_content = new_lines.join("\n") + "\n"
       self
     end
 


### PR DESCRIPTION
Add missing `\n` to end of rewritten `viewportPreset.js` file

All tests pass locally.

The `vets-website` files that are re-written by the Cypress Viewport Updater pass in Jenkins and Circle - https://github.com/department-of-veterans-affairs/vets-website/pull/16047