### PR TITLE
[API-4120] - Return error 403 when v0 intent-to-file type is 'burial'

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -123,6 +123,7 @@ module ClaimsApi
       if form_type == 'burial'
         message = "Representative cannot file for type 'burial'"
         raise(::Common::Exceptions::Forbidden, detail: message) if @current_user.blank? && v0?
+
         begin
           @current_user.participant_id
         rescue ArgumentError

--- a/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/base_form_controller.rb
@@ -121,10 +121,12 @@ module ClaimsApi
 
     def participant_claimant_id
       if form_type == 'burial'
+        message = "Representative cannot file for type 'burial'"
+        raise(::Common::Exceptions::Forbidden, detail: message) if @current_user.blank? && v0?
         begin
           @current_user.participant_id
         rescue ArgumentError
-          raise ::Common::Exceptions::Forbidden, detail: "Representative cannot file for type 'burial'"
+          raise ::Common::Exceptions::Forbidden, detail: message
         end
       else
         target_veteran.participant_id

--- a/modules/claims_api/spec/requests/v0/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/intent_to_file_request_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe 'Intent to file', type: :request do
       post path, headers: headers
       expect(response.status).to eq(422)
     end
+
+    it "returns a 403 when 'burial' type is provided" do
+      data[:data][:attributes][:type] = 'burial'
+      post path, params: data.to_json, headers: headers
+      expect(response.status).to eq(403)
+    end
   end
 
   describe '#active' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
v0 does not have the concept of submitting a form 0966 on behalf of a veteran.
It doesn't make sense for a deceased veteran to submit an intent-to-file for their own burial.  
So when a v0 intent-to-file request with the `type` set as `"burial"` is received, forbid the request.

## Original issue(s)
[API-4120](https://vajira.max.gov/browse/API-4120)
