### PR TITLE
Pv mobile sm controllers

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -105,9 +105,6 @@ development: &defaults
   va_mobile_session_refresh_lock:
     namespace: va-mobile-session-refresh-lock
     each_ttl: 60
-  va_mobile_sm_store:
-    namespace: va-mobile-sm-service
-    each_ttl: 1200
   saml_request_tracker:
     namespace: saml_request_tracker
     each_ttl: 3600 # 1 hour

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -105,6 +105,9 @@ development: &defaults
   va_mobile_session_refresh_lock:
     namespace: va-mobile-session-refresh-lock
     each_ttl: 60
+  va_mobile_sm_store:
+    namespace: va-mobile-sm-service
+    each_ttl: 1200
   saml_request_tracker:
     namespace: saml_request_tracker
     each_ttl: 3600 # 1 hour

--- a/modules/mobile/app/controllers/mobile/messaging_controller.rb
+++ b/modules/mobile/app/controllers/mobile/messaging_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_dependency 'mobile/application_controller'
+require 'sm/client'
+
+module Mobile
+  class MessagingController < ApplicationController
+    include ActionController::Serialization
+
+    before_action :authorize
+    before_action :authenticate_client
+
+    protected
+
+    def client
+      @client ||= SM::Client.new(session: { user_id: current_user.mhv_correlation_id })
+    end
+
+    def authorize
+      raise_access_denied unless current_user.authorize(:mhv_messaging, :access?)
+    end
+
+    def raise_access_denied
+      raise Common::Exceptions::Forbidden, detail: 'You do not have access to messaging'
+    end
+
+    def authenticate_client
+      # TODO: is this audit service call still needed?
+      MHVLoggingService.login(current_user)
+      client.authenticate if client.session.expired?
+    end
+
+    def pagination_params
+      {
+         page: params[:page],
+        per_page: params[:per_page]
+      }
+    end
+  end
+end

--- a/modules/mobile/app/controllers/mobile/messaging_controller.rb
+++ b/modules/mobile/app/controllers/mobile/messaging_controller.rb
@@ -32,7 +32,7 @@ module Mobile
 
     def pagination_params
       {
-         page: params[:page],
+        page: params[:page],
         per_page: params[:per_page]
       }
     end

--- a/modules/mobile/app/controllers/mobile/messaging_controller.rb
+++ b/modules/mobile/app/controllers/mobile/messaging_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency 'mobile/application_controller'
-require 'sm/client'
+require 'mobile/v0/messaging/client'
 
 module Mobile
   class MessagingController < ApplicationController
@@ -13,7 +13,7 @@ module Mobile
     protected
 
     def client
-      @client ||= SM::Client.new(session: { user_id: current_user.mhv_correlation_id })
+      @client ||= Mobile::V0::Messaging::Client.new(session: { user_id: current_user.mhv_correlation_id })
     end
 
     def authorize

--- a/modules/mobile/app/controllers/mobile/v0/folders_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/folders_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_dependency 'mobile/messaging_controller'
+require_dependency 'mobile/v0/folder_serializer'
+
+module Mobile
+  module V0
+    class FoldersController < MessagingController
+      def index
+        resource = client.get_folders
+        resource = resource.paginate(pagination_params)
+
+        render json: resource.data,
+               serializer: CollectionSerializer,
+               each_serializer: Mobile::V0::FolderSerializer,
+               meta: resource.metadata
+      end
+
+      def show
+        id = params[:id].try(:to_i)
+        resource = client.get_folder(id)
+        raise Common::Exceptions::RecordNotFound, id if resource.blank?
+
+        render json: resource,
+               serializer: Mobile::V0::FolderSerializer,
+               meta: resource.metadata
+      end
+
+      def create
+        folder = Folder.new(create_folder_params)
+        raise Common::Exceptions::ValidationErrors, folder unless folder.valid?
+
+        resource = client.post_create_folder(folder.name)
+
+        render json: resource,
+               serializer: Mobile::V0::FolderSerializer,
+               meta: resource.metadata,
+               status: :created
+      end
+
+      def destroy
+        client.delete_folder(params[:id])
+        head :no_content
+      end
+
+      private
+
+      def create_folder_params
+        params.require(:folder).permit(:name)
+      end
+    end
+  end
+end

--- a/modules/mobile/app/controllers/mobile/v0/messages_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/messages_controller.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require_dependency 'mobile/messaging_controller'
+
+module Mobile
+  module V0
+    class MessagesController < MessagingController
+      include Filterable
+
+      def index
+        resource = client.get_folder_messages(params[:folder_id].to_s)
+        raise Common::Exceptions::RecordNotFound, params[:folder_id] if resource.blank?
+
+        resource = params[:filter].present? ? resource.find_by(filter_params) : resource
+        resource = resource.sort(params[:sort])
+        resource = resource.paginate(pagination_params)
+
+        render json: resource.data,
+               serializer: CollectionSerializer,
+               each_serializer: Mobile::V0::MessagesSerializer,
+               meta: resource.metadata
+      end
+
+      def show
+        message_id = params[:id].try(:to_i)
+        response = client.get_message(message_id)
+
+        raise Common::Exceptions::RecordNotFound, message_id if response.blank?
+
+        render json: response,
+               serializer: Mobile::V0::MessageSerializer,
+               include: 'attachments',
+               meta: response.metadata
+      end
+
+      def create
+        message = Message.new(message_params.merge(upload_params))
+        raise Common::Exceptions::ValidationErrors, message unless message.valid?
+
+        message_params[:id] = message_params.delete(:draft_id) if message_params[:draft_id].present?
+        create_message_params = { message: message_params }.merge(upload_params)
+
+        client_response = if message.uploads.present?
+                            client.post_create_message_with_attachment(create_message_params)
+                          else
+                            client.post_create_message(message_params)
+                          end
+
+        render json: client_response,
+               serializer: Mobile::V0::MessageSerializer,
+               include: 'attachments',
+               meta: {}
+      end
+
+      def destroy
+        client.delete_message(params[:id])
+        head :no_content
+      end
+
+      def thread
+        message_id = params[:id].try(:to_i)
+        resource = client.get_message_history(message_id)
+        raise Common::Exceptions::RecordNotFound, message_id if resource.blank?
+
+        render json: resource.data,
+               serializer: CollectionSerializer,
+               each_serializer: Mobile::V0::MessagesSerializer,
+               meta: resource.metadata
+      end
+
+      def reply
+        message = Message.new(message_params.merge(upload_params)).as_reply
+        raise Common::Exceptions::ValidationErrors, message unless message.valid?
+
+        message_params[:id] = message_params.delete(:draft_id) if message_params[:draft_id].present?
+        create_message_params = { message: message_params }.merge(upload_params)
+
+        client_response = if message.uploads.present?
+                            client.post_create_message_reply_with_attachment(params[:id], create_message_params)
+                          else
+                            client.post_create_message_reply(params[:id], message_params)
+                          end
+
+        render json: client_response,
+               serializer: Mobile::V0::MessageSerializer,
+               include: 'attachments',
+               status: :created
+      end
+
+      def categories
+        resource = client.get_categories
+
+        render json: resource,
+               serializer: Mobile::V0::CategorySerializer
+      end
+
+      def move
+        folder_id = params.require(:folder_id)
+        client.post_move_message(params[:id], folder_id)
+        head :no_content
+      end
+
+      private
+
+      def message_params
+        @message_params ||= params.require(:message).permit(:draft_id, :category, :body, :recipient_id, :subject)
+      end
+
+      def upload_params
+        @upload_params ||= { uploads: params[:uploads] }
+      end
+    end
+  end
+end

--- a/modules/mobile/app/controllers/mobile/v0/triage_teams_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/triage_teams_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_dependency 'mobile/messaging_controller'
+
+module Mobile
+  module V0
+    class TriageTeamsController < MessagingController
+      def index
+        resource = client.get_triage_teams
+        raise Common::Exceptions::InternalServerError if resource.blank?
+
+        resource = resource.sort(params[:sort])
+
+        # Even though this is a collection action we are not going to paginate
+        render json: resource.data,
+               serializer: CollectionSerializer,
+               each_serializer: TriageTeamSerializer,
+               meta: resource.metadata
+      end
+    end
+  end
+end

--- a/modules/mobile/app/helpers/mobile/routing.rb
+++ b/modules/mobile/app/helpers/mobile/routing.rb
@@ -1,0 +1,14 @@
+module Mobile
+  module Routing
+    extend ActiveSupport::Concern
+    include Mobile::Engine.routes.url_helpers
+
+    included do
+      def default_url_options
+        Rails.application.routes.default_url_options
+      end
+    end
+  end
+end
+
+

--- a/modules/mobile/app/helpers/mobile/routing.rb
+++ b/modules/mobile/app/helpers/mobile/routing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mobile
   module Routing
     extend ActiveSupport::Concern
@@ -10,5 +12,3 @@ module Mobile
     end
   end
 end
-
-

--- a/modules/mobile/app/helpers/mobile/url_helper.rb
+++ b/modules/mobile/app/helpers/mobile/url_helper.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 module Mobile
   class UrlHelper
     include Mobile::Routing
   end
 end
-

--- a/modules/mobile/app/helpers/mobile/url_helper.rb
+++ b/modules/mobile/app/helpers/mobile/url_helper.rb
@@ -1,0 +1,6 @@
+module Mobile
+  class UrlHelper
+    include Mobile::Routing
+  end
+end
+

--- a/modules/mobile/app/serializers/mobile/v0/category_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/category_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Mobile
+  module V0
+    class CategorySerializer < ActiveModel::Serializer
+      def id
+        object.category_id
+      end
+
+      attribute(:message_category_type)
+    end
+  end
+end

--- a/modules/mobile/app/serializers/mobile/v0/folder_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/folder_serializer.rb
@@ -3,7 +3,6 @@
 module Mobile
   module V0
     class FolderSerializer < ActiveModel::Serializer
-
       include Mobile::Engine.routes.url_helpers
 
       attribute :id

--- a/modules/mobile/app/serializers/mobile/v0/folder_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/folder_serializer.rb
@@ -3,6 +3,9 @@
 module Mobile
   module V0
     class FolderSerializer < ActiveModel::Serializer
+
+      include Mobile::Engine.routes.url_helpers
+
       attribute :id
 
       attribute(:folder_id) { object.id }
@@ -11,7 +14,7 @@ module Mobile
       attribute :unread_count
       attribute :system_folder
 
-      link(:self) { v0_folder_url(object.id) }
+      link(:self) { Mobile::UrlHelper.new.v0_folder_url(object.id) }
     end
   end
 end

--- a/modules/mobile/app/serializers/mobile/v0/folder_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/folder_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Mobile
+  module V0
+    class FolderSerializer < ActiveModel::Serializer
+      attribute :id
+
+      attribute(:folder_id) { object.id }
+      attribute :name
+      attribute :count
+      attribute :unread_count
+      attribute :system_folder
+
+      link(:self) { v0_folder_url(object.id) }
+    end
+  end
+end

--- a/modules/mobile/app/serializers/mobile/v0/message_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/message_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Mobile
+  module V0
+    class MessageSerializer < MessagesSerializer
+      has_many :attachments, each_serializer: AttachmentSerializer
+    end
+  end
+end

--- a/modules/mobile/app/serializers/mobile/v0/messages_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/messages_serializer.rb
@@ -17,7 +17,7 @@ module Mobile
       attribute :recipient_name
       attribute :read_receipt
 
-      link(:self) { v0_message_url(object.id) }
+      link(:self) { Mobile::UrlHelper.new.v0_message_url(object.id) }
     end
   end
 end

--- a/modules/mobile/app/serializers/mobile/v0/messages_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/messages_serializer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Mobile
+  module V0
+    class MessagesSerializer < ActiveModel::Serializer
+      attribute :id
+
+      attribute(:message_id) { object.id }
+      attribute :category
+      attribute :subject
+      attribute :body
+      attribute :attachment
+      attribute :sent_date
+      attribute :sender_id
+      attribute :sender_name
+      attribute :recipient_id
+      attribute :recipient_name
+      attribute :read_receipt
+
+      link(:self) { v0_message_url(object.id) }
+    end
+  end
+end
+

--- a/modules/mobile/app/serializers/mobile/v0/messages_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/messages_serializer.rb
@@ -21,4 +21,3 @@ module Mobile
     end
   end
 end
-

--- a/modules/mobile/app/serializers/mobile/v0/triage_team_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/triage_team_serializer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Mobile
+  module V0
+    class TriageTeamSerializer < ActiveModel::Serializer
+      def id
+        object.triage_team_id
+      end
+
+      attribute :triage_team_id
+      attribute :name
+      attribute :relation_type
+    end
+  end
+end

--- a/modules/mobile/config/routes.rb
+++ b/modules/mobile/config/routes.rb
@@ -27,5 +27,23 @@ Mobile::Engine.routes.draw do
     put '/user/emails', to: 'emails#update'
     post '/user/phones', to: 'phones#create'
     put '/user/phones', to: 'phones#update'
+
+    scope :messaging do
+      scope :health do
+        resources :triage_teams, only: [:index], defaults: { format: :json }, path: 'recipients'
+
+        resources :folders, only: %i[index show create destroy], defaults: { format: :json }  do
+          resources :messages, only: [:index], defaults: { format: :json }
+        end
+
+        resources :messages, only: %i[show create destroy], defaults: { format: :json } do
+          get :thread, on: :member
+          get :categories, on: :collection
+          patch :move, on: :member
+          post :reply, on: :member
+          resources :attachments, only: [:show], defaults: { format: :json }
+        end
+      end
+    end
   end
 end

--- a/modules/mobile/config/routes.rb
+++ b/modules/mobile/config/routes.rb
@@ -32,7 +32,7 @@ Mobile::Engine.routes.draw do
       scope :health do
         resources :triage_teams, only: [:index], defaults: { format: :json }, path: 'recipients'
 
-        resources :folders, only: %i[index show create destroy], defaults: { format: :json }  do
+        resources :folders, only: %i[index show create destroy], defaults: { format: :json } do
           resources :messages, only: [:index], defaults: { format: :json }
         end
 

--- a/modules/mobile/spec/request/folders_request_spec.rb
+++ b/modules/mobile/spec/request/folders_request_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../support/iam_session_helper'
+require_relative '../support/mobile_sm_client_helper'
+
+RSpec.describe 'Mobile Folders Integration', type: :request do
+  include Mobile::MessagingClientHelper
+  include SchemaMatchers
+
+  let(:user_id) { '10616687' }
+  let(:inbox_id) { 0 }
+  let(:message_id) { 573_059 }
+  let(:va_patient) { true }
+  # let(:current_user) { build(:user, :mhv, va_patient: va_patient, mhv_account_type: mhv_account_type) }
+
+  before do
+    allow_any_instance_of(MHVAccountTypeService).to receive(:mhv_account_type).and_return(mhv_account_type)
+    allow(Mobile::V0::Messaging::Client).to receive(:new).and_return(authenticated_client)
+    iam_sign_in(build(:iam_user, iam_mhv_id: '123'))
+  end
+
+  context 'Basic User' do
+    let(:mhv_account_type) { 'Basic' }
+
+    it 'is not authorized' do
+      get '/mobile/v0/messaging/health/folders', headers: iam_headers
+      expect(response).not_to be_successful
+      expect(response.status).to eq(403)
+    end
+  end
+
+  context 'Advanced User' do
+    let(:mhv_account_type) { 'Advanced' }
+
+    it 'is not authorized' do
+      get '/mobile/v0/messaging/health/folders', headers: iam_headers
+      expect(response).not_to be_successful
+      expect(response.status).to eq(403)
+    end
+  end
+
+  context 'Premium User' do
+    let(:mhv_account_type) { 'Premium' }
+
+    describe '#index' do
+      it 'responds to GET #index' do
+        VCR.use_cassette('sm_client/folders/gets_a_collection_of_folders') do
+          get '/mobile/v0/messaging/health/folders', headers: iam_headers
+        end
+
+        expect(response).to be_successful
+        expect(response.body).to be_a(String)
+        expect(response).to match_camelized_response_schema('folders')
+      end
+
+      it 'generates mobile-specific metadata links' do
+        VCR.use_cassette('sm_client/folders/gets_a_collection_of_folders') do
+          get '/mobile/v0/messaging/health/folders', headers: iam_headers
+        end
+
+        result = JSON.parse(response.body)
+        folder = result['data'].first
+        expect(folder['links']['self']).to match(%r{/mobile/v0})
+        expect(result['links']['self']).to match(%r{/mobile/v0})
+      end
+    end
+
+    describe '#show' do
+      context 'with valid id' do
+        it 'response to GET #show' do
+          VCR.use_cassette('sm_client/folders/gets_a_single_folder') do
+            get "/mobile/v0/messaging/health/folders/#{inbox_id}", headers: iam_headers
+          end
+
+          expect(response).to be_successful
+          expect(response.body).to be_a(String)
+          expect(response).to match_camelized_response_schema('folder')
+        end
+      end
+    end
+
+    describe '#create' do
+      context 'with valid name' do
+        let(:params) { { folder: { name: 'test folder create name 160805101218' } } }
+
+        it 'response to POST #create' do
+          VCR.use_cassette('sm_client/folders/creates_a_folder_and_deletes_a_folder') do
+            post '/mobile/v0/messaging/health/folders', headers: iam_headers, params: params
+          end
+
+          expect(response).to be_successful
+          expect(response).to have_http_status(:created)
+          expect(response).to match_camelized_response_schema('folder')
+        end
+      end
+    end
+
+    describe '#destroy' do
+      context 'with valid folder id' do
+        let(:id) { 674_886 }
+
+        it 'responds to DELETE #destroy' do
+          VCR.use_cassette('sm_client/folders/creates_a_folder_and_deletes_a_folder') do
+            delete "/mobile/v0/messaging/health/folders/#{id}", headers: iam_headers
+          end
+
+          expect(response).to be_successful
+          expect(response).to have_http_status(:no_content)
+        end
+      end
+    end
+
+    describe 'nested resources' do
+      it 'gets messages#index' do
+        VCR.use_cassette('sm_client/folders/nested_resources/gets_a_collection_of_messages') do
+          get "/mobile/v0/messaging/health/folders/#{inbox_id}/messages", headers: iam_headers
+        end
+
+        expect(response).to be_successful
+        expect(response).to have_http_status(:ok)
+        expect(response).to match_camelized_response_schema('messages')
+      end
+    end
+  end
+end

--- a/modules/mobile/spec/request/messages_request_spec.rb
+++ b/modules/mobile/spec/request/messages_request_spec.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../support/iam_session_helper'
+require_relative '../support/mobile_sm_client_helper'
+
+RSpec.describe 'Mobile Messages Integration', type: :request do
+  include Mobile::MessagingClientHelper
+  include SchemaMatchers
+
+  let(:user_id) { '10616687' }
+  let(:inbox_id) { 0 }
+  let(:message_id) { 573_059 }
+  let(:va_patient) { true }
+
+  before do
+    allow_any_instance_of(MHVAccountTypeService).to receive(:mhv_account_type).and_return(mhv_account_type)
+    allow(Mobile::V0::Messaging::Client).to receive(:new).and_return(authenticated_client)
+    iam_sign_in(build(:iam_user, iam_mhv_id: '123'))
+  end
+
+  context 'Basic User' do
+    let(:mhv_account_type) { 'Basic' }
+
+    it 'is not authorized' do
+      get '/mobile/v0/messaging/health/messages/categories', headers: iam_headers
+      expect(response).not_to be_successful
+      expect(response.status).to eq(403)
+    end
+  end
+
+  context 'Advanced User' do
+    let(:mhv_account_type) { 'Advanced' }
+
+    it 'is not authorized' do
+      get '/mobile/v0/messaging/health/messages/categories', headers: iam_headers
+      expect(response).not_to be_successful
+      expect(response.status).to eq(403)
+    end
+  end
+
+  context 'Premium User' do
+    let(:mhv_account_type) { 'Premium' }
+
+    it 'responds to GET messages/categories' do
+      VCR.use_cassette('sm_client/messages/gets_message_categories') do
+        get '/mobile/v0/messaging/health/messages/categories', headers: iam_headers
+      end
+
+      expect(response).to be_successful
+      expect(response.body).to be_a(String)
+      expect(response).to match_camelized_response_schema('category')
+    end
+
+    it 'responds to GET #show' do
+      VCR.use_cassette('sm_client/messages/gets_a_message_with_id') do
+        get "/mobile/v0/messaging/health/messages/#{message_id}", headers: iam_headers
+      end
+
+      expect(response).to be_successful
+      expect(response.body).to be_a(String)
+      expect(response).to match_camelized_response_schema('message')
+    end
+
+    it 'generates mobile-specific metadata links' do
+      VCR.use_cassette('sm_client/messages/gets_a_message_with_id') do
+        get "/mobile/v0/messaging/health/messages/#{message_id}", headers: iam_headers
+      end
+
+      result = JSON.parse(response.body)
+      expect(result['data']['links']['self']).to match(%r{/mobile/v0})
+    end
+
+    describe 'POST create' do
+      let(:attachment_type) { 'image/jpg' }
+      let(:uploads) do
+        [
+          Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file1.jpg', attachment_type),
+          Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file2.jpg', attachment_type),
+          Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file3.jpg', attachment_type),
+          Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file4.jpg', attachment_type)
+        ]
+      end
+      let(:message_params) { attributes_for(:message, subject: 'CI Run', body: 'Continuous Integration') }
+      let(:params) { message_params.slice(:subject, :category, :recipient_id, :body) }
+      let(:params_with_attachments) { { message: params }.merge(uploads: uploads) }
+
+      context 'message' do
+        it 'without attachments' do
+          VCR.use_cassette('sm_client/messages/creates/a_new_message_without_attachments') do
+            post '/mobile/v0/messaging/health/messages', headers: iam_headers, params: { message: params }
+          end
+
+          expect(response).to be_successful
+          expect(response.body).to be_a(String)
+          expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
+          expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
+          expect(response).to match_camelized_response_schema('message')
+        end
+
+        it 'with attachments' do
+          VCR.use_cassette('sm_client/messages/creates/a_new_message_with_4_attachments') do
+            post '/mobile/v0/messaging/health/messages', headers: iam_headers, params: params_with_attachments
+          end
+
+          expect(response).to be_successful
+          expect(response.body).to be_a(String)
+          expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
+          expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
+          expect(response).to match_camelized_response_schema('message_with_attachment')
+        end
+      end
+
+      context 'reply' do
+        let(:reply_message_id) { 674_838 }
+
+        it 'without attachments' do
+          VCR.use_cassette('sm_client/messages/creates/a_reply_without_attachments') do
+            post "/mobile/v0/messaging/health/messages/#{reply_message_id}/reply",
+                 headers: iam_headers, params: { message: params }
+          end
+
+          expect(response).to be_successful
+          expect(response.body).to be_a(String)
+          expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
+          expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
+          expect(response).to match_camelized_response_schema('message')
+        end
+
+        it 'with attachments' do
+          VCR.use_cassette('sm_client/messages/creates/a_reply_with_4_attachments') do
+            post "/mobile/v0/messaging/health/messages/#{reply_message_id}/reply",
+                 headers: iam_headers, params: params_with_attachments
+          end
+
+          expect(response).to be_successful
+          expect(response.body).to be_a(String)
+          expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('CI Run')
+          expect(JSON.parse(response.body)['data']['attributes']['body']).to eq('Continuous Integration')
+          expect(response).to match_camelized_response_schema('message_with_attachment')
+        end
+      end
+    end
+
+    describe '#thread' do
+      let(:thread_id) { 573_059 }
+
+      it 'responds to GET #thread' do
+        VCR.use_cassette('sm_client/messages/gets_a_message_thread') do
+          get "/mobile/v0/messaging/health/messages/#{thread_id}/thread", headers: iam_headers
+        end
+
+        expect(response).to be_successful
+        expect(response.body).to be_a(String)
+        expect(response).to match_camelized_response_schema('messages_thread')
+      end
+    end
+
+    describe '#destroy' do
+      let(:message_id) { 573_052 }
+
+      it 'responds to DELETE' do
+        VCR.use_cassette('sm_client/messages/deletes_the_message_with_id') do
+          delete "/mobile/v0/messaging/health/messages/#{message_id}", headers: iam_headers
+        end
+
+        expect(response).to be_successful
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    describe '#move' do
+      let(:message_id) { 573_052 }
+
+      it 'responds to PATCH messages/move' do
+        VCR.use_cassette('sm_client/messages/moves_a_message_with_id') do
+          patch "/mobile/v0/messaging/health/messages/#{message_id}/move?folder_id=0", headers: iam_headers
+        end
+
+        expect(response).to be_successful
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+  end
+end

--- a/modules/mobile/spec/request/triage_teams_request_spec.rb
+++ b/modules/mobile/spec/request/triage_teams_request_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../support/iam_session_helper'
+require_relative '../support/mobile_sm_client_helper'
+
+RSpec.describe 'Mobile Triage Teams Integration', type: :request do
+  include Mobile::MessagingClientHelper
+  include SchemaMatchers
+
+  let(:va_patient) { true }
+  # let(:current_user) { build(:user, :mhv, va_patient: va_patient, mhv_account_type: mhv_account_type) }
+
+  before do
+    allow_any_instance_of(MHVAccountTypeService).to receive(:mhv_account_type).and_return(mhv_account_type)
+    allow(Mobile::V0::Messaging::Client).to receive(:new).and_return(authenticated_client)
+    iam_sign_in(build(:iam_user, iam_mhv_id: '123'))
+  end
+
+  context 'Premium User' do
+    let(:mhv_account_type) { 'Premium' }
+
+    context 'not a va patient' do
+      before { get '/mobile/v0/messaging/health/recipients', headers: iam_headers }
+
+      let(:va_patient) { false }
+    end
+
+    it 'responds to GET #index' do
+      VCR.use_cassette('sm_client/triage_teams/gets_a_collection_of_triage_team_recipients') do
+        get '/mobile/v0/messaging/health/recipients', headers: iam_headers
+      end
+
+      expect(response).to be_successful
+      expect(response.body).to be_a(String)
+      expect(response).to match_camelized_response_schema('triage_teams')
+    end
+  end
+
+  context 'Advanced User' do
+    let(:mhv_account_type) { 'Advanced' }
+
+    it 'is not authorized' do
+      get '/mobile/v0/messaging/health/recipients', headers: iam_headers
+      expect(response).not_to be_successful
+      expect(response.status).to eq(403)
+    end
+  end
+
+  context 'Basic User' do
+    let(:mhv_account_type) { 'Basic' }
+
+    it 'is not authorized' do
+      get '/mobile/v0/messaging/health/recipients', headers: iam_headers
+      expect(response).not_to be_successful
+      expect(response.status).to eq(403)
+    end
+  end
+end

--- a/modules/mobile/spec/support/mobile_sm_client_helper.rb
+++ b/modules/mobile/spec/support/mobile_sm_client_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'mobile/v0/messaging/client'
+
+module Mobile
+  module MessagingClientHelper
+    TOKEN = 'GkuX2OZ4dCE=48xrH6ObGXZ45ZAg70LBahi7CjswZe8SZGKMUVFIU88='
+
+    def authenticated_client
+      Mobile::V0::Messaging::Client.new(session: { user_id: 123,
+                                                   expires_at: Time.current + 60 * 60,
+                                                   token: TOKEN })
+    end
+  end
+end


### PR DESCRIPTION
*Note: chained PR on top of https://github.com/department-of-veterans-affairs/vets-api/pull/5933  which is on top of https://github.com/department-of-veterans-affairs/vets-api/pull/5929*

Will rebase  this as those PRs are merged, which should make it only require mobile-team review.

## Description of change
Adds secure-messaging Mobile API routes/controllers/serializers. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR

<!-- Please describe testing done to verify the changes or any testing planned. -->
