### PR TITLE
Removed OMB/Expiration date feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -359,11 +359,6 @@ features:
     enable_in_development: true
     description: >
       Add automated decision to 10203 application workflow
-  edu_form_omb_and_expiration:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Update OMB # and expiration dates for forms
   in_progress_form_custom_expiration:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Description
As a developer, I need to remove the 'edu_form_omb_and_expiration' feature flag toggle so that it is no longer configurable, and the new functionality is permanent.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/18294

Front End PR: https://github.com/department-of-veterans-affairs/vets-website/pull/16080

## Testing done

Check the OMB / expiration details of each page 
http://localhost:3001/education/apply-for-education-benefits/application/1990/introduction

http://localhost:3001/education/apply-for-education-benefits/application/1990E/introduction

http://localhost:3001/education/apply-for-education-benefits/application/1990N/introduction

http://localhost:3001/education/apply-for-education-benefits/application/5495/introduction

## Screenshots


## Acceptance criteria
- [x] The usage of feature flag 'edu_form_omb_and_expiration' is removed.
- [x] The feature flag is 'off' when displayed here: https://[environment]-api.va.gov/flipper/features.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
