### PR TITLE
Mobile appointment address bug fix

### DIFF
--- a/modules/mobile/app/models/mobile/v0/appointment.rb
+++ b/modules/mobile/app/models/mobile/v0/appointment.rb
@@ -46,9 +46,13 @@ module Mobile
       attribute :time_zone, TIME_ZONE_TYPE
 
       def self.toggle_non_prod_id!(id)
-        return id if Settings.hostname == 'www.va.gov' || !%w[442 552 983 984].include?(id)
-        return (%w[442 983] - [id]).first if %w[442 983].include? id
-        return (%w[552 984] - [id]).first if %w[552 984].include? id
+        return id if Settings.hostname == 'www.va.gov'
+        
+        match = id.match /\A(983|984|552|442)/
+        return id unless match
+        
+        return id.sub(match[0], (%w[442 983] - [id]).first) if %w[442 983].include? match[0]
+        return id.sub(match[0], (%w[552 984] - [id]).first) if %w[552 984].include? match[0]
       end
     end
   end

--- a/modules/mobile/app/models/mobile/v0/appointment.rb
+++ b/modules/mobile/app/models/mobile/v0/appointment.rb
@@ -47,10 +47,10 @@ module Mobile
 
       def self.toggle_non_prod_id!(id)
         return id if Settings.hostname == 'www.va.gov'
-        
-        match = id.match /\A(983|984|552|442)/
+
+        match = id.match(/\A(983|984|552|442)/)
         return id unless match
-        
+
         return id.sub(match[0], (%w[442 983] - [id]).first) if %w[442 983].include? match[0]
         return id.sub(match[0], (%w[552 984] - [id]).first) if %w[552 984].include? match[0]
       end

--- a/modules/mobile/spec/models/appointment_spec.rb
+++ b/modules/mobile/spec/models/appointment_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mobile::V0::Appointment, type: :model do
+  describe '.toggle_non_prod_id!' do
+    it 'toggles mocked ids to real ones' do
+      expect(Mobile::V0::Appointment.toggle_non_prod_id!('983')).to eq('442')
+    end
+
+    it 'toggles real ids back to mocked ones' do
+      expect(Mobile::V0::Appointment.toggle_non_prod_id!('442')).to eq('983')
+    end
+
+    it 'keeps secondary identifiers' do
+      expect(Mobile::V0::Appointment.toggle_non_prod_id!('983GC')).to eq('442GC')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Fixed a bug where ids with secondary appointment facility identifiers where not toggled correctly in staging because only the main clinic's id was being returned.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#14965

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
