### PR TITLE
form526: updated rated disabilities location

### DIFF
--- a/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
@@ -24,7 +24,7 @@ module V0
       if rated_disabilities_evss.present? &&
          names_arr(prased_form_data.dig('ratedDisabilities')) != names_arr(rated_disabilities_evss.rated_disabilities)
         if prased_form_data['ratedDisabilities'].present? &&
-           prased_form_data.dig("view:claimType","view:claimingIncrease")
+           prased_form_data.dig('view:claimType', 'view:claimingIncrease')
           metadata['returnUrl'] = '/disabilities/rated-disabilities'
         end
         evss_rated_disabilites = JSON.parse(rated_disabilities_evss.rated_disabilities.to_json)

--- a/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
@@ -23,11 +23,8 @@ module V0
       # If EVSS's list of rated disabilties does not match our prefilled rated disabilites
       if rated_disabilities_evss.present? &&
          names_arr(prased_form_data.dig('ratedDisabilities')) != names_arr(rated_disabilities_evss.rated_disabilities)
-        # If the user has viewed the rated disabiltiy page the form data ratedDisabilities will have a "view:selected"
-        # key if they've gotten to the ratedDisabilities page or further send them back to the ratedDisabilities page
-        # when the list of rated disabilities is updated.
         if prased_form_data['ratedDisabilities'].present? &&
-           prased_form_data['ratedDisabilities'][0].keys.include?('view:selected')
+           prased_form_data.dig("view:claimType","view:claimingIncrease")
           metadata['returnUrl'] = '/disabilities/rated-disabilities'
         end
         evss_rated_disabilites = JSON.parse(rated_disabilities_evss.rated_disabilities.to_json)


### PR DESCRIPTION
## Description of change
rather than checking if a veteran has seen the rated disabilities page, check if they have selected any rated disabilities for increase before sending them back to that page if the list has updated.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18681

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
