### PR TITLE
fetch access tokens from health and pgd api

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -721,12 +721,34 @@ hqva_mobile:
   lighthouse:
     url: "https://sandbox-api.va.gov"
     pgd_path: "/services/pgd/v0/r4"
+    pgd_token_path: "/oauth2/pgd/v1/token"
+    health_api_path: "/services/fhir/v0/r4"
+    health_token_path: "/oauth2/health/system/v1/token"
     host: "sandbox-api.va.gov"
-    aud_claim_url: "https://deptva-eval.okta.com/oauth2/aus8x27nv4g4BS01v2p7"
+    pgd_aud_claim_url: "https://deptva-eval.okta.com/oauth2/aus8x27nv4g4BS01v2p7"
+    health_aud_claim_url: "https://deptva-eval.okta.com/oauth2/aus8nm1q0f7VQ0a482p7"
     claim_common_id: "0oa9gvwf5mvxcX3zH2p7"
+    grant_type: "client_credentials"
+    client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
     redis_session_prefix: "healthquest_lighthouse"
+    health_api: "health_api"
+    pgd_api: "pgd_api"
     mock: false
     key_path: /srv/vets-api/secret/health-quest.lighthouse.key
+    pgd_api_scopes:
+      - "launch/patient"
+      - "patient/Observation.read"
+      - "patient/Observation.write"
+      - "patient/Questionnaire.read"
+      - "patient/Questionnaire.write"
+      - "patient/QuestionnaireResponse.read"
+      - "patient/QuestionnaireResponse.write"
+    health_api_scopes:
+      - "launch/patient"
+      - "patient/Appointment.read"
+      - "patient/Location.read"
+      - "patient/Organization.read"
+      - "patient/Patient.read"
 
 lighthouse:
   api_key: fake_key

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -106,9 +106,31 @@ hqva_mobile:
   lighthouse:
     url: "https://sandbox-api.va.gov"
     pgd_path: "/services/pgd/v0/r4"
+    pgd_token_path: "/oauth2/pgd/v1/token"
+    health_api_path: "/services/fhir/v0/r4"
+    health_token_path: "/oauth2/health/system/v1/token"
     host: "sandbox-api.va.gov"
-    aud_claim_url: "https://deptva-eval.okta.com/oauth2/aus8x27nv4g4BS01v2p7"
+    pgd_aud_claim_url: "https://deptva-eval.okta.com/oauth2/aus8x27nv4g4BS01v2p7"
+    health_aud_claim_url: "https://deptva-eval.okta.com/oauth2/aus8nm1q0f7VQ0a482p7"
     claim_common_id: "0oa9gvwf5mvxcX3zH2p7"
+    grant_type: "client_credentials"
+    client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
     redis_session_prefix: "healthquest_lighthouse"
+    health_api: "health_api"
+    pgd_api: "pgd_api"
     mock: false
     key_path: modules/health_quest/config/rsa/sandbox_rsa
+    pgd_api_scopes:
+      - "launch/patient"
+      - "patient/Observation.read"
+      - "patient/Observation.write"
+      - "patient/Questionnaire.read"
+      - "patient/Questionnaire.write"
+      - "patient/QuestionnaireResponse.read"
+      - "patient/QuestionnaireResponse.write"
+    health_api_scopes:
+      - "launch/patient"
+      - "patient/Appointment.read"
+      - "patient/Location.read"
+      - "patient/Organization.read"
+      - "patient/Patient.read"

--- a/modules/health_quest/app/services/health_quest/health_api/patient/factory.rb
+++ b/modules/health_quest/app/services/health_quest/health_api/patient/factory.rb
@@ -27,7 +27,7 @@ module HealthQuest
 
         def initialize(user)
           @user = user
-          @session_service = HealthQuest::Lighthouse::Session.build(user)
+          @session_service = HealthQuest::Lighthouse::Session.build(user: user, api: health_api)
           @map_query = HealthApi::Patient::MapQuery.build(session_service.retrieve)
         end
 
@@ -47,6 +47,12 @@ module HealthQuest
         #
         def create
           map_query.create(user)
+        end
+
+        private
+
+        def health_api
+          Settings.hqva_mobile.lighthouse.health_api
         end
       end
     end

--- a/modules/health_quest/app/services/health_quest/lighthouse/claims_token.rb
+++ b/modules/health_quest/app/services/health_quest/lighthouse/claims_token.rb
@@ -10,13 +10,20 @@ module HealthQuest
       SIGNING_ALGORITHM = 'RS512'
       TOKEN_PATH = '/v1/token'
 
+      attr_reader :api
+
       ##
       # Builds a Lighthouse::ClaimsToken instance
       #
+      # @param api [String] the Lighthouse api
       # @return [Lighthouse::ClaimsToken] an instance of this class
       #
-      def self.build
-        new
+      def self.build(api:)
+        new(api: api)
+      end
+
+      def initialize(opts)
+        @api = opts[:api]
       end
 
       ##
@@ -28,11 +35,14 @@ module HealthQuest
         JWT.encode(claims, rsa_key, signing_algorithm)
       end
 
-      private
-
+      ##
+      # Builds the claims hash for the `sign_assertion` method
+      #
+      # @return [Hash]
+      #
       def claims
         {
-          aud: aud,
+          aud: aud[api],
           iss: iss,
           sub: sub,
           jti: random_uuid,
@@ -46,7 +56,10 @@ module HealthQuest
       end
 
       def aud
-        "#{lighthouse.aud_claim_url}#{TOKEN_PATH}"
+        {
+          'pgd_api' => "#{lighthouse.pgd_aud_claim_url}#{TOKEN_PATH}",
+          'health_api' => "#{lighthouse.health_aud_claim_url}#{TOKEN_PATH}"
+        }
       end
 
       def iss

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/factory.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/factory.rb
@@ -31,7 +31,7 @@ module HealthQuest
 
         def initialize(user)
           @user = user
-          @session_service = HealthQuest::Lighthouse::Session.build(user)
+          @session_service = HealthQuest::Lighthouse::Session.build(user: user, api: pgd_api)
           @map_query = PatientGeneratedData::Questionnaire::MapQuery.build(session_service.retrieve)
           @options_builder = OptionsBuilder
         end
@@ -66,6 +66,12 @@ module HealthQuest
         #
         def resource_name
           { resource_name: 'questionnaire' }
+        end
+
+        private
+
+        def pgd_api
+          Settings.hqva_mobile.lighthouse.pgd_api
         end
       end
     end

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/factory.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/factory.rb
@@ -29,7 +29,7 @@ module HealthQuest
 
         def initialize(user)
           @user = user
-          @session_service = HealthQuest::Lighthouse::Session.build(user)
+          @session_service = HealthQuest::Lighthouse::Session.build(user: user, api: pgd_api)
           @map_query = PatientGeneratedData::QuestionnaireResponse::MapQuery.build(session_service.retrieve)
           @options_builder = OptionsBuilder
         end
@@ -74,6 +74,12 @@ module HealthQuest
         #
         def resource_name
           { resource_name: 'questionnaire_response' }
+        end
+
+        private
+
+        def pgd_api
+          Settings.hqva_mobile.lighthouse.pgd_api
         end
       end
     end

--- a/modules/health_quest/spec/services/health_api/patient/factory_spec.rb
+++ b/modules/health_quest/spec/services/health_api/patient/factory_spec.rb
@@ -7,11 +7,13 @@ describe HealthQuest::HealthApi::Patient::Factory do
 
   let(:user) { double('User', icn: '1008596379V859838') }
   let(:session_store) { double('SessionStore', token: '123abc') }
-  let(:session_service) { double('HealthQuest::Lighthouse::Session', user: user, retrieve: session_store) }
+  let(:session_service) do
+    double('HealthQuest::Lighthouse::Session', user: user, api: 'pgd_api', retrieve: session_store)
+  end
   let(:client_reply) { double('FHIR::ClientReply') }
 
   before do
-    allow(HealthQuest::Lighthouse::Session).to receive(:build).with(user).and_return(session_service)
+    allow(HealthQuest::Lighthouse::Session).to receive(:build).and_return(session_service)
   end
 
   describe '#get' do

--- a/modules/health_quest/spec/services/lighthouse/claims_token_spec.rb
+++ b/modules/health_quest/spec/services/lighthouse/claims_token_spec.rb
@@ -19,21 +19,45 @@ describe HealthQuest::Lighthouse::ClaimsToken do
     end
   end
 
+  describe 'attributes' do
+    it 'responds to api' do
+      expect(subject.build(api: '').respond_to?(:api)).to be(true)
+    end
+  end
+
   describe '.build' do
     it 'returns an instance of ClaimsToken' do
-      expect(subject.build).to be_an_instance_of(HealthQuest::Lighthouse::ClaimsToken)
+      expect(subject.build(api: 'pgd_api')).to be_an_instance_of(HealthQuest::Lighthouse::ClaimsToken)
     end
   end
 
   describe '#sign_assertion' do
     it 'is a String' do
-      expect(subject.build.sign_assertion).to be_a(String)
+      expect(subject.build(api: 'pgd_api').sign_assertion).to be_a(String)
     end
 
     it 'decoded jwt token has a set of keys' do
-      signed_claims = subject.build.sign_assertion
+      signed_claims = subject.build(api: 'pgd_api').sign_assertion
 
       expect(JWT.decode(signed_claims, nil, false).first.keys.sort).to eq(%w[aud exp iat iss jti sub])
+    end
+  end
+
+  describe '#claims' do
+    context 'when pgd_api' do
+      it 'aud points to pgd api' do
+        aud_url = 'https://deptva-eval.okta.com/oauth2/aus8x27nv4g4BS01v2p7/v1/token'
+
+        expect(subject.build(api: 'pgd_api').claims[:aud]).to eq(aud_url)
+      end
+    end
+
+    context 'when health_api' do
+      it 'aud points to health api' do
+        aud_url = 'https://deptva-eval.okta.com/oauth2/aus8nm1q0f7VQ0a482p7/v1/token'
+
+        expect(subject.build(api: 'health_api').claims[:aud]).to eq(aud_url)
+      end
     end
   end
 end

--- a/modules/health_quest/spec/services/lighthouse/session_spec.rb
+++ b/modules/health_quest/spec/services/lighthouse/session_spec.rb
@@ -8,7 +8,11 @@ describe HealthQuest::Lighthouse::Session do
   let(:user) { double('User', account_uuid: 'abc123', icn: '1008596379V859838') }
 
   describe 'attributes' do
-    let(:session) { subject.build(user) }
+    let(:session) { subject.build(user: user, api: 'pgd_api') }
+
+    it 'responds to api' do
+      expect(session.respond_to?(:api)).to be(true)
+    end
 
     it 'responds to user' do
       expect(session.respond_to?(:user)).to be(true)
@@ -29,7 +33,7 @@ describe HealthQuest::Lighthouse::Session do
 
   describe '.build' do
     it 'returns an instance of Session' do
-      expect(subject.build(user)).to be_an_instance_of(HealthQuest::Lighthouse::Session)
+      expect(subject.build(user: user, api: 'pgd_api')).to be_an_instance_of(HealthQuest::Lighthouse::Session)
     end
   end
 
@@ -40,7 +44,7 @@ describe HealthQuest::Lighthouse::Session do
       it 'returns existing session' do
         allow_any_instance_of(subject).to receive(:session_from_redis).and_return('existing_session_123')
 
-        expect(subject.build(user).retrieve).to eq('existing_session_123')
+        expect(subject.build(user: user, api: 'pgd_api').retrieve).to eq('existing_session_123')
       end
     end
 
@@ -49,7 +53,7 @@ describe HealthQuest::Lighthouse::Session do
         allow_any_instance_of(subject).to receive(:session_from_redis).and_return(nil)
         allow_any_instance_of(subject).to receive(:establish_lighthouse_session).and_return(session_store)
 
-        expect(subject.build(user).retrieve).to eq(session_store)
+        expect(subject.build(user: user, api: 'pgd_api').retrieve).to eq(session_store)
       end
     end
   end
@@ -61,7 +65,7 @@ describe HealthQuest::Lighthouse::Session do
       it 'returns an instance of SessionStore' do
         allow(HealthQuest::SessionStore).to receive(:find).with(anything).and_return(session_store)
 
-        expect(subject.build(user).session_from_redis).to eq(session_store)
+        expect(subject.build(user: user, api: 'pgd_api').session_from_redis).to eq(session_store)
       end
     end
 
@@ -69,18 +73,18 @@ describe HealthQuest::Lighthouse::Session do
       it 'returns nil' do
         allow(HealthQuest::SessionStore).to receive(:find).with(anything).and_return(nil)
 
-        expect(subject.build(user).session_from_redis).to eq(nil)
+        expect(subject.build(user: user, api: 'pgd_api').session_from_redis).to eq(nil)
       end
     end
   end
 
   describe '#lighthouse_access_token' do
-    let(:token) { HealthQuest::Lighthouse::Token.build(user: user) }
+    let(:token) { HealthQuest::Lighthouse::Token.build(user: user, api: 'pgd_api') }
 
     it 'returns a Token instance' do
       allow_any_instance_of(HealthQuest::Lighthouse::Token).to receive(:fetch).and_return(token)
 
-      expect(subject.build(user).lighthouse_access_token).to eq(token)
+      expect(subject.build(user: user, api: 'pgd_api').lighthouse_access_token).to eq(token)
     end
   end
 
@@ -90,7 +94,25 @@ describe HealthQuest::Lighthouse::Session do
     it 'returns a session store' do
       allow_any_instance_of(subject).to receive(:lighthouse_access_token).and_return(token)
 
-      expect(subject.build(user).establish_lighthouse_session).to be_a(HealthQuest::SessionStore)
+      expect(subject.build(user: user, api: 'pgd_api').establish_lighthouse_session).to be_a(HealthQuest::SessionStore)
+    end
+  end
+
+  describe '#session_id' do
+    context 'when pgd_api' do
+      it 'builds a pgd session_id' do
+        pgd_session_id = 'healthquest_lighthouse_pgd_api_abc123'
+
+        expect(subject.build(user: user, api: 'pgd_api').session_id).to eq(pgd_session_id)
+      end
+    end
+
+    context 'when health_api' do
+      it 'builds a health session_id' do
+        health_session_id = 'healthquest_lighthouse_health_api_abc123'
+
+        expect(subject.build(user: user, api: 'health_api').session_id).to eq(health_session_id)
+      end
     end
   end
 end

--- a/modules/health_quest/spec/services/patient_generated_data/questionnaire/factory_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/questionnaire/factory_spec.rb
@@ -7,11 +7,13 @@ describe HealthQuest::PatientGeneratedData::Questionnaire::Factory do
 
   let(:user) { double('User', icn: '1008596379V859838') }
   let(:session_store) { double('SessionStore', token: '123abc') }
-  let(:session_service) { double('HealthQuest::Lighthouse::Session', user: user, retrieve: session_store) }
+  let(:session_service) do
+    double('HealthQuest::Lighthouse::Session', user: user, api: 'pgd_api', retrieve: session_store)
+  end
   let(:client_reply) { double('FHIR::ClientReply') }
 
   before do
-    allow(HealthQuest::Lighthouse::Session).to receive(:build).with(user).and_return(session_service)
+    allow(HealthQuest::Lighthouse::Session).to receive(:build).and_return(session_service)
   end
 
   describe 'object initialization' do

--- a/modules/health_quest/spec/services/patient_generated_data/questionnaire_response/factory_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/questionnaire_response/factory_spec.rb
@@ -7,11 +7,13 @@ describe HealthQuest::PatientGeneratedData::QuestionnaireResponse::Factory do
 
   let(:user) { double('User', icn: '1008596379V859838') }
   let(:session_store) { double('SessionStore', token: '123abc') }
-  let(:session_service) { double('HealthQuest::Lighthouse::Session', user: user, retrieve: session_store) }
+  let(:session_service) do
+    double('HealthQuest::Lighthouse::Session', user: user, api: 'pgd_api', retrieve: session_store)
+  end
   let(:client_reply) { double('FHIR::ClientReply') }
 
   before do
-    allow(HealthQuest::Lighthouse::Session).to receive(:build).with(user).and_return(session_service)
+    allow(HealthQuest::Lighthouse::Session).to receive(:build).and_return(session_service)
   end
 
   describe 'object initialization' do

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -7,13 +7,15 @@ describe HealthQuest::QuestionnaireManager::Factory do
 
   let(:user) { double('User', icn: '1008596379V859838', account_uuid: 'abc123', uuid: '789defg') }
   let(:session_store) { double('SessionStore', token: '123abc') }
-  let(:session_service) { double('HealthQuest::Lighthouse::Session', user: user, retrieve: session_store) }
+  let(:session_service) do
+    double('HealthQuest::Lighthouse::Session', user: user, api: 'pgd_api', retrieve: session_store)
+  end
   let(:client_reply) { double('FHIR::ClientReply') }
   let(:default_appointments) { { data: [] } }
   let(:appointments) { { data: [{}, {}] } }
 
   before do
-    allow(HealthQuest::Lighthouse::Session).to receive(:build).with(user).and_return(session_service)
+    allow(HealthQuest::Lighthouse::Session).to receive(:build).and_return(session_service)
   end
 
   describe 'object initialization' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- The vets-api health-quest module will interact with two APIs in the Lighthouse: PGD and Health API.
- Health-quest module was already obtaining access_tokens from the PGD API and was getting and creating resources in that system.
- When Lighthouse introduced the new Health API, the health-quest module had to be modified to obtain access_tokens from this new service as well.
- In this PR, the vets-api health-quest module acquires the capability to fetch access_tokens from both the PGD and Health API services and hence have the authorization to make HTTP requests for resources from both Lighthouse services.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#19059

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature flag: show_healthcare_experience_questionnaire
- [x] Additions to settings.yml
- [x] Settings will vary by environment. New PR will be created to add those.  
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests are written and the entire test suite passing.