### PR TITLE
Add source and subject to questionnaire response

### DIFF
--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/resource.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/resource.rb
@@ -16,9 +16,9 @@ module HealthQuest
       #   @return [FHIR::Meta]
       # @!attribute data
       #   @return [Hash]
-      # @!attribute author_reference
+      # @!attribute source_reference
       #   @return [FHIR::Reference]
-      # @!attribute questionnaire_reference
+      # @!attribute subject_reference
       #   @return [FHIR::Reference]
       class Resource
         include Shared::IdentityMetaInfo
@@ -27,15 +27,21 @@ module HealthQuest
         #
         COMPLETED_STATUS = 'completed'
         ##
-        # Set the QuestionnaireResponse's subject use
-        #
-        SUBJECT_USE = 'usual'
-        ##
         # Set the default Questionnaire ID
         #
         DEFAULT_QUESTIONNAIRE_ID = '1776c749-91b8-4f33-bece-a5a72f3bb09b'
+        ##
+        # Set the default Questionnaire Title if one is not present
+        #
+        DEFAULT_QUESTIONNAIRE_TITLE = 'Pre-Visit Questionnaire'
 
-        attr_reader :user, :model, :identifier, :meta, :data, :author_reference, :questionnaire_reference
+        attr_reader :user,
+                    :model,
+                    :identifier,
+                    :meta,
+                    :data,
+                    :source_reference,
+                    :subject_reference
 
         ##
         # Builds a HealthApi::Patient::Resource instance from a given User
@@ -54,8 +60,8 @@ module HealthQuest
           @user = user
           @identifier = FHIR::Identifier.new
           @meta = FHIR::Meta.new
-          @author_reference = FHIR::Reference.new
-          @questionnaire_reference = FHIR::Reference.new
+          @source_reference = FHIR::Reference.new
+          @subject_reference = FHIR::Reference.new
         end
 
         ##
@@ -65,15 +71,15 @@ module HealthQuest
         #
         def prepare
           model.tap do |p|
-            p.identifier = set_identifiers
-            p.meta = set_meta
-            p.text = set_text
-            p.status = COMPLETED_STATUS
             p.authored = set_date
-            p.author = set_author
-            p.subject = set_subject
-            p.questionnaire = set_questionnaire
+            p.identifier = set_identifiers
             p.item = set_item
+            p.meta = set_meta
+            p.questionnaire = set_questionnaire
+            p.source = set_source
+            p.subject = set_subject
+            p.status = set_status
+            p.text = set_text
           end
         end
 
@@ -85,51 +91,57 @@ module HealthQuest
         def set_text
           {
             status: 'generated',
-            div: '<div><h1>Pre-Visit Questionnaire</h1></div>'
+            div: "<div><h1>#{questionnaire_title}</h1></div>"
           }
         end
 
         ##
-        # Sets the author reference for the FHIR::Reference object.
+        # Builds the subject reference.
         #
-        # @return [FHIR::Reference] a reference for the author
-        #
-        def set_author
-          author_reference.reference = "Patient/#{user.icn}"
-        end
-
-        ##
-        # Builds the subject hash attribute for the FHIR::QuestionnaireResponse object.
-        #
-        # @return [Hash] subject information
+        # @return [FHIR::Reference]
         #
         def set_subject
-          url = Settings.hqva_mobile.url
-          icn = user.icn
-          appointment_id = data[:appointment_id]
+          appointment_id = data.dig(:appointment, :id)
 
-          {
-            use: SUBJECT_USE,
-            value: "#{url}/appointments/v1/patients/#{icn}/Appointment/#{appointment_id}"
-          }
+          subject_reference.reference = "#{health_api_url_path}/Appointment/#{appointment_id}"
         end
 
         ##
-        # Sets the questionnaire reference for the FHIR::Reference object.
+        # Builds the source reference.
         #
-        # @return [FHIR::Reference] a reference for the questionnaire
+        # @return [FHIR::Reference]
+        #
+        def set_source
+          source_reference.reference = "#{health_api_url_path}/Patient/#{user.icn}"
+        end
+
+        ##
+        # Builds the questionnaire id.
+        #
+        # @return [String]
         #
         def set_questionnaire
-          questionnaire_reference.reference = "Questionnaire/#{DEFAULT_QUESTIONNAIRE_ID}"
+          questionnaire_id = data.dig(:questionnaire, :id) || DEFAULT_QUESTIONNAIRE_ID
+
+          "Questionnaire/#{questionnaire_id}"
         end
 
         ##
         # Builds the item array attribute for the FHIR::QuestionnaireResponse object.
         #
-        # @return [Array] item information
+        # @return [Array]
         #
         def set_item
           data[:item]
+        end
+
+        ##
+        # Returns the questionnaire's title.
+        #
+        # @return [String]
+        #
+        def questionnaire_title
+          data.dig(:questionnaire, :title) || DEFAULT_QUESTIONNAIRE_TITLE
         end
 
         ##
@@ -139,6 +151,15 @@ module HealthQuest
         #
         def set_date
           Time.zone.today.to_s
+        end
+
+        ##
+        # Returns the completed status.
+        #
+        # @return [String]
+        #
+        def set_status
+          COMPLETED_STATUS
         end
 
         ##
@@ -157,6 +178,15 @@ module HealthQuest
         #
         def identifier_code
           'QuestionnaireResponseID'
+        end
+
+        private
+
+        def health_api_url_path
+          url = Settings.hqva_mobile.lighthouse.url
+          health_api_path = Settings.hqva_mobile.lighthouse.health_api_path
+
+          "#{url}#{health_api_path}"
         end
       end
     end

--- a/modules/health_quest/app/services/health_quest/shared/identity_meta_info.rb
+++ b/modules/health_quest/app/services/health_quest/shared/identity_meta_info.rb
@@ -14,11 +14,11 @@ module HealthQuest
       ##
       # Operation Resource meta tag for the FHIR::Meta object
       #   VA URI
-      META_SYSTEM = 'https://wiki.mobilehealth.va.gov/display/PGDMS/Client+Provenance+Mapping'
+      META_SYSTEM = 'https://api.va.gov/services/pgd'
       ##
       # Operation Resource meta tag for the FHIR::Meta object
       #   VA identifier
-      META_CODE = 'vagov-a0e116eb-faa1-4703-aafe-1a270128607a'
+      META_CODE = '66a5960c-68ee-4689-88ae-4c7cccf7ca79'
       ##
       # Operation Resource meta tag for the FHIR::Meta object
       #   VA application identifier

--- a/modules/health_quest/spec/services/shared/identity_meta_info_spec.rb
+++ b/modules/health_quest/spec/services/shared/identity_meta_info_spec.rb
@@ -54,11 +54,11 @@ describe HealthQuest::Shared::IdentityMetaInfo do
     end
 
     it 'has a META_SYSTEM' do
-      expect(subject::META_SYSTEM).to eq('https://wiki.mobilehealth.va.gov/display/PGDMS/Client+Provenance+Mapping')
+      expect(subject::META_SYSTEM).to eq('https://api.va.gov/services/pgd')
     end
 
     it 'has a META_CODE' do
-      expect(subject::META_CODE).to eq('vagov-a0e116eb-faa1-4703-aafe-1a270128607a')
+      expect(subject::META_CODE).to eq('66a5960c-68ee-4689-88ae-4c7cccf7ca79')
     end
 
     it 'has a META_DISPLAY' do
@@ -71,8 +71,8 @@ describe HealthQuest::Shared::IdentityMetaInfo do
       meta_hash = {
         'tag' => [
           {
-            system: 'https://wiki.mobilehealth.va.gov/display/PGDMS/Client+Provenance+Mapping',
-            code: 'vagov-a0e116eb-faa1-4703-aafe-1a270128607a',
+            system: 'https://api.va.gov/services/pgd',
+            code: '66a5960c-68ee-4689-88ae-4c7cccf7ca79',
             display: 'VA GOV CLIPBOARD'
           }
         ]


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- This PR implements the code which sets an `Appointments` reference URL in the Questionnaire Response's `subject` field and **also** sets the `Patient's` reference URL in the Questionnaire Response's `source` field.
- We're removing the code which was setting the `author` field since it's not a requirement by the Lighthouse PGD.
- The `questionnaire` field is being set directly as a string value instead of as a reference.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#19209

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature Flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests were written and the suite is all green