### PR TITLE
Removed gibctBenefitFilterEnhancement from features.yml

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -296,10 +296,6 @@ features:
     actor_type: user
     description: >
       This will show the Cerner facility 757 as `isCerner`.
-  gibct_benefit_filter_enhancement:
-    actor_type: user
-    description: >
-      Comparison Tool Search Results Benefit UI Enhancements to improve usability
   gibct_school_ratings:
     actor_type: user
     description: >


### PR DESCRIPTION
## Description
As a developer, I need to remove the 'gibctBenefitFilterEnhancement' feature flag toggle and related functionality so that dead code is no longer in the codebase.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13364

Frontend PR: https://github.com/department-of-veterans-affairs/vets-website/pull/16112
## Testing done
local testing

## Screenshots
![Screen Shot 2021-02-19 at 1 25 31 PM](https://user-images.githubusercontent.com/50601724/108545651-0d702600-72b6-11eb-97b4-a71acfb368da.png)
![Screen Shot 2021-02-19 at 1 25 17 PM](https://user-images.githubusercontent.com/50601724/108545656-0ea15300-72b6-11eb-928d-78f229bbd462.png)
![Screen Shot 2021-02-19 at 1 17 37 PM](https://user-images.githubusercontent.com/50601724/108545664-1103ad00-72b6-11eb-8aba-939218aa94fe.png)

## Acceptance criteria
- [x] The feature flag 'gibctBenefitFilterEnhancement' is removed.
- [x] The feature flag is not displayed here: https://[environment]-api.va.gov/flipper/features.
- [x] The functionality shown in SA1 is removed from staging and matches current production functionality.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
