### PR TITLE
move options_builder to shared folder

### DIFF
--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/factory.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire/factory.rb
@@ -15,7 +15,7 @@ module HealthQuest
       # @!attribute map_query
       #   @return [PatientGeneratedData::Questionnaire::MapQuery]
       # @!attribute options_builder
-      #   @return [PatientGeneratedData::Questionnaire::OptionsBuilder]
+      #   @return [Shared::OptionsBuilder]
       class Factory
         attr_reader :session_service, :user, :map_query, :options_builder
 
@@ -33,7 +33,7 @@ module HealthQuest
           @user = user
           @session_service = HealthQuest::Lighthouse::Session.build(user: user, api: pgd_api)
           @map_query = PatientGeneratedData::Questionnaire::MapQuery.build(session_service.retrieve)
-          @options_builder = OptionsBuilder
+          @options_builder = Shared::OptionsBuilder
         end
 
         ##

--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/factory.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/factory.rb
@@ -13,7 +13,7 @@ module HealthQuest
       # @!attribute map_query
       #   @return [PatientGeneratedData::QuestionnaireResponse::MapQuery]
       # @!attribute options_builder
-      #   @return [PatientGeneratedData::QuestionnaireResponse::OptionsBuilder]
+      #   @return [Shared::OptionsBuilder]
       class Factory
         attr_reader :session_service, :user, :map_query, :options_builder
 
@@ -31,7 +31,7 @@ module HealthQuest
           @user = user
           @session_service = HealthQuest::Lighthouse::Session.build(user: user, api: pgd_api)
           @map_query = PatientGeneratedData::QuestionnaireResponse::MapQuery.build(session_service.retrieve)
-          @options_builder = OptionsBuilder
+          @options_builder = Shared::OptionsBuilder
         end
 
         ##
@@ -48,7 +48,7 @@ module HealthQuest
         # Gets Questionnaire Responses from a given set of OptionsBuilder
         #
         # @param filters [Hash] the set of query options.
-        # @return [FHIR::QuestionnaireResponse::ClientReply] an instance of ClientReply
+        # @return [FHIR::ClientReply] an instance of ClientReply
         #
         def search(filters = {})
           filters.merge!(resource_name)

--- a/modules/health_quest/app/services/health_quest/shared/options_builder.rb
+++ b/modules/health_quest/app/services/health_quest/shared/options_builder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module HealthQuest
-  module PatientGeneratedData
+  module Shared
     ##
     # A search options hash builder for a FHIR::Client's search instance method.
     #
@@ -13,11 +13,11 @@ module HealthQuest
       attr_reader :user, :filters
 
       ##
-      # Builds a PatientGeneratedData::OptionsBuilder instance from a given User and Hash
+      # Builds a Shared::OptionsBuilder instance from a given User and Hash
       #
       # @param user [User] the currently logged in user.
-      # @param filters [PatientGeneratedData::QuestionnaireResponse::OptionsBuilder] the set of query options.
-      # @return [PatientGeneratedData::QuestionnaireResponse::Factory] an instance of this class
+      # @param filters [Hash] the set of query options.
+      # @return [Shared::OptionsBuilder] an instance of this class
       #
       def self.manufacture(user, filters)
         new(user, filters)
@@ -29,7 +29,7 @@ module HealthQuest
       end
 
       ##
-      # Build the options hash that will be used to query the PGD for resources.
+      # Build the options hash that will be used to query the lighthouse for resources.
       #
       # @return [Hash]
       #

--- a/modules/health_quest/spec/services/patient_generated_data/questionnaire/factory_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/questionnaire/factory_spec.rb
@@ -34,7 +34,7 @@ describe HealthQuest::PatientGeneratedData::Questionnaire::Factory do
 
   describe '#search' do
     let(:filters) { { resource_name: 'questionnaire', appointment_id: nil }.with_indifferent_access }
-    let(:options_builder) { HealthQuest::PatientGeneratedData::OptionsBuilder.manufacture(user, filters) }
+    let(:options_builder) { HealthQuest::Shared::OptionsBuilder.manufacture(user, filters) }
 
     it 'returns a ClientReply' do
       allow_any_instance_of(FHIR::Client).to receive(:search).with(anything, anything).and_return(client_reply)

--- a/modules/health_quest/spec/services/patient_generated_data/questionnaire_response/factory_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/questionnaire_response/factory_spec.rb
@@ -34,7 +34,7 @@ describe HealthQuest::PatientGeneratedData::QuestionnaireResponse::Factory do
 
   describe '#search' do
     let(:filters) { { resource_name: 'questionnaire_response', appointment_id: nil }.with_indifferent_access }
-    let(:options_builder) { HealthQuest::PatientGeneratedData::OptionsBuilder.manufacture(user, filters) }
+    let(:options_builder) { HealthQuest::Shared::OptionsBuilder.manufacture(user, filters) }
 
     it 'returns a ClientReply' do
       allow_any_instance_of(FHIR::Client).to receive(:search).with(anything, anything).and_return(client_reply)

--- a/modules/health_quest/spec/services/shared/options_builder_spec.rb
+++ b/modules/health_quest/spec/services/shared/options_builder_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe HealthQuest::PatientGeneratedData::OptionsBuilder do
+describe HealthQuest::Shared::OptionsBuilder do
   subject { described_class }
 
   let(:user) { double('User', icn: '1008596379V859838') }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- This pr moves the `options_builder.rb` class from inside the `patient_generated_data` folder into the `shared` folder. This way, services created within the `health_api` folder can also share the functionality provided by the `options_builder.rb` class: Build and return search parameters for either the Lighthouse `PGD` or `Health API`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19656

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature Flag: show_healthcare_experience_questionnaire

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests were written and the suite is passing