### PR TITLE
Hotfix for lib/apps/client.rb#get_app

### DIFF
--- a/lib/apps/client.rb
+++ b/lib/apps/client.rb
@@ -4,7 +4,7 @@ require 'common/client/base'
 require 'common/client/concerns/monitoring'
 require_relative 'configuration'
 require_relative 'responses/response'
-require 'cgi'
+require 'erb'
 
 module Apps
   # Proxy Service for Apps API.
@@ -37,7 +37,7 @@ module Apps
     #
     def get_app
       with_monitoring do
-        escaped_code = CGI.escape(@search_term)
+        escaped_code = ERB::Util.url_encode(@search_term)
         raw_response = perform(:get, "directory/#{escaped_code}", nil)
         Apps::Responses::Response.new(raw_response.status, raw_response.body, 'app')
       end

--- a/spec/lib/apps/client_spec.rb
+++ b/spec/lib/apps/client_spec.rb
@@ -30,6 +30,17 @@ describe Apps::Client do
         end
       end
     end
+
+    context 'with a query that includes whitespace' do
+      let(:search_term) { 'Apple Health' }
+
+      it 'returns an app response object' do
+        VCR.use_cassette('apps/200_apple_health_query', match_requests_on: %i[method path]) do
+          response = subject.get_app
+          expect(response).to be_a Apps::Responses::Response
+        end
+      end
+    end
   end
 
   describe '#get_scopes' do

--- a/spec/support/vcr_cassettes/apps/200_apple_health_query.yml
+++ b/spec/support/vcr_cassettes/apps/200_apple_health_query.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/services/apps/v0/directory/Apple%20Health
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Apikey:
+      - giraffescantdance
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Git-Sha:
+      - MISSING_GIT_REVISION
+      X-Github-Repository:
+      - https://github.com/department-of-veterans-affairs/vets-api
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"e09fabbee0deab443ad9ebfcae1ae941"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 87c6696a-8b8e-4cf2-abf7-8c6f1c633459
+      X-Runtime:
+      - '0.036470'
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJkYXRhIjp7ImlkIjoyMSwibmFtZSI6IkFwcGxlIEhlYWx0aCIsImxvZ29fdXJsIjoiaHR0cHM6Ly9kdnAtb2F1dGgtYXBwbGljYXRpb24tZGlyZWN0b3J5LWxvZ29zLnMzLXVzLWdvdi13ZXN0LTEuYW1hem9uYXdzLmNvbS9BcHBsZUhlYWx0aCtMb2dvKzEwMjR4MTAyNC5wbmciLCJhcHBfdHlwZSI6IlRoaXJkLVBhcnR5LU9BdXRoIiwic2VydmljZV9jYXRlZ29yaWVzIjpbIkhlYWx0aCJdLCJwbGF0Zm9ybXMiOlsiaU9TIl0sImFwcF91cmwiOiJodHRwczovL3d3dy5hcHBsZS5jb20vaW9zL2hlYWx0aC8iLCJkZXNjcmlwdGlvbiI6IldpdGggdGhlIEFwcGxlIEhlYWx0aCBhcHAsIHlvdSBjYW4gc2VlIGFsbCB5b3VyIGhlYWx0aCByZWNvcmRzIOKAlCBzdWNoIGFzIG1lZGljYXRpb25zLCBpbW11bml6YXRpb25zLCBsYWIgcmVzdWx0cywgYW5kIG1vcmUg4oCUIGluIG9uZSBwbGFjZS4gVGhlIEhlYWx0aCBhcHAgY29udGludWFsbHkgdXBkYXRlcyB0aGVzZSByZWNvcmRzIGdpdmluZyB5b3UgYWNjZXNzIHRvIGEgc2luZ2xlLCBpbnRlZ3JhdGVkIHNuYXBzaG90IG9mIHlvdXIgaGVhbHRoIHByb2ZpbGUgd2hlbmV2ZXIgeW91IHdhbnQsIHF1aWNrbHkgYW5kIHByaXZhdGVseS4gQWxsIEhlYWx0aCBSZWNvcmRzIGRhdGEgaXMgZW5jcnlwdGVkIGFuZCBwcm90ZWN0ZWQgd2l0aCB0aGUgdXNlcuKAmXMgaVBob25lIHBhc3Njb2RlLCBUb3VjaCBJRCBvciBGYWNlIElELiIsInByaXZhY3lfdXJsIjoiaHR0cHM6Ly93d3cuYXBwbGUuY29tL2xlZ2FsL3ByaXZhY3kvIiwidG9zX3VybCI6Imh0dHBzOi8vd3d3LmFwcGxlLmNvbS9sZWdhbC9zbGEvIiwiY3JlYXRlZF9hdCI6IjIwMjAtMTEtMTZUMTg6MDA6MTIuNjExWiIsInVwZGF0ZWRfYXQiOiIyMDIxLTAxLTExVDIyOjAzOjM5LjExM1oifX0=
+  recorded_at: Mon, 22 Feb 2021 18:31:01 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Originally the `get_app` method used `URI.escape` to handle a `search_term` with whitespace in it (IE: 'Apple Health'). Rubocop throws a deprecation error for `URI.escape` and suggests using `CGI.escape`. The test written for `get_app` used `iBlueButton` as the `search_term`, and therefor didn't catch the issue when replacing `URI.escape` with `CGI.escape`. When passing a `search_term` with whitespace in it , IE: `"Apple Health"`, `CGI.escape` parses that as "Apple+Health" instead of "Apple%20Health" as `URI.escape` did.

The method now uses `ERB::Util.url_encode`, which works as expected, and a test has been included to ensure it parses whitespace correctly.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
