### PR TITLE
set subject and source as references

### DIFF
--- a/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/resource.rb
+++ b/modules/health_quest/app/services/health_quest/patient_generated_data/questionnaire_response/resource.rb
@@ -102,8 +102,8 @@ module HealthQuest
         #
         def set_subject
           appointment_id = data.dig(:appointment, :id)
-
           subject_reference.reference = "#{health_api_url_path}/Appointment/#{appointment_id}"
+          subject_reference
         end
 
         ##
@@ -113,6 +113,7 @@ module HealthQuest
         #
         def set_source
           source_reference.reference = "#{health_api_url_path}/Patient/#{user.icn}"
+          source_reference
         end
 
         ##

--- a/modules/health_quest/spec/services/patient_generated_data/questionnaire_response/resource_spec.rb
+++ b/modules/health_quest/spec/services/patient_generated_data/questionnaire_response/resource_spec.rb
@@ -132,7 +132,7 @@ describe HealthQuest::PatientGeneratedData::QuestionnaireResponse::Resource do
       health_api_path = Settings.hqva_mobile.lighthouse.health_api_path
       appt_reference = "#{url}#{health_api_path}/Appointment/abc123"
 
-      expect(subject.manufacture(data, user).prepare.subject).to eq(appt_reference)
+      expect(subject.manufacture(data, user).prepare.subject.reference).to eq(appt_reference)
     end
 
     it 'has a source' do
@@ -140,7 +140,7 @@ describe HealthQuest::PatientGeneratedData::QuestionnaireResponse::Resource do
       health_api_path = Settings.hqva_mobile.lighthouse.health_api_path
       patient_reference = "#{url}#{health_api_path}/Patient/1008596379V859838"
 
-      expect(subject.manufacture(data, user).prepare.source).to eq(patient_reference)
+      expect(subject.manufacture(data, user).prepare.source.reference).to eq(patient_reference)
     end
 
     it 'has a questionnaire' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Questionnaire Response FHIR objects need to be created with `subject` and `source` fields set as `reference`s. This is a FHIR protocol requirement.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#19053

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature Flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec test suite passing