### PR TITLE
Requiring the specialties parameter for type=provider

### DIFF
--- a/app/controllers/v1/facilities/ccp_controller.rb
+++ b/app/controllers/v1/facilities/ccp_controller.rb
@@ -59,6 +59,22 @@ class V1::Facilities::CcpController < FacilitiesController
     )
   end
 
+  def ppms_provider_params
+    params.require(:type)
+    params.require(:specialties)
+    params.permit(
+      :address,
+      :latitude,
+      :longitude,
+      :page,
+      :per_page,
+      :radius,
+      :type,
+      bbox: [],
+      specialties: []
+    )
+  end
+
   def ppms_show_params
     params.permit(:id)
   end
@@ -67,16 +83,12 @@ class V1::Facilities::CcpController < FacilitiesController
     if ppms_params[:type] == 'provider' && ppms_params[:specialties] == ['261QU0200X']
       api.pos_locator(ppms_params)
     elsif ppms_params[:type] == 'provider'
-      provider_search
+      api.provider_locator(ppms_provider_params)
     elsif ppms_params[:type] == 'pharmacy'
-      provider_search(specialties: ['3336C0003X'])
+      api.provider_locator(ppms_params.merge(specialties: ['3336C0003X']))
     elsif ppms_params[:type] == 'urgent_care'
       api.pos_locator(ppms_params)
     end
-  end
-
-  def provider_search(options = {})
-    api.provider_locator(ppms_params.merge(options))
   end
 
   def resource_path(options)

--- a/spec/request/v1/facilities/ccp_request_spec.rb
+++ b/spec/request/v1/facilities/ccp_request_spec.rb
@@ -69,6 +69,34 @@ RSpec.describe 'Community Care Providers', type: :request, team: :facilities, vc
     end
 
     context 'type=provider' do
+      context 'Missing specialties param' do
+        let(:params) do
+          {
+            latitude: 40.415217,
+            longitude: -74.057114,
+            radius: 200,
+            type: 'provider'
+          }
+        end
+
+        it 'requires a specialty code' do
+          get '/v1/facilities/ccp', params: params
+
+          bod = JSON.parse(response.body)
+
+          expect(bod).to include(
+            'errors' => [{
+              'title' => 'Missing parameter',
+              'detail' => 'The required parameter "specialties", is missing',
+              'code' => '108',
+              'status' => '400'
+            }]
+          )
+
+          expect(response).not_to be_successful
+        end
+      end
+
       context 'specialties=261QU0200X' do
         let(:params) do
           {


### PR DESCRIPTION
PPMS doesn't require the specialties code but its absence causes
performance issues. A bug in the client code was preventing these
requests from going out. The bug was fixed exposing this issue.

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
The specialties parameter is used by PPMS to filter providers. by not requiring it we are requesting all providers in a given area.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19655

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
