### PR TITLE
Api 4765/add slack notification for sidekiq retries

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,7 @@
 
 require 'sidekiq_stats_instrumentation/client_middleware'
 require 'sidekiq_stats_instrumentation/server_middleware'
+require 'sidekiq/retry_monitoring'
 require 'sidekiq/error_tag'
 require 'sidekiq/semantic_logging'
 require 'sidekiq/set_request_id'
@@ -24,6 +25,7 @@ Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     chain.add Sidekiq::SemanticLogging
     chain.add SidekiqStatsInstrumentation::ServerMiddleware
+    chain.add Sidekiq::RetryMonitoring
     chain.add Sidekiq::ErrorTag
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -156,7 +156,9 @@ decision_review:
 
 # Settings for modules/appeals_api
 modules_appeals_api:
-  slack_sidekiq_webhook_creds: ''
+  slack:
+    api_token: ''
+    appeals_channel_id: ''
   documentation:
     notice_of_disagreements_v1: false
   higher_level_review_pii_expunge_enabled: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -156,6 +156,7 @@ decision_review:
 
 # Settings for modules/appeals_api
 modules_appeals_api:
+  slack_sidekiq_webhook_creds: ''
   documentation:
     notice_of_disagreements_v1: false
   higher_level_review_pii_expunge_enabled: true

--- a/lib/sidekiq/monitored_worker.rb
+++ b/lib/sidekiq/monitored_worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sidekiq
   module MonitoredWorker
     # this Module is to mark workers as monitored, allowing RetryMonitoring to

--- a/lib/sidekiq/monitored_worker.rb
+++ b/lib/sidekiq/monitored_worker.rb
@@ -1,0 +1,6 @@
+module Sidekiq
+  module MonitoredWorker
+    # this Module is to mark workers as monitored, allowing RetryMonitoring to
+    # check against it's existence.
+  end
+end

--- a/lib/sidekiq/retry_monitoring.rb
+++ b/lib/sidekiq/retry_monitoring.rb
@@ -13,7 +13,7 @@ module Sidekiq
     def should_notify?(worker, job)
       # retry_count is incremented after all middlewares are called
 
-      worker.is_a?(Sidekiq::RetryMonitoring::MonitoredWorker) &&
+      worker.is_a?(Sidekiq::MonitoredWorker) &&
         (Integer(job['retry_count']) + 1).in?(worker.retry_limits_for_notification)
     end
   end

--- a/lib/sidekiq/retry_monitoring.rb
+++ b/lib/sidekiq/retry_monitoring.rb
@@ -5,7 +5,7 @@ module Sidekiq
     def call(worker, params, _queue)
       worker.notify(params) if should_notify?(worker, params)
     rescue => e
-      Rails.logger.error e
+      ::Rails.logger.error e
     ensure
       yield
     end

--- a/lib/sidekiq/retry_monitoring.rb
+++ b/lib/sidekiq/retry_monitoring.rb
@@ -1,7 +1,7 @@
 module Sidekiq
   class RetryMonitoring
     def call(worker, params, _queue)
-      worker.notify(params['jid'], *params['args']) if should_notify?(worker, params)
+      worker.notify(params) if should_notify?(worker, params)
     rescue StandardError => e
       Rails.logger.error e
     ensure

--- a/lib/sidekiq/retry_monitoring.rb
+++ b/lib/sidekiq/retry_monitoring.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module Sidekiq
   class RetryMonitoring
     def call(worker, params, _queue)
       worker.notify(params) if should_notify?(worker, params)
-    rescue StandardError => e
+    rescue => e
       Rails.logger.error e
     ensure
       yield

--- a/lib/sidekiq/retry_monitoring/monitored_worker.rb
+++ b/lib/sidekiq/retry_monitoring/monitored_worker.rb
@@ -1,6 +1,0 @@
-module Sidekiq
-  module RetryMonitoring
-    module MonitoredWorker
-    end
-  end
-end

--- a/lib/sidekiq/retry_monitoring/monitored_worker.rb
+++ b/lib/sidekiq/retry_monitoring/monitored_worker.rb
@@ -1,0 +1,6 @@
+module Sidekiq
+  module RetryMonitoring
+    module MonitoredWorker
+    end
+  end
+end

--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -2,6 +2,7 @@
 
 require 'sidekiq'
 require 'appeals_api/upload_error'
+require 'appeals_api/sidekiq_retry_notifier'
 require 'central_mail/utilities'
 require 'central_mail/service'
 require 'pdf_info'
@@ -32,8 +33,8 @@ module AppealsApi
       [6, 10]
     end
 
-    def notify(job_id, param)
-      # SlackNotifier.new("HigherLevelReviewPdfSubmitJob has hit a retry threshold.")
+    def notify(retry_params)
+      SidekiqRetryNotifier.notify!(retry_params)
     end
 
     private

--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -5,11 +5,12 @@ require 'appeals_api/upload_error'
 require 'central_mail/utilities'
 require 'central_mail/service'
 require 'pdf_info'
+require 'sidekiq/monitored_worker'
 
 module AppealsApi
   class HigherLevelReviewPdfSubmitJob
     include Sidekiq::Worker
-    include Sidekiq::RetryMonitoring::MonitoredWorker
+    include Sidekiq::MonitoredWorker
     include CentralMail::Utilities
 
     def perform(higher_level_review_id, retries = 0)
@@ -27,15 +28,15 @@ module AppealsApi
       end
     end
 
-    private
-
     def retry_limits_for_notification
       [6, 10]
     end
 
     def notify(job_id, param)
-      SlackNotifier.new("HigherLevelReviewPdfSubmitJob has hit a retry threshold.")
+      # SlackNotifier.new("HigherLevelReviewPdfSubmitJob has hit a retry threshold.")
     end
+
+    private
 
     def upload_to_central_mail(higher_level_review, pdf_path)
       metadata = {

--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -34,7 +34,7 @@ module AppealsApi
     end
 
     def notify(retry_params)
-      SidekiqRetryNotifier.notify!(retry_params)
+      AppealsApi::SidekiqRetryNotifier.notify!(retry_params)
     end
 
     private

--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_upload_status_updater.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_upload_status_updater.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require 'sidekiq'
-include 'sidekiq/monitored_worker'
-include 'appeals_api/sidekiq_retry_notifier'
+require 'sidekiq/monitored_worker'
+require 'appeals_api/sidekiq_retry_notifier'
 
 module AppealsApi
   class HigherLevelReviewUploadStatusUpdater

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
@@ -2,13 +2,16 @@
 
 require 'sidekiq'
 require 'appeals_api/upload_error'
+require 'appeals_api/sidekiq_retry_notifier'
 require 'central_mail/utilities'
 require 'central_mail/service'
 require 'pdf_info'
+require 'sidekiq/monitored_worker'
 
 module AppealsApi
   class NoticeOfDisagreementPdfSubmitJob
     include Sidekiq::Worker
+    include Sidekiq::MonitoredWorker
     include CentralMail::Utilities
 
     def perform(id, retries = 0)
@@ -25,6 +28,16 @@ module AppealsApi
         raise
       end
     end
+
+    def retry_limits_for_notification
+      [6, 10]
+    end
+
+    def notify(retry_params)
+      SidekiqRetryNotifier.notify!(retry_params)
+    end
+
+    private
 
     def upload_to_central_mail(notice_of_disagreement, pdf_path)
       metadata = {

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_upload_status_updater.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_upload_status_updater.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require 'sidekiq'
+require 'sidekiq/monitored_worker'
+require 'appeals_api/sidekiq_retry_notifier'
 
 module AppealsApi
   class NoticeOfDisagreementUploadStatusUpdater
     include Sidekiq::Worker
+    include Sidekiq::MonitoredWorker
 
     # Only retry for ~30 minutes since the job that spawns this one runs every hour
     sidekiq_options retry: 5, unique_until: :success
@@ -14,6 +17,14 @@ module AppealsApi
       NoticeOfDisagreement.where(id: ids).find_in_batches(batch_size: batch_size) do |batch|
         CentralMailUpdater.new.call(batch)
       end
+    end
+
+    def retry_limits_for_notification
+      [6, 10]
+    end
+
+    def notify(retry_params)
+      SidekiqRetryNotifier.notify!(retry_params)
     end
   end
 end

--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -4,13 +4,16 @@ require 'common/client/base'
 
 module AppealsApi
   class SidekiqRetryNotifier
+    API_PATH = 'https://slack.com/api/chat.postMessage'
+
     class << self
       def notify!(params)
-        Faraday.post(slack_api_path) do |req|
-          req.headers['Content-Type'] = 'application/json'
-          req.headers['Authorization'] = 'application/json'
+        Faraday.post(API_PATH) do |req|
+          req.headers['Content-type'] = 'application/json; charset=utf-8'
+          req.headers['Authorization'] = "Bearer #{slack_api_token}"
           req.body = {
-            text: message_text(params)
+            text: message_text(params),
+            channel: slack_channel_id
           }.to_json
         end
       end
@@ -23,22 +26,14 @@ This job failed at: #{Time.zone.at(params['failed_at'])}, and was retried at: #{
         "''
       end
 
-      def slack_api_path
-        "#{base_path}/#{slack_team_id}/#{slack_channel_id}"
-      end
-
       private
 
-      def base_path
-        'https://slack.com/api/chat.postMessage'
-      end
-
-      def slack_team_id
-        Settings.modules_appeals_api.lighthouse_team_id
-      end
-
       def slack_channel_id
-        Settings.modules_appeals_api.appeals_channel_id
+        Settings.modules_appeals_api.slack.appeals_channel_id
+      end
+
+      def slack_api_token
+        Settings.modules_appeals_api.slack.api_token
       end
     end
   end

--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -4,7 +4,7 @@ require 'common/client/base'
 
 module AppealsApi
   class SidekiqRetryNotifier
-    WEBHOOK_URL = 'https://hooks.slack.com/services/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'
+    WEBHOOK_URL = "https://hooks.slack.com/services/#{Settings.modules_appeals_api.slack_sidekiq_webhook_creds}"
 
     def self.notify!(params)
       Faraday.post(WEBHOOK_URL, message_text(params))

--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -8,14 +8,7 @@ module AppealsApi
 
     class << self
       def notify!(params)
-        Faraday.post(API_PATH) do |req|
-          req.headers['Content-type'] = 'application/json; charset=utf-8'
-          req.headers['Authorization'] = "Bearer #{slack_api_token}"
-          req.body = {
-            text: message_text(params),
-            channel: slack_channel_id
-          }.to_json
-        end
+        Faraday.post(API_PATH, request_body(params), request_headers)
       end
 
       def message_text(params)
@@ -27,6 +20,20 @@ This job failed at: #{Time.zone.at(params['failed_at'])}, and was retried at: #{
       end
 
       private
+
+      def request_body(params)
+        {
+          text: message_text(params),
+          channel: slack_channel_id
+        }.to_json
+      end
+
+      def request_headers
+        {
+          'Content-type' => 'application/json; charset=utf-8',
+          'Authorization' => "Bearer #{slack_api_token}"
+        }
+      end
 
       def slack_channel_id
         Settings.modules_appeals_api.slack.appeals_channel_id

--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -1,21 +1,22 @@
-# frozen_string_literal
+# frozen_string_literal: true
 
 require 'common/client/base'
 
 module AppealsApi
   class SidekiqRetryNotifier
-
     WEBHOOK_URL = 'https://hooks.slack.com/services/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'
 
     def self.notify!(params)
       Faraday.post(WEBHOOK_URL, message_text(params))
     end
 
-    private
-
     def self.message_text(params)
       {
-        text: "The sidekiq job #{params['class']} has hit #{params['retry_count']} retries.\nError Type: #{params['error_class']} \n Error Message: \n #{params['error_message']} \n\nThis job failed at: #{Time.at(params['failed_at'])}, and was retried at: #{Time.at(params['retried_at'])}"
+        text: ''"
+        The sidekiq job #{params['class']} has hit #{params['retry_count']} retries.
+        \nError Type: #{params['error_class']} \n Error Message: \n #{params['error_message']} \n\n
+This job failed at: #{Time.zone.at(params['failed_at'])}, and was retried at: #{Time.zone.at(params['retried_at'])}
+        "''
       }.to_json
     end
   end

--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal
+
+require 'common/client/base'
+
+module AppealsApi
+  class SidekiqRetryNotifier
+
+    WEBHOOK_URL = 'https://hooks.slack.com/services/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'
+
+    def self.notify!(params)
+      Faraday.post(WEBHOOK_URL, message_text(params))
+    end
+
+    private
+
+    def self.message_text(params)
+      {
+        text: "The sidekiq job #{params['class']} has hit #{params['retry_count']} retries.\nError Type: #{params['error_class']} \n Error Message: \n #{params['error_message']} \n\nThis job failed at: #{Time.at(params['failed_at'])}, and was retried at: #{Time.at(params['retried_at'])}"
+      }.to_json
+    end
+  end
+end

--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -4,20 +4,42 @@ require 'common/client/base'
 
 module AppealsApi
   class SidekiqRetryNotifier
-    WEBHOOK_URL = "https://hooks.slack.com/services/#{Settings.modules_appeals_api.slack_sidekiq_webhook_creds}"
+    class << self
+      def notify!(params)
+        Faraday.post(slack_api_path) do |req|
+          req.headers['Content-Type'] = 'application/json'
+          req.headers['Authorization'] = 'application/json'
+          req.body = {
+            text: message_text(params)
+          }.to_json
+        end
+      end
 
-    def self.notify!(params)
-      Faraday.post(WEBHOOK_URL, message_text(params))
-    end
-
-    def self.message_text(params)
-      {
-        text: ''"
+      def message_text(params)
+        ''"
         The sidekiq job #{params['class']} has hit #{params['retry_count']} retries.
         \nError Type: #{params['error_class']} \n Error Message: \n #{params['error_message']} \n\n
 This job failed at: #{Time.zone.at(params['failed_at'])}, and was retried at: #{Time.zone.at(params['retried_at'])}
         "''
-      }.to_json
+      end
+
+      def slack_api_path
+        "#{base_path}/#{slack_team_id}/#{slack_channel_id}"
+      end
+
+      private
+
+      def base_path
+        'https://slack.com/api/chat.postMessage'
+      end
+
+      def slack_team_id
+        Settings.modules_appeals_api.lighthouse_team_id
+      end
+
+      def slack_channel_id
+        Settings.modules_appeals_api.appeals_channel_id
+      end
     end
   end
 end

--- a/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
+++ b/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
@@ -17,13 +17,11 @@ module AppealsApi
       end
 
       it 'sends a network request' do
-        text = SidekiqRetryNotifier.message_text(params)
-
-        allow(Faraday).to receive(:post).with(SidekiqRetryNotifier.slack_api_path)
+        allow(Faraday).to receive(:post).with(SidekiqRetryNotifier::API_PATH)
 
         SidekiqRetryNotifier.notify!(params)
 
-        expect(Faraday).to have_received(:post).with(SidekiqRetryNotifier.slack_api_path)
+        expect(Faraday).to have_received(:post).with(SidekiqRetryNotifier::API_PATH)
       end
     end
   end

--- a/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
+++ b/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
@@ -19,11 +19,11 @@ module AppealsApi
       it 'sends a network request' do
         text = SidekiqRetryNotifier.message_text(params)
 
-        allow(Faraday).to receive(:post).with(SidekiqRetryNotifier::WEBHOOK_URL, text)
+        allow(Faraday).to receive(:post).with(SidekiqRetryNotifier.slack_api_path)
 
         SidekiqRetryNotifier.notify!(params)
 
-        expect(Faraday).to have_received(:post).with(SidekiqRetryNotifier::WEBHOOK_URL, text)
+        expect(Faraday).to have_received(:post).with(SidekiqRetryNotifier.slack_api_path)
       end
     end
   end

--- a/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
+++ b/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'appeals_api/sidekiq_retry_notifier'
+
+module AppealsApi
+  RSpec.describe SidekiqRetryNotifier do
+    describe '.notify!' do
+      let(:params) do
+        {
+          'class' => 'HigherLevelReviewPdfSubmitJob',
+          'retry_count' => 2,
+          'error_class' => 'RuntimeError',
+          'error_message' => '',
+          'failed_at' => 1613670737.966083,
+          'retried_at' => 1613680062.5507782
+        }
+      end
+      it 'sends a network request' do
+        text = SidekiqRetryNotifier.message_text(params)
+
+        allow(Faraday).to receive(:post).with(SidekiqRetryNotifier::WEBHOOK_URL, text)
+
+        SidekiqRetryNotifier.notify!(params)
+
+        expect(Faraday).to have_received(:post).with(SidekiqRetryNotifier::WEBHOOK_URL, text)
+      end
+    end
+  end
+end

--- a/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
+++ b/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
@@ -11,10 +11,11 @@ module AppealsApi
           'retry_count' => 2,
           'error_class' => 'RuntimeError',
           'error_message' => '',
-          'failed_at' => 1613670737.966083,
-          'retried_at' => 1613680062.5507782
+          'failed_at' => 1_613_670_737.966083,
+          'retried_at' => 1_613_680_062.5507782
         }
       end
+
       it 'sends a network request' do
         text = SidekiqRetryNotifier.message_text(params)
 

--- a/modules/appeals_api/spec/support/shared_examples_for_monitored_worker.rb
+++ b/modules/appeals_api/spec/support/shared_examples_for_monitored_worker.rb
@@ -8,7 +8,7 @@ shared_examples 'a monitored worker' do |_options|
   end
 
   it 'requires a parameter for notify' do
-    expect{ described_class.new.notify }
+    expect { described_class.new.notify }
       .to raise_error(ArgumentError, 'wrong number of arguments (given 0, expected 1)')
   end
 

--- a/modules/appeals_api/spec/support/shared_examples_for_monitored_worker.rb
+++ b/modules/appeals_api/spec/support/shared_examples_for_monitored_worker.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'appeals_api/sidekiq_retry_notifier'
+
+shared_examples 'a monitored worker' do |options|
+  it 'calls defines #notify' do
+    expect(described_class.new.respond_to?(:notify)).to eq(true)
+  end
+
+  it 'defines retry_limits_for_notification' do
+    expect(described_class.new.respond_to?(:retry_limits_for_notification)).to eq(true)
+  end
+
+  it 'returns an array of integers from retry_limits_for_notification' do
+    expect(described_class.new.retry_limits_for_notification).to be_a(Array)
+  end
+
+  it 'calls SidekiqRetryNotifer' do
+    allow(AppealsApi::SidekiqRetryNotifier).to receive(:notify!)
+    described_class.new.notify({})
+    expect(AppealsApi::SidekiqRetryNotifier).to have_received(:notify!)
+  end
+end

--- a/modules/appeals_api/spec/support/shared_examples_for_monitored_worker.rb
+++ b/modules/appeals_api/spec/support/shared_examples_for_monitored_worker.rb
@@ -7,6 +7,11 @@ shared_examples 'a monitored worker' do |_options|
     expect(described_class.new.respond_to?(:notify)).to eq(true)
   end
 
+  it 'requires a parameter for notify' do
+    expect{ described_class.new.notify }
+      .to raise_error(ArgumentError, 'wrong number of arguments (given 0, expected 1)')
+  end
+
   it 'defines retry_limits_for_notification' do
     expect(described_class.new.respond_to?(:retry_limits_for_notification)).to eq(true)
   end

--- a/modules/appeals_api/spec/support/shared_examples_for_monitored_worker.rb
+++ b/modules/appeals_api/spec/support/shared_examples_for_monitored_worker.rb
@@ -2,7 +2,7 @@
 
 require 'appeals_api/sidekiq_retry_notifier'
 
-shared_examples 'a monitored worker' do |options|
+shared_examples 'a monitored worker' do |_options|
   it 'defines #notify' do
     expect(described_class.new.respond_to?(:notify)).to eq(true)
   end

--- a/modules/appeals_api/spec/support/shared_examples_for_monitored_worker.rb
+++ b/modules/appeals_api/spec/support/shared_examples_for_monitored_worker.rb
@@ -3,7 +3,7 @@
 require 'appeals_api/sidekiq_retry_notifier'
 
 shared_examples 'a monitored worker' do |options|
-  it 'calls defines #notify' do
+  it 'defines #notify' do
     expect(described_class.new.respond_to?(:notify)).to eq(true)
   end
 

--- a/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
+require AppealsApi::Engine.root.join('spec', 'support', 'shared_examples_for_monitored_worker.rb')
 
 RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
   include FixtureHelpers
@@ -15,6 +16,8 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
   let(:client_stub) { instance_double('CentralMail::Service') }
   let(:faraday_response) { instance_double('Faraday::Response') }
   let(:valid_doc) { fixture_to_s 'valid_200996.json' }
+
+  it_behaves_like 'a monitored worker'
 
   it 'uploads a valid payload' do
     allow(CentralMail::Service).to receive(:new) { client_stub }

--- a/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require AppealsApi::Engine.root.join('spec', 'support', 'shared_examples_for_monitored_worker.rb')
 
 describe AppealsApi::HigherLevelReviewUploadStatusUpdater, type: :job do
   let(:client_stub) { instance_double('CentralMail::Service') }
@@ -12,6 +13,8 @@ describe AppealsApi::HigherLevelReviewUploadStatusUpdater, type: :job do
        "errorMessage": '',
        "lastUpdated": '2018-04-25 00:02:39' }]
   end
+
+  it_behaves_like 'a monitored worker'
 
   describe '#perform' do
     it 'updates the status of a HigherLevelReview' do

--- a/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/notice_of_disagreement_pdf_submit_job_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
+require AppealsApi::Engine.root.join('spec', 'support', 'shared_examples_for_monitored_worker.rb')
 
 RSpec.describe AppealsApi::NoticeOfDisagreementPdfSubmitJob, type: :job do
   include FixtureHelpers
@@ -15,6 +16,8 @@ RSpec.describe AppealsApi::NoticeOfDisagreementPdfSubmitJob, type: :job do
   let(:client_stub) { instance_double('CentralMail::Service') }
   let(:faraday_response) { instance_double('Faraday::Response') }
   let(:valid_doc) { fixture_to_s 'valid_10182.json' }
+
+  it_behaves_like 'a monitored worker'
 
   it 'uploads a valid payload' do
     allow(CentralMail::Service).to receive(:new) { client_stub }

--- a/modules/appeals_api/spec/workers/notice_of_disagreement_upload_status_updater_spec.rb
+++ b/modules/appeals_api/spec/workers/notice_of_disagreement_upload_status_updater_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require AppealsApi::Engine.root.join('spec', 'support', 'shared_examples_for_monitored_worker.rb')
 
 describe AppealsApi::NoticeOfDisagreementUploadStatusUpdater, type: :job do
   let(:client_stub) { instance_double('CentralMail::Service') }
@@ -12,6 +13,8 @@ describe AppealsApi::NoticeOfDisagreementUploadStatusUpdater, type: :job do
        "errorMessage": '',
        "lastUpdated": '2018-04-25 00:02:39' }]
   end
+
+  it_behaves_like 'a monitored worker'
 
   describe '#perform' do
     it 'updates the status of a NoticeOfDisagreement' do

--- a/spec/lib/sidekiq/retry_monitoring_spec.rb
+++ b/spec/lib/sidekiq/retry_monitoring_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/monitored_worker'
+
+describe Sidekiq::RetryMonitoring do
+  class TestJob
+    include Sidekiq::Worker
+    include Sidekiq::MonitoredWorker
+
+    def perform
+    end
+
+    def notify(_params)
+    end
+
+    def retry_limits_for_notification
+      [4]
+    end
+  end
+
+  let(:middleware) { Sidekiq::RetryMonitoring.new }
+  let(:params) do
+    {
+      "class"=>"TestJob",
+      "args"=>[],
+      "retry"=>true,
+      "queue"=>"default",
+      "created_at"=>1613662230.2647018,
+      "error_message"=>"",
+      "error_class"=>"RuntimeError",
+      "failed_at"=>1613670737.966083,
+      "retry_count"=>1,
+      "retried_at"=>1613680062.5507782
+    }
+  end
+
+  it 'it calls notify after retry limit is hit' do
+    params["retry_count"] = 3
+
+    TestJob.perform_async
+    worker = TestJob.new
+    allow(worker).to receive(:notify).and_return(true)
+
+    middleware.call(worker, params, nil) {}
+
+    expect(worker).to have_received(:notify).with(params)
+  end
+end

--- a/spec/lib/sidekiq/retry_monitoring_spec.rb
+++ b/spec/lib/sidekiq/retry_monitoring_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'sidekiq/monitored_worker'
 
 describe Sidekiq::RetryMonitoring do
-  class TestJob
+  class RetryTestJob
     include Sidekiq::Worker
     include Sidekiq::MonitoredWorker
 
@@ -36,8 +36,8 @@ describe Sidekiq::RetryMonitoring do
   it 'calls notify after retry limit is hit' do
     params['retry_count'] = 3
 
-    TestJob.perform_async
-    worker = TestJob.new
+    RetryTestJob.perform_async
+    worker = RetryTestJob.new
     allow(worker).to receive(:notify).and_return(true)
 
     middleware.call(worker, params, nil) {}

--- a/spec/lib/sidekiq/retry_monitoring_spec.rb
+++ b/spec/lib/sidekiq/retry_monitoring_spec.rb
@@ -8,11 +8,9 @@ describe Sidekiq::RetryMonitoring do
     include Sidekiq::Worker
     include Sidekiq::MonitoredWorker
 
-    def perform
-    end
+    def perform; end
 
-    def notify(_params)
-    end
+    def notify(_params); end
 
     def retry_limits_for_notification
       [4]
@@ -22,21 +20,21 @@ describe Sidekiq::RetryMonitoring do
   let(:middleware) { Sidekiq::RetryMonitoring.new }
   let(:params) do
     {
-      "class"=>"TestJob",
-      "args"=>[],
-      "retry"=>true,
-      "queue"=>"default",
-      "created_at"=>1613662230.2647018,
-      "error_message"=>"",
-      "error_class"=>"RuntimeError",
-      "failed_at"=>1613670737.966083,
-      "retry_count"=>1,
-      "retried_at"=>1613680062.5507782
+      'class' => 'TestJob',
+      'args' => [],
+      'retry' => true,
+      'queue' => 'default',
+      'created_at' => 1_613_662_230.2647018,
+      'error_message' => '',
+      'error_class' => 'RuntimeError',
+      'failed_at' => 1_613_670_737.966083,
+      'retry_count' => 1,
+      'retried_at' => 1_613_680_062.5507782
     }
   end
 
-  it 'it calls notify after retry limit is hit' do
-    params["retry_count"] = 3
+  it 'calls notify after retry limit is hit' do
+    params['retry_count'] = 3
 
     TestJob.perform_async
     worker = TestJob.new


### PR DESCRIPTION
[API-4765](https://vajira.max.gov/browse/API-4765)

This PR adds sidekiq middleware to handle sidekiq job retry threshold notfiications. When a monitored worker hits a designated retry limit, a notify callback will be called within that monitored worker. 

AppealsAPI makes use of a Slack incoming webhook to post this retry warning directly to slack.

## Things to know about this PR
<!--
* It adds a global sidekiq middleware to _every_ job. It checks if the `Sidekiq::MonitoredWorker` module is included.
-->

This will be unit tested with shared examples for each monitored worker, testing that the interface called by the middleware is defined.


This PR will add middleware to ALL sidekiq jobs, but will only "work" if the included `Sidekiq::MonitoredWorker` is included.