### PR TITLE
Add `birls_ids_tried` Helper Methods to Form526Submission Model

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -24,6 +24,7 @@ class Form526Submission < ApplicationRecord
   #
   attr_encrypted(:auth_headers_json, key: Settings.db_encryption_key)
   attr_encrypted(:form_json, key: Settings.db_encryption_key)
+  attr_encrypted(:birls_ids_tried, key: Settings.db_encryption_key)
 
   belongs_to :saved_claim,
              class_name: 'SavedClaim::DisabilityCompensation',
@@ -87,6 +88,58 @@ class Form526Submission < ApplicationRecord
   #
   def auth_headers
     @auth_headers_hash ||= JSON.parse(auth_headers_json)
+  end
+
+  # this method is for queuing up BIRLS ids in the birls_ids_tried hash,
+  # and can also be used for initializing birls_ids_tried.
+  # birls_ids_tried has this shape:
+  # {
+  #   birls_id => [timestamp, timestamp, ...],
+  #   birls_id => [timestamp, timestamp, ...], # in practice, will be only 1 timestamp
+  #   ...
+  # }
+  # where each timestamp notes when a submissison job (start) was started
+  # with that BIRLS id (birls_id_tried keeps track of which BIRLS id
+  # have been tried so far).
+  # add_birls_ids does not overwrite birls_ids_tried.
+  # example:
+  # > sub.birls_ids_tried = { '111' => ['2021-01-01T0000Z'] }
+  # > sub.add_birls_ids ['111', '222', '333']
+  # > pp sub.birls_ids_tried
+  #    {
+  #      '111' => ['2021-01-01T0000Z'], # a tried BIRLS ID
+  #      '222' => [],  # an untried BIRLS ID
+  #      '333' => []   # an untried BIRLS ID
+  #    }
+  # NOTE: '111' was not cleared
+  def add_birls_ids(id_or_ids)
+    ids = Array.wrap(id_or_ids).map { |id| id.is_a?(Symbol) ? id.to_s : id }
+    hash = birls_ids_tried_hash
+    ids.each { |id| hash[id] ||= [] }
+    self.birls_ids_tried = hash.to_json
+    self.multiple_birls = true if birls_ids.length > 1
+    ids
+  end
+
+  def birls_ids
+    [*birls_ids_tried_hash&.keys, birls_id].compact.uniq
+  end
+
+  def birls_ids_tried_hash
+    birls_ids_tried.presence&.then { |json| JSON.parse json } || {}
+  end
+
+  def mark_birls_id_as_tried(id = birls_id!, timestamp_string: Time.zone.now.iso8601.to_s)
+    ids = add_birls_ids id
+    hash = birls_ids_tried_hash
+    hash[ids.first] << timestamp_string
+    self.birls_ids_tried = hash.to_json
+    timestamp_string
+  end
+
+  def birls_ids_that_havent_been_tried_yet
+    add_birls_ids birls_id if birls_id.present?
+    birls_ids_tried_hash.select { |_id, timestamps| timestamps.blank? }.keys
   end
 
   def birls_id!


### PR DESCRIPTION
Veterans sometimes have multiple BIRLS IDs, but, currently, we only try the first one returned. This PR tweaks Form526Submission model to keep track of which BIRLS IDs have been tried so far when trying to submit to EVSS.

The column in the DB is already set up (encrypted string for storing JSON).

An example of the shape of `birls_ids_tried`:
 ```
{
  '111' => ['2021-01-01T0000Z'], # a tried BIRLS ID
  '222' => [],  # an untried BIRLS ID
  '333' => []   # an untried BIRLS ID
}
```
--a hash where the keys are the BIRLS ID and the values are arrays of timestamps which record when that BIRLS ID was used for a submit job.

Manually manipulating this data structure is cumbersome and error-prone. This PR introduces methods for working with the `birls_ids_tried` column.

### Acceptance Criteria
- [x] Add helper methods for `birls_ids_tried` encrypted json column (Form526Submission)