### PR TITLE
[Bugfix] Send CentralMail receiveDt in central timezone

### DIFF
--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -36,7 +36,7 @@ module AppealsApi
         'uuid' => higher_level_review.id,
         'hashV' => Digest::SHA256.file(pdf_path).hexdigest,
         'numberAttachments' => 0,
-        'receiveDt' => higher_level_review.created_at.strftime('%Y-%m-%d %H:%M:%S'),
+        'receiveDt' => receive_date(higher_level_review),
         'numberPages' => PdfInfo::Metadata.read(pdf_path).pages,
         'docType' => '20-0996'
       }
@@ -54,6 +54,13 @@ module AppealsApi
       else
         map_error(response.status, response.body, AppealsApi::UploadError)
       end
+    end
+
+    def receive_date(higher_level_review)
+      higher_level_review
+        .created_at
+        .in_time_zone('Central Time (US & Canada)')
+        .strftime('%Y-%m-%d %H:%M:%S')
     end
   end
 end

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
@@ -36,7 +36,7 @@ module AppealsApi
         'uuid' => notice_of_disagreement.id,
         'hashV' => Digest::SHA256.file(pdf_path).hexdigest,
         'numberAttachments' => 0,
-        'receiveDt' => notice_of_disagreement.created_at.strftime('%Y-%m-%d %H:%M:%S'),
+        'receiveDt' => receive_date(notice_of_disagreement),
         'numberPages' => PdfInfo::Metadata.read(pdf_path).pages,
         'docType' => '10182',
         'lob' => notice_of_disagreement.lob
@@ -55,6 +55,13 @@ module AppealsApi
       else
         map_error(response.status, response.body, AppealsApi::UploadError)
       end
+    end
+
+    def receive_date(notice_of_disagreement)
+      notice_of_disagreement
+        .created_at
+        .in_time_zone('Central Time (US & Canada)')
+        .strftime('%Y-%m-%d %H:%M:%S')
     end
   end
 end


### PR DESCRIPTION
## Description of change
CentralMail expects its `receiveDt` to be in Central timezone. This fixes the bug where we were sending the date in UTC instead of Central timezone.

## Original issue(s)
https://vajira.max.gov/browse/API-5366