### PR TITLE
Remove outdated comment

### DIFF
--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -28,9 +28,6 @@ module EducationForm
     # Setting the default value to the `unprocessed` scope is safe
     # because the execution of the query itself is deferred until the
     # data is accessed by the code inside of the method.
-    # Be *EXTREMELY* careful running this manually as it may overwrite
-    # existing files on the SFTP server if one was already written out
-    # for the day.
     def perform(
       records: EducationBenefitsClaim.unprocessed.includes(:saved_claim, :education_stem_automated_decision).where(
         saved_claims: {


### PR DESCRIPTION
[This comment was added](https://github.com/department-of-veterans-affairs/vets-api/commit/d9ebb619d56f3835e5b309b73a9119fe2db86f8e) when the spool files were saved with [only the day](https://github.com/department-of-veterans-affairs/vets-api/blob/d9ebb619d56f3835e5b309b73a9119fe2db86f8e/app/workers/education_form/create_daily_spool_files.rb#L39) in the timestamp [rather than the second](https://github.com/department-of-veterans-affairs/vets-api/blob/08c844ab02d787349f5215bfdcedfaf72bf6338e/app/workers/education_form/create_daily_spool_files.rb#L85).