### PR TITLE
API-5338 - Provide better error when v0 form2122 endpoints can't find POA

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v0/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/power_of_attorney_controller.rb
@@ -54,12 +54,16 @@ module ClaimsApi
         def status
           power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(id: params[:id],
                                                                                           source_name: source_name)
+          render_poa_not_found and return unless power_of_attorney
+
           render json: power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
         end
 
         def active
           power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(header_md5: header_md5,
                                                                                           source_name: source_name)
+          render_poa_not_found and return unless power_of_attorney
+
           render json: power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
         end
 
@@ -93,6 +97,10 @@ module ClaimsApi
               }
             }
           }
+        end
+
+        def render_poa_not_found
+          render json: { errors: [{ status: 404, detail: 'POA not found' }] }, status: :not_found
         end
       end
     end

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -351,6 +351,7 @@ module ClaimsApi
             key :name, 'X-VA-SSN'
             key :in, :header
             key :description, 'SSN of Veteran being represented'
+            key :example, '123121234'
             key :required, true
             key :type, :string
           end
@@ -359,6 +360,7 @@ module ClaimsApi
             key :name, 'X-VA-First-Name'
             key :in, :header
             key :description, 'First Name of Veteran being represented'
+            key :example, 'John'
             key :required, true
             key :type, :string
           end
@@ -367,6 +369,7 @@ module ClaimsApi
             key :name, 'X-VA-Last-Name'
             key :in, :header
             key :description, 'Last Name of Veteran being represented'
+            key :example, 'Doe'
             key :required, true
             key :type, :string
           end
@@ -375,15 +378,8 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
+            key :example, '1954-12-15'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
             key :type, :string
           end
 
@@ -391,7 +387,8 @@ module ClaimsApi
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
-            key :required, false
+            key :example, 'lighthouse'
+            key :required, true
             key :type, :string
           end
 

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -351,7 +351,7 @@ module ClaimsApi
             key :name, 'X-VA-SSN'
             key :in, :header
             key :description, 'SSN of Veteran being represented'
-            key :example, '123121234'
+            key :example, '796130115'
             key :required, true
             key :type, :string
           end
@@ -360,7 +360,7 @@ module ClaimsApi
             key :name, 'X-VA-First-Name'
             key :in, :header
             key :description, 'First Name of Veteran being represented'
-            key :example, 'John'
+            key :example, 'Tamara'
             key :required, true
             key :type, :string
           end
@@ -369,7 +369,7 @@ module ClaimsApi
             key :name, 'X-VA-Last-Name'
             key :in, :header
             key :description, 'Last Name of Veteran being represented'
-            key :example, 'Doe'
+            key :example, 'Ellis'
             key :required, true
             key :type, :string
           end
@@ -378,7 +378,7 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :example, '1954-12-15'
+            key :example, '1967-06-19'
             key :required, true
             key :type, :string
           end
@@ -466,7 +466,7 @@ module ClaimsApi
             key :in, :header
             key :description, 'SSN of Veteran being represented'
             key :required, true
-            key :example, '123121234'
+            key :example, '796130115'
             key :type, :string
           end
 
@@ -474,7 +474,7 @@ module ClaimsApi
             key :name, 'X-VA-First-Name'
             key :in, :header
             key :description, 'First Name of Veteran being represented'
-            key :example, 'John'
+            key :example, 'Tamara'
             key :required, true
             key :type, :string
           end
@@ -483,7 +483,7 @@ module ClaimsApi
             key :name, 'X-VA-Last-Name'
             key :in, :header
             key :description, 'Last Name of Veteran being represented'
-            key :example, 'Doe'
+            key :example, 'Ellis'
             key :required, true
             key :type, :string
           end
@@ -492,7 +492,7 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :example, '1954-12-15'
+            key :example, '1967-06-19'
             key :required, true
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -468,7 +468,8 @@ module ClaimsApi
             key :name, 'X-VA-SSN'
             key :in, :header
             key :description, 'SSN of Veteran being represented'
-            key :required, false
+            key :required, true
+            key :example, '123121234'
             key :type, :string
           end
 
@@ -476,7 +477,8 @@ module ClaimsApi
             key :name, 'X-VA-First-Name'
             key :in, :header
             key :description, 'First Name of Veteran being represented'
-            key :required, false
+            key :example, 'John'
+            key :required, true
             key :type, :string
           end
 
@@ -484,7 +486,8 @@ module ClaimsApi
             key :name, 'X-VA-Last-Name'
             key :in, :header
             key :description, 'Last Name of Veteran being represented'
-            key :required, false
+            key :example, 'Doe'
+            key :required, true
             key :type, :string
           end
 
@@ -492,15 +495,8 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
+            key :example, '1954-12-15'
+            key :required, true
             key :type, :string
           end
 
@@ -508,7 +504,17 @@ module ClaimsApi
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
-            key :required, false
+            key :example, 'lighthouse'
+            key :required, true
+            key :type, :string
+          end
+
+          parameter do
+            key :name, 'X-VA-LOA'
+            key :in, :header
+            key :description, 'The level of assurance of the user making the request'
+            key :example, '3'
+            key :required, true
             key :type, :string
           end
 
@@ -535,6 +541,22 @@ module ClaimsApi
                   key :type, :array
                   items do
                     key :'$ref', :NotAuthorizedModel
+                  end
+                end
+              end
+            end
+          end
+
+          response 404 do
+            key :description, 'Resource not found'
+            content 'application/json' do
+              schema do
+                key :type, :object
+                key :required, [:errors]
+                property :errors do
+                  key :type, :array
+                  items do
+                    key :'$ref', :NotFoundModel
                   end
                 end
               end

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -388,7 +388,7 @@ module ClaimsApi
             key :in, :header
             key :description, 'VA username of the person making the request'
             key :example, 'lighthouse'
-            key :required, true
+            key :required, false
             key :type, :string
           end
 
@@ -502,7 +502,7 @@ module ClaimsApi
             key :in, :header
             key :description, 'VA username of the person making the request'
             key :example, 'lighthouse'
-            key :required, true
+            key :required, false
             key :type, :string
           end
 

--- a/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
@@ -79,6 +79,16 @@ RSpec.describe 'Power of Attorney ', type: :request do
         expect(parsed['data']['type']).to eq('claims_api_power_of_attorneys')
         expect(parsed['data']['attributes']['status']).to eq('submitted')
       end
+
+      context 'when power of attorney cannot be found' do
+        it 'returns a 404' do
+          get('/services/claims/v0/forms/2122/999999',
+              params: nil, headers: headers)
+
+          allow(ClaimsApi::PowerOfAttorney).to receive(:find_using_identifier_and_source).and_return(nil)
+          expect(response.status).to eq(404)
+        end
+      end
     end
 
     describe '#upload_power_of_attorney_document' do
@@ -129,6 +139,18 @@ RSpec.describe 'Power of Attorney ', type: :request do
       it 'responds properly when JSON parse error' do
         post "#{path}/validate", params: 'hello', headers: headers
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    describe 'active' do
+      context 'when there is no active power of attorney' do
+        it 'returns a 404' do
+          get('/services/claims/v0/forms/2122/active',
+              params: nil, headers: headers)
+
+          allow(ClaimsApi::PowerOfAttorney).to receive(:find_using_identifier_and_source).and_return(nil)
+          expect(response.status).to eq(404)
+        end
       end
     end
   end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
In `/claims/v0/forms/2122/active` and `/claims/v0/forms/2122/{id}/status`, it's possible that a Power of Attorney (POA) cannot be found.  When that happens, we need to return a 404 rather than allowing the code to blow up and return a 500.

## Original issue(s)
[API-5338](https://vajira.max.gov/browse/API-5338)