### PR TITLE
Adds and documents "hybrid mode" vets-api setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ For frontend, see [vets-website](https://github.com/department-of-veterans-affai
 
    **DO NOT commit local Gemfile modifications that remove the `sidekiq-ent` and `sidekiq-pro` gems.**
 
-1. Developers who work with vets-api daily tend to prefer the native setup because they don't have to deal with the abstraction of docker-compose while those who would to spend less time on getting started prefer the docker setup. Docker is also useful when it's necessary to have a setup as close to production as possible.
+1. Developers who work with vets-api daily tend to prefer the native setup because they don't have to deal with the abstraction of docker-compose while those who would to spend less time on getting started prefer the docker setup. Docker is also useful when it's necessary to have a setup as close to production as possible. Finally, it's possible to use a hybrid setup where you run vets-api natively, but run the Postgres and Redis dependencies in docker.
 
    - [Native setup](docs/setup/native.md) (OSX/Ubuntu)
    - [Docker setup](docs/setup/docker.md)
+   - [Hybrid setup](docs/setup/hybrid.md)
 
 ## Running the app
 

--- a/docker-compose-deps.yml
+++ b/docker-compose-deps.yml
@@ -1,0 +1,16 @@
+version: '3.4'
+services:
+  redis:
+    image: redis:5.0-alpine
+    ports:
+      - "63790:6379"
+  postgres:
+    image: mdillon/postgis:11-alpine
+    environment:
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
+      POSTGRES_USER: "${POSTGRES_USER:-postgres}"
+    volumes:
+      - ./data:/var/lib/postgresql/data:cached
+    ports:
+      - "54320:5432"
+

--- a/docs/setup/hybrid.md
+++ b/docs/setup/hybrid.md
@@ -1,0 +1,34 @@
+# Developer Setup
+
+In hybrid mode, you will run vets-api natively, but run Postgres and Redis in Docker. By doing so you avoid any challenges of installing these two software packages and keeping them upgraded to the appropriate version.
+
+
+
+## Base Setup
+
+1. Install Docker as referenced in the [Docker setup instructions](docker.md).
+
+1. Follow the [Native setup instructions](native.md), but skip any steps related to installing Postgres, Postgis, or Redis. You *will* need to install the other dependencies such as pdftk and clamav.
+
+1. Configure vets-api to point to the Docker-ized dependencies. Add the following to `config/settings.local.yml`:
+
+```
+database_url: postgis://postgres:password@localhost:54320/vets_api_development?pool=4
+test_database_url: postgis://postgres:password@localhost:54320/vets_api_test?pool=4
+
+redis:
+  host: localhost
+  port: 63790
+  app_data:
+    url: redis://localhost:63790
+  sidekiq:
+    url: redis://localhost:63790
+```
+
+*Note: If you have local instances of Postgres or Redis that were only for use by vets-api, you can stop them to save system resources.*
+
+## Running
+
+1. To start Postgres and Redis: `docker-compose -f docker-compose-deps.yml up`
+
+1. Start vets-api as per the [native running instructions](running_natively.md).


### PR DESCRIPTION

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Adds instructions and a docker-compose file for running Postgres
and Redis in docker but running vets-api natively.

This is a setup that works well for me and I thought others might benefit. Happy to have either the documentation or the setup itself altered if people see an opportunity for streamlining. 

* It's possible to map Redis and Postgres straight through on their default ports, but I figured if people already had either of those things running natively it would conflict and generate support questions, so I went with `default port * 10`
* If redis is mapped to its default port, then no settings.local.yml stanza is needed. A local configuration *is* still needed for Postgres because the default settings tries to connects on a unix domain socket which doesn't work with Docker without some extra doing. 
