### PR TITLE
Feature flags for 526 subforms

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -180,10 +180,12 @@ features:
       Enables ssoe, as opposed to saml authentication wrapped by id.me
   form526_original_claims:
     actor_type: user
+    enable_in_development: true
     description: >
       Allows veterans to access form526 as an original claims user. Owned by va-benefits-memorial-1 team.
   form526_benefits_delivery_at_discharge:
     actor_type: user
+    enable_in_development: true
     description: >
       Allows veterans to access the BDD flow in the 526 form. Owned by va-benefits-memorial-1 team.
   form526_confirmation_email:
@@ -215,6 +217,7 @@ features:
       Panel that displays while the user is modifying inputs to give context to their currently estimated benefits until they reach the full your estimated benefits panel.
   form996_higher_level_review:
     actor_type: user
+    enable_in_development: true
     description: >
       Allows veterans request a higher-level review of an existing claim. Owned by va-benefits-memorial-1 team.
   debt_letters_show_letters:
@@ -266,6 +269,7 @@ features:
       Enables showing the pre-appointment questionnaire feature.
   show526_wizard:
     actor_type: user
+    enable_in_development: true
     description: >
       This determines when the wizard should show up on the form 526 intro page
   show_new_get_medical_records_page:

--- a/config/features.yml
+++ b/config/features.yml
@@ -389,3 +389,8 @@ features:
     enable_in_development: true
     description: >
       Allow consumer to use service specific VaNotify client. Owned by va-notify team.
+  subform_8940_4192:
+    actor_type: user
+    enable_in_development: true
+    description: >
+      Form 526 subforms for unemployability & connected employment information


### PR DESCRIPTION
## Description of change

Form 526 contains subforms 8940 and 4192 which are currently only visible in a non-production environment. Adding feature flags to enable a future rollout.

Also added `enable_in_development` settings for various forms we support.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/13848

## Things to know about this PR

* Adding 8940 & 4192 combined feature flag
* Adding `enable_in_development` settings for existing form 526 & 996 features

