### PR TITLE
upgrade carrierwave

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (>= 0.18, < 2)
     byebug (11.1.3)
-    carrierwave (2.1.1)
+    carrierwave (2.2.0)
       activemodel (>= 5.0.0)
       activesupport (>= 5.0.0)
       addressable (~> 2.6)
@@ -474,7 +474,7 @@ GEM
     httpi (2.4.5)
       rack
       socksify
-    i18n (1.8.8)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     image_processing (1.12.1)
@@ -524,7 +524,7 @@ GEM
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     msgpack (1.3.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)

--- a/app/uploaders/evss_claim_document_uploader.rb
+++ b/app/uploaders/evss_claim_document_uploader.rb
@@ -56,7 +56,7 @@ class EVSSClaimDocumentUploader < CarrierWave::Uploader::Base
     store_dir
   end
 
-  def extension_whitelist
+  def extension_allowlist
     %w[pdf gif tiff tif jpeg jpg bmp txt]
   end
 

--- a/app/uploaders/hca_attachment_uploader.rb
+++ b/app/uploaders/hca_attachment_uploader.rb
@@ -25,7 +25,7 @@ class HCAAttachmentUploader < CarrierWave::Uploader::Base
     end
   end
 
-  def extension_whitelist
+  def extension_allowlist
     # accepted by enrollment system: PDF,WORD,JPG,RTF
     %w[pdf doc docx jpg jpeg rtf png]
   end

--- a/app/uploaders/preneed_attachment_uploader.rb
+++ b/app/uploaders/preneed_attachment_uploader.rb
@@ -25,7 +25,7 @@ class PreneedAttachmentUploader < CarrierWave::Uploader::Base
     end
   end
 
-  def extension_whitelist
+  def extension_allowlist
     %w[pdf jpg jpeg png]
   end
 

--- a/app/uploaders/profile_photo_attachment_uploader.rb
+++ b/app/uploaders/profile_photo_attachment_uploader.rb
@@ -24,7 +24,7 @@ class ProfilePhotoAttachmentUploader < CarrierWave::Uploader::Base
     end
   end
 
-  def extension_whitelist
+  def extension_allowlist
     %w[jpg jpeg gif png tif tiff]
   end
 

--- a/app/uploaders/supporting_documentation_attachment_uploader.rb
+++ b/app/uploaders/supporting_documentation_attachment_uploader.rb
@@ -24,7 +24,7 @@ class SupportingDocumentationAttachmentUploader < CarrierWave::Uploader::Base
     end
   end
 
-  def extension_whitelist
+  def extension_allowlist
     %w[pdf jpg jpeg gif png tif tiff]
   end
 

--- a/app/uploaders/supporting_evidence_attachment_uploader.rb
+++ b/app/uploaders/supporting_evidence_attachment_uploader.rb
@@ -24,7 +24,7 @@ class SupportingEvidenceAttachmentUploader < CarrierWave::Uploader::Base
     end
   end
 
-  def extension_whitelist
+  def extension_allowlist
     %w[pdf png gif tiff tif jpeg jpg bmp txt]
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,10 +40,10 @@ en:
       carrierwave_processing_error: We couldn’t process your file.
       carrierwave_integrity_error: We couldn’t upload your file because it’s not one of the allowed file types.
       carrierwave_download_error: We couldn’t download your file.
-      extension_whitelist_error: "You can’t upload %{extension} files. The allowed file types are: %{allowed_types}"
-      # extension_blacklist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
-      content_type_whitelist_error: "You can’t upload %{content_type} files. The allowed file types are: %{allowed_types}"
-      #content_type_blacklist_error: "You are not allowed to upload %{content_type} files"
+      extension_allowlist_error: "You can’t upload %{extension} files. The allowed file types are: %{allowed_types}"
+      # extension_denylist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
+      content_type_allowlist_error: "You can’t upload %{content_type} files. The allowed file types are: %{allowed_types}"
+      # content_type_denylist_error: "You are not allowed to upload %{content_type} files"
       # rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image?"
       # mini_magick_processing_error: "Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: %{e}"
       min_size_error: "We couldn’t upload your file because it’s too small. File size needs to be greater than %{min_size}"

--- a/spec/request/upload_supporting_evidence_spec.rb
+++ b/spec/request/upload_supporting_evidence_spec.rb
@@ -72,9 +72,9 @@ RSpec.describe 'Upload supporting evidence', type: :request do
         err = JSON.parse(response.body)['errors'][0]
         expect(err['title']).to eq 'Unprocessable Entity'
         expect(err['detail']).to eq(
-          I18n.t('errors.messages.extension_whitelist_error',
+          I18n.t('errors.messages.extension_allowlist_error',
                  extension: '"crt"',
-                 allowed_types: SupportingEvidenceAttachmentUploader.new('a').extension_whitelist.join(', '))
+                 allowed_types: SupportingEvidenceAttachmentUploader.new('a').extension_allowlist.join(', '))
         )
       end
 

--- a/spec/uploaders/supporting_documentation_attachment_uploader_spec.rb
+++ b/spec/uploaders/supporting_documentation_attachment_uploader_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SupportingDocumentationAttachmentUploader do
 
   let(:guid) { '1234' }
 
-  it 'allow image and pdf files' do
+  it 'allows image and pdf files' do
     expect(subject.extension_allowlist).to match_array %w[pdf png gif tiff tif jpeg jpg]
   end
 

--- a/spec/uploaders/supporting_documentation_attachment_uploader_spec.rb
+++ b/spec/uploaders/supporting_documentation_attachment_uploader_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe SupportingDocumentationAttachmentUploader do
 
   let(:guid) { '1234' }
 
-  it 'whitelists image and pdf files' do
-    expect(subject.extension_whitelist).to match_array %w[pdf png gif tiff tif jpeg jpg]
+  it 'allow image and pdf files' do
+    expect(subject.extension_allowlist).to match_array %w[pdf png gif tiff tif jpeg jpg]
   end
 
   it 'returns a store directory containing guid' do

--- a/spec/uploaders/supporting_evidence_attachment_uploader_spec.rb
+++ b/spec/uploaders/supporting_evidence_attachment_uploader_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SupportingEvidenceAttachmentUploader do
 
   let(:guid) { '1234' }
 
-  it 'allow image, pdf, and text files' do
+  it 'allows image, pdf, and text files' do
     expect(subject.extension_allowlist).to match_array %w[pdf png gif tiff tif jpeg jpg bmp txt]
   end
 

--- a/spec/uploaders/supporting_evidence_attachment_uploader_spec.rb
+++ b/spec/uploaders/supporting_evidence_attachment_uploader_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe SupportingEvidenceAttachmentUploader do
 
   let(:guid) { '1234' }
 
-  it 'whitelists image, pdf, and text files' do
-    expect(subject.extension_whitelist).to match_array %w[pdf png gif tiff tif jpeg jpg bmp txt]
+  it 'allow image, pdf, and text files' do
+    expect(subject.extension_allowlist).to match_array %w[pdf png gif tiff tif jpeg jpg bmp txt]
   end
 
   it 'returns a store directory containing guid' do


### PR DESCRIPTION
## Description of change
upgrade carrierwave gem. [changelog](https://github.com/carrierwaveuploader/carrierwave/blob/master/CHANGELOG.md#220---2021-02-23) includes several bug fixes and a few deprecated method names. 
