### PR TITLE
Add AppealsApi::EvidenceSubmission

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 2021_02_25_160010) do
   create_table "appeals_api_evidence_submissions", force: :cascade do |t|
     t.string "status", default: "pending", null: false
     t.string "supportable_type"
-    t.bigint "supportable_id"
+    t.string "supportable_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["supportable_type", "supportable_id"], name: "evidence_submission_supportable_id_type_index"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_23_132223) do
+ActiveRecord::Schema.define(version: 2021_02_25_160010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -53,6 +53,15 @@ ActiveRecord::Schema.define(version: 2021_02_23_132223) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "appeals_api_evidence_submissions", force: :cascade do |t|
+    t.string "status", default: "pending", null: false
+    t.string "supportable_type"
+    t.bigint "supportable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["supportable_type", "supportable_id"], name: "evidence_submission_supportable_id_type_index"
   end
 
   create_table "appeals_api_higher_level_reviews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/modules/appeals_api/db/migrate/20210225160010_create_evidence_submission.rb
+++ b/modules/appeals_api/db/migrate/20210225160010_create_evidence_submission.rb
@@ -1,0 +1,10 @@
+class CreateEvidenceSubmission < ActiveRecord::Migration[6.0]
+  def change
+    create_table :appeals_api_evidence_submissions do |t|
+      t.string :status, null: false, default: 'pending'
+      t.references :supportable, polymorphic: true, index: { name: 'evidence_submission_supportable_id_type_index' }
+
+      t.timestamps
+    end
+  end
+end

--- a/modules/appeals_api/db/migrate/20210225160010_create_evidence_submission.rb
+++ b/modules/appeals_api/db/migrate/20210225160010_create_evidence_submission.rb
@@ -2,7 +2,7 @@ class CreateEvidenceSubmission < ActiveRecord::Migration[6.0]
   def change
     create_table :appeals_api_evidence_submissions do |t|
       t.string :status, null: false, default: 'pending'
-      t.references :supportable, polymorphic: true, index: { name: 'evidence_submission_supportable_id_type_index' }
+      t.references :supportable, polymorphic: true, type: :string, index: { name: 'evidence_submission_supportable_id_type_index' }
 
       t.timestamps
     end


### PR DESCRIPTION
This PR is the migration for `AppealsApi::EvidenceSubmission`, which we will use to track the status of supporting evidence uploads for both NoticeOfDisagreement appeals and SupplementalClaims (eventually).

Epic Link: [4117-Evidence-Submission](https://vajira.max.gov/browse/API-4117)