### PR TITLE
[API-4808] - Do not require auth for claims api schema endpoints

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -12,7 +12,9 @@ module ClaimsApi
 
         FORM_NUMBER = '526'
 
-        before_action { permit_scopes %w[claim.write] }
+        before_action except: %i[schema] do
+          permit_scopes %w[claim.write]
+        end
         before_action :validate_json_schema, only: %i[submit_form_526 validate_form_526]
         before_action :validate_initial_claim, only: %i[submit_form_526 validate_form_526]
         before_action :validate_documents_content_type, only: %i[upload_supporting_documents upload_form_526]

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
@@ -9,7 +9,9 @@ module ClaimsApi
       class IntentToFileController < BaseFormController
         include ClaimsApi::PoaVerification
 
-        before_action { permit_scopes %w[claim.write] }
+        before_action except: %i[schema] do
+          permit_scopes %w[claim.write]
+        end
         before_action :validate_json_schema, only: %i[submit_form_0966 validate]
         before_action :check_for_type, only: %i[active]
 

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -8,7 +8,9 @@ module ClaimsApi
       class PowerOfAttorneyController < ClaimsApi::BaseFormController
         include ClaimsApi::DocumentValidations
 
-        before_action { permit_scopes %w[claim.write] }
+        before_action except: %i[schema] do
+          permit_scopes %w[claim.write]
+        end
         before_action :validate_json_schema, only: %i[submit_form_2122 validate]
         before_action :validate_documents_content_type, only: %i[upload]
         before_action :validate_documents_page_size, only: %i[upload]

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe 'Disability Claims ', type: :request do
     let(:path) { '/services/claims/v1/forms/526' }
     let(:schema) { File.read(Rails.root.join('modules', 'claims_api', 'config', 'schemas', '526.json')) }
 
-    it 'returns a successful get response with json schema' do
-      with_okta_user(scopes) do |auth_header|
-        get path, headers: headers.merge(auth_header)
+    describe 'schema' do
+      it 'returns a successful get response with json schema' do
+        get path
         json_schema = JSON.parse(response.body)['data'][0]
         expect(json_schema).to eq(JSON.parse(schema))
       end

--- a/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe 'Intent to file', type: :request do
   end
 
   describe '#0966' do
-    it 'returns a successful get response with json schema' do
-      with_okta_user(scopes) do |auth_header|
-        get path, headers: headers.merge(auth_header)
+    describe 'schema' do
+      it 'returns a successful get response with json schema' do
+        get path
         json_schema = JSON.parse(response.body)['data'][0]
         expect(json_schema).to eq(JSON.parse(schema))
       end

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe 'Power of Attorney ', type: :request do
     let(:path) { '/services/claims/v1/forms/2122' }
     let(:schema) { File.read(Rails.root.join('modules', 'claims_api', 'config', 'schemas', '2122.json')) }
 
-    it 'returns a successful get response with json schema' do
-      with_okta_user(scopes) do |auth_header|
-        get path, headers: headers.merge(auth_header)
+    describe 'schema' do
+      it 'returns a successful get response with json schema' do
+        get path
         json_schema = JSON.parse(response.body)['data'][0]
         expect(json_schema).to eq(JSON.parse(schema))
       end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Allow the `ClaimsAPI` `Form` "schema" endpoints (see below) to be accessed without authentication.
- `GET /services/claims/v1/forms/526`
- `GET /services/claims/v1/forms/0966`
- `GET /services/claims/v1/forms/2122`

## Original issue(s)
[API-4808](https://vajira.max.gov/browse/API-4808)