### PR TITLE
Handle partial results returned from MAS; Fixes #20483

### DIFF
--- a/modules/vaos/app/controllers/vaos/v0/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v0/appointments_controller.rb
@@ -8,7 +8,7 @@ module VAOS
       before_action :validate_params, only: :index
 
       def index
-        if appointments[:meta][:errors].any?
+        if appointments[:meta][:errors]&.any?
           render json: each_serializer.new(appointments[:data], meta: appointments[:meta]), status: 207
         else
           render json: each_serializer.new(appointments[:data], meta: appointments[:meta]), status: 200

--- a/modules/vaos/app/controllers/vaos/v0/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v0/appointments_controller.rb
@@ -8,7 +8,11 @@ module VAOS
       before_action :validate_params, only: :index
 
       def index
-        render json: each_serializer.new(appointments[:data], meta: appointments[:meta])
+        if appointments[:meta][:errors].any?
+          render json: each_serializer.new(appointments[:data], meta: appointments[:meta]), status: 207
+        else
+          render json: each_serializer.new(appointments[:data], meta: appointments[:meta]), status: 200
+        end
       end
 
       def create

--- a/modules/vaos/app/services/vaos/appointment_service.rb
+++ b/modules/vaos/app/services/vaos/appointment_service.rb
@@ -95,7 +95,7 @@ module VAOS
     end
 
     def partial_errors(response)
-      if response.status == 200 && response.body[:errors]
+      if response.status == 200 && response.body[:errors]&.any?
         log_message_to_sentry(
           'VAOS::AppointmentService#get_appointments has response errors.',
           :info,

--- a/modules/vaos/app/services/vaos/appointment_service.rb
+++ b/modules/vaos/app/services/vaos/appointment_service.rb
@@ -11,17 +11,9 @@ module VAOS
       with_monitoring do
         response = perform(:get, get_appointments_base_url(type), params, headers, timeout: 55)
 
-        if response.status == 200 && response.body[:errors]
-          log_message_to_sentry(
-            'VAOS::AppointmentService#get_appointments has response errors.',
-            :info,
-            errors: response.body[:errors].to_json
-          )
-        end
-
         {
           data: deserialized_appointments(response.body, type),
-          meta: pagination(pagination_params)
+          meta: pagination(pagination_params).merge(partial_errors(response))
         }
       end
     end
@@ -99,6 +91,20 @@ module VAOS
           total_pages: 0, # underlying api doesn't provide this; how do you build a pagination UI without it?
           total_entries: 0 # underlying api doesn't provide this.
         }
+      }
+    end
+
+    def partial_errors(response)
+      if response.status == 200 && response.body[:errors]
+        log_message_to_sentry(
+          'VAOS::AppointmentService#get_appointments has response errors.',
+          :info,
+          errors: response.body[:errors].to_json
+        )
+      end
+
+      {
+        errors: (response.body[:errors] || []) # VAMF drops null valued keys; ensure we always return empty array
       }
     end
 

--- a/modules/vaos/spec/request/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/appointments_request_spec.rb
@@ -140,7 +140,18 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
           VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method uri]) do
             get '/vaos/v0/appointments', params: params
 
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to be_a(String)
+            expect(JSON.parse(response.body)['data'].first['id']).to eq('202006031600983000030800000000000000')
+            expect(response).to match_response_schema('vaos/va_appointments', { strict: false })
+          end
+        end
+
+        it 'has access and returns va appointments having partial errors' do
+          VCR.use_cassette('vaos/appointments/get_appointments_200_partial_error', match_requests_on: %i[method uri]) do
+            get '/vaos/v0/appointments', params: params
+
+            expect(response).to have_http_status(:multi_status)
             expect(response.body).to be_a(String)
             expect(JSON.parse(response.body)['data'].first['id']).to eq('202006031600983000030800000000000000')
             expect(response).to match_response_schema('vaos/va_appointments', { strict: false })
@@ -151,7 +162,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
           VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method uri]) do
             get '/vaos/v0/appointments', params: params, headers: inflection_header
 
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
             expect(response).to match_camelized_response_schema('vaos/va_appointments', { strict: false })
           end
@@ -162,7 +173,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         it 'returns single appointment based on appointment id' do
           VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method uri]) do
             get '/vaos/v0/appointments/va/202006031600983000030800000000000000', params: params
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
             expect(JSON.parse(response.body)['data']['id']).to eq('202006031600983000030800000000000000')
             expect(response).to match_response_schema('vaos/va_appointment', { strict: false })
@@ -174,7 +185,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
             get '/vaos/v0/appointments/va/202006031600983000030800000000000000',
                 params: params,
                 headers: inflection_header
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
             expect(JSON.parse(response.body)['data']['id']).to eq('202006031600983000030800000000000000')
             expect(response).to match_camelized_response_schema('vaos/va_appointment', { strict: false })
@@ -186,7 +197,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         it 'has access and returns cc appointments' do
           VCR.use_cassette('vaos/appointments/get_cc_appointments', match_requests_on: %i[method uri]) do
             get '/vaos/v0/appointments', params: params.merge(type: 'cc')
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
             expect(response).to match_response_schema('vaos/cc_appointments')
           end
@@ -195,7 +206,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         it 'has access and returns cc appointments when camel-inflected' do
           VCR.use_cassette('vaos/appointments/get_cc_appointments', match_requests_on: %i[method uri]) do
             get '/vaos/v0/appointments', params: params.merge(type: 'cc'), headers: inflection_header
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
             expect(response).to match_camelized_response_schema('vaos/cc_appointments')
           end
@@ -206,7 +217,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         it 'returns an empty list' do
           VCR.use_cassette('vaos/appointments/get_appointments_empty', match_requests_on: %i[method uri]) do
             get '/vaos/v0/appointments', params: params
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:ok)
             expect(JSON.parse(response.body)).to eq(
               'data' => [],
               'meta' => {
@@ -215,7 +226,8 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
                   'per_page' => 0,
                   'total_entries' => 0,
                   'total_pages' => 0
-                }
+                },
+                'errors' => []
               }
             )
             expect(response).to match_response_schema('vaos/va_appointments')
@@ -225,7 +237,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         it 'returns an empty list when camel-inflected' do
           VCR.use_cassette('vaos/appointments/get_appointments_empty', match_requests_on: %i[method uri]) do
             get '/vaos/v0/appointments', params: params, headers: inflection_header
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:ok)
             expect(JSON.parse(response.body)).to eq(
               'data' => [],
               'meta' => {
@@ -234,7 +246,8 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
                   'perPage' => 0,
                   'totalEntries' => 0,
                   'totalPages' => 0
-                }
+                },
+                'errors' => []
               }
             )
             expect(response).to match_camelized_response_schema('vaos/va_appointments')
@@ -247,7 +260,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
           VCR.use_cassette('vaos/appointments/get_appointments_map_error',
                            match_requests_on: %i[method uri], tag: :force_utf8) do
             get '/vaos/v0/appointments', params: params
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('vaos/va_appointments', { strict: false })
           end
         end
@@ -256,7 +269,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
           VCR.use_cassette('vaos/appointments/get_appointments_map_error',
                            match_requests_on: %i[method uri], tag: :force_utf8) do
             get '/vaos/v0/appointments', params: params, headers: inflection_header
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:ok)
             expect(response).to match_camelized_response_schema('vaos/va_appointments', { strict: false })
           end
         end
@@ -329,7 +342,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
           VCR.use_cassette('vaos/appointments/post_appointment', match_requests_on: %i[method uri]) do
             post '/vaos/v0/appointments', params: request_body
 
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:no_content)
             expect(response.body).to be_an_instance_of(String).and be_empty
           end
         end
@@ -408,7 +421,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
           VCR.use_cassette('vaos/appointments/put_cancel_appointment', match_requests_on: %i[method uri]) do
             put '/vaos/v0/appointments/cancel', params: request_body
 
-            expect(response).to have_http_status(:success)
+            expect(response).to have_http_status(:no_content)
             expect(response.body).to be_an_instance_of(String).and be_empty
           end
         end

--- a/spec/support/schemas/vaos/cc_appointments.json
+++ b/spec/support/schemas/vaos/cc_appointments.json
@@ -13,7 +13,7 @@
     },
     "meta": {
       "type": "object",
-      "required": ["pagination"],
+      "required": ["pagination", "errors"],
       "properties": {
         "pagination": {
           "type": "object",
@@ -23,6 +23,20 @@
             "per_page": { "type": "integer" },
             "total_pages": { "type": "integer" },
             "total_entries": { "type": "integer" }
+          }
+        },
+        "errors": {
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "type": "object",
+            "required": ["code", "source", "summary"],
+            "properties": {
+              "code": { "type": "integer" },
+              "source": { "type": "string" },
+              "summary": { "type": "string" }
+            }
           }
         }
       }

--- a/spec/support/schemas/vaos/va_appointments.json
+++ b/spec/support/schemas/vaos/va_appointments.json
@@ -13,7 +13,7 @@
     },
     "meta": {
       "type": "object",
-      "required": ["pagination"],
+      "required": ["pagination", "errors"],
       "properties": {
         "pagination": {
           "type": "object",
@@ -23,6 +23,20 @@
             "per_page": { "type": "integer" },
             "total_pages": { "type": "integer" },
             "total_entries": { "type": "integer" }
+          }
+        },
+        "errors": {
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "type": "object",
+            "required": ["code", "source", "summary"],
+            "properties": {
+              "code": { "type": "integer" },
+              "source": { "type": "string" },
+              "summary": { "type": "string" }
+            }
           }
         }
       }

--- a/spec/support/schemas_camelized/vaos/cc_appointments.json
+++ b/spec/support/schemas_camelized/vaos/cc_appointments.json
@@ -16,30 +16,29 @@
     },
     "meta": {
       "type": "object",
-      "required": [
-        "pagination"
-      ],
+      "required": ["pagination", "errors"],
       "properties": {
         "pagination": {
           "type": "object",
-          "required": [
-            "currentPage",
-            "perPage",
-            "totalPages",
-            "totalEntries"
-          ],
+          "required": ["currentPage", "perPage", "totalPages", "totalEntries"],
           "properties": {
-            "currentPage": {
-              "type": "integer"
-            },
-            "perPage": {
-              "type": "integer"
-            },
-            "totalPages": {
-              "type": "integer"
-            },
-            "totalEntries": {
-              "type": "integer"
+            "currentPage": { "type": "integer" },
+            "perPage": { "type": "integer" },
+            "totalPages": { "type": "integer" },
+            "totalEntries": { "type": "integer" }
+          }
+        },
+        "errors": {
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "type": "object",
+            "required": ["code", "source", "summary"],
+            "properties": {
+              "code": { "type": "integer" },
+              "source": { "type": "string" },
+              "summary": { "type": "string" }
             }
           }
         }

--- a/spec/support/schemas_camelized/vaos/va_appointments.json
+++ b/spec/support/schemas_camelized/vaos/va_appointments.json
@@ -16,30 +16,29 @@
     },
     "meta": {
       "type": "object",
-      "required": [
-        "pagination"
-      ],
+      "required": ["pagination", "errors"],
       "properties": {
         "pagination": {
           "type": "object",
-          "required": [
-            "currentPage",
-            "perPage",
-            "totalPages",
-            "totalEntries"
-          ],
+          "required": ["currentPage", "perPage", "totalPages", "totalEntries"],
           "properties": {
-            "currentPage": {
-              "type": "integer"
-            },
-            "perPage": {
-              "type": "integer"
-            },
-            "totalPages": {
-              "type": "integer"
-            },
-            "totalEntries": {
-              "type": "integer"
+            "currentPage": { "type": "integer" },
+            "perPage": { "type": "integer" },
+            "totalPages": { "type": "integer" },
+            "totalEntries": { "type": "integer" }
+          }
+        },
+        "errors": {
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "type": "object",
+            "required": ["code", "source", "summary"],
+            "properties": {
+              "code": { "type": "integer" },
+              "source": { "type": "string" },
+              "summary": { "type": "string" }
             }
           }
         }


### PR DESCRIPTION
## Description of change
Add errors partial to meta. Updates schema definitions for both va_appointments and cc_appointments schemas. Will always include an errors array even when no elements in the array. When errors are present http status will become 207 Multi Status, essentially successful with partial errors. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/20483