### PR TITLE
Add integer type to latestIssuesInChain

### DIFF
--- a/modules/appeals_api/app/swagger/appeals_api/v1/responses_contestable_issues.json
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/responses_contestable_issues.json
@@ -84,7 +84,7 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "id": { "type": "string", "nullable": true, "example": null },
+                            "id": { "type": ["integer", "string"], "nullable": true, "example": null },
                             "approxDecisionDate": {
                               "type": "string",
                               "nullable": true,


### PR DESCRIPTION
**Description**
Our documentation needs to account for contestable issues, lastestIssuesInChain IDs as integers in addition to the already expected string type.

**Ticket**
https://vajira.max.gov/browse/API-5455