### PR TITLE
19656 get lighthouse appointment

### DIFF
--- a/modules/health_quest/app/controllers/health_quest/v0/lighthouse_appointments_controller.rb
+++ b/modules/health_quest/app/controllers/health_quest/v0/lighthouse_appointments_controller.rb
@@ -8,7 +8,7 @@ module HealthQuest
       end
 
       def show
-        render json: {}
+        render json: factory.get(params[:id]).response[:body]
       end
 
       private

--- a/modules/health_quest/app/controllers/health_quest/v0/lighthouse_appointments_controller.rb
+++ b/modules/health_quest/app/controllers/health_quest/v0/lighthouse_appointments_controller.rb
@@ -13,10 +13,6 @@ module HealthQuest
 
       private
 
-      def appointment_params
-        params.permit(:id)
-      end
-
       def factory
         @factory =
           HealthQuest::HealthApi::Appointment::Factory.manufacture(current_user)

--- a/modules/health_quest/app/services/health_quest/health_api/appointment/factory.rb
+++ b/modules/health_quest/app/services/health_quest/health_api/appointment/factory.rb
@@ -35,6 +35,16 @@ module HealthQuest
         end
 
         ##
+        # Gets the appointment from it's unique ID
+        #
+        # @param id [String] a unique string value
+        # @return [FHIR::ClientReply]
+        #
+        def get(id) # rubocop:disable Rails/Delegate
+          map_query.get(id)
+        end
+
+        ##
         # Gets appointments from a given set of query parameters
         #
         # @param filters [Hash] the set of query options.

--- a/modules/health_quest/app/services/health_quest/health_api/appointment/map_query.rb
+++ b/modules/health_quest/app/services/health_quest/health_api/appointment/map_query.rb
@@ -32,6 +32,16 @@ module HealthQuest
         end
 
         ##
+        # Gets an appointment by it's ID
+        #
+        # @param id [String] the appointment ID.
+        # @return [FHIR::ClientReply] an instance of ClientReply
+        #
+        def get(id)
+          client.read(fhir_model, id)
+        end
+
+        ##
         # Gets appointments from the provided options
         #
         # @param options [Hash] the search options.

--- a/modules/health_quest/spec/request/lighthouse_appointments_request_spec.rb
+++ b/modules/health_quest/spec/request/lighthouse_appointments_request_spec.rb
@@ -29,15 +29,23 @@ RSpec.describe 'Lighthouse appointments', type: :request do
 
     context 'health quest user' do
       let(:current_user) { build(:user, :health_quest) }
+      let(:id) { 'faae134c-9c7b-49d7-8161-10e314da4de1' }
+      let(:session_store) { double('SessionStore', token: '123abc') }
+      let(:client_reply) do
+        double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Appointment' } })
+      end
 
       before do
         sign_in_as(current_user)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
+        allow_any_instance_of(HealthQuest::HealthApi::Appointment::MapQuery)
+          .to receive(:get).with(anything).and_return(client_reply)
       end
 
-      it 'returns an empty appointment' do
+      it 'returns a FHIR type of Appointment' do
         get '/health_quest/v0/lighthouse_appointments/I2-ABC123'
 
-        expect(JSON.parse(response.body)).to eq({})
+        expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Appointment' })
       end
     end
   end

--- a/modules/health_quest/spec/services/health_api/appointment/factory_spec.rb
+++ b/modules/health_quest/spec/services/health_api/appointment/factory_spec.rb
@@ -48,4 +48,15 @@ describe HealthQuest::HealthApi::Appointment::Factory do
       expect(described_class.manufacture(user).search(options_builder.to_hash)).to eq(client_reply)
     end
   end
+
+  describe '#get' do
+    let(:id) { 'I2-ABC1234' }
+
+    it 'returns a ClientReply' do
+      allow_any_instance_of(HealthQuest::HealthApi::Appointment::MapQuery)
+        .to receive(:get).with(id).and_return(client_reply)
+
+      expect(described_class.manufacture(user).get(id)).to eq(client_reply)
+    end
+  end
 end

--- a/modules/health_quest/spec/services/health_api/appointment/map_query_spec.rb
+++ b/modules/health_quest/spec/services/health_api/appointment/map_query_spec.rb
@@ -71,4 +71,30 @@ describe HealthQuest::HealthApi::Appointment::MapQuery do
       end
     end
   end
+
+  describe '#get' do
+    context 'with valid id' do
+      let(:client) { double('HealthQuest::Lighthouse::FHIRClient') }
+      let(:id) { 'I2-ABC123' }
+
+      before do
+        allow_any_instance_of(subject).to receive(:client).and_return(client)
+      end
+
+      it 'returns an instance of Reply' do
+        expect(client).to receive(:read).with(FHIR::Appointment, id).exactly(1).time
+
+        subject.build(session_store).get(id)
+      end
+
+      it 'has request headers' do
+        allow(client).to receive(:read).with(FHIR::Appointment, id).and_return(anything)
+
+        map_query = subject.build(session_store)
+        map_query.get(id)
+
+        expect(map_query.headers).to eq({ 'Authorization' => 'Bearer 123abc' })
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- This PR gives the health-quest module the ability to fetch a single appointment resource by its ID from the Lighthouse Health API.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#19656

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature Flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests are written and the entire suite is passing