### PR TITLE
[#357] Add first name to personalization params for Form526ConfirmationEmailJob

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -64,14 +64,14 @@ class Form526Submission < ApplicationRecord
     jids.first
   end
 
-  def get_first_name
-    user = User.find(user_uuid)
-    user&.first_name&.capitalize
-  end
-
   def get_full_name
     user = User.find(user_uuid)
     user&.full_name_normalized&.values&.compact&.join(' ')&.upcase
+  end
+
+  def get_first_name
+    user = User.find(user_uuid)
+    user&.first_name&.upcase
   end
 
   # @return [Hash] parsed version of the form json
@@ -171,7 +171,9 @@ class Form526Submission < ApplicationRecord
   def perform_ancillary_jobs_handler(_status, options)
     submission = Form526Submission.find(options['submission_id'])
     # Only run ancillary jobs if submission succeeded
-    submission.perform_ancillary_jobs(options['full_name'], options['first_name']) if submission.form526_job_statuses.all?(&:success?)
+    if submission.form526_job_statuses.all?(&:success?)
+      submission.perform_ancillary_jobs(options['full_name'], options['first_name'])
+    end
   end
 
   # Creates a batch for the ancillary jobs, sets up the callback, and adds the jobs to the batch if necessary

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -54,13 +54,19 @@ class Form526Submission < ApplicationRecord
       :success,
       'Form526Submission#perform_ancillary_jobs_handler',
       'submission_id' => id,
-      'full_name' => get_full_name
+      'full_name' => get_full_name,
+      'first_name' => get_first_name
     )
     jids = workflow_batch.jobs do
       EVSS::DisabilityCompensationForm::SubmitForm526AllClaim.perform_async(id)
     end
 
     jids.first
+  end
+
+  def get_first_name
+    user = User.find(user_uuid)
+    user&.first_name&.capitalize
   end
 
   def get_full_name
@@ -165,7 +171,7 @@ class Form526Submission < ApplicationRecord
   def perform_ancillary_jobs_handler(_status, options)
     submission = Form526Submission.find(options['submission_id'])
     # Only run ancillary jobs if submission succeeded
-    submission.perform_ancillary_jobs(options['full_name']) if submission.form526_job_statuses.all?(&:success?)
+    submission.perform_ancillary_jobs(options['full_name'], options['first_name']) if submission.form526_job_statuses.all?(&:success?)
   end
 
   # Creates a batch for the ancillary jobs, sets up the callback, and adds the jobs to the batch if necessary
@@ -173,13 +179,14 @@ class Form526Submission < ApplicationRecord
   # @param full_name [String] the full name of the user that submitted Form526
   # @return [String] the workflow batch id
   #
-  def perform_ancillary_jobs(full_name)
+  def perform_ancillary_jobs(full_name, first_name)
     workflow_batch = Sidekiq::Batch.new
     workflow_batch.on(
       :success,
       'Form526Submission#workflow_complete_handler',
       'submission_id' => id,
-      'full_name' => full_name
+      'full_name' => full_name,
+      'first_name' => first_name
     )
     workflow_batch.jobs do
       submit_uploads if form[FORM_526_UPLOADS].present?
@@ -201,20 +208,21 @@ class Form526Submission < ApplicationRecord
     if submission.form526_job_statuses.all?(&:success?)
       user = User.find(submission.user_uuid)
       if Flipper.enabled?(:form526_confirmation_email, user)
-        submission.send_form526_confirmation_email(options['full_name'])
+        submission.send_form526_confirmation_email(options['full_name'], options['first_name'])
       end
       submission.workflow_complete = true
       submission.save
     end
   end
 
-  def send_form526_confirmation_email(full_name)
+  def send_form526_confirmation_email(full_name, first_name)
     email_address = form['form526']['form526']['veteran']['emailAddress']
     personalization_parameters = {
       'email' => email_address,
       'submitted_claim_id' => submitted_claim_id,
       'date_submitted' => created_at.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.'),
-      'full_name' => full_name
+      'full_name' => full_name,
+      'first_name' => first_name
     }
     Form526ConfirmationEmailJob.perform_async(personalization_parameters)
   end

--- a/app/workers/form526_confirmation_email_job.rb
+++ b/app/workers/form526_confirmation_email_job.rb
@@ -25,7 +25,8 @@ class Form526ConfirmationEmailJob
       personalisation: {
         'claim_id' => personalization_parameters['submitted_claim_id'],
         'date_submitted' => personalization_parameters['date_submitted'],
-        'full_name' => personalization_parameters['full_name']
+        'full_name' => personalization_parameters['full_name'],
+        'first_name' => personalization_parameters['first_name']
       }
     )
     StatsD.increment(STATSD_SUCCESS_NAME)

--- a/spec/jobs/form526_confirmation_email_job_spec.rb
+++ b/spec/jobs/form526_confirmation_email_job_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
     let(:notification_client) { double('Notifications::Client') }
 
     context 'with default attributes' do
-      before do
-        @email_address = 'foo@example.com'
-        @email_response = {
+      let(:email_address) { 'foo@example.com' }
+      let(:email_response) do
+        {
           'content': {
             'body': '<html><body><h1>Hello</h1> World.</body></html>',
             'from_email': 'from_email',
@@ -30,6 +30,15 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
           'uri': 'url'
         }
       end
+      let(:personalization_parameters) do
+        {
+          'email' => email_address,
+          'submitted_claim_id' => '600191990',
+          'date_submitted' => 'July 12, 2020',
+          'full_name' => 'first last',
+          'first_name' => 'firstname'
+        }
+      end
 
       it 'the service is initialized with the correct parameters with enabled toggle' do
         Flipper.enable(:vanotify_service_enhancement)
@@ -39,7 +48,7 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
         ) do
           mocked_notification_service = instance_double('VaNotify::Service')
           allow(VaNotify::Service).to receive(:new).and_return(mocked_notification_service)
-          allow(mocked_notification_service).to receive(:send_email).and_return(@email_response)
+          allow(mocked_notification_service).to receive(:send_email).and_return(email_response)
           subject.perform('')
           expect(VaNotify::Service).to have_received(:new).with(test_service_api_key)
         end
@@ -53,7 +62,7 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
         ) do
           mocked_notification_service = instance_double('VaNotify::Service')
           allow(VaNotify::Service).to receive(:new).and_return(mocked_notification_service)
-          allow(mocked_notification_service).to receive(:send_email).and_return(@email_response)
+          allow(mocked_notification_service).to receive(:send_email).and_return(email_response)
           subject.perform('')
           expect(VaNotify::Service).to have_received(:new).with(test_service_api_key)
         end
@@ -61,26 +70,22 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
 
       it 'sends a confirmation email' do
         requirements = {
-          email_address: @email_address,
+          email_address: email_address,
           template_id: Settings.vanotify
                                .template_id
                                .form526_confirmation_email,
           personalisation: {
             'claim_id' => '600191990',
             'date_submitted' => 'July 12, 2020',
-            'full_name' => 'first last'
+            'full_name' => 'first last',
+            'first_name' => 'firstname'
           }
         }
         allow(Notifications::Client).to receive(:new).and_return(notification_client)
-        allow(notification_client).to receive(:send_email).and_return(@email_response)
+        allow(notification_client).to receive(:send_email).and_return(email_response)
 
         expect(notification_client).to receive(:send_email).with(requirements)
-        subject.perform({
-                          'email' => @email_address,
-                          'submitted_claim_id' => '600191990',
-                          'date_submitted' => 'July 12, 2020',
-                          'full_name' => 'first last'
-                        })
+        subject.perform(personalization_parameters)
       end
 
       it 'handles 4xx errors when sending an email' do
@@ -94,12 +99,6 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
         )
         allow(notification_client).to receive(:send_email).and_raise(error)
 
-        personalization_parameters = {
-          'email' => @email_address,
-          'submitted_claim_id' => '600191990',
-          'date_submitted' => 'July 12, 2020',
-          'full_name' => 'first last'
-        }
         expect(subject).to receive(:log_exception_to_sentry).with(error)
         expect { subject.perform(personalization_parameters) }
           .to trigger_statsd_increment('worker.form526_confirmation_email.error')
@@ -116,12 +115,6 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
         )
         allow(notification_client).to receive(:send_email).and_raise(error)
 
-        personalization_parameters = {
-          'email' => @email_address,
-          'submitted_claim_id' => '600191990',
-          'date_submitted' => 'July 12, 2020',
-          'full_name' => 'first last'
-        }
         expect(subject).to receive(:log_exception_to_sentry).with(error)
         expect { subject.perform(personalization_parameters) }
           .to raise_error(Common::Exceptions::BackendServiceException)
@@ -130,15 +123,9 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
 
       it 'returns one job triggered' do
         allow(Notifications::Client).to receive(:new).and_return(notification_client)
-        allow(notification_client).to receive(:send_email).and_return(@email_response)
+        allow(notification_client).to receive(:send_email).and_return(email_response)
 
         expect do
-          personalization_parameters = {
-            'email' => @email_address,
-            'submitted_claim_id' => '600191990',
-            'date_submitted' => 'July 12, 2020',
-            'full_name' => 'first last'
-          }
           Form526ConfirmationEmailJob.perform_async(personalization_parameters)
         end.to change(Form526ConfirmationEmailJob.jobs, :size).by(1)
       end

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -485,7 +485,7 @@ RSpec.describe Form526Submission do
         expect(subject.get_first_name).to eql(test_param[:expected])
       end
     end
-  end      
+  end
 
   describe '#workflow_complete_handler' do
     let(:options) do

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe Form526Submission do
     end
   end
 
-  describe "#get_first_name" do
+  describe '#get_first_name' do
     [
       {
         input: 'Joe',
@@ -485,17 +485,17 @@ RSpec.describe Form526Submission do
         expect(subject.get_first_name).to eql(test_param[:expected])
       end
     end
-  end           
+  end      
 
   describe '#workflow_complete_handler' do
-    let(:options) do 
+    let(:options) do
       {
         'submission_id' => subject.id,
         'full_name' => 'some name',
         'first_name' => 'firstname'
       }
     end
-      
+
     context 'with a single successful job' do
       subject { create(:form526_submission, :with_one_succesful_job) }
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Adding `first_name` to personalization parameters to send form526 confirmation email job. Upon successful addition of this parameter, will create a separate PR to remove full_name from personalization parameters in order to be HIPPA compliant.

## Original issue(s)
department-of-veterans-affairs/notification-api#357

## Things to know about this PR
* This is part of existing feature flag "form526_confirmation_email", which is currently enabled in production.
* Motivation for this change is to be HIPPA compliant. Upon successful addition of first_name parameters, will create separate PR to remove full_name from personalization parameters to email confirmation job.


<!-- Please describe testing done to verify the changes or any testing planned. -->
* Made modifications to respective unit and integration tests.
