### PR TITLE
Permanent fix viewport spec

### DIFF
--- a/spec/jobs/cypress_viewport_updater/viewport_spec.rb
+++ b/spec/jobs/cypress_viewport_updater/viewport_spec.rb
@@ -66,7 +66,10 @@ RSpec.describe CypressViewportUpdater::Viewport do
 
   describe '#percentTrafficPeriod' do
     it 'returns the correct value' do
-      expect(@viewport.percentTrafficPeriod).to eq('From: 02/01/2021, To: 02/28/2021')
+      beginning_of_month = Time.zone.today.prev_month.beginning_of_month.strftime('%m/%d/%Y')
+      end_of_month = Time.zone.today.prev_month.end_of_month.strftime('%m/%d/%Y')
+
+      expect(@viewport.percentTrafficPeriod).to eq("From: #{beginning_of_month}, To: #{end_of_month}")
     end
   end
 

--- a/spec/jobs/cypress_viewport_updater/viewport_spec.rb
+++ b/spec/jobs/cypress_viewport_updater/viewport_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe CypressViewportUpdater::Viewport do
       expect(@viewport.percentTrafficPeriod).to include(beginning_of_month)
     end
   end
- 
+
   describe '#viewportPreset' do
     it 'returns the correct value' do
       expect(@viewport.viewportPreset).to eq('va-top-desktop-1')

--- a/spec/jobs/cypress_viewport_updater/viewport_spec.rb
+++ b/spec/jobs/cypress_viewport_updater/viewport_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe CypressViewportUpdater::Viewport do
       expect(@viewport.percentTrafficPeriod).to include(beginning_of_month)
     end
   end
-
+ 
   describe '#viewportPreset' do
     it 'returns the correct value' do
       expect(@viewport.viewportPreset).to eq('va-top-desktop-1')

--- a/spec/jobs/cypress_viewport_updater/viewport_spec.rb
+++ b/spec/jobs/cypress_viewport_updater/viewport_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe CypressViewportUpdater::Viewport do
       end_of_month = Time.zone.today.prev_month.end_of_month.strftime('%m/%d/%Y')
 
       expect(@viewport.percentTrafficPeriod).to eq("From: #{beginning_of_month}, To: #{end_of_month}")
+      expect(@viewport.percentTrafficPeriod).to include(beginning_of_month)
     end
   end
 


### PR DESCRIPTION
## Description of change
While working on [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/5997), I hit [a failing spec](https://github.com/department-of-veterans-affairs/vets-api/pull/5997/files#diff-538bb209a64e00cdefa341e0341fb6d8a97e0c1f83c4d5c6bbf617557b2c93ebL69).

Being in a hurry and considering it was a static string already, I changed the dates with the intent to make a more permanent solution in a separate PR. @bosawt HMU on slack asking about it and this is the PR from that conversation.

Trevor suggested `Timecop.freeze(Time.zone.parse('2021-03-01')` but I couldn't get that to work.

I'm not _wild_ about my solution. Seems to just do what the code is doing that it's supposed to test. I added another expectation as another option.

## Original issue(s)
No issue for this

## Things to know about this PR
* Are there additions to a `settings.yml` file? Do they vary by environment?
  * No tests
* Is there a feature flag? What is it?
  * no FF
* Is there some Sentry logging that was added? What alerts are relevant?
  * Nope
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
  * no metrics
* Are there Swagger docs that were updated?
  * no updates
* Is there any PII concerns or questions?
  * no concerns


<!-- Please describe testing done to verify the changes or any testing planned. -->
