### PR TITLE
API-5382 Return service history as array type, add 401 status code

### DIFF
--- a/modules/veteran_verification/VETERAN_VERIFICATION.yml
+++ b/modules/veteran_verification/VETERAN_VERIFICATION.yml
@@ -89,9 +89,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/VeteranStatusConfirmation'
         '401':
-          description: Unauthorized.
-        '403':
-          description: Provided Access Token Does not have the required scopes to access.
+          description: Not authorized
         '502':
           description: eMIS failed to respond or responded in a way we cannot handle.
   /disability_rating:
@@ -117,7 +115,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DisabilityRatingToken'
         '401':
-          description: Unauthorized.
+          description: Not authorized
         '502':
           description: BGS service responded with something other than the expected disability rating response.
   /service_history:
@@ -143,7 +141,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/ServiceHistoryToken'
         '401':
-          description: Unauthorized.
+          description: Not authorized
         '404':
           description: No service history found
   /keys:
@@ -160,7 +158,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/JWKKeyset'
         '401':
-          description: Unauthorized.
+          description: Not authorized
 components:
   securitySchemes:
     bearer_token:

--- a/modules/veteran_verification/VETERAN_VERIFICATION.yml
+++ b/modules/veteran_verification/VETERAN_VERIFICATION.yml
@@ -88,6 +88,8 @@ paths:
                 properties:
                   data:
                     $ref: '#/components/schemas/VeteranStatusConfirmation'
+        '401':
+          description: Unauthorized.
         '403':
           description: Provided Access Token Does not have the required scopes to access.
         '502':
@@ -114,6 +116,8 @@ paths:
             application/jwt:
               schema:
                 $ref: '#/components/schemas/DisabilityRatingToken'
+        '401':
+          description: Unauthorized.
         '502':
           description: BGS service responded with something other than the expected disability rating response.
   /service_history:
@@ -130,14 +134,16 @@ paths:
           content:
             application/json:
               schema:
-                required:
-                  - data
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ServiceHistoryEpisode'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ServiceHistoryEpisode'
             application/jwt:
               schema:
-                $ref: '#/components/schemas/ServiceHistoryToken'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ServiceHistoryToken'
+        '401':
+          description: Unauthorized.
         '404':
           description: No service history found
   /keys:
@@ -153,6 +159,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JWKKeyset'
+        '401':
+          description: Unauthorized.
 components:
   securitySchemes:
     bearer_token:
@@ -224,27 +232,27 @@ components:
       type: string
       example: 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjA4OGQyNDIzMmZmNmZhYTRjZDRjZmVjMTI2YWQwNDMxZGZmMWVhMDI4YWZkYjFjODZiMzcxOGQ3MDE3MWFlZDYifQ.eyJkYXRhIjp7ImlkIjoxMjMwMywidHlwZSI6ImRvY3VtZW50X3VwbG9hZCIsImF0dHJpYnV0ZXMiOnsiZGVjaXNpb24iOiJTZXJ2aWNlIENvbm5lY3RlZCIsImVmZmVjdGl2ZV9kYXRlIjoiMjAxOC0wMy0yN1QyMTowMDo0MS4wMDArMDAwMCIsInJhdGluZ19wZXJjZW50YWdlIjo1MH19fQ.z3EeYFixwdmG_4_LFdzy6fdF2Y7nj3y9uOPRTwLqsXVcLNUDIN72atn0SSI-hkF-rRkbFdyzLDaY2AWtQ-LmBPdeWqyv4U2ZnjynAwlCnG0VNG3x4Wz2qSW7BW1cQVBx0yvWag_NmQ74AfOBNz7K2qz8aEOvYIJaicRr2hSAu7A'
     VeteranStatusConfirmation:
-          description: |
-            Veteran status confirmation for an individual
+      description: |
+        Veteran status confirmation for an individual
+      type: object
+      properties:
+        id:
+          type: string
+          description: Confirmation UUID
+          example: "833c6ffc-efef-4775-9355-f836b4f57501"
+        type:
+          type: string
+          example: veteran_status_confirmations
+        attributes:
           type: object
           properties:
-            id:
+            veteran_status:
               type: string
-              description: Confirmation UUID
-              example: "833c6ffc-efef-4775-9355-f836b4f57501"
-            type:
-              type: string
-              example: veteran_status_confirmations
-            attributes:
-              type: object
-              properties:
-                veteran_status:
-                  type: string
-                  description: |
-                    Whether the system could confirm the Veteran status of the authorized individual
-                  enum:
-                    - confirmed
-                    - not confirmed
+              description: |
+                Whether the system could confirm the Veteran status of the authorized individual
+              enum:
+                - confirmed
+                - not confirmed
     ServiceHistoryEpisode:
       description: |
         Service History for authorized Veteran


### PR DESCRIPTION


<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Specifying in the documentation that service history endpoint returns an array of ServiceHistoryEpisode objects. Adding 401 unauthorizes status code response to all veteran verification endpoints. 

## Original issue(s)
https://vajira.max.gov/browse/API-5382

## Things to know about this PR
Veteran Verification swagger docs were updated.

Verified that the documentation was parsing and displaying correctly in the editor.swagger.io webpage.