### PR TITLE
Fix Secure Messaging POSTs

### DIFF
--- a/lib/sm/client.rb
+++ b/lib/sm/client.rb
@@ -210,7 +210,7 @@ module SM
     def post_create_message(args = {})
       validate_create_context(args)
 
-      json = perform(:post, 'message', args, token_headers).body
+      json = perform(:post, 'message', args.to_h, token_headers).body
       Message.new(json)
     end
 
@@ -225,7 +225,7 @@ module SM
       validate_create_context(args)
 
       custom_headers = token_headers.merge('Content-Type' => 'multipart/form-data')
-      json = perform(:post, 'message/attach', args, custom_headers).body
+      json = perform(:post, 'message/attach', args.to_h, custom_headers).body
       Message.new(json)
     end
 
@@ -240,7 +240,7 @@ module SM
       validate_reply_context(args)
 
       custom_headers = token_headers.merge('Content-Type' => 'multipart/form-data')
-      json = perform(:post, "message/#{id}/reply/attach", args, custom_headers).body
+      json = perform(:post, "message/#{id}/reply/attach", args.to_h, custom_headers).body
       Message.new(json)
     end
 
@@ -254,7 +254,7 @@ module SM
     def post_create_message_reply(id, args = {})
       validate_reply_context(args)
 
-      json = perform(:post, "message/#{id}/reply", args, token_headers).body
+      json = perform(:post, "message/#{id}/reply", args.to_h, token_headers).body
       Message.new(json)
     end
 

--- a/lib/sm/configuration.rb
+++ b/lib/sm/configuration.rb
@@ -51,8 +51,8 @@ module SM
         conn.request :json
 
         # Uncomment this if you want curl command equivalent or response output to log
-        # conn.request(:curl, ::Logger.new(STDOUT), :warn) unless Rails.env.production?
-        # conn.response(:logger, ::Logger.new(STDOUT), bodies: true) unless Rails.env.production?
+        conn.request(:curl, ::Logger.new(STDOUT), :warn) unless Rails.env.production?
+        conn.response(:logger, ::Logger.new(STDOUT), bodies: true) unless Rails.env.production?
 
         conn.response :betamocks if Settings.mhv.sm.mock
         conn.response :sm_parser

--- a/lib/sm/configuration.rb
+++ b/lib/sm/configuration.rb
@@ -49,10 +49,10 @@ module SM
         conn.request :multipart_request
         conn.request :multipart
         conn.request :json
-
+        
         # Uncomment this if you want curl command equivalent or response output to log
-        conn.request(:curl, ::Logger.new(STDOUT), :warn) unless Rails.env.production?
-        conn.response(:logger, ::Logger.new(STDOUT), bodies: true) unless Rails.env.production?
+        # conn.request(:curl, logger, :warn) unless Rails.env.production?
+        # conn.response(:logger, logger, bodies: true) unless Rails.env.production?
 
         conn.response :betamocks if Settings.mhv.sm.mock
         conn.response :sm_parser

--- a/lib/sm/configuration.rb
+++ b/lib/sm/configuration.rb
@@ -49,10 +49,10 @@ module SM
         conn.request :multipart_request
         conn.request :multipart
         conn.request :json
-        
+
         # Uncomment this if you want curl command equivalent or response output to log
-        # conn.request(:curl, logger, :warn) unless Rails.env.production?
-        # conn.response(:logger, logger, bodies: true) unless Rails.env.production?
+        # conn.request(:curl, ::Logger.new(STDOUT), :warn) unless Rails.env.production?
+        # conn.response(:logger, ::Logger.new(STDOUT), bodies: true) unless Rails.env.production?
 
         conn.response :betamocks if Settings.mhv.sm.mock
         conn.response :sm_parser


### PR DESCRIPTION
## Description of change
Secure Messaging `POST` requests that include a body such as sending a message and replying to a message were not being sent correctly because args were being passed as `ActionController:Parameters` instead of hashes.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#20189

## Things to know about this PR
May need additional changes to support file uploads

<!-- Please describe testing done to verify the changes or any testing planned. -->
