### PR TITLE
[API-4124] - Fix bug when trying to raise exception for inability to va…

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -16,7 +16,7 @@ module ClaimsApi
       rescue # => e
         # Need to eventually start logging poa error logs.
         # log_message_to_sentry('PoA claims', :warning, body: e.message)
-        raise Common::Exceptions::Unauthorized, detail: 'Cannot validate Power of Attorney'
+        raise ::Common::Exceptions::Unauthorized, detail: 'Cannot validate Power of Attorney'
       end
 
       def verify_representative_and_veteran(logged_in_representative_user, target_veteran_to_be_verified)


### PR DESCRIPTION
…lidate POA

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
The reason a 500 was being returned is because when the [call to BGS](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb#L23) fails, we would try to raise a custom exception.  The custom exception was not properly namespaced.  Which lead to an "_Uninitialized Constant_" error.  This change fixes that namespacing problem and allows the custom exception to be raised.

## Original issue(s)
[API-4124](https://vajira.max.gov/browse/API-4124)