### PR TITLE
fetch locations from the health api

### DIFF
--- a/modules/health_quest/app/controllers/health_quest/v0/locations_controller.rb
+++ b/modules/health_quest/app/controllers/health_quest/v0/locations_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module V0
+    class LocationsController < HealthQuest::V0::BaseController
+      def index
+        render json: factory.search(request.query_parameters).response[:body]
+      end
+
+      private
+
+      def factory
+        @factory =
+          HealthQuest::HealthApi::Location::Factory.manufacture(current_user)
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/health_api/location/factory.rb
+++ b/modules/health_quest/app/services/health_quest/health_api/location/factory.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module HealthApi
+    module Location
+      ##
+      # A service object for isolating dependencies from any implementing service or controller.
+      #
+      # @!attribute session_service
+      #   @return [HealthQuest::Lighthouse::Session]
+      # @!attribute user
+      #   @return [User]
+      # @!attribute map_query
+      #   @return [HealthApi::Location::MapQuery]
+      # @!attribute options_builder
+      #   @return [Shared::OptionsBuilder]
+      class Factory
+        attr_reader :session_service, :user, :map_query, :options_builder
+
+        ##
+        # Builds a HealthApi::Location::Factory instance from a given User
+        #
+        # @param user [User] the currently logged in user.
+        # @return [HealthApi::Location::Factory] an instance of this class
+        #
+        def self.manufacture(user)
+          new(user)
+        end
+
+        def initialize(user)
+          @user = user
+          @session_service = HealthQuest::Lighthouse::Session.build(user: user, api: health_api)
+          @map_query = HealthApi::Location::MapQuery.build(session_service.retrieve)
+          @options_builder = Shared::OptionsBuilder
+        end
+
+        ##
+        # Gets locations from a given set of query parameters
+        #
+        # @param filters [Hash] the set of query options.
+        # @return [FHIR::ClientReply] an instance of ClientReply
+        #
+        def search(filters = {})
+          filters.merge!(resource_name)
+
+          with_options = options_builder.manufacture(user, filters).to_hash
+          map_query.search(with_options)
+        end
+
+        ##
+        # Builds the key/value pair for identifying the resource
+        #
+        # @return [Hash] a key value pair
+        #
+        def resource_name
+          { resource_name: 'location' }
+        end
+
+        private
+
+        def health_api
+          Settings.hqva_mobile.lighthouse.health_api
+        end
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/health_api/location/map_query.rb
+++ b/modules/health_quest/app/services/health_quest/health_api/location/map_query.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module HealthApi
+    module Location
+      ##
+      # A service object for querying the Health API for Location resources.
+      #
+      # @!attribute access_token
+      #   @return [String]
+      # @!attribute headers
+      #   @return [Hash]
+      class MapQuery
+        include Lighthouse::FHIRClient
+        include Lighthouse::FHIRHeaders
+
+        attr_reader :access_token, :headers
+
+        ##
+        # Builds a PatientGeneratedData::QuestionnaireResponse::MapQuery instance from a redis session.
+        #
+        # @param session_store [HealthQuest::SessionStore] the users redis session.
+        # @return [PatientGeneratedData::QuestionnaireResponse::MapQuery] an instance of this class
+        #
+        def self.build(session_store)
+          new(session_store)
+        end
+
+        def initialize(session_store)
+          @access_token = session_store.token
+          @headers = auth_header
+        end
+
+        ##
+        # Gets locations from the provided options
+        #
+        # @param options [Hash] the search options.
+        # @return [FHIR::Bundle] an instance of Bundle
+        #
+        def search(options)
+          client.search(fhir_model, search_options(options))
+        end
+
+        ##
+        # Returns the FHIR::Location class object
+        #
+        # @return [FHIR::Location]
+        #
+        def fhir_model
+          FHIR::Location
+        end
+
+        ##
+        # Builds a hash of options for the `#search` method
+        #
+        # @param options [Hash] search options.
+        # @return [Hash] a configured set of key values
+        #
+        def search_options(options)
+          {
+            search: {
+              parameters: options
+            }
+          }
+        end
+
+        ##
+        # Returns the health api path
+        #
+        # @return [String]
+        #
+        def api_query_path
+          Settings.hqva_mobile.lighthouse.health_api_path
+        end
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/shared/options_builder.rb
+++ b/modules/health_quest/app/services/health_quest/shared/options_builder.rb
@@ -41,7 +41,8 @@ module HealthQuest
       end
 
       ##
-      # The registry which holds the return value for the `to_hash` method.
+      # The registry which holds the return value for the `to_hash`
+      # method based on which controller and resource is being accessed.
       #
       # @return [Hash]
       #
@@ -51,6 +52,9 @@ module HealthQuest
             patient: user.icn,
             date: appointment_dates,
             location: clinic_id
+          },
+          location: {
+            _id: location_ids
           },
           questionnaire_response: {
             subject: appointment_reference,
@@ -107,6 +111,15 @@ module HealthQuest
       #
       def resource_created_date
         @resource_created_date ||= filters&.fetch(:authored, nil)
+      end
+
+      ##
+      # Get the string of location ids from the filters.
+      #
+      # @return [String]
+      #
+      def location_ids
+        @location_ids ||= filters&.fetch(:_id, nil)
       end
 
       ##

--- a/modules/health_quest/config/routes.rb
+++ b/modules/health_quest/config/routes.rb
@@ -4,6 +4,7 @@ HealthQuest::Engine.routes.draw do
   namespace :v0, defaults: { format: :json } do
     resources :appointments, only: %i[index show]
     resources :lighthouse_appointments, only: %i[index show]
+    resources :locations, only: %i[index show]
     resources :pgd_questionnaires, only: %i[show]
     resources :patients, only: %i[create]
     resources :questionnaires, only: %i[index show]

--- a/modules/health_quest/spec/request/locations_request_spec.rb
+++ b/modules/health_quest/spec/request/locations_request_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Lighthouse locations', type: :request do
+  let(:access_denied_message) { 'You do not have access to the health quest service' }
+
+  describe 'GET locations `index`' do
+    context 'loa1 user' do
+      let(:current_user) { build(:user, :loa1) }
+
+      before do
+        sign_in_as(current_user)
+      end
+
+      it 'has forbidden status' do
+        get '/health_quest/v0/locations?_id=1234'
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'has access denied message' do
+        get '/health_quest/v0/locations?_id=1234'
+
+        expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
+      end
+    end
+
+    context 'health quest user' do
+      let(:current_user) { build(:user, :health_quest) }
+      let(:session_store) { double('SessionStore', token: '123abc') }
+      let(:client_reply) { double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Bundle' } }) }
+
+      before do
+        sign_in_as(current_user)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
+        allow_any_instance_of(HealthQuest::HealthApi::Location::MapQuery)
+          .to receive(:search).with(anything).and_return(client_reply)
+      end
+
+      it 'returns a FHIR Bundle ' do
+        get '/health_quest/v0/locations?_id=abc123,def456'
+
+        expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Bundle' })
+      end
+    end
+  end
+end

--- a/modules/health_quest/spec/services/health_api/location/factory_spec.rb
+++ b/modules/health_quest/spec/services/health_api/location/factory_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::HealthApi::Location::Factory do
+  subject { described_class }
+
+  let(:user) { double('User', icn: '1008596379V859838') }
+  let(:session_store) { double('SessionStore', token: '123abc') }
+  let(:session_service) do
+    double('HealthQuest::Lighthouse::Session', user: user, api: 'health_api', retrieve: session_store)
+  end
+  let(:client_reply) { double('FHIR::ClientReply') }
+
+  before do
+    allow(HealthQuest::Lighthouse::Session).to receive(:build).and_return(session_service)
+  end
+
+  describe 'object initialization' do
+    let(:factory) { described_class.manufacture(user) }
+
+    it 'responds to attributes' do
+      expect(factory.respond_to?(:session_service)).to eq(true)
+      expect(factory.respond_to?(:user)).to eq(true)
+      expect(factory.respond_to?(:map_query)).to eq(true)
+    end
+  end
+
+  describe '.manufacture' do
+    it 'returns an instance of the described class' do
+      expect(described_class.manufacture(user)).to be_an_instance_of(described_class)
+    end
+  end
+
+  describe '#resource_name' do
+    it 'returns the resource name hash' do
+      expect(described_class.manufacture(user).resource_name).to eq({ resource_name: 'location' })
+    end
+  end
+
+  describe '#search' do
+    let(:filters) { { resource_name: 'location', patient: user.icn }.with_indifferent_access }
+    let(:options_builder) { HealthQuest::Shared::OptionsBuilder.manufacture(user, filters) }
+
+    it 'returns a ClientReply' do
+      allow_any_instance_of(FHIR::Client).to receive(:search).with(anything, anything).and_return(client_reply)
+
+      expect(described_class.manufacture(user).search(options_builder.to_hash)).to eq(client_reply)
+    end
+  end
+end

--- a/modules/health_quest/spec/services/health_api/location/map_query_spec.rb
+++ b/modules/health_quest/spec/services/health_api/location/map_query_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::HealthApi::Location::MapQuery do
+  subject { described_class }
+
+  let(:session_store) { double('SessionStore', token: '123abc') }
+  let(:client) { double('HealthQuest::Lighthouse::FHIRClient') }
+
+  describe 'included modules' do
+    it 'includes Lighthouse::FHIRClient' do
+      expect(subject.ancestors).to include(HealthQuest::Lighthouse::FHIRClient)
+    end
+
+    it 'includes Lighthouse::FHIRHeaders' do
+      expect(subject.ancestors).to include(HealthQuest::Lighthouse::FHIRHeaders)
+    end
+  end
+
+  describe '.build' do
+    it 'returns an instance of MapQuery' do
+      expect(subject.build(session_store)).to be_an_instance_of(subject)
+    end
+  end
+
+  describe 'object initialization' do
+    it 'has a headers attribute' do
+      expect(subject.new(session_store).respond_to?(:headers)).to eq(true)
+    end
+  end
+
+  describe '#api_query_path' do
+    it 'returns the health api path' do
+      expect(subject.new(session_store).api_query_path).to eq('/services/fhir/v0/r4')
+    end
+  end
+
+  describe '#fhir_model' do
+    it 'is a FHIR::Location class' do
+      expect(subject.new(session_store).fhir_model).to eq(FHIR::Location)
+    end
+  end
+
+  describe '#search_options' do
+    let(:options) { { search: { parameters: { _id: '123abc' } } } }
+
+    it 'builds options' do
+      expect(subject.new(session_store).search_options(_id: '123abc')).to eq(options)
+    end
+  end
+
+  describe '#search' do
+    context 'with valid options' do
+      let(:options) do
+        {
+          search: {
+            parameters: { _id: '123abc' }
+          }
+        }
+      end
+
+      before do
+        allow_any_instance_of(subject).to receive(:client).and_return(client)
+      end
+
+      it 'calls search on the FHIR client' do
+        expect(client).to receive(:search).with(FHIR::Location, options).exactly(1).time
+
+        subject.build(session_store).search(_id: '123abc')
+      end
+    end
+  end
+end

--- a/modules/health_quest/spec/services/shared/options_builder_spec.rb
+++ b/modules/health_quest/spec/services/shared/options_builder_spec.rb
@@ -10,6 +10,7 @@ describe HealthQuest::Shared::OptionsBuilder do
   let(:qr_filter) { { resource_name: 'questionnaire_response' } }
   let(:appt_filter) { { resource_name: 'appointment' } }
   let(:q_filter) { { resource_name: 'questionnaire' } }
+  let(:loc_filter) { { resource_name: 'location' } }
   let(:lighthouse) { Settings.hqva_mobile.lighthouse }
 
   describe '.manufacture' do
@@ -69,6 +70,14 @@ describe HealthQuest::Shared::OptionsBuilder do
     end
   end
 
+  describe '#location_ids' do
+    let(:filters) { loc_filter.merge!('_id': '123abc,456def').with_indifferent_access }
+
+    it 'has a location_ids' do
+      expect(options_builder.location_ids).to eq('123abc,456def')
+    end
+  end
+
   describe '#appointment_reference' do
     let(:filters) { qr_filter.merge!(subject: '123').with_indifferent_access }
 
@@ -102,6 +111,14 @@ describe HealthQuest::Shared::OptionsBuilder do
 
       it 'has relevant keys' do
         expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[context-type-value])
+      end
+    end
+
+    context 'when resource is location' do
+      let(:filters) { loc_filter.merge!('_id': '123abc,456def').with_indifferent_access }
+
+      it 'has relevant keys' do
+        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[_id])
       end
     end
   end
@@ -145,6 +162,17 @@ describe HealthQuest::Shared::OptionsBuilder do
         it 'returns an use_context hash' do
           expect(options_builder.to_hash)
             .to eq({ 'context-type-value': '' })
+        end
+      end
+    end
+
+    context 'when resource is location' do
+      context 'when _id' do
+        let(:filters) { loc_filter.merge!('_id': '123abc,456def').with_indifferent_access }
+
+        it 'returns an _id hash' do
+          expect(options_builder.to_hash)
+            .to eq({ '_id': '123abc,456def' })
         end
       end
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- This PR provides the health-quest module the ability to fetch Location resources by a list of unique location ids from the Lighthouse Health API
- The next PR in this series will give the health-quest module the capacity to GET a single Location resource by its id from the Lighthouse Health API
- The last PR in the series will introduce a refactor to deal with an emerging pattern in the `services` module within the health-quest engine.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#20246

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests were written and the entire suite is passing
- [x] Manually tested the route against the lighthouse health API sandbox 