### PR TITLE
Add basic upload endpoint

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -23,7 +23,7 @@ module AppealsApi::V1
           if status == :ok
             render json: { document: params[:document], uuid: params[:uuid] }
           else
-            render json: error, status: 422
+            render json: { errors: [error] }, status: 422
           end
         end
       end

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -5,6 +5,7 @@ module AppealsApi::V1
     module NoticeOfDisagreements
       class EvidenceSubmissionsController < AppealsApi::ApplicationController
         skip_before_action :authenticate
+
         def show
           submissions = AppealsApi::EvidenceSubmission.where(
             supportable_id: params[:id],
@@ -14,6 +15,10 @@ module AppealsApi::V1
           serialized = AppealsApi::EvidenceSubmissionSerializer.new(submissions)
 
           render json: serialized.serializable_hash
+        end
+
+        def upload
+          render json: { message: 'Good work.', document: params[:document], uuid: params[:uuid] }
         end
       end
     end

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -17,8 +17,14 @@ module AppealsApi::V1
           render json: serialized.serializable_hash
         end
 
-        def upload
-          render json: { message: 'Good work.', document: params[:document], uuid: params[:uuid] }
+        def create
+          status, error = AppealsApi::FileValidator.new(params[:document]).call
+
+          if status == :ok
+            render json: { document: params[:document], uuid: params[:uuid] }
+          else
+            render json: error, status: 422
+          end
         end
       end
     end

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -22,11 +22,7 @@ AppealsApi::Engine.routes.draw do
       end
       namespace :notice_of_disagreements do
         get 'contestable_issues', to: 'contestable_issues#index'
-        resources :evidence_submissions, only: %i[show] do
-          collection do
-            post 'upload'
-          end
-        end
+        resources :evidence_submissions, only: %i[create show]
       end
       resources :notice_of_disagreements, only: %i[create show] do
         collection do

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -22,12 +22,16 @@ AppealsApi::Engine.routes.draw do
       end
       namespace :notice_of_disagreements do
         get 'contestable_issues', to: 'contestable_issues#index'
-        resources :evidence_submissions, only: %i[show]
+        resources :evidence_submissions, only: %i[show] do
+          collection do
+            post 'upload'
+          end
+        end
       end
       resources :notice_of_disagreements, only: %i[create show] do
         collection do
-          get 'schema', to: 'notice_of_disagreements#schema'
-          post 'validate', to: 'notice_of_disagreements#validate'
+          get 'schema'
+          post 'validate'
         end
       end
     end

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -4,19 +4,15 @@ require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmissionsController, type: :request do
+  include FixtureHelpers
+
   let(:notice_of_disagreement) { create(:notice_of_disagreement) }
   let(:evidence_submissions) { create_list(:evidence_submission, 3, supportable: notice_of_disagreement) }
-
-  def base_path(path)
-    "/services/appeals/v1/decision_reviews/notice_of_disagreements/evidence_submissions/#{path}"
-  end
-  # let(:path) { '/services/appeals/v1/decision_reviews/notice_of_disagreements/evidence_submissions/' }
+  let(:path) { '/services/appeals/v1/decision_reviews/notice_of_disagreements/evidence_submissions/' }
 
   describe '#show' do
-    let(:path) { base_path notice_of_disagreement.id}
-
     it 'successfully requests the evidence submissions' do
-      get path
+      get "#{path}#{notice_of_disagreement.id}"
 
       expect(response).to have_http_status(:ok)
     end
@@ -24,7 +20,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
     it 'queries all evidence submissions for the nod' do
       submissions = AppealsApi::EvidenceSubmissionSerializer.new(evidence_submissions).serializable_hash
 
-      get path
+      get "#{path}#{notice_of_disagreement.id}"
 
       body = JSON.parse(response.body)['data']
       serialized = JSON.parse(submissions[:data].to_json)
@@ -33,18 +29,21 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
     end
   end
 
+  describe '#create' do
+    let(:uploaded_file) { Rack::Test::UploadedFile }
 
-  describe '#upload' do
-    let(:path) { base_path 'upload' }
-    let(:fixtures_path) { '/modules/appeals_api/spec/fixtures/' }
-    let(:file) { 'expected_10182_extra.pdf' }
-    let(:upload_params) do
-      { document: Rack::Test::UploadedFile.new("#{::Rails.root}#{fixtures_path}#{file}"), uuid: '1234' }
+    it 'successfully responds to a valid document upload' do
+      valid_doc = fixture_filepath('expected_10182_minimum.pdf')
+      valid_params = { document: uploaded_file.new(valid_doc), uuid: '1234' }
+      post(path, params: valid_params)
+      expect(response).to have_http_status(:ok)
     end
 
-    it 'successfully responds to document upload' do
-      post(path, params: upload_params)
-      expect(response).to have_http_status(:ok)
+    it 'responds with an error document upload is invalid' do
+      oversize_doc = fixture_filepath('oversize_11x17.pdf')
+      invalid_params = { document: uploaded_file.new(oversize_doc), uuid: '6789' }
+      post(path, params: invalid_params)
+      expect(response).to have_http_status(:unprocessable_entity)
     end
   end
 end

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -38,7 +38,9 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
     let(:path) { base_path 'upload' }
     let(:fixtures_path) { '/modules/appeals_api/spec/fixtures/' }
     let(:file) { 'expected_10182_extra.pdf' }
-    let(:upload_params) { { document: Rack::Test::UploadedFile.new("#{::Rails.root}#{fixtures_path}#{file}") } }
+    let(:upload_params) do
+      { document: Rack::Test::UploadedFile.new("#{::Rails.root}#{fixtures_path}#{file}"), uuid: '1234' }
+    end
 
     it 'successfully responds to document upload' do
       post(path, params: upload_params)

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -6,11 +6,17 @@ require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmissionsController, type: :request do
   let(:notice_of_disagreement) { create(:notice_of_disagreement) }
   let(:evidence_submissions) { create_list(:evidence_submission, 3, supportable: notice_of_disagreement) }
-  let(:path) { '/services/appeals/v1/decision_reviews/notice_of_disagreements/evidence_submissions/' }
+
+  def base_path(path)
+    "/services/appeals/v1/decision_reviews/notice_of_disagreements/evidence_submissions/#{path}"
+  end
+  # let(:path) { '/services/appeals/v1/decision_reviews/notice_of_disagreements/evidence_submissions/' }
 
   describe '#show' do
+    let(:path) { base_path notice_of_disagreement.id}
+
     it 'successfully requests the evidence submissions' do
-      get "#{path}#{notice_of_disagreement.id}"
+      get path
 
       expect(response).to have_http_status(:ok)
     end
@@ -18,12 +24,23 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
     it 'queries all evidence submissions for the nod' do
       submissions = AppealsApi::EvidenceSubmissionSerializer.new(evidence_submissions).serializable_hash
 
-      get "#{path}#{notice_of_disagreement.id}"
+      get path
 
       body = JSON.parse(response.body)['data']
       serialized = JSON.parse(submissions[:data].to_json)
 
       expect(body).to match_array(serialized)
+    end
+  end
+
+
+  describe '#upload' do
+    let(:path) { base_path 'upload'}
+    let(:upload_params) { { document: Rack::Test::UploadedFile.new("#{::Rails.root}/modules/appeals_api/spec/fixtures/expected_10182_extra.pdf") } }
+
+    it 'successfully responds to document upload' do
+      post(path, params: upload_params)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -35,8 +35,10 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
 
 
   describe '#upload' do
-    let(:path) { base_path 'upload'}
-    let(:upload_params) { { document: Rack::Test::UploadedFile.new("#{::Rails.root}/modules/appeals_api/spec/fixtures/expected_10182_extra.pdf") } }
+    let(:path) { base_path 'upload' }
+    let(:fixtures_path) { '/modules/appeals_api/spec/fixtures/' }
+    let(:file) { 'expected_10182_extra.pdf' }
+    let(:upload_params) { { document: Rack::Test::UploadedFile.new("#{::Rails.root}#{fixtures_path}#{file}") } }
 
     it 'successfully responds to document upload' do
       post(path, params: upload_params)


### PR DESCRIPTION
Adding basic NOD evidence submission upload endpoint
It should:
- take in a document and uuid
- validate document
- return meaningful response if document is invalid

Ticket
https://vajira.max.gov/browse/API-5221