### PR TITLE
Fix date issue in Cypress Viewport Updater spec

### DIFF
--- a/spec/jobs/cypress_viewport_updater/viewport_spec.rb
+++ b/spec/jobs/cypress_viewport_updater/viewport_spec.rb
@@ -66,7 +66,9 @@ RSpec.describe CypressViewportUpdater::Viewport do
 
   describe '#percentTrafficPeriod' do
     it 'returns the correct value' do
-      expect(@viewport.percentTrafficPeriod).to eq('From: 02/01/2021, To: 02/28/2021')
+      start_date = Time.zone.today.prev_month.beginning_of_month
+      end_date = Time.zone.today.prev_month.end_of_month
+      expect(@viewport.percentTrafficPeriod).to eq("From: #{start_date.strftime('%m/%d/%Y')}, To: #{end_date.strftime('%m/%d/%Y')}")
     end
   end
 


### PR DESCRIPTION
## Description of change
The `CypressViewportUpdater` and its associated classes rely on relative dates to generate viewport reports. This PR modifies a failing spec to ensure tests pass for all dates and not a fixed date.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/20738

## Things to know about this PR
Ran tests locally without any failures.