### PR TITLE
API-5512: 500 response for 526 uploading supporting documents in sandbox

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -77,7 +77,7 @@ module ClaimsApi
             ClaimsApi::ClaimUploader.perform_async(claim_document.id)
           end
 
-          render json: @claim, serializer: ClaimsApi::ClaimDetailSerializer, uuid: claim.id
+          render json: @claim, serializer: ClaimsApi::ClaimDetailSerializer, uuid: @claim.id
         end
 
         def validate_form_526

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -419,6 +419,7 @@ RSpec.describe 'Disability Claims ', type: :request do
         allow_any_instance_of(ClaimsApi::SupportingDocumentUploader).to receive(:store!)
         put("/services/claims/v1/forms/526/#{auto_claim.id}",
             params: binary_params, headers: headers.merge(auth_header))
+        expect(response.status).to eq(200)
         auto_claim.reload
         expect(auto_claim.file_data).to be_truthy
       end
@@ -429,6 +430,7 @@ RSpec.describe 'Disability Claims ', type: :request do
         allow_any_instance_of(ClaimsApi::SupportingDocumentUploader).to receive(:store!)
         put("/services/claims/v1/forms/526/#{auto_claim.id}",
             params: base64_params, headers: headers.merge(auth_header))
+        expect(response.status).to eq(200)
         auto_claim.reload
         expect(auto_claim.file_data).to be_truthy
       end
@@ -439,7 +441,6 @@ RSpec.describe 'Disability Claims ', type: :request do
         allow_any_instance_of(ClaimsApi::SupportingDocumentUploader).to receive(:store!)
         put("/services/claims/v1/forms/526/#{non_auto_claim.id}",
             params: binary_params, headers: headers.merge(auth_header))
-        non_auto_claim.reload
         expect(response.status).to eq(422)
       end
     end
@@ -450,6 +451,7 @@ RSpec.describe 'Disability Claims ', type: :request do
         count = auto_claim.supporting_documents.count
         post("/services/claims/v1/forms/526/#{auto_claim.id}/attachments",
              params: binary_params, headers: headers.merge(auth_header))
+        expect(response.status).to eq(200)
         auto_claim.reload
         expect(auto_claim.supporting_documents.count).to eq(count + 2)
       end
@@ -461,6 +463,7 @@ RSpec.describe 'Disability Claims ', type: :request do
         count = auto_claim.supporting_documents.count
         post("/services/claims/v1/forms/526/#{auto_claim.id}/attachments",
              params: base64_params, headers: headers.merge(auth_header))
+        expect(response.status).to eq(200)
         auto_claim.reload
         expect(auto_claim.supporting_documents.count).to eq(count + 2)
       end


### PR DESCRIPTION
## Description of change
Copy/paste mistake introduced a 500 response when uploading supporting documents for a 526 submission.

## Original issue(s)
https://vajira.max.gov/browse/API-5512

## Things to know about this PR
Ensured tests were failing before implementing the fix.