### PR TITLE
fetch organizations from lighthouse

### DIFF
--- a/modules/health_quest/app/controllers/health_quest/v0/organizations_controller.rb
+++ b/modules/health_quest/app/controllers/health_quest/v0/organizations_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  module V0
+    class OrganizationsController < HealthQuest::V0::BaseController
+      def index
+        render json: factory.search(request.query_parameters).response[:body]
+      end
+
+      def show
+        render json: factory.get(params[:id]).response[:body]
+      end
+
+      private
+
+      def factory
+        HealthQuest::Resource::Factory.manufacture(
+          user: current_user,
+          resource_identifier: 'organization',
+          api: Settings.hqva_mobile.lighthouse.health_api
+        )
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/shared/options_builder.rb
+++ b/modules/health_quest/app/services/health_quest/shared/options_builder.rb
@@ -52,22 +52,23 @@ module HealthQuest
             date: appointment_dates,
             location: clinic_id
           },
-          location: {
-            _id: location_ids
-          },
+          location: { _id: location_ids },
+          organization: { _id: organization_ids },
           questionnaire_response: {
             subject: appointment_reference,
             source: user.icn,
             authored: resource_created_date
           },
-          questionnaire: {
-            'context-type-value': context_type_value
-          }
+          questionnaire: { 'context-type-value': context_type_value }
         }
       end
 
       def location_ids
         @location_ids ||= filters&.fetch(:_id, nil)
+      end
+
+      def organization_ids
+        @organization_ids ||= filters&.fetch(:_id, nil)
       end
 
       ##

--- a/modules/health_quest/config/routes.rb
+++ b/modules/health_quest/config/routes.rb
@@ -5,6 +5,7 @@ HealthQuest::Engine.routes.draw do
     resources :appointments, only: %i[index show]
     resources :lighthouse_appointments, only: %i[index show]
     resources :locations, only: %i[index show]
+    resources :organizations, only: %i[index show]
     resources :pgd_questionnaires, only: %i[show]
     resources :patients, only: %i[create]
     resources :questionnaires, only: %i[index show]

--- a/modules/health_quest/spec/request/organizations_request_spec.rb
+++ b/modules/health_quest/spec/request/organizations_request_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Lighthouse organizations', type: :request do
+  let(:access_denied_message) { 'You do not have access to the health quest service' }
+
+  describe 'GET organizations `index`' do
+    context 'loa1 user' do
+      let(:current_user) { build(:user, :loa1) }
+
+      before do
+        sign_in_as(current_user)
+      end
+
+      it 'has forbidden status' do
+        get '/health_quest/v0/organizations?_id=1234'
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'has access denied message' do
+        get '/health_quest/v0/organizations?_id=1234'
+
+        expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
+      end
+    end
+
+    context 'health quest user' do
+      let(:current_user) { build(:user, :health_quest) }
+      let(:session_store) { double('SessionStore', token: '123abc') }
+      let(:client_reply) { double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Bundle' } }) }
+
+      before do
+        sign_in_as(current_user)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
+        allow_any_instance_of(HealthQuest::Resource::Query).to receive(:search).with(anything).and_return(client_reply)
+      end
+
+      it 'returns a FHIR Bundle ' do
+        get '/health_quest/v0/organizations?_id=abc123,def456'
+
+        expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Bundle' })
+      end
+    end
+  end
+
+  describe 'GET organization `show`' do
+    context 'loa1 user' do
+      before do
+        sign_in_as(current_user)
+      end
+
+      let(:current_user) { build(:user, :loa1) }
+
+      it 'has forbidden status' do
+        get '/health_quest/v0/organizations/I2-ABC123'
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'has access denied message' do
+        get '/health_quest/v0/organizations/I2-ABC123'
+
+        expect(JSON.parse(response.body)['errors'].first['detail']).to eq(access_denied_message)
+      end
+    end
+
+    context 'health quest user' do
+      let(:current_user) { build(:user, :health_quest) }
+      let(:session_store) { double('SessionStore', token: '123abc') }
+      let(:client_reply) do
+        double('FHIR::ClientReply', response: { body: { 'resourceType' => 'Location' } })
+      end
+
+      before do
+        sign_in_as(current_user)
+        allow_any_instance_of(HealthQuest::Lighthouse::Session).to receive(:retrieve).and_return(session_store)
+        allow_any_instance_of(HealthQuest::Resource::Query).to receive(:get).with(anything).and_return(client_reply)
+      end
+
+      it 'returns a FHIR type of Location' do
+        get '/health_quest/v0/organizations/I2-ABC123'
+
+        expect(JSON.parse(response.body)).to eq({ 'resourceType' => 'Location' })
+      end
+    end
+  end
+end

--- a/modules/health_quest/spec/services/shared/options_builder_spec.rb
+++ b/modules/health_quest/spec/services/shared/options_builder_spec.rb
@@ -11,6 +11,7 @@ describe HealthQuest::Shared::OptionsBuilder do
   let(:appt_filter) { { resource_name: 'appointment' } }
   let(:q_filter) { { resource_name: 'questionnaire' } }
   let(:loc_filter) { { resource_name: 'location' } }
+  let(:org_filter) { { resource_name: 'organization' } }
   let(:lighthouse) { Settings.hqva_mobile.lighthouse }
 
   describe '.manufacture' do
@@ -78,6 +79,14 @@ describe HealthQuest::Shared::OptionsBuilder do
     end
   end
 
+  describe '#organization_ids' do
+    let(:filters) { org_filter.merge!('_id': '123abc,456def').with_indifferent_access }
+
+    it 'has a organization_ids' do
+      expect(options_builder.organization_ids).to eq('123abc,456def')
+    end
+  end
+
   describe '#appointment_reference' do
     let(:filters) { qr_filter.merge!(subject: '123').with_indifferent_access }
 
@@ -116,6 +125,14 @@ describe HealthQuest::Shared::OptionsBuilder do
 
     context 'when resource is location' do
       let(:filters) { loc_filter.merge!('_id': '123abc,456def').with_indifferent_access }
+
+      it 'has relevant keys' do
+        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[_id])
+      end
+    end
+
+    context 'when resource is organization' do
+      let(:filters) { org_filter.merge!('_id': '123abc,456def').with_indifferent_access }
 
       it 'has relevant keys' do
         expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[_id])
@@ -169,6 +186,17 @@ describe HealthQuest::Shared::OptionsBuilder do
     context 'when resource is location' do
       context 'when _id' do
         let(:filters) { loc_filter.merge!('_id': '123abc,456def').with_indifferent_access }
+
+        it 'returns an _id hash' do
+          expect(options_builder.to_hash)
+            .to eq({ '_id': '123abc,456def' })
+        end
+      end
+    end
+
+    context 'when resource is organization' do
+      context 'when _id' do
+        let(:filters) { org_filter.merge!('_id': '123abc,456def').with_indifferent_access }
 
         it 'returns an _id hash' do
           expect(options_builder.to_hash)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- This PR provides the health-quest module the ability to fetch `Organization` resources from the Lighthouse Health API.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#20246

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests written and are passing