### PR TITLE
[notification-api#357] Remove full name from personalization param for form526ez confirmation email

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -54,7 +54,6 @@ class Form526Submission < ApplicationRecord
       :success,
       'Form526Submission#perform_ancillary_jobs_handler',
       'submission_id' => id,
-      'full_name' => get_full_name,
       'first_name' => get_first_name
     )
     jids = workflow_batch.jobs do
@@ -62,11 +61,6 @@ class Form526Submission < ApplicationRecord
     end
 
     jids.first
-  end
-
-  def get_full_name
-    user = User.find(user_uuid)
-    user&.full_name_normalized&.values&.compact&.join(' ')&.upcase
   end
 
   def get_first_name
@@ -171,23 +165,20 @@ class Form526Submission < ApplicationRecord
   def perform_ancillary_jobs_handler(_status, options)
     submission = Form526Submission.find(options['submission_id'])
     # Only run ancillary jobs if submission succeeded
-    if submission.form526_job_statuses.all?(&:success?)
-      submission.perform_ancillary_jobs(options['full_name'], options['first_name'])
-    end
+    submission.perform_ancillary_jobs(options['first_name']) if submission.form526_job_statuses.all?(&:success?)
   end
 
   # Creates a batch for the ancillary jobs, sets up the callback, and adds the jobs to the batch if necessary
   #
-  # @param full_name [String] the full name of the user that submitted Form526
+  # @param first_name [String] the first name of the user that submitted Form526
   # @return [String] the workflow batch id
   #
-  def perform_ancillary_jobs(full_name, first_name)
+  def perform_ancillary_jobs(first_name)
     workflow_batch = Sidekiq::Batch.new
     workflow_batch.on(
       :success,
       'Form526Submission#workflow_complete_handler',
       'submission_id' => id,
-      'full_name' => full_name,
       'first_name' => first_name
     )
     workflow_batch.jobs do
@@ -210,20 +201,19 @@ class Form526Submission < ApplicationRecord
     if submission.form526_job_statuses.all?(&:success?)
       user = User.find(submission.user_uuid)
       if Flipper.enabled?(:form526_confirmation_email, user)
-        submission.send_form526_confirmation_email(options['full_name'], options['first_name'])
+        submission.send_form526_confirmation_email(options['first_name'])
       end
       submission.workflow_complete = true
       submission.save
     end
   end
 
-  def send_form526_confirmation_email(full_name, first_name)
+  def send_form526_confirmation_email(first_name)
     email_address = form['form526']['form526']['veteran']['emailAddress']
     personalization_parameters = {
       'email' => email_address,
       'submitted_claim_id' => submitted_claim_id,
       'date_submitted' => created_at.strftime('%B %-d, %Y %-l:%M %P %Z').sub(/([ap])m/, '\1.m.'),
-      'full_name' => full_name,
       'first_name' => first_name
     }
     Form526ConfirmationEmailJob.perform_async(personalization_parameters)

--- a/app/workers/form526_confirmation_email_job.rb
+++ b/app/workers/form526_confirmation_email_job.rb
@@ -25,7 +25,6 @@ class Form526ConfirmationEmailJob
       personalisation: {
         'claim_id' => personalization_parameters['submitted_claim_id'],
         'date_submitted' => personalization_parameters['date_submitted'],
-        'full_name' => personalization_parameters['full_name'],
         'first_name' => personalization_parameters['first_name']
       }
     )

--- a/spec/jobs/form526_confirmation_email_job_spec.rb
+++ b/spec/jobs/form526_confirmation_email_job_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
           'email' => email_address,
           'submitted_claim_id' => '600191990',
           'date_submitted' => 'July 12, 2020',
-          'full_name' => 'first last',
           'first_name' => 'firstname'
         }
       end
@@ -77,7 +76,6 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
           personalisation: {
             'claim_id' => '600191990',
             'date_submitted' => 'July 12, 2020',
-            'full_name' => 'first last',
             'first_name' => 'firstname'
           }
         }

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -359,7 +359,6 @@ RSpec.describe Form526Submission do
   end
 
   describe '#perform_ancillary_jobs' do
-    let(:full_name) { 'some name' }
     let(:first_name) { 'firstname' }
 
     context 'with (3) uploads' do
@@ -369,7 +368,7 @@ RSpec.describe Form526Submission do
 
       it 'queues 1 upload jobs' do
         expect do
-          subject.perform_ancillary_jobs(full_name, first_name)
+          subject.perform_ancillary_jobs(first_name)
         end.to change(EVSS::DisabilityCompensationForm::SubmitUploads.jobs, :size).by(1)
       end
     end
@@ -381,7 +380,7 @@ RSpec.describe Form526Submission do
 
       it 'queues 1 UploadBddInstructions job' do
         expect do
-          subject.perform_ancillary_jobs(full_name, first_name)
+          subject.perform_ancillary_jobs(first_name)
         end.to change(EVSS::DisabilityCompensationForm::UploadBddInstructions.jobs, :size).by(1)
       end
     end
@@ -393,7 +392,7 @@ RSpec.describe Form526Submission do
 
       it 'queues a 4142 job' do
         expect do
-          subject.perform_ancillary_jobs(full_name, first_name)
+          subject.perform_ancillary_jobs(first_name)
         end.to change(CentralMail::SubmitForm4142Job.jobs, :size).by(1)
       end
     end
@@ -405,7 +404,7 @@ RSpec.describe Form526Submission do
 
       it 'queues a 0781 job' do
         expect do
-          subject.perform_ancillary_jobs(full_name, first_name)
+          subject.perform_ancillary_jobs(first_name)
         end.to change(EVSS::DisabilityCompensationForm::SubmitForm0781.jobs, :size).by(1)
       end
     end
@@ -417,49 +416,8 @@ RSpec.describe Form526Submission do
 
       it 'queues a 8940 job' do
         expect do
-          subject.perform_ancillary_jobs(full_name, first_name)
+          subject.perform_ancillary_jobs(first_name)
         end.to change(EVSS::DisabilityCompensationForm::SubmitForm8940.jobs, :size).by(1)
-      end
-    end
-  end
-
-  describe '#get_full_name' do
-    [
-      {
-        input:
-          {
-            first_name: 'Joe',
-            middle_name: 'Doe',
-            last_name: 'Smith',
-            suffix: 'Jr.'
-          },
-        expected: 'JOE DOE SMITH JR.'
-      },
-      {
-        input:
-          {
-            first_name: 'Joe',
-            middle_name: nil,
-            last_name: 'Smith',
-            suffix: nil
-          },
-        expected: 'JOE SMITH'
-      }, {
-        input:
-          {
-            first_name: 'Joe',
-            middle_name: 'Doe',
-            last_name: 'Smith',
-            suffix: nil
-          },
-        expected: 'JOE DOE SMITH'
-      }
-    ].each do |test_param|
-      it 'gets correct full name' do
-        allow(User).to receive(:find).with(anything).and_return(user)
-        allow_any_instance_of(User).to receive(:full_name_normalized).and_return(test_param[:input])
-
-        expect(subject.get_full_name).to eql(test_param[:expected])
       end
     end
   end
@@ -491,7 +449,6 @@ RSpec.describe Form526Submission do
     let(:options) do
       {
         'submission_id' => subject.id,
-        'full_name' => 'some name',
         'first_name' => 'firstname'
       }
     end
@@ -529,7 +486,6 @@ RSpec.describe Form526Submission do
         Flipper.enable(:form526_confirmation_email)
 
         allow(Form526ConfirmationEmailJob).to receive(:perform_async) do |*args|
-          expect(args[0]['full_name']).to eql('some name')
           expect(args[0]['first_name']).to eql('firstname')
           expect(args[0]['submitted_claim_id']).to be(123_654_879)
           expect(args[0]['email']).to eql('test@email.com')
@@ -551,7 +507,6 @@ RSpec.describe Form526Submission do
         Flipper.enable(:form526_confirmation_email)
 
         allow(Form526ConfirmationEmailJob).to receive(:perform_async) do |*args|
-          expect(args[0]['full_name']).to eql('some name')
           expect(args[0]['first_name']).to eql('firstname')
           expect(args[0]['submitted_claim_id']).to be(123_654_879)
           expect(args[0]['email']).to eql('test@email.com')
@@ -573,7 +528,6 @@ RSpec.describe Form526Submission do
         Flipper.enable(:form526_confirmation_email)
 
         allow(Form526ConfirmationEmailJob).to receive(:perform_async) do |*args|
-          expect(args[0]['full_name']).to eql('some name')
           expect(args[0]['first_name']).to eql('firstname')
           expect(args[0]['submitted_claim_id']).to be(123_654_879)
           expect(args[0]['email']).to eql('test@email.com')


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This is a follow-up change to remove `full_name` from personalization parameters for the form526ez confirmation email. We've successfully incorporated `first_name` recently. These changes are meant to be HIPPA compliant.

## Original issue(s)
department-of-veterans-affairs/notification-api#357

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

This is part of existing feature flag "form526_confirmation_email", which is currently enabled in production.
Motivation for this change is to be HIPPA compliant. Had recently successfully added `first_name` to personalization parameters and updated template accordingly on the notification-api end in prod. Therefore we are ready to now remove `full_name` from personalization parameters to the form526ez email confirmation job.

<!-- Please describe testing done to verify the changes or any testing planned. -->
* Made modifications to respective unit and integration tests.
* Have already manually tested across all environments the successful use of `first_name` and no reference to `full_name`.
