### PR TITLE
New identity module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ path 'modules' do
   gem 'covid_research'
   gem 'covid_vaccine'
   gem 'health_quest'
+  gem 'identity'
   gem 'mobile'
   gem 'openid_auth'
   gem 'test_user_dashboard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ PATH
     covid_vaccine (0.1.0)
       sidekiq
     health_quest (0.1.0)
+    identity (0.1.0)
     mobile (0.1.0)
       dry-validation
     openid_auth (0.0.1)
@@ -975,6 +976,7 @@ DEPENDENCIES
   holidays
   httpclient
   ice_nine
+  identity!
   iso_country_codes
   json (>= 2.3.0)
   json-schema

--- a/modules/identity/Gemfile
+++ b/modules/identity/Gemfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Declare your gem's dependencies in identity.gemspec.
+# Bundler will treat runtime dependencies like base dependencies, and
+# development dependencies will be added by default to the :development group.
+gemspec
+
+# Declare any dependencies that are still in development here instead of in
+# your gemspec. These might include edge Rails or gems from your path or
+# Git. Remember to move these dependencies to your gemspec before releasing
+# your gem to rubygems.org.
+
+# To use a debugger
+# gem 'byebug', group: [:development, :test]

--- a/modules/identity/README.rdoc
+++ b/modules/identity/README.rdoc
@@ -1,0 +1,10 @@
+= Identity
+TODO: Short description and motivation.
+
+== Installation
+Ensure the following line is in the root project's Gemfile:
+
+  gem 'identity', path: 'modules/identity'
+
+== License
+This module is open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/modules/identity/Rakefile
+++ b/modules/identity/Rakefile
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+require 'rdoc/task'
+
+RDoc::Task.new(:rdoc) do |rdoc|
+  rdoc.rdoc_dir = 'rdoc'
+  rdoc.title    = 'Identity'
+  rdoc.options << '--line-numbers'
+  rdoc.rdoc_files.include('README.md')
+  rdoc.rdoc_files.include('lib/**/*.rb')
+end
+
+load 'rails/tasks/statistics.rake'
+
+require 'bundler/gem_tasks'
+
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = false
+end
+
+task default: :test

--- a/modules/identity/bin/rails
+++ b/modules/identity/bin/rails
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+ENGINE_ROOT = File.expand_path('../..', __dir__)
+ENGINE_PATH = File.expand_path('../../lib/identity/engine', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails/all'
+require 'rails/engine/commands'

--- a/modules/identity/config/routes.rb
+++ b/modules/identity/config/routes.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+Identity::Engine.routes.draw do
+end

--- a/modules/identity/identity.gemspec
+++ b/modules/identity/identity.gemspec
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
+
+# Maintain your gem's version:
+require 'identity/version'
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |spec|
+  spec.name        = 'identity'
+  spec.version     = Identity::VERSION
+  spec.authors     = ['Jim Ray']
+  spec.email       = ['jim.ray@oddball.io']
+  spec.homepage    = 'https://api.va.gov'
+  spec.summary     = 'An api.va.gov module'
+  spec.description = 'This module was auto-generated please update this description'
+  spec.license     = 'CC0-1.0'
+
+  spec.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
+end

--- a/modules/identity/lib/identity.rb
+++ b/modules/identity/lib/identity.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'identity/engine'
+
+module Identity
+  # Your code goes here...
+end

--- a/modules/identity/lib/identity/engine.rb
+++ b/modules/identity/lib/identity/engine.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Identity
+  class Engine < ::Rails::Engine
+    isolate_namespace Identity
+    config.generators.api_only = true
+
+    initializer 'model_core.factories', after: 'factory_bot.set_factory_paths' do
+      FactoryBot.definition_file_paths << File.expand_path('../../spec/factories', __dir__) if defined?(FactoryBot)
+    end
+  end
+end

--- a/modules/identity/lib/identity/version.rb
+++ b/modules/identity/lib/identity/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Identity
+  VERSION = '0.1.0'
+end

--- a/modules/identity/spec/spec_helper.rb
+++ b/modules/identity/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Configure Rails Envinronment
+ENV['RAILS_ENV'] = 'test'
+# require File.expand_path('dummy/config/environment.rb', __dir__)
+
+require 'rspec/rails'
+
+ENGINE_RAILS_ROOT = File.join(File.dirname(__FILE__), '../')
+
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir[File.join(ENGINE_RAILS_ROOT, 'spec/support/**/*.rb')].sort.each { |f| require f }
+
+RSpec.configure { |config| config.use_transactional_fixtures = true }

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -64,6 +64,7 @@ class SimpleCovHelper
     add_group 'AppealsApi', 'modules/appeals_api/'
     add_group 'ClaimsApi', 'modules/claims_api/'
     add_group 'CovidVaccine', 'modules/covid_vaccine/'
+    add_group 'Identity', 'modules/identity/'
     add_group 'OpenidAuth', 'modules/openid_auth/'
     add_group 'Policies', 'app/policies'
     add_group 'Serializers', 'app/serializers'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,7 @@ unless ENV['NOCOVERAGE']
     add_group 'ClaimsApi', 'modules/claims_api/'
     add_group 'CovidVaccine', 'modules/covid_vaccine/'
     add_group 'HealthQuest', 'modules/health_quest/'
+    add_group 'Identity', 'modules/identity/'
     add_group 'Mobile', 'modules/mobile/'
     add_group 'OpenidAuth', 'modules/openid_auth/'
     add_group 'Policies', 'app/policies'


### PR DESCRIPTION
## Description of change

Use vtk to create new identity module for code refactors and consolidation


## Original issue(s)


## Things to know about this PR

Identity team is implementing a consistent interface to Identity / Sessions / MPI information.

