### PR TITLE
updated rated disablities

### DIFF
--- a/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
@@ -28,10 +28,8 @@ module V0
           metadata['returnUrl'] = '/disabilities/rated-disabilities'
         end
         evss_rated_disabilites = JSON.parse(rated_disabilities_evss.rated_disabilities.to_json)
-        prased_form_data['ratedDisabilities'] = camelize_with_olivebranch(evss_rated_disabilites)
-        metadata['ratedDisabilitiesUpdated'] = true
+        prased_form_data['updatedRatedDisabilities'] = camelize_with_olivebranch(evss_rated_disabilites)
       else
-        metadata['ratedDisabilitiesUpdated'] = false
       end
 
       {

--- a/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
@@ -17,23 +17,22 @@ module V0
     end
 
     def data_and_metadata_with_updated_rated_disabilites
-      prased_form_data = JSON.parse(form_for_user.form_data)
+      parsed_form_data = JSON.parse(form_for_user.form_data)
       metadata = form_for_user.metadata
 
       # If EVSS's list of rated disabilties does not match our prefilled rated disabilites
       if rated_disabilities_evss.present? &&
-         names_arr(prased_form_data.dig('ratedDisabilities')) != names_arr(rated_disabilities_evss.rated_disabilities)
-        if prased_form_data['ratedDisabilities'].present? &&
-           prased_form_data.dig('view:claimType', 'view:claimingIncrease')
+         names_arr(parsed_form_data.dig('ratedDisabilities')) != names_arr(rated_disabilities_evss.rated_disabilities)
+        if parsed_form_data['ratedDisabilities'].present? &&
+           parsed_form_data.dig('view:claimType', 'view:claimingIncrease')
           metadata['returnUrl'] = '/disabilities/rated-disabilities'
         end
         evss_rated_disabilites = JSON.parse(rated_disabilities_evss.rated_disabilities.to_json)
-        prased_form_data['updatedRatedDisabilities'] = camelize_with_olivebranch(evss_rated_disabilites)
-      else
+        parsed_form_data['updatedRatedDisabilities'] = camelize_with_olivebranch(evss_rated_disabilites)
       end
 
       {
-        formData: prased_form_data,
+        formData: parsed_form_data,
         metadata: metadata
       }
     end

--- a/spec/request/v0/disability_compensation_in_progress_forms_controller_request_spec.rb
+++ b/spec/request/v0/disability_compensation_in_progress_forms_controller_request_spec.rb
@@ -53,14 +53,15 @@ RSpec.describe V0::DisabilityCompensationInProgressFormsController, type: :reque
         end
 
         it 'returns the form as JSON' do
+          rated_disabilities_before = JSON.parse(in_progress_form.form_data).dig('ratedDisabilities')
           VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
             get v0_disability_compensation_in_progress_form_url(in_progress_form.form_id), params: nil
           end
           expect(response).to have_http_status(:ok)
           json_response = JSON.parse(response.body)
-          expect(json_response['formData']['ratedDisabilities']).to eq(rated_disabilites_from_evss)
+          expect(json_response['formData']['ratedDisabilities']).to eq(rated_disabilities_before)
+          expect(json_response['formData']['updatedRatedDisabilities']).to eq(rated_disabilites_from_evss)
           expect(json_response['metadata']['returnUrl']).to eq('/disabilities/rated-disabilities')
-          expect(json_response['metadata']['ratedDisabilitiesUpdated']).to be_truthy
         end
       end
     end


### PR DESCRIPTION
## Description of change
After a disuccion with @Mottie we settled on adding a `updatedRatedDisabilities` element to the form rather than replacing `ratedDisabilities` and adding something to the metadata.  This controller is not yet used in prod. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18681