### PR TITLE
veteran must have an address in order to make an evss letters call

### DIFF
--- a/app/controllers/v0/letters_controller.rb
+++ b/app/controllers/v0/letters_controller.rb
@@ -6,7 +6,7 @@ require 'evss/letters/service'
 
 module V0
   class LettersController < ApplicationController
-    before_action { authorize :evss, :access? }
+    before_action { authorize :evss, :access_letters? }
 
     def index
       response = service.get_letters

--- a/app/policies/evss_policy.rb
+++ b/app/policies/evss_policy.rb
@@ -1,31 +1,42 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 EVSSPolicy = Struct.new(:user, :evss) do
   def access?
     if user.edipi.present? && user.ssn.present? && user.participant_id.present?
-      log_success
+      log_success('access')
     else
-      log_failure
+      log_failure('access')
+    end
+  end
+
+  def access_letters?
+    if user.edipi.present? && user.ssn.present? && user.participant_id.present? &&
+       user&.vet360_contact_info&.mailing_address&.address_line1
+      log_success('letters')
+    else
+      log_failure('letters')
     end
   end
 
   def access_form526?
     if user.edipi.present? && user.ssn.present? && user.birls_id.present? && user.participant_id.present?
-      log_success
+      log_success('form526')
     else
-      log_failure
+      log_failure('form526')
     end
   end
 
   private
 
-  def log_success
-    StatsD.increment('api.evss.policy.success') if user.loa3?
+  def log_success(policy)
+    StatsD.increment('api.evss.policy.success', tags: ["policy:#{policy}"]) if user.loa3?
     true
   end
 
-  def log_failure
-    StatsD.increment('api.evss.policy.failure') if user.loa3?
+  def log_failure(policy)
+    StatsD.increment('api.evss.policy.failure', tags: ["policy:#{policy}"]) if user.loa3?
     false
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/swagger/swagger/requests/letters.rb
+++ b/app/swagger/swagger/requests/letters.rb
@@ -8,6 +8,7 @@ module Swagger
       swagger_path '/v0/letters' do
         operation :get do
           extend Swagger::Responses::AuthenticationError
+          extend Swagger::Responses::ForbiddenError
 
           key :description, 'Get a list of available letters for a veteran'
           key :operationId, 'getLetters'
@@ -27,6 +28,7 @@ module Swagger
       swagger_path '/v0/letters/beneficiary' do
         operation :get do
           extend Swagger::Responses::AuthenticationError
+          extend Swagger::Responses::ForbiddenError
 
           key :description, 'Returns service history, and a list of benefit options for use with POST /v0/letters'
           key :operationId, 'getLettersBeneficiary'
@@ -46,6 +48,7 @@ module Swagger
       swagger_path '/v0/letters/{id}' do
         operation :post do
           extend Swagger::Responses::AuthenticationError
+          extend Swagger::Responses::ForbiddenError
 
           key :description, 'Returns a letter as a PDF blob'
           key :operationId, 'postLetter'

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -1542,6 +1542,18 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
       end
     end
 
+    context 'with a loa1 user' do
+      let(:mhv_user) { build(:user, :loa1) }
+
+      it 'rejects getting EVSS Letters for loa1 users' do
+        expect(subject).to validate(:get, '/v0/letters', 403, headers)
+      end
+
+      it 'rejects getting EVSS benefits Letters for loa1 users' do
+        expect(subject).to validate(:get, '/v0/letters/beneficiary', 403, headers)
+      end
+    end
+
     context 'without EVSS mock' do
       before do
         Settings.evss.mock_gi_bill_status = false


### PR DESCRIPTION
## Description of change
A veteran must have an address available to EVSS before we can make a call to the letters api or [we see an error](http://sentry.vfs.va.gov/organizations/vsp/issues/6135/?query=source%3Aletters&statsPeriod=14d).  

In a roundabout way, if we see there is an address in Va Profile then we know that EVSS can get the address. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#7816

## Things to know about this PR

