### PR TITLE
Temporary Fix: Truncate Names That Are Longer Than Schema Allows (HLR)

### DIFF
--- a/lib/decision_review/service.rb
+++ b/lib/decision_review/service.rb
@@ -86,9 +86,10 @@ module DecisionReview
 
       {
         'X-VA-SSN' => user.ssn.to_s,
-        'X-VA-First-Name' => user.first_name.to_s,
-        'X-VA-Middle-Initial' => user.middle_name.presence&.first&.to_s,
-        'X-VA-Last-Name' => user.last_name.to_s,
+        'X-VA-First-Name' => user.first_name.to_s.first(12),
+        # middle_name can return either a string or an array (hence the strange chain)
+        'X-VA-Middle-Initial' => user.middle_name.presence&.first&.to_s&.first,
+        'X-VA-Last-Name' => user.last_name.to_s.first(18),
         'X-VA-Birth-Date' => user.birth_date.to_s,
         'X-VA-File-Number' => nil,
         'X-VA-Service-Number' => nil,

--- a/spec/lib/decision_review/service_spec.rb
+++ b/spec/lib/decision_review/service_spec.rb
@@ -46,6 +46,21 @@ describe DecisionReview::Service do
     end
   end
 
+  describe '#create_higher_level_review_headers' do
+    subject { described_class.new.send(:create_higher_level_review_headers, user) }
+
+    let(:user) do
+      name = 'x' * 100
+      build :user, first_name: name, middle_name: name, last_name: name
+    end
+
+    it 'returns a properly formatted 200 response' do
+      expect(subject['X-VA-First-Name']).to eq 'x' * 12
+      expect(subject['X-VA-Middle-Initial']).to eq 'x'
+      expect(subject['X-VA-Last-Name']).to eq 'x' * 18
+    end
+  end
+
   describe '#create_higher_level_review' do
     subject { described_class.new.create_higher_level_review(request_body: body.to_json, user: user) }
 


### PR DESCRIPTION
temp fix for https://github.com/department-of-veterans-affairs/va.gov-team/issues/20627

see [comment](https://github.com/department-of-veterans-affairs/va.gov-team/issues/20627#issuecomment-793984108)