### PR TITLE
Change doctype for ch31

### DIFF
--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -42,7 +42,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     service.submit
   end
 
-  def upload_to_vbms(doc_type: '171')
+  def upload_to_vbms(doc_type: '1167')
     form_path = PdfFill::Filler.fill_form(self)
 
     uploader = ClaimsApi::VBMSUploader.new(


### PR DESCRIPTION
## Description of change
During testing, we found out that VBMS expects a different `doc_type` code than what we're sending.

While referencing [this doc](https://github.com/department-of-veterans-affairs/caseflow-commons/blob/master/app/models/caseflow/document_types.rb), we found this [doc typ](https://github.com/department-of-veterans-affairs/caseflow-commons/blob/master/app/models/caseflow/document_types.rb#L139). Turns out there are actually 2 codes for the same form.[ Here is the other one](https://github.com/department-of-veterans-affairs/caseflow-commons/blob/master/app/models/caseflow/document_types.rb#L921)

So we're just switching the string here.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#21236

## Things to know about this PR
* Are there additions to a `settings.yml` file? Do they vary by environment?
  * No additions
* Is there a feature flag? What is it?
  * This form is not available yet to the public
* Is there some Sentry logging that was added? What alerts are relevant?
  * no logging added
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
  * none
* Are there Swagger docs that were updated?
  * no need for swaggs
* Is there any PII concerns or questions?
  * not that I'm aware

<!-- Please describe testing done to verify the changes or any testing planned. -->
