### PR TITLE
add encrypted file data to evidence_submissions

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_155617) do
+ActiveRecord::Schema.define(version: 2021_03_09_193554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -61,6 +61,8 @@ ActiveRecord::Schema.define(version: 2021_03_05_155617) do
     t.string "supportable_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "encrypted_file_data"
+    t.string "encrypted_file_data_iv"
     t.index ["supportable_type", "supportable_id"], name: "evidence_submission_supportable_id_type_index"
   end
 

--- a/modules/appeals_api/db/migrate/20210309193554_add_meta_data_to_evidence_submissions.rb
+++ b/modules/appeals_api/db/migrate/20210309193554_add_meta_data_to_evidence_submissions.rb
@@ -1,0 +1,6 @@
+class AddMetaDataToEvidenceSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :appeals_api_evidence_submissions, :encrypted_file_data, :string
+    add_column :appeals_api_evidence_submissions, :encrypted_file_data_iv, :string
+  end
+end


### PR DESCRIPTION
This PR adds a column called `file_data` to the EvidenceSubmission model for AppealsApi.

related issue: [API-5224](https://vajira.max.gov/browse/API-5224)

