### PR TITLE
Add Exception's Class Name to PII Log `error_class` Field (HLR)

### DIFF
--- a/app/controllers/v0/higher_level_reviews/contestable_issues_controller.rb
+++ b/app/controllers/v0/higher_level_reviews/contestable_issues_controller.rb
@@ -10,7 +10,7 @@ module V0
       rescue => e
         log_exception_to_personal_information_log(
           e,
-          error_class: "#{self.class.name}#index exception (HLR)",
+          error_class: "#{self.class.name}#index exception #{e.class} (HLR)",
           benefit_type: params[:benefit_type]
         )
         raise

--- a/app/controllers/v0/higher_level_reviews_controller.rb
+++ b/app/controllers/v0/higher_level_reviews_controller.rb
@@ -5,7 +5,9 @@ module V0
     def show
       render json: decision_review_service.get_higher_level_review(params[:id]).body
     rescue => e
-      log_exception_to_personal_information_log e, error_class: error_class('show'), id: params[:id]
+      log_exception_to_personal_information_log(
+        e, error_class: error_class(method: 'show', exception_class: e.class), id: params[:id]
+      )
       raise
     end
 
@@ -20,14 +22,16 @@ module V0
                   request_body_debug_data
                 end
 
-      log_exception_to_personal_information_log e, error_class: error_class('create'), request: request
+      log_exception_to_personal_information_log(
+        e, error_class: error_class(method: 'create', exception_class: e.class), request: request
+      )
       raise
     end
 
     private
 
-    def error_class(method)
-      "#{self.class.name}##{method} exception (HLR)"
+    def error_class(method:, exception_class:)
+      "#{self.class.name}##{method} exception #{exception_class} (HLR)"
     end
   end
 end

--- a/spec/request/v0/higher_level_reviews_controller_request_spec.rb
+++ b/spec/request/v0/higher_level_reviews_controller_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe V0::HigherLevelReviewsController, type: :request do
 
   describe '#create' do
     def personal_information_logs
-      PersonalInformationLog.where error_class: 'V0::HigherLevelReviewsController#create exception (HLR)'
+      PersonalInformationLog.where 'error_class like ?', 'V0::HigherLevelReviewsController#create exception % (HLR)'
     end
 
     subject do
@@ -32,6 +32,7 @@ RSpec.describe V0::HigherLevelReviewsController, type: :request do
         expect(personal_information_logs.count).to be 0
         subject
         expect(personal_information_logs.count).to be 1
+byebug
         pil = personal_information_logs.first
         %w[
           first_name last_name birls_id icn edipi mhv_correlation_id

--- a/spec/request/v0/higher_level_reviews_controller_request_spec.rb
+++ b/spec/request/v0/higher_level_reviews_controller_request_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe V0::HigherLevelReviewsController, type: :request do
         expect(personal_information_logs.count).to be 0
         subject
         expect(personal_information_logs.count).to be 1
-byebug
         pil = personal_information_logs.first
         %w[
           first_name last_name birls_id icn edipi mhv_correlation_id


### PR DESCRIPTION
resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/21302

We weren't saving the exception's class name in the `error_class` field when creating a `PersonalInfomationLog`. Adding it to aid in debugging.

## AC
- [x] add exception's class name to PersonalInformationLog `error_class` field