### PR TITLE
add timecop freeze and return

### DIFF
--- a/spec/jobs/cypress_viewport_updater/viewport_spec.rb
+++ b/spec/jobs/cypress_viewport_updater/viewport_spec.rb
@@ -65,10 +65,17 @@ RSpec.describe CypressViewportUpdater::Viewport do
   end
 
   describe '#percentTrafficPeriod' do
-    it 'returns the correct value' do
-      beginning_of_month = Time.zone.today.prev_month.beginning_of_month.strftime('%m/%d/%Y')
-      end_of_month = Time.zone.today.prev_month.end_of_month.strftime('%m/%d/%Y')
+    let(:prev_month) { Time.zone.today.prev_month }
 
+    before do
+      Timecop.freeze(prev_month)
+    end
+
+    after { Timecop.return }
+
+    it 'returns the correct value' do
+      beginning_of_month = prev_month.beginning_of_month.strftime('%m/%d/%Y')
+      end_of_month = prev_month.end_of_month.strftime('%m/%d/%Y')
       expect(@viewport.percentTrafficPeriod).to eq("From: #{beginning_of_month}, To: #{end_of_month}")
       expect(@viewport.percentTrafficPeriod).to include(beginning_of_month)
     end


### PR DESCRIPTION


## Description of change
There's been a flapping spec related to dates/times. To make the dates more permanent, this PR adds a Timecop.freeze to the spec. This spec tends to randomly fail in CI based on the random test run ordering.  

Link to [slack conversation](https://dsva.slack.com/archives/CBU0KDSB1/p1615385008425700)


## Testing
- [x] Test suite passing locally
