### PR TITLE
adding ability to get location resources

### DIFF
--- a/modules/health_quest/app/services/health_quest/shared/options_builder.rb
+++ b/modules/health_quest/app/services/health_quest/shared/options_builder.rb
@@ -63,10 +63,20 @@ module HealthQuest
         }
       end
 
+      ##
+      # Get the list of location ids from the filters.
+      #
+      # @return [String]
+      #
       def location_ids
         @location_ids ||= filters&.fetch(:_id, nil)
       end
 
+      ##
+      # Get the list of organization ids from the filters.
+      #
+      # @return [String]
+      #
       def organization_ids
         @organization_ids ||= filters&.fetch(:_id, nil)
       end

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -14,10 +14,31 @@ describe HealthQuest::QuestionnaireManager::Factory do
   end
   let(:client_reply) { double('FHIR::ClientReply') }
   let(:default_appointments) { { data: [] } }
+  let(:default_location) { [double('FHIR::Location')] }
   let(:appointments) { { data: [{}, {}] } }
 
   before do
     allow(HealthQuest::Lighthouse::Session).to receive(:build).and_return(session_service)
+  end
+
+  describe 'included modules' do
+    it 'includes FactoryTypes' do
+      expect(subject.ancestors).to include(HealthQuest::QuestionnaireManager::FactoryTypes)
+    end
+  end
+
+  describe 'constants' do
+    it 'has a HEALTH_CARE_FORM_PREFIX' do
+      expect(subject::HEALTH_CARE_FORM_PREFIX).to eq('HC-QSTNR')
+    end
+
+    it 'has an USE_CONTEXT_DELIMITER' do
+      expect(subject::USE_CONTEXT_DELIMITER).to eq(',')
+    end
+
+    it 'has an ID_MATCHER' do
+      expect(subject::ID_MATCHER).to eq(/([I2\-a-zA-Z0-9]+)\z/i)
+    end
   end
 
   describe 'object initialization' do
@@ -26,12 +47,14 @@ describe HealthQuest::QuestionnaireManager::Factory do
     it 'responds to attributes' do
       expect(factory.respond_to?(:appointments)).to eq(true)
       expect(factory.respond_to?(:lighthouse_appointments)).to eq(true)
+      expect(factory.respond_to?(:locations)).to eq(true)
       expect(factory.respond_to?(:aggregated_data)).to eq(true)
       expect(factory.respond_to?(:patient)).to eq(true)
       expect(factory.respond_to?(:questionnaires)).to eq(true)
       expect(factory.respond_to?(:save_in_progress)).to eq(true)
       expect(factory.respond_to?(:appointment_service)).to eq(true)
       expect(factory.respond_to?(:lighthouse_appointment_service)).to eq(true)
+      expect(factory.respond_to?(:location_service)).to eq(true)
       expect(factory.respond_to?(:patient_service)).to eq(true)
       expect(factory.respond_to?(:questionnaire_service)).to eq(true)
       expect(factory.respond_to?(:sip_model)).to eq(true)
@@ -53,11 +76,13 @@ describe HealthQuest::QuestionnaireManager::Factory do
     end
     let(:fhir_questionnaire_response_bundle) { fhir_data }
     let(:questionnaire_client_reply) { double('FHIR::ClientReply', resource: fhir_questionnaire_bundle) }
+    let(:appointments_client_reply) { double('FHIR::ClientReply', resource: fhir_data) }
 
     before do
       allow_any_instance_of(subject).to receive(:get_patient).and_return(client_reply)
       allow_any_instance_of(subject).to receive(:get_appointments).and_return(appointments)
-      allow_any_instance_of(subject).to receive(:get_lighthouse_appointments).and_return(client_reply)
+      allow_any_instance_of(subject).to receive(:get_lighthouse_appointments).and_return(appointments_client_reply)
+      allow_any_instance_of(subject).to receive(:get_locations).and_return(default_location)
       allow_any_instance_of(subject).to receive(:get_save_in_progress).and_return([{}])
       allow_any_instance_of(subject)
         .to receive(:get_questionnaire_responses).and_return(questionnaire_response_client_reply)
@@ -169,6 +194,29 @@ describe HealthQuest::QuestionnaireManager::Factory do
       allow_any_instance_of(HealthQuest::Resource::Factory).to receive(:search).with(anything).and_return(client_reply)
 
       expect(described_class.manufacture(user).get_lighthouse_appointments).to eq(client_reply)
+    end
+  end
+
+  describe '#get_locations' do
+    let(:client_reply) { double('FHIR::ClientReply', resource: double('FHIR::Bundle', entry: [{}])) }
+    let(:appointments) do
+      [
+        double('Object',
+               resource: double('FHIR::Appointment',
+                                participant: [
+                                  double('Object', actor: double('Reference', reference: '/foo/I2-3JYDMXC'))
+                                ]))
+      ]
+    end
+    let(:location) { double('FHIR::Location', resource: OpenStruct.new) }
+
+    before do
+      allow_any_instance_of(subject).to receive(:lighthouse_appointments).and_return(appointments)
+      allow_any_instance_of(HealthQuest::Resource::Factory).to receive(:get).with(anything).and_return(location)
+    end
+
+    it 'returns a FHIR::ClientReply' do
+      expect(described_class.manufacture(user).get_locations).to eq([location])
     end
   end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- PR series: #6120
- Adding the ability for the Questionnaire Response Factory to fetch locations from the Lighthouse.
- Note that we're still fetching appointments from the MAP/MAS service. This ability will be removed once the rest of the code has been added to the Questionnaire Manager and other classes. The reason for keeping the MAP appointments around, for the time being, is so that the tests don't break if they get removed and we don't end up going on a large refactoring spree!
## Original issue(s)
department-of-veterans-affairs/va.gov-team#20248

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec test suites are passing.