### PR TITLE
invalid cron

### DIFF
--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -201,6 +201,6 @@ CypressViewportUpdater::UpdateCypressViewportsJob:
   description: "Updates Cypress files in vets-website with data from Google Analytics."
 
 ClaimsApi::ClaimAuditor:
-  cron: "0 0 0/12 1/1 * ? * America/New_York"
+  every: "12h"
   class: ClaimsApi::ClaimAuditor
   description: "Daily alert of pending claims longer than acceptable threshold"


### PR DESCRIPTION
## Description of change
Sidekiq scheduler reads previous config as invalid cron. Switching to simpler "every 12 hours" configuration

## Original issue(s)
https://vajira.max.gov/browse/API-5477