### PR TITLE
Adding ability to fetch organizations

### DIFF
--- a/modules/health_quest/app/services/health_quest/questionnaire_manager/factory_types.rb
+++ b/modules/health_quest/app/services/health_quest/questionnaire_manager/factory_types.rb
@@ -42,6 +42,14 @@ module HealthQuest
           api: Settings.hqva_mobile.lighthouse.health_api
         }
       end
+
+      def organization_type
+        {
+          user: user,
+          resource_identifier: 'organization',
+          api: Settings.hqva_mobile.lighthouse.health_api
+        }
+      end
     end
   end
 end

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -15,6 +15,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
   let(:client_reply) { double('FHIR::ClientReply') }
   let(:default_appointments) { { data: [] } }
   let(:default_location) { [double('FHIR::Location')] }
+  let(:default_organization) { [double('FHIR::Organization')] }
   let(:appointments) { { data: [{}, {}] } }
 
   before do
@@ -48,6 +49,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       expect(factory.respond_to?(:appointments)).to eq(true)
       expect(factory.respond_to?(:lighthouse_appointments)).to eq(true)
       expect(factory.respond_to?(:locations)).to eq(true)
+      expect(factory.respond_to?(:organizations)).to eq(true)
       expect(factory.respond_to?(:aggregated_data)).to eq(true)
       expect(factory.respond_to?(:patient)).to eq(true)
       expect(factory.respond_to?(:questionnaires)).to eq(true)
@@ -55,6 +57,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       expect(factory.respond_to?(:appointment_service)).to eq(true)
       expect(factory.respond_to?(:lighthouse_appointment_service)).to eq(true)
       expect(factory.respond_to?(:location_service)).to eq(true)
+      expect(factory.respond_to?(:organization_service)).to eq(true)
       expect(factory.respond_to?(:patient_service)).to eq(true)
       expect(factory.respond_to?(:questionnaire_service)).to eq(true)
       expect(factory.respond_to?(:sip_model)).to eq(true)
@@ -83,6 +86,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       allow_any_instance_of(subject).to receive(:get_appointments).and_return(appointments)
       allow_any_instance_of(subject).to receive(:get_lighthouse_appointments).and_return(appointments_client_reply)
       allow_any_instance_of(subject).to receive(:get_locations).and_return(default_location)
+      allow_any_instance_of(subject).to receive(:get_organizations).and_return(default_organization)
       allow_any_instance_of(subject).to receive(:get_save_in_progress).and_return([{}])
       allow_any_instance_of(subject)
         .to receive(:get_questionnaire_responses).and_return(questionnaire_response_client_reply)
@@ -215,8 +219,22 @@ describe HealthQuest::QuestionnaireManager::Factory do
       allow_any_instance_of(HealthQuest::Resource::Factory).to receive(:get).with(anything).and_return(location)
     end
 
-    it 'returns a FHIR::ClientReply' do
+    it 'returns an array of locations' do
       expect(described_class.manufacture(user).get_locations).to eq([location])
+    end
+  end
+
+  describe '#get_organizations' do
+    let(:locations) { [double('FHIR::Location', resource: double('FHIR::Bundle', id: '123abc'))] }
+
+    before do
+      allow_any_instance_of(subject).to receive(:locations).and_return(locations)
+      allow_any_instance_of(HealthQuest::Resource::Factory).to receive(:get)
+        .with(anything).and_return(default_organization)
+    end
+
+    it 'returns an array of organizations' do
+      expect(described_class.manufacture(user).get_organizations).to eq([default_organization])
     end
   end
 

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_types_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_types_spec.rb
@@ -39,4 +39,10 @@ describe HealthQuest::QuestionnaireManager::FactoryTypes do
       expect(location_type).to eq({ user: user, resource_identifier: 'location', api: 'health_api' })
     end
   end
+
+  describe '#organization_type' do
+    it 'returns a hash' do
+      expect(organization_type).to eq({ user: user, resource_identifier: 'organization', api: 'health_api' })
+    end
+  end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- PR series: #6120, #6127
- Adding the ability for the Questionnaire Manager Factory to fetch Organizations from the Lighthouse.
- Note that we're still fetching appointments from the MAP/MAS service. The MAP/MAS appointment code will be removed from the Questionniare Manager Factory in the next PR.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#20248

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec test suites are passing.