### PR TITLE
[API-5517] - Attempt to make from2122 active endpoints less confusing

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -67,11 +67,16 @@ module ClaimsApi
         def active
           power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(header_md5: header_md5,
                                                                                           source_name: source_name)
-          if power_of_attorney
-            render json: power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
+          render_poa_not_found and return unless power_of_attorney
+
+          if current_poa
+            lighthouse_poa = power_of_attorney.attributes
+            lighthouse_poa['current_poa'] = current_poa
+            combined = ClaimsApi::PowerOfAttorney.new(lighthouse_poa)
+
+            render json: combined, serializer: ClaimsApi::PowerOfAttorneySerializer
           else
-            previous_poa = ClaimsApi::PowerOfAttorney.new(form_data: {}, current_poa: current_poa)
-            render json: previous_poa, serializer: ClaimsApi::PowerOfAttorneySerializer
+            render json: power_of_attorney, serializer: ClaimsApi::PowerOfAttorneySerializer
           end
         end
 

--- a/modules/claims_api/app/swagger/claims_api/forms/form_2122_response_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_2122_response_swagger.rb
@@ -398,6 +398,20 @@ with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as
             end
           end
         end
+
+        schema :NoPOAFound do
+          property :status do
+            key :type, :string
+            key :example, '404'
+            key :description, 'HTTP error code'
+          end
+
+          property :detail do
+            key :type, :string
+            key :example, 'POA not found'
+            key :description, 'HTTP error detail'
+          end
+        end
       end
     end
   end

--- a/modules/claims_api/app/swagger/claims_api/forms/form_2122_response_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_2122_response_swagger.rb
@@ -322,6 +322,82 @@ with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as
             end
           end
         end
+
+        schema :Form2122NoPreviousPOAOutput do
+          key :required, %i[type attributes]
+          key :description, '2122 Power of Attorney Form response'
+
+          property :id do
+            key :type, :string
+            key :example, '6e47701b-802b-4520-8a41-9af2117a20bd'
+            key :description, 'Power of Attorney Submission UUID'
+          end
+
+          property :type do
+            key :type, :string
+            key :example, 'evss_power_of_attorney'
+            key :description, 'Required by JSON API standard'
+          end
+
+          property :attributes do
+            key :type, :object
+            key :description, 'Required by JSON API standard'
+
+            property :relationship_type do
+              key :type, :string
+              key :example, ''
+              key :description, 'Type of relationships'
+            end
+
+            property :date_request_accepted do
+              key :type, :string
+              key :format, 'date'
+              key :example, '2014-07-28'
+              key :description, 'Date request was first accepted'
+            end
+
+            property :status do
+              key :type, :string
+              key :example, 'submitted'
+              key :description, 'Says if the power of attorney is pending, submitted, updated or errored'
+              key :enum, %w[
+                pending
+                submitted
+                updated
+                errored
+              ]
+            end
+
+            property :representative do
+              key :type, :object
+              key :description, 'Information about VSO, Attorney or Claims Agents'
+
+              property :poa_code do
+                key :type, :string
+                key :example, 'A01'
+                key :description, 'Power of Attorney Code submitted for Veteran'
+              end
+
+              property :poa_first_name do
+                key :type, :string
+                key :example, 'John'
+                key :description, 'Power of Attorney representative first name submitted for Veteran'
+              end
+
+              property :poa_last_name do
+                key :type, :string
+                key :example, 'Doe'
+                key :description, 'Power of Attorney representative last name submitted for Veteran'
+              end
+            end
+
+            property :previous_poa do
+              key :type, :object
+              key :example, nil
+              key :description, 'Current or Previous Power of Attorney Code submitted for Veteran'
+            end
+          end
+        end
       end
     end
   end

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -452,9 +452,9 @@ module ClaimsApi
         operation :get do
           key :summary, 'Check active power of attorney status'
           key :description,
-               <<~X
-                 Returns last Power of Attorney submission sent to this API.
-               X
+              <<~X
+                Returns last Power of Attorney submission sent to this API.
+              X
           key :operationId, 'getActive2122Poa'
           key :tags, [
             'Power of Attorney'
@@ -556,7 +556,7 @@ module ClaimsApi
                 property :errors do
                   key :type, :array
                   items do
-                    key :'$ref', :NotFoundModel
+                    key :'$ref', :NoPOAFound
                   end
                 end
               end

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -451,7 +451,7 @@ module ClaimsApi
       swagger_path '/forms/2122/active' do
         operation :get do
           key :summary, 'Check active power of attorney status'
-          key :description, 'Returns last active JSON payload.'
+          key :description, 'Returns last Power of Attorney submission sent to this API.'
           key :operationId, 'getActive2122Poa'
           key :tags, [
             'Power of Attorney'
@@ -522,7 +522,7 @@ module ClaimsApi
                 key :type, :object
                 key :required, [:data]
                 property :data do
-                  key :'$ref', :Form2122Output
+                  key :'$ref', :Form2122NoPreviousPOAOutput
                 end
               end
             end

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -451,7 +451,10 @@ module ClaimsApi
       swagger_path '/forms/2122/active' do
         operation :get do
           key :summary, 'Check active power of attorney status'
-          key :description, 'Returns last Power of Attorney submission sent to this API.'
+          key :description,
+               <<~X
+                 Returns last Power of Attorney submission sent to this API.
+               X
           key :operationId, 'getActive2122Poa'
           key :tags, [
             'Power of Attorney'

--- a/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
@@ -428,8 +428,9 @@ module ClaimsApi
           key :summary, 'Check active power of attorney status'
           key :description,
               <<~X
-                Returns last active JSON payload.
+                Returns last Power of Attorney submission sent to this API.
                 * Any authenticated user can view any individual's active, and previous, POA.
+                * Returned payload will also include `previous_poa` if a previous POA is detected.
               X
           key :operationId, 'getActive2122Poa'
           key :tags, [

--- a/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
@@ -517,6 +517,22 @@ module ClaimsApi
               end
             end
           end
+
+          response 404 do
+            key :description, 'Resource not found'
+            content 'application/json' do
+              schema do
+                key :type, :object
+                key :required, [:errors]
+                property :errors do
+                  key :type, :array
+                  items do
+                    key :'$ref', :NoPOAFound
+                  end
+                end
+              end
+            end
+          end
         end
       end
 

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -178,10 +178,9 @@ RSpec.describe 'Power of Attorney ', type: :request do
 
       context 'when there is a Lightouse active power of attorney' do
         let(:power_of_attorney) { create(:power_of_attorney, auth_headers: headers) }
+        let(:bgs_poa_verifier) { BGS::PowerOfAttorneyVerifier.new(nil) }
 
         context 'when there is no BGS active power of attorney' do
-          let(:bgs_poa_verifier) { BGS::PowerOfAttorneyVerifier.new(nil) }
-
           it "the 'previous_poa' attribute is nil" do
             with_okta_user(scopes) do |auth_header|
               expect(ClaimsApi::PowerOfAttorney).to receive(
@@ -201,9 +200,7 @@ RSpec.describe 'Power of Attorney ', type: :request do
         end
 
         context 'when there is a BGS active power of attorney' do
-          let(:bgs_poa_verifier) { BGS::PowerOfAttorneyVerifier.new(nil) }
-
-          it "the 'previous_poa' attribute is nil" do
+          it "the 'previous_poa' attribute is populated" do
             with_okta_user(scopes) do |auth_header|
               expect(ClaimsApi::PowerOfAttorney).to receive(
                 :find_using_identifier_and_source

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -162,5 +162,64 @@ RSpec.describe 'Power of Attorney ', type: :request do
         end
       end
     end
+
+    describe '#active' do
+      context 'when there is no Lighthouse active power of attorney' do
+        it 'returns a 404' do
+          with_okta_user(scopes) do |auth_header|
+            allow(ClaimsApi::PowerOfAttorney).to receive(:find_using_identifier_and_source).and_return(nil)
+            get('/services/claims/v1/forms/2122/active',
+                params: nil, headers: headers.merge(auth_header))
+
+            expect(response.status).to eq(404)
+          end
+        end
+      end
+
+      context 'when there is a Lightouse active power of attorney' do
+        let(:power_of_attorney) { create(:power_of_attorney, auth_headers: headers) }
+
+        context 'when there is no BGS active power of attorney' do
+          let(:bgs_poa_verifier) { BGS::PowerOfAttorneyVerifier.new(nil) }
+
+          it "the 'previous_poa' attribute is nil" do
+            with_okta_user(scopes) do |auth_header|
+              expect(ClaimsApi::PowerOfAttorney).to receive(
+                :find_using_identifier_and_source
+              ).and_return(power_of_attorney)
+              allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(bgs_poa_verifier)
+              expect(bgs_poa_verifier).to receive(:current_poa).and_return(nil)
+              get('/services/claims/v1/forms/2122/active',
+                  params: nil, headers: headers.merge(auth_header))
+
+              parsed = JSON.parse(response.body)
+              expect(response.status).to eq(200)
+              expect(parsed['data']['attributes']['representative']['service_organization']['poa_code']).to eq('074')
+              expect(parsed['data']['attributes']['previous_poa']).to eq(nil)
+            end
+          end
+        end
+
+        context 'when there is a BGS active power of attorney' do
+          let(:bgs_poa_verifier) { BGS::PowerOfAttorneyVerifier.new(nil) }
+
+          it "the 'previous_poa' attribute is nil" do
+            with_okta_user(scopes) do |auth_header|
+              expect(ClaimsApi::PowerOfAttorney).to receive(
+                :find_using_identifier_and_source
+              ).and_return(power_of_attorney)
+              allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(bgs_poa_verifier)
+              expect(bgs_poa_verifier).to receive(:current_poa).and_return('HelloWorld')
+              get('/services/claims/v1/forms/2122/active',
+                  params: nil, headers: headers.merge(auth_header))
+
+              parsed = JSON.parse(response.body)
+              expect(response.status).to eq(200)
+              expect(parsed['data']['attributes']['previous_poa']).to eq('HelloWorld')
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -90,16 +90,6 @@ RSpec.describe 'Power of Attorney ', type: :request do
           expect(parsed['data']['attributes']['status']).to eq('submitted')
         end
       end
-
-      it 'return the active status of a PoA without a GUID' do
-        with_okta_user(scopes) do |auth_header|
-          get('/services/claims/v1/forms/2122/active',
-              params: nil, headers: headers.merge(auth_header))
-          parsed = JSON.parse(response.body)
-          expect(parsed['data']['type']).to eq('claims_api_power_of_attorneys')
-          expect(parsed['data']['attributes']['previous_poa']).to eq('A01')
-        end
-      end
     end
 
     describe '#upload_power_of_attorney_document' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Make the `v1 ​GET /forms​/2122​/active` endpoint return a 404 if there is not a Lighthouse POA submission.  If there is a Lighthouse POA submission, return it, but also check BGS to see if it has a POA.  If BGS, does have a POA, set the `previous_poa` attribute to the value of the BGS POA, else `previous_poa` attribute will be `null`.


## Original issue(s)
[API-5517](https://vajira.max.gov/browse/API-5517)