### PR TITLE
Pv sm attachment fix

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/messages_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/messages_controller.rb
@@ -36,17 +36,16 @@ module Mobile
       end
 
       def create
-        binding.pry
         message = Message.new(message_params.merge(upload_params))
         raise Common::Exceptions::ValidationErrors, message unless message.valid?
 
         message_params[:id] = message_params.delete(:draft_id) if message_params[:draft_id].present?
-        create_message_params = { message: message_params }.merge(upload_params)
+        create_message_params = { message: message_params.to_h }.merge(upload_params)
 
         client_response = if message.uploads.present?
                             client.post_create_message_with_attachment(create_message_params)
                           else
-                            client.post_create_message(message_params)
+                            client.post_create_message(message_params.to_h)
                           end
 
         render json: client_response,
@@ -76,12 +75,12 @@ module Mobile
         raise Common::Exceptions::ValidationErrors, message unless message.valid?
 
         message_params[:id] = message_params.delete(:draft_id) if message_params[:draft_id].present?
-        create_message_params = { message: message_params }.merge(upload_params)
+        create_message_params = { message: message_params.to_h }.merge(upload_params)
 
         client_response = if message.uploads.present?
                             client.post_create_message_reply_with_attachment(params[:id], create_message_params)
                           else
-                            client.post_create_message_reply(params[:id], message_params)
+                            client.post_create_message_reply(params[:id], message_params.to_h)
                           end
 
         render json: client_response,
@@ -105,11 +104,14 @@ module Mobile
 
       private
 
+      # When we get message parameters as part of a multipart payload (i.e. with attachments),
+      # ActionController::Parameters leaves the message part as a string so we have to turn it into
+      # an object
       def message_params
-        #@message_params ||= params.require(:message).permit(:draft_id, :category, :body, :recipient_id, :subject)
-        # TODO: Recreate above validation without strongparams, since
-        # Rails is passing the :message part as a string instead of JSON
-        @message_params ||= JSON.parse(params[:message])
+        @message_params ||= begin
+          params[:message] = JSON.parse(params[:message]) if params[:message].is_a?(String)
+          params.require(:message).permit(:draft_id, :category, :body, :recipient_id, :subject)
+        end
       end
 
       def upload_params

--- a/modules/mobile/app/controllers/mobile/v0/messages_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/messages_controller.rb
@@ -36,6 +36,7 @@ module Mobile
       end
 
       def create
+        binding.pry
         message = Message.new(message_params.merge(upload_params))
         raise Common::Exceptions::ValidationErrors, message unless message.valid?
 
@@ -105,7 +106,10 @@ module Mobile
       private
 
       def message_params
-        @message_params ||= params.require(:message).permit(:draft_id, :category, :body, :recipient_id, :subject)
+        #@message_params ||= params.require(:message).permit(:draft_id, :category, :body, :recipient_id, :subject)
+        # TODO: Recreate above validation without strongparams, since
+        # Rails is passing the :message part as a string instead of JSON
+        @message_params ||= JSON.parse(params[:message])
       end
 
       def upload_params


### PR DESCRIPTION
## Description of change
Updates the mobile messaging controller to handle posting messages with/without attachments. 

A message with attachments gets sent as a `multipart/form-data`, and current implementation of ActionController::Parameters treats the JSON payload in a multipart payload as a String instead of parsing it into a Hash. So we coerce that into an object that we can do strong parameter validation on. 

Then also turn Parameters objects into Hashes before passing to the SM client. 


## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/20750

## Things to know about this PR

Tested locally to make sure eventual payload to SM client was correct in all cases. 