### PR TITLE
API-5651 Adjust retry attempts for email report jobs

### DIFF
--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_daily.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_daily.rb
@@ -5,6 +5,8 @@ require 'sidekiq'
 module AppealsApi
   class DecisionReviewReportDaily
     include Sidekiq::Worker
+    # Only retry for ~8 hours since the job is run daily
+    sidekiq_options retry: 11
 
     def perform(to: Time.zone.now, from: (to.monday? ? 3.days.ago : 1.day.ago))
       DecisionReviewMailer.build(date_from: from, date_to: to, friendly_duration: 'Daily').deliver_now if enabled?

--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_daily.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_daily.rb
@@ -8,7 +8,7 @@ module AppealsApi
     # Only retry for ~8 hours since the job is run daily
     sidekiq_options retry: 11
 
-    def perform(to: Time.zone.now, from: (to.monday? ? 3.days.ago : 1.day.ago))
+    def perform(to: Time.zone.now, from: (to.monday? ? 3.days.ago.beginning_of_day : 1.day.ago.beginning_of_day))
       DecisionReviewMailer.build(date_from: from, date_to: to, friendly_duration: 'Daily').deliver_now if enabled?
     end
 

--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_weekly.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_weekly.rb
@@ -8,7 +8,7 @@ module AppealsApi
     # Only retry for ~48 hours since the job is run weekly
     sidekiq_options retry: 16
 
-    def perform(to: Time.zone.now, from: 1.week.ago)
+    def perform(to: Time.zone.now, from: 1.week.ago.beginning_of_day)
       DecisionReviewMailer.build(date_from: from, date_to: to, friendly_duration: 'Weekly').deliver_now if enabled?
     end
 

--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_weekly.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_weekly.rb
@@ -5,6 +5,8 @@ require 'sidekiq'
 module AppealsApi
   class DecisionReviewReportWeekly
     include Sidekiq::Worker
+    # Only retry for ~48 hours since the job is run weekly
+    sidekiq_options retry: 16
 
     def perform(to: Time.zone.now, from: 1.week.ago)
       DecisionReviewMailer.build(date_from: from, date_to: to, friendly_duration: 'Weekly').deliver_now if enabled?

--- a/modules/appeals_api/spec/workers/decision_review_report_daily_spec.rb
+++ b/modules/appeals_api/spec/workers/decision_review_report_daily_spec.rb
@@ -11,7 +11,7 @@ describe AppealsApi::DecisionReviewReportDaily, type: :job do
         date_from = date_to.monday? ? 3.days.ago : 1.day.ago
 
         expect(AppealsApi::DecisionReviewMailer).to receive(:build).once.with(
-          date_from: date_from,
+          date_from: date_from.beginning_of_day,
           date_to: date_to,
           friendly_duration: 'Daily'
         ).and_return(double.tap do |mailer|

--- a/modules/appeals_api/spec/workers/decision_review_report_weekly_spec.rb
+++ b/modules/appeals_api/spec/workers/decision_review_report_weekly_spec.rb
@@ -8,7 +8,7 @@ describe AppealsApi::DecisionReviewReportWeekly, type: :job do
       with_settings(Settings.modules_appeals_api.reports.decision_review, enabled: true) do
         Timecop.freeze
         date_to = Time.zone.now
-        date_from = 1.week.ago
+        date_from = 1.week.ago.beginning_of_day
 
         expect(AppealsApi::DecisionReviewMailer).to receive(:build).once.with(
           date_from: date_from,


### PR DESCRIPTION
## Description of change

Having a daily or weekly report retry for 21 days doesn't really make a whole lot of sense. This PR adjusts the retry count to be more sensible for each report type.

It also makes sure that the start time of the reports is less dependent on the runtime of the job, setting itself to the beginning of the day the job is ran to avoid missing something as the retries get longer and longer.

## Original issue(s)
https://vajira.max.gov/browse/API-5651