### PR TITLE
[21030] Add parallel spec functionality for Jenkins test runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,9 +37,9 @@ pipeline {
       }
     }
 
-    stage('Setup Testing DB') {
+    stage('Setup Testing parallel DBs') {
       steps {
-        sh 'env=$RAILS_ENV make db'
+        sh 'env=$RAILS_ENV make spec_parallel_setup'
       }
     }
 
@@ -75,7 +75,7 @@ pipeline {
 
     stage('Run tests') {
       steps {
-        sh 'env=$RAILS_ENV make spec'
+        sh 'env=$RAILS_ENV make spec_parallel'
       }
       post {
         success {

--- a/Makefile
+++ b/Makefile
@@ -137,11 +137,19 @@ endif
 
 .PHONY: spec_parallel_setup
 spec_parallel_setup:  ## Setup the parallel test dbs. This resets the curret test db, as well as the parallel tests dbs
+ifeq ($(ENV_ARG), dev)
 	@$(BASH_DEV) "RAILS_ENV=test DISABLE_BOOTSNAP=true parallel_test -e 'rake db:reset'"
+else
+	@$(COMPOSE_TEST) $(BASH) -c "RAILS_ENV=test DISABLE_BOOTSNAP=true parallel_test -e 'rake db:reset'"
+endif
 
 .PHONY: spec_parallel
 spec_parallel:  ## Runs spec tests in parallel
+ifeq ($(ENV_ARG), dev)
 	@$(BASH_DEV) "RAILS_ENV=test DISABLE_BOOTSNAP=true NOCOVERAGE=true parallel_rspec ${SPEC_PATH}"
+else
+	@$(COMPOSE_TEST) $(BASH) -c "CIRCLE_JOB=true RAILS_ENV=test DISABLE_BOOTSNAP=true parallel_rspec ${SPEC_PATH}"
+endif
 
 .PHONY: up
 up: db  ## Starts the server and associated services with docker-compose, use `clam=1 make up` to run ClamAV

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -18,7 +18,7 @@ services:
       - test_bundle:/usr/local/bundle
     environment:
       "Settings.database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
-      "Settings.test_database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}?pool=4"
+      "Settings.test_database_url": "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
       "Settings.saml.cert_path": "/srv/vets-api/src/spec/support/certificates/ruby-saml.crt"
       "Settings.saml.key_path": "/srv/vets-api/src/spec/support/certificates/ruby-saml.key"
       "Settings.binaries.clamdscan": "clamscan"           # Not running a separate process within the container for clamdscan, so we use clamscan which requires no daemon


### PR DESCRIPTION


## Description of change
This PR adds parallel spec functionality for Jenkins test runs. This should provide the same coverage as the existing single-threaded spec run, but at a significantly faster completion time

## Original issue(s)
department-of-veterans-affairs/va.gov-team/21030

## Things to know about this PR

