### PR TITLE
API-5577 Add Legal Effective Date to Veteran Verification API

### DIFF
--- a/modules/veteran_verification/VETERAN_VERIFICATION.yml
+++ b/modules/veteran_verification/VETERAN_VERIFICATION.yml
@@ -192,6 +192,10 @@ components:
           type: integer
           example: 100
         combined_effective_date:
+          description: The effective date of the latest combined disability rating for the Veteran
+          type: datetime
+          example: "2018-03-27T21:00:41.000+0000"
+        legal_effective_date:
           description: When the Veteran could begin claiming benefits for combined disability rating
           type: datetime
           example: "2018-03-27T21:00:41.000+0000"

--- a/modules/veteran_verification/VETERAN_VERIFICATION.yml
+++ b/modules/veteran_verification/VETERAN_VERIFICATION.yml
@@ -185,6 +185,8 @@ components:
         Body of the disability rating response
       required:
         - combined_disability_rating
+        - combined_effective_date
+        - legal_effective_date
         - individual_ratings
       properties:
         combined_disability_rating:

--- a/modules/veteran_verification/app/models/veteran_verification/disability_rating.rb
+++ b/modules/veteran_verification/app/models/veteran_verification/disability_rating.rb
@@ -12,6 +12,7 @@ module VeteranVerification
     attribute :id, String
     attribute :combined_disability_rating, Integer
     attribute :combined_effective_date, String
+    attribute :legal_effective_date, String
     attribute :individual_ratings, Array
 
     def self.rating_service
@@ -44,6 +45,7 @@ module VeteranVerification
         id: 0,
         combined_disability_rating: response[:disability_rating_record][:service_connected_combined_degree],
         combined_effective_date: get_combined_effective_date(response[:disability_rating_record]),
+        legal_effective_date: get_combined_effective_date(response[:disability_rating_record]),
         individual_ratings: individual_ratings(response)
       )
     end
@@ -53,6 +55,14 @@ module VeteranVerification
         nil
       else
         DateTime.strptime(disability_rating_record[:combined_degree_effective_date], '%m%d%Y')
+      end
+    end
+
+    def self.get_legal_effective_date(disability_rating_record)
+      if disability_rating_record[:legal_effective_date].nil?
+        nil
+      else
+        DateTime.strptime(disability_rating_record[:legal_effective_date], '%m%d%Y')
       end
     end
 

--- a/modules/veteran_verification/app/models/veteran_verification/disability_rating.rb
+++ b/modules/veteran_verification/app/models/veteran_verification/disability_rating.rb
@@ -45,7 +45,7 @@ module VeteranVerification
         id: 0,
         combined_disability_rating: response[:disability_rating_record][:service_connected_combined_degree],
         combined_effective_date: get_combined_effective_date(response[:disability_rating_record]),
-        legal_effective_date: get_combined_effective_date(response[:disability_rating_record]),
+        legal_effective_date: get_legal_effective_date(response[:disability_rating_record]),
         individual_ratings: individual_ratings(response)
       )
     end

--- a/modules/veteran_verification/app/models/veteran_verification/disability_rating.rb
+++ b/modules/veteran_verification/app/models/veteran_verification/disability_rating.rb
@@ -44,26 +44,10 @@ module VeteranVerification
       DisabilityRating.new(
         id: 0,
         combined_disability_rating: response[:disability_rating_record][:service_connected_combined_degree],
-        combined_effective_date: get_combined_effective_date(response[:disability_rating_record]),
-        legal_effective_date: get_legal_effective_date(response[:disability_rating_record]),
+        combined_effective_date: get_formatted_date(response[:disability_rating_record][:combined_degree_effective_date]),
+        legal_effective_date: get_formatted_date(response[:disability_rating_record][:legal_effective_date]),
         individual_ratings: individual_ratings(response)
       )
-    end
-
-    def self.get_combined_effective_date(disability_rating_record)
-      if disability_rating_record[:combined_degree_effective_date].nil?
-        nil
-      else
-        DateTime.strptime(disability_rating_record[:combined_degree_effective_date], '%m%d%Y')
-      end
-    end
-
-    def self.get_legal_effective_date(disability_rating_record)
-      if disability_rating_record[:legal_effective_date].nil?
-        nil
-      else
-        DateTime.strptime(disability_rating_record[:legal_effective_date], '%m%d%Y')
-      end
     end
 
     def self.individual_ratings(response)
@@ -76,7 +60,7 @@ module VeteranVerification
       ratings = response[:disability_rating_record][:ratings].map do |rating|
         {
           decision: rating[:disability_decision_type_name],
-          effective_date: (DateTime.strptime(rating[:begin_date], '%m%d%Y') unless rating[:begin_date].nil?),
+          effective_date: get_formatted_date(rating[:begin_date]),
           rating_percentage: rating[:diagnostic_percent].to_i
         }
       end
@@ -84,6 +68,14 @@ module VeteranVerification
         (rating[:decision].eql? 'Service Connected')
       end
       filtered_ratings.compact
+    end
+
+    def self.get_formatted_date(rating_date)
+      if rating_date.nil?
+        nil
+      else
+        DateTime.strptime(rating_date, '%m%d%Y')
+      end
     end
   end
 end

--- a/modules/veteran_verification/app/models/veteran_verification/disability_rating.rb
+++ b/modules/veteran_verification/app/models/veteran_verification/disability_rating.rb
@@ -44,7 +44,8 @@ module VeteranVerification
       DisabilityRating.new(
         id: 0,
         combined_disability_rating: response[:disability_rating_record][:service_connected_combined_degree],
-        combined_effective_date: get_formatted_date(response[:disability_rating_record][:combined_degree_effective_date]),
+        combined_effective_date:
+            get_formatted_date(response[:disability_rating_record][:combined_degree_effective_date]),
         legal_effective_date: get_formatted_date(response[:disability_rating_record][:legal_effective_date]),
         individual_ratings: individual_ratings(response)
       )

--- a/modules/veteran_verification/app/serializers/veteran_verification/disability_rating_serializer.rb
+++ b/modules/veteran_verification/app/serializers/veteran_verification/disability_rating_serializer.rb
@@ -2,7 +2,7 @@
 
 module VeteranVerification
   class DisabilityRatingSerializer < ActiveModel::Serializer
-    attributes :combined_disability_rating, :combined_effective_date, :individual_ratings
+    attributes :combined_disability_rating, :combined_effective_date, :legal_effective_date, :individual_ratings
     type 'disability_ratings'
   end
 end

--- a/modules/veteran_verification/spec/models/disability_rating_spec.rb
+++ b/modules/veteran_verification/spec/models/disability_rating_spec.rb
@@ -15,6 +15,7 @@ describe VeteranVerification::DisabilityRating do
         result = described_class.for_user(user)
         expect(result[:combined_disability_rating]).to eq(100)
         expect(result[:combined_effective_date]).to eq('2019-01-01T00:00:00+00:00')
+        expect(result[:legal_effective_date]).to eq('2019-01-01T00:00:00+00:00')
         expect(result[:individual_ratings][0][:decision]).to eq('Service Connected')
         expect(result[:individual_ratings][0][:effective_date]).to eq('2005-01-01T00:00:00.000+00:00')
         expect(result[:individual_ratings][0][:rating_percentage]).to eq(100)
@@ -26,6 +27,7 @@ describe VeteranVerification::DisabilityRating do
         result = described_class.for_user(user)
         expect(result[:combined_disability_rating]).to eq(100)
         expect(result[:combined_effective_date]).to eq('2019-01-01T00:00:00+00:00')
+        expect(result[:legal_effective_date]).to eq('2019-01-01T00:00:00+00:00')
         expect(result[:individual_ratings][0][:decision]).to eq('Service Connected')
         expect(result[:individual_ratings][0][:effective_date]).to eq('2005-01-01T00:00:00.000+00:00')
         expect(result[:individual_ratings][0][:rating_percentage]).to eq(100)
@@ -37,6 +39,7 @@ describe VeteranVerification::DisabilityRating do
         result = described_class.for_user(user)
         expect(result[:combined_disability_rating]).to eq(100)
         expect(result[:combined_effective_date]).to eq('2019-01-01T00:00:00+00:00')
+        expect(result[:legal_effective_date]).to eq('2019-01-01T00:00:00+00:00')
       end
     end
   end

--- a/modules/veteran_verification/spec/models/disability_rating_spec.rb
+++ b/modules/veteran_verification/spec/models/disability_rating_spec.rb
@@ -15,7 +15,7 @@ describe VeteranVerification::DisabilityRating do
         result = described_class.for_user(user)
         expect(result[:combined_disability_rating]).to eq(100)
         expect(result[:combined_effective_date]).to eq('2019-01-01T00:00:00+00:00')
-        expect(result[:legal_effective_date]).to eq('2019-01-01T00:00:00+00:00')
+        expect(result[:legal_effective_date]).to eq('2018-12-31T00:00:00+00:00')
         expect(result[:individual_ratings][0][:decision]).to eq('Service Connected')
         expect(result[:individual_ratings][0][:effective_date]).to eq('2005-01-01T00:00:00.000+00:00')
         expect(result[:individual_ratings][0][:rating_percentage]).to eq(100)
@@ -27,7 +27,7 @@ describe VeteranVerification::DisabilityRating do
         result = described_class.for_user(user)
         expect(result[:combined_disability_rating]).to eq(100)
         expect(result[:combined_effective_date]).to eq('2019-01-01T00:00:00+00:00')
-        expect(result[:legal_effective_date]).to eq('2019-01-01T00:00:00+00:00')
+        expect(result[:legal_effective_date]).to eq('2018-12-31T00:00:00+00:00')
         expect(result[:individual_ratings][0][:decision]).to eq('Service Connected')
         expect(result[:individual_ratings][0][:effective_date]).to eq('2005-01-01T00:00:00.000+00:00')
         expect(result[:individual_ratings][0][:rating_percentage]).to eq(100)
@@ -39,7 +39,7 @@ describe VeteranVerification::DisabilityRating do
         result = described_class.for_user(user)
         expect(result[:combined_disability_rating]).to eq(100)
         expect(result[:combined_effective_date]).to eq('2019-01-01T00:00:00+00:00')
-        expect(result[:legal_effective_date]).to eq('2019-01-01T00:00:00+00:00')
+        expect(result[:legal_effective_date]).to eq('2018-12-31T00:00:00+00:00')
       end
     end
   end

--- a/spec/support/schemas/disability_rating_response.json
+++ b/spec/support/schemas/disability_rating_response.json
@@ -20,6 +20,9 @@
             "combined_effective_date": {
               "type": "string"
             },
+            "legal_effective_date": {
+              "type": "string"
+            },
             "individual_ratings": {
               "type": "array",
               "items": {

--- a/spec/support/schemas_camelized/disability_rating_response.json
+++ b/spec/support/schemas_camelized/disability_rating_response.json
@@ -20,6 +20,9 @@
             "combinedEffectiveDate": {
               "type": "string"
             },
+            "legalEffectiveDate": {
+              "type": "string"
+            },
             "individualRatings": {
               "type": "array",
               "items": {


### PR DESCRIPTION
## Description of change
Addition of the legal effective date to the Disability Rating response for the Veteran Verification API, so that the date the disability became effective is correctly displayed in the USA Jobs application for Veteran Preference.

## Original issue(s)
https://vajira.max.gov/browse/API-5577

## Things to know about this PR
* Field addition utilizing existing recordings
* Awaiting final confirmation on the language used in the Dev Portal yml
