### PR TITLE
Removed feature flag for 10203 processing

### DIFF
--- a/app/models/saved_claim/education_benefits/va_10203.rb
+++ b/app/models/saved_claim/education_benefits/va_10203.rb
@@ -4,7 +4,7 @@ class SavedClaim::EducationBenefits::VA10203 < SavedClaim::EducationBenefits
   add_form_and_validation('22-10203')
 
   def after_submit(user)
-    create_stem_automated_decision(user) if user.present? && Flipper.enabled?(:stem_automated_decision)
+    create_stem_automated_decision(user) if user.present? && Flipper.enabled?(:stem_automated_decision, user)
 
     email_sent(false)
     return unless FeatureFlipper.send_email?

--- a/app/workers/education_form/create10203_applicant_decision_letters.rb
+++ b/app/workers/education_form/create10203_applicant_decision_letters.rb
@@ -27,7 +27,6 @@ module EducationForm
         }
       )
     )
-      return false unless Flipper.enabled?(:stem_automated_decision)
 
       if records.count.zero?
         log_info('No records to process.')

--- a/app/workers/education_form/create10203_spool_submissions_report.rb
+++ b/app/workers/education_form/create10203_spool_submissions_report.rb
@@ -80,8 +80,6 @@ module EducationForm
     end
 
     def perform
-      return false unless Flipper.enabled?(:stem_automated_decision)
-
       @time = Time.zone.now
       folder = 'tmp/spool10203_reports'
       FileUtils.mkdir_p(folder)

--- a/app/workers/education_form/process10203_submissions.rb
+++ b/app/workers/education_form/process10203_submissions.rb
@@ -25,7 +25,7 @@ module EducationForm
         }
       ).order('education_benefits_claims.created_at')
     )
-      return false unless Flipper.enabled?(:stem_automated_decision) && evss_is_healthy?
+      return false unless evss_is_healthy?
 
       if records.count.zero?
         log_info('No records to process.')

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -191,7 +191,7 @@ AppsApi::FetchConnections:
   description: "Fetches and handles notifications for recent application connections and disconnections"
 
 EducationForm::Process10203Submissions:
-  cron: "0 6-18 * * * America/New_York"
+  cron: "2m"
   class: EducationForm::Process10203Submissions
   description: "Go through 22-10203 submissions and determine if application should be processed as part of normal submission process or rejected"
 

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -191,7 +191,7 @@ AppsApi::FetchConnections:
   description: "Fetches and handles notifications for recent application connections and disconnections"
 
 EducationForm::Process10203Submissions:
-  cron: "2m"
+  every: '2m'
   class: EducationForm::Process10203Submissions
   description: "Go through 22-10203 submissions and determine if application should be processed as part of normal submission process or rejected"
 

--- a/spec/jobs/education_form/create10203_applicant_decision_letters_spec.rb
+++ b/spec/jobs/education_form/create10203_applicant_decision_letters_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe EducationForm::Create10203ApplicantDecisionLetters, type: :model,
     EducationStemAutomatedDecision.delete_all
 
     before do
-      expect(Flipper).to receive(:enabled?).with(:stem_automated_decision).and_return(true)
       subject.instance_variable_set(:@time, time)
     end
 

--- a/spec/jobs/education_form/create10203_spool_submissions_report_spec.rb
+++ b/spec/jobs/education_form/create10203_spool_submissions_report_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe EducationForm::Create10203SpoolSubmissionsReport, type: :aws_help
     describe '#perform' do
       before do
         expect(FeatureFlipper).to receive(:send_edu_report_email?).once.and_return(true)
-        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision).and_return(true)
       end
 
       after do

--- a/spec/jobs/education_form/process10203_submissions_spec.rb
+++ b/spec/jobs/education_form/process10203_submissions_spec.rb
@@ -9,43 +9,6 @@ RSpec.describe EducationForm::Process10203Submissions, type: :model, form: :educ
   let(:evss_user2) { create(:evss_user, uuid: '87ebe3da-36a3-4c92-9a73-61e9d700f6ea') }
   let(:evss_response_with_poa) { OpenStruct.new(body: get_fixture('json/evss_with_poa')) }
 
-  context 'scheduling' do
-    before do
-      allow(Rails.env).to receive('development?').and_return(true)
-    end
-
-    context 'job only runs between 6-18', run_at: '2017-01-01 00:00:00 EDT' do
-      let(:scheduler) { Rufus::Scheduler.new }
-      let(:possible_runs) do
-        ['2017-01-01 06:00:00 -0500',
-         '2017-01-01 07:00:00 -0500',
-         '2017-01-01 08:00:00 -0500',
-         '2017-01-01 09:00:00 -0500',
-         '2017-01-01 10:00:00 -0500',
-         '2017-01-01 11:00:00 -0500',
-         '2017-01-01 12:00:00 -0500',
-         '2017-01-01 13:00:00 -0500',
-         '2017-01-01 14:00:00 -0500',
-         '2017-01-01 15:00:00 -0500',
-         '2017-01-01 16:00:00 -0500',
-         '2017-01-01 17:00:00 -0500',
-         '2017-01-01 18:00:00 -0500']
-      end
-
-      before do
-        yaml = YAML.load_file(Rails.root.join('config', 'sidekiq_scheduler.yml'))
-        cron = yaml['EducationForm::Process10203Submissions']['cron']
-        scheduler.schedule_cron(cron) {} # schedule_cron requires a block
-      end
-
-      it 'is only triggered by sidekiq-scheduler between 6-18' do
-        upcoming_runs = scheduler.timeline(Time.zone.now, 1.day.from_now).map(&:first)
-        expected_runs = possible_runs.map { |d| EtOrbi.parse(d.to_s) }
-        expect(upcoming_runs.map(&:seconds)).to eq(expected_runs.map(&:seconds))
-      end
-    end
-  end
-
   describe '#format_application' do
     it 'logs an error if the record is invalid' do
       application_10203 = create(:va10203)

--- a/spec/models/saved_claim/education_benefits/va10203_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va10203_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
     context 'stem_automated_decision feature disabled' do
       it 'does not create education_stem_automated_decision' do
-        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision).and_return(false)
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(false)
         instance.after_submit(user)
         expect(instance.education_benefits_claim.education_stem_automated_decision).to be_nil
       end
@@ -39,7 +39,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
     context 'stem_automated_decision feature enabled' do
       it 'creates education_stem_automated_decision for user' do
-        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision).and_return(true)
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(true)
         instance.after_submit(user)
         expect(instance.education_benefits_claim.education_stem_automated_decision).not_to be_nil
         expect(instance.education_benefits_claim.education_stem_automated_decision.user_uuid)
@@ -48,7 +48,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
       end
 
       it 'saves user auth_headers' do
-        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision).and_return(true)
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(true)
         instance.after_submit(user)
         expect(instance.education_benefits_claim.education_stem_automated_decision.auth_headers).not_to be_nil
       end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Removed feature flag check around automated processing of 10203 STEM claims.  The creation of `education_stem_automated_decision` records is still be behind the feature flag, so the job will only be processing claims from UAT next week.

Updated frequency of `EducationForm::Process10203Submissions` job to run every 2 minutes.  This change will be reverted after UAT testing

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
