### PR TITLE
Inflection Fix - Old-style Inflection in va_forms Migration

### DIFF
--- a/modules/va_forms/db/migrate/20200817140442_add_form_details_url_to_va_forms.rb
+++ b/modules/va_forms/db/migrate/20200817140442_add_form_details_url_to_va_forms.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFormDetailsUrlToVaForms < ActiveRecord::Migration[6.0]
+class AddFormDetailsUrlToVAForms < ActiveRecord::Migration[6.0]
   def change
     add_column :va_forms_forms, :form_details_url, :string
   end


### PR DESCRIPTION
_for any poor soul who does `db:drop` then `db:migrate` (or clones vets-api for the first time and does a `db:migrate`)..._

I think this migration just got overlooked by the zeitwerk / inflection PRs.

When loading `modules/va_forms/db/migrate/20200817140442_add_form_details_url_to_va_forms.rb`, Rails predicts that the class will be named `AddFormDetailsUrlToVAForms` (capital VA) not `AddFormDetailsUrlToVaForms` (like the migration has).

The relevant code in active record:
```
    def migrations
      migrations = migration_files.map do |file|
        version, name, scope = parse_migration_filename(file)
        raise IllegalMigrationNameError.new(file) unless version
        version = version.to_i
        name = name.camelize 

        MigrationProxy.new(name, version, file, scope)
      end
```
([link](https://github.com/rails/rails/blob/bf11820213ba0f1a3b3ba556f1f8da2d132357a1/activerecord/lib/active_record/migration.rb#L1107))

For the aforementioned migration, the result of `parse_migration_filename` is `["20200817140442", "add_form_details_url_to_va_forms", ""]`, and then further down `name` is camelized resulting in `AddFormDetailsUrlToVAForms` --which is not the name of the class in the migration file.