### PR TITLE
Added catch for opaque tokens.

### DIFF
--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -50,9 +50,10 @@ class OpenidApplicationController < ApplicationController
   def token_from_request
     auth_request = request.authorization.to_s
     return unless auth_request[TOKEN_REGEX]
+
     token_string = auth_request.sub(TOKEN_REGEX, '').gsub(/^"|"$/, '')
 
-    if is_jwt?(token_string)
+    if jwt?(token_string)
       Token.new(token_string, fetch_aud)
     else
       # Future block for opaque tokens
@@ -60,11 +61,11 @@ class OpenidApplicationController < ApplicationController
     end
   end
 
-  def is_jwt?(token_string)
+  def jwt?(token_string)
     JWT.decode(token_string, nil, false, algorithm: 'RS256')
-    return true
-  rescue JWT::DecodeError => e
-    return false
+    true
+  rescue JWT::DecodeError
+    false
   end
 
   def error_klass(error_detail_string)

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -50,8 +50,28 @@ class OpenidApplicationController < ApplicationController
   def token_from_request
     auth_request = request.authorization.to_s
     return unless auth_request[TOKEN_REGEX]
+    token_string = auth_request.sub(TOKEN_REGEX, '').gsub(/^"|"$/, '')
 
-    Token.new(auth_request.sub(TOKEN_REGEX, '').gsub(/^"|"$/, ''), fetch_aud)
+    if is_jwt?(token_string)
+      Token.new(token_string, fetch_aud)
+    else
+      # Future block for opaque tokens
+      raise error_klass('Opaque tokens not supported.')
+    end
+  end
+
+  def is_jwt?(token_string)
+    JWT.decode(token_string, nil, false, algorithm: 'RS256')
+    return true
+  rescue JWT::DecodeError => e
+    return false
+  end
+
+  def error_klass(error_detail_string)
+    # Errors from the jwt gem (and other dependencies) are reraised with
+    # this class so we can exclude them from Sentry without needing to know
+    # all the classes used by our dependencies.
+    Common::Exceptions::TokenValidationError.new(detail: error_detail_string)
   end
 
   def establish_session

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -57,7 +57,7 @@ class OpenidApplicationController < ApplicationController
       Token.new(token_string, fetch_aud)
     else
       # Future block for opaque tokens
-      raise error_klass('Opaque tokens not supported.')
+      raise error_klass('Invalid token.')
     end
   end
 

--- a/spec/controllers/openid_application_controller_spec.rb
+++ b/spec/controllers/openid_application_controller_spec.rb
@@ -221,6 +221,18 @@ RSpec.describe OpenidApplicationController, type: :controller do
       end
     end
 
+    context 'with an opaque token supplied and no session' do
+      it 'returns 200 and add the user to the session' do
+        with_okta_configured do
+          request.headers['Authorization'] = 'Bearer FakeToken'
+          get :index
+          expect(response.status).to eq(401)
+          errors = JSON.parse(response.body)['errors']
+          expect(errors[0]['detail']).to eq('Opaque tokens not supported.')
+        end
+      end
+    end
+
     context 'with a MHV credential profile' do
       let(:mvi_profile) do
         build(:mvi_profile,

--- a/spec/controllers/openid_application_controller_spec.rb
+++ b/spec/controllers/openid_application_controller_spec.rb
@@ -222,14 +222,12 @@ RSpec.describe OpenidApplicationController, type: :controller do
     end
 
     context 'with an opaque token supplied and no session' do
-      it 'returns 200 and add the user to the session' do
-        with_okta_configured do
-          request.headers['Authorization'] = 'Bearer FakeToken'
-          get :index
-          expect(response.status).to eq(401)
-          errors = JSON.parse(response.body)['errors']
-          expect(errors[0]['detail']).to eq('Opaque tokens not supported.')
-        end
+      it 'returns 401' do
+        request.headers['Authorization'] = 'Bearer FakeToken'
+        get :index
+        expect(response.status).to eq(401)
+        errors = JSON.parse(response.body)['errors']
+        expect(errors[0]['detail']).to eq('Invalid token.')
       end
     end
 


### PR DESCRIPTION
## Description of change
In preparation for SSOi and SSOe access tokens usage with the Lighthouse API's, this adds a small foundation for detecting those non-JWT tokens prior to the Token.rb instantiation which relies on JWT access token structure.

## Original issue(s)
https://vajira.max.gov/browse/API-5576

## Things to know about this PR
* This is a first step PR only to gracefully handle SSOi & SSOe opaque tokens rather than stack trace errors on JWT decode failures.
* Future additions will add support for introspect calls, scope validation, etc.
