### PR TITLE
Add Some More Introspection Methods to exception_hash (FailedRequestLoggable)

### DIFF
--- a/app/controllers/concerns/failed_request_loggable.rb
+++ b/app/controllers/concerns/failed_request_loggable.rb
@@ -26,11 +26,9 @@ module FailedRequestLoggable
         to_json
         to_s
       ].each do |method|
-        begin
-          hash[method] = exception.send method
-        rescue
-          nil
-        end
+        hash[method] = exception.send method
+      rescue
+        nil
       end
       hash
     end

--- a/app/controllers/concerns/failed_request_loggable.rb
+++ b/app/controllers/concerns/failed_request_loggable.rb
@@ -7,24 +7,12 @@ module FailedRequestLoggable
     def exception_hash(exception)
       hash = {}
       %i[
-        as_json
-        attributes
-        backtrace
-        errors
-        inspect
-        instance_values
-        key
-        message
-        original_body
-        original_status
-        response_values
-        sentry_type
-        serializable_hash
-        status_code
-        to_a
-        to_h
-        to_json
-        to_s
+        as_json attributes backtrace errors
+        inspect instance_values key message
+        original_body original_status
+        response_values sentry_type
+        serializable_hash status_code
+        to_a to_h to_json to_s
       ].each do |method|
         hash[method] = exception.send method
       rescue

--- a/app/controllers/concerns/failed_request_loggable.rb
+++ b/app/controllers/concerns/failed_request_loggable.rb
@@ -7,19 +7,30 @@ module FailedRequestLoggable
     def exception_hash(exception)
       hash = {}
       %i[
+        as_json
+        attributes
         backtrace
         errors
+        inspect
+        instance_values
         key
         message
         original_body
         original_status
         response_values
         sentry_type
+        serializable_hash
         status_code
+        to_a
+        to_h
+        to_json
+        to_s
       ].each do |method|
-        next unless exception.respond_to? method
-
-        hash[method] = exception.try method
+        begin
+          hash[method] = exception.send method
+        rescue
+          nil
+        end
       end
       hash
     end


### PR DESCRIPTION
Adding [these methods](https://github.com/department-of-veterans-affairs/vets-api/pull/6159/commits/096e99f3cc4db78df4ccc1d1f2cf0555b880b2e8#diff-e49eb6621cc44ba8b5d20efbd30dd4a10ea4332ce02b746d05ead7a355011d81R10) to `exception_hash` (hard to see in final rubocopping)