### PR TITLE
Remove most direct user.mpi calls [#5411]

### DIFF
--- a/lib/evss/disability_compensation_auth_headers.rb
+++ b/lib/evss/disability_compensation_auth_headers.rb
@@ -31,7 +31,7 @@ module EVSS
     end
 
     def gender
-      case @user.gender || @user.mpi&.profile&.gender
+      case @user.gender
       when 'F'
         'FEMALE'
       when 'M'

--- a/modules/health_quest/app/services/health_quest/jwt_wrapper.rb
+++ b/modules/health_quest/app/services/health_quest/jwt_wrapper.rb
@@ -22,11 +22,11 @@ module HealthQuest
     def payload
       {
         authenticated: true,
-        sub: icn,
+        sub: @user.icn,
         idType: ID_TYPE,
         iss: ISS,
-        firstName: first_name,
-        lastName: last_name,
+        firstName: @user.first_name,
+        lastName: @user.last_name,
         authenticationAuthority: AUTHORITY,
         jti: SecureRandom.uuid,
         nbf: 1.minute.ago.to_i,
@@ -34,27 +34,15 @@ module HealthQuest
         sst: 1.minute.ago.to_i + 50,
         version: VERSION,
         gender: gender,
-        dob: birth_date,
-        dateOfBirth: birth_date,
-        edipid: edipi,
-        ssn: ssn
+        dob: @user.birth_date,
+        dateOfBirth: @user.birth_date,
+        edipid: @user.edipi,
+        ssn: @user.ssn
       }
     end
 
-    def icn
-      user.icn
-    end
-
-    def first_name
-      user.mpi&.profile&.given_names&.first
-    end
-
-    def last_name
-      user.mpi&.profile&.family_name
-    end
-
     def gender
-      type = user.mpi&.profile&.gender
+      type = @user.gender
       return '' unless type.is_a?(String)
 
       case type.upcase[0, 1]
@@ -63,18 +51,6 @@ module HealthQuest
       when 'F'
         'FEMALE'
       end
-    end
-
-    def birth_date
-      user.birth_date
-    end
-
-    def edipi
-      user.mpi&.profile&.edipi
-    end
-
-    def ssn
-      user.mpi&.profile&.ssn
     end
   end
 end

--- a/modules/health_quest/app/services/health_quest/jwt_wrapper.rb
+++ b/modules/health_quest/app/services/health_quest/jwt_wrapper.rb
@@ -22,11 +22,11 @@ module HealthQuest
     def payload
       {
         authenticated: true,
-        sub: @user.icn,
+        sub: user.icn,
         idType: ID_TYPE,
         iss: ISS,
-        firstName: @user.first_name,
-        lastName: @user.last_name,
+        firstName: user.first_name,
+        lastName: user.last_name,
         authenticationAuthority: AUTHORITY,
         jti: SecureRandom.uuid,
         nbf: 1.minute.ago.to_i,
@@ -34,16 +34,16 @@ module HealthQuest
         sst: 1.minute.ago.to_i + 50,
         version: VERSION,
         gender: gender,
-        dob: @user.birth_date,
-        dateOfBirth: @user.birth_date,
-        edipid: @user.edipi,
-        ssn: @user.ssn
+        dob: user.birth_date,
+        dateOfBirth: user.birth_date,
+        edipid: user.edipi,
+        ssn: user.ssn
       }
     end
 
     def gender
-      type = @user.gender
-      return '' unless type.is_a?(String)
+      type = user.gender
+      return '' unless type
 
       case type.upcase[0, 1]
       when 'M'

--- a/modules/vaos/app/models/vaos/appointment_form.rb
+++ b/modules/vaos/app/models/vaos/appointment_form.rb
@@ -99,8 +99,8 @@ module VAOS
 
     def name
       {
-        first_name: @user.mpi&.profile&.given_names&.first,
-        last_name: @user.mpi&.profile&.family_name
+        first_name: @user.first_name,
+        last_name: @user.last_name
       }
     end
   end

--- a/modules/vaos/app/models/vaos/appointment_request_form.rb
+++ b/modules/vaos/app/models/vaos/appointment_request_form.rb
@@ -59,7 +59,7 @@ module VAOS
       @appointment_request_id = @id # ensure these are the same (and the FE doesn't have to pass in redundant data)
       @unique_id = @id # ensure these are the same (and the FE doesn't have to pass in redundant data)
       @date = Time.current.strftime('%Y-%m-%dT%H:%M:%S.%L%z') if @id.blank? # only set for create in proper format
-      @patient_id = edipi
+      @patient_id = @user.edipi
       super(json_hash)
     end
 
@@ -82,17 +82,17 @@ module VAOS
     # These values ought to be derived from MVI vs user input, except for inpatient and text_messaging_allowed
     def patient=(values_hash)
       @patient = {
-        display_name: "#{last_name}, #{first_name}",
-        first_name: first_name,
-        last_name: last_name,
+        display_name: "#{@user.last_name}, #{@user.first_name}",
+        first_name: @user.first_name,
+        last_name: @user.last_name,
         date_of_birth: birth_date,
         patient_identifier: {
-          unique_id: edipi
+          unique_id: @user.edipi
         },
-        ssn: ssn,
+        ssn: @user.ssn,
         inpatient: values_hash[:inpatient],
         text_messaging_allowed: values_hash[:text_messaging_allowed],
-        id: edipi,
+        id: @user.edipi,
         object_type: 'Patient'
       }.compact
     end
@@ -133,24 +133,8 @@ module VAOS
       }
     end
 
-    def first_name
-      @user.mpi&.profile&.given_names&.first
-    end
-
-    def last_name
-      @user.mpi&.profile&.family_name
-    end
-
     def birth_date
       Formatters::DateFormatter.format_date(@user.birth_date, :month_day_year)
-    end
-
-    def edipi
-      @user.mpi&.profile&.edipi
-    end
-
-    def ssn
-      @user.mpi&.profile&.ssn
     end
   end
 end

--- a/modules/vaos/app/services/vaos/jwt_wrapper.rb
+++ b/modules/vaos/app/services/vaos/jwt_wrapper.rb
@@ -24,11 +24,11 @@ module VAOS
     def payload
       {
         authenticated: true,
-        sub: @user.icn,
+        sub: user.icn,
         idType: ID_TYPE,
         iss: ISS,
-        firstName: @user.first_name,
-        lastName: @user.last_name,
+        firstName: user.first_name,
+        lastName: user.last_name,
         authenticationAuthority: AUTHORITY,
         jti: SecureRandom.uuid,
         nbf: 1.minute.ago.to_i,
@@ -38,13 +38,13 @@ module VAOS
         gender: gender,
         dob: parsed_date,
         dateOfBirth: parsed_date,
-        edipid: @user.edipi,
-        ssn: @user.ssn
+        edipid: user.edipi,
+        ssn: user.ssn
       }
     end
 
     def gender
-      type = @user.gender
+      type = user.gender
       return '' unless type.is_a?(String)
 
       case type.upcase[0, 1]

--- a/modules/vaos/app/services/vaos/jwt_wrapper.rb
+++ b/modules/vaos/app/services/vaos/jwt_wrapper.rb
@@ -24,11 +24,11 @@ module VAOS
     def payload
       {
         authenticated: true,
-        sub: icn,
+        sub: @user.icn,
         idType: ID_TYPE,
         iss: ISS,
-        firstName: first_name,
-        lastName: last_name,
+        firstName: @user.first_name,
+        lastName: @user.last_name,
         authenticationAuthority: AUTHORITY,
         jti: SecureRandom.uuid,
         nbf: 1.minute.ago.to_i,
@@ -38,25 +38,13 @@ module VAOS
         gender: gender,
         dob: parsed_date,
         dateOfBirth: parsed_date,
-        edipid: edipi,
-        ssn: ssn
+        edipid: @user.edipi,
+        ssn: @user.ssn
       }
     end
 
-    def icn
-      user.icn
-    end
-
-    def first_name
-      user.mpi&.profile&.given_names&.first
-    end
-
-    def last_name
-      user.mpi&.profile&.family_name
-    end
-
     def gender
-      type = user.mpi&.profile&.gender
+      type = @user.gender
       return '' unless type.is_a?(String)
 
       case type.upcase[0, 1]
@@ -69,14 +57,6 @@ module VAOS
 
     def parsed_date
       Formatters::DateFormatter.format_date(user.birth_date, :number_iso8601)
-    end
-
-    def edipi
-      user.mpi&.profile&.edipi
-    end
-
-    def ssn
-      user.mpi&.profile&.ssn
     end
   end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Further refactoring of the User model to internally handle requests for identity information, this change takes out most `user.mpi` calls that occur outside of the model. This should not result in no noticeable change with the exception of instances when the cached SAML payload's information differs from MPI's, since the User model defaults to using the SAML payload's information over MPI.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#5411

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Existing unit tests continue to pass and cover User model methods replacing User.mpi calls