### PR TITLE
Add Net::ReadTimeout error to client base request

### DIFF
--- a/lib/common/client/base.rb
+++ b/lib/common/client/base.rb
@@ -109,7 +109,7 @@ module Common
         raise config.service_exception.new(
           e.key, e.response_values, e.original_status, e.original_body
         )
-      rescue Timeout::Error, Faraday::TimeoutError => e
+      rescue Net::ReadTimeout, Timeout::Error, Faraday::TimeoutError => e
         Raven.extra_context(service_name: config.service_name, url: path)
         raise Common::Exceptions::GatewayTimeout, e.class.name
       rescue Faraday::ClientError => e


### PR DESCRIPTION
## Description of change
Sentry is reporting a Faraday::TimeoutError, pointing to the HLR Contestable Issues get request to Caseflow. Sentry Issue: [PLATFORM-API-2KF](http://sentry.vfs.va.gov/organizations/vsp/issues/17730/?environment=production&project=3).

It looks like a rescue was put in place to catch a Faraday::TimeoutError, but not a Net::ReadTimeout error.

The latter error has been added to the rescue statement in this PR.

We were unable to recreate the actual error, but via tests it appears this is the fix.

## Original issue(s)
https://vajira.max.gov/browse/API-5608