### PR TITLE
[API-5536] - Update SpecialIssueUpdater worker to use simple arguments

### DIFF
--- a/modules/claims_api/app/workers/claims_api/claim_establisher.rb
+++ b/modules/claims_api/app/workers/claims_api/claim_establisher.rb
@@ -48,7 +48,8 @@ module ClaimsApi
         }
         ClaimsApi::SpecialIssueUpdater.perform_async(bgs_user(auth_headers),
                                                      contention_id,
-                                                     disability['special_issues'])
+                                                     disability['special_issues'],
+                                                     auto_claim.id)
       end
     end
 
@@ -68,7 +69,8 @@ module ClaimsApi
 
     def bgs_user(auth_headers)
       {
-        'ssn' => auth_headers['va_eauth_pnid']
+        'ssn' => auth_headers['va_eauth_pnid'],
+        'participant_id' => auth_headers['va_eauth_pid']
       }
     end
   end

--- a/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
+++ b/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
@@ -19,11 +19,12 @@ module ClaimsApi
     # @param contention_id [Hash(claim_id:, code:, name:)] Identifier to match existing contention
     # @param special_issues [Array(String)] List of special issues to append
     # @param auto_claim_id [Integer] default: nil
-    def perform(user, contention_id, special_issues, auto_claim_id: nil)
+    def perform(user, contention_id, special_issues, auto_claim_id = nil)
+      contention_id.symbolize_keys!
       validate_contention_id_structure(contention_id)
       service = bgs_service(user).contention
 
-      claims = service.find_contentions_by_ptcpnt_id(user.participant_id)[:benefit_claims]
+      claims = service.find_contentions_by_ptcpnt_id(user['participant_id'])[:benefit_claims]
       claim = claim_from_contention_id(claims, contention_id)
       raise "Claim not found with contention: #{contention_id}" if claim.blank?
 
@@ -52,11 +53,9 @@ module ClaimsApi
     # @param user [OpenStruct] Veteran to attach special issues to
     # @return [BGS::Services] Service object
     def bgs_service(user)
-      external_key = user.common_name || user.email
-
       BGS::Services.new(
-        external_uid: user.icn || user.uuid,
-        external_key: external_key
+        external_uid: user['ssn'],
+        external_key: user['ssn']
       )
     end
 

--- a/modules/claims_api/spec/workers/flash_updater_spec.rb
+++ b/modules/claims_api/spec/workers/flash_updater_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe ClaimsApi::FlashUpdater, type: :job do
   end
 
   let(:user) do
+    user_mock = FactoryBot.create(:evss_user, :loa3)
     {
-      'ssn' => '796043735'
+      'ssn' => user_mock.ssn
     }
   end
   let(:flashes) { %w[Homeless POW] }

--- a/modules/claims_api/spec/workers/special_issue_updater_spec.rb
+++ b/modules/claims_api/spec/workers/special_issue_updater_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe ClaimsApi::SpecialIssueUpdater, type: :job do
   end
 
   let(:user) do
+    user_mock = FactoryBot.create(:evss_user, :loa3)
     {
-      'ssn' => '796043735'
+      'ssn' => user_mock.ssn
     }
   end
   let(:contention_id) { { claim_id: '123', code: '200', name: 'contention-name-here' } }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Switches the ClaimsAPI SpecialIssuesUpdater worker to require simple arguments. This should prevent the problems that occur when marshalling/unmarshalling complex JSON objects into and out of REDIS.

## Original issue(s)
[API-5536](https://vajira.max.gov/browse/API-5536)