### PR TITLE
Generates 400 error on out-of-bounds pagination

### DIFF
--- a/lib/common/models/collection.rb
+++ b/lib/common/models/collection.rb
@@ -163,6 +163,9 @@ module Common
     def paginator(page, per_page)
       if defined?(::WillPaginate::Collection)
         WillPaginate::Collection.create(page, per_page, @data.length) do |pager|
+          if pager.out_of_bounds?
+            raise Common::Exceptions::InvalidPaginationParams.new({ page: page, per_page: per_page })
+          end
           pager.replace @data[pager.offset, pager.per_page]
         end
       else


### PR DESCRIPTION
Checks for out-of-bounds pagination parameter and generates a 400
response instead of a 500 internal server error


## Description of change
While validating that the secure messaging API pagination was working correctly, I idly tested with an out-of-bounds `page` parameter and got a 500. This PR adds a check for the `out_of_bounds?` accessor in the pagination library and returns a more helpful 400. 

There are probably other invalid pagination parameters like negative numbers, etc, that are not covered, but this is a small iterative improvement, and I could see a client accidentally walking past the end of the pages more easily than some other errors.  

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/21454

## Things to know about this PR
