### PR TITLE
create spool_file_events table

### DIFF
--- a/db/migrate/20210317132241_create_spool_file_event.rb
+++ b/db/migrate/20210317132241_create_spool_file_event.rb
@@ -1,0 +1,13 @@
+class CreateSpoolFileEvent < ActiveRecord::Migration[6.0]
+  def change
+    create_table :spool_file_events do |t|
+      t.string :rpo
+      t.integer :number_of_submissions
+      t.string :filename
+      t.timestamp :successful_at
+      t.integer :retry_attempt
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210317132241_create_spool_file_event.rb
+++ b/db/migrate/20210317132241_create_spool_file_event.rb
@@ -1,7 +1,7 @@
 class CreateSpoolFileEvent < ActiveRecord::Migration[6.0]
   def change
     create_table :spool_file_events do |t|
-      t.string :rpo
+      t.integer :rpo
       t.integer :number_of_submissions
       t.string :filename
       t.timestamp :successful_at

--- a/db/migrate/20210317132241_create_spool_file_event.rb
+++ b/db/migrate/20210317132241_create_spool_file_event.rb
@@ -8,6 +8,8 @@ class CreateSpoolFileEvent < ActiveRecord::Migration[6.0]
       t.integer :retry_attempt
 
       t.timestamps
+
+      t.index [ :rpo, :filename ], name: "index_spool_file_events_uniqueness", unique: true
     end
   end
 end

--- a/db/migrate/20210317132241_create_spool_file_event.rb
+++ b/db/migrate/20210317132241_create_spool_file_event.rb
@@ -5,7 +5,7 @@ class CreateSpoolFileEvent < ActiveRecord::Migration[6.0]
       t.integer :number_of_submissions
       t.string :filename
       t.timestamp :successful_at
-      t.integer :retry_attempt
+      t.integer :retry_attempt, default: 0
 
       t.timestamps
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -594,7 +594,7 @@ ActiveRecord::Schema.define(version: 2021_03_17_132241) do
     t.integer "number_of_submissions"
     t.string "filename"
     t.datetime "successful_at"
-    t.integer "retry_attempt"
+    t.integer "retry_attempt", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["rpo", "filename"], name: "index_spool_file_events_uniqueness", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -597,6 +597,7 @@ ActiveRecord::Schema.define(version: 2021_03_17_132241) do
     t.integer "retry_attempt"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["rpo", "filename"], name: "index_spool_file_events_uniqueness", unique: true
   end
 
   create_table "terms_and_conditions", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_15_162119) do
+ActiveRecord::Schema.define(version: 2021_03_17_132241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -589,6 +589,17 @@ ActiveRecord::Schema.define(version: 2021_03_15_162119) do
     t.index ["name"], name: "index_session_activities_on_name"
     t.index ["status"], name: "index_session_activities_on_status"
     t.index ["user_uuid"], name: "index_session_activities_on_user_uuid"
+  end
+
+  create_table "spool_file_events", force: :cascade do |t|
+    t.string "rpo"
+    t.integer "number_of_submissions"
+    t.string "filename"
+    t.datetime "successful_at"
+    t.integer "retry_attempt", default: 0
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["rpo", "filename"], name: "index_spool_file_events_uniqueness", unique: true
   end
 
   create_table "terms_and_conditions", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_15_162119) do
+ActiveRecord::Schema.define(version: 2021_03_17_132241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -317,8 +317,6 @@ ActiveRecord::Schema.define(version: 2021_03_15_162119) do
     t.string "encrypted_auth_headers_json"
     t.string "encrypted_auth_headers_json_iv"
     t.integer "remaining_entitlement"
-    t.datetime "denial_email_sent_at"
-    t.datetime "confirmation_email_sent_at"
     t.index ["education_benefits_claim_id"], name: "index_education_stem_automated_decisions_on_claim_id"
     t.index ["user_uuid"], name: "index_education_stem_automated_decisions_on_user_uuid"
   end
@@ -591,6 +589,16 @@ ActiveRecord::Schema.define(version: 2021_03_15_162119) do
     t.index ["user_uuid"], name: "index_session_activities_on_user_uuid"
   end
 
+  create_table "spool_file_events", force: :cascade do |t|
+    t.string "rpo"
+    t.integer "number_of_submissions"
+    t.string "filename"
+    t.datetime "successful_at"
+    t.integer "retry_attempt"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "terms_and_conditions", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "title"
@@ -682,7 +690,6 @@ ActiveRecord::Schema.define(version: 2021_03_15_162119) do
     t.uuid "consumer_id"
     t.json "uploaded_pdf"
     t.boolean "use_active_storage", default: false
-    t.jsonb "metadata", default: {}
     t.index ["guid"], name: "index_vba_documents_upload_submissions_on_guid"
     t.index ["status"], name: "index_vba_documents_upload_submissions_on_status"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -592,7 +592,7 @@ ActiveRecord::Schema.define(version: 2021_03_17_132241) do
   end
 
   create_table "spool_file_events", force: :cascade do |t|
-    t.string "rpo"
+    t.integer "rpo"
     t.integer "number_of_submissions"
     t.string "filename"
     t.datetime "successful_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_17_132241) do
+ActiveRecord::Schema.define(version: 2021_03_15_162119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -317,6 +317,8 @@ ActiveRecord::Schema.define(version: 2021_03_17_132241) do
     t.string "encrypted_auth_headers_json"
     t.string "encrypted_auth_headers_json_iv"
     t.integer "remaining_entitlement"
+    t.datetime "denial_email_sent_at"
+    t.datetime "confirmation_email_sent_at"
     t.index ["education_benefits_claim_id"], name: "index_education_stem_automated_decisions_on_claim_id"
     t.index ["user_uuid"], name: "index_education_stem_automated_decisions_on_user_uuid"
   end
@@ -589,17 +591,6 @@ ActiveRecord::Schema.define(version: 2021_03_17_132241) do
     t.index ["user_uuid"], name: "index_session_activities_on_user_uuid"
   end
 
-  create_table "spool_file_events", force: :cascade do |t|
-    t.string "rpo"
-    t.integer "number_of_submissions"
-    t.string "filename"
-    t.datetime "successful_at"
-    t.integer "retry_attempt", default: 0
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["rpo", "filename"], name: "index_spool_file_events_uniqueness", unique: true
-  end
-
   create_table "terms_and_conditions", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "title"
@@ -691,6 +682,7 @@ ActiveRecord::Schema.define(version: 2021_03_17_132241) do
     t.uuid "consumer_id"
     t.json "uploaded_pdf"
     t.boolean "use_active_storage", default: false
+    t.jsonb "metadata", default: {}
     t.index ["guid"], name: "index_vba_documents_upload_submissions_on_guid"
     t.index ["status"], name: "index_vba_documents_upload_submissions_on_status"
   end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Add a table to track spool file creation successes and failures in CreateDailySpoolFiles.
This table will be used to prevent multiple spool files per RPO being created during retries.

The goal is to create this flow for when a failure happens during a scheduled run:
- failure for eastern RPO happens, only western RPO is spool file is created
- retry attempt 1 out of 5: doesn’t make a new western RPO cause not a “new” run of job, successfully makes an eastern RPO file
- sftps western RPO from first run and eastern RPO from first retry

Database PR for https://github.com/department-of-veterans-affairs/vets-api/pull/6169
## Original issue(s)
department-of-veterans-affairs/va.gov-team#21243
department-of-veterans-affairs/va.gov-team#21246

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
