### PR TITLE
Update awesome print to latest minor version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -166,7 +166,7 @@ end
 
 # rubocop:disable Metrics/BlockLength
 group :development, :test do
-  gem 'awesome_print', '~> 1.8' # Pretty print your Ruby objects in full color and with proper indentation
+  gem 'awesome_print', '~> 1.9' # Pretty print your Ruby objects in full color and with proper indentation
   gem 'bootsnap', require: false
   gem 'brakeman', '~> 4.7'
   gem 'bundler-audit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -928,7 +928,7 @@ DEPENDENCIES
   appeals_api!
   apps_api!
   attr_encrypted (= 3.1.0)
-  awesome_print (~> 1.8)
+  awesome_print (~> 1.9)
   aws-sdk-s3 (~> 1)
   aws-sdk-sns (~> 1)
   benchmark-ips

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
     attr_extras (6.2.4)
-    awesome_print (1.8.0)
+    awesome_print (1.9.2)
     aws-eventstream (1.1.0)
     aws-partitions (1.380.0)
     aws-sdk-core (3.109.0)


### PR DESCRIPTION


## Description of change
As the next step in the gem update series, this PR updates the awesome_print gem to the latest minor version. It's best to update each gem individually, in order to avoid issues when rolling back.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#20261

## Testing Completed
- [x] ci make target passing locally 

