### PR TITLE
update danger to latest minor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,7 +263,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
-    danger (8.0.6)
+    danger (8.2.3)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -275,7 +275,7 @@ GEM
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
       octokit (~> 4.7)
-      terminal-table (~> 1)
+      terminal-table (>= 1, < 4)
     database_cleaner (1.8.5)
     date_time_precision (0.8.1)
     date_validator (0.9.0)


### PR DESCRIPTION
## Description of change
As the next step in the gem update series, this PR updates the danger gem to the latest minor version. It's best to update each gem individually, in order to avoid issues if a roll back is needed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#20261


## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 