### PR TITLE
Fix Uploader Bug For AWS S3 Objects (EVSSClaimDocumentUploader)

### DIFF
--- a/app/uploaders/evss_claim_document_uploader.rb
+++ b/app/uploaders/evss_claim_document_uploader.rb
@@ -27,7 +27,7 @@ class EVSSClaimDocumentUploader < CarrierWave::Uploader::Base
       file_obj = carrier_wave_sanitized_file&.to_file
       file_obj && MimeMagic.by_magic(file_obj)
     ensure
-      file_obj&.close
+      file_obj.close if file_obj.respond_to? :close
     end
   end
 


### PR DESCRIPTION
bug fix for https://github.com/department-of-veterans-affairs/vets-api/pull/5995

[AWS S3 objects don't have a close method.](http://sentry.vfs.va.gov/organizations/vsp/issues/30394/?end=2021-03-18T23%3A59%3A59&environment=production&project=3&query=is%3Aunresolved&start=2021-03-18T14%3A00%3A00&utc=true)