### PR TITLE
bump to latest minor version of parallel_tests 3.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,7 +597,7 @@ GEM
       activerecord (>= 4.2)
       request_store (~> 1.1)
     parallel (1.19.2)
-    parallel_tests (3.4.0)
+    parallel_tests (3.5.2)
       parallel
     parser (2.7.1.4)
       ast (~> 2.4.1)


### PR DESCRIPTION
## Description of change
As the next step in the gem update series, this PR updates the parallel_tests gem to the latest minor version. It's best to update each gem individually, in order to avoid issues if a roll back is needed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#20261


## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 