### PR TITLE
bump webmock to the latest minor version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -894,7 +894,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webmock (3.8.3)
+    webmock (3.12.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)


### PR DESCRIPTION
## Description of change
As the next step in the gem update series, this PR updates the webmock gem to the latest minor version. It's best to update each gem individually, in order to avoid issues if a roll back is needed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#20261


## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 