### PR TITLE
update pact gem to lastest minor version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -570,7 +570,7 @@ GEM
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)
     ox (2.13.2)
-    pact (1.55.7)
+    pact (1.57.0)
       pact-mock_service (~> 3.0, >= 3.3.1)
       pact-support (~> 1.15)
       rack-test (>= 0.6.3, < 2.0.0)


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the pact gem (test group) to the latest minor version. It's best to update each gem individually, in order to avoid issues if a roll back is needed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#20261


## Testing Completed
- [x] CI make target passing locally 
- [x] Pact verification passing locally
- [x] Reviewed gem change log updates 