### PR TITLE
Pact mock service gem minor update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,7 +578,7 @@ GEM
       term-ansicolor (~> 1.0)
       thor (>= 0.20, < 2.0)
       webrick (~> 1.3)
-    pact-mock_service (3.7.0)
+    pact-mock_service (3.8.0)
       filelock (~> 1.1)
       find_a_port (~> 1.0.1)
       json


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the pact-mock_service gem (test group) to the latest minor version. It's best to update each gem individually, in order to avoid issues if a roll back is needed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#20261


## Testing Completed
- [x] CI make target passing locally 
- [x] Pact verification passing locally
- [x] Reviewed gem change log updates 