### PR TITLE
[21004] Add relationship object to MPI Profile

### DIFF
--- a/lib/mpi/models/mvi_profile.rb
+++ b/lib/mpi/models/mvi_profile.rb
@@ -2,57 +2,19 @@
 
 require 'common/models/attribute_types/date_time_string'
 require_relative 'mvi_profile_address'
+require_relative 'mvi_profile_identity'
+require_relative 'mvi_profile_ids'
+require_relative 'mvi_profile_relationship'
 
 module MPI
   module Models
     class MviProfile
       include Virtus.model
+      include MviProfileIdentity
+      include MviProfileIds
 
-      attribute :given_names, Array[String]
-      attribute :family_name, String
-      attribute :suffix, String
-      attribute :gender, String
-      attribute :birth_date, Common::DateTimeString
-      attribute :ssn, String
-      attribute :address, MviProfileAddress
-      attribute :home_phone, String
-      attribute :full_mvi_ids, Array[String]
-      attribute :icn, String
-      attribute :icn_with_aaid, String
-      attribute :mhv_ids, Array[String]
-      attribute :active_mhv_ids, Array[String]
-      attribute :vha_facility_ids, Array[String]
-      attribute :edipi, String
-      attribute :participant_id, String
-      attribute :birls_id, String
-      attribute :birls_ids, Array[String]
-      attribute :sec_id, String
-      attribute :vet360_id, String
-      attribute :historical_icns, Array[String]
       attribute :search_token, String
-      attribute :cerner_facility_ids, Array[String]
-      attribute :cerner_id, String
-      attribute :person_type_code, String
-      attribute :relationships, Array[MviProfile]
-
-      def mhv_correlation_id
-        @active_mhv_ids&.first
-      end
-
-      def normalized_suffix
-        case @suffix
-        when /jr\.?/i
-          'Jr.'
-        when /sr\.?/i
-          'Sr.'
-        when /iii/i
-          'III'
-        when /ii/i
-          'II'
-        when /iv/i
-          'IV'
-        end
-      end
+      attribute :relationships, Array[MviProfileRelationship]
     end
   end
 end

--- a/lib/mpi/models/mvi_profile.rb
+++ b/lib/mpi/models/mvi_profile.rb
@@ -32,6 +32,8 @@ module MPI
       attribute :search_token, String
       attribute :cerner_facility_ids, Array[String]
       attribute :cerner_id, String
+      attribute :person_type_code, String
+      attribute :relationships, Array[MviProfile]
 
       def mhv_correlation_id
         @active_mhv_ids&.first

--- a/lib/mpi/models/mvi_profile_identity.rb
+++ b/lib/mpi/models/mvi_profile_identity.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'common/models/attribute_types/date_time_string'
+require_relative 'mvi_profile_address'
+
+module MPI
+  module Models
+    module MviProfileIdentity
+      include Virtus.model
+
+      attribute :given_names, Array[String]
+      attribute :family_name, String
+      attribute :suffix, String
+      attribute :gender, String
+      attribute :birth_date, Common::DateTimeString
+      attribute :ssn, String
+      attribute :address, MviProfileAddress
+      attribute :home_phone, String
+      attribute :person_type_code, String
+
+      def normalized_suffix
+        case @suffix
+        when /jr\.?/i
+          'Jr.'
+        when /sr\.?/i
+          'Sr.'
+        when /iii/i
+          'III'
+        when /ii/i
+          'II'
+        when /iv/i
+          'IV'
+        end
+      end
+    end
+  end
+end

--- a/lib/mpi/models/mvi_profile_identity.rb
+++ b/lib/mpi/models/mvi_profile_identity.rb
@@ -6,7 +6,7 @@ require_relative 'mvi_profile_address'
 module MPI
   module Models
     module MviProfileIdentity
-      include Virtus.model
+      include Virtus.module
 
       attribute :given_names, Array[String]
       attribute :family_name, String

--- a/lib/mpi/models/mvi_profile_ids.rb
+++ b/lib/mpi/models/mvi_profile_ids.rb
@@ -3,7 +3,7 @@
 module MPI
   module Models
     module MviProfileIds
-      include Virtus.model
+      include Virtus.module
 
       attribute :full_mvi_ids, Array[String]
       attribute :icn, String

--- a/lib/mpi/models/mvi_profile_ids.rb
+++ b/lib/mpi/models/mvi_profile_ids.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module MPI
+  module Models
+    module MviProfileIds
+      include Virtus.model
+
+      attribute :full_mvi_ids, Array[String]
+      attribute :icn, String
+      attribute :icn_with_aaid, String
+      attribute :mhv_ids, Array[String]
+      attribute :active_mhv_ids, Array[String]
+      attribute :vha_facility_ids, Array[String]
+      attribute :edipi, String
+      attribute :participant_id, String
+      attribute :birls_id, String
+      attribute :birls_ids, Array[String]
+      attribute :sec_id, String
+      attribute :vet360_id, String
+      attribute :historical_icns, Array[String]
+      attribute :cerner_facility_ids, Array[String]
+      attribute :cerner_id, String
+
+      def mhv_correlation_id
+        @active_mhv_ids&.first
+      end
+    end
+  end
+end

--- a/lib/mpi/models/mvi_profile_relationship.rb
+++ b/lib/mpi/models/mvi_profile_relationship.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative 'mvi_profile_identity'
+require_relative 'mvi_profile_ids'
+
+module MPI
+  module Models
+    class MviProfileRelationship
+      include Virtus.model
+      include MviProfileIdentity
+      include MviProfileIds
+    end
+  end
+end

--- a/lib/mpi/responses/profile_parser.rb
+++ b/lib/mpi/responses/profile_parser.rb
@@ -27,6 +27,14 @@ module MPI
       ADDRESS_XPATH = 'patientPerson/addr'
       PHONE = 'patientPerson/telecom'
 
+      PATIENT_PERSON_PREFIX = 'patientPerson/'
+      GENDER_XPATH = 'administrativeGenderCode/@code'
+      DOB_XPATH = 'birthTime/@value'
+      SSN_XPATH = 'asOtherIDs'
+      NAME_XPATH = 'name'
+      ADDRESS_XPATH = 'addr'
+      PHONE = 'telecom'
+
       HISTORICAL_ICN_XPATH = [
         'controlActProcess/subject', # matches SUBJECT_XPATH
         'registrationEvent',
@@ -74,7 +82,7 @@ module MPI
 
       # rubocop:disable Metrics/MethodLength
       def build_mvi_profile(patient)
-        name = parse_name(get_patient_name(patient))
+        name = parse_name(locate_element(patient, PATIENT_PERSON_PREFIX + NAME_XPATH))
         full_mvi_ids = get_extensions(patient.locate('id'))
         parsed_mvi_ids = parse_xml_gcids(patient.locate('id'))
         log_inactive_mhv_ids(parsed_mvi_ids[:mhv_ids].to_a, parsed_mvi_ids[:active_mhv_ids].to_a)
@@ -82,9 +90,9 @@ module MPI
           given_names: name[:given],
           family_name: name[:family],
           suffix: name[:suffix],
-          gender: locate_element(patient, GENDER_XPATH),
-          birth_date: locate_element(patient, DOB_XPATH),
-          ssn: parse_ssn(locate_element(patient, SSN_XPATH)),
+          gender: locate_element(patient, PATIENT_PERSON_PREFIX + GENDER_XPATH),
+          birth_date: locate_element(patient, PATIENT_PERSON_PREFIX + DOB_XPATH),
+          ssn: parse_ssn(locate_element(patient, PATIENT_PERSON_PREFIX + SSN_XPATH)),
           address: parse_address(patient),
           home_phone: parse_phone(patient),
           full_mvi_ids: full_mvi_ids,
@@ -161,7 +169,7 @@ module MPI
       end
 
       def parse_address(patient)
-        el = locate_element(patient, ADDRESS_XPATH)
+        el = locate_element(patient, PATIENT_PERSON_PREFIX + ADDRESS_XPATH)
         return nil unless el
 
         address_hash = el.nodes.map { |n| { n.value.snakecase.to_sym => n.nodes.first } }.reduce({}, :merge)
@@ -170,7 +178,7 @@ module MPI
       end
 
       def parse_phone(patient)
-        el = locate_element(patient, PHONE)
+        el = locate_element(patient, PATIENT_PERSON_PREFIX + PHONE)
         return nil unless el
 
         el.attributes[:value]

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -103,6 +103,16 @@ FactoryBot.define do
       birls_id { birls.first }
       birls_ids { birls }
       vet360_id { '123456789' }
+      sec_id { '0001234567' }
+      search_token { 'WSDOC2002071538432741110027956' }
+
+      trait :with_nil_address do
+        address { nil }
+      end
+
+      trait :with_relationship do
+        relationships { [build(:mpi_profile_relationship)] }
+      end
 
       trait :missing_attrs do
         given_names { %w[Mitchell] }
@@ -145,6 +155,46 @@ FactoryBot.define do
       trait :address_austin do
         address { build(:mvi_profile_address_austin) }
       end
+    end
+
+    factory :mpi_profile_relationship do
+      person_type_code { 'VET' }
+      given_names { %w[Joe William] }
+      family_name { 'Smith' }
+      suffix { 'Sr' }
+      gender { 'M' }
+      birth_date { '19500101' }
+      ssn { '955443333' }
+      address { nil }
+      home_phone { '1112223377' }
+      full_mvi_ids {
+        [
+          '9900123456V123456^NI^200M^USVHA^P',
+          '99345^PI^916^USVHA^PCE',
+          '2^PI^593^USVHA^PCE',
+          '99345^PI^200HD^USVHA^A',
+          'TKIP993456^PI^200IP^USVHA^A',
+          '993456^PI^200MHV^USVHA^A',
+          '9934567890^NI^200DOD^USDOD^A',
+          '99654321^PI^200CORP^USVBA^H',
+          '99345678^PI^200CORP^USVBA^A',
+          '993456789^PI^200VETS^USDVA^A',
+          '9923454432^PI^200CRNR^USVHA^A'
+        ]
+      }
+      icn { '9900123456V123456' }
+      mhv_ids { ['993456'] }
+      active_mhv_ids { ['993456'] }
+      edipi { '9934567890' }
+      participant_id { '99345678' }
+      vha_facility_ids { %w[916 593 200HD 200IP 200MHV] }
+      sec_id { '9901234567' }
+      birls_id { birls_ids.first }
+      birls_ids { ['996122306'] }
+      vet360_id { '993456789' }
+      icn_with_aaid { '9900123456V123456^NI^200M^USVHA' }
+      cerner_id { '9923454432' }
+      cerner_facility_ids { ['200CRNR'] }
     end
   end
 end

--- a/spec/lib/mpi/responses/profile_parser_spec.rb
+++ b/spec/lib/mpi/responses/profile_parser_spec.rb
@@ -38,6 +38,7 @@ describe MPI::Responses::ProfileParser do
       end
 
       context 'when name parsing fails' do
+        let(:body) { Ox.parse(File.read('spec/support/mpi/find_candidate_missing_name_response.xml')) }
         let(:mvi_profile) do
           build(
             :mpi_profile_response,
@@ -54,7 +55,6 @@ describe MPI::Responses::ProfileParser do
         end
 
         it 'sets the names to false' do
-          allow(parser).to receive(:get_patient_name).and_return(nil)
           expect(parser.parse).to have_deep_attributes(mvi_profile)
         end
       end

--- a/spec/lib/mpi/responses/profile_parser_spec.rb
+++ b/spec/lib/mpi/responses/profile_parser_spec.rb
@@ -124,6 +124,94 @@ describe MPI::Responses::ProfileParser do
     end
   end
 
+  context 'given a valid response with relationship information' do
+    let(:body) { Ox.parse(File.read('spec/support/mpi/find_candidate_with_relationship_response.xml')) }
+
+    before do
+      allow(faraday_response).to receive(:body) { body }
+    end
+
+    describe '#parse' do
+      let(:mvi_profile) do
+        build(
+          :mpi_profile_response,
+          :with_relationship,
+          :with_nil_address,
+          given_names: %w[Randy],
+          family_name: 'Little',
+          suffix: 'Jr',
+          gender: 'M',
+          birth_date: '19901004',
+          ssn: '999123456',
+          home_phone: nil,
+          icn: nil,
+          icn_with_aaid: nil,
+          historical_icns: ['1008691087V194812'],
+          full_mvi_ids: [],
+          sec_id: nil,
+          vet360_id: nil,
+          mhv_ids: [],
+          active_mhv_ids: [],
+          vha_facility_ids: [],
+          edipi: nil,
+          participant_id: nil,
+          birls_id: nil,
+          birls_ids: [],
+          search_token: 'WSDOC2005221733165441605720989',
+          relationships: [mpi_profile_relationship_component]
+        )
+      end
+
+      let(:mpi_profile_relationship_component) do
+        build(
+          :mpi_profile_relationship,
+          person_type_code: 'DEL',
+          given_names: %w[Mark],
+          family_name: 'Webb',
+          suffix: 'Jr',
+          gender: 'M',
+          birth_date: '19501004',
+          ssn: '796104437',
+          address: nil,
+          home_phone: 'mailto:Daniel.Rocha@va.gov',
+          full_mvi_ids: [
+            '1008709396V637156^NI^200M^USVHA^P',
+            '1013590059^NI^200DOD^USDOD^A',
+            '0001740097^PN^200PROV^USDVA^A',
+            '796104437^PI^200BRLS^USVBA^A',
+            '13367440^PI^200CORP^USVBA^A',
+            '0000027647^PN^200PROV^USDVA^A',
+            '0000027648^PN^200PROV^USDVA^A',
+            '1babbd957ca14e44880a534b65bb0ed4^PN^200VIDM^USDVA^A',
+            '4795335^PI^200MH^USVHA^A',
+            '7909^PI^200VETS^USDVA^A',
+            '6400bbf301eb4e6e95ccea7693eced6f^PN^200VIDM^USDVA^A'
+          ],
+          icn: '1008709396V637156',
+          icn_with_aaid: '1008709396V637156^NI^200M^USVHA',
+          mhv_ids: ['4795335'],
+          active_mhv_ids: ['4795335'],
+          vha_facility_ids: %w[200MH],
+          edipi: '1013590059',
+          participant_id: '13367440',
+          birls_id: '796104437',
+          birls_ids: ['796104437'],
+          sec_id: '0001740097',
+          vet360_id: '7909',
+          historical_icns: [],
+          cerner_id: nil,
+          cerner_facility_ids: [],
+          search_token: nil,
+          relationships: []
+        )
+      end
+
+      it 'returns a MviProfile with the parsed attributes' do
+        expect(parser.parse).to have_deep_attributes(mvi_profile)
+      end
+    end
+  end
+
   context 'with no subject element' do
     let(:body) { Ox.parse(File.read('spec/support/mpi/find_candidate_no_subject_response.xml')) }
     let(:mvi_profile) { build(:mpi_profile_response, :missing_attrs) }

--- a/spec/lib/mpi/responses/profile_parser_spec.rb
+++ b/spec/lib/mpi/responses/profile_parser_spec.rb
@@ -165,7 +165,7 @@ describe MPI::Responses::ProfileParser do
       let(:mpi_profile_relationship_component) do
         build(
           :mpi_profile_relationship,
-          person_type_code: 'DEL',
+          person_type_code: nil,
           given_names: %w[Mark],
           family_name: 'Webb',
           suffix: 'Jr',

--- a/spec/support/mpi/find_candidate_missing_name_response.xml
+++ b/spec/support/mpi/find_candidate_missing_name_response.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+              xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <env:Header/>
+  <env:Body>
+    <idm:PRPA_IN201306UV02 xmlns="urn:hl7-org:v3" xmlns:idm="http://vaww.oed.oit.va.gov" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           ITSVersion="XML_1.0" xsi:schemaLocation="urn:hl7-org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/PRPA_IN201306UV02.xsd">
+      <id extension="WSDOC1609131753362231779394902" root="2.16.840.1.113883.4.349"/>
+      <creationTime value="20160913175336"/>
+      <versionCode code="4.1"/>
+      <interactionId extension="PRPA_IN201306UV02" root="2.16.840.1.113883.1.6"/>
+      <processingCode code="T"/>
+      <processingModeCode code="T"/>
+      <acceptAckCode code="NE"/>
+      <receiver typeCode="RCV">
+        <device determinerCode="INSTANCE" classCode="DEV">
+          <id extension="200VGOV" root="2.16.840.1.113883.4.349"/>
+        </device>
+      </receiver>
+      <sender typeCode="SND">
+        <device determinerCode="INSTANCE" classCode="DEV">
+          <id extension="200M" root="2.16.840.1.113883.4.349"/>
+        </device>
+      </sender>
+      <acknowledgement>
+        <typeCode code="AA"/>
+        <targetMessage>
+          <id extension="MCID-12345" root="1.2.840.114350.1.13.0.1.7.1.1"/>
+        </targetMessage>
+        <acknowledgementDetail>
+          <code codeSystemName="MVI" code="132" displayName="IMT"/>
+          <text>Identity Match Threshold</text>
+        </acknowledgementDetail>
+        <acknowledgementDetail>
+          <code codeSystemName="MVI" code="120" displayName="PDT"/>
+          <text>Potential Duplicate Threshold</text>
+        </acknowledgementDetail>
+      </acknowledgement>
+      <controlActProcess classCode="CACT" moodCode="EVN">
+        <code codeSystem="2.16.840.1.113883.1.6" code="PRPA_TE201306UV02"/>
+        <subject typeCode="SUBJ">
+          <registrationEvent classCode="REG" moodCode="EVN">
+            <id nullFlavor="NA"/>
+            <statusCode code="active"/>
+            <subject1 typeCode="SBJ">
+              <patient classCode="PAT">
+                <id extension="1000123456V123456^NI^200M^USVHA^P" root="2.16.840.1.113883.4.349"/>
+                <id extension="12345^PI^516^USVHA^PCE" root="2.16.840.1.113883.4.349"/>
+                <id extension="2^PI^553^USVHA^PCE" root="2.16.840.1.113883.4.349"/>
+                <id extension="12345^PI^200HD^USVHA^A" root="2.16.840.1.113883.4.349"/>
+                <id extension="TKIP123456^PI^200IP^USVHA^A" root="2.16.840.1.113883.4.349"/>
+                <id extension="123456^PI^200MHV^USVHA^A" root="2.16.840.1.113883.4.349"/>
+                <id extension="1234567890^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12" />
+                <id extension="87654321^PI^200CORP^USVBA^H" root="2.16.840.1.113883.4.349"/>
+                <id extension="12345678^PI^200CORP^USVBA^A" root="2.16.840.1.113883.4.349"/>
+                <id extension="123456789^PI^200VETS^USDVA^A" root="2.16.840.1.113883.4.349" />
+                <statusCode code="active"/>
+                <patientPerson>
+                  <telecom value="1112223333" use="HP"/>
+                  <administrativeGenderCode code="M"/>
+                  <birthTime value="19800101"/>
+                  <addr use="PHYS">
+                    <streetAddressLine>121 A St</streetAddressLine>
+                    <city>Austin</city>
+                    <state>TX</state>
+                    <postalCode>78772</postalCode>
+                    <country>USA</country>
+                  </addr>
+                  <multipleBirthInd value="true"/>
+                  <asOtherIDs classCode="SSN">
+                    <id extension="555443333" root="2.16.840.1.113883.4.1"/>
+                    <scopingOrganization determinerCode="INSTANCE" classCode="ORG">
+                      <id root="1.2.840.114350.1.13.99997.2.3412"/>
+                    </scopingOrganization>
+                  </asOtherIDs>
+                  <birthPlace>
+                    <addr>
+                      <city>JOHNSON CITY</city>
+                      <state>MS</state>
+                      <country>USA</country>
+                    </addr>
+                  </birthPlace>
+                </patientPerson>
+                <subjectOf1>
+                  <queryMatchObservation classCode="COND" moodCode="EVN">
+                    <code code="IHE_PDQ"/>
+                    <value value="162" xsi:type="INT"/>
+                  </queryMatchObservation>
+                </subjectOf1>
+              </patient>
+            </subject1>
+            <custodian typeCode="CST">
+              <assignedEntity classCode="ASSIGNED">
+                <id root="2.16.840.1.113883.4.349"/>
+              </assignedEntity>
+            </custodian>
+          </registrationEvent>
+        </subject>
+        <queryAck>
+          <queryId extension="18204" root="2.16.840.1.113883.3.933"/>
+          <queryResponseCode code="OK"/>
+          <resultCurrentQuantity value="1"/>
+        </queryAck>
+        <queryByParameter>
+          <queryId extension="18204" root="2.16.840.1.113883.3.933"/>
+          <statusCode code="new"/>
+          <modifyCode code="MVI.COMP1"/>
+          <initialQuantity value="1"/>
+          <parameterList>
+            <livingSubjectName>
+              <value use="L">
+                <given>John</given>
+                <given>William</given>
+                <family>Smith</family>
+              </value>
+              <semanticsText>LivingSubject.name</semanticsText>
+            </livingSubjectName>
+            <livingSubjectBirthTime>
+              <value value="19800101"/>
+              <semanticsText>LivingSubject..birthTime</semanticsText>
+            </livingSubjectBirthTime>
+            <livingSubjectId>
+              <value extension="555-44-3333" root="2.16.840.1.113883.4.1"/>
+              <semanticsText>SSN</semanticsText>
+            </livingSubjectId>
+          </parameterList>
+        </queryByParameter>
+      </controlActProcess>
+    </idm:PRPA_IN201306UV02>
+  </env:Body>
+</env:Envelope>

--- a/spec/support/mpi/find_candidate_with_relationship_response.xml
+++ b/spec/support/mpi/find_candidate_with_relationship_response.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <env:Header/>
+  <env:Body>
+    <idm:PRPA_IN201306UV02 ITSVersion="XML_1.0" xsi:schemaLocation="urn:hl7-org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/PRPA_IN201306UV02.xsd"
+      xmlns="urn:hl7-org:v3"
+      xmlns:idm="http://vaww.oed.oit.va.gov">
+      <id extension="WSDOC2005221733165441605720989" root="2.16.840.1.113883.4.349"/>
+      <creationTime value="20200522173316"/>
+      <versionCode code="4.1"/>
+      <interactionId extension="PRPA_IN201306UV02" root="2.16.840.1.113883.1.6"/>
+      <processingCode code="T"/>
+      <processingModeCode code="T"/>
+      <acceptAckCode code="NE"/>
+      <receiver typeCode="RCV">
+        <device determinerCode="INSTANCE" classCode="DEV">
+          <id extension="200VGOV" root="2.16.840.1.113883.4.349"/>
+        </device>
+      </receiver>
+      <sender typeCode="SND">
+        <device determinerCode="INSTANCE" classCode="DEV">
+          <id extension="200M" root="2.16.840.1.113883.4.349"/>
+        </device>
+      </sender>
+      <acknowledgement>
+        <typeCode code="AA"/>
+        <targetMessage>
+          <id extension="200VGOV-c88239c0-ee47-455c-867b-3a6941beeaa0" root="1.2.840.114350.1.13.0.1.7.1.1"/>
+        </targetMessage>
+        <acknowledgementDetail>
+          <code codeSystemName="MVI" code="132" displayName="IMT"/>
+          <text>Identity Match Threshold</text>
+        </acknowledgementDetail>
+        <acknowledgementDetail>
+          <code codeSystemName="MVI" code="120" displayName="PDT"/>
+          <text>Potential Duplicate Threshold</text>
+        </acknowledgementDetail>
+      </acknowledgement>
+      <controlActProcess classCode="CACT" moodCode="EVN">
+        <code codeSystem="2.16.840.1.113883.1.6" code="PRPA_TE201306UV02"/>
+        <subject typeCode="SUBJ">
+          <registrationEvent classCode="REG" moodCode="EVN">
+            <id nullFlavor="NA"/>
+            <statusCode code="active"/>
+            <subject1 typeCode="SBJ">
+              <patient classCode="PAT">
+                <statusCode code="active"/>
+                <patientPerson>
+                  <name use="L">
+                    <given>RANDY</given>
+                    <family>LITTLE</family>
+                    <suffix>JR</suffix>
+                  </name>
+                  <administrativeGenderCode code="M"/>
+                  <birthTime value="19901004"/>
+                  <multipleBirthInd value="false"/>
+                  <asOtherIDs classCode="SSN">
+                    <id extension="999123456" root="2.16.840.1.113883.4.1"/>
+                    <scopingOrganization determinerCode="INSTANCE" classCode="ORG">
+                      <id root="1.2.840.114350.1.13.99997.2.3412"/>
+                    </scopingOrganization>
+                  </asOtherIDs>
+                  <personalRelationship>
+                    <code codeSystemName="RoleCode" codeSystem="2.16.840.1.113883.5.111" code="DEL" displayName="VA Healthcare Proxy"></code>
+                    <translation codeSystemName="RoleCode" codeSystem="2.16.840.1.113883.5.111" code="PRS"/>
+                    <telecom value="mailto:Daniel.Rocha@va.gov" use="H"/>
+                    <statusCode code="ACTIVE"/>
+                    <effectiveTime value="20160705"/>
+                    <relationshipHolder1 determinerCode="INSTANCE" classCode="PAT">
+                      <id extension="1008709396V637156^NI^200M^USVHA^P" root="2.16.840.1.113883.4.349"/>
+                      <id extension="1013590059^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12"/>
+                      <id extension="0001740097^PN^200PROV^USDVA^A" root="2.16.840.1.113883.4.349"/>
+                      <id extension="796104437^PI^200BRLS^USVBA^A" root="2.16.840.1.113883.4.349"/>
+                      <id extension="13367440^PI^200CORP^USVBA^A" root="2.16.840.1.113883.4.349"/>
+                      <id extension="0000027647^PN^200PROV^USDVA^A" root="2.16.840.1.113883.4.349"/>
+                      <id extension="0000027648^PN^200PROV^USDVA^A" root="2.16.840.1.113883.4.349"/>
+                      <id extension="1babbd957ca14e44880a534b65bb0ed4^PN^200VIDM^USDVA^A" root="2.16.840.1.113883.4.349"/>
+                      <id extension="4795335^PI^200MH^USVHA^A" root="2.16.840.1.113883.4.349"/>
+                      <id extension="7909^PI^200VETS^USDVA^A" root="2.16.840.1.113883.4.349"/>
+                      <id extension="6400bbf301eb4e6e95ccea7693eced6f^PN^200VIDM^USDVA^A" root="2.16.840.1.113883.4.349"/>
+                      <name use="L">
+                        <given>MARK</given>
+                        <family>WEBB</family>
+                        <suffix>JR</suffix>
+                      </name>
+                      <administrativeGenderCode code="M"/>
+                      <birthTime value="19501004"/>
+                      <asOtherIDs classCode="SSN">
+                        <id extension="796104437" root="2.16.840.1.113883.4.1"/>
+                        <scopingOrganization determinerCode="INSTANCE" classCode="ORG">
+                          <id root="1.2.840.114350.1.13.99997.2.3412"/>
+                        </scopingOrganization>
+                      </asOtherIDs>
+                      <asOtherIDs classCode="EXP">
+                        <id extension="20160705" root="2.16.840.1.113883.4.349"/>
+                      </asOtherIDs>
+                      <asOtherIDs classCode="PREF">
+                        <id extension="FULL" root="2.16.840.1.113883.4.349"/>
+                      </asOtherIDs>
+                    </relationshipHolder1>
+                  </personalRelationship>
+                </patientPerson>
+                <subjectOf1>
+                  <queryMatchObservation classCode="COND" moodCode="EVN">
+                    <code code="IHE_PDQ"/>
+                    <value value="167" xsi:type="INT"/>
+                  </queryMatchObservation>
+                </subjectOf1>
+                <subjectOf2 typeCode="SBJ">
+                  <administrativeObservation classCode="VERIF">
+                    <code codeSystem="2.16.840.1.113883.4.349" code="PERSON_TYPE" displayName="Person Type"/>
+                    <value xsi:type="CD" code="DEP" displayName="Dependent"/>
+                  </administrativeObservation>
+                </subjectOf2>
+              </patient>
+            </subject1>
+            <custodian typeCode="CST">
+              <assignedEntity classCode="ASSIGNED">
+                <id root="2.16.840.1.113883.4.349"/>
+              </assignedEntity>
+            </custodian>
+            <replacementOf typeCode="RPLC">
+              <priorRegistration classCode="REG" moodCode="EVN">
+                <id extension="1008691087V194812^NI^200M^USVHA^D" root="2.16.840.1.113883.4.349"/>
+              </priorRegistration>
+            </replacementOf>
+          </registrationEvent>
+        </subject>
+        <queryAck>
+          <queryId extension="18204" root="1.2.840.114350.1.13.28.1.18.5.999"/>
+          <queryResponseCode code="OK"/>
+          <resultCurrentQuantity value="1"/>
+        </queryAck>
+        <queryByParameter>
+          <queryId extension="18204" root="1.2.840.114350.1.13.28.1.18.5.999"/>
+          <statusCode code="new"/>
+          <modifyCode code="MVI.COMP1.RMS"/>
+          <initialQuantity value="1"/>
+          <parameterList>
+            <livingSubjectAdministrativeGender>
+              <value code="M"/>
+              <semanticsText>Gender</semanticsText>
+            </livingSubjectAdministrativeGender>
+            <livingSubjectBirthTime>
+              <value value="199001004"/>
+              <semanticsText>Date of Birth</semanticsText>
+            </livingSubjectBirthTime>
+            <livingSubjectId>
+              <value extension="999123456" root="2.16.840.1.113883.4.1"/>
+              <semanticsText>SSN</semanticsText>
+            </livingSubjectId>
+            <livingSubjectName>
+              <value use="L">
+                <given>RANDY</given>
+                <family>LITTLE</family>
+              </value>
+              <semanticsText>Legal Name</semanticsText>
+            </livingSubjectName>
+          </parameterList>
+        </queryByParameter>
+      </controlActProcess>
+    </idm:PRPA_IN201306UV02>
+  </env:Body>
+</env:Envelope> 


### PR DESCRIPTION
## Description of change
This PR adds the `relationships` field to the `MVIProfile` class, which is a recursive `MVIProfile` that defines an entity with a relationship to the MPI User. This definition is parsed from the `personalRelationship` tag in an MPI Response

## Original issue(s)
department-of-veterans-affairs/va.gov-team/issues/21004

## Things to know about this PR
- There shouldn't be any changes on the frontend at this point, and we currently do not have access to relationship data with MPI, so basically testing should just show that this currently doesn't break anything.
- On local, if you check out the branch `https://github.com/department-of-veterans-affairs/vets-api-mockdata/tree/5987_development_branch_mpi_relationship_mock`, and sign in with `vets.gov.user+dependent.1@gmail.com`, you should get a mocked response from MPI with relationship information
