### PR TITLE
Adding test coverage step to Jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ ifeq ($(ENV_ARG), dev)
 	@$(BASH_DEV) "RAILS_ENV=test DISABLE_BOOTSNAP=true NOCOVERAGE=true parallel_rspec ${SPEC_PATH}"
 else
 	@$(COMPOSE_TEST) $(BASH) -c "CIRCLE_JOB=true RAILS_ENV=test DISABLE_BOOTSNAP=true parallel_rspec ${SPEC_PATH}"
+	@$(BASH_TEST) "DISABLE_BOOTSNAP=true RUN_COVERAGE=true bin/rails simplecov:report_coverage"
 endif
 
 .PHONY: up

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -38,7 +38,7 @@ class SimpleCovHelper
     end
   end
 
-  def add_filters
+  def self.add_filters
     add_filter 'app/controllers/concerns/accountable.rb'
     add_filter 'config/initializers/clamscan.rb'
     add_filter 'lib/apps/configuration.rb'
@@ -59,7 +59,7 @@ class SimpleCovHelper
     add_filter 'version.rb'
   end
 
-  def add_modules
+  def self.add_modules
     # Modules
     add_group 'AppealsApi', 'modules/appeals_api/'
     add_group 'ClaimsApi', 'modules/claims_api/'


### PR DESCRIPTION

## Description of change
The test coverage step was disabled when we enabled parallel specs for Jenkins, and we did not have a followup step to run the tests. This PR adds this step to inspect the coverage report and output the test results appropriately

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/6220

## Things to know about this PR
