### PR TITLE
update super_diff to latest minor version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -848,7 +848,7 @@ GEM
     statsd-instrument (2.6.0)
     strong_migrations (0.7.3)
       activerecord (>= 5)
-    super_diff (0.5.3)
+    super_diff (0.6.1)
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the super_diff gem (test group) to the latest minor version. It's best to update each gem individually, in order to avoid issues if a roll back is needed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#20261


## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 