### PR TITLE
21584 mobile delete email fix

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/emails_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/emails_controller.rb
@@ -19,9 +19,9 @@ module Mobile
       end
 
       def destroy
-        email_params[:effective_end_date] = Time.now.utc.iso8601
+        delete_params = email_params.merge(effective_end_date: Time.now.utc.iso8601)
         render_transaction_to_json(
-          service.save_and_await_response(resource_type: :email, params: email_params, update: true)
+          service.save_and_await_response(resource_type: :email, params: delete_params, update: true)
         )
       end
 

--- a/modules/mobile/app/controllers/mobile/v0/emails_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/emails_controller.rb
@@ -19,7 +19,7 @@ module Mobile
       end
 
       def destroy
-        delete_params = email_params.merge(effective_end_date: Time.now.utc.iso8601)
+        delete_params = email_params.to_h.merge(effective_end_date: Time.now.utc.iso8601)
         render_transaction_to_json(
           service.save_and_await_response(resource_type: :email, params: delete_params, update: true)
         )


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
In which Alastair learns controller params !== hashes. Correctly adds the `effective_end_date` key to the params used to soft delete an email in Vet360.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#21584
