### PR TITLE
bump database_cleaner to latest major version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,12 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (>= 1, < 4)
-    database_cleaner (1.8.5)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date_time_precision (0.8.1)
     date_validator (0.9.0)
       activemodel


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the database_cleaner gem to the latest major version.. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#20261


## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 