### PR TITLE
21261 endpoint for diary entries

### DIFF
--- a/app/controllers/v0/dependents_verifications_controller.rb
+++ b/app/controllers/v0/dependents_verifications_controller.rb
@@ -11,7 +11,7 @@ module V0
     def create
       dependency_verification_service.update_diaries if params[:update_diaries] == 'true'
 
-      status :ok
+      head :ok
     end
 
     private

--- a/app/controllers/v0/dependents_verifications_controller.rb
+++ b/app/controllers/v0/dependents_verifications_controller.rb
@@ -8,6 +8,12 @@ module V0
       render json: dependents, serializer: DependentsVerificationsSerializer
     end
 
+    def create
+      dependency_verification_service.update_diaries if params[:update_diaries] == 'true'
+
+      status :ok
+    end
+
     private
 
     def dependency_verification_service

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -20,6 +20,7 @@ module BGS
     end
 
     def update_diaries
+      binding.pry
       diaries = read_diaries[:diaries]
       updated_diaries = updated_diaries(diaries)
 

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -20,7 +20,6 @@ module BGS
     end
 
     def update_diaries
-      binding.pry
       diaries = read_diaries[:diaries]
       updated_diaries = updated_diaries(diaries)
 

--- a/app/swagger/swagger/requests/dependents_verifications.rb
+++ b/app/swagger/swagger/requests/dependents_verifications.rb
@@ -26,7 +26,6 @@ module Swagger
 
       swagger_path '/v0/dependents_verifications' do
         operation :post do
-          extend Swagger::Responses::ValidationError
           extend Swagger::Responses::SavedForm
 
           key :description, 'Update diaries by sending true'

--- a/app/swagger/swagger/requests/dependents_verifications.rb
+++ b/app/swagger/swagger/requests/dependents_verifications.rb
@@ -23,6 +23,30 @@ module Swagger
           end
         end
       end
+
+      swagger_path '/v0/dependents_verifications' do
+        operation :post do
+          extend Swagger::Responses::ValidationError
+          extend Swagger::Responses::SavedForm
+
+          key :description, 'Update diaries by sending true'
+          key :operationId, 'adDependentsVerifications'
+          key :tags, %w[dependents_verifications]
+
+          parameter :authorization
+
+          parameter do
+            key :name, :form
+            key :in, :body
+            key :description, 'Veteran Diary verification'
+            key :required, true
+
+            schema do
+              key :type, :string
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,7 +102,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :dependents_verifications, only: :index
+    resources :dependents_verifications, only: %i[create index]
 
     if Settings.central_mail.upload.enabled
       resources :pension_claims, only: %i[create show]

--- a/spec/controllers/v0/dependents_verifications_controller_spec.rb
+++ b/spec/controllers/v0/dependents_verifications_controller_spec.rb
@@ -24,14 +24,12 @@ RSpec.describe V0::DependentsVerificationsController do
 
   describe 'POST create' do
     it 'fires the #update_diaries call' do
-      VCR.use_cassette('bgs/diaries/read') do
-        depenency_verification_service = double('dep_verification')
+      depenency_verification_service = double('dep_verification')
 
-        expect(depenency_verification_service).to receive(:update_diaries)
-        expect(BGS::DependencyVerificationService).to receive(:new) { depenency_verification_service }
+      expect(depenency_verification_service).to receive(:update_diaries)
+      expect(BGS::DependencyVerificationService).to receive(:new) { depenency_verification_service }
 
-        post(:create, params: {update_diaries: true})
-      end
+      post(:create, params: { update_diaries: true })
     end
   end
 end

--- a/spec/controllers/v0/dependents_verifications_controller_spec.rb
+++ b/spec/controllers/v0/dependents_verifications_controller_spec.rb
@@ -21,4 +21,17 @@ RSpec.describe V0::DependentsVerificationsController do
       end
     end
   end
+
+  describe 'POST create' do
+    it 'fires the #update_diaries call' do
+      VCR.use_cassette('bgs/diaries/read') do
+        depenency_verification_service = double('dep_verification')
+
+        expect(depenency_verification_service).to receive(:update_diaries)
+        expect(BGS::DependencyVerificationService).to receive(:new) { depenency_verification_service }
+
+        post(:create, params: {update_diaries: true})
+      end
+    end
+  end
 end

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -3088,7 +3088,6 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
             '_data' => { 'update_diaries' => 'true' }
           )
         )
-
       end
     end
 

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -3068,11 +3068,26 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
     end
 
     describe 'dependents verifications' do
-      it 'supports getting dependent information' do
+      it 'supports getting diary information' do
         expect(subject).to validate(:get, '/v0/dependents_verifications', 401)
         VCR.use_cassette('bgs/diaries/read') do
           expect(subject).to validate(:get, '/v0/dependents_verifications', 200, headers)
         end
+      end
+
+      it 'supports updating diaries' do
+        depenency_verification_service = double('dep_verification')
+        expect(depenency_verification_service).to receive(:update_diaries)
+        expect(BGS::DependencyVerificationService).to receive(:new) { depenency_verification_service }
+
+        expect(subject).to validate(
+          :post,
+          '/v0/dependents_verifications',
+          200,
+          headers.merge(
+            '_data' => {'update_diaries' => 'true'}
+          )
+        )
       end
     end
 

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -3088,6 +3088,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
             '_data' => { 'update_diaries' => 'true' }
           )
         )
+
       end
     end
 

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -3085,7 +3085,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
           '/v0/dependents_verifications',
           200,
           headers.merge(
-            '_data' => {'update_diaries' => 'true'}
+            '_data' => { 'update_diaries' => 'true' }
           )
         )
       end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR adds an endpoint that allows the veteran to verify the status of their dependents. Here are the possible scenarios.

1. Veteran clicks button verifying their dependent status
    * FE sends `{update_diaries: 'true'}`
    * we run update diary service which pulls the diaries for that veteran, updates a date and sends to bgs

2. Veteran just doesn't click the button 🤷🏻 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#21261

## Things to know about this PR
* Are there additions to a `settings.yml` file? Do they vary by environment?
  * No settings added
* Is there a feature flag? What is it?
  *  This feature is not live yet
* Is there some Sentry logging that was added? What alerts are relevant?
  * No sentry logs added for this PR
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
  * none added
* Are there Swagger docs that were updated?
  * Yes. Swagger docs updated
* Is there any PII concerns or questions?
  * No concerns

<!-- Please describe testing done to verify the changes or any testing planned. -->
