### PR TITLE
API-5780 Move weekly report to Sunday eve

### DIFF
--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -135,7 +135,7 @@ AppealsApi::DecisionReviewReportDaily:
   description: "Daily report of appeals submissions"
 
 AppealsApi::DecisionReviewReportWeekly:
-  cron: "0 23 * * MON America/New_York"
+  cron: "0 23 * * SUN America/New_York"
   class: AppealsApi::DecisionReviewReportWeekly
   description: "Weekly report of appeals submissions"
 


### PR DESCRIPTION

## Description of change

Changes weekly report schedule to report on Monday through Sunday (before it was Tuesday through Monday).

## Original issue(s)
https://vajira.max.gov/browse/API-5780
