### PR TITLE
Adds additional fields for vaccine expansion flow

### DIFF
--- a/db/migrate/20210323001250_add_vaccine_expansion_fields.rb
+++ b/db/migrate/20210323001250_add_vaccine_expansion_fields.rb
@@ -1,0 +1,8 @@
+class AddVaccineExpansionFields < ActiveRecord::Migration[6.0]
+  def change
+    add_column :covid_vaccine_registration_submissions, :expanded, :boolean, default: false, null: false
+    add_column :covid_vaccine_registration_submissions, :sequestered, :boolean, default: false, null: false
+    add_column :covid_vaccine_registration_submissions, :email_confirmation_id, :string
+    add_column :covid_vaccine_registration_submissions, :enrollment_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_17_132241) do
+ActiveRecord::Schema.define(version: 2021_03_23_001250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -228,6 +228,10 @@ ActiveRecord::Schema.define(version: 2021_03_17_132241) do
     t.datetime "updated_at", null: false
     t.string "encrypted_raw_form_data"
     t.string "encrypted_raw_form_data_iv"
+    t.boolean "expanded", default: false, null: false
+    t.boolean "sequestered", default: false, null: false
+    t.string "email_confirmation_id"
+    t.string "enrollment_id"
     t.index ["account_id", "created_at"], name: "index_covid_vaccine_registry_submissions_2"
     t.index ["encrypted_form_data_iv"], name: "index_covid_vaccine_registry_submissions_on_iv", unique: true
     t.index ["sid"], name: "index_covid_vaccine_registry_submissions_on_sid", unique: true


### PR DESCRIPTION


## Description of change
Adds additional fields to the vaccine registration db schema in support of the expanded eligibility flow. 

The enrollment_id and email_confirmation_id let us track response ids for submissions to those systems. The expanded and sequestered flags let us differentiate the new submission flow and temporarily set them aside until they can be processed by the HCA enrollment system. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/21894

## Things to know about this PR
- This adds columns with default values. All our AWS environments are running Postgres 11 where columns with default values can be added safely (without locking the table). The strong_migrations documentation backs this up. 