### PR TITLE
API-5917: Documentation example has a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Vets API
 
-
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Vets API
 
+
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/modules/claims_api/app/swagger/claims_api/forms/form_2122_example.json
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_2122_example.json
@@ -2,7 +2,7 @@
   "type": "form/21-22",
   "attributes": {
     "serviceOrganization": {
-      "poaCode": "1AQ"
+      "poaCode": "A1Q"
     }
   }
 }


### PR DESCRIPTION
## Description of change
Example provides 1AQ as a poa code. Neither of the documented representatives have that as their poa code, but they do have A1Q.
We believe this may be causing issues with an invalid poa being set for Veterans in sandbox.

## Original issue(s)
https://vajira.max.gov/browse/API-5917

## Things to know about this PR
Viewed in developer portal locally
