### PR TITLE
Add NOD feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -434,3 +434,8 @@ features:
     enable_in_development: true
     description: >
       Feature gates the dependency verification modal for updating the diaries service.
+  form10182_nod:
+    actor_type: user
+    enable_in_development: true
+    description: >
+      Form 10182 Notice of Disagreement - Request a board appeal


### PR DESCRIPTION
## Description of change

Adding a feature flag for the Notice of Disagreement (NOD) form for VSA claims & appeals team

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/21954
