### PR TITLE
[API-5826] - Remove EDIPI header from claims api endpoints

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -151,7 +151,7 @@ module ClaimsApi
                 end
       vet.mpi_record?
       vet.gender = header('X-VA-Gender') || vet.mpi.profile&.gender if with_gender
-      vet.edipi = header('X-VA-EDIPI') || vet.mpi.profile&.edipi
+      vet.edipi = vet.mpi.profile&.edipi
       vet.participant_id = vet.mpi.profile&.participant_id
       vet
     end

--- a/modules/claims_api/app/swagger/claims_api/v0/claims_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/claims_controller_swagger.rb
@@ -75,14 +75,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -206,14 +198,6 @@ module ClaimsApi
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :example, '1954-12-15'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
             key :type, :string
           end
 

--- a/modules/claims_api/app/swagger/claims_api/v0/form_0966_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_0966_controller_swagger.rb
@@ -118,14 +118,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -301,14 +293,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
             key :type, :string
           end
 

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -130,14 +130,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -276,14 +268,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
             key :type, :string
           end
 
@@ -669,14 +653,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
             key :type, :string
           end
 

--- a/modules/claims_api/app/swagger/claims_api/v0/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_526_controller_swagger.rb
@@ -142,14 +142,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -292,14 +284,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -432,14 +416,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
             key :type, :string
           end
 
@@ -604,14 +580,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
             key :type, :string
           end
 

--- a/modules/claims_api/app/swagger/claims_api/v1/claims_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/claims_controller_swagger.rb
@@ -64,14 +64,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -175,14 +167,6 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
@@ -105,14 +105,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -260,14 +252,6 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
@@ -115,14 +115,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -244,14 +236,6 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end
@@ -379,14 +363,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -492,14 +468,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -595,14 +563,6 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
@@ -128,14 +128,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -266,14 +258,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-User'
             key :in, :header
             key :description, 'VA username of the person making the request'
@@ -394,14 +378,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
-            key :required, false
             key :type, :string
           end
 
@@ -565,14 +541,6 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-EDIPI'
-            key :in, :header
-            key :description, 'EDIPI Number of Veteran being represented'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/spec/requests/document_validations_request_spec.rb
+++ b/modules/claims_api/spec/requests/document_validations_request_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'Document Validations Requests', type: :request do
       { 'X-VA-SSN': '796-04-3735',
         'X-VA-First-Name': 'WESLEY',
         'X-VA-Last-Name': 'FORD',
-        'X-VA-EDIPI': '1007697216',
         'X-Consumer-Username': 'TestConsumer',
         'X-VA-User': 'adhoc.test.user',
         'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',

--- a/modules/claims_api/spec/requests/v0/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/claims_request_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe 'EVSS Claims management', type: :request do
     { 'X-VA-SSN' => '796-04-3735',
       'X-VA-First-Name' => 'WESLEY',
       'X-VA-Last-Name' => 'FORD',
-      'X-VA-EDIPI' => '1007697216',
       'X-Consumer-Username' => 'TestConsumer',
       'X-VA-User' => 'adhoc.test.user',
       'X-VA-LOA' => '3',
@@ -63,7 +62,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
             params: nil,
             headers: {
               'X-VA-SSN' => '796-04-3735', 'X-VA-First-Name' => 'WESLEY',
-              'X-VA-Last-Name' => 'FORD', 'X-VA-EDIPI' => '1007697216',
+              'X-VA-Last-Name' => 'FORD',
               'X-Consumer-Username' => 'TestConsumer', 'X-VA-User' => 'adhoc.test.user',
               'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-VA-LOA' => '3'
             }
@@ -86,7 +85,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
             params: nil,
             headers: {
               'X-VA-SSN' => '796-04-3735', 'X-VA-First-Name' => 'WESLEY',
-              'X-VA-Last-Name' => 'FORD', 'X-VA-EDIPI' => '1007697216',
+              'X-VA-Last-Name' => 'FORD',
               'X-Consumer-Username' => 'TestConsumer', 'X-VA-User' => 'adhoc.test.user',
               'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-VA-LOA' => '3'
             }
@@ -122,7 +121,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
       let(:wesley_ford_headers) do
         {
           'X-VA-SSN' => '796-04-3735', 'X-VA-First-Name' => 'WESLEY',
-          'X-VA-Last-Name' => 'FORD', 'X-VA-EDIPI' => '1007697216',
+          'X-VA-Last-Name' => 'FORD',
           'X-Consumer-Username' => 'TestConsumer', 'X-VA-User' => 'adhoc.test.user',
           'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-VA-LOA' => '3'
         }
@@ -177,7 +176,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
           params: nil,
           headers: {
             'X-VA-SSN' => '796-04-3735', 'X-VA-First-Name' => 'WESLEY',
-            'X-VA-Last-Name' => 'FORD', 'X-VA-EDIPI' => '1007697216',
+            'X-VA-Last-Name' => 'FORD',
             'X-Consumer-Username' => 'TestConsumer',
             'X-VA-User' => 'adhoc.test.user',
             'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-Consumer-PoA' => 'A1Q'

--- a/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Disability Claims ', type: :request do
     { 'X-VA-SSN': '796-04-3735',
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
-      'X-VA-EDIPI': '1007697216',
       'X-Consumer-Username': 'TestConsumer',
       'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',

--- a/modules/claims_api/spec/requests/v0/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/intent_to_file_request_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Intent to file', type: :request do
     { 'X-VA-SSN': '796-10-4437',
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
-      'X-VA-EDIPI': '1007697216',
       'X-Consumer-Username': 'TestConsumer',
       'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',

--- a/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Power of Attorney ', type: :request do
     { 'X-VA-SSN': '796-04-3735',
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
-      'X-VA-EDIPI': '1007697216',
       'X-Consumer-Username': 'Abe Lincoln',
       'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Disability Claims ', type: :request do
     { 'X-VA-SSN': '796-04-3735',
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
-      'X-VA-EDIPI': '1007697216',
       'X-Consumer-Username': 'TestConsumer',
       'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',

--- a/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Intent to file', type: :request do
     { 'X-VA-SSN': '796-10-4437',
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
-      'X-VA-EDIPI': '1007697216',
       'X-Consumer-Username': 'TestConsumer',
       'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Power of Attorney ', type: :request do
     { 'X-VA-SSN': '796-04-3735',
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
-      'X-VA-EDIPI': '1007697216',
       'X-Consumer-Username': 'TestConsumer',
       'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Removes documentation and logic references for EDIPI header from v0 and v1 ClaimsAPI endpoints, as it does not appear that the EDIPI header is actually used.

## Original issue(s)
[API-5826](https://vajira.max.gov/browse/API-5826)