### PR TITLE
21005 add relationship hash to user model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -359,7 +359,22 @@ class User < Common::RedisStore
     email&.downcase || account_uuid
   end
 
+  def relationships
+    @relationships ||= mpi_profile_relationships.map { |relationship| relationship_hash(relationship) }
+  end
+
   private
+
+  def relationship_hash(mpi_relationship)
+    return unless mpi_relationship
+
+    {
+      first_name: mpi_relationship.given_names&.first,
+      last_name: mpi_relationship.family_name,
+      birth_date: mpi_relationship.birth_date,
+      person_type_code: mpi_relationship.person_type_code
+    }
+  end
 
   def mpi_profile
     return nil unless mpi
@@ -376,6 +391,12 @@ class User < Common::RedisStore
     end
 
     mpi_profile.birth_date
+  end
+
+  def mpi_profile_relationships
+    return [] unless mpi_profile
+
+    mpi_profile.relationships
   end
 
   def pciu

--- a/spec/factories/mvi_profile_relationships.rb
+++ b/spec/factories/mvi_profile_relationships.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :mpi_profile_relationship, class: 'MPI::Models::MviProfileRelationship' do
+    person_type_code { 'VET' }
+    given_names { %w[Joe William] }
+    family_name { 'Smith' }
+    suffix { 'Sr' }
+    gender { 'M' }
+    birth_date { '19500101' }
+    ssn { '955443333' }
+    address { nil }
+    home_phone { '1112223377' }
+    full_mvi_ids {
+      [
+        '9900123456V123456^NI^200M^USVHA^P',
+        '99345^PI^916^USVHA^PCE',
+        '2^PI^593^USVHA^PCE',
+        '99345^PI^200HD^USVHA^A',
+        'TKIP993456^PI^200IP^USVHA^A',
+        '993456^PI^200MHV^USVHA^A',
+        '9934567890^NI^200DOD^USDOD^A',
+        '99654321^PI^200CORP^USVBA^H',
+        '99345678^PI^200CORP^USVBA^A',
+        '993456789^PI^200VETS^USDVA^A',
+        '9923454432^PI^200CRNR^USVHA^A'
+      ]
+    }
+    icn { '9900123456V123456' }
+    mhv_ids { ['993456'] }
+    active_mhv_ids { ['993456'] }
+    edipi { '9934567890' }
+    participant_id { '99345678' }
+    vha_facility_ids { %w[916 593 200HD 200IP 200MHV] }
+    sec_id { '9901234567' }
+    birls_id { birls_ids.first }
+    birls_ids { ['996122306'] }
+    vet360_id { '993456789' }
+    icn_with_aaid { '9900123456V123456^NI^200M^USVHA' }
+    cerner_id { '9923454432' }
+    cerner_facility_ids { ['200CRNR'] }
+  end
+end

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -156,45 +156,5 @@ FactoryBot.define do
         address { build(:mvi_profile_address_austin) }
       end
     end
-
-    factory :mpi_profile_relationship do
-      person_type_code { 'VET' }
-      given_names { %w[Joe William] }
-      family_name { 'Smith' }
-      suffix { 'Sr' }
-      gender { 'M' }
-      birth_date { '19500101' }
-      ssn { '955443333' }
-      address { nil }
-      home_phone { '1112223377' }
-      full_mvi_ids {
-        [
-          '9900123456V123456^NI^200M^USVHA^P',
-          '99345^PI^916^USVHA^PCE',
-          '2^PI^593^USVHA^PCE',
-          '99345^PI^200HD^USVHA^A',
-          'TKIP993456^PI^200IP^USVHA^A',
-          '993456^PI^200MHV^USVHA^A',
-          '9934567890^NI^200DOD^USDOD^A',
-          '99654321^PI^200CORP^USVBA^H',
-          '99345678^PI^200CORP^USVBA^A',
-          '993456789^PI^200VETS^USDVA^A',
-          '9923454432^PI^200CRNR^USVHA^A'
-        ]
-      }
-      icn { '9900123456V123456' }
-      mhv_ids { ['993456'] }
-      active_mhv_ids { ['993456'] }
-      edipi { '9934567890' }
-      participant_id { '99345678' }
-      vha_facility_ids { %w[916 593 200HD 200IP 200MHV] }
-      sec_id { '9901234567' }
-      birls_id { birls_ids.first }
-      birls_ids { ['996122306'] }
-      vet360_id { '993456789' }
-      icn_with_aaid { '9900123456V123456^NI^200M^USVHA' }
-      cerner_id { '9923454432' }
-      cerner_facility_ids { ['200CRNR'] }
-    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -188,6 +188,17 @@ FactoryBot.define do
       end
     end
 
+    factory :user_with_relationship, traits: [:loa3] do
+      after(:build) do
+        stub_mpi(
+          build(
+            :mpi_profile_response,
+            :with_relationship
+          )
+        )
+      end
+    end
+
     factory :vets360_user, traits: [:loa3] do
       after(:build) do
         stub_mpi(

--- a/spec/lib/mpi/responses/profile_parser_spec.rb
+++ b/spec/lib/mpi/responses/profile_parser_spec.rb
@@ -200,9 +200,7 @@ describe MPI::Responses::ProfileParser do
           vet360_id: '7909',
           historical_icns: [],
           cerner_id: nil,
-          cerner_facility_ids: [],
-          search_token: nil,
-          relationships: []
+          cerner_facility_ids: []
         )
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -758,4 +758,47 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#relationships' do
+    let(:user) { described_class.new(build(:user_with_relationship)) }
+
+    before do
+      allow(user.mpi.profile).to receive(:relationships).and_return([mpi_relationship])
+    end
+
+    context 'when there are relationship entities in the MPI response' do
+      let(:mpi_relationship) do
+        build(:mpi_profile_relationship,
+              given_names: relationship_first_name,
+              family_name: relationship_last_name,
+              birth_date: relationship_birth_date,
+              person_type_code: relationship_person_type_code)
+      end
+
+      let(:relationship_first_name) { 'some-first-name' }
+      let(:relationship_last_name) { 'some-last-name' }
+      let(:relationship_birth_date) { '20100101' }
+      let(:relationship_person_type_code) { 'some-person-type-code' }
+      let(:expected_relationship_hash) do
+        {
+          first_name: relationship_first_name,
+          last_name: relationship_last_name,
+          birth_date: relationship_birth_date,
+          person_type_code: relationship_person_type_code
+        }
+      end
+
+      it 'returns a parsed array of hashes representing the different relationship entities' do
+        expect(user.relationships).to eq [expected_relationship_hash]
+      end
+    end
+
+    context 'when there are not relationship entities in the MPI response' do
+      let(:mpi_relationship) { nil }
+
+      it 'returns an empty array' do
+        expect(user.relationships).to eq [nil]
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
This PR adds a function on the `User` model, `relationships`, that describes the parsed relationships from the `MPI` response. Right now these `relationships` have just a subset of the MPI data for a relationship. We'll expand the data presented here as necessary

## Original issue(s)
department-of-veterans-affairs/va.gov-team/issues/21005

## Things to know about this PR
- This shouldn't have negative impacts on a user without a relationship defined. 
- For testing, you'll have to check out the `5987_development_branch_mpi_relationship_mock` branch in `vets-api-mockdata`, then log in with `vets.gov.user+dependent.1@gmail.com`
- No data will be serialized to the frontend yet, so you'll have to set a `binding.pry` in the codebase somewhere after the user has been authenticated and `MPI` has been called, one place is in `sessions_controller`, `log_persisted_session_and_warnings` (make sure to skip the first pass and stop the second time this function is called). Then check `current_user.relationships` to confirm it has been filled out

- For testing, I authenticated with a user that has no relationship data and a user that has relationship data, to confirm both work fine.
