### PR TITLE
bump mimemagic to 0.3.6 (0.3.5 tag was removed)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -527,7 +527,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
CI was failing due to mimemagic v0.3.5 being removed. This PR bumps mimemagic to 0.3.6

"Your bundle is locked to mimemagic (0.3.5), but that version could not be found in any of the sources listed in your Gemfile. If you haven't changed sources, that means the author of mimemagic (0.3.5) has removed it. You'll need to update your bundle to a version other than mimemagic (0.3.5) that hasn't been removed"

