### PR TITLE
[API-5827] - Remove User Header from ClaimsAPI endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ The version of Ruby and gem dependencies (including Rails) used are defined in t
 
 #### Version Policy
 
-The goal is to have vets-api use supported versions of gems and Ruby, which is often the latest. However the versions are generally updated as need or availability arise. If you need a newer version of a gem, please submit a pull-request marked as `draft` with just the gem updated and passing tests.
+The goal is to have vets-api use supported versions of gems and Ruby, which is often the latest. However the versions are generally updated as need or availability arise. If you need a newer version of a gem, please submit a pull-request marked as `draft` with just the gem updated and passing tests

--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ The version of Ruby and gem dependencies (including Rails) used are defined in t
 
 #### Version Policy
 
-The goal is to have vets-api use supported versions of gems and Ruby, which is often the latest. However the versions are generally updated as need or availability arise. If you need a newer version of a gem, please submit a pull-request marked as `draft` with just the gem updated and passing tests
+The goal is to have vets-api use supported versions of gems and Ruby, which is often the latest. However the versions are generally updated as need or availability arise. If you need a newer version of a gem, please submit a pull-request marked as `draft` with just the gem updated and passing tests.

--- a/modules/claims_api/app/controllers/claims_api/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/application_controller.rb
@@ -112,9 +112,9 @@ module ClaimsApi
     end
 
     def check_source_user
-      if !header('X-VA-User') && request.headers['X-Consumer-Username']
+      if request.headers['X-Consumer-Username']
         request.headers['X-VA-User'] = request.headers['X-Consumer-Username']
-      elsif !request.headers['X-Consumer-Username']
+      else
         log_message_to_sentry('Kong no longer sending X-Consumer-Username', :error,
                               body: request.body)
         validate_headers(['X-Consumer-Username'])

--- a/modules/claims_api/app/swagger/claims_api/v0/claims_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/claims_controller_swagger.rb
@@ -75,15 +75,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :example, 'lighthouse'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-LOA'
             key :in, :header
             key :description, 'The level of assurance of the user making the request'
@@ -198,15 +189,6 @@ module ClaimsApi
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :example, '1954-12-15'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :example, 'lighthouse'
-            key :required, false
             key :type, :string
           end
 

--- a/modules/claims_api/app/swagger/claims_api/v0/form_0966_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_0966_controller_swagger.rb
@@ -118,14 +118,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-LOA'
             key :in, :header
             key :description, 'The level of assurance of the user making the request'
@@ -293,14 +285,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
             key :type, :string
           end
 

--- a/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_2122_controller_swagger.rb
@@ -130,14 +130,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-LOA'
             key :in, :header
             key :description, 'The level of assurance of the user making the request'
@@ -268,14 +260,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
             key :type, :string
           end
 
@@ -414,15 +398,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :example, 'lighthouse'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-LOA'
             key :in, :header
             key :description, 'The level of assurance of the user making the request'
@@ -540,15 +515,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :example, 'lighthouse'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-LOA'
             key :in, :header
             key :description, 'The level of assurance of the user making the request'
@@ -653,14 +619,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
             key :type, :string
           end
 

--- a/modules/claims_api/app/swagger/claims_api/v0/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_526_controller_swagger.rb
@@ -142,14 +142,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-LOA'
             key :in, :header
             key :description, 'The level of assurance of the user making the request'
@@ -284,14 +276,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'X-VA-LOA'
             key :in, :header
             key :description, 'The level of assurance of the user making the request'
@@ -416,14 +400,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
             key :type, :string
           end
 
@@ -580,14 +556,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
             key :type, :string
           end
 

--- a/modules/claims_api/app/swagger/claims_api/v1/claims_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/claims_controller_swagger.rb
@@ -63,14 +63,6 @@ module ClaimsApi
             key :type, :string
           end
 
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
           response 200 do
             key :description, 'claims response'
             content 'application/json' do
@@ -167,14 +159,6 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_0966_controller_swagger.rb
@@ -104,14 +104,6 @@ module ClaimsApi
             key :type, :string
           end
 
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
           request_body do
             key :description, 'JSON API Payload of Veteran being submitted'
             key :required, true
@@ -252,14 +244,6 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_2122_controller_swagger.rb
@@ -114,14 +114,6 @@ module ClaimsApi
             key :type, :string
           end
 
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
           request_body do
             key :description, 'JSON API Payload of Veteran being submitted'
             key :required, true
@@ -241,14 +233,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'attachment'
             key :in, :formData
             key :type, :file
@@ -362,14 +346,6 @@ module ClaimsApi
             key :type, :string
           end
 
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
           response 200 do
             key :description, '2122 response'
             content 'application/json' do
@@ -467,14 +443,6 @@ module ClaimsApi
             key :type, :string
           end
 
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
           response 200 do
             key :description, '2122 response'
             content 'application/json' do
@@ -563,14 +531,6 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
@@ -127,14 +127,6 @@ module ClaimsApi
             key :type, :string
           end
 
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
           request_body do
             key :description, 'JSON API Payload of Veteran being submitted'
             key :required, true
@@ -258,14 +250,6 @@ module ClaimsApi
           end
 
           parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
             key :name, 'attachment'
             key :in, :formData
             key :type, :file
@@ -378,14 +362,6 @@ module ClaimsApi
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
             key :required, true
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
-            key :required, false
             key :type, :string
           end
 
@@ -541,14 +517,6 @@ module ClaimsApi
             key :name, 'X-VA-Birth-Date'
             key :in, :header
             key :description, 'Date of Birth of Veteran being represented, in iso8601 format'
-            key :required, false
-            key :type, :string
-          end
-
-          parameter do
-            key :name, 'X-VA-User'
-            key :in, :header
-            key :description, 'VA username of the person making the request'
             key :required, false
             key :type, :string
           end

--- a/modules/claims_api/spec/requests/document_validations_request_spec.rb
+++ b/modules/claims_api/spec/requests/document_validations_request_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'Document Validations Requests', type: :request do
         'X-VA-First-Name': 'WESLEY',
         'X-VA-Last-Name': 'FORD',
         'X-Consumer-Username': 'TestConsumer',
-        'X-VA-User': 'adhoc.test.user',
         'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',
         'X-VA-LOA' => '3',
         'X-VA-Gender': 'M' }

--- a/modules/claims_api/spec/requests/v0/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/claims_request_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe 'EVSS Claims management', type: :request do
       'X-VA-First-Name' => 'WESLEY',
       'X-VA-Last-Name' => 'FORD',
       'X-Consumer-Username' => 'TestConsumer',
-      'X-VA-User' => 'adhoc.test.user',
       'X-VA-LOA' => '3',
       'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00' }
   end
@@ -63,7 +62,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
             headers: {
               'X-VA-SSN' => '796-04-3735', 'X-VA-First-Name' => 'WESLEY',
               'X-VA-Last-Name' => 'FORD',
-              'X-Consumer-Username' => 'TestConsumer', 'X-VA-User' => 'adhoc.test.user',
+              'X-Consumer-Username' => 'TestConsumer',
               'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-VA-LOA' => '3'
             }
           )
@@ -86,7 +85,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
             headers: {
               'X-VA-SSN' => '796-04-3735', 'X-VA-First-Name' => 'WESLEY',
               'X-VA-Last-Name' => 'FORD',
-              'X-Consumer-Username' => 'TestConsumer', 'X-VA-User' => 'adhoc.test.user',
+              'X-Consumer-Username' => 'TestConsumer',
               'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-VA-LOA' => '3'
             }
           )
@@ -122,7 +121,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
         {
           'X-VA-SSN' => '796-04-3735', 'X-VA-First-Name' => 'WESLEY',
           'X-VA-Last-Name' => 'FORD',
-          'X-Consumer-Username' => 'TestConsumer', 'X-VA-User' => 'adhoc.test.user',
+          'X-Consumer-Username' => 'TestConsumer',
           'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-VA-LOA' => '3'
         }
       end
@@ -178,7 +177,6 @@ RSpec.describe 'EVSS Claims management', type: :request do
             'X-VA-SSN' => '796-04-3735', 'X-VA-First-Name' => 'WESLEY',
             'X-VA-Last-Name' => 'FORD',
             'X-Consumer-Username' => 'TestConsumer',
-            'X-VA-User' => 'adhoc.test.user',
             'X-VA-Birth-Date' => '1986-05-06T00:00:00+00:00', 'X-Consumer-PoA' => 'A1Q'
           }
         )

--- a/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'Disability Claims ', type: :request do
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
       'X-Consumer-Username': 'TestConsumer',
-      'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',
       'X-VA-LOA' => '3',
       'X-VA-Gender': 'M' }

--- a/modules/claims_api/spec/requests/v0/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/intent_to_file_request_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'Intent to file', type: :request do
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
       'X-Consumer-Username': 'TestConsumer',
-      'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',
       'X-VA-LOA' => '3',
       'X-VA-Gender': 'M' }

--- a/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'Power of Attorney ', type: :request do
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
       'X-Consumer-Username': 'Abe Lincoln',
-      'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',
       'X-VA-Gender': 'M',
       'X-VA-LOA': '3' }

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'Disability Claims ', type: :request do
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
       'X-Consumer-Username': 'TestConsumer',
-      'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',
       'X-VA-Gender': 'M' }
   end

--- a/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'Intent to file', type: :request do
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
       'X-Consumer-Username': 'TestConsumer',
-      'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',
       'X-VA-Gender': 'M' }
   end

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'Power of Attorney ', type: :request do
       'X-VA-First-Name': 'WESLEY',
       'X-VA-Last-Name': 'FORD',
       'X-Consumer-Username': 'TestConsumer',
-      'X-VA-User': 'adhoc.test.user',
       'X-VA-Birth-Date': '1986-05-06T00:00:00+00:00',
       'X-VA-Gender': 'M' }
   end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Removes documentation and logic references for USER header from v0 and v1 ClaimsAPI endpoints.

## Original issue(s)
[API-5827](https://vajira.max.gov/browse/API-5827)