### PR TITLE
API-5947: 2122 active endpoint issue when "previous poa" exists

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -72,6 +72,7 @@ module ClaimsApi
           if current_poa
             lighthouse_poa = power_of_attorney.attributes
             lighthouse_poa['current_poa'] = current_poa
+            lighthouse_poa['form_data'] = power_of_attorney.form_data
             combined = ClaimsApi::PowerOfAttorney.new(lighthouse_poa)
 
             render json: combined, serializer: ClaimsApi::PowerOfAttorneySerializer

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -201,6 +201,7 @@ RSpec.describe 'Power of Attorney ', type: :request do
 
               parsed = JSON.parse(response.body)
               expect(response.status).to eq(200)
+              expect(parsed['data']['attributes']['representative']['service_organization']['poa_code']).to eq('074')
               expect(parsed['data']['attributes']['previous_poa']).to eq('HelloWorld')
             end
           end


### PR DESCRIPTION
## Description of change
The issue presents with "representative" in the response payload being null if a "previous poa" is present.

## Original issue(s)
https://vajira.max.gov/browse/API-5947

## Things to know about this PR
Fixed specs to detect this issue and double-checked through debugging locally 