### PR TITLE
exclude failing offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -207,6 +207,11 @@ RSpec/FilePath:
     - 'spec/request/in_progress_forms_request_spec.rb'
     - 'spec/jobs/pagerduty/**/*'
     - 'spec/lib/pagerduty/**/*'
+    - 'spec/lib/common/client/middleware/response/appeals_response_middleware_spec.rb'
+    - 'spec/lib/common/client/middleware/response/gids_response_middleware_spec.rb'
+    - 'spec/lib/common/client/middleware/response/response_middleware_spec.rb'
+    - 'spec/lib/evss/pciu_address/pciu_address_spec.rb'
+    - 'spec/lib/sm/client/message_drafts_spec.rb'
   CustomTransform:
     SSOeSettingsService: ssoe_settings_service
 
@@ -305,6 +310,7 @@ RSpec/MultipleDescribes:
     - 'spec/jobs/evss/request_decision_spec.rb'
     - 'spec/lib/emis/veteran_status_service_spec.rb'
     - 'spec/request/swagger_spec.rb'
+    - 'spec/jobs/cypress_viewport_updater/existing_github_file_spec.rb'
 
 # These instances seem to be false positives
 RSpec/RepeatedExample:


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR adds rubocop exclusions for the RSpec/FilePath and RSpec/MultipleDescribes cops that were failing CI 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


