### PR TITLE
remove vanotify_service_enhancement toggle

### DIFF
--- a/app/workers/form526_confirmation_email_job.rb
+++ b/app/workers/form526_confirmation_email_job.rb
@@ -12,13 +12,8 @@ class Form526ConfirmationEmailJob
   STATSD_SUCCESS_NAME = 'worker.form526_confirmation_email.success'
 
   def perform(personalization_parameters)
-    if Flipper.enabled?(:vanotify_service_enhancement)
-      @notify_client ||= VaNotify::Service.new(Settings.vanotify.services.va_gov.api_key)
-      @template_id ||= Settings.vanotify.services.va_gov.template_id.form526_confirmation_email
-    else
-      @notify_client ||= VaNotify::Service.new(Settings.vanotify.api_key)
-      @template_id ||= Settings.vanotify.template_id.form526_confirmation_email
-    end
+    @notify_client ||= VaNotify::Service.new(Settings.vanotify.services.va_gov.api_key)
+    @template_id ||= Settings.vanotify.services.va_gov.template_id.form526_confirmation_email
     @notify_client.send_email(
       email_address: personalization_parameters['email'],
       template_id: @template_id,

--- a/app/workers/va_notify_dd_email_job.rb
+++ b/app/workers/va_notify_dd_email_job.rb
@@ -23,7 +23,7 @@ class VANotifyDdEmailJob
   def perform(email, dd_type)
     notify_client = VaNotify::Service.new(Settings.vanotify.services.va_gov.api_key)
     template_type = "direct_deposit_#{dd_type.to_sym == :ch33 ? 'edu' : 'comp_pen'}"
-    template_id = Settings.vanotify.template_id.public_send(template_type)
+    template_id = Settings.vanotify.services.va_gov.template_id.public_send(template_type)
 
     notify_client.send_email(
       email_address: email,

--- a/config/features.yml
+++ b/config/features.yml
@@ -407,11 +407,6 @@ features:
     enable_in_development: true
     description: >
       Manage dependent removal from view dependent page
-  vanotify_service_enhancement:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Allow consumer to use service specific VaNotify client. Owned by va-notify team.
   subform_8940_4192:
     actor_type: user
     enable_in_development: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -825,21 +825,13 @@ vanotify:
       template_id:
         form526_confirmation_email: fake_template_id
         covid_vaccine_registration: fake_template_id
+        direct_deposit_edu: edu_template_id
+        direct_deposit_comp_pen: comp_pen_template_id
     lighthouse:
       api_key: fake_secret
       template_id:
         disconnection_template: fake_template_id
         connection_template: fake_template_id
-
-  # will be removed once the vanotify_service_enhancement feature toggle is removed
-  api_key: fake_secret
-  template_id:
-    form526_confirmation_email: fake_template_id
-    connection_template: fake_template_id
-    disconnection_template: fake_template_id
-    covid_vaccine_registration: fake_template_id
-    direct_deposit_edu: edu_template_id
-    direct_deposit_comp_pen: comp_pen_template_id
   mock: false
   links:
     connected_applications: https://www.va.gov/profile/connected-applications

--- a/modules/covid_vaccine/app/jobs/covid_vaccine/registration_email_job.rb
+++ b/modules/covid_vaccine/app/jobs/covid_vaccine/registration_email_job.rb
@@ -13,13 +13,8 @@ module CovidVaccine
     STATSD_SUCCESS_NAME = 'worker.covid_vaccine_registration_email.success'
 
     def perform(email, date, sid)
-      if Flipper.enabled?(:vanotify_service_enhancement)
-        @notify_client ||= VaNotify::Service.new(Settings.vanotify.services.va_gov.api_key)
-        @template_id ||= Settings.vanotify.services.va_gov.template_id.covid_vaccine_registration
-      else
-        @notify_client ||= VaNotify::Service.new(Settings.vanotify.api_key)
-        @template_id ||= Settings.vanotify.template_id.covid_vaccine_registration
-      end
+      @notify_client ||= VaNotify::Service.new(Settings.vanotify.services.va_gov.api_key)
+      @template_id ||= Settings.vanotify.services.va_gov.template_id.covid_vaccine_registration
 
       @notify_client.send_email(
         email_address: email,

--- a/modules/covid_vaccine/spec/jobs/covid_vaccine/registration_email_job_spec.rb
+++ b/modules/covid_vaccine/spec/jobs/covid_vaccine/registration_email_job_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe CovidVaccine::RegistrationEmailJob, type: :worker do
     let(:confirmation_id) { 'confirmation_id_uuid' }
 
     it 'the service is initialized with the correct parameters with enabled toggle' do
-      Flipper.enable(:vanotify_service_enhancement)
       test_service_api_key = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
       instance = instance_double(VaNotify::Service)
       allow(instance).to receive(:send_email)
@@ -24,12 +23,11 @@ RSpec.describe CovidVaccine::RegistrationEmailJob, type: :worker do
     end
 
     it 'the service is initialized with the correct parameters with disabled toggle' do
-      Flipper.disable(:vanotify_service_enhancement)
       test_service_api_key = 'baaaaaaa-1111-aaaa-aaaa-aaaaaaaaaaaa-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
       instance = instance_double(VaNotify::Service)
       allow(instance).to receive(:send_email)
       with_settings(
-        Settings.vanotify, { api_key: test_service_api_key }
+        Settings.vanotify.services.va_gov, { api_key: test_service_api_key }
       ) do
         expect(VaNotify::Service).to receive(:new).with(test_service_api_key).and_return(instance)
         described_class.new.perform(email, date, confirmation_id)
@@ -53,7 +51,7 @@ RSpec.describe CovidVaccine::RegistrationEmailJob, type: :worker do
         .to receive(:send_email).with(
           {
             email_address: email,
-            template_id: Settings.vanotify.template_id.covid_vaccine_registration,
+            template_id: Settings.vanotify.services.va_gov.template_id.covid_vaccine_registration,
             personalisation: {
               'date' => date,
               'confirmation_id' => confirmation_id

--- a/spec/jobs/form526_confirmation_email_job_spec.rb
+++ b/spec/jobs/form526_confirmation_email_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
           'reference': nil,
           'scheduled_for': nil,
           'template': {
-            'id': Settings.vanotify.template_id.form526_confirmation_email,
+            'id': Settings.vanotify.services.va_gov.template_id.form526_confirmation_email,
             'uri': 'template_url',
             'version': 1
           },
@@ -39,25 +39,10 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
         }
       end
 
-      it 'the service is initialized with the correct parameters with enabled toggle' do
-        Flipper.enable(:vanotify_service_enhancement)
+      it 'the service is initialized with the correct parameters' do
         test_service_api_key = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
         with_settings(
           Settings.vanotify.services.va_gov, { api_key: test_service_api_key }
-        ) do
-          mocked_notification_service = instance_double('VaNotify::Service')
-          allow(VaNotify::Service).to receive(:new).and_return(mocked_notification_service)
-          allow(mocked_notification_service).to receive(:send_email).and_return(email_response)
-          subject.perform('')
-          expect(VaNotify::Service).to have_received(:new).with(test_service_api_key)
-        end
-      end
-
-      it 'the service is initialized with the correct parameters with disabled toggle' do
-        Flipper.disable(:vanotify_service_enhancement)
-        test_service_api_key = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
-        with_settings(
-          Settings.vanotify, { api_key: test_service_api_key }
         ) do
           mocked_notification_service = instance_double('VaNotify::Service')
           allow(VaNotify::Service).to receive(:new).and_return(mocked_notification_service)
@@ -71,6 +56,8 @@ RSpec.describe Form526ConfirmationEmailJob, type: :worker do
         requirements = {
           email_address: email_address,
           template_id: Settings.vanotify
+                               .services
+                               .va_gov
                                .template_id
                                .form526_confirmation_email,
           personalisation: {

--- a/spec/lib/va_notify/service_spec.rb
+++ b/spec/lib/va_notify/service_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 require 'va_notify/service'
 
 describe VaNotify::Service do
-  before(:example, vanotify_service_enhancement: false) do
-    Flipper.disable(:vanotify_service_enhancement)
+  before(:example, test_service: false) do
     @test_api_key = 'test-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
     @test_base_url = 'http://fakeapi.com'
     allow_any_instance_of(VaNotify::Configuration).to receive(:base_path).and_return(@test_base_url)
@@ -19,11 +18,10 @@ describe VaNotify::Service do
     }
   }
 
-  describe 'service initialization' do
+  describe 'service initialization', test_service: true do
     let(:notification_client) { double('Notifications::Client') }
 
-    it 'api key based on service and client is called with expected parameters', vanotify_service_enhancement: true do
-      Flipper.enable(:vanotify_service_enhancement)
+    it 'api key based on service and client is called with expected parameters' do
       test_service_api_key = 'fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a'
       test_service_base_url = 'https://fakishapi.com'
       parameters = test_service_api_key, test_service_base_url
@@ -40,9 +38,7 @@ describe VaNotify::Service do
       end
     end
 
-    it 'correct api key passed to initialize when'\
-    ' multiple services are defined', vanotify_service_enhancement: true do
-      Flipper.enable(:vanotify_service_enhancement)
+    it 'correct api key passed to initialize when multiple services are defined' do
       test_service1_api_key = 'fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a'
       test_base_url = 'https://fakishapi.com'
       parameters = test_service1_api_key, test_base_url
@@ -63,7 +59,7 @@ describe VaNotify::Service do
     end
   end
 
-  describe '#send_email', vanotify_service_enhancement: false do
+  describe '#send_email', test_service: false do
     subject { VaNotify::Service.new(@test_api_key) }
 
     let(:notification_client) { double('Notifications::Client') }
@@ -77,7 +73,7 @@ describe VaNotify::Service do
     end
   end
 
-  describe 'error handling', vanotify_service_enhancement: false do
+  describe 'error handling', test_service: false do
     subject { VaNotify::Service.new(@test_api_key) }
 
     it 'raises a 400 exception' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
vanotify_service_enhancement feature toggle duplicated some entries in settings.xml and the the corresponding devops files.  This PR will remove the feature toggle to avoid further confusion as to where the new template ids should be added.

## Original issue(s)
department-of-veterans-affairs/notification-api#401

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment? No, but settings.xml changes.
* Is there a feature flag? What is it? No, but a feature flag is removed.
* Is there some Sentry logging that was added? What alerts are relevant? No.
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do? No.
* Are there Swagger docs that were updated? No.
* Is there any PII concerns or questions? No.
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
All unit tests passed and all references to the olds settings entries replaced with the new ones.