### PR TITLE
get facilities by organization ids

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -744,6 +744,9 @@ hqva_mobile:
   key_path: /srv/vets-api/secret/health-quest.key
   development_key_path: modules/health_quest/config/rsa/sandbox_rsa
   timeout: 15
+  facilities:
+    url: "https://api.va.gov"
+    ids_path: "/v1/facilities/va"
   lighthouse:
     url: "https://sandbox-api.va.gov"
     pgd_path: "/services/pgd/v0/r4"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -113,6 +113,9 @@ hqva_mobile:
   key_path: modules/health_quest/config/rsa/sandbox_rsa
   development_key_path: modules/health_quest/config/rsa/sandbox_rsa
   timeout: 15
+  facilities:
+    url: "https://sandbox-api.va.gov"
+    ids_path: "/v1/facilities/va"
   lighthouse:
     url: "https://sandbox-api.va.gov"
     pgd_path: "/services/pgd/v0/r4"

--- a/modules/health_quest/app/services/health_quest/facilities/request.rb
+++ b/modules/health_quest/app/services/health_quest/facilities/request.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+Faraday::Response.register_middleware health_quest_errors: HealthQuest::Middleware::Response::Errors
+Faraday::Middleware.register_middleware health_quest_logging: HealthQuest::Middleware::HealthQuestLogging
+
+module HealthQuest
+  module Facilities
+    ##
+    # An object responsible for making HTTP calls to the Facilities API
+    #
+    class Request
+      ##
+      # Builds a Facilities::Request instance
+      # @return [Facilities::Request] an instance of this class
+      #
+      def self.build
+        new
+      end
+
+      ##
+      # HTTP GET call to the Facilities API to retrieve a list of facilities by IDs
+      #
+      # @param query_params [String]
+      # @return [Array]
+      #
+      def get(query_params)
+        resp = connection.get(ids_path) { |req| req.params['ids'] = query_params }
+
+        JSON.parse(resp.body).fetch('data', [])
+      end
+
+      private
+
+      def connection
+        Faraday.new(url: url) do |conn|
+          conn.response :health_quest_errors
+          conn.use :health_quest_logging
+          conn.adapter Faraday.default_adapter
+        end
+      end
+
+      def ids_path
+        Settings.hqva_mobile.facilities.ids_path
+      end
+
+      def url
+        Settings.hqva_mobile.facilities.url
+      end
+    end
+  end
+end

--- a/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
+++ b/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
@@ -13,6 +13,8 @@ module HealthQuest
     #   @return [Array]
     # @!attribute organizations
     #   @return [Array]
+    # @!attribute facilities
+    #   @return [Array]
     # @!attribute aggregated_data
     #   @return [Hash]
     # @!attribute patient
@@ -35,6 +37,8 @@ module HealthQuest
     #   @return [HealthQuest::Resource::Factory]
     # @!attribute questionnaire_service
     #   @return [HealthQuest::Resource::Factory]
+    # @!attribute facilities_request
+    #   @return [HealthQuest::Facilities::Request]
     # @!attribute sip_model
     #   @return [InProgressForm]
     # @!attribute transformer
@@ -51,6 +55,7 @@ module HealthQuest
       attr_reader :lighthouse_appointments,
                   :locations,
                   :organizations,
+                  :facilities,
                   :aggregated_data,
                   :patient,
                   :questionnaires,
@@ -64,6 +69,7 @@ module HealthQuest
                   :patient_service,
                   :questionnaire_response_service,
                   :questionnaire_service,
+                  :facilities_request,
                   :sip_model,
                   :transformer,
                   :user
@@ -87,6 +93,7 @@ module HealthQuest
         @patient_service = HealthQuest::Resource::Factory.manufacture(patient_type)
         @questionnaire_service = HealthQuest::Resource::Factory.manufacture(questionnaire_type)
         @questionnaire_response_service = HealthQuest::Resource::Factory.manufacture(questionnaire_response_type)
+        @facilities_request = HealthQuest::Facilities::Request.build
         @request_threads = []
         @sip_model = InProgressForm
         @transformer = Transformer
@@ -134,6 +141,7 @@ module HealthQuest
         # rubocop:disable ThreadSafety/NewThread
         request_threads << Thread.new { @patient = get_patient.resource }
         request_threads << Thread.new { @organizations = get_organizations }
+        request_threads << Thread.new { @facilities = get_facilities }
         request_threads << Thread.new { @questionnaires = get_questionnaires.resource&.entry }
         request_threads << Thread.new { @questionnaire_responses = get_questionnaire_responses.resource&.entry }
         request_threads << Thread.new { @save_in_progress = get_save_in_progress }
@@ -210,6 +218,19 @@ module HealthQuest
       end
 
       ##
+      # Return a list of facilities from the Facilities API
+      # so that we can add phone numbers to our organizations
+      #
+      # @return [Array]
+      #
+      def get_facilities
+        list = locations.map { |loc| loc.resource.identifier.first.value }
+        facilities_ids = list.join(',')
+
+        facilities_request.get(facilities_ids)
+      end
+
+      ##
       # Gets a list of Questionnaires from the PGD.
       #
       # @return [FHIR::Bundle] an object containing the
@@ -259,6 +280,7 @@ module HealthQuest
             lighthouse_appointments: lighthouse_appointments,
             locations: locations,
             organizations: organizations,
+            facilities: facilities,
             questionnaires: questionnaires,
             questionnaire_responses: questionnaire_responses,
             save_in_progress: save_in_progress

--- a/modules/health_quest/app/services/health_quest/questionnaire_manager/organization_formatter.rb
+++ b/modules/health_quest/app/services/health_quest/questionnaire_manager/organization_formatter.rb
@@ -3,38 +3,84 @@
 module HealthQuest
   module QuestionnaireManager
     ##
-    # An object for formatting Resource data into a hash of key/value pairs
+    # An object responsible for formatting organization data into a hash of key/value pairs
     #
     # @!attribute orgs_array
     #   @return [Array]
+    # @!attribute facilities
+    #   @return [Array]
     class OrganizationFormatter
-      attr_reader :orgs_array
+      attr_reader :orgs_array, :facilities
 
       ##
       # Builds a HealthQuest::QuestionnaireManager::OrganizationFormatter instance
       #
       # @param orgs_array [Array] an array of `Organization` instances.
+      # @param facilities [Array] facilities data to patch missing organization phone numbers.
       # @return [HealthQuest::QuestionnaireManager::OrganizationFormatter] an instance of this class
       #
-      def self.build(orgs_array)
-        new(orgs_array)
+      def self.build(orgs_array, facilities)
+        new(orgs_array, facilities)
       end
 
-      def initialize(orgs_array)
+      def initialize(orgs_array, facilities)
         @orgs_array = orgs_array
+        @facilities = facilities
       end
 
       ##
-      # Builds and returns a hash of resources with IDs for keys
+      # Builds and returns a hash of organization with IDs for keys; Sets the orgs phone numbers
+      # from the `facilities_by_ids` hash
       #
       # @return [Hash]
       #
       def to_h
         orgs_array.each_with_object({}) do |org, accumulator|
-          facility_id = org.resource.identifier.last.value
+          add_phones_to_org(org)
 
+          facility_id = org.resource.identifier.last.value
           accumulator[facility_id] = org
         end
+      end
+
+      ##
+      # Returns an Organization `FHIR::ClientReply` instance with the `telecom` field
+      # populated with `FHIR::ContactPoint` instances based on data from the Facilities API
+      # for the given `org` attribute.
+      #
+      # @param org [FHIR::ClientReply]
+      # @return [FHIR::ClientReply]
+      #
+      def add_phones_to_org(org)
+        id = org.resource.identifier.last.value
+        phones = facilities_by_ids.dig(id, 'attributes', 'phone')
+        telecom = org.resource.telecom
+
+        telecom.clear
+
+        phones.each do |key, val|
+          contact = FHIR::ContactPoint.new
+          contact.system = key
+          contact.value = val
+
+          telecom << contact
+        end
+
+        org
+      end
+
+      ##
+      # Builds and returns a hash of facilities with IDs for keys
+      #
+      # @return [Hash]
+      #
+      def facilities_by_ids
+        @facilities_by_ids ||=
+          facilities.each_with_object({}) do |fac, acc|
+            id = fac['id']
+
+            acc[id] = fac
+          end
       end
     end
   end

--- a/modules/health_quest/app/services/health_quest/questionnaire_manager/transformer.rb
+++ b/modules/health_quest/app/services/health_quest/questionnaire_manager/transformer.rb
@@ -11,6 +11,8 @@ module HealthQuest
     #   @return [Array]
     # @!attribute organizations
     #   @return [Array]
+    # @!attribute facilities
+    #   @return [Array]
     # @!attribute questionnaires
     #   @return [Array]
     # @!attribute questionnaire_responses
@@ -27,6 +29,7 @@ module HealthQuest
       attr_reader :appointments,
                   :locations,
                   :organizations,
+                  :facilities,
                   :questionnaires,
                   :questionnaire_responses,
                   :save_in_progress,
@@ -50,6 +53,7 @@ module HealthQuest
         @appointments = opts[:lighthouse_appointments]
         @locations = opts[:locations]
         @organizations = opts[:organizations]
+        @facilities = opts[:facilities]
         @questionnaires = opts[:questionnaires]
         @questionnaire_responses = opts[:questionnaire_responses]
         @save_in_progress = opts[:save_in_progress]
@@ -166,7 +170,7 @@ module HealthQuest
       # @return [Hash] a hash of organizations
       #
       def organizations_by_facility_ids
-        OrganizationFormatter.build(organizations).to_h
+        OrganizationFormatter.build(organizations, facilities).to_h
       end
     end
   end

--- a/modules/health_quest/spec/services/facilities/request_spec.rb
+++ b/modules/health_quest/spec/services/facilities/request_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::Facilities::Request do
+  subject { described_class }
+
+  describe '.build' do
+    it 'returns an instance of Request' do
+      expect(subject.build).to be_an_instance_of(HealthQuest::Facilities::Request)
+    end
+  end
+
+  describe '#get' do
+    let(:query_params) { 'vha_442' }
+    let(:json_string) { { data: [{ id: 'vha_442', type: 'facility', attributes: '' }] }.to_json }
+
+    it 'returns a Faraday::Response' do
+      allow_any_instance_of(Faraday::Connection).to receive(:get).and_return(Faraday::Response.new)
+      allow_any_instance_of(Faraday::Response).to receive(:body).and_return(json_string)
+
+      expect(subject.build.get(query_params)).to eq(JSON.parse(json_string)['data'])
+    end
+  end
+end

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -16,6 +16,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
   let(:default_appointments) { double('FHIR::ClientReply', resource: double('Entry', entry: [])) }
   let(:default_location) { [double('FHIR::Location')] }
   let(:default_organization) { [double('FHIR::Organization')] }
+  let(:default_facilities) { [double('Facilities')] }
   let(:appointments) { { data: [{}, {}] } }
 
   before do
@@ -49,6 +50,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       expect(factory.respond_to?(:lighthouse_appointments)).to eq(true)
       expect(factory.respond_to?(:locations)).to eq(true)
       expect(factory.respond_to?(:organizations)).to eq(true)
+      expect(factory.respond_to?(:facilities)).to eq(true)
       expect(factory.respond_to?(:aggregated_data)).to eq(true)
       expect(factory.respond_to?(:patient)).to eq(true)
       expect(factory.respond_to?(:questionnaires)).to eq(true)
@@ -58,6 +60,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       expect(factory.respond_to?(:organization_service)).to eq(true)
       expect(factory.respond_to?(:patient_service)).to eq(true)
       expect(factory.respond_to?(:questionnaire_service)).to eq(true)
+      expect(factory.respond_to?(:facilities_request)).to eq(true)
       expect(factory.respond_to?(:sip_model)).to eq(true)
       expect(factory.respond_to?(:transformer)).to eq(true)
       expect(factory.respond_to?(:user)).to eq(true)
@@ -84,6 +87,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       allow_any_instance_of(subject).to receive(:get_lighthouse_appointments).and_return(appointments_client_reply)
       allow_any_instance_of(subject).to receive(:get_locations).and_return(default_location)
       allow_any_instance_of(subject).to receive(:get_organizations).and_return(default_organization)
+      allow_any_instance_of(subject).to receive(:get_facilities).and_return(default_facilities)
       allow_any_instance_of(subject).to receive(:get_save_in_progress).and_return([{}])
       allow_any_instance_of(subject)
         .to receive(:get_questionnaire_responses).and_return(questionnaire_response_client_reply)
@@ -243,6 +247,26 @@ describe HealthQuest::QuestionnaireManager::Factory do
 
     it 'returns an array of organizations' do
       expect(described_class.manufacture(user).get_organizations).to eq([default_organization])
+    end
+  end
+
+  describe '#get_facilities' do
+    let(:facilities) { [] }
+    let(:locations) do
+      [
+        double('FHIR::Location',
+               resource: double('FHIR::Bundle',
+                                identifier: [double('first', value: 'vha_442'), double('last', value: 'vha_442_3049')]))
+      ]
+    end
+
+    before do
+      allow_any_instance_of(subject).to receive(:locations).and_return(locations)
+      allow_any_instance_of(HealthQuest::Facilities::Request).to receive(:get).with(anything).and_return(facilities)
+    end
+
+    it 'returns an array of facilities' do
+      expect(described_class.manufacture(user).get_facilities).to eq(facilities)
     end
   end
 

--- a/modules/health_quest/spec/services/questionnaire_manager/organization_formatter_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/organization_formatter_spec.rb
@@ -5,27 +5,45 @@ require 'rails_helper'
 describe HealthQuest::QuestionnaireManager::OrganizationFormatter do
   subject { described_class }
 
+  let(:org) do
+    double('Organization', resource: double('Resource',
+                                            identifier: [double('first'), double('last', value: 'vha_333')],
+                                            telecom: []))
+  end
+  let(:orgs_array) { [org] }
+  let(:facilities) { [{ 'id' => 'vha_333', 'attributes' => { 'phone' => { 'main' => '555-555-5555' } } }] }
+
   describe '.build' do
     it 'returns an instance of subject' do
-      expect(subject.build([])).to be_a(HealthQuest::QuestionnaireManager::OrganizationFormatter)
+      expect(subject.build([], [])).to be_a(HealthQuest::QuestionnaireManager::OrganizationFormatter)
     end
   end
 
   describe 'attributes' do
     it 'responds to orgs_array' do
-      expect(subject.build([]).respond_to?(:orgs_array)).to eq(true)
+      expect(subject.build([], []).respond_to?(:orgs_array)).to eq(true)
     end
   end
 
   describe '#to_h' do
-    let(:org) do
-      double('Organization', resource: double('Resource',
-                                              identifier: [double('first'), double('last', value: 'vha_333')]))
-    end
-    let(:orgs_array) { [org] }
-
     it 'builds a formatted hash' do
-      expect(subject.build(orgs_array).to_h).to eq({ 'vha_333' => org })
+      expect(subject.build(orgs_array, facilities).to_h).to eq({ 'vha_333' => org })
+    end
+  end
+
+  describe '#add_phones_to_org' do
+    it 'adds phone number to org' do
+      with_phone = subject.build(orgs_array, facilities).add_phones_to_org(org)
+
+      expect(with_phone.resource.telecom.first).to be_a(FHIR::ContactPoint)
+    end
+  end
+
+  describe '#facilities_by_ids' do
+    it 'formats facilities by ids' do
+      hash = { 'vha_333' => { 'id' => 'vha_333', 'attributes' => { 'phone' => { 'main' => '555-555-5555' } } } }
+
+      expect(subject.build(orgs_array, facilities).facilities_by_ids).to eq(hash)
     end
   end
 end


### PR DESCRIPTION
- Request a list of facilities from the Facilities API by organizations
- Add phone numbers from facilities to associated organizations

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- The Questionnaire Manager fetches a list of facilities from the `Facilities API` for a given set of Organization resources belonging to a user's appointments.
- We then patch the `Organizations` `telecom` field with the phone numbers from the corresponding facilities which we pulled down from the Facilities API.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature Flag: show_healthcare_experience_questionnaire
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec test suite passing
- [x] Manually tested the questionnaire manager index route
- [x] No Rubocop warnings  