### PR TITLE
Add db migration for expanded covid registration model

### DIFF
--- a/db/migrate/20210325230116_add_expanded_covid_registration.rb
+++ b/db/migrate/20210325230116_add_expanded_covid_registration.rb
@@ -1,0 +1,26 @@
+class AddExpandedCovidRegistration < ActiveRecord::Migration[6.0]
+  def change
+    create_table :covid_vaccine_expanded_registration_submissions, id: :serial do |t|
+      t.string "submission_uuid", null: false
+      t.string "vetext_sid"
+      t.boolean "sequestered", default: true, null: false
+      t.string "state"
+      t.string "email_confirmation_id"
+      t.string "enrollment_id"
+      t.string "batch_id"
+      t.string "encrypted_raw_form_data"
+      t.string "encrypted_raw_form_data_iv"
+      t.string "encrypted_eligibility_info"
+      t.string "encrypted_eligibility_info_iv"
+      t.string "encrypted_form_data"
+      t.string "encrypted_form_data_iv"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index ["submission_uuid"], name: "index_covid_vaccine_expanded_on_submission_id", unique: true
+      t.index ["vetext_sid"], name: "index_covid_vaccine_expanded_on_vetext_sid", unique: true
+      t.index ["encrypted_raw_form_data_iv"], name: "index_covid_vaccine_expanded_on_raw_iv", unique: true
+      t.index ["encrypted_eligibility_info_iv"], name: "index_covid_vaccine_expanded_on_el_iv", unique: true
+      t.index ["encrypted_form_data_iv"], name: "index_covid_vaccine_expanded_on_form_iv", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,13 +89,13 @@ ActiveRecord::Schema.define(version: 2021_03_25_230116) do
   end
 
   create_table "appeals_api_notice_of_disagreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "status", default: "pending", null: false
     t.string "encrypted_form_data"
     t.string "encrypted_form_data_iv"
     t.string "encrypted_auth_headers"
     t.string "encrypted_auth_headers_iv"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
     t.string "source"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_24_135731) do
+ActiveRecord::Schema.define(version: 2021_03_25_230116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -89,13 +89,13 @@ ActiveRecord::Schema.define(version: 2021_03_24_135731) do
   end
 
   create_table "appeals_api_notice_of_disagreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "status", default: "pending", null: false
     t.string "encrypted_form_data"
     t.string "encrypted_form_data_iv"
     t.string "encrypted_auth_headers"
     t.string "encrypted_auth_headers_iv"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "status", default: "pending", null: false
     t.string "code"
     t.string "detail"
     t.string "source"
@@ -217,6 +217,29 @@ ActiveRecord::Schema.define(version: 2021_03_24_135731) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "auto_established_claim_id"
+  end
+
+  create_table "covid_vaccine_expanded_registration_submissions", id: :serial, force: :cascade do |t|
+    t.string "submission_uuid", null: false
+    t.string "vetext_sid"
+    t.boolean "sequestered", default: true, null: false
+    t.string "state"
+    t.string "email_confirmation_id"
+    t.string "enrollment_id"
+    t.string "batch_id"
+    t.string "encrypted_raw_form_data"
+    t.string "encrypted_raw_form_data_iv"
+    t.string "encrypted_eligibility_info"
+    t.string "encrypted_eligibility_info_iv"
+    t.string "encrypted_form_data"
+    t.string "encrypted_form_data_iv"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["encrypted_eligibility_info_iv"], name: "index_covid_vaccine_expanded_on_el_iv", unique: true
+    t.index ["encrypted_form_data_iv"], name: "index_covid_vaccine_expanded_on_form_iv", unique: true
+    t.index ["encrypted_raw_form_data_iv"], name: "index_covid_vaccine_expanded_on_raw_iv", unique: true
+    t.index ["submission_uuid"], name: "index_covid_vaccine_expanded_on_submission_id", unique: true
+    t.index ["vetext_sid"], name: "index_covid_vaccine_expanded_on_vetext_sid", unique: true
   end
 
   create_table "covid_vaccine_registration_submissions", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Description of change
Adds a new DB table/model for the expanded covid vaccine registration workflow.
Because these submissions wind up having a quite different processing model than the original covid vaccine registrations, we opted to fork the model. Key differences:

- We will be resolving some eligibility info and need to store a record of that. This may include lookup data from MPI/EMIS so we encrypt that attribute.
- We will be pushing the objects through various offline ETL processes so we need the `state` and `batch_id` parameters to keep track of where they are in that pipeline. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/22118

## Things to know about this PR

