### PR TITLE
Adds settings entry for vaccine expansion mailer

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -828,6 +828,7 @@ vanotify:
       template_id:
         form526_confirmation_email: fake_template_id
         covid_vaccine_registration: fake_template_id
+        covid_vaccine_expanded_registration: fake_template_id
         direct_deposit_edu: edu_template_id
         direct_deposit_comp_pen: comp_pen_template_id
     lighthouse:


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Adds a VANotify template ID entry for covid vaccine expansion workflow. This will send a slightly different confirmation email that the original KMI flow, hence a new template.

Template IDs are already configured in devops repo in 
https://github.com/department-of-veterans-affairs/devops/pull/8797/files

Change that consumes this setting will happen in a CODEOWNERS-ed PR in the covid_vaccine module.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/22118

## Things to know about this PR
* Are there additions to a `settings.yml` file? Do they vary by environment?
Yes, see above comment.

