### PR TITLE
[6303] Update Jenkins parallel spec run so that modules directory is properly run

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -5,4 +5,3 @@
 --format RspecJunitFormatter
 --out log/rspec<%= ENV['TEST_ENV_NUMBER'] %>.xml
 <% end %>
-

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ COMPOSE_TEST := docker-compose -f docker-compose.test.yml
 BASH         := run --rm --service-ports vets-api bash
 BASH_DEV     := $(COMPOSE_DEV) $(BASH) -c
 BASH_TEST    := $(COMPOSE_TEST) $(BASH) --login -c
-SPEC_PATH    := spec/
+SPEC_PATH    := spec/ modules/
 DB           := "bin/rails db:setup db:migrate"
 LINT         := "bin/rails lint['$(files)']"
 DOWN         := down
@@ -148,7 +148,9 @@ spec_parallel:  ## Runs spec tests in parallel
 ifeq ($(ENV_ARG), dev)
 	@$(BASH_DEV) "RAILS_ENV=test DISABLE_BOOTSNAP=true NOCOVERAGE=true bundle exec parallel_rspec ${SPEC_PATH}"
 else
-	@$(COMPOSE_TEST) $(BASH) -c "CIRCLE_JOB=true RAILS_ENV=test DISABLE_BOOTSNAP=true bundle exec parallel_rspec ${SPEC_PATH}"
+	@$(COMPOSE_TEST) $(BASH) -c "cc-test-reporter before-build"
+	@$(COMPOSE_TEST) $(BASH) -c "DISABLE_BOOTSNAP=true bundle exec parallel_rspec ${SPEC_PATH}"
+	@$(COMPOSE_TEST) $(BASH) -c "cc-test-reporter after-build -t simplecov"
 endif
 
 .PHONY: up

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -26,7 +26,7 @@ services:
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
-      CI:
+      CI: "true"
       RAILS_ENV: test
       CC_TEST_REPORTER_ID: '0c396adc254b0317e2c3a89a1c929fd61270b133c944d3e9c0f13b3937a7ce45'
       CHANGE_ID:           "${CHANGE_ID}"

--- a/modules/covid_research/spec/mailers/covid_research/volunteer/submission_mailer_spec.rb
+++ b/modules/covid_research/spec/mailers/covid_research/volunteer/submission_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require CovidResearch::Engine.root.join('spec', 'rails_helper.rb')
 
 RSpec.describe CovidResearch::Volunteer::SubmissionMailer, type: :mailer do
   let(:recipient) { 'recipient@example.com' }

--- a/modules/covid_research/spec/rails_helper.rb
+++ b/modules/covid_research/spec/rails_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/factory_bot'
+require CovidResearch::Engine.root.join('spec', 'spec_helper.rb')

--- a/modules/covid_research/spec/requests/volunteer_request_spec.rb
+++ b/modules/covid_research/spec/requests/volunteer_request_spec.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../covid_research_spec_helper.rb'
-
-RSpec.configure do |c|
-  c.include CovidResearchSpecHelper
-end
+require CovidResearch::Engine.root.join('spec', 'rails_helper.rb')
 
 RSpec.describe 'covid research volunteer submissions', type: :request do
   describe 'POST /covid-research/volunteer/create' do

--- a/modules/covid_research/spec/serializers/covid_research/genisis_serializer_spec.rb
+++ b/modules/covid_research/spec/serializers/covid_research/genisis_serializer_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require_relative '../../covid_research_spec_helper.rb'
+require 'rails_helper'
+require CovidResearch::Engine.root.join('spec', 'rails_helper.rb')
 require_relative '../../../app/serializers/covid_research/genisis_serializer.rb'
 # Because we aren't requiring the Rails helper so it isn't autoloaded
 require_relative '../../../app/serializers/covid_research/volunteer/name_serializer.rb'
-
-RSpec.configure do |c|
-  c.include CovidResearchSpecHelper
-end
 
 RSpec.describe CovidResearch::GenisisSerializer do
   let(:subject)  { described_class.new }

--- a/modules/covid_research/spec/serializers/covid_research/volunteer/name_serializer_spec.rb
+++ b/modules/covid_research/spec/serializers/covid_research/volunteer/name_serializer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
+require CovidResearch::Engine.root.join('spec', 'rails_helper.rb')
 require_relative '../../../../app/serializers/covid_research/volunteer/name_serializer.rb'
 
 RSpec.describe CovidResearch::Volunteer::NameSerializer do

--- a/modules/covid_research/spec/services/covid_research/volunteer/form_crypto_service_spec.rb
+++ b/modules/covid_research/spec/services/covid_research/volunteer/form_crypto_service_spec.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require_relative '../../../../app/services/covid_research/volunteer/form_crypto_service.rb'
-require_relative '../../../covid_research_spec_helper.rb'
-
-RSpec.configure do |c|
-  c.include CovidResearchSpecHelper
-end
+require 'rails_helper'
+require CovidResearch::Engine.root.join('spec', 'rails_helper.rb')
 
 RSpec.describe CovidResearch::Volunteer::FormCryptoService do
   let(:subject)        { described_class.new }

--- a/modules/covid_research/spec/services/covid_research/volunteer/form_service_spec.rb
+++ b/modules/covid_research/spec/services/covid_research/volunteer/form_service_spec.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+require CovidResearch::Engine.root.join('spec', 'rails_helper.rb')
 require_relative '../../../../app/services/covid_research/volunteer/form_service.rb'
-require_relative '../../../covid_research_spec_helper.rb'
 require_relative '../../../../lib/redis_format.rb' # No Rails helper no auto-load
-
-RSpec.configure do |c|
-  c.include CovidResearchSpecHelper
-end
 
 RSpec.describe CovidResearch::Volunteer::FormService do
   let(:valid)   { JSON.parse(read_fixture('valid-submission.json')) }

--- a/modules/covid_research/spec/services/covid_research/volunteer/genisis_service_spec.rb
+++ b/modules/covid_research/spec/services/covid_research/volunteer/genisis_service_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
+require CovidResearch::Engine.root.join('spec', 'rails_helper.rb')
+
 require_relative '../../../../app/services/covid_research/volunteer/genisis_service.rb'
-require_relative '../../../covid_research_spec_helper.rb'
 
 RSpec.configure do |c|
-  c.include CovidResearchSpecHelper
   c.include StatsD::Instrument::Matchers
 end
 

--- a/modules/covid_research/spec/spec_helper.rb
+++ b/modules/covid_research/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Configure Rails Envinronment
+ENV['RAILS_ENV'] = 'test'
+# require File.expand_path('dummy/config/environment.rb', __dir__)
+
+require 'rspec/rails'
+require_relative 'covid_research_spec_helper'
+
+ENGINE_RAILS_ROOT = File.join(File.dirname(__FILE__), '../')
+
+RSpec.configure { |config| config.use_transactional_fixtures = true }
+RSpec.configure { |config| config.include CovidResearchSpecHelper }

--- a/modules/covid_research/spec/workers/covid_research/volunteer/confirmation_mailer_job_spec.rb
+++ b/modules/covid_research/spec/workers/covid_research/volunteer/confirmation_mailer_job_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
+require CovidResearch::Engine.root.join('spec', 'rails_helper.rb')
 require_relative '../../../../app/workers/covid_research/volunteer/confirmation_mailer_job.rb'
 
 RSpec.describe CovidResearch::Volunteer::ConfirmationMailerJob do

--- a/modules/covid_research/spec/workers/covid_research/volunteer/genisis_delivery_job_spec.rb
+++ b/modules/covid_research/spec/workers/covid_research/volunteer/genisis_delivery_job_spec.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
+require CovidResearch::Engine.root.join('spec', 'rails_helper.rb')
 require_relative '../../../../app/workers/covid_research/volunteer/genisis_delivery_job.rb'
 require_relative '../../../../lib/redis_format.rb'
-require_relative '../../../covid_research_spec_helper.rb'
-
-RSpec.configure do |c|
-  c.include CovidResearchSpecHelper
-end
 
 RSpec.describe CovidResearch::Volunteer::GenisisDeliveryJob do
   subject               { described_class.new }

--- a/modules/mobile/app/serializers/mobile/v0/push_get_prefs_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/push_get_prefs_serializer.rb
@@ -12,8 +12,8 @@ module Mobile
         resource = PushStruct.new(id, preferences)
         super(resource, options)
       end
-    end
 
-    PushStruct = Struct.new(:id, :preferences)
+      PushStruct = Struct.new(:id, :preferences)
+    end
   end
 end

--- a/modules/mobile/app/serializers/mobile/v0/push_register_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/push_register_serializer.rb
@@ -12,8 +12,8 @@ module Mobile
         resource = PushStruct.new(id, endpoint_sid)
         super(resource, options)
       end
-    end
 
-    PushStruct = Struct.new(:id, :endpoint_sid)
+      PushStruct = Struct.new(:id, :endpoint_sid)
+    end
   end
 end

--- a/modules/va_forms/spec/models/form_spec.rb
+++ b/modules/va_forms/spec/models/form_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe VAForms::Form, type: :model do
       form.pages = 2
       form.sha256 = 'somelongsha'
       form.valid_pdf = true
+      form.row_id = 4909
       form.save
       form.reload
       expect(form.last_revision_on).to eq(form.first_issued_on)

--- a/modules/va_forms/spec/workers/form_reloader_spec.rb
+++ b/modules/va_forms/spec/workers/form_reloader_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require VAForms::Engine.root.join('spec', 'rails_helper.rb')
 
 RSpec.describe VAForms::FormReloader, type: :job do
   subject { described_class }

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request, retry: 3 do
 
     it '200S even with an invalid doc' do
       allow(VBADocuments::PayloadManager).to receive(:download_raw_file).and_return(invalid_doc)
-      get "/services/vba_documents/v0/uploads/#{upload.guid}/download"
+      get "/services/vba_documents/v1/uploads/#{upload.guid}/download"
       expect(response.status).to eq(200)
       expect(response.headers['Content-Type']).to eq('application/zip')
     end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -425,8 +425,9 @@ RSpec.describe V1::SessionsController, type: :controller do
 
           callback_tags = ['status:success', "context:#{LOA::IDME_LOA3}", 'version:v1']
 
-          Timecop.freeze(Time.current)
-          cookie_expiration_time = 30.minutes.from_now.iso8601(0)
+          new_user_sign_in = Time.current + 30.minutes
+          Timecop.freeze(new_user_sign_in)
+          cookie_expiration_time = (new_user_sign_in + 30.minutes).iso8601(0)
           expect { post(:saml_callback) }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)
             .and trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_TOTAL_KEY, **once)

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -88,5 +88,5 @@ Pact.service_provider 'VA.gov API' do
 
   app_version git_sha
   app_version_tags git_branch
-  publish_verification_results publish_flag if ENV['CIRCLE_JOB']
+  publish_verification_results publish_flag if ENV['CI']
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,7 @@ unless ENV['NOCOVERAGE']
     add_group 'AppealsApi', 'modules/appeals_api/'
     add_group 'AppsApi', 'modules/apps_api'
     add_group 'ClaimsApi', 'modules/claims_api/'
+    add_group 'CovidResearch', 'modules/covid_research/'
     add_group 'CovidVaccine', 'modules/covid_vaccine/'
     add_group 'FacilitiesApi', 'modules/facilities_api/'
     add_group 'HealthQuest', 'modules/health_quest/'
@@ -63,13 +64,20 @@ unless ENV['NOCOVERAGE']
     add_group 'TestUserDashboard', 'modules/test_user_dashboard/'
     add_group 'Uploaders', 'app/uploaders'
     add_group 'VAOS', 'modules/vaos/'
+    add_group 'VAForms', 'modules/va_forms/'
     add_group 'VBADocuments', 'modules/vba_documents/'
     add_group 'Veteran', 'modules/veteran/'
     add_group 'VeteranVerification', 'modules/veteran_verification/'
     # End Modules
 
-    SimpleCov.minimum_coverage_by_file 90 unless ENV['CIRCLE_JOB']
-    SimpleCov.refuse_coverage_drop unless ENV['CIRCLE_JOB']
+    SimpleCov.minimum_coverage_by_file 90 unless ENV['CI']
+    SimpleCov.refuse_coverage_drop unless ENV['CI']
+  end
+  if ENV['TEST_ENV_NUMBER'] # parallel specs
+    SimpleCov.at_exit do
+      result = SimpleCov.result
+      result.format! if ParallelTests.number_of_running_processes <= 1
+    end
   end
 end
 

--- a/spec/support/vcr_cassettes/va_forms/gql_forms.yml
+++ b/spec/support/vcr_cassettes/va_forms/gql_forms.yml
@@ -1,0 +1,137 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://internal-dsva-vagov-dev-cms-812329399.us-gov-west-1.elb.amazonaws.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"{\n  nodeQuery(limit: 1000, offset: 0, filter: {conditions:
+        [{ field: \"field_va_form_number\", value: \"26-8599\", operator: LIKE }]})
+        {\n    entities {\n      ... on NodePage {\n        fieldRelatedLinks {\n          entity
+        {\n            parentFieldName\n          }\n        }\n      }\n      ...vaForm\n    }\n  }\n}\nfragment
+        vaForm on NodeVaForm {\n  fieldVaFormNumber\n  fieldVaFormRowId\n  entityBundle\n  entityId\n  entityPublished\n  entityUrl
+        {\n    path\n  }\n  entityTranslations {\n    entityCreated\n    entityLabel\n    entityId\n    entityChanged\n    entityBundle\n    entityType\n    entityUuid\n  }\n  entityRevisions
+        {\n    entities {\n      entityChanged\n      ... on NodeVaForm {\n        fieldVaFormName\n      }\n    }\n  }\n  title\n  status\n  revisionLog\n  fieldVaFormDeleted\n  fieldVaFormDeletedDate
+        {\n    value\n  }\n  langcode {\n    value\n  }\n  title\n  fieldVaFormName\n  fieldVaFormTitle\n  fieldVaFormType\n  fieldVaFormUrl
+        {\n    uri\n  }\n  fieldVaFormUsage {\n    value\n    format\n    processed\n  }\n  fieldVaFormToolIntro\n  fieldVaFormToolUrl
+        {\n    uri\n    title\n    options\n  }\n  fieldBenefitCategories {\n    targetId\n    entity
+        {\n      entityLabel\n      ... on NodeLandingPage {\n        fieldHomePageHubLabel\n      }\n    }\n  }\n  fieldVaFormRevisionDate
+        {\n    value\n    date\n  }\n  fieldVaFormIssueDate {\n    value\n    date\n  }\n  fieldVaFormNumPages\n\n  fieldVaFormLinkTeasers
+        {\n    entity {\n      entityLabel\n      parentFieldName\n      ... on ParagraphLinkTeaser
+        {\n        entityId\n    \t\tfieldLink {\n          url {\n            path\n          }\n          title\n          options\n        }\n        fieldLinkSummary\n      }\n    }\n  }\n  fieldVaFormRelatedForms
+        {\n    entity {\n      ... on NodeVaForm {\n        fieldVaFormNumber\n      }\n    }\n  }\n  fieldVaFormAdministration
+        {\n        entity {\n          entityLabel\n        }\n  }\n  changed\n  status\n}\n"}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic YXBpOmRydXBhbDg=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Mar 2021 19:45:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2321'
+      Connection:
+      - keep-alive
+      Server:
+      - Apache/2.4.46 (Amazon) OpenSSL/1.0.2k-fips PHP/7.3.23
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Powered-By:
+      - PHP/7.3.23
+      Set-Cookie:
+      - SimpleSAMLSessionID=d0784ade04bd6ac328db4b5ce9506e15; path=/; HttpOnly
+      Cache-Control:
+      - must-revalidate, no-cache, private
+      X-Ua-Compatible:
+      - IE=edge
+      Content-Language:
+      - en
+      X-Frame-Options:
+      - SAMEORIGIN
+      Expires:
+      - Sun, 19 Nov 1978 05:00:00 GMT
+      X-Generator:
+      - Drupal 8 (https://www.drupal.org)
+    body:
+      encoding: UTF-8
+      string: '{"data":{"nodeQuery":{"entities":[{"fieldVaFormNumber":"26-8599","fieldVaFormRowId":1352,"entityBundle":"va_form","entityId":"6025","entityPublished":true,"entityUrl":{"path":"\/find-forms\/about-form-26-8599"},"entityTranslations":[],"entityRevisions":{"entities":[{"entityChanged":"2020-06-22T16:05:31-0400","fieldVaFormName":"Manufactured
+        Home Warranty (Limited Warranty)"},{"entityChanged":"2020-06-22T16:28:37-0400","fieldVaFormName":"Manufactured
+        Home Warranty (Limited Warranty)"},{"entityChanged":"2020-06-24T16:24:00-0400","fieldVaFormName":"Manufactured
+        Home Warranty (Limited Warranty)"},{"entityChanged":"2020-06-25T16:12:18-0400","fieldVaFormName":"Manufactured
+        Home Warranty (Limited Warranty)"},{"entityChanged":"2020-07-21T12:54:22-0400","fieldVaFormName":"Manufactured
+        Home Warranty (Limited Warranty)"},{"entityChanged":"2020-07-21T16:56:30-0400","fieldVaFormName":"Manufactured
+        Home Warranty (Limited Warranty)"},{"entityChanged":"2020-07-23T14:11:51-0400","fieldVaFormName":"Manufactured
+        Home Warranty (Limited Warranty)"},{"entityChanged":"2020-08-10T17:26:56-0400","fieldVaFormName":"Manufactured
+        Home Warranty (Limited Warranty)"},{"entityChanged":"2020-08-11T16:38:09-0400","fieldVaFormName":"Manufactured
+        Home Warranty (Limited Warranty)"},{"entityChanged":"2020-09-17T13:36:55-0400","fieldVaFormName":"Manufactured
+        Home Warranty (Limited Warranty)"}]},"title":"About VA Form 26-8599","status":true,"revisionLog":"Update
+        of form metadata from Forms DB.","fieldVaFormDeleted":false,"fieldVaFormDeletedDate":null,"langcode":{"value":"en"},"fieldVaFormName":"Manufactured
+        Home Warranty (Limited Warranty)","fieldVaFormTitle":"Manufactured Home Warranty
+        (Limited Warranty)","fieldVaFormType":"benefit","fieldVaFormUrl":{"uri":"http:\/\/www.vba.va.gov\/pubs\/forms\/26-8599.pdf"},"fieldVaFormUsage":null,"fieldVaFormToolIntro":null,"fieldVaFormToolUrl":null,"fieldBenefitCategories":[{"targetId":74,"entity":{"entityLabel":"VA
+        housing assistance","fieldHomePageHubLabel":"Housing assistance"}}],"fieldVaFormRevisionDate":null,"fieldVaFormIssueDate":{"value":"2002-01-07","date":"2002-01-07
+        12:00:00 UTC"},"fieldVaFormNumPages":1,"fieldVaFormLinkTeasers":[],"fieldVaFormRelatedForms":[],"fieldVaFormAdministration":{"entity":{"entityLabel":"Veterans
+        Benefits Administration"}},"changed":1613538230}]}}}'
+  recorded_at: Mon, 29 Mar 2021 19:45:00 GMT
+- request:
+    method: get
+    uri: https://www.vba.va.gov/pubs/forms/26-8599.pdf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/pdf
+      Last-Modified:
+      - Wed, 03 Apr 2019 17:49:47 GMT
+      Accept-Ranges:
+      - bytes
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 10 Mar 2021 17:47:43 GMT
+      Content-Length:
+      - '1328291'
+      Set-Cookie:
+      - BIGipServerwww.vba.va.gov_http=444976650.20480.0000; path=/; Httponly; Secure
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        JVBERi0xLjINCiVKZXRGb3JtIFBERiBTdXBwb3J0IFZlcnNpb24gMi4yLjAwMA0KJfv8/f4NCjEgMCBvYmoKPDwKL1R5cGUgL0NhdGFsb2cKL1BhZ2VzIDMgMCBSCi9PdXRsaW5lcyA0IDAgUgo+PgplbmRvYmoKMiAwIG9iaiA8PA0KL1R5cGUgL0VuY29kaW5nDQovRGlmZmVyZW5jZXMgWzEyOCAvZG90bGVzc2kgL2NlZGlsbGEgMTMwIC9jYXJvbiAxMzEgL3F1ZXN0aW9uZG93biAxMzIgL3F1ZXN0aW9uZG93biAxMzMgL3F1ZXN0aW9uZG93biAxMzQgL3F1ZXN0aW9uZG93biAxMzUgL3F1ZXN0aW9uZG93biAxMzYgL3F1ZXN0aW9uZG93biAxMzcgL3F1ZXN0aW9uZG93biAxMzggL3F1ZXN0aW9uZG93biAxMzkgL2J1bGxldCAxNDAgL3F1ZXN0aW9uZG93biAxNDEgL2xvZ2ljYWxub3QgMTQyIC9xdWVzdGlvbmRvd24gMTQzIC9xdWVzdGlvbmRvd24gMTQ0IC9xdWVzdGlvbmRvd24gMTQ1IC9xdWVzdGlvbmRvd24gMTQ2IC9vbmVzdXBlcmlvciAxNDcgL3R3b3N1cGVyaW9yIDE0OCAvdGhyZWVzdXBlcmlvciAxNDkgL3F1ZXN0aW9uZG93biAxNTAgL3F1ZXN0aW9uZG93biAxNTEgL3F1ZXN0aW9uZG93biAxNTIgL3F1ZXN0aW9uZG93biAxNTMgL3F1ZXN0aW9uZG93biAxNTQgL3F1ZXN0aW9uZG93biAxNTUgL3F1ZXN0aW9uZG93biAxNTYgL3F1ZXN0aW9uZG93biAxNTcgL3F1ZXN0aW9uZG93biAxNTggL3F1ZXN0aW9uZG93biAxNTkgL3F1ZXN0aW9uZG93biAxNjAgL3F1ZXN0aW9uZG93biAxNjEgL0FncmF2ZSAvQWNpcmN1bWZsZXggL0VncmF2ZSAvRWNpcmN1bWZsZXggL0VkaWVyZXNpcyAvSWNpcmN1bWZsZXggL0lkaWVyZXNpcyAvYWN1dGUgL2dyYXZlIC9jaXJjdW1mbGV4IC9kaWVyZXNpcyAvdGlsZGUgL1VncmF2ZSAvVWNpcmN1bWZsZXggMTc1IC9xdWVzdGlvbmRvd24gL21hY3JvbiAvWWFjdXRlIC95YWN1dGUgMTc5IC9yaW5nIC9DY2VkaWxsYSAvY2NlZGlsbGEgL050aWxkZSAvbnRpbGRlIC9leGNsYW1kb3duIC9xdWVzdGlvbmRvd24gL2N1cnJlbmN5IC9zdGVybGluZyAveWVuIC9zZWN0aW9uIC9mbG9yaW4gL2NlbnQgL2FjaXJjdW1mbGV4IC9lY2lyY3VtZmxleCAvb2NpcmN1bWZsZXggL3VjaXJjdW1mbGV4IC9hYWN1dGUgL2VhY3V0ZSAvb2FjdXRlIC91YWN1dGUgL2FncmF2ZSAvZWdyYXZlIC9vZ3JhdmUgL3VncmF2ZSAvYWRpZXJlc2lzIC9lZGllcmVzaXMgL29kaWVyZXNpcyAvdWRpZXJlc2lzIC9BcmluZyAvaWNpcmN1bWZsZXggL09zbGFzaCAvQUUgL2FyaW5nIC9pYWN1dGUgL29zbGFzaCAvYWUgL0FkaWVyZXNpcyAvaWdyYXZlIC9PZGllcmVzaXMgL1VkaWVyZXNpcyAvRWFjdXRlIC9pZGllcmVzaXMgL2dlcm1hbmRibHMgL09jaXJjdW1mbGV4IC9BYWN1dGUgL0F0aWxkZSAvYXRpbGRlIC9FdGggL2V0aCAvSWFjdXRlIC9JZ3JhdmUgL09hY3V0ZSAvT2dyYXZlIC9PdGlsZGUgL290aWxkZSAvU2Nhcm9uIC9zY2Fyb24gL1VhY3V0ZSAvWWRpZXJlc2lzIC95ZGllcmVzaXMgL1Rob3JuIC90aG9ybiAvcGVyaW9kY2VudGVyZWQgL211IC9wYXJhZ3JhcGggL3RocmVlcXVhcnRlcnMgL2VtZGFzaCAvb25lcXVhcnRlciAvb25laGFsZiAvb3JkZmVtaW5pbmUgL29yZG1hc2N1bGluZSAvZ3VpbGxlbW90bGVmdCAyNTIgL3F1ZXN0aW9uZG93biAvZ3VpbGxlbW90cmlnaHQgL3BsdXNtaW51cyAvcXVlc3Rpb25kb3duXQ0KPj4gZW5kb2JqDQo1IDAgb2JqCjw8Ci9UeXBlIC9Gb250IC9TdWJ0eXBlIC9UeXBlMSAvTmFtZSAvQ291cmllciAvRW5jb2RpbmcgMiAwIFINCi9CYXNlRm9udCAvQ291cmllcg0KPj4KZW5kb2JqCjYgMCBvYmoKPDwKL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9OYW1lIC9IZWx2ZXRpY2EtQm9sZCAvRW5jb2RpbmcgMiAwIFINCi9CYXNlRm9udCAvSGVsdmV0aWNhLUJvbGQNCj4+CmVuZG9iago3IDAgb2JqCjw8Ci9UeXBlIC9Gb250IC9TdWJ0eXBlIC9UeXBlMSAvTmFtZSAvSGVsdmV0aWNhIC9FbmNvZGluZyAyIDAgUg0KL0Jhc2VGb250IC9IZWx2ZXRpY2ENCj4+CmVuZG9iago4IDAgb2JqCjw8Ci9UeXBlIC9Gb250IC9TdWJ0eXBlIC9UeXBlMSAvTmFtZSAvVGltZXMtUm9tYW4gL0VuY29kaW5nIDIgMCBSDQovQmFzZUZvbnQgL1RpbWVzLVJvbWFuDQo+PgplbmRvYmoKOSAwIG9iago8PAovVHlwZSAvRm9udCAvU3VidHlwZSAvVHlwZTEgL05hbWUgL1RpbWVzLUl0YWxpYyAvRW5jb2RpbmcgMiAwIFINCi9CYXNlRm9udCAvVGltZXMtSXRhbGljDQo+PgplbmRvYmoKMTAgMCBvYmoKPDwKL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9OYW1lIC9IZWx2ZXRpY2EtT2JsaXF1ZSAvRW5jb2RpbmcgMiAwIFINCi9CYXNlRm9udCAvSGVsdmV0aWNhLU9ibGlxdWUNCj4+CmVuZG9iagoxMSAwIG9iago8PAovVHlwZSAvWE9iamVjdCAvU3VidHlwZSAvRm9ybSAvRm9ybVR5cGUgMSAvTWF0cml4IFsxIDAgMCAxIDAgMF0gL0JCb3ggWzAgMCA4NTAwIDE0MDAwXSAvTmFtZSAvRm0wMSAvRmlsdGVyIC9GbGF0ZURlY29kZSAKL1Jlc291cmNlcwo8PAovUHJvY1NldCBbL1BERiAvSW1hZ2VCIC9UZXh0IF0KL0ZvbnQ8PC9Db3VyaWVyIDUgMCBSIC9IZWx2ZXRpY2EtQm9sZCA2IDAgUiAvSGVsdmV0aWNhIDcgMCBSIC9UaW1lcy1Sb21hbiA4IDAgUiAvVGltZXMtSXRhbGljIDkgMCBSIC9IZWx2ZXRpY2EtT2JsaXF1ZSAxMCAwIFIgPj4KL0VuY29kaW5nIDIgMCBSCj4+Ci9MZW5ndGggMDAwMDAwMzY0Mj4+CnN0cmVhbQ0KeNrFXN9v48YRfi+Q/2GRl1wAn4/7k2TeeDadUyNLhkRf6uaKgJYoi40suiRl1/3rO0vJPvuOM5MwBaoHg7L4zc7O7nw7M7vkL/8QgVh+8xcZiAf/NwiE1FqLWxHap+uNmH/zl196bpQufL7RX6M3Ri8kRv0SVfS56f01cqNVn2/srrVv4tWNvwi4VQWvYLpTcq9xpJ6/vMKp10Z4ZQXcDJGNn83QXWM3xkH0LLK77rlRR6EF7TX8fWq8+4LfGmr3+Vb/5dWt7zMh4SoQb6VQNjAiipTIbsW7D8XmvmjLRf72fbVZChkbka3Em/NkcnmWnGSXs/RUfJiep+LnZDZLJtnV9yL7p0iz1yK1dhIsqb+QKaRznbhPb8aj81EGsp7EfPq+V5CKjbdzEH4pSEeIXqfp/GQ2ushG00mvxP0wGuW+kAgD1AmcnqbjflUiEigml+fv01kvdD83cehpkqVieiYuLmcnH5J5SgiJUSFP4NmnN/NP3/9AdB6VMUnAgMnkVCSnp7N0Pvc6nabJOJ29m6fjMdK7TigMVNwJzcrbonk7q27zrZDK7nUT/UAbRkIrmPEY8Kyq+5ERTFkSeVNVy/5hBG+gofkWQWqYiyTyPt/s8utNgcwfGdPwRbVtymVR521ZbY/6HctGwTDtdSQ1jWyrfmDsFA0st8vdor/TRhum03e7erHOGwQeGWaGVKt+Zwm4CdKuC8zNGI3z6+oewVrWVMti25arsugfJBfEjhYA17tVvmh3NSYi0oz+6+q2X/1QOgZ6/dgP1MYNs3bHHdoQ3NFZ++02v0X6K0MjaQkXhxlWf3rTYMuMgYWcVgMjBec5jEIibqW6caKAq10NZusnQK2ModGEU2pnmN5iw6UjxwzXvFjURZvXjwgdxIy1EH82FiIHEvixaIE5tw1CByEDT1arvKwRtInNoDG2zloaeLPLQem26De3UwFnrv7p4XxsSAJv89+QNkPJeSTCO4qZz5sq3yK8EwzzoVA5ps1mt1gTxOOk+zO0IV1kaCG77RLxYBVAFEZiwZV8INA/JyFoD2m4BrNigQijNTKrVBxqtk2FBC5aMvY+Wed3LUZ3oTNcy0i7sfcECpmVLRKxQcAeMa1G/a0aE8Y08nJbtsiKZqKQmxlt3hYIVyktGTtXy+IICV8gCSSxaNAUxvJ3OEJT3myxsMU4RsKLyKdGaCRiXAJZXPbhy5B+71kkpILFVVUXTV4uxcvITfgYTCyrohGwwhfXj+Ihr/1CINpKQGPiNfkIiD66X/wCtwJA0f37CG7NWyTTcxBeGEnOg23T1ruOY5B8J5S0CMSeCiYSDcTsqcJY00g2/tU+UiBFoPGv9okxCWXCd1iJGIvhuQN4PdP1RXV7tykxvzcBY/OHsl0jzivVsOGysWEaPSt8PrtBXB6WMBJ9zg126OtTpIgP2GB3rmuonIV1EEiXGBFY1iBjb3IKOc9XRdsfRCvlZwoJbqHhvF42WCErpvHlFivGhTSwWK0gaEEyFk7rHAGagAGi2YqvutLIEqOCyMbDGjWBZYaWpTDjFxQzKIW3MmBaL7G4AX43XHWqc4diiYQPPm4Z5A4ugLRwiNZOKUkDVzWWW0FKyUGrWyRFMqzf97uuix2jb7O7bsB72xIhzT1tUSnPsvA+2G8vaSSDRlxfWq84nVBC8I5p3SU7ZkAiq2RkaeBDVf8G35t1eXeMsBYkaaSIbI1ML624Xh/Ctkcsa2HgzTrfbAgaIS12vSlvwOhIvUQyTaP8BWE0N9JMIG6NYXTH6iU2ZoaqxcoWNrIhDc3v7urqDqZoixECN08WVV37nByJ4MLAMDbP8VgCKEUN88yOEKjkpdx6RlkggaO0gaPxSJQvnWWAHJcp5XMUSsK22r6FdQdyqNsSc7IgNLQQbF9DSVZ/pHikuzifhJIRmAl8+EfhAf0OoUQD+eafGXATeUodMOA20ObPDTgsIiEtgVq8XCBjruP9QOmY4XpavJCGnWPUxsqwETfFXqxehHdTBYaHdYmVOLWRNPa6WORYehT6AJgCF/ddNows284wakM2iqUZVjJNV1usfKAtjXwscqy2GTkaioaDECUwnUUTFOMXeQq5xFYrDaEkY6QVktlwNqJ3ZLUPDwa0a4xfoIdYyUCoTiPZjMp2paxwUEbla/wkFMtqbMz5bo4RnWYcAFnSgF7lULZwVqph4+NCrp+vq5lHSBE2ZkYZOwvSUSR1/OTLsilCeIGhxdxggZ+MHQN9qMu2LbAyq9M0elu15QJjPMmA0e1ny+iMklZgJY1kEwRIjCzbZewwSkwjNzm2iWTA0lyXkR1KiMsZKLYkmVAxsxNdkkwcMVCUeVTA2BebjLZLQyjkMn9EKkguZGyUr7ChsbENhs1GJ31NkkKe4gmf4gZ1hVBlyPjOBbWEhkHI2LgpWmS/2zLjCplSS2x4W3Zv4liIOaQ94sBYYs89oitUiOtCLIsN0KDfwjrsVL109neHckhVi7ztfs2Xy7poGgE9Ep1u3X5XuT3GUsrAVw+oUg1GwUFII2Hq3SKxahzR0G/ZfQgdgF1JGX4f4lskCIS0isQiYYJ2AWOtXYPpG8WKhu6HCd8WtwPLWsASNLbcLja7JUKmcRwzo4ye6pOMkfkYMuZUR2NIp7nZua+sQ9tIHhnEv8dq5fYG3+AeZLc9a1AZ7N1md3sNDR+BZ+ctXHSb1cUG0vi6XOQb0Tw2bXHbdP/2JJLf3W3KrjwhukLFZgNkAoxxGPil5w0/98T141cEg9GGUn4vckCFV0ZhTEPJCq/SloHjrqCcYrDXWMwXSRqI7t9Jxk5A1yVaotTaRjS8rbBTyxAE2SGRjPYZvR0WKXLmxegt4MZ0WdTVTY7ayTjNjE+1Qo4N+UcMaDthvBpzSlfoWVKrLKNvXd6sW6Riz7keGqP6Z1JI5F1d3peb4qbA9v4cI4BIdl3AYNHar4tCZox+z8FBT6uOPufyKNb5fSG6g1NAno+iG0GxyR/2bOmXjNti2x4TLVCUP5qILJ1no/Pp5Er8/CGd+UdQjsRXnAtqQPzWndzqOLwp8k3H0mXzdGrpsftG6EGZ61fqA9mGqFa//pHPkej9N65daIZq9/oj/OfXYR9CO6ok8n/XLqLm8P+sFamNF/n6CTAp9+e+E3E2nZ1TYAtZRT94Mv0IqUOssYpQ17SLkafYlHsb2TgmnhYj9E7/NgLnm/wo5tn05KfuUatDV8RB7pH4azIB9SJ9RDVh0SZ+Ho3H4n0qLufp6TGSQgB9S4l3cTSZZ7PLE/803ZwwsYwOT+i9mgaHZ/TQnM1nszSUDcpV0D1oSMlAo3JlIKqmsXTwFxtef2TTUnV2p6BI8KchrmGQxb+LxQ47XAzwkMEj57BM4LjuYsdejA44qD+JdYyEU46bYR+qh+K+qJFjSQqSH6ZxLGs07AwlZwg4Maf67a5pkfAmjtmBbgvsRJV/ioNGYxXLbrGmoWjJMlQqYrDoNtqBSeLQ/OFxkko5BopupEkrDYNFD0BElkGSW2lK6ZDBQwSJbdBC+si1jtSNVBgPtpYOooHW0nu2p5DoA0KwgksGu9hUTbm9wXZ3gOoVZy3ElbpHWIfNS+MLxTT0fv/YGnLgwnDdRunDasdNrmvsIVbLKb3a1duyWWOPcvjbaAHoWXTIWORAY3enNJhmKbIG7uL4Z3dXEYewpJKgPOpS+8L5I3IuMw4ZPH4KSzFIlDUjHzuRUD7+ci5iZPj46xgjE8eAs/WuOcLK5tHAjmtnOGvjBBjLoc0aqbhmKTYAMuHg+eK3bfUA2fkN/pQIJ6MuFkV5h5BKpNywaWrjSA40m5Mx51ukX7uQVRpl0TDQlsEiLBr6LVjGVMhJUA0JP4OsKRbSVITut2C7Eo+f4d2FX3VF2Qi/ghbLY0qyIz0VzfI0A2XPC6hAO1YGVqGXioHmu3Zd1eV/sNd2QHLMCECilqBjKEd6y6pcYKcltX+IlMMjBKc5m+NP+BtupJe+AIgdsZBcl5HzKAZImUH6GiRWcB/aXcN394lcjrGz7pYRMNpih905W2HVflgJuEbx+nXgwyQSu4CMBVl1nWHRayoZDwMlBw7VPrekFa/uHin+ItNhJL6SPllSQ6oH0hgOSteXAmUYPB2IK6cVpzt2Okxx9vqY9POHDCSDRFfb7jgsjcWqYs5pBpkv/POz+RZ/drdjW7JxpLrlOkcmG6fIhwKiM9rKWA6b0VZH4cAZbZ3moPvF4bsGO4jPdfhpMca3V10ccuZGa0yhVvFQb95TCJmMv9w1aytxKMR2UdbzTlm1/WqH7btGXBfrfLOigi9gvqD/rW1fbRuQuxran0oOowB7Nd/7K2R9hk6G8WGvYd/7UZtvysXzdsOnN/PRj5PEv4uve4lcNsrG3Wvtksvsw3Q2+nt6Ct/ORiejZIzui0KgFykbU630vaXuxXsAZ+8O7xSczqjd1yj0o4aMpDh8ztLTdJaMxTyDbmXpXFzMph9Hp6mYpx/9hulFOknG2Qh+gBEQZ7PkEro4E6NJlk78nkkyJhSIA3wqnY/ms/QCegdyEi/Jv97vYjoHE2ZTkH82vkwnJ6nIPqRiNJ9fJv6LN/XkSvx4mXSvVPSawO+4BnEQ4mvpefKT3506yBxPk4l4f9W1N09PZmmWzK66Pas0AwtN5iI5O0tGszkxhWP/8ifO4jB5s5Hv2PTzCw1/EJ0Oh1+g0cl0cjKd+Ek/gm6eX84zv811mo5HflQ6E9Edtw43/fPs8Q2KcQL9A2nQ/ekkFVdpMuvmngzEaXIF4z6bnndW+fIdjpQhIsIQs33+LarVF1vscP0iv99vwP/h3fKnzXHs+AkwaxCp6ItXgU6vN+W/dkWvp7/o8v7Nk8+i/wsXWOJUDQplbmRzdHJlYW0NCmVuZG9iagoxMiAwIG9iago8PAovUHJvY1NldCBbL1BERiAvSW1hZ2VCIC9UZXh0IF0KL0ZvbnQ8PC9Db3VyaWVyIDUgMCBSIC9IZWx2ZXRpY2EtQm9sZCA2IDAgUiAvSGVsdmV0aWNhIDcgMCBSIC9UaW1lcy1Sb21hbiA4IDAgUiAvVGltZXMtSXRhbGljIDkgMCBSIC9IZWx2ZXRpY2EtT2JsaXF1ZSAxMCAwIFIgPj4KL1hPYmplY3Q8PC9GbTAxIDExIDAgUiA+PgovRW5jb2RpbmcgMiAwIFIKPj4KZW5kb2JqCjEzIDAgb2JqCjw8Ci9UeXBlIC9QYWdlCi9QYXJlbnQgICAgICAgICAgMyAwIFIKL1Jlc291cmNlcyAxMiAwIFIKL01lZGlhQm94IFswIDAgNjEyIDEwMDhdCi9Db250ZW50cyAxNCAwIFIKPj4KZW5kb2JqCjE0IDAgb2JqCjw8L0xlbmd0aCAxNSAwIFIgL0ZpbHRlciAvRmxhdGVEZWNvZGU+PgpzdHJlYW0KeNoz0DMwNzIwMFAAQV0DBM/QwMBCITmXl0vfLdfAUMElH8hyzi8tykwtUjA0tlAISePlAgB23A0eCmVuZHN0cmVhbQplbmRvYmoKMTUgMCBvYmoKNTcKZW5kb2JqCjQgMCBvYmoKPDwKL0NvdW50IDAKPj4KZW5kb2JqCjMgMCBvYmoKPDwKL1R5cGUgL1BhZ2VzCi9LaWRzIFsxMyAwIFIgXQovQ291bnQgMQo+PgplbmRvYmoKeHJlZgowIDE2CjAwMDAwMDAwMDAgNjU1MzUgZiAKMDAwMDAwMDA1NSAwMDAwMCBuIAowMDAwMDAwMTIwIDAwMDAwIG4gCjAwMDAwMDY4NzEgMDAwMDAgbiAKMDAwMDAwNjg0MSAwMDAwMCBuIAowMDAwMDAxNjcwIDAwMDAwIG4gCjAwMDAwMDE3NzEgMDAwMDAgbiAKMDAwMDAwMTg4NiAwMDAwMCBuIAowMDAwMDAxOTkxIDAwMDAwIG4gCjAwMDAwMDIxMDAgMDAwMDAgbiAKMDAwMDAwMjIxMSAwMDAwMCBuIAowMDAwMDAyMzMzIDAwMDAwIG4gCjAwMDAwMDYzNTAgMDAwMDAgbiAKMDAwMDAwNjU3NCAwMDAwMCBuIAowMDAwMDA2NjkxIDAwMDAwIG4gCjAwMDAwMDY4MjIgMDAwMDAgbiAKdHJhaWxlcgo8PAovU2l6ZSAxNgovUm9vdCAxIDAgUgo+PgpzdGFydHhyZWYKNjkzMAolJUVPRgo=
+    http_version: 
+  recorded_at: Sat, 15 Feb 2020 16:40:15 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Description of change
This PR updates the Jenkins parallel RSpec run so that the `modules` directory is included  in the spec run, turns out they weren't being run with the previous `parallel_specs` implementation`. Additionally, this adds back the code-climate reporting that was in the previous implementation

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/6303


