### PR TITLE
Changes facilities response on invalid zip

### DIFF
--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/facility_suggestion_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/facility_suggestion_service.rb
@@ -21,7 +21,7 @@ module CovidVaccine
       # return a list of nearby facilities based on provided zipcode
       def facilities_for(zipcode, count = 3)
         zcta_row = ZCTA[zipcode&.[](0...5)]
-        raise Common::Exceptions::UnprocessableEntity.new(detail: 'Invalid ZIP Code') if zcta_row.blank?
+        return [] if zcta_row.blank?
 
         lat = zcta_row[ZCTA_LAT_HEADER]
         lng = zcta_row[ZCTA_LON_HEADER]

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/facilities_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/facilities_request_spec.rb
@@ -70,9 +70,11 @@ RSpec.describe 'Covid Vaccine Facilities', type: :request do
                          match_requests_on: %i[method path], &example)
       end
 
-      it 'returns a 4xx error' do
+      it 'returns an empty list' do
         get "/covid_vaccine/v0/facilities/#{non_existent_zip}"
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body['data'].length).to eq(0)
       end
     end
 


### PR DESCRIPTION
## Description of change
Per agreement with frontend engineers, switching to return a 200 with an empty result for an unknown zip code. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR

Tested locally. 
```
curl http://localhost:3000/covid_vaccine/v0/facilities/00000

{"data":[]}
```