### PR TITLE
Adds audit log line to vaccine controller

### DIFF
--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/expanded_registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/expanded_registration_controller.rb
@@ -13,7 +13,7 @@ module CovidVaccine
         raw_form_data = params[:registration]
         record = CovidVaccine::V0::ExpandedRegistrationSubmission.create!({ submission_uuid: SecureRandom.uuid,
                                                                             raw_form_data: raw_form_data })
-
+        audit_log(raw_form_data)
         CovidVaccine::ExpandedRegistrationEmailJob.perform_async(record.id)
         render json: record, serializer: CovidVaccine::V0::ExpandedRegistrationSerializer, status: :created
       end
@@ -27,6 +27,17 @@ module CovidVaccine
 
       def check_flipper
         routing_error unless Flipper.enabled?(:covid_vaccine_registration_expanded)
+      end
+
+      def audit_log(raw_form_data)
+        log_attrs = {
+          applicant_type: raw_form_data[:applicant_type],
+          country_name: raw_form_data[:country_name],
+          state_code: raw_form_data[:state_code],
+          preferred_facility: raw_form_data[:preferred_facility],
+          has_email: raw_form_data[:email_address].present?
+        }
+        Rails.logger.info('Covid_Vaccine Expanded_Submission', log_attrs)
       end
     end
   end

--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/expanded_registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/expanded_registration_controller.rb
@@ -35,9 +35,10 @@ module CovidVaccine
           country_name: raw_form_data[:country_name],
           state_code: raw_form_data[:state_code],
           preferred_facility: raw_form_data[:preferred_facility],
-          has_email: raw_form_data[:email_address].present?
+          has_email: raw_form_data[:email_address].present?,
+          sms_acknowledgement: raw_form_data[:sms_acknowledgement]
         }
-        Rails.logger.info('Covid_Vaccine Expanded_Submission', log_attrs)
+        Rails.logger.info('Covid_Vaccine Expanded_Submission', log_attrs.to_json)
       end
     end
   end

--- a/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
+++ b/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
@@ -70,7 +70,7 @@ FactoryBot.define do
           'city' => 'Manila',
           'state_code' => 'Ermita',
           'zip_code' => '1000',
-          'country' => 'Philippines'
+          'country_name' => 'Philippines'
         }
       }
     end

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
       it 'logs an audit record with appropriate applicant type' do
         allow(Rails.logger).to receive(:info)
         expect(Rails.logger).to receive(:info).with('Covid_Vaccine Expanded_Submission',
-                                                    hash_including(applicant_type: 'veteran'))
+                                                    /"applicant_type":"veteran"/)
         post '/covid_vaccine/v0/expanded_registration', params: { registration: registration_attributes }
       end
     end
@@ -190,7 +190,7 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
       it 'logs an audit record with appropriate applicant type' do
         allow(Rails.logger).to receive(:info)
         expect(Rails.logger).to receive(:info).with('Covid_Vaccine Expanded_Submission',
-                                                    hash_including(applicant_type: 'spouse'))
+                                                    /"applicant_type":"spouse"/)
         post '/covid_vaccine/v0/expanded_registration', params: { registration: registration_attributes }
       end
     end

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
 
   let(:registration_attributes) do
     {
+      applicant_type: 'veteran',
       first_name: 'Jane',
       last_name: 'Doe',
       birth_date: '1952-02-02',
@@ -162,6 +163,13 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
         expect { post '/covid_vaccine/v0/expanded_registration', params: { registration: registration_attributes } }
           .to change(CovidVaccine::ExpandedRegistrationEmailJob.jobs, :size).by(1)
       end
+
+      it 'logs an audit record with appropriate applicant type' do
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with('Covid_Vaccine Expanded_Submission',
+                                                    hash_including(applicant_type: 'veteran'))
+        post '/covid_vaccine/v0/expanded_registration', params: { registration: registration_attributes }
+      end
     end
 
     context 'with a spouse submission' do
@@ -177,6 +185,13 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
       it 'records the submission for processing' do
         expect { post '/covid_vaccine/v0/expanded_registration', params: { registration: registration_attributes } }
           .to change(CovidVaccine::V0::ExpandedRegistrationSubmission, :count).by(1)
+      end
+
+      it 'logs an audit record with appropriate applicant type' do
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with('Covid_Vaccine Expanded_Submission',
+                                                    hash_including(applicant_type: 'spouse'))
+        post '/covid_vaccine/v0/expanded_registration', params: { registration: registration_attributes }
       end
     end
   end


### PR DESCRIPTION
## Description of change
Adds an audit log line to covid vaccine expanded registration controller. Logs limited attributes suitable for aggregation in Cloudwatch Insights or similar. 

## Original issue(s)

## Things to know about this PR
* No PII - attributes are limited to country/state/applicant_type/preferred facility/presence or absence of email address.