### PR TITLE
uses VANotify template for expanded registration

### DIFF
--- a/modules/covid_vaccine/app/jobs/covid_vaccine/expanded_registration_email_job.rb
+++ b/modules/covid_vaccine/app/jobs/covid_vaccine/expanded_registration_email_job.rb
@@ -17,7 +17,7 @@ module CovidVaccine
       return if submission.email_confirmation_id.present?
 
       notify_client = VaNotify::Service.new(Settings.vanotify.services.va_gov.api_key)
-      template_id = Settings.vanotify.services.va_gov.template_id.covid_vaccine_registration
+      template_id = Settings.vanotify.services.va_gov.template_id.covid_vaccine_expanded_registration
       email_address = submission.raw_form_data[:email]
 
       notify_response = notify_client.send_email(email_address: email_address, template_id: template_id,

--- a/modules/covid_vaccine/app/jobs/covid_vaccine/expanded_registration_email_job.rb
+++ b/modules/covid_vaccine/app/jobs/covid_vaccine/expanded_registration_email_job.rb
@@ -18,7 +18,7 @@ module CovidVaccine
 
       notify_client = VaNotify::Service.new(Settings.vanotify.services.va_gov.api_key)
       template_id = Settings.vanotify.services.va_gov.template_id.covid_vaccine_expanded_registration
-      email_address = submission.raw_form_data[:email_address]
+      email_address = submission.raw_form_data['email_address']
 
       notify_response = notify_client.send_email(email_address: email_address, template_id: template_id,
                                                  personalisation: { 'date' => formatted_date(submission.created_at),

--- a/modules/covid_vaccine/app/jobs/covid_vaccine/expanded_registration_email_job.rb
+++ b/modules/covid_vaccine/app/jobs/covid_vaccine/expanded_registration_email_job.rb
@@ -18,7 +18,7 @@ module CovidVaccine
 
       notify_client = VaNotify::Service.new(Settings.vanotify.services.va_gov.api_key)
       template_id = Settings.vanotify.services.va_gov.template_id.covid_vaccine_expanded_registration
-      email_address = submission.raw_form_data[:email]
+      email_address = submission.raw_form_data[:email_address]
 
       notify_response = notify_client.send_email(email_address: email_address, template_id: template_id,
                                                  personalisation: { 'date' => formatted_date(submission.created_at),

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
@@ -19,7 +19,6 @@ module CovidVaccine
         reg.raw_form_data&.symbolize_keys!
       end
 
-
       attr_encrypted :form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller
       attr_encrypted :raw_form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller
       attr_encrypted :eligibility_info, key: Settings.db_encryption_key, marshal: true,

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
@@ -15,10 +15,6 @@ module CovidVaccine
         reg.form_data&.symbolize_keys!
       end
 
-      after_find do |reg|
-        reg.raw_form_data&.symbolize_keys!
-      end
-
       attr_encrypted :form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller
       attr_encrypted :raw_form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller
       attr_encrypted :eligibility_info, key: Settings.db_encryption_key, marshal: true,

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
@@ -15,6 +15,11 @@ module CovidVaccine
         reg.form_data&.symbolize_keys!
       end
 
+      after_find do |reg|
+        reg.raw_form_data&.symbolize_keys!
+      end
+
+
       attr_encrypted :form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller
       attr_encrypted :raw_form_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller
       attr_encrypted :eligibility_info, key: Settings.db_encryption_key, marshal: true,

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
@@ -147,7 +147,6 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
 
       it 'returns a submission summary' do
         post '/covid_vaccine/v0/expanded_registration', params: { registration: registration_attributes }
-
         expect(response).to have_http_status(:created)
         body = JSON.parse(response.body)
         expect(body['data']['id']).to eq('')

--- a/spec/support/vcr_cassettes/covid_vaccine/vanotify/send_email.yml
+++ b/spec/support/vcr_cassettes/covid_vaccine/vanotify/send_email.yml
@@ -6,7 +6,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"email_address":"vets.gov.user+0@gmail.com","template_id":"999edcfa-5b8a-4322-ada7-4ab60baf66d3","personalisation":{"date":"March
-        29, 2021 4:10 p.m. UTC","confirmation_id":"0b946c9e-3441-4fd1-a15c-d30804ce2784"},"reference":"0b946c9e-3441-4fd1-a15c-d30804ce2784"}'
+        29, 2021 4:43 p.m. UTC","confirmation_id":"3f3fdeb6-9d65-4503-89c4-43a223515581"},"reference":"3f3fdeb6-9d65-4503-89c4-43a223515581"}'
     headers:
       Accept:
       - "*/*"
@@ -24,7 +24,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Mon, 29 Mar 2021 16:10:25 GMT
+      - Mon, 29 Mar 2021 16:43:50 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -75,8 +75,8 @@ http_interactions:
         COVID-19 vaccine plans. If someone forwarded this email to you, you can [sign
         up to receive future updates](https://www.va.gov/health-care/covid-19-vaccine/stay-informed/?utm_source=VANotify&utm_medium=email&utm_campaign=covid_19_vaccine).\r\n\r\nPlease
         don\u2019t reply to this email. If you need to contact us, go to https://www.va.gov.","subject":"Thank
-        you for signing up for COVID-19 vaccine updates"},"id":"6b4a71ed-68c7-4c8e-809d-a57193b12ed5","reference":"0b946c9e-3441-4fd1-a15c-d30804ce2784","scheduled_for":null,"template":{"id":"999edcfa-5b8a-4322-ada7-4ab60baf66d3","uri":"https://staging.api.notifications.va.gov/services/5e5cded3-3c76-46a3-9eef-cb63589e76be/templates/999edcfa-5b8a-4322-ada7-4ab60baf66d3","version":7},"uri":"https://staging.api.notifications.va.gov/v2/notifications/6b4a71ed-68c7-4c8e-809d-a57193b12ed5"}
+        you for signing up for COVID-19 vaccine updates"},"id":"a4bf29d9-7543-486d-bc31-934b95cfe7e3","reference":"3f3fdeb6-9d65-4503-89c4-43a223515581","scheduled_for":null,"template":{"id":"999edcfa-5b8a-4322-ada7-4ab60baf66d3","uri":"https://staging.api.notifications.va.gov/services/5e5cded3-3c76-46a3-9eef-cb63589e76be/templates/999edcfa-5b8a-4322-ada7-4ab60baf66d3","version":7},"uri":"https://staging.api.notifications.va.gov/v2/notifications/a4bf29d9-7543-486d-bc31-934b95cfe7e3"}
 
         '
-  recorded_at: Mon, 29 Mar 2021 16:10:25 GMT
+  recorded_at: Mon, 29 Mar 2021 16:43:50 GMT
 recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/covid_vaccine/vanotify/send_email.yml
+++ b/spec/support/vcr_cassettes/covid_vaccine/vanotify/send_email.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://localhost:2005/v2/notifications/email
     body:
       encoding: UTF-8
-      string: '{"email_address":"vets.gov.user+0@gmail.com","template_id":"9fd3fd52-5205-4fd1-bd98-1ddbef54bc44","personalisation":{"date":"2021-03-26
-        21:46:03 UTC","confirmation_id":"3efbfe9d-7441-4851-bdbe-11fffdc13c76"},"reference":"3efbfe9d-7441-4851-bdbe-11fffdc13c76"}'
+      string: '{"email_address":"vets.gov.user+0@gmail.com","template_id":"999edcfa-5b8a-4322-ada7-4ab60baf66d3","personalisation":{"date":"March
+        29, 2021 4:10 p.m. UTC","confirmation_id":"0b946c9e-3441-4fd1-a15c-d30804ce2784"},"reference":"0b946c9e-3441-4fd1-a15c-d30804ce2784"}'
     headers:
       Accept:
       - "*/*"
@@ -14,7 +14,8 @@ http_interactions:
       - application/json
       User-Agent:
       - NOTIFY-API-RUBY-CLIENT/5.1.2
-      Authorization: "<BEARER_TOKEN>"
+      Authorization:
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -23,11 +24,11 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 26 Mar 2021 21:46:03 GMT
+      - Mon, 29 Mar 2021 16:10:25 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '4300'
+      - '3336'
       Server:
       - gunicorn/20.0.4
       Access-Control-Allow-Origin:
@@ -42,53 +43,40 @@ http_interactions:
       - None
     body:
       encoding: UTF-8
-      string: '{"content":{"body":"# We''ve received your information\n\nThank you
-        for signing up to stay informed about COVID-19 vaccines at VA. When we have
-        new information to share about our COVID-19 plans and your vaccine options,
-        we''ll send you updates by email or text.\n\nYour local VA health facility
-        may also use the information you provided to determine when to contact you
-        about getting a vaccine once your risk group becomes eligible. If you told
-        us you plan to get a vaccine, your facility may contact you sooner. You can
-        always change your mind about getting a vaccine. And you can submit a new
-        form to update your information at any time.\n\n__Note for caregivers:__ If
-        you\u2019re a designated primary or secondary caregiver in the Program of
-        Comprehensive Assistance for Family Caregivers, your facility will tell you
-        when you can get a vaccine at the same time as the Veteran you care for.\n\n__You
-        should know:__\n- To get a vaccine at VA, Veterans must be already receiving
-        health care at VA. If you don\u2019t\u00a0receive care at VA now, [find out
-        if you''re eligible for VA health care and how to apply](https://www.va.gov/health-care/how-to-apply).\n-
-        To get a vaccine at VA, family caregivers must be enrolled in our [Program
-        of Comprehensive Assistance for Family Caregivers](https://www.va.gov/family-member-benefits/comprehensive-assistance-for-family-caregivers/).
-        Caregivers are eligible for a vaccine when the Veteran they care for becomes
-        eligible for one.\n- You can change your mind about getting a vaccine at any
-        time. If you want to learn more before you decide:\n[Get answers to common
-        questions about COVID-19 vaccines at VA](https://www.va.gov/health-care/covid-19-vaccine/)\n[Get
-        more facts about COVID-19 vaccines from the Centers for Disease Control and
-        Prevention (CDC)](https://www.cdc.gov/coronavirus/2019-ncov/vaccines/facts.html)\n[Read
-        about one VA nurse\u2019s decision to get a COVID-19 vaccine](https://blogs.va.gov/VAntage/83031/va-nurse-tuskegee-daughter-urges-veterans-learn-vaccines/)\n\n##
-        How will VA contact me when I can get a COVID-19 vaccine?\nYour local VA health
-        facility may contact you by phone, email, or text message. If you\u2019re
-        eligible and want to get a vaccine, we encourage you to respond.\n\nBut before
-        you provide any personal information or click on any links, be sure the call,
-        email, or text is really from VA.\n- Text messages will always come from __53079__.\n-
-        Emails will always come from a __va.gov__ email address.\n- If someone calls
-        you from VA and you don\u2019t recognize the phone number, ask for a number
-        to call them back. Then call your local VA health facility to verify. \n\nYour
-        facility may invite you to get a vaccine in different ways:\n- They may invite
-        you to a large vaccination event, like a drive-thru clinic.\n- They may offer
-        you a specific date and time to get a vaccine.\n- They may ask you to schedule
-        an appointment.\n\n__Please know:__ By sharing your plans for getting a vaccine,
-        you help us better plan our efforts. But we\u2019ll still contact every eligible
-        Veteran in each risk group to ask if they want to get a vaccine. You don\u2019t
-        need to call or come to a VA facility to request or reserve a vaccine. \n\n---\nYou\u2019re
+      string: '{"content":{"body":"# Thank you for signing up\r\nThank you for signing
+        up to stay informed about COVID-19 vaccines at VA. When we have new information
+        to share about our COVID-19 plans and your vaccine options, we''ll send you
+        updates by email or text.\r\n\r\n## When can I get a COVID-19 vaccine at VA?\r\nAt
+        this time, we still have a limited amount of vaccines.\u00a0We\u2019re working
+        to determine how quickly we can begin to offer vaccines to\u00a0people other
+        than Veterans who are already enrolled in VA health care.\u00a0We\u00a0appreciate
+        your patience as we\u00a0prepare to offer more vaccines.\r\n\r\nYour employer,
+        pharmacy, healthcare provider\u2019s office, or local public health officials
+        may offer you a COVID-19 vaccine. We encourage you to take the first opportunity
+        you have to get a vaccine at the most convenient location for you.\r\n\r\nIf
+        you\u2019re a Veteran who\u2019s not currently receiving health care through
+        VA,\u00a0[find out if you''re eligible for VA health care and how to apply](https://www.va.gov/health-care/how-to-apply/?utm_source=VANotify&utm_medium=email&utm_campaign=covid_19_vaccine).\r\n__Note:__
+        We\u2019ll contact you when you can get a vaccine. You don\u2019t need to
+        call or go in person to a VA health facility.\r\n\r\n## How will VA contact
+        me when I can get a COVID-19 vaccine?\r\nYour closest VA health facility may
+        contact you by phone, email, or text message. If you\u2019re eligible and
+        want to get a vaccine, we encourage you to respond.\r\n\r\nBut before you
+        provide any personal information or click on any links, be sure the call,
+        email, or text is really from VA.\r\n- Text messages will always come from
+        __53079__.\r\n- Emails will always come from a __va.gov__ email address.\r\n-
+        If someone calls you from VA and you don\u2019t recognize the phone number,
+        ask for a number to call them back. Then call your local VA health facility
+        to verify.\r\n\r\nYour facility may invite you to get a vaccine in different
+        ways:\r\n- They may invite you to a large vaccination event, like a drive-thru
+        clinic.\r\n- They may offer you a specific date and time to get a vaccine.\r\n-
+        They may ask you to schedule an appointment.\r\n\r\nYou can also get updates
+        and answers to common questions on our main [COVID-19 vaccines page](https://www.va.gov/health-care/covid-19-vaccine/?utm_source=VANotify&utm_medium=email&utm_campaign=covid_19_vaccine).\r\n\r\n---\r\nYou\u2019re
         getting this email because you signed up on VA.gov to get updates about our
         COVID-19 vaccine plans. If someone forwarded this email to you, you can [sign
-        up to receive future updates](https://www.va.gov/health-care/covid-19-vaccine/stay-informed).\n\nIf
-        you don\u2019t want to get these emails anymore, [you can unsubscribe at any
-        time](https://www.va.gov/health-care/covid-19-vaccine/stay-informed/unsubscribe?sid=3efbfe9d-7441-4851-bdbe-11fffdc13c76).\n\nPlease
-        don\u2019t reply to this email. If you need to contact us, go to [https://www.va.gov](https://www.va.gov).","subject":"Thank
-        you for signing up for COVID-19 vaccine updates"},"id":"b6bcef48-2eb0-42dc-a56c-0457c69ba530","reference":"3efbfe9d-7441-4851-bdbe-11fffdc13c76","scheduled_for":null,"template":{"id":"9fd3fd52-5205-4fd1-bd98-1ddbef54bc44","uri":"https://staging.api.notifications.va.gov/services/5e5cded3-3c76-46a3-9eef-cb63589e76be/templates/9fd3fd52-5205-4fd1-bd98-1ddbef54bc44","version":21},"uri":"https://staging.api.notifications.va.gov/v2/notifications/b6bcef48-2eb0-42dc-a56c-0457c69ba530"}
+        up to receive future updates](https://www.va.gov/health-care/covid-19-vaccine/stay-informed/?utm_source=VANotify&utm_medium=email&utm_campaign=covid_19_vaccine).\r\n\r\nPlease
+        don\u2019t reply to this email. If you need to contact us, go to https://www.va.gov.","subject":"Thank
+        you for signing up for COVID-19 vaccine updates"},"id":"6b4a71ed-68c7-4c8e-809d-a57193b12ed5","reference":"0b946c9e-3441-4fd1-a15c-d30804ce2784","scheduled_for":null,"template":{"id":"999edcfa-5b8a-4322-ada7-4ab60baf66d3","uri":"https://staging.api.notifications.va.gov/services/5e5cded3-3c76-46a3-9eef-cb63589e76be/templates/999edcfa-5b8a-4322-ada7-4ab60baf66d3","version":7},"uri":"https://staging.api.notifications.va.gov/v2/notifications/6b4a71ed-68c7-4c8e-809d-a57193b12ed5"}
 
         '
-  recorded_at: Fri, 26 Mar 2021 21:46:03 GMT
+  recorded_at: Mon, 29 Mar 2021 16:10:25 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
[Commit 1606376](https://github.com/department-of-veterans-affairs/devops/commit/16063769de866ae15a8f42a9d7a3201fc52bdbbb) added template IDs for the new registration email for expanded eligibility.

This commit fixes the `expanded_registration_email_job` (added in #6295) to use the new template ID, instead of the old registration template ID.
