### PR TITLE
only run simplecov exceptions in CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ unless ENV['NOCOVERAGE']
   require 'simplecov'
 
   SimpleCov.start 'rails' do
-    track_files '**/{app,lib}/**/*.rb'
+    # track_files '**/{app,lib}/**/*.rb'
 
     add_filter 'app/controllers/concerns/accountable.rb'
     add_filter 'app/models/in_progress_disability_compensation_form.rb'
@@ -68,8 +68,10 @@ unless ENV['NOCOVERAGE']
     add_group 'VeteranVerification', 'modules/veteran_verification/'
     # End Modules
 
-    SimpleCov.minimum_coverage_by_file 90 unless ENV['CIRCLE_JOB']
-    SimpleCov.refuse_coverage_drop unless ENV['CIRCLE_JOB']
+    if ENV['CI']
+      SimpleCov.minimum_coverage_by_file 90
+      SimpleCov.refuse_coverage_drop
+    end
   end
 end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Hotfix for SimpleCov reporting errors. Only want these to report in CI otherwise running single file specs locally will cause these to throw
