### PR TITLE
Added v2 validation documentation route.

### DIFF
--- a/modules/openid_auth/README_V2.yml
+++ b/modules/openid_auth/README_V2.yml
@@ -1,0 +1,147 @@
+openapi: '3.0.0'
+info:
+  version: 0.0.1
+  title: Validation
+  description: |
+    Oauth Validation for internal 3rd Party Services
+
+    ## Background
+
+
+
+    ## Design
+
+    ### Authorization
+
+    API requests are authorized using a Bearer token issued through an OpenID
+    Connect service to allow third-party applications. The token should be
+    submitted as an `Authorization` header in the form `Bearer <token>`.
+
+    ### Token Validation Request
+
+    Allows a third-party application to request the validated token along with actor and launch characteristics:
+
+    1. Client Request: POST https://api.va.gov/internal/auth/v2/validation
+       * Provide the Bearer token as a header: `Authorization: Bearer <token>`
+       * Provide a body parameter for appropriate audience for validation
+         aud: https://api.va.gov/services/fhir
+
+    2. Status Response: A JSON API object with the individual's validated token and VA identifier ICN
+
+    ## Reference
+
+    Raw Open API Spec: http://sandbox-api.va.gov/internal/auth/docs/v2/validation
+
+  termsOfService: ''
+  contact:
+    name: VA.gov
+tags:
+  - name: validated_token
+    description: Oauth Validation for internal 3rd Party Services
+servers:
+  - url: https://sandbox-api.va.gov/internal/auth/{version}
+    description: VA.gov API sandbox environment
+    variables:
+      version:
+        default: v2
+  - url: https://api.va.gov/internal/auth/{version}
+    description: VA.gov API production environment
+    variables:
+      version:
+        default: v2
+paths:
+  /validation:
+    post:
+      tags:
+        - validated_token
+      summary: Get confirmation of a validated token and VA identifier ICN
+      operationId: getValidatedToken
+      security:
+        - bearer_token: []
+      responses:
+        '200':
+          description: Validated token successfully retrieved
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/components/schemas/ValidatedToken'
+        '404':
+          description: Auth service responded that data for token was not found
+        '502':
+          description: Auth service responded with something other than the necessary information
+components:
+  securitySchemes:
+    bearer_token:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    ValidatedToken:
+      description: |
+        Validated token for internal API providers
+      type: object
+      properties:
+        id:
+          type: string
+          description: Valid token JTI
+          example: "AT.MAt1vXM4AsglMo7LvOwyQpoUbLWVQEk3Ab3bJfmb4c8"
+        type:
+          type: string
+          example: validated_token
+        attributes:
+          type: object
+          properties:
+            ver:
+              type: integer
+              description: |
+                Okta API version number.
+            jti:
+              type: string
+              description: |
+                JWT generated ID for the user.
+            iss:
+              type: string
+              description: |
+                Matches the identifier of your Okta Authorization Server.
+            aud:
+              type: string
+              description: |
+                Should match the Client ID that you used to request the ID Token
+            iat:
+              type: integer
+              description: |
+                Indicates when this ID token was issued, expressed in Unix time.
+            exp:
+              type: integer
+              description: |
+                Is the time at which this token will expire., expressed in Unix time. You should make sure that this time has not already passed.
+            cid:
+              type: string
+              description: |
+                Consumer ID
+            uid:
+              type: string
+              description: |
+                User ID
+            scp:
+              type: array
+              description: |
+                Includes the different scopes that the user has access to within the approved application.
+              items:
+                type: string
+            sub:
+              type: string
+              description: |
+                The subject ID from either a group or individual, can be an email address.
+            act:
+              type: object
+              description: |
+                Different VA Identifiers corresponding to acting user including ICN, SEC_ID, etc.
+            launch:
+              type: object
+              description: |
+                Different VA Identifiers corresponding to the target user including ICN

--- a/modules/openid_auth/app/controllers/openid_auth/docs/v2/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/docs/v2/validation_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module OpenidAuth
+  module Docs
+    module V2
+      class ValidationController < ApplicationController
+        skip_before_action(:authenticate)
+
+        def index
+          swagger = YAML.safe_load(File.read(OpenidAuth::Engine.root.join('README_V2.yml')))
+          render json: swagger
+        end
+      end
+    end
+  end
+end

--- a/modules/openid_auth/config/routes.rb
+++ b/modules/openid_auth/config/routes.rb
@@ -21,5 +21,8 @@ OpenidAuth::Engine.routes.draw do
     namespace :v1, defaults: { format: 'json' } do
       get 'validation', to: 'validation#index'
     end
+    namespace :v2, defaults: { format: 'json' } do
+      get 'validation', to: 'validation#index'
+    end
   end
 end


### PR DESCRIPTION
## Description of change
API-4750 adds a V2 token validation endpoint for Lighthouse API's to support SSOi and Client Credentials auth scenarios where different identifiers were needed for the responses.

https://community.max.gov/display/VAExternal/Token+Validation+v2

Main PR: https://github.com/department-of-veterans-affairs/vets-api/pull/6359

## Original issue(s)
https://vajira.max.gov/browse/API-4750

## Things to know about this PR
- This is a new V2 endpoint that will not interfere with existing validation endpoint calls
- Testing includes unit testing and local testing with standard auth code, client credentials, and SSOi based access tokens