### PR TITLE
21961 add person type field from mpi

### DIFF
--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -45,6 +45,7 @@ FactoryBot.define do
     ssn { Faker::IDNumber.valid.delete('-') }
     address { build(:mvi_profile_address) }
     home_phone { Faker::PhoneNumber.phone_number }
+    person_type_code { 'Patient' }
     full_mvi_ids {
       [
         '1000123456V123456^NI^200M^USVHA^P',

--- a/spec/lib/mpi/responses/profile_parser_spec.rb
+++ b/spec/lib/mpi/responses/profile_parser_spec.rb
@@ -143,7 +143,7 @@ describe MPI::Responses::ProfileParser do
           gender: 'M',
           birth_date: '19901004',
           ssn: '999123456',
-          home_phone: nil,
+          home_phone: '1112223333',
           icn: nil,
           icn_with_aaid: nil,
           historical_icns: ['1008691087V194812'],
@@ -153,11 +153,14 @@ describe MPI::Responses::ProfileParser do
           mhv_ids: [],
           active_mhv_ids: [],
           vha_facility_ids: [],
+          cerner_id: nil,
+          cerner_facility_ids: [],
           edipi: nil,
           participant_id: nil,
           birls_id: nil,
           birls_ids: [],
           search_token: 'WSDOC2005221733165441605720989',
+          person_type_code: 'Dependent',
           relationships: [mpi_profile_relationship_component]
         )
       end
@@ -165,7 +168,7 @@ describe MPI::Responses::ProfileParser do
       let(:mpi_profile_relationship_component) do
         build(
           :mpi_profile_relationship,
-          person_type_code: nil,
+          person_type_code: [],
           given_names: %w[Mark],
           family_name: 'Webb',
           suffix: 'Jr',
@@ -282,7 +285,8 @@ describe MPI::Responses::ProfileParser do
           '0001234567^PN^200PROV^USDVA^A',
           '123412345^PI^200BRLS^USVBA^A'
         ],
-        search_token: 'WSDOC1611060614456041732180196'
+        search_token: 'WSDOC1611060614456041732180196',
+        person_type_code: 'Patient'
       )
     end
 

--- a/spec/lib/mpi/service_spec.rb
+++ b/spec/lib/mpi/service_spec.rb
@@ -31,6 +31,7 @@ describe MPI::Service do
       birls_ids: ['796122306'],
       historical_icns: nil,
       icn_with_aaid: icn_with_aaid,
+      person_type_code: [],
       full_mvi_ids: [
         '1008714701V416111^NI^200M^USVHA^P',
         '796122306^PI^200BRLS^USVBA^A',

--- a/spec/support/mpi/find_candidate_missing_attrs_response.xml
+++ b/spec/support/mpi/find_candidate_missing_attrs_response.xml
@@ -72,6 +72,12 @@
                     <value nullFlavor="NA" xsi:type="INT"/>
                   </queryMatchObservation>
                 </subjectOf1>
+                <subjectOf2 typeCode="SBJ">
+                  <administrativeObservation classCode="VERIF">
+                    <code codeSystem="2.16.840.1.113883.4.349" code="PERSON_TYPE" displayName="Person Type"/>
+                    <value xsi:type="CD" code="PAT" displayName="Patient"/>
+                  </administrativeObservation>
+                </subjectOf2>
               </patient>
             </subject1>
             <custodian typeCode="CST">

--- a/spec/support/mpi/find_candidate_missing_name_response.xml
+++ b/spec/support/mpi/find_candidate_missing_name_response.xml
@@ -87,6 +87,12 @@
                     <value value="162" xsi:type="INT"/>
                   </queryMatchObservation>
                 </subjectOf1>
+                <subjectOf2 typeCode="SBJ">
+                  <administrativeObservation classCode="VERIF">
+                    <code codeSystem="2.16.840.1.113883.4.349" code="PERSON_TYPE" displayName="Person Type"/>
+                    <value xsi:type="CD" code="PAT" displayName="Patient"/>
+                  </administrativeObservation>
+                </subjectOf2>
               </patient>
             </subject1>
             <custodian typeCode="CST">

--- a/spec/support/mpi/find_candidate_multiple_mhv_response.xml
+++ b/spec/support/mpi/find_candidate_multiple_mhv_response.xml
@@ -81,6 +81,12 @@
                     <value value="169" xsi:type="INT"/>
                   </queryMatchObservation>
                 </subjectOf1>
+                <subjectOf2 typeCode="SBJ">
+                  <administrativeObservation classCode="VERIF">
+                    <code codeSystem="2.16.840.1.113883.4.349" code="PERSON_TYPE" displayName="Person Type"/>
+                    <value xsi:type="CD" code="PAT" displayName="Patient"/>
+                  </administrativeObservation>
+                </subjectOf2>
               </patient>
             </subject1>
             <custodian typeCode="CST">

--- a/spec/support/mpi/find_candidate_response.xml
+++ b/spec/support/mpi/find_candidate_response.xml
@@ -101,6 +101,12 @@
                     <value value="162" xsi:type="INT"/>
                   </queryMatchObservation>
                 </subjectOf1>
+                <subjectOf2 typeCode="SBJ">
+                  <administrativeObservation classCode="VERIF">
+                    <code codeSystem="2.16.840.1.113883.4.349" code="PERSON_TYPE" displayName="Person Type"/>
+                    <value xsi:type="CD" code="PAT" displayName="Patient"/>
+                  </administrativeObservation>
+                </subjectOf2>
               </patient>
             </subject1>
             <custodian typeCode="CST">

--- a/spec/support/mpi/find_candidate_response_nil_address.xml
+++ b/spec/support/mpi/find_candidate_response_nil_address.xml
@@ -92,6 +92,12 @@
                     <value value="162" xsi:type="INT"/>
                   </queryMatchObservation>
                 </subjectOf1>
+                <subjectOf2 typeCode="SBJ">
+                  <administrativeObservation classCode="VERIF">
+                    <code codeSystem="2.16.840.1.113883.4.349" code="PERSON_TYPE" displayName="Person Type"/>
+                    <value xsi:type="CD" code="PAT" displayName="Patient"/>
+                  </administrativeObservation>
+                </subjectOf2>
               </patient>
             </subject1>
             <custodian typeCode="CST">

--- a/spec/support/mpi/find_candidate_valid_response.xml
+++ b/spec/support/mpi/find_candidate_valid_response.xml
@@ -80,6 +80,12 @@
                     <value value="169" xsi:type="INT"/>
                   </queryMatchObservation>
                 </subjectOf1>
+                <subjectOf2 typeCode="SBJ">
+                  <administrativeObservation classCode="VERIF">
+                    <code codeSystem="2.16.840.1.113883.4.349" code="PERSON_TYPE" displayName="Person Type"/>
+                    <value xsi:type="CD" code="PAT" displayName="Patient"/>
+                  </administrativeObservation>
+                </subjectOf2>
               </patient>
             </subject1>
             <custodian typeCode="CST">

--- a/spec/support/mpi/find_candidate_with_relationship_response.xml
+++ b/spec/support/mpi/find_candidate_with_relationship_response.xml
@@ -54,6 +54,7 @@
                     <family>LITTLE</family>
                     <suffix>JR</suffix>
                   </name>
+                  <telecom value="1112223333" use="HP"/>
                   <administrativeGenderCode code="M"/>
                   <birthTime value="19901004"/>
                   <multipleBirthInd value="false"/>


### PR DESCRIPTION

## Description of change
This PR parses Person Type from an MPI Response. Currently it isn't being used on the frontend, and we don't yet propagate this to the `User` model, so this is just in the Profile Parsing logic

## Original issue(s)
department-of-veterans-affairs/va.gov-team/issues/21961

## Things to know about this PR
- To test this, will have to set a `binding.pry` somewhere after the MPI Response has been returned
- A good place is probably when we create the `MPIData` object: `app/models/mpi_data.rb`, breakpoint somewhere in the `self.for_user` function

