### PR TITLE
Revert "removes redundant User getter methods [#5411]"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,10 +65,6 @@ class User < Common::RedisStore
     identity.first_name || (mhv_icn.present? ? mpi&.profile&.given_names&.first : nil)
   end
 
-  def first_name_mpi
-    mpi&.profile&.given_names&.first
-  end
-
   def full_name_normalized
     {
       first: first_name&.capitalize,
@@ -90,16 +86,8 @@ class User < Common::RedisStore
     identity.last_name || (mhv_icn.present? ? mpi&.profile&.family_name : nil)
   end
 
-  def last_name_mpi
-    mpi&.profile&.family_name
-  end
-
   def gender
     identity.gender || (mhv_icn.present? ? mpi&.profile&.gender : nil)
-  end
-
-  def gender_mpi
-    mpi&.profile&.gender
   end
 
   # Returns a Date string in iso8601 format, eg. '{year}-{month}-{day}'
@@ -136,10 +124,6 @@ class User < Common::RedisStore
 
   def ssn
     identity.ssn || (mhv_icn.present? ? mpi&.profile&.ssn : nil)
-  end
-
-  def ssn_mpi
-    mpi&.profile&.ssn
   end
 
   def mhv_correlation_id
@@ -181,10 +165,6 @@ class User < Common::RedisStore
 
   def edipi
     loa3? && dslogon_edipi.present? ? dslogon_edipi : mpi&.edipi
-  end
-
-  def edipi_mpi
-    mpi&.profile&.edipi
   end
 
   def sec_id

--- a/lib/evss/disability_compensation_auth_headers.rb
+++ b/lib/evss/disability_compensation_auth_headers.rb
@@ -31,14 +31,14 @@ module EVSS
     end
 
     def gender
-      case @user.gender || @user.gender_mpi
+      case @user.gender || @user.mpi&.profile&.gender
       when 'F'
         'FEMALE'
       when 'M'
         'MALE'
       else
         Raven.extra_context(user_gender: @user.gender,
-                            mvi_gender: @user.gender_mpi)
+                            mvi_gender: @user.mpi&.profile&.gender)
         raise Common::Exceptions::UnprocessableEntity,
               detail: 'Gender is required & must be "F" or "M"',
               source: self.class,

--- a/modules/vaos/app/models/vaos/appointment_form.rb
+++ b/modules/vaos/app/models/vaos/appointment_form.rb
@@ -99,8 +99,8 @@ module VAOS
 
     def name
       {
-        first_name: @user.first_name_mpi,
-        last_name: @user.last_name_mpi
+        first_name: @user.mpi&.profile&.given_names&.first,
+        last_name: @user.mpi&.profile&.family_name
       }
     end
   end

--- a/modules/vaos/app/models/vaos/appointment_request_form.rb
+++ b/modules/vaos/app/models/vaos/appointment_request_form.rb
@@ -82,17 +82,17 @@ module VAOS
     # These values ought to be derived from MVI vs user input, except for inpatient and text_messaging_allowed
     def patient=(values_hash)
       @patient = {
-        display_name: "#{@user.last_name_mpi}, #{@user.first_name_mpi}",
-        first_name: @user.first_name_mpi,
-        last_name: @user.last_name_mpi,
+        display_name: "#{last_name}, #{first_name}",
+        first_name: first_name,
+        last_name: last_name,
         date_of_birth: birth_date,
         patient_identifier: {
-          unique_id: @user.edipi_mpi
+          unique_id: edipi
         },
-        ssn: @user.ssn_mpi,
+        ssn: ssn,
         inpatient: values_hash[:inpatient],
         text_messaging_allowed: values_hash[:text_messaging_allowed],
-        id: @user.edipi_mpi,
+        id: edipi,
         object_type: 'Patient'
       }.compact
     end
@@ -133,8 +133,24 @@ module VAOS
       }
     end
 
+    def first_name
+      @user.mpi&.profile&.given_names&.first
+    end
+
+    def last_name
+      @user.mpi&.profile&.family_name
+    end
+
     def birth_date
       Formatters::DateFormatter.format_date(@user.birth_date, :month_day_year)
+    end
+
+    def edipi
+      @user.mpi&.profile&.edipi
+    end
+
+    def ssn
+      @user.mpi&.profile&.ssn
     end
   end
 end

--- a/modules/vaos/app/services/vaos/jwt_wrapper.rb
+++ b/modules/vaos/app/services/vaos/jwt_wrapper.rb
@@ -24,11 +24,11 @@ module VAOS
     def payload
       {
         authenticated: true,
-        sub: user.icn,
+        sub: icn,
         idType: ID_TYPE,
         iss: ISS,
-        firstName: user.first_name_mpi,
-        lastName: user.last_name_mpi,
+        firstName: first_name,
+        lastName: last_name,
         authenticationAuthority: AUTHORITY,
         jti: SecureRandom.uuid,
         nbf: 1.minute.ago.to_i,
@@ -38,13 +38,25 @@ module VAOS
         gender: gender,
         dob: parsed_date,
         dateOfBirth: parsed_date,
-        edipid: user.edipi_mpi,
-        ssn: user.ssn_mpi
+        edipid: edipi,
+        ssn: ssn
       }
     end
 
+    def icn
+      user.icn
+    end
+
+    def first_name
+      user.mpi&.profile&.given_names&.first
+    end
+
+    def last_name
+      user.mpi&.profile&.family_name
+    end
+
     def gender
-      type = user.gender_mpi
+      type = user.mpi&.profile&.gender
       return '' unless type.is_a?(String)
 
       case type.upcase[0, 1]
@@ -57,6 +69,14 @@ module VAOS
 
     def parsed_date
       Formatters::DateFormatter.format_date(user.birth_date, :number_iso8601)
+    end
+
+    def edipi
+      user.mpi&.profile&.edipi
+    end
+
+    def ssn
+      user.mpi&.profile&.ssn
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -358,35 +358,6 @@ RSpec.describe User, type: :model do
         end
       end
 
-      context 'explicit MPI getter methods' do
-        let(:mvi_profile) { build(:mvi_profile) }
-        let(:user) { build(:user, :loa3, middle_name: 'J', mhv_icn: mvi_profile.icn) }
-
-        before do
-          stub_mpi(mvi_profile)
-        end
-
-        it 'fetches first_name from MPI' do
-          expect(user.first_name_mpi).to be(user.mpi.profile.given_names.first)
-        end
-
-        it 'fetches last_name from MPI' do
-          expect(user.last_name_mpi).to be(user.mpi.profile.family_name)
-        end
-
-        it 'fetches gender from MPI' do
-          expect(user.gender_mpi).to be(user.mpi.profile.gender)
-        end
-
-        it 'fetches edipi from MPI' do
-          expect(user.edipi_mpi).to be(user.mpi.profile.edipi)
-        end
-
-        it 'fetches ssn from MPI' do
-          expect(user.ssn_mpi).to be(user.mpi.profile.ssn)
-        end
-      end
-
       context 'when saml user attributes NOT available, icn is available, and user LOA3' do
         let(:mvi_profile) { build(:mvi_profile) }
         let(:user) { build(:user, :loa3, :mhv_sign_in, mhv_icn: mvi_profile.icn) }


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#6206

When this was merged, specs had been inadvertently disabled in modules. Once they were re-enabled, this is now causing tests to break.