### PR TITLE
updates the mvi.rake task to support generating a csv in staging

### DIFF
--- a/rakelib/mvi.rake
+++ b/rakelib/mvi.rake
@@ -81,7 +81,7 @@ middle_name="W" last_name="Smith" birth_date="1945-01-25" gender="M" ssn="555443
     end
   end
 
-  desc 'Build mock MVI yaml database for users in given CSV' do
+  desc 'Build mock MVI yaml database for users in given CSV'
   task :mock_database, [:csvfile] => [:environment] do |_, args|
     raise 'No input CSV provided' unless args[:csvfile]
 


### PR DESCRIPTION
## Description of change
Handy / useful rake task for fetching attributes in a csv format based on ICN. Can be used to stage users in ID.me and other environments, build fixtures, etc.

## Original issue(s)
None; sitting in my git stash and time to get it out of there.

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
