### PR TITLE
Suppresses zip code validation for non-US addresses

### DIFF
--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/raw_expanded_form_data.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/raw_expanded_form_data.rb
@@ -24,20 +24,20 @@ module CovidVaccine
       validates :veteran_birth_date, format: { with: /\A\d{4}-\d{2}-\d{2}\z/,
                                                message: 'should be in the form yyyy-mm-dd' }, allow_blank: true
       validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
-      # TODO: Check whether this is required or not, and if so, whether may be multi-value
-      # validates :preferred_facility, presence: true
       validates :address_line1, presence: true
       validates :city, presence: true
       validates :state_code, presence: true
-      validates :zip_code, format: { with: ZIP_REGEX, message: 'should be in the form 12345 or 12345-1234' }
-
-      # TODO: Conditional validation of veteran_ssn veteran_birth_date presence if non-veteran applicant_type
-      # TODO: Conditional validation of date_range[from] and date_range[to] if veteran appplicant_type
+      validates :zip_code, format: { with: ZIP_REGEX, message: 'should be in the form 12345 or 12345-1234' },
+                           if: :us_address?
 
       def initialize(attributes = {})
         attributes.each do |name, value|
           send("#{name}=", value) if name.to_s.in?(ATTRIBUTES)
         end
+      end
+
+      def us_address?
+        country_name == 'USA'
       end
     end
   end

--- a/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
+++ b/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
@@ -70,7 +70,34 @@ FactoryBot.define do
           'city' => 'Manila',
           'state_code' => 'Ermita',
           'zip_code' => '1000',
-          'country' => 'Philippines'
+          'country_name' => 'Philippines'
+        }
+      }
+    end
+
+    trait :canada do
+      default_raw_options {
+        {
+          'preferred_facility' => 'vha_358',
+          'address_line1' => '6393 NW Marine Dr',
+          'city' => 'Vancouver',
+          'state_code' => 'BC',
+          'zip_code' => 'V6T 1Z2',
+          'country_name' => 'Canada'
+        }
+      }
+    end
+
+    trait :mexico do
+      default_raw_options {
+        {
+          'preferred_facility' => 'vha_358',
+          'address_line1' => 'Calz Independencia 998',
+          'address_line2' => 'Centro Cívico',
+          'city' => 'Mexicali',
+          'state_code' => 'BC',
+          'zip_code' => '21000',
+          'country_name' => 'Mexico'
         }
       }
     end

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
@@ -124,15 +124,6 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
                   'pointer' => 'data/attributes/state-code'
                 },
                 'status' => '422'
-              },
-              {
-                'title' => 'Zip code should be in the form 12345 or 12345-1234',
-                'detail' => 'zip-code - should be in the form 12345 or 12345-1234',
-                'code' => '100',
-                'source' => {
-                  'pointer' => 'data/attributes/zip-code'
-                },
-                'status' => '422'
               }
             ]
           }
@@ -177,6 +168,26 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
       it 'records the submission for processing' do
         expect { post '/covid_vaccine/v0/expanded_registration', params: { registration: registration_attributes } }
           .to change(CovidVaccine::V0::ExpandedRegistrationSubmission, :count).by(1)
+      end
+    end
+
+    context 'with non-US submissions' do
+      it 'accepts a Canada address' do
+        attrs = build(:covid_vax_expanded_registration, :canada).raw_form_data.symbolize_keys
+        post '/covid_vaccine/v0/expanded_registration', params: { registration: attrs }
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'accepts a Mexico address' do
+        attrs = build(:covid_vax_expanded_registration, :mexico).raw_form_data.symbolize_keys
+        post '/covid_vaccine/v0/expanded_registration', params: { registration: attrs }
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'accepts a Phillipines address' do
+        attrs = build(:covid_vax_expanded_registration, :non_us).raw_form_data.symbolize_keys
+        post '/covid_vaccine/v0/expanded_registration', params: { registration: attrs }
+        expect(response).to have_http_status(:created)
       end
     end
   end

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
@@ -190,5 +190,12 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
         expect(response).to have_http_status(:created)
       end
     end
+
+    it 'accepts submission with a nil country' do
+      attrs = build(:covid_vax_expanded_registration,
+                    raw_options: { 'country_name' => nil }).raw_form_data.symbolize_keys
+      post '/covid_vaccine/v0/expanded_registration', params: { registration: attrs }
+      expect(response).to have_http_status(:created)
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Updates covid vaccine expanded submission endpoint to only enforce zip/zip+4 format for USA addresses.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR

<!-- Please describe testing done to verify the changes or any testing planned. -->
