### PR TITLE
Updates Gemfile.lock update missed in PR #6334

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ PATH
       sidekiq
     vaos (0.1.0)
       sidekiq
-    vba_documents (0.0.1)
+    vba_documents (1.0.0)
       aws-sdk-s3 (~> 1)
       sidekiq
     veteran (0.0.1)


### PR DESCRIPTION
## Description of change
Commits Gemfile.lock update that was omitted from https://github.com/department-of-veterans-affairs/vets-api/pull/6334

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
