### PR TITLE
Switches log parameters to hash instead of JSON

### DIFF
--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/expanded_registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/expanded_registration_controller.rb
@@ -38,7 +38,7 @@ module CovidVaccine
           has_email: raw_form_data[:email_address].present?,
           sms_acknowledgement: raw_form_data[:sms_acknowledgement]
         }
-        Rails.logger.info('Covid_Vaccine Expanded_Submission', log_attrs.to_json)
+        Rails.logger.info('Covid_Vaccine Expanded_Submission', log_attrs)
       end
     end
   end

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
       it 'logs an audit record with appropriate applicant type' do
         allow(Rails.logger).to receive(:info)
         expect(Rails.logger).to receive(:info).with('Covid_Vaccine Expanded_Submission',
-                                                    /"applicant_type":"veteran"/)
+                                                    hash_including(applicant_type: 'veteran'))
         post '/covid_vaccine/v0/expanded_registration', params: { registration: registration_attributes }
       end
     end
@@ -190,7 +190,7 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
       it 'logs an audit record with appropriate applicant type' do
         allow(Rails.logger).to receive(:info)
         expect(Rails.logger).to receive(:info).with('Covid_Vaccine Expanded_Submission',
-                                                    /"applicant_type":"spouse"/)
+                                                    hash_including(applicant_type: 'spouse'))
         post '/covid_vaccine/v0/expanded_registration', params: { registration: registration_attributes }
       end
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Switches audit log parameters to hash - this shows up in Cloudwatch more nicely, without the extraneous backslashes from escaping JSON output.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR

<!-- Please describe testing done to verify the changes or any testing planned. -->
