### PR TITLE
Api 6002 - evidence_submissions#create to return s3 url

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -199,6 +199,10 @@ modules_appeals_api:
         - laura.trager@adhocteam.us
         - nathan.wright@oddball.io
   schema_dir: config/schemas
+  evidence_submissions:
+    location:
+      prefix: http://some.fakesite.com/path
+      replacement: http://another.fakesite.com/rewrittenpath
   s3:
     uploads_enabled: false
     aws_access_key_id: "aws_access_key_id"

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -22,7 +22,8 @@ AppealsApi::Engine.routes.draw do
       end
       namespace :notice_of_disagreements do
         get 'contestable_issues', to: 'contestable_issues#index'
-        resources :evidence_submissions, only: %i[create show]
+        resources :evidence_submissions, only: %i[show]
+        put 'evidence_submissions', to: 'evidence_submissions#create'
       end
       resources :notice_of_disagreements, only: %i[create show] do
         collection do


### PR DESCRIPTION
## Description of change
Refactoring the EvidenceSubmission create endpoint to not take in a document, but to return an s3 location url.

Pushing this PR to get the ok that this is in fact the url we are looking for, and that we want to do the same url rewrite as vba docs.

Will be pulling this all into an upload submission model like vba docs