### PR TITLE
Allow nil name in PTSD trauma form

### DIFF
--- a/lib/pdf_fill/forms/va210781a.rb
+++ b/lib/pdf_fill/forms/va210781a.rb
@@ -260,7 +260,7 @@ module PdfFill
         overflow_sources = []
 
         sources.each do |source|
-          overflow = source['name'] + " \n " + combine_full_address(source['address'])
+          overflow = "#{source['name']} \n #{combine_full_address(source['address'])}"
           overflow_sources.push(overflow)
         end
 

--- a/spec/support/disability_compensation_form/submissions/with_0781.json
+++ b/spec/support/disability_compensation_form/submissions/with_0781.json
@@ -280,6 +280,10 @@
                 "country": "USA",
                 "postalCode": "21200-1111"
               }
+            },
+            {
+              "address":
+              {"country":"USA"}
             }
           ]
         }


### PR DESCRIPTION

## Description of change
`nil + "string"` errors so use  "#{nil} string"

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22439

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
