### PR TITLE
Adds index for state column for covid vax table

### DIFF
--- a/db/migrate/20210401071242_add_covid_vaccine_expanded_state_index.rb
+++ b/db/migrate/20210401071242_add_covid_vaccine_expanded_state_index.rb
@@ -1,0 +1,7 @@
+class AddCovidVaccineExpandedStateIndex < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :covid_vaccine_expanded_registration_submissions, :state, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_30_170327) do
+ActiveRecord::Schema.define(version: 2021_04_01_071242) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -241,6 +241,7 @@ ActiveRecord::Schema.define(version: 2021_03_30_170327) do
     t.index ["encrypted_eligibility_info_iv"], name: "index_covid_vaccine_expanded_on_el_iv", unique: true
     t.index ["encrypted_form_data_iv"], name: "index_covid_vaccine_expanded_on_form_iv", unique: true
     t.index ["encrypted_raw_form_data_iv"], name: "index_covid_vaccine_expanded_on_raw_iv", unique: true
+    t.index ["state"], name: "index_covid_vaccine_expanded_registration_submissions_on_state"
     t.index ["submission_uuid"], name: "index_covid_vaccine_expanded_on_submission_id", unique: true
     t.index ["vetext_sid"], name: "index_covid_vaccine_expanded_on_vetext_sid", unique: true
   end


### PR DESCRIPTION
## Description of change
Adds an index on the state column of the covid_vaccine_expanded_registration_submission table. The need for this was observed when implementing https://github.com/department-of-veterans-affairs/vets-api/pull/6392 which batch processes records according to their current state. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/22490

## Things to know about this PR
* Given the number of columns in this table currently, this is not a drop-everything-and-deploy kind of schema change, but it will be increasingly important as that table grows.

* Tested locally, confirmed that without the index the where(state: received) query was doing a seq scan; with the index it is doing an index scan. 
