### PR TITLE
Remove Unnecessary Require in Test

### DIFF
--- a/spec/request/v1/facilities/va_request_spec.rb
+++ b/spec/request/v1/facilities/va_request_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'rspec-instrumentation-matcher'
 
 RSpec.shared_examples 'paginated request from params with expected IDs' do |request_params, ids, mobile = nil|
   let(:params) { request_params }


### PR DESCRIPTION
[Added this `require` to help CI/CD pass](https://github.com/department-of-veterans-affairs/vets-api/pull/6391), but it shouldn't be necessary ([other tests that use `instrument` method don't need it](https://github.com/department-of-veterans-affairs/vets-api/pull/6391#issuecomment-811617928)), _also_ I don't even think this require works (running that line locally on my comp later returned `false`) **therefore I'm removing it**