### PR TITLE
Removing success from monitoring

### DIFF
--- a/modules/vba_documents/app/workers/vba_documents/slack_notifier.rb
+++ b/modules/vba_documents/app/workers/vba_documents/slack_notifier.rb
@@ -60,7 +60,8 @@ module VBADocuments
     end
 
     def long_flyers_alert
-      alert_on = fetch_stuck_in_state(UploadSubmission::IN_FLIGHT_STATUSES, @in_flight_hungtime, :days)
+      statuses = UploadSubmission::IN_FLIGHT_STATUSES - ['success']
+      alert_on = fetch_stuck_in_state(statuses, @in_flight_hungtime, :days)
       text = 'ALERT - GUIDS in flight for too long! (Top 10 shown)\n'
       alert(alert_on, text)
     end

--- a/modules/vba_documents/spec/jobs/slack_notifier_spec.rb
+++ b/modules/vba_documents/spec/jobs/slack_notifier_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'VBADocuments::SlackNotifier', type: :job do
   context 'long_flyers only' do
     before do
       u = VBADocuments::UploadSubmission.new
-      status = 'success'
+      status = 'received'
       u.status = status
       u.save!
       u.metadata['status'][status]['start'] = 5.years.ago.to_i


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Removing success status from slack alerts

## Original issue(s)
https://vajira.max.gov/browse/API-6104

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
RSPEC testing updated.