### PR TITLE
bump typhoeus to the latest minor verison

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -876,7 +876,7 @@ GEM
       sync
     trollop (1.16.2)
     ttfunk (1.5.1)
-    typhoeus (1.3.1)
+    typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the typhoeus gem (default group) to the latest minor version. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

https://github.com/typhoeus/typhoeus/blob/master/CHANGELOG.md

## Original issue(s)
department-of-veterans-affairs/va.gov-team##22278


## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 