### PR TITLE
Updating Doc Type for 674

### DIFF
--- a/app/workers/vbms/submit_dependents_pdf_job.rb
+++ b/app/workers/vbms/submit_dependents_pdf_job.rb
@@ -36,7 +36,7 @@ module VBMS
 
     def generate_pdf(claim, submittable_686, submittable_674)
       claim.upload_pdf('686C-674') if submittable_686
-      claim.upload_pdf('21-674', doc_type: '143') if submittable_674
+      claim.upload_pdf('21-674', doc_type: '142') if submittable_674
     end
   end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
When submitting VA Form 674, we upload a PDF and currently it is using the doc type referencing Form 674b.  During integration testing, we were asked to update the doc type to reference Form 674 rather than 674b.  

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22488

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is just a minor PR to update the doc type code being used, so no new settings or logging have been added.

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] Local testing
- [x] Staging testing planned