### PR TITLE
Save questionnaire response to DB

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -18,6 +18,8 @@ reports:
     region: region
     secret_access_key: secret
 
+db_encryption_key: f01ff8ebd1a2b053ad697ae1f0d86adb
+
 saml:
   cert_path: spec/support/certificates/ruby-saml.crt
   key_path: spec/support/certificates/ruby-saml.key

--- a/db/migrate/20210331131558_create_questionnaire_responses.health_quest.rb
+++ b/db/migrate/20210331131558_create_questionnaire_responses.health_quest.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# This migration comes from health_quest (originally 20210330134533)
+
+class CreateQuestionnaireResponses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :health_quest_questionnaire_responses do |t|
+      t.string :user_uuid, :appointment_id, :questionnaire_response_id
+      t.string :encrypted_questionnaire_response_data
+      t.string :encrypted_questionnaire_response_data_iv
+      t.string :encrypted_user_demographics_data
+      t.string :encrypted_user_demographics_data_iv
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210331131559_add_index_to_health_quest_questionnaire_responses_fields.health_quest.rb
+++ b/db/migrate/20210331131559_add_index_to_health_quest_questionnaire_responses_fields.health_quest.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexToHealthQuestQuestionnaireResponsesFields < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :health_quest_questionnaire_responses, [:user_uuid, :questionnaire_response_id], unique: true, algorithm: :concurrently, name: 'find_by_user_qr'
+  end
+end

--- a/db/migrate/20210331131560_add_index_to_health_quest_questionnaire_responses_encrypted_questionnaire_response_data_iv.health_quest.rb
+++ b/db/migrate/20210331131560_add_index_to_health_quest_questionnaire_responses_encrypted_questionnaire_response_data_iv.health_quest.rb
@@ -1,0 +1,7 @@
+class AddIndexToHealthQuestQuestionnaireResponsesEncryptedQuestionnaireResponseDataIv < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :health_quest_questionnaire_responses, :encrypted_questionnaire_response_data_iv, unique: true, algorithm: :concurrently, name: 'qr_key'
+  end
+end

--- a/db/migrate/20210331131561_add_index_to_health_quest_questionnaire_responses_encrypted_user_demographics_data_iv.health_quest.rb
+++ b/db/migrate/20210331131561_add_index_to_health_quest_questionnaire_responses_encrypted_user_demographics_data_iv.health_quest.rb
@@ -1,0 +1,7 @@
+class AddIndexToHealthQuestQuestionnaireResponsesEncryptedUserDemographicsDataIv < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :health_quest_questionnaire_responses, :encrypted_user_demographics_data_iv, unique: true, algorithm: :concurrently, name: 'user_demographics_key'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -465,6 +465,21 @@ ActiveRecord::Schema.define(version: 2021_04_01_071242) do
     t.string "timestamp"
   end
 
+  create_table "health_quest_questionnaire_responses", force: :cascade do |t|
+    t.string "user_uuid"
+    t.string "appointment_id"
+    t.string "questionnaire_response_id"
+    t.string "encrypted_questionnaire_response_data"
+    t.string "encrypted_questionnaire_response_data_iv"
+    t.string "encrypted_user_demographics_data"
+    t.string "encrypted_user_demographics_data_iv"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["encrypted_questionnaire_response_data_iv"], name: "qr_key", unique: true
+    t.index ["encrypted_user_demographics_data_iv"], name: "user_demographics_key", unique: true
+    t.index ["user_uuid", "questionnaire_response_id"], name: "find_by_user_qr", unique: true
+  end
+
   create_table "id_card_announcement_subscriptions", id: :serial, force: :cascade do |t|
     t.string "email", null: false
     t.datetime "created_at", null: false
@@ -670,10 +685,10 @@ ActiveRecord::Schema.define(version: 2021_04_01_071242) do
     t.datetime "checkout_time"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "services"
     t.string "id_type"
     t.string "loa"
     t.string "account_type"
-    t.text "services"
     t.uuid "idme_uuid"
   end
 

--- a/modules/health_quest/app/models/health_quest/questionnaire_response.rb
+++ b/modules/health_quest/app/models/health_quest/questionnaire_response.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json_marshal/marshaller'
+
 module HealthQuest
   ##
   # An ActiveRecord object for modeling and persisting questionnaire response and user demographics data to the DB.

--- a/modules/health_quest/app/models/health_quest/questionnaire_response.rb
+++ b/modules/health_quest/app/models/health_quest/questionnaire_response.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module HealthQuest
+  ##
+  # An ActiveRecord object for modeling and persisting questionnaire response and user demographics data to the DB.
+  #
+  # @!attribute appointment_id
+  #   @return [String]
+  # @!attribute user_uuid
+  #   @return [String]
+  # @!attribute questionnaire_response_id
+  #   @return [String]
+  # @!attribute questionnaire_response_data
+  #   @return [String]
+  # @!attribute user_demographics_data
+  #   @return [String]
+  # @!attribute user
+  #   @return [User]
+  class QuestionnaireResponse < ApplicationRecord
+    attr_accessor :user
+
+    attr_encrypted :questionnaire_response_data,
+                   key: Settings.db_encryption_key,
+                   marshal: true,
+                   marshaler: JsonMarshal::Marshaller
+    attr_encrypted :user_demographics_data,
+                   key: Settings.db_encryption_key,
+                   marshal: true,
+                   marshaler: JsonMarshal::Marshaller
+
+    validates :questionnaire_response_data, presence: true
+
+    before_save :set_user_demographics
+
+    private
+
+    def set_user_demographics
+      demographics = {
+        first_name: user.first_name,
+        middle_name: user.middle_name,
+        last_name: user.last_name,
+        gender: user.gender,
+        address: user.address,
+        vas_contact_info: user.vet360_contact_info
+      }
+
+      self.user_demographics_data = demographics
+    end
+  end
+end

--- a/modules/health_quest/spec/models/questionnaire_response_spec.rb
+++ b/modules/health_quest/spec/models/questionnaire_response_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::QuestionnaireResponse do
+  subject { described_class.new }
+
+  let(:user) do
+    double(
+      'User',
+      icn: '1008596379V859838',
+      account_uuid: 'abc123',
+      uuid: '789defg',
+      first_name: 'Foo',
+      middle_name: 'Baz',
+      last_name: 'Bar',
+      gender: 'M',
+      address: '221B Baker Street',
+      vet360_contact_info: {}
+    )
+  end
+
+  describe 'object initialization' do
+    it 'responds to appointment_id' do
+      expect(subject.respond_to?(:appointment_id)).to eq(true)
+    end
+
+    it 'responds to user_uuid' do
+      expect(subject.respond_to?(:user_uuid)).to eq(true)
+    end
+
+    it 'responds to questionnaire_response_id' do
+      expect(subject.respond_to?(:questionnaire_response_id)).to eq(true)
+    end
+
+    it 'responds to questionnaire_response_data' do
+      expect(subject.respond_to?(:questionnaire_response_data)).to eq(true)
+    end
+
+    it 'responds to user_demographics_data' do
+      expect(subject.respond_to?(:user_demographics_data)).to eq(true)
+    end
+
+    it 'responds to user' do
+      expect(subject.respond_to?(:user)).to eq(true)
+    end
+  end
+
+  describe 'validations' do
+    it 'is not valid without questionnaire_response_data' do
+      subject.questionnaire_response_data = nil
+
+      expect(subject.valid?).to eq(false)
+    end
+
+    it 'is valid with questionnaire_response_data' do
+      subject.questionnaire_response_data = { 'foo' => 'bar' }
+
+      expect(subject.valid?).to eq(true)
+    end
+  end
+
+  describe 'encryption' do
+    before do
+      subject.user = user
+      subject.questionnaire_response_data = { 'foo' => 'bar' }
+      subject.save
+      subject.reload
+    end
+
+    it 'encrypts questionnaire_response_data' do
+      expect(subject.encrypted_questionnaire_response_data).to be_a(String)
+    end
+
+    it 'encrypts user_demographics_data' do
+      expect(subject.encrypted_user_demographics_data).to be_a(String)
+    end
+  end
+
+  describe 'before_save' do
+    before do
+      subject.user = user
+      subject.questionnaire_response_data = { 'foo' => 'bar' }
+      subject.save
+      subject.reload
+    end
+
+    it 'returns the user_demographics_data' do
+      hash = {
+        'first_name' => 'Foo',
+        'middle_name' => 'Baz',
+        'last_name' => 'Bar',
+        'gender' => 'M',
+        'address' => '221B Baker Street',
+        'vas_contact_info' => {}
+      }
+
+      expect(subject.user_demographics_data).to eq(hash)
+    end
+  end
+end

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -54,6 +54,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       expect(factory.respond_to?(:aggregated_data)).to eq(true)
       expect(factory.respond_to?(:patient)).to eq(true)
       expect(factory.respond_to?(:questionnaires)).to eq(true)
+      expect(factory.respond_to?(:questionnaire_response)).to eq(true)
       expect(factory.respond_to?(:save_in_progress)).to eq(true)
       expect(factory.respond_to?(:lighthouse_appointment_service)).to eq(true)
       expect(factory.respond_to?(:location_service)).to eq(true)
@@ -289,9 +290,14 @@ describe HealthQuest::QuestionnaireManager::Factory do
         item: []
       }
     end
+    let(:client_reply) do
+      double('FHIR::ClientReply', response: { code: '201' }, resource: double('Resource', id: '123abc'))
+    end
 
     it 'returns a ClientReply' do
       allow_any_instance_of(HealthQuest::Resource::Factory).to receive(:create).with(anything).and_return(client_reply)
+      allow_any_instance_of(HealthQuest::QuestionnaireResponse).to receive(:save)
+        .and_return(double('HealthQuest::QuestionnaireResponse'))
 
       expect(described_class.new(user).create_questionnaire_response(data)).to eq(client_reply)
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Save questionnaire response to DB
    - Created migration files to save and index QR and user demographics
    - Save QR to DB if Lighthouse post response is successful
    - Encrypt all QR and user demographics data
    - Encrypted data will be used to build a PDF for the end-user
## Original issue(s)
department-of-veterans-affairs/va.gov-team#19061

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature Flag: show_healthcare_experience_questionnaire
- [x] PII data is being encrypted in the database in the `health_quest_questionnaire_responses` table 
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec test suite passing.
- [x] Rubocop passing.
- [x] Manually tested submission of Questionnaire Response data and then compared values against new row created in the database.  