### PR TITLE
Add filenumber check for submission

### DIFF
--- a/app/controllers/v0/dependents_verifications_controller.rb
+++ b/app/controllers/v0/dependents_verifications_controller.rb
@@ -21,4 +21,3 @@ module V0
     end
   end
 end
-

--- a/app/controllers/v0/dependents_verifications_controller.rb
+++ b/app/controllers/v0/dependents_verifications_controller.rb
@@ -21,3 +21,4 @@ module V0
     end
   end
 end
+

--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -6,7 +6,9 @@ require 'vre/ch31_form'
 class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
   include SentryLogging
   FORM = '28-1900'
-  PERMITTED_OFFICE_LOCATIONS = %w[319 325 339 377].freeze
+  # We will be adding numbers here and eventually completeley removing this and the caller to open up VRE submissions
+  # to all vets
+  PERMITTED_OFFICE_LOCATIONS = %w[325].freeze
 
   validate :veteran_information, on: :prepare_form_data
 
@@ -47,7 +49,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
 
     uploader = ClaimsApi::VBMSUploader.new(
       filepath: form_path,
-      file_number: parsed_form['veteranInformation']['ssn'],
+      file_number: parsed_form['veteranInformation']['VAFileNumber'] || parsed_form['veteranInformation']['ssn'],
       doc_type: doc_type
     )
 

--- a/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
+++ b/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
@@ -59,6 +59,10 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     context 'submission to VRE' do
       before do
         expect(ClaimsApi::VBMSUploader).to receive(:new) { OpenStruct.new(upload!: true) }
+
+        # As the PERMITTED_OFFICE_LOCATIONS constant at the top of: app/models/saved_claim/veteran_readiness_employment_claim.rb
+        # gets changed you will may need to change this mock below and maybe even move it into different 'it'
+        # blocks if you need to test different routing offices
         expect_any_instance_of(BGS::RORoutingService).to receive(:get_regional_office_by_zip_code).and_return(
           { regional_office: { number: '325' } }
         )

--- a/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
+++ b/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
@@ -60,8 +60,9 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
       before do
         expect(ClaimsApi::VBMSUploader).to receive(:new) { OpenStruct.new(upload!: true) }
 
-        # As the PERMITTED_OFFICE_LOCATIONS constant at the top of: app/models/saved_claim/veteran_readiness_employment_claim.rb
-        # gets changed you will may need to change this mock below and maybe even move it into different 'it'
+        # As the PERMITTED_OFFICE_LOCATIONS constant at
+        # the top of: app/models/saved_claim/veteran_readiness_employment_claim.rb gets changed, you
+        # may need to change this mock below and maybe even move it into different 'it'
         # blocks if you need to test different routing offices
         expect_any_instance_of(BGS::RORoutingService).to receive(:get_regional_office_by_zip_code).and_return(
           { regional_office: { number: '325' } }

--- a/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
+++ b/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
       before do
         expect(ClaimsApi::VBMSUploader).to receive(:new) { OpenStruct.new(upload!: true) }
         expect_any_instance_of(BGS::RORoutingService).to receive(:get_regional_office_by_zip_code).and_return(
-          { regional_office: { number: '319' } }
+          { regional_office: { number: '325' } }
         )
       end
 


### PR DESCRIPTION
## Description of change
This PR makes changes to the CH31 form.

The CH31 form is doing a 'soft rollout' to our partner (VRE/CMS) meaning we will only send them JSON data when vets close to a certain office fill out the form. We will always send the PDF to VBMS efolder.

After a few email exchanges with our VA partners, we understood that we were starting ONLY with a certain office so this PR removes some of the others. As time goes on we'll add more office numbers (about 5 total) and then completely remove office number whitelisting altogether.

This PR also prioritizes VAFileNumber as the id to send to VBMS when submitting to eFolder. We were using SSN which would have worked the majority of the time but in those few instances that va file number is diff from SSN VBMS would have looked up a vet by file number with ssn and it would have failed. 

## Original issue(s)
No issue for this currently
# department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
* Are there additions to a `settings.yml` file? Do they vary by environment?
  * no additions
* Is there a feature flag? What is it?
  * This is not live yet
* Is there some Sentry logging that was added? What alerts are relevant?
  * None added in this PR
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
  * nope
* Are there Swagger docs that were updated?
  * none updated
* Is there any PII concerns or questions?
  * no concerns

<!-- Please describe testing done to verify the changes or any testing planned. -->
