### PR TITLE
Api 6002 - Refactor submissions#create to return submission data and signed url

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -199,6 +199,10 @@ modules_appeals_api:
         - laura.trager@adhocteam.us
         - nathan.wright@oddball.io
   schema_dir: config/schemas
+  evidence_submissions:
+    location:
+      prefix: http://some.fakesite.com/path
+      replacement: http://another.fakesite.com/rewrittenpath
   s3:
     uploads_enabled: false
     aws_access_key_id: "aws_access_key_id"

--- a/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
+++ b/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
@@ -4,8 +4,30 @@ require 'json_marshal/marshaller'
 
 module AppealsApi
   class EvidenceSubmission < ApplicationRecord
-    belongs_to :supportable, polymorphic: true
+    belongs_to :supportable, polymorphic: true, optional: true
 
     attr_encrypted(:file_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
+
+    def get_location
+      rewrite_url(signed_url(id))
+    end
+
+    private
+
+    def rewrite_url(url)
+      rewritten = url.sub!(Settings.modules_appeals_api.evidence_submissions.location.prefix,
+                           Settings.modules_appeals_api.evidence_submissions.location.replacement)
+      raise 'Unable to provide document upload location' unless rewritten
+
+      rewritten
+    end
+
+    def signed_url(id)
+      s3 = Aws::S3::Resource.new(region: Settings.modules_appeals_api.s3.region,
+                                 access_key_id: Settings.modules_appeals_api.s3.aws_access_key_id,
+                                 secret_access_key: Settings.modules_appeals_api.s3.aws_secret_access_key)
+      obj = s3.bucket(Settings.modules_appeals_api.s3.bucket).object(id)
+      obj.presigned_url(:put, {})
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Instead of taking in actual uploaded documents, we will provide the consumer with an s3 url, after creating an evidence submission instance and, when possible, linking it to an existing Appeal.

## Original issue(s)
https://vajira.max.gov/browse/API-6002

## Things to know about this PR
Tests updated in controller spec
