### PR TITLE
Adds imports for json_marshal dependency

### DIFF
--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json_marshal/marshaller'
+
 module CovidVaccine
   module V0
     class ExpandedRegistrationSubmission < ApplicationRecord

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/registration_submission.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/registration_submission.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json_marshal/marshaller'
+
 module CovidVaccine
   module V0
     class RegistrationSubmission < ApplicationRecord


### PR DESCRIPTION
## Description of change
Import json_marshal class where used for attr_encrypted. Not causing any runtime issues generally, but causes some rake tasks to break when run with Zeitwerk loader. 

Workaround is to add this require to the top of your rake task definition. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR

