### PR TITLE
Remove external 'User.va_profile' references

### DIFF
--- a/app/controllers/concerns/failed_request_loggable.rb
+++ b/app/controllers/concerns/failed_request_loggable.rb
@@ -37,7 +37,7 @@ module FailedRequestLoggable
                              end
 
     hash[:birth_date] = begin
-                          @current_user.va_profile.birth_date.to_date.iso8601
+                          @current_user.mpi_profile_birth_date.to_date.iso8601
                         rescue
                           nil
                         end

--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -256,7 +256,7 @@ module V0
       # We want to log when SSNs do not match between MVI and SAML Identity. And might take future
       # action if this appears to be happening frequently.
       if current_user.ssn_mismatch?
-        additional_context = StringHelpers.heuristics(current_user.identity.ssn, current_user.va_profile.ssn)
+        additional_context = StringHelpers.heuristics(current_user.identity.ssn, current_user.ssn_mpi)
         log_message_to_sentry(
           'SessionsController version:v0 message:SSN from MPI Lookup does not match UserIdentity cache',
           :warn,

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -341,7 +341,7 @@ module V1
       # We want to log when SSNs do not match between MVI and SAML Identity. And might take future
       # action if this appears to be happening frequently.
       if current_user.ssn_mismatch?
-        additional_context = StringHelpers.heuristics(current_user.identity.ssn, current_user.va_profile.ssn)
+        additional_context = StringHelpers.heuristics(current_user.identity.ssn, current_user.ssn_mpi)
         log_message_to_sentry(
           'SessionsController version:v1 message:SSN from MPI Lookup does not match UserIdentity cache',
           :warn,

--- a/app/models/gi_bill_feedback.rb
+++ b/app/models/gi_bill_feedback.rb
@@ -28,11 +28,10 @@ class GIBillFeedback < Common::RedisStore
     profile_data = {}
 
     if user.present?
-      va_profile = user.va_profile
       profile_data = {
         'active_ICN' => user.icn,
-        'historical_ICN' => va_profile&.historical_icns,
-        'sec_ID' => va_profile&.sec_id
+        'historical_ICN' => user.historical_icns,
+        'sec_ID' => user.sec_id_mpi
       }
     end
 

--- a/app/models/id_card_attributes.rb
+++ b/app/models/id_card_attributes.rb
@@ -20,7 +20,7 @@ class IdCardAttributes
       'state' => @user.address[:state] || '',
       'zip' => @user.address[:zip] || '',
       'email' => @user.email || '',
-      'phone' => @user.va_profile&.home_phone || '',
+      'phone' => @user.home_phone || '',
       'title38status' => title38_status_code,
       'branchofservice' => branches_of_service,
       'dischargetype' => discharge_types

--- a/app/models/mhv_account.rb
+++ b/app/models/mhv_account.rb
@@ -200,7 +200,7 @@ class MHVAccount < ApplicationRecord
     if previously_upgraded? || previously_registered?
       false
     else
-      user.va_profile.active_mhv_ids.size > 1
+      user.active_mhv_ids.size > 1
     end
   end
 
@@ -208,7 +208,7 @@ class MHVAccount < ApplicationRecord
     if previously_upgraded? || previously_registered?
       false
     else
-      (user.va_profile.mhv_ids.to_a - user.va_profile.active_mhv_ids.to_a).any?
+      (user.mhv_ids.to_a - user.active_mhv_ids.to_a).any?
     end
   end
 

--- a/app/models/mpi_data.rb
+++ b/app/models/mpi_data.rb
@@ -79,6 +79,16 @@ class MPIData < Common::RedisStore
   # @return [String] the search token
   delegate :search_token, to: :profile, allow_nil: true
 
+  # A Cerner ID
+  #
+  # @return [String] the Cerner id
+  delegate :cerner_id, to: :profile, allow_nil: true
+
+  # The user's Cerner facility ids
+  #
+  # @return [Array[String]] the the list of Cerner facility ids
+  delegate :cerner_facility_ids, to: :profile
+
   # The profile returned from the MVI service. Either returned from cached response in Redis or the MVI service.
   #
   # @return [MPI::Models::MviProfile] patient 'golden record' data from MVI

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -427,7 +427,6 @@ class User < Common::RedisStore
     email&.downcase || account_uuid
   end
 
-<<<<<<< HEAD
   def relationships
     @relationships ||= mpi_profile_relationships.map { |relationship| relationship_hash(relationship) }
   end
@@ -451,22 +450,8 @@ class User < Common::RedisStore
     mpi.profile
   end
 
-  def mpi_profile_birth_date
-    return nil unless mpi_profile
-
-    if mpi_profile.birth_date.nil?
-      Rails.logger.info "[User] Cannot find birth date from MPI profile for User with uuid: #{uuid}"
-      return nil
-    end
-
-    mpi_profile.birth_date
-  end
-
   def mpi_profile_relationships
     return [] unless mpi_profile
-=======
-  private
->>>>>>> spec updates and organizes identity & mpi getter methods
 
     mpi_profile.relationships
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,7 +93,7 @@ class User < Common::RedisStore
       first: first_name&.capitalize,
       middle: middle_name&.capitalize,
       last: last_name&.capitalize,
-      suffix: mpi_profile&.normalized_suffix
+      suffix: normalized_suffix
     }
   end
 
@@ -163,7 +163,7 @@ class User < Common::RedisStore
   end
 
   def edipi_mpi
-    mpi&.profile&.edipi
+    mpi_profile&.edipi
   end
 
   def first_name_mpi
@@ -213,6 +213,10 @@ class User < Common::RedisStore
     mpi_profile.birth_date
   end
 
+  def normalized_suffix
+    mpi_profile&.normalized_suffix
+  end
+
   def sec_id_mpi
     mpi_profile&.sec_id
   end
@@ -222,7 +226,11 @@ class User < Common::RedisStore
   end
 
   def suffix
-    mpi&.profile&.suffix
+    mpi_profile&.suffix
+  end
+
+  def mpi_profile?
+    mpi_profile != nil
   end
 
   def va_profile
@@ -235,6 +243,14 @@ class User < Common::RedisStore
 
   def va_profile_status
     mpi.status
+  end
+
+  # MPI setter methods
+
+  def set_mhv_ids(mhv_id)
+    mpi_profile.mhv_ids = [mhv_id] + mhv_ids
+    mpi_profile.active_mhv_ids = [mhv_id] + active_mhv_ids
+    recache
   end
 
   # identity attributes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,10 +62,61 @@ class User < Common::RedisStore
     pciu&.get_alternate_phone&.to_s
   end
 
-  # Identity getter methods
+  def first_name
+    identity.first_name || (mhv_icn.present? ? mpi&.profile&.given_names&.first : nil)
+  end
 
-  def birls_id
-    identity&.birls_id || mpi&.birls_id
+  def first_name_mpi
+    mpi&.profile&.given_names&.first
+  end
+
+  def full_name_normalized
+    {
+      first: first_name&.capitalize,
+      middle: middle_name&.capitalize,
+      last: last_name&.capitalize,
+      suffix: va_profile&.normalized_suffix
+    }
+  end
+
+  def ssn_normalized
+    ssn&.gsub(/[^\d]/, '')
+  end
+
+  def middle_name
+    identity.middle_name || (mhv_icn.present? ? mpi&.profile&.given_names.to_a[1..-1]&.join(' ').presence : nil)
+  end
+
+  def last_name
+    identity.last_name || (mhv_icn.present? ? mpi&.profile&.family_name : nil)
+  end
+
+  def last_name_mpi
+    mpi&.profile&.family_name
+  end
+
+  def gender
+    identity.gender || (mhv_icn.present? ? mpi&.profile&.gender : nil)
+  end
+
+  def gender_mpi
+    mpi&.profile&.gender
+  end
+
+  def given_names
+    mpi_profile&.given_names
+  end
+
+  def historical_icns
+    mpi_profile&.historical_icns
+  end
+
+  def home_phone
+    mpi_profile&.home_phone
+  end
+
+  def normalized_suffix
+    mpi_profile&.normalized_suffix
   end
 
   # Returns a Date string in iso8601 format, eg. '{year}-{month}-{day}'
@@ -81,74 +132,8 @@ class User < Common::RedisStore
       Rails.logger.info "[User] Cannot find birth date for User with uuid: #{uuid}"
       return nil
     end
+
     Formatters::DateFormatter.format_date(birth_date)
-  end
-
-  def first_name
-    identity.first_name || (mhv_icn.present? ? first_name_mpi : nil)
-  end
-
-  def full_name_normalized
-    {
-      first: first_name&.capitalize,
-      middle: middle_name&.capitalize,
-      last: last_name&.capitalize,
-      suffix: normalized_suffix
-    }
-  end
-
-  def gender
-    identity.gender || (mhv_icn.present? ? mpi&.profile&.gender : nil)
-  end
-
-  def icn
-    identity&.icn || mpi&.icn
-  end
-
-  def loa
-    identity&.loa || {}
-  end
-
-  def mhv_account_type
-    identity.mhv_account_type || MHVAccountTypeService.new(self).mhv_account_type
-  end
-
-  def mhv_correlation_id
-    identity.mhv_correlation_id || mpi.mhv_correlation_id
-  end
-
-  def middle_name
-    identity.middle_name || (mhv_icn.present? ? mpi&.profile&.given_names.to_a[1..-1]&.join(' ').presence : nil)
-  end
-
-  def last_name
-    identity.last_name || (mhv_icn.present? ? mpi&.profile&.family_name : nil)
-  end
-
-  def participant_id
-    identity&.participant_id || mpi&.participant_id
-  end
-
-  def sec_id
-    identity.sec_id || mpi_profile&.sec_id
-  end
-
-  def ssn
-    identity.ssn || (mhv_icn.present? ? mpi&.profile&.ssn : nil)
-  end
-
-  def ssn_normalized
-    ssn&.gsub(/[^\d]/, '')
-  end
-
-  def zip
-    identity.zip || (mhv_icn.present? ? mpi&.profile&.address&.postal_code : nil)
-  end
-
-  # MPI getter methods
-
-  def active_mhv_ids
-    mpi_profile&.active_mhv_ids
   end
 
   def address
@@ -162,90 +147,25 @@ class User < Common::RedisStore
     }
   end
 
-  def edipi_mpi
-    mpi_profile&.edipi
+  def zip
+    identity.zip || (mhv_icn.present? ? mpi&.profile&.address&.postal_code : nil)
   end
 
-  def first_name_mpi
-    given_names&.first
-  end
-
-  def gender_mpi
-    mpi_profile&.gender
-  end
-
-  def given_names
-    mpi_profile&.given_names
-  end
-
-  def historical_icns
-    mpi_profile&.historical_icns
-  end
-
-  def home_phone
-    mpi_profile&.home_phone
-  end
-
-  def last_name_mpi
-    mpi_profile&.family_name
-  end
-
-  def mhv_account_state
-    return 'DEACTIVATED' if (mhv_ids.to_a - active_mhv_ids.to_a).any?
-    return 'MULTIPLE' if active_mhv_ids.to_a.size > 1
-    return 'NONE' if mhv_correlation_id.blank?
-
-    'OK'
-  end
-
-  def mhv_ids
-    mpi_profile&.mhv_ids
-  end
-
-  def mpi_profile_birth_date
-    return nil unless mpi_profile
-
-    if mpi_profile.birth_date.nil?
-      Rails.logger.info "[User] Cannot find birth date from MPI profile for User with uuid: #{uuid}"
-      return nil
-    end
-
-    mpi_profile.birth_date
-  end
-
-  def normalized_suffix
-    mpi_profile&.normalized_suffix
-  end
-
-  def sec_id_mpi
-    mpi_profile&.sec_id
+  def ssn
+    identity.ssn || (mhv_icn.present? ? mpi&.profile&.ssn : nil)
   end
 
   def ssn_mpi
-    mpi_profile&.ssn
+    mpi&.profile&.ssn
   end
 
-  def suffix
-    mpi_profile&.suffix
+  def active_mhv_ids
+    mpi_profile&.active_mhv_ids
   end
 
-  def mpi_profile?
-    mpi_profile != nil
+  def mhv_correlation_id
+    identity.mhv_correlation_id || mpi.mhv_correlation_id
   end
-
-  def va_profile
-    mpi.profile
-  end
-
-  def va_profile_error
-    mpi.error
-  end
-
-  def va_profile_status
-    mpi.status
-  end
-
-  # MPI setter methods
 
   def set_mhv_ids(mhv_id)
     mpi_profile.mhv_ids = [mhv_id] + mhv_ids
@@ -253,7 +173,22 @@ class User < Common::RedisStore
     recache
   end
 
-  # identity attributes
+  def mhv_account_type
+    identity.mhv_account_type || MHVAccountTypeService.new(self).mhv_account_type
+  end
+
+  def mhv_account_state
+    return 'DEACTIVATED' if (va_profile.mhv_ids.to_a - va_profile.active_mhv_ids.to_a).any?
+    return 'MULTIPLE' if va_profile.active_mhv_ids.to_a.size > 1
+    return 'NONE' if mhv_correlation_id.blank?
+
+    'OK'
+  end
+
+  def loa
+    identity&.loa || {}
+  end
+
   delegate :multifactor, to: :identity, allow_nil: true
   delegate :authn_context, to: :identity, allow_nil: true
   delegate :mhv_icn, to: :identity, allow_nil: true
@@ -279,6 +214,42 @@ class User < Common::RedisStore
     loa3? && dslogon_edipi.present? ? dslogon_edipi : mpi&.edipi
   end
 
+  def edipi_mpi
+    mpi&.profile&.edipi
+  end
+
+  def sec_id
+    identity.sec_id || va_profile&.sec_id
+  end
+
+  def sec_id_mpi
+    mpi_profile&.sec_id
+  end
+
+  def icn
+    identity&.icn || mpi&.icn
+  end
+
+  def birls_id
+    identity&.birls_id || mpi&.birls_id
+  end
+
+  def participant_id
+    identity&.participant_id || mpi&.participant_id
+  end
+
+  def va_profile
+    mpi.profile
+  end
+
+  def va_profile_status
+    mpi.status
+  end
+
+  def va_profile_error
+    mpi.error
+  end
+
   # LOA1 no longer just means ID.me LOA1.
   # It could also be DSLogon or MHV NON PREMIUM users who have not yet done ID.me FICAM LOA3.
   # See also lib/saml/user_attributes/dslogon.rb
@@ -302,9 +273,9 @@ class User < Common::RedisStore
   end
 
   def ssn_mismatch?
-    return false unless loa3? && identity&.ssn && ssn_mpi
+    return false unless loa3? && identity&.ssn && va_profile&.ssn
 
-    identity.ssn != ssn_mpi
+    identity.ssn != va_profile.ssn
   end
 
   def can_access_user_profile?
@@ -319,7 +290,7 @@ class User < Common::RedisStore
   # User's profile contains a list of VHA facility-specific identifiers.
   # Facilities in the defined range are treating facilities
   def va_treatment_facility_ids
-    facilities = mpi_profile&.vha_facility_ids
+    facilities = va_profile&.vha_facility_ids
     facilities.to_a.select do |f|
       Settings.mhv.facility_range.any? { |range| f.to_i.between?(*range) } ||
         Settings.mhv.facility_specific.include?(f)
@@ -340,6 +311,14 @@ class User < Common::RedisStore
   def mhv_account
     @mhv_account ||= MHVAccount.find_or_initialize_by(user_uuid: uuid, mhv_correlation_id: mhv_correlation_id)
                                .tap { |m| m.user = self } # MHV account should not re-initialize use
+  end
+
+  def mhv_ids
+    mpi_profile&.mhv_ids
+  end
+
+  def suffix
+    mpi_profile&.suffix
   end
 
   def in_progress_forms
@@ -445,6 +424,21 @@ class User < Common::RedisStore
 
   def relationships
     @relationships ||= mpi_profile_relationships.map { |relationship| relationship_hash(relationship) }
+  end
+
+  def mpi_profile_birth_date
+    return nil unless mpi_profile
+
+    if mpi_profile.birth_date.nil?
+      Rails.logger.info "[User] Cannot find birth date from MPI profile for User with uuid: #{uuid}"
+      return nil
+    end
+
+    mpi_profile.birth_date
+  end
+
+  def mpi_profile?
+    mpi_profile != nil
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,12 +62,20 @@ class User < Common::RedisStore
     pciu&.get_alternate_phone&.to_s
   end
 
+  def home_phone
+    mpi&.profile&.home_phone
+  end
+
   def first_name
     identity.first_name || (mhv_icn.present? ? mpi&.profile&.given_names&.first : nil)
   end
 
   def first_name_mpi
-    mpi&.profile&.given_names&.first
+    given_names_mpi&.first
+  end
+
+  def given_names_mpi
+    mpi&.profile&.given_names
   end
 
   def full_name_normalized
@@ -140,7 +148,7 @@ class User < Common::RedisStore
   end
 
   def ssn_mpi
-    mpi&.profile&.ssn
+    mpi_profile&.ssn
   end
 
   def mhv_correlation_id
@@ -152,11 +160,19 @@ class User < Common::RedisStore
   end
 
   def mhv_account_state
-    return 'DEACTIVATED' if (va_profile.mhv_ids.to_a - va_profile.active_mhv_ids.to_a).any?
-    return 'MULTIPLE' if va_profile.active_mhv_ids.to_a.size > 1
+    return 'DEACTIVATED' if (mhv_ids.to_a - active_mhv_ids.to_a).any?
+    return 'MULTIPLE' if active_mhv_ids.to_a.size > 1
     return 'NONE' if mhv_correlation_id.blank?
 
     'OK'
+  end
+
+  def mhv_ids
+    mpi_profile&.mhv_ids
+  end
+
+  def active_mhv_ids
+    mpi_profile&.active_mhv_ids
   end
 
   def loa
@@ -175,6 +191,8 @@ class User < Common::RedisStore
   delegate :icn_with_aaid, to: :mpi
   delegate :vet360_id, to: :mpi
   delegate :search_token, to: :mpi
+  delegate :status, to: :mpi
+  delegate :error, to: :mpi
 
   # emis attributes
   delegate :military_person?, to: :veteran_status
@@ -189,11 +207,19 @@ class User < Common::RedisStore
   end
 
   def sec_id
-    identity.sec_id || va_profile&.sec_id
+    identity.sec_id || mpi_profile&.sec_id
+  end
+
+  def sec_id_mpi
+    mpi_profile&.sec_id
   end
 
   def icn
     identity&.icn || mpi&.icn
+  end
+
+  def historical_icns
+    mpi_profile&.historical_icns
   end
 
   def birls_id
@@ -256,7 +282,7 @@ class User < Common::RedisStore
   # User's profile contains a list of VHA facility-specific identifiers.
   # Facilities in the defined range are treating facilities
   def va_treatment_facility_ids
-    facilities = va_profile&.vha_facility_ids
+    facilities = mpi_profile&.vha_facility_ids
     facilities.to_a.select do |f|
       Settings.mhv.facility_range.any? { |range| f.to_i.between?(*range) } ||
         Settings.mhv.facility_specific.include?(f)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,19 +63,19 @@ class User < Common::RedisStore
   end
 
   def home_phone
-    mpi&.profile&.home_phone
+    mpi_profile&.home_phone
   end
 
   def first_name
-    identity.first_name || (mhv_icn.present? ? mpi&.profile&.given_names&.first : nil)
+    identity.first_name || (mhv_icn.present? ? first_name_mpi : nil)
   end
 
   def first_name_mpi
-    given_names_mpi&.first
+    given_names&.first
   end
 
-  def given_names_mpi
-    mpi&.profile&.given_names
+  def given_names
+    mpi_profile&.given_names
   end
 
   def full_name_normalized
@@ -100,7 +100,7 @@ class User < Common::RedisStore
   end
 
   def last_name_mpi
-    mpi&.profile&.family_name
+    mpi_profile&.family_name
   end
 
   def gender
@@ -108,7 +108,7 @@ class User < Common::RedisStore
   end
 
   def gender_mpi
-    mpi&.profile&.gender
+    mpi_profile&.gender
   end
 
   # Returns a Date string in iso8601 format, eg. '{year}-{month}-{day}'
@@ -191,10 +191,19 @@ class User < Common::RedisStore
   delegate :icn_with_aaid, to: :mpi
   delegate :vet360_id, to: :mpi
   delegate :search_token, to: :mpi
-  delegate :status, to: :mpi
-  delegate :error, to: :mpi
+  delegate :status, to: :mpi, prefix: true
+  delegate :error, to: :mpi, prefix: true
+  delegate :cerner_id, to: :mpi
+  delegate :cerner_facility_ids, to: :mpi
 
   # emis attributes
+  # def cerner_id
+  #   mpi_profile.cerner_id
+  # end
+
+  # def cerner_facility_ids
+  #   mpi_profile.cerner_facility_ids
+  # end
   delegate :military_person?, to: :veteran_status
   delegate :veteran?, to: :veteran_status
 

--- a/app/services/mhv_accounts_service.rb
+++ b/app/services/mhv_accounts_service.rb
@@ -42,9 +42,7 @@ class MHVAccountsService
         mhv_account.registered_at = Time.current
         mhv_account.mhv_correlation_id = mhv_id
         mhv_account.register!
-        user.va_profile.mhv_ids = [mhv_id] + user.mhv_ids
-        user.va_profile.active_mhv_ids = [mhv_id] + user.active_mhv_ids
-        user.recache
+        user.set_mhv_ids(mhv_id)
       end
     end
   rescue => e

--- a/app/services/mhv_accounts_service.rb
+++ b/app/services/mhv_accounts_service.rb
@@ -110,7 +110,7 @@ class MHVAccountsService
       is_veteran: user.veteran?,
       province: nil, # TODO: We need to determine if this is something that could actually happen (non USA)
       email: user.email,
-      home_phone: user.va_profile&.home_phone,
+      home_phone: user.home_phone,
       sign_in_partners: 'VA.GOV',
       terms_version: mhv_account.terms_and_conditions_accepted.terms_and_conditions.version,
       terms_accepted_date: mhv_account.terms_and_conditions_accepted.created_at

--- a/app/services/mhv_accounts_service.rb
+++ b/app/services/mhv_accounts_service.rb
@@ -42,8 +42,8 @@ class MHVAccountsService
         mhv_account.registered_at = Time.current
         mhv_account.mhv_correlation_id = mhv_id
         mhv_account.register!
-        user.va_profile.mhv_ids = [mhv_id] + user.va_profile.mhv_ids
-        user.va_profile.active_mhv_ids = [mhv_id] + user.va_profile.active_mhv_ids
+        user.va_profile.mhv_ids = [mhv_id] + user.mhv_ids
+        user.va_profile.active_mhv_ids = [mhv_id] + user.active_mhv_ids
         user.recache
       end
     end

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -102,22 +102,22 @@ module Users
     end
 
     def va_profile
-      status = user.va_profile_status
+      status = user.mpi_status
 
       if status == RESPONSE_STATUS[:ok]
         {
           status: status,
-          birth_date: user.va_profile.birth_date,
-          family_name: user.va_profile.family_name,
-          gender: user.va_profile.gender,
-          given_names: user.va_profile.given_names,
-          is_cerner_patient: !user.va_profile.cerner_id.nil?,
+          birth_date: user.mpi_profile_birth_date,
+          family_name: user.last_name_mpi,
+          gender: user.gender_mpi,
+          given_names: user.given_names,
+          is_cerner_patient: !user.cerner_id.nil?,
           facilities: user.va_treatment_facility_ids.map { |id| facility(id) },
           va_patient: user.va_patient?,
           mhv_account_state: user.mhv_account_state
         }
       else
-        scaffold.errors << Users::ExceptionHandler.new(user.va_profile_error, 'MVI').serialize_error
+        scaffold.errors << Users::ExceptionHandler.new(user.mpi_error, 'MVI').serialize_error
         nil
       end
     end
@@ -162,7 +162,7 @@ module Users
     end
 
     def facility(facility_id)
-      cerner_facility_ids = user.va_profile.cerner_facility_ids || []
+      cerner_facility_ids = user.cerner_facility_ids || []
       {
         facility_id: facility_id,
         is_cerner: cerner_facility_ids.include?(facility_id)

--- a/lib/va_profile/contact_information/transaction_response.rb
+++ b/lib/va_profile/contact_information/transaction_response.rb
@@ -74,7 +74,7 @@ module VAProfile
         return_val = super(raw_response)
         @user = user
 
-        log_mpi_error if @user.va_profile_status == Common::Client::Concerns::ServiceStatus::RESPONSE_STATUS[:ok]
+        log_mpi_error if @user.mpi_status == Common::Client::Concerns::ServiceStatus::RESPONSE_STATUS[:ok]
 
         return_val
       end

--- a/modules/openid_auth/app/controllers/openid_auth/application_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/application_controller.rb
@@ -7,7 +7,7 @@ module OpenidAuth
     skip_before_action :set_tags_and_extra_content, raise: false
 
     def validate_user
-      unless token.client_credentials_token?
+      unless token.client_credentials_token? || token.ssoi_token?
         raise Common::Exceptions::RecordNotFound, @current_user.uuid if @current_user.mpi_status == 'NOT_FOUND'
         raise Common::Exceptions::BadGateway if @current_user.mpi_status == 'SERVER_ERROR'
 

--- a/modules/openid_auth/app/controllers/openid_auth/application_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/application_controller.rb
@@ -7,9 +7,9 @@ module OpenidAuth
     skip_before_action :set_tags_and_extra_content, raise: false
 
     def validate_user
-      unless token.client_credentials_token? || token.ssoi_token?
-        raise Common::Exceptions::RecordNotFound, @current_user.uuid if @current_user.va_profile_status == 'NOT_FOUND'
-        raise Common::Exceptions::BadGateway if @current_user.va_profile_status == 'SERVER_ERROR'
+      unless token.client_credentials_token?
+        raise Common::Exceptions::RecordNotFound, @current_user.uuid if @current_user.mpi_status == 'NOT_FOUND'
+        raise Common::Exceptions::BadGateway if @current_user.mpi_status == 'SERVER_ERROR'
 
         obscure_token = Session.obscure_token(token.to_s)
         Rails.logger.info("Logged in user with id #{@session.uuid}, token #{obscure_token}")

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -163,8 +163,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
       end
     end
 
-    it 'v1 POST returns a not found when va profile returns not found', :aggregate_failures do
-      allow_any_instance_of(OpenidUser).to receive(:va_profile_status).and_return('NOT_FOUND')
+    it 'v1 POST returns a not found when mpi profile returns not found', :aggregate_failures do
+      allow_any_instance_of(OpenidUser).to receive(:mpi_status).and_return('NOT_FOUND')
       with_okta_configured do
         post '/internal/auth/v1/validation', params: nil, headers: auth_header
 
@@ -173,8 +173,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
       end
     end
 
-    it 'v1 POST returns a server error when va profile returns server error', :aggregate_failures do
-      allow_any_instance_of(OpenidUser).to receive(:va_profile_status).and_return('SERVER_ERROR')
+    it 'v1 POST returns a server error when mpi profile returns server error', :aggregate_failures do
+      allow_any_instance_of(OpenidUser).to receive(:mpi_status).and_return('SERVER_ERROR')
       with_okta_configured do
         post '/internal/auth/v1/validation', params: nil, headers: auth_header
 

--- a/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
@@ -245,8 +245,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
       end
     end
 
-    it 'v2 POST returns a not found when va profile returns not found', :aggregate_failures do
-      allow_any_instance_of(OpenidUser).to receive(:va_profile_status).and_return('NOT_FOUND')
+    it 'v2 POST returns a not found when mpi profile returns not found', :aggregate_failures do
+      allow_any_instance_of(OpenidUser).to receive(:mpi_status).and_return('NOT_FOUND')
       with_okta_configured do
         post '/internal/auth/v1/validation', params: nil, headers: auth_header
 
@@ -255,8 +255,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
       end
     end
 
-    it 'v2 POST returns a server error when va profile returns server error', :aggregate_failures do
-      allow_any_instance_of(OpenidUser).to receive(:va_profile_status).and_return('SERVER_ERROR')
+    it 'v2 POST returns a server error when mpi profile returns server error', :aggregate_failures do
+      allow_any_instance_of(OpenidUser).to receive(:mpi_status).and_return('SERVER_ERROR')
       with_okta_configured do
         post '/internal/auth/v1/validation', params: nil, headers: auth_header
 

--- a/rakelib/connectivity.rake
+++ b/rakelib/connectivity.rake
@@ -99,7 +99,7 @@ namespace :connectivity do
         }
       )
 
-      raise ConnectivityError if user.va_profile[:status] == 'SERVER_ERROR'
+      raise ConnectivityError if user.mpi_status == 'SERVER_ERROR'
     end
   end
 

--- a/rakelib/mvi.rake
+++ b/rakelib/mvi.rake
@@ -110,7 +110,7 @@ middle_name="W" last_name="Smith" birth_date="1945-01-25" gender="M" ssn="555443
         uuid: SecureRandom.uuid,
         loa: { current: LOA::THREE, highest: LOA::THREE }
       )
-      if user.va_profile.nil?
+      unless user.mpi_profile?
         puts "Row #{i} #{row['first_name']} #{row['last_name']}: No MVI profile"
         next
       end

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe V0::SessionsController, type: :controller do
 
           new_user = User.find(uuid)
           expect(new_user.ssn).to eq('796111863')
-          expect(new_user.va_profile.ssn).not_to eq('155256322')
+          expect(new_user.ssn_mpi).not_to eq('155256322')
           expect(new_user.loa).to eq(highest: LOA::THREE, current: LOA::THREE)
           expect(new_user.multifactor).to be_falsey
           expect(new_user.last_signed_in).not_to eq(existing_user.last_signed_in)

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe V1::SessionsController, type: :controller do
 
           new_user = User.find(uuid)
           expect(new_user.ssn).to eq('796111863')
-          expect(new_user.va_profile.ssn).not_to eq('155256322')
+          expect(new_user.ssn_mpi).not_to eq('155256322')
           expect(new_user.loa).to eq(highest: LOA::THREE, current: LOA::THREE)
           expect(new_user.multifactor).to be_falsey
           expect(new_user.last_signed_in).not_to eq(existing_user.last_signed_in)

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FormProfile, type: :model do
   let(:user) { build(:user, :loa3) }
 
   before do
-    user.va_profile.suffix = 'Jr.'
+    user.mpi.profile.suffix = 'Jr.'
     user.address[:country] = 'USA'
     stub_evss_pciu(user)
     described_class.instance_variable_set(:@mappings, nil)

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FormProfile, type: :model do
     {
       'first' => user.first_name&.capitalize,
       'last' => user.last_name&.capitalize,
-      'suffix' => user.va_profile[:suffix]
+      'suffix' => user.suffix
     }
   end
 
@@ -267,15 +267,15 @@ RSpec.describe FormProfile, type: :model do
       'veteranAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'city' => user.address[:city],
+        'state' => user.address[:state],
+        'country' => user.address[:country],
+        'postal_code' => user.address[:zip][0..4]
       },
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'gender' => user.gender,
       'homePhone' => us_phone,
@@ -290,7 +290,7 @@ RSpec.describe FormProfile, type: :model do
       'claimantFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'claimantSocialSecurityNumber' => user.ssn
     }
@@ -302,15 +302,15 @@ RSpec.describe FormProfile, type: :model do
       'mailingAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'city' => user.address[:city],
+        'state' => user.address[:state],
+        'country' => user.address[:country],
+        'postal_code' => user.address[:zip][0..4]
       },
       'applicantFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'applicantGender' => user.gender,
       'dayTimePhone' => us_phone,
@@ -336,15 +336,15 @@ RSpec.describe FormProfile, type: :model do
       'veteranAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'city' => user.address[:city],
+        'state' => user.address[:state],
+        'country' => user.address[:country],
+        'postal_code' => user.address[:zip][0..4]
       },
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'gender' => user.gender,
       'homePhone' => us_phone,
@@ -359,15 +359,15 @@ RSpec.describe FormProfile, type: :model do
       'relativeAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'city' => user.address[:city],
+        'state' => user.address[:state],
+        'country' => user.address[:country],
+        'postal_code' => user.address[:zip][0..4]
       },
       'relativeFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'relativeSocialSecurityNumber' => user.ssn
     }
@@ -378,15 +378,15 @@ RSpec.describe FormProfile, type: :model do
       'veteranAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'city' => user.address[:city],
+        'state' => user.address[:state],
+        'country' => user.address[:country],
+        'postal_code' => user.address[:zip][0..4]
       },
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'homePhone' => us_phone,
       'veteranSocialSecurityNumber' => user.ssn,
@@ -399,15 +399,15 @@ RSpec.describe FormProfile, type: :model do
       'veteranAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'city' => user.address[:city],
+        'state' => user.address[:state],
+        'country' => user.address[:country],
+        'postal_code' => user.address[:zip][0..4]
       },
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'homePhone' => us_phone,
       'veteranSocialSecurityNumber' => user.ssn,
@@ -420,15 +420,15 @@ RSpec.describe FormProfile, type: :model do
       'veteranAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'city' => user.address[:city],
+        'state' => user.address[:state],
+        'country' => user.address[:country],
+        'postal_code' => user.address[:zip][0..4]
       },
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'homePhone' => us_phone,
       'veteranSocialSecurityNumber' => user.ssn,
@@ -450,7 +450,7 @@ RSpec.describe FormProfile, type: :model do
       'relativeFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'relativeSocialSecurityNumber' => user.ssn,
       'relativeDateOfBirth' => user.birth_date
@@ -471,7 +471,7 @@ RSpec.describe FormProfile, type: :model do
       'relativeFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'relativeSocialSecurityNumber' => user.ssn,
       'relativeDateOfBirth' => user.birth_date
@@ -483,17 +483,17 @@ RSpec.describe FormProfile, type: :model do
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'veteranDateOfBirth' => user.birth_date,
       'email' => user.pciu_email,
       'veteranAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'city' => user.address[:city],
+        'state' => user.address[:state],
+        'country' => user.address[:country],
+        'postal_code' => user.address[:zip][0..4]
       },
       'swAsiaCombat' => true,
       'lastServiceBranch' => 'air force',
@@ -513,7 +513,7 @@ RSpec.describe FormProfile, type: :model do
       'fullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'permanentAddress' => {
         'street' => '456 ANYPLACE RD',
@@ -620,15 +620,15 @@ RSpec.describe FormProfile, type: :model do
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'veteranAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'city' => user.address[:city],
+        'state' => user.address[:state],
+        'country' => user.address[:country],
+        'postal_code' => user.address[:zip][0..4]
       },
       'gender' => user.gender,
       'dayPhone' => us_phone,
@@ -642,15 +642,15 @@ RSpec.describe FormProfile, type: :model do
       'claimantFullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'claimantAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
+        'city' => user.address[:city],
+        'state' => user.address[:state],
         'country' => 'US',
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'postal_code' => user.address[:zip][0..4]
       },
       'claimantPhone' => us_phone,
       'claimantEmail' => user.pciu_email
@@ -717,16 +717,16 @@ RSpec.describe FormProfile, type: :model do
       'address' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
+        'city' => user.address[:city],
+        'state' => user.address[:state],
         'country' => 'US',
-        'postal_code' => user.va_profile[:address][:postal_code][0..4]
+        'postal_code' => user.address[:zip][0..4]
       },
       'serviceBranch' => 'Air Force',
       'fullName' => {
         'first' => user.first_name&.capitalize,
         'last' => user.last_name&.capitalize,
-        'suffix' => user.va_profile[:suffix]
+        'suffix' => user.suffix
       },
       'applicantEmail' => user.pciu_email,
       'phone' => us_phone,
@@ -742,10 +742,10 @@ RSpec.describe FormProfile, type: :model do
       'claimantAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
-        'postalCode' => user.va_profile[:address][:postal_code][0..4]
+        'city' => user.address[:city],
+        'state' => user.address[:state],
+        'country' => user.address[:country],
+        'postal_code' => user.address[:zip][0..4]
       },
       'claimantPhoneNumber' => us_phone,
       'claimantEmailAddress' => user.pciu_email
@@ -766,10 +766,10 @@ RSpec.describe FormProfile, type: :model do
       'veteranAddress' => {
         'street' => street_check[:street],
         'street2' => street_check[:street2],
-        'city' => user.va_profile[:address][:city],
-        'state' => user.va_profile[:address][:state],
-        'country' => user.va_profile[:address][:country],
-        'postalCode' => user.va_profile[:address][:postal_code][0..4]
+        'city' => user.address[:city],
+        'state' => user.address[:state],
+        'country' => user.address[:country],
+        'postal_code' => user.address[:zip][0..4]
       },
       'mainPhone' => us_phone,
       'email' => user.pciu_email
@@ -1158,7 +1158,7 @@ RSpec.describe FormProfile, type: :model do
             'claimantFullName' => {
               'first' => user.first_name&.capitalize,
               'last' => user.last_name&.capitalize,
-              'suffix' => user.va_profile[:suffix]
+              'suffix' => user.suffix
             }
           }
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -165,8 +165,8 @@ RSpec.describe User, type: :model do
     it 'returns false if user is not loa3?' do
       allow(user).to receive(:loa3?).and_return(false)
       expect(user).not_to be_loa3
-      expect(user.identity&.ssn).to eq(user.ssn)
-      expect(user.va_profile&.ssn).to be_falsey
+      expect(user.ssn).to eq(user.ssn)
+      expect(user.ssn_mpi).to be_falsey
       expect(user).not_to be_ssn_mismatch
     end
 
@@ -175,8 +175,8 @@ RSpec.describe User, type: :model do
 
       it 'returns false' do
         expect(user).to be_loa3
-        expect(user.identity&.ssn).to be_falsey
-        expect(user.va_profile&.ssn).to be_truthy
+        expect(user.ssn).to be_falsey
+        expect(user.ssn_mpi).to be_truthy
         expect(user).not_to be_ssn_mismatch
       end
     end
@@ -186,8 +186,8 @@ RSpec.describe User, type: :model do
 
       it 'returns false' do
         expect(user).to be_loa3
-        expect(user.identity&.ssn).to be_truthy
-        expect(user.va_profile&.ssn).to be_falsey
+        expect(user.ssn).to be_truthy
+        expect(user.ssn_mpi).to be_falsey
         expect(user).not_to be_ssn_mismatch
       end
     end
@@ -197,8 +197,8 @@ RSpec.describe User, type: :model do
 
       it 'returns false if user identity ssn is nil' do
         expect(user).to be_loa3
-        expect(user.identity&.ssn).to be_truthy
-        expect(user.va_profile&.ssn).to be_truthy
+        expect(user.ssn).to be_truthy
+        expect(user.ssn_mpi).to be_truthy
         expect(user).not_to be_ssn_mismatch
       end
     end
@@ -418,7 +418,7 @@ RSpec.describe User, type: :model do
         before { stub_mpi(mvi_profile) }
 
         it 'fetches first_name from MVI' do
-          expect(user.first_name).to be(user.va_profile.given_names.first)
+          expect(user.first_name).to be(user.first_name_mpi)
         end
 
         context 'when given_names has no middle_name' do
@@ -446,15 +446,15 @@ RSpec.describe User, type: :model do
         end
 
         it 'fetches last_name from MVI' do
-          expect(user.last_name).to be(user.va_profile.family_name)
+          expect(user.last_name).to be(user.last_name_mpi)
         end
 
         it 'fetches gender from MVI' do
-          expect(user.gender).to be(user.va_profile.gender)
+          expect(user.gender).to be(user.gender_mpi)
         end
 
         it 'fetches properly parsed birth_date from MVI' do
-          expect(user.birth_date).to eq(Date.parse(user.va_profile.birth_date).iso8601)
+          expect(user.birth_date).to eq(Date.parse(user.mpi_profile_birth_date).iso8601)
         end
 
         it 'fetches address data from MPI and stores it as a hash' do
@@ -466,7 +466,7 @@ RSpec.describe User, type: :model do
         end
 
         it 'fetches ssn from MVI' do
-          expect(user.ssn).to be(user.va_profile.ssn)
+          expect(user.ssn).to be(user.ssn_mpi)
         end
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -390,51 +390,51 @@ RSpec.describe User, type: :model do
         end
 
         it 'fetches given_names from MPI' do
-          expect(user.given_names).to be(user.mpi.profile.given_names)
+          expect(user.given_names).to be(mvi_profile.given_names)
         end
 
         it 'fetches first_name from MPI' do
-          expect(user.first_name_mpi).to be(user.mpi.profile.given_names.first)
+          expect(user.first_name_mpi).to be(mvi_profile.given_names.first)
         end
 
         it 'fetches last_name from MPI' do
-          expect(user.last_name_mpi).to be(user.mpi.profile.family_name)
+          expect(user.last_name_mpi).to be(mvi_profile.family_name)
         end
 
         it 'fetches gender from MPI' do
-          expect(user.gender_mpi).to be(user.mpi.profile.gender)
+          expect(user.gender_mpi).to be(mvi_profile.gender)
         end
 
         it 'fetches edipi from MPI' do
-          expect(user.edipi_mpi).to be(user.mpi.profile.edipi)
+          expect(user.edipi_mpi).to be(mvi_profile.edipi)
         end
 
         it 'fetches ssn from MPI' do
-          expect(user.ssn_mpi).to be(user.mpi.profile.ssn)
+          expect(user.ssn_mpi).to be(mvi_profile.ssn)
         end
 
         it 'fetches home_phone from MPI' do
-          expect(user.home_phone).to be(user.mpi.profile.home_phone)
+          expect(user.home_phone).to be(mvi_profile.home_phone)
         end
 
         it 'fetches mhv_ids from MPI' do
-          expect(user.mhv_ids).to be(user.mpi.profile.mhv_ids)
+          expect(user.mhv_ids).to be(mvi_profile.mhv_ids)
         end
 
         it 'fetches active_mhv_ids from MPI' do
-          expect(user.active_mhv_ids).to be(user.mpi.profile.active_mhv_ids)
+          expect(user.active_mhv_ids).to be(mvi_profile.active_mhv_ids)
         end
 
         it 'fetches sec_id from MPI' do
-          expect(user.sec_id_mpi).to be(user.mpi.profile.sec_id)
+          expect(user.sec_id_mpi).to be(mvi_profile.sec_id)
         end
 
         it 'fetches historical_icns from MPI' do
-          expect(user.historical_icns).to be(user.mpi.profile.historical_icns)
+          expect(user.historical_icns).to be(mvi_profile.historical_icns)
         end
 
         it 'fetches suffix from MPI' do
-          expect(user.suffix).to be(user.mpi.profile.suffix)
+          expect(user.suffix).to be(mvi_profile.suffix)
         end
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -366,6 +366,10 @@ RSpec.describe User, type: :model do
           stub_mpi(mvi_profile)
         end
 
+        it 'fetches given_names from MPI' do
+          expect(user.given_names).to be(user.mpi.profile.given_names)
+        end
+
         it 'fetches first_name from MPI' do
           expect(user.first_name_mpi).to be(user.mpi.profile.given_names.first)
         end
@@ -384,6 +388,26 @@ RSpec.describe User, type: :model do
 
         it 'fetches ssn from MPI' do
           expect(user.ssn_mpi).to be(user.mpi.profile.ssn)
+        end
+
+        it 'fetches home_phone from MPI' do
+          expect(user.home_phone).to be(user.mpi.profile.home_phone)
+        end
+
+        it 'fetches mhv_ids from MPI' do
+          expect(user.mhv_ids).to be(user.mpi.profile.mhv_ids)
+        end
+
+        it 'fetches active_mhv_ids from MPI' do
+          expect(user.active_mhv_ids).to be(user.mpi.profile.active_mhv_ids)
+        end
+
+        it 'fetches sec_id from MPI' do
+          expect(user.sec_id_mpi).to be(user.mpi.profile.sec_id)
+        end
+
+        it 'fetches historical_icns from MPI' do
+          expect(user.historical_icns).to be(user.mpi.profile.historical_icns)
         end
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -307,6 +307,29 @@ RSpec.describe User, type: :model do
       end
     end
 
+    describe '#mpi_profile?' do
+      context 'when user has mpi profile' do
+        let(:mvi_profile) { build(:mvi_profile) }
+        let(:user) { build(:user, :loa3, middle_name: 'J', mhv_icn: mvi_profile.icn) }
+
+        before do
+          stub_mpi(mvi_profile)
+        end
+
+        it 'returns true' do
+          expect(user.mpi_profile?).to be(true)
+        end
+      end
+
+      context 'when user does not have an mpi profile' do
+        let(:user) { build(:user) }
+
+        it 'returns false' do
+          expect(user.mpi_profile?).to be(false)
+        end
+      end
+    end
+
     describe 'getter methods' do
       context 'when saml user attributes available, icn is available, and user LOA3' do
         let(:mvi_profile) { build(:mvi_profile) }
@@ -354,7 +377,7 @@ RSpec.describe User, type: :model do
         end
 
         it 'has a vet360 id if one exists' do
-          expect(user.vet360_id).to be(user.va_profile.vet360_id)
+          expect(user.vet360_id).to be(mvi_profile.vet360_id)
         end
       end
 
@@ -409,6 +432,25 @@ RSpec.describe User, type: :model do
         it 'fetches historical_icns from MPI' do
           expect(user.historical_icns).to be(user.mpi.profile.historical_icns)
         end
+
+        it 'fetches suffix from MPI' do
+          expect(user.suffix).to be(user.mpi.profile.suffix)
+        end
+      end
+
+      describe 'set_mhv_ids do' do
+        let(:mvi_profile) { build(:mvi_profile) }
+        let(:user) { build(:user, :loa3, middle_name: 'J', mhv_icn: mvi_profile.icn) }
+
+        before do
+          stub_mpi(mvi_profile)
+          user.set_mhv_ids('1234567890')
+        end
+
+        it 'sets new mhv ids to a users MPI profile' do
+          expect(user.mpi.profile.mhv_ids).to include('1234567890')
+          expect(user.mpi.profile.active_mhv_ids).to include('1234567890')
+        end
       end
 
       context 'when saml user attributes NOT available, icn is available, and user LOA3' do
@@ -417,14 +459,14 @@ RSpec.describe User, type: :model do
 
         before { stub_mpi(mvi_profile) }
 
-        it 'fetches first_name from MVI' do
+        it 'fetches first_name from MPI' do
           expect(user.first_name).to be(user.first_name_mpi)
         end
 
         context 'when given_names has no middle_name' do
           let(:mvi_profile) { build(:mvi_profile, given_names: ['Joe']) }
 
-          it 'fetches middle name from MVI' do
+          it 'fetches middle name from MPI' do
             expect(user.middle_name).to be_nil
           end
         end
@@ -432,7 +474,7 @@ RSpec.describe User, type: :model do
         context 'when given_names has middle_name' do
           let(:mvi_profile) { build(:mvi_profile, given_names: %w[Joe Bob]) }
 
-          it 'fetches middle name from MVI' do
+          it 'fetches middle name from MPI' do
             expect(user.middle_name).to eq('Bob')
           end
         end
@@ -440,32 +482,32 @@ RSpec.describe User, type: :model do
         context 'when given_names has multiple middle names' do
           let(:mvi_profile) { build(:mvi_profile, given_names: %w[Michael Joe Bob Sinclair]) }
 
-          it 'fetches middle name from MVI' do
+          it 'fetches middle name from MPI' do
             expect(user.middle_name).to eq('Joe Bob Sinclair')
           end
         end
 
-        it 'fetches last_name from MVI' do
+        it 'fetches last_name from MPI' do
           expect(user.last_name).to be(user.last_name_mpi)
         end
 
-        it 'fetches gender from MVI' do
+        it 'fetches gender from MPI' do
           expect(user.gender).to be(user.gender_mpi)
         end
 
-        it 'fetches properly parsed birth_date from MVI' do
+        it 'fetches properly parsed birth_date from MPI' do
           expect(user.birth_date).to eq(Date.parse(user.mpi_profile_birth_date).iso8601)
         end
 
         it 'fetches address data from MPI and stores it as a hash' do
-          expect(user.address[:street]).to eq(user.va_profile.address.street)
+          expect(user.address[:street]).to eq(mvi_profile.address.street)
         end
 
-        it 'fetches zip from MVI' do
-          expect(user.zip).to be(user.va_profile.address.postal_code)
+        it 'fetches zip from MPI' do
+          expect(user.zip).to be(mvi_profile.address.postal_code)
         end
 
-        it 'fetches ssn from MVI' do
+        it 'fetches ssn from MPI' do
           expect(user.ssn).to be(user.ssn_mpi)
         end
       end

--- a/spec/request/in_progress_forms_request_spec.rb
+++ b/spec/request/in_progress_forms_request_spec.rb
@@ -223,9 +223,7 @@ RSpec.describe V0::InProgressFormsController, type: :request do
           expected_data
           get v0_in_progress_form_url('FAKEFORM'), params: nil
 
-          if user.va_profile&.normalized_suffix.present?
-            expected_data['veteranFullName']['suffix'] = user.va_profile&.normalized_suffix
-          end
+          expected_data['veteranFullName']['suffix'] = user.normalized_suffix if user.normalized_suffix.present?
 
           check_case_of_keys_recursively = lambda do |value|
             case value

--- a/spec/request/letters_request_spec.rb
+++ b/spec/request/letters_request_spec.rb
@@ -127,8 +127,8 @@ RSpec.describe 'letters', type: :request do
       end
 
       before do
-        user.va_profile.edipi = '1005079999'
-        user.va_profile.participant_id = '600039999'
+        user.mpi.profile.edipi = '1005079999'
+        user.mpi.profile.participant_id = '600039999'
       end
 
       it 'returns a 404' do
@@ -169,8 +169,8 @@ RSpec.describe 'letters', type: :request do
       end
 
       before do
-        user.va_profile.edipi = '1005079124'
-        user.va_profile.participant_id = '600036159'
+        user.mpi.profile.edipi = '1005079124'
+        user.mpi.profile.participant_id = '600036159'
       end
 
       it 'returns a 502' do

--- a/spec/request/letters_request_spec.rb
+++ b/spec/request/letters_request_spec.rb
@@ -122,13 +122,13 @@ RSpec.describe 'letters', type: :request do
     end
 
     context 'with a 404 evss response' do
+      let(:mvi_profile) { build(:mvi_profile, edipi: '1005079999', participant_id: '600039999') }
       let(:user) do
         build(:user, :loa3, first_name: 'John', last_name: 'SMith', birth_date: '1942-02-12', ssn: '799111223')
       end
 
       before do
-        user.mpi.profile.edipi = '1005079999'
-        user.mpi.profile.participant_id = '600039999'
+        stub_mpi(mvi_profile)
       end
 
       it 'returns a 404' do

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -180,19 +180,19 @@ RSpec.describe Users::Profile do
     context '#va_profile' do
       context 'when user.mpi is not nil' do
         it 'includes birth_date' do
-          expect(va_profile[:birth_date]).to eq(user.va_profile[:birth_date])
+          expect(va_profile[:birth_date]).to eq(user.mpi_profile_birth_date)
         end
 
         it 'includes family_name' do
-          expect(va_profile[:family_name]).to eq(user.va_profile[:family_name])
+          expect(va_profile[:family_name]).to eq(user.last_name_mpi)
         end
 
         it 'includes gender' do
-          expect(va_profile[:gender]).to eq(user.va_profile[:gender])
+          expect(va_profile[:gender]).to eq(user.gender_mpi)
         end
 
         it 'includes given_names' do
-          expect(va_profile[:given_names]).to eq(user.va_profile[:given_names])
+          expect(va_profile[:given_names]).to eq(user.given_names)
         end
 
         it 'includes status' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This change removes `va_profile` references from outside the User class as part of a larger refactor and move to keep specific User trait calls (Identity vs. MPI) contained within the User class to reduce complexity across vets-api. This change is intended only to simplify existing functionality and should not cause any noticeable changes.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18740

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
New unit tests have been added for explicit MPI getter & setter methods.