### PR TITLE
longer evss document timeout

### DIFF
--- a/lib/evss/documents_service.rb
+++ b/lib/evss/documents_service.rb
@@ -7,7 +7,7 @@ module EVSS
     API_VERSION = Settings.evss.versions.documents
     BASE_URL = "#{Settings.evss.url}/wss-document-services-web-#{API_VERSION}/rest/"
     # this service is only used from an async worker so long timeout is acceptable here
-    DEFAULT_TIMEOUT = 360 # seconds
+    DEFAULT_TIMEOUT = 480 # seconds
 
     def upload(file_body, document_data)
       headers = { 'Content-Type' => 'application/octet-stream' }


### PR DESCRIPTION
## Description of change
EVSS takes forever, even for successful large document uploads.  If we let the request timeout after 6 minutes, then we keep sending the document several times.  Each one is actually successful, but we don't get the response in time so we retry later.  It's better to just up the timeout until EVSS can respond faster. 

I'm sad to do this, but it beats sending the same document several times.


fixes http://sentry.vfs.va.gov/organizations/vsp/issues/30718/?environment=production&project=3&query=evss+transaction%3ASidekiq%2FEVSS%3A%3ADisabilityCompensationForm%3A%3ASubmitUploads&statsPeriod=14d and 
http://sentry.vfs.va.gov/organizations/vsp/issues/30719/?environment=production&project=3&query=evss+transaction%3ASidekiq%2FEVSS%3A%3ADisabilityCompensationForm%3A%3ASubmitUploads&statsPeriod=14d
## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

