### PR TITLE
Updates covid vax SFTP to use separate port config

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -841,6 +841,7 @@ covid_vaccine:
   enrollment_service:
     sftp:
       host: fake_host
+      port: ~
       username: fake_username
       password: fake_password
 

--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/enrollment_upload_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/enrollment_upload_service.rb
@@ -12,7 +12,7 @@ module CovidVaccine
       attr_reader :io, :file_name
 
       def upload
-        Net::SFTP.start(sftp_host, sftp_username, password: sftp_password) do |sftp|
+        Net::SFTP.start(sftp_host, sftp_username, password: sftp_password, port: sftp_port) do |sftp|
           sftp.upload!(@io, file_name, name: file_name, progress: EnrollmentHandler.new)
         end
       end
@@ -29,6 +29,10 @@ module CovidVaccine
 
       def sftp_password
         Settings.covid_vaccine.enrollment_service.sftp.password
+      end
+
+      def sftp_port
+        Settings.covid_vaccine.enrollment_service.sftp.port
       end
     end
   end

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/enrollment_upload_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/enrollment_upload_service_spec.rb
@@ -28,7 +28,7 @@ describe CovidVaccine::V0::EnrollmentUploadService do
     let(:sftp_double) { double(:sftp, sftp: sftp_connection_double) }
     let(:handler) { CovidVaccine::V0::EnrollmentHandler }
 
-    it 'responds to send_enrollment_file' do
+    it 'responds to upload' do
       with_settings(Settings.covid_vaccine.enrollment_service.sftp, host: host, username: username,
                                                                     password: password, port: port) do
         expect(Net::SFTP).to receive(:start).with(host, username, password: password,

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/enrollment_upload_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/enrollment_upload_service_spec.rb
@@ -20,18 +20,23 @@ describe CovidVaccine::V0::EnrollmentUploadService do
   end
 
   context 'sftp interactions' do
-    let(:host) { 'fake_host' }
-    let(:username) { 'fake_username' }
-    let(:password) { 'fake_password' }
+    let(:host) { 'mysftp_host' }
+    let(:username) { 'mysftp_username' }
+    let(:password) { 'mysftp_password' }
+    let(:port) { 9999 }
     let(:sftp_connection_double) { double(:sftp_connection_double, upload!: true, download!: true) }
     let(:sftp_double) { double(:sftp, sftp: sftp_connection_double) }
     let(:handler) { CovidVaccine::V0::EnrollmentHandler }
 
     it 'responds to send_enrollment_file' do
-      expect(Net::SFTP).to receive(:start).with(host, username, password: password).and_yield(sftp_connection_double)
-      expect(sftp_connection_double)
-        .to receive(:upload!).with(subject.io, file_name, name: file_name, progress: instance_of(handler))
-      subject.upload
+      with_settings(Settings.covid_vaccine.enrollment_service.sftp, host: host, username: username,
+                                                                    password: password, port: port) do
+        expect(Net::SFTP).to receive(:start).with(host, username, password: password,
+                                                                  port: port).and_yield(sftp_connection_double)
+        expect(sftp_connection_double)
+          .to receive(:upload!).with(subject.io, file_name, name: file_name, progress: instance_of(handler))
+        subject.upload
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
Updates covid vaccine SFTP connection to use a separate port setting from settings.yml. This needed for Net::SFTP because we are connecting over a non-default port. 

Corresponding devops PR: https://github.com/department-of-veterans-affairs/devops/pull/8876

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/22613


## Things to know about this PR

