### PR TITLE
Maps birth sex values as expected by enrollment service upstream

### DIFF
--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_csv_generator.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_csv_generator.rb
@@ -17,13 +17,19 @@ module CovidVaccine
         r.raw_form_data['preferred_facility']&.delete_prefix('vha_')
       end
 
+      birth_sex_proc = proc do |r|
+        next r.raw_form_data['birth_sex'][0] if %w[Male Female].include? r.raw_form_data['birth_sex']
+
+        nil
+      end
+
       MAPPER = {
         first_name: proc { |r| r.raw_form_data['first_name'] },
         middle_name: proc { |r| r.raw_form_data['middle_name'] },
         last_name: proc { |r| r.raw_form_data['last_name'] },
         birth_date: proc { |r| Date.parse(r.raw_form_data['birth_date']).strftime('%m/%d/%Y') },
         ssn: proc { |r| r.raw_form_data['ssn'] },
-        birth_sex: proc { |r| r.raw_form_data['birth_sex'][0] },
+        birth_sex: birth_sex_proc,
         icn: proc { |r| r&.eligibility_info&.fetch('icn', nil) },
         address: proc do |r|
                    [

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_csv_generator_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_csv_generator_spec.rb
@@ -43,6 +43,34 @@ describe CovidVaccine::V0::ExpandedRegistrationCsvGenerator do
       generator = described_class.new([record])
       expect(generator.csv).to include('^688^')
     end
+
+    describe 'birth sex field' do
+      it 'maps Male value to M' do
+        record = build(:covid_vax_expanded_registration, raw_options: { 'ssn' => '123456789', 'birth_sex' => 'Male' })
+        generator = described_class.new([record])
+        expect(generator.csv).to include('^123456789^M^')
+      end
+
+      it 'maps Female value to F' do
+        record = build(:covid_vax_expanded_registration, raw_options: { 'ssn' => '123456789', 'birth_sex' => 'Female' })
+        generator = described_class.new([record])
+        expect(generator.csv).to include('^123456789^F^')
+      end
+
+      it 'maps Prefer not to state value to nil' do
+        record = build(:covid_vax_expanded_registration,
+                       raw_options: { 'ssn' => '123456789', 'birth_sex' => 'Prefer not to state' })
+        generator = described_class.new([record])
+        expect(generator.csv).to include('^123456789^^')
+        expect(generator.csv).not_to include('^P^')
+      end
+
+      it 'maps nil value to nil' do
+        record = build(:covid_vax_expanded_registration, raw_options: { 'ssn' => '123456789', 'birth_sex' => nil })
+        generator = described_class.new([record])
+        expect(generator.csv).to include('^123456789^^')
+      end
+    end
   end
 
   describe '#io' do


### PR DESCRIPTION
## Description of change
Updates CSV generation for to map values to "M","F",or empty string as expected by enrollment service. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/22643

## Things to know about this PR
