### PR TITLE
API-4750 Corrected issue with Client Credentials token v2 token auth

### DIFF
--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -37,7 +37,11 @@ class OpenidApplicationController < ApplicationController
 
     # issued for a client vs a user
     if token.client_credentials_token? || ssoi_token?
-      token.payload[:icn] = fetch_smart_launch_context if token.payload['scp'].include?('launch/patient')
+      if token.payload['scp'].include?('launch/patient')
+        launch = fetch_smart_launch_context
+        token.payload[:icn] = launch
+        token.payload[:launch] = { icn: launch } unless launch.nil?
+      end
       if token.payload['scp'].include?('launch')
         launch = fetch_smart_launch_context
         token.payload[:launch] = base64_json?(launch) ? JSON.parse(Base64.decode64(launch)) : { icn: launch }

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -40,7 +40,7 @@ class OpenidApplicationController < ApplicationController
       if token.payload['scp'].include?('launch/patient')
         launch = fetch_smart_launch_context
         token.payload[:icn] = launch
-        token.payload[:launch] = { icn: launch } unless launch.nil?
+        token.payload[:launch] = { patient: launch } unless launch.nil?
       end
       if token.payload['scp'].include?('launch')
         launch = fetch_smart_launch_context

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -44,7 +44,7 @@ class OpenidApplicationController < ApplicationController
       end
       if token.payload['scp'].include?('launch')
         launch = fetch_smart_launch_context
-        token.payload[:launch] = base64_json?(launch) ? JSON.parse(Base64.decode64(launch)) : { icn: launch }
+        token.payload[:launch] = base64_json?(launch) ? JSON.parse(Base64.decode64(launch)) : { patient: launch }
       end
       return true
     end

--- a/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
@@ -43,8 +43,8 @@ module OpenidAuth
         payload_object.act[:npi] = nil
         payload_object.act[:sec_id] = nil
         payload_object.act[:vista_id] = nil
-        if (token.payload['scp'].include?('launch') || token.payload['scp'].include?('launch/patient')) &&
-            !token.payload[:launch].nil?
+        if (token.payload['scp'].include?('launch') ||
+            token.payload['scp'].include?('launch/patient')) && !token.payload[:launch].nil?
           payload_object.launch = token.payload[:launch]
         end
         payload_object

--- a/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
@@ -28,10 +28,6 @@ module OpenidAuth
           return payload_object
         end
 
-        # Sometimes we'll already have an `icn` in the token. If we do, copy if down into `act`
-        # for consistency. Otherwise use the ICN value we used to look up the MVI attributes.
-        payload_object.act[:icn] = payload_object.try(:icn)
-
         # Client Credentials will not populate the @current_user, so only fill if not that token type
         unless token.client_credentials_token? || !payload_object[:icn].nil?
           payload_object.act[:icn] = @current_user.icn
@@ -47,8 +43,9 @@ module OpenidAuth
         payload_object.act[:npi] = nil
         payload_object.act[:sec_id] = nil
         payload_object.act[:vista_id] = nil
-        payload_object.launch = token.payload[:launch] if token.payload['scp'].include?('launch')
-
+        if token.payload['scp'].include?('launch') || token.payload['scp'].include?('launch/patient')
+          payload_object.launch = token.payload[:launch] if !token.payload[:launch].nil?
+        end
         payload_object
       end
     end

--- a/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
@@ -43,8 +43,8 @@ module OpenidAuth
         payload_object.act[:npi] = nil
         payload_object.act[:sec_id] = nil
         payload_object.act[:vista_id] = nil
-        if token.payload['scp'].include?('launch') || token.payload['scp'].include?('launch/patient')
-          payload_object.launch = token.payload[:launch] unless token.payload[:launch].nil?
+        if (token.payload['scp'].include?('launch') || token.payload['scp'].include?('launch/patient')) && !token.payload[:launch].nil?
+          payload_object.launch = token.payload[:launch]
         end
         payload_object
       end

--- a/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
@@ -44,7 +44,7 @@ module OpenidAuth
         payload_object.act[:sec_id] = nil
         payload_object.act[:vista_id] = nil
         if token.payload['scp'].include?('launch') || token.payload['scp'].include?('launch/patient')
-          payload_object.launch = token.payload[:launch] if !token.payload[:launch].nil?
+          payload_object.launch = token.payload[:launch] unless token.payload[:launch].nil?
         end
         payload_object
       end

--- a/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
@@ -43,7 +43,8 @@ module OpenidAuth
         payload_object.act[:npi] = nil
         payload_object.act[:sec_id] = nil
         payload_object.act[:vista_id] = nil
-        if (token.payload['scp'].include?('launch') || token.payload['scp'].include?('launch/patient')) && !token.payload[:launch].nil?
+        if (token.payload['scp'].include?('launch') || token.payload['scp'].include?('launch/patient')) &&
+            !token.payload[:launch].nil?
           payload_object.launch = token.payload[:launch]
         end
         payload_object

--- a/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
@@ -231,7 +231,7 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
         expect(response.body).to be_a(String)
         expect(JSON.parse(response.body)['data']['attributes'].keys)
           .to eq(json_cc_api_response['data']['attributes'].keys)
-        expect(JSON.parse(response.body)['data']['attributes']['launch']['icn']).to eq('73806470379396828')
+        expect(JSON.parse(response.body)['data']['attributes']['launch']['patient']).to eq('73806470379396828')
       end
     end
   end
@@ -249,7 +249,7 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
         expect(response.body).to be_a(String)
         expect(JSON.parse(response.body)['data']['attributes'].keys)
           .to eq(json_cc_api_response['data']['attributes'].keys)
-        expect(JSON.parse(response.body)['data']['attributes']['launch']['icn']).to eq(nil)
+        expect(JSON.parse(response.body)['data']['attributes']['launch']['patient']).to eq(nil)
       end
     end
   end

--- a/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
@@ -229,8 +229,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
         post '/internal/auth/v2/validation', params: nil, headers: auth_header
         expect(response).to have_http_status(:ok)
         expect(response.body).to be_a(String)
-        expect(
-          JSON.parse(response.body)['data']['attributes'].keys).to eq(json_cc_api_response['data']['attributes'].keys)
+        expect(JSON.parse(response.body)['data']['attributes'].keys)
+          .to eq(json_cc_api_response['data']['attributes'].keys)
         expect(JSON.parse(response.body)['data']['attributes']['launch']['icn']).to eq('73806470379396828')
       end
     end
@@ -247,8 +247,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
         post '/internal/auth/v2/validation', params: nil, headers: auth_header
         expect(response).to have_http_status(:ok)
         expect(response.body).to be_a(String)
-        expect(
-          JSON.parse(response.body)['data']['attributes'].keys).to eq(json_cc_api_response['data']['attributes'].keys)
+        expect(JSON.parse(response.body)['data']['attributes'].keys)
+          .to eq(json_cc_api_response['data']['attributes'].keys)
         expect(JSON.parse(response.body)['data']['attributes']['launch']['icn']).to eq(nil)
       end
     end

--- a/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
@@ -104,33 +104,33 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
   end
   let(:json_cc_api_response) do
     {
-        'data' => {
-            'id' => 'AT.04f_GBSkMkWYbLgG5joGNlApqUthsZnYXhiyPc_5KZ0',
-            'type' => 'validated_token',
-            'attributes' => {
-                'ver' => 1,
-                'jti' => 'AT.04f_GBSkMkWYbLgG5joGNlApqUthsZnYXhiyPc_5KZ0',
-                'iss' => 'https://example.com/oauth2/default',
-                'aud' => 'api://default',
-                'iat' => 1_541_453_784,
-                'exp' => 1_541_457_384,
-                'cid' => '0oa1c01m77heEXUZt2p7',
-                'uid' => '00u1zlqhuo3yLa2Xs2p7',
-                'scp' => [
-                    'profile',
-                    'email',
-                    'openid',
-                    'veteran_status.read'
-                ],
-                'sub' => 'ae9ff5f4e4b741389904087d94cd19b2',
-                'act' => {
-                    'icn' => nil
-                },
-                'launch' => {
-                    'icn' => '73806470379396828'
-                }
-            }
+      'data' => {
+        'id' => 'AT.04f_GBSkMkWYbLgG5joGNlApqUthsZnYXhiyPc_5KZ0',
+        'type' => 'validated_token',
+        'attributes' => {
+          'ver' => 1,
+          'jti' => 'AT.04f_GBSkMkWYbLgG5joGNlApqUthsZnYXhiyPc_5KZ0',
+          'iss' => 'https://example.com/oauth2/default',
+          'aud' => 'api://default',
+          'iat' => 1_541_453_784,
+          'exp' => 1_541_457_384,
+          'cid' => '0oa1c01m77heEXUZt2p7',
+          'uid' => '00u1zlqhuo3yLa2Xs2p7',
+          'scp' => [
+            'profile',
+            'email',
+            'openid',
+            'veteran_status.read'
+          ],
+          'sub' => 'ae9ff5f4e4b741389904087d94cd19b2',
+          'act' => {
+            'icn' => nil
+          },
+          'launch' => {
+            'icn' => '73806470379396828'
+          }
         }
+      }
     }
   end
   let(:auth_header) { { 'Authorization' => "Bearer #{token}" } }

--- a/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
@@ -127,7 +127,7 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
             'icn' => nil
           },
           'launch' => {
-            'icn' => '73806470379396828'
+            'patient' => '73806470379396828'
           }
         }
       }

--- a/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
@@ -102,6 +102,37 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
       }
     }
   end
+  let(:json_cc_api_response) do
+    {
+        'data' => {
+            'id' => 'AT.04f_GBSkMkWYbLgG5joGNlApqUthsZnYXhiyPc_5KZ0',
+            'type' => 'validated_token',
+            'attributes' => {
+                'ver' => 1,
+                'jti' => 'AT.04f_GBSkMkWYbLgG5joGNlApqUthsZnYXhiyPc_5KZ0',
+                'iss' => 'https://example.com/oauth2/default',
+                'aud' => 'api://default',
+                'iat' => 1_541_453_784,
+                'exp' => 1_541_457_384,
+                'cid' => '0oa1c01m77heEXUZt2p7',
+                'uid' => '00u1zlqhuo3yLa2Xs2p7',
+                'scp' => [
+                    'profile',
+                    'email',
+                    'openid',
+                    'veteran_status.read'
+                ],
+                'sub' => 'ae9ff5f4e4b741389904087d94cd19b2',
+                'act' => {
+                    'icn' => nil
+                },
+                'launch' => {
+                    'icn' => '73806470379396828'
+                }
+            }
+        }
+    }
+  end
   let(:auth_header) { { 'Authorization' => "Bearer #{token}" } }
   let(:user) { OpenidUser.new(build(:user_identity_attrs, :loa3)) }
 
@@ -198,8 +229,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
         post '/internal/auth/v2/validation', params: nil, headers: auth_header
         expect(response).to have_http_status(:ok)
         expect(response.body).to be_a(String)
-        expect(JSON.parse(response.body)['data']['attributes'].keys).to eq(json_api_response['data']['attributes'].keys)
-        expect(JSON.parse(response.body)['data']['attributes']['act']['icn']).to eq('73806470379396828')
+        expect(JSON.parse(response.body)['data']['attributes'].keys).to eq(json_cc_api_response['data']['attributes'].keys)
+        expect(JSON.parse(response.body)['data']['attributes']['launch']['icn']).to eq('73806470379396828')
       end
     end
   end
@@ -215,8 +246,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
         post '/internal/auth/v2/validation', params: nil, headers: auth_header
         expect(response).to have_http_status(:ok)
         expect(response.body).to be_a(String)
-        expect(JSON.parse(response.body)['data']['attributes'].keys).to eq(json_api_response['data']['attributes'].keys)
-        expect(JSON.parse(response.body)['data']['attributes']['act']['icn']).to eq(nil)
+        expect(JSON.parse(response.body)['data']['attributes'].keys).to eq(json_cc_api_response['data']['attributes'].keys)
+        expect(JSON.parse(response.body)['data']['attributes']['launch']['icn']).to eq(nil)
       end
     end
   end

--- a/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
@@ -229,7 +229,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
         post '/internal/auth/v2/validation', params: nil, headers: auth_header
         expect(response).to have_http_status(:ok)
         expect(response.body).to be_a(String)
-        expect(JSON.parse(response.body)['data']['attributes'].keys).to eq(json_cc_api_response['data']['attributes'].keys)
+        expect(
+          JSON.parse(response.body)['data']['attributes'].keys).to eq(json_cc_api_response['data']['attributes'].keys)
         expect(JSON.parse(response.body)['data']['attributes']['launch']['icn']).to eq('73806470379396828')
       end
     end
@@ -246,7 +247,8 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
         post '/internal/auth/v2/validation', params: nil, headers: auth_header
         expect(response).to have_http_status(:ok)
         expect(response.body).to be_a(String)
-        expect(JSON.parse(response.body)['data']['attributes'].keys).to eq(json_cc_api_response['data']['attributes'].keys)
+        expect(
+          JSON.parse(response.body)['data']['attributes'].keys).to eq(json_cc_api_response['data']['attributes'].keys)
         expect(JSON.parse(response.body)['data']['attributes']['launch']['icn']).to eq(nil)
       end
     end


### PR DESCRIPTION
## Description of change
One additional change to new v2 token validation endpoint to ensure Client Credentials Auth does not incorrectly populate the `act` field in the token validation response.

## Original issue(s)
- https://vajira.max.gov/browse/API-4750
- https://github.com/department-of-veterans-affairs/vets-api/pull/6359
