### PR TITLE
Adds rake task to manually update submission state

### DIFF
--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/enrollment_processor.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/enrollment_processor.rb
@@ -46,15 +46,17 @@ module CovidVaccine
         records.length
       end
 
-      # def self.set_pending_state(batch_id)
-      #   CovidVaccine::V0::ExpandedRegistrationSubmission.where(batch_id: batch_id).find_each do |submission|
-      #     submission.submitted_for_enrollment
-      #     submission.save!
-      #   end
-      # end
+      # Updates a specified batch to pending state. Used in conjunction with above write_to_file
+      # method in the case of out-of-band submission to enrollment service.
+      # rubocop:disable Rails/SkipsModelValidations
+      def self.update_state_to_pending(batch_id)
+        return if batch_id.nil?
+
+        CovidVaccine::V0::ExpandedRegistrationSubmission
+          .where(batch_id: batch_id).update_all(state: 'enrollment_pending')
+      end
 
       # TODO: Should this be private? Or public to be used by scanner job
-      # rubocop:disable Rails/SkipsModelValidations
       def batch_records!
         records = CovidVaccine::V0::ExpandedRegistrationSubmission.where(state: 'received', batch_id: nil)
         records.update_all(batch_id: @batch_id)

--- a/rakelib/covid_vaccine.rake
+++ b/rakelib/covid_vaccine.rake
@@ -22,12 +22,14 @@ namespace :covid_vaccine do
     end
   end
 
-  # desc 'Update state of records in batch to pending'
-  # task :set_pending_state, [:batch_id] => [:environment] do |_, args|
-  #   batch_id = args[:batch_id]
-  #   CovidVaccine::V0::EnrollmentProcessor.set_pending_state(batch_id)
-  #   puts "Updated state to enrollment_pending for batch id #{batch_id}"
-  # end
+  desc 'Update state of records in batch to pending'
+  task :set_pending_state, [:batch_id] => [:environment] do |_, args|
+    raise 'No batch_id provided' unless args[:batch_id]
+
+    batch_id = args[:batch_id]
+    CovidVaccine::V0::EnrollmentProcessor.update_state_to_pending(batch_id)
+    puts "Updated state to enrollment_pending for batch id #{batch_id}"
+  end
 
   desc 'Perform enrollment SFTP upload for max (count) records'
   task :perform_enrollment_upload, [:count] => [:environment] do |_, _args|


### PR DESCRIPTION
## Description of change
Adds a rake task to manually move a specified batch into `enrollment_pending` state. This is needed for the (so far) 1 batch that we had to submit to ES out of band.

There's room here to reconcile the static and non-static variations of this method. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR


<!-- Please describe testing done to verify the changes or any testing planned. -->
