### PR TITLE
Spool: Disable emails for invalid submissions

### DIFF
--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -120,18 +120,15 @@ module EducationForm
       writer.close
     end
 
+    # Previously there was data.saved_claim.valid? check but this was causing issues for forms when
+    # 1. on submission the submission data is validated against vets-json-schema
+    # 2. vets-json-schema is updated in vets-api
+    # 3. during spool file creation the schema is then again validated against vets-json-schema
+    # 4. submission is no longer valid due to changes in step 2
     def format_application(data, rpo: 0)
-      # This check was added to ensure that the model passes validation before
-      # attempting to build a form from it. This logic should be refactored as
-      # part of a larger effort to clean up the spool file generation if that occurs.
-      if data.saved_claim.valid?
-        form = EducationForm::Forms::Base.build(data)
-        track_form_type("22-#{data.form_type}", rpo)
-        form
-      else
-        inform_on_error(data, rpo)
-        nil
-      end
+      form = EducationForm::Forms::Base.build(data)
+      track_form_type("22-#{data.form_type}", rpo)
+      form
     rescue => e
       inform_on_error(data, rpo, e)
       nil

--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -144,7 +144,7 @@ module EducationForm
                   else
                     FormattingError.new("Could not format #{claim.confirmation_number}")
                   end
-      log_exception(exception)
+      log_exception(exception, nil, false)
     end
 
     private
@@ -183,10 +183,10 @@ module EducationForm
       @stats ||= Hash.new(Hash.new(0))
     end
 
-    def log_exception(exception, region = nil)
+    def log_exception(exception, region = nil, send_email = true)
       log_exception_to_sentry(exception)
       log_to_slack(exception.to_s)
-      log_to_email(region)
+      log_to_email(region) if send_email
     end
 
     def log_info(message)

--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -144,7 +144,7 @@ module EducationForm
                   else
                     FormattingError.new("Could not format #{claim.confirmation_number}")
                   end
-      log_exception(exception, nil, false)
+      log_exception(exception, nil, send_email: false)
     end
 
     private
@@ -183,7 +183,7 @@ module EducationForm
       @stats ||= Hash.new(Hash.new(0))
     end
 
-    def log_exception(exception, region = nil, send_email = true)
+    def log_exception(exception, region = nil, send_email: true)
       log_exception_to_sentry(exception)
       log_to_slack(exception.to_s)
       log_to_email(region) if send_email

--- a/app/workers/education_form/process10203_submissions.rb
+++ b/app/workers/education_form/process10203_submissions.rb
@@ -162,15 +162,7 @@ module EducationForm
     end
 
     def format_application(data)
-      # This check was added to ensure that the model passes validation before
-      # attempting to build a form from it. This logic should be refactored as
-      # part of a larger effort to clean up the spool file generation if that occurs.
-      if data.saved_claim.valid?
-        EducationForm::Forms::VA10203.build(data)
-      else
-        inform_on_error(data)
-        nil
-      end
+      EducationForm::Forms::VA10203.build(data)
     rescue => e
       inform_on_error(data, e)
       nil

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
       it 'processes the valid messages' do
         expect(subject).to receive(:log_exception_to_sentry).at_least(:once)
         expect(Flipper).to receive(:enabled?).with(any_args).and_return(false).at_least(:once)
-        expect { subject.perform }.to change { EducationBenefitsClaim.unprocessed.count }.from(4).to(1)
+        expect { subject.perform }.to change { EducationBenefitsClaim.unprocessed.count }.from(4).to(0)
         expect(Dir[spool_files].count).to eq(2)
       end
     end

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -69,16 +69,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
   end
 
   context '#format_application' do
-    it 'logs an error if the record is invalid' do
-      application_1606.saved_claim.form = {}.to_json
-      application_1606.saved_claim.save!(validate: false)
-
-      expect(subject).to receive(:log_exception_to_sentry).with(instance_of(EducationForm::FormattingError))
-      expect(Flipper).to receive(:enabled?).with(:spool_testing_error_2).and_return(false).at_least(:once)
-
-      subject.format_application(EducationBenefitsClaim.find(application_1606.id))
-    end
-
     context 'with a 1990 form' do
       it 'tracks and returns a form object' do
         expect(subject).to receive(:track_form_type).with('22-1990', 999)

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
       end
 
       it 'processes the valid messages' do
+        expect(Flipper).to receive(:enabled?).with(any_args).and_return(false).at_least(:once)
         expect { subject.perform }.to change { EducationBenefitsClaim.unprocessed.count }.from(4).to(0)
         expect(Dir[spool_files].count).to eq(2)
       end

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
       application_1606.saved_claim.save!(validate: false)
 
       expect(subject).to receive(:log_exception_to_sentry).with(instance_of(EducationForm::FormattingError))
-      expect(Flipper).to receive(:enabled?).with(:spool_testing_error_3).and_return(false).at_least(:once)
       expect(Flipper).to receive(:enabled?).with(:spool_testing_error_2).and_return(false).at_least(:once)
 
       subject.format_application(EducationBenefitsClaim.find(application_1606.id))

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -118,8 +118,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
       end
 
       it 'processes the valid messages' do
-        expect(subject).to receive(:log_exception_to_sentry).at_least(:once)
-        expect(Flipper).to receive(:enabled?).with(any_args).and_return(false).at_least(:once)
         expect { subject.perform }.to change { EducationBenefitsClaim.unprocessed.count }.from(4).to(0)
         expect(Dir[spool_files].count).to eq(2)
       end

--- a/spec/jobs/education_form/process10203_submissions_spec.rb
+++ b/spec/jobs/education_form/process10203_submissions_spec.rb
@@ -46,19 +46,6 @@ RSpec.describe EducationForm::Process10203Submissions, type: :model, form: :educ
     end
   end
 
-  describe '#format_application' do
-    it 'logs an error if the record is invalid' do
-      application_10203 = create(:va10203)
-      application_10203.create_stem_automated_decision(evss_user)
-      application_10203.education_benefits_claim.saved_claim.form = {}.to_json
-      application_10203.education_benefits_claim.saved_claim.save!(validate: false)
-
-      expect(subject).to receive(:log_exception_to_sentry).with(instance_of(EducationForm::FormattingError))
-
-      subject.send(:format_application, EducationBenefitsClaim.find(application_10203.education_benefits_claim.id))
-    end
-  end
-
   describe '#group_user_uuid' do
     it 'takes a list of records into groups by user_uuid' do
       application_10203 = create(:va10203)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Too many emails were being sent when a submission can't be formatted, turning off email notifications for this error

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
