### PR TITLE
Update gh stats rake task

### DIFF
--- a/rakelib/github_stats.rake
+++ b/rakelib/github_stats.rake
@@ -37,7 +37,7 @@ namespace :github_stats do
     # iterate thru responses and collect just the needed data
     responses.each do |repo, json_response|
       open_prs = JSON.parse(json_response)
-      open_prs.each do |pr|
+      open_prs.map do |pr|
         # parse vals from json
         user = pr['user']['login']
         number = pr['number']
@@ -59,7 +59,7 @@ namespace :github_stats do
         # send duration to StatsD
         StatsD.measure(STATSD_METRIC, duration,
                        tags: { repo: repo, number: number, user: user })
-      end
+      end.compact
     end
   end
 end

--- a/rakelib/github_stats.rake
+++ b/rakelib/github_stats.rake
@@ -54,7 +54,7 @@ namespace :github_stats do
         # calculate the duration excluding weekends
         duration = calculator.seconds_between_times(pr_created_at, first_reviewed_at)
 
-        #send duration to StatsD
+        # send duration to StatsD
         StatsD.measure(STATSD_METRIC, duration,
                        tags: { repo: repo, number: number, user: user })
       end.compact


### PR DESCRIPTION


## Description of change
To accurately calculate PR review time metrics for the QASP report, this PR updates the logic in the github_stats rake task. The review time duration was being calculated for PRs with no review and the logic was inaccurately influencing the review time metrics

[Grafana Board](http://grafana.vfs.va.gov/d/jmb16qwWk/pull-request-dashboard?orgId=1&from=now-2d&to=now)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

