### PR TITLE
changed unenrolled vaccine feature flag name to be under VAOS scope

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -55,11 +55,6 @@ features:
     enable_in_development: true
     description: >
       Toggles availability of covid vaccine expanded registration form API.
-  unenrolled_vaccine_scheduling:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Toggle for unenrolled vaccine scheduling discovery work.
   covid_volunteer_delivery:
     actor_type: cookie_id
     description: >
@@ -190,6 +185,11 @@ features:
     enable_in_development: true
     description: >
       Set up toggle in anticipation of the next iteration of facility selection, version 2.2.
+  va_online_scheduling_unenrolled_vaccine:
+    actor_type: user
+    enable_in_development: true
+    description: >
+      Toggle for unenrolled vaccine scheduling discovery work.
   va_global_downtime_notification:
     actor_type: user
     description: >


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Renaming previously introduced `unenrolled_vaccine_scheduling` feature flag to `va_online_scheduling_unenrolled_vaccine` in order to properly scope it with the other VAOS feature flags.

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/22079

## Things to know about this PR
This change is based on the previously merged code from https://github.com/department-of-veterans-affairs/vets-api/pull/6442

<!-- Please describe testing done to verify the changes or any testing planned. -->
