### PR TITLE
[6460] Add CSP Nonce to fix CSP violation for inline scripts on backe…

### DIFF
--- a/lib/flipper/views/layout.erb
+++ b/lib/flipper/views/layout.erb
@@ -61,7 +61,7 @@
       </div>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script nonce="**CSP_NONCE**" src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script nonce="**CSP_NONCE**" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/lib/saml/templates/sso_post_form.html.erb
+++ b/lib/saml/templates/sso_post_form.html.erb
@@ -22,7 +22,7 @@
     </noscript>
   <% end %>
 
-  <script>
+  <script nonce="**CSP_NONCE**">
     (function() {
       var req = new XMLHttpRequest();
       var qs = "id=" + encodeURIComponent("<%= id %>") +


### PR DESCRIPTION
…nd erb pages

## Description of change
This PR adds CSP_NONCE directives in inline scripts on the .erb scripts so they no longer violate the new CSP directive that is rolling out.

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/6460

## Things to know about this PR
- Unfortunately there are other CSP violations breaking local, so it is difficult to test
- This should at least not break staging, so we could confirm that once the instance is built

