### PR TITLE
Don't perform covid email jobs if submissions have a blank email

### DIFF
--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/expanded_registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/expanded_registration_controller.rb
@@ -14,7 +14,7 @@ module CovidVaccine
         record = CovidVaccine::V0::ExpandedRegistrationSubmission.create!({ submission_uuid: SecureRandom.uuid,
                                                                             raw_form_data: raw_form_data })
         audit_log(raw_form_data)
-        CovidVaccine::ExpandedRegistrationEmailJob.perform_async(record.id)
+        CovidVaccine::ExpandedRegistrationEmailJob.perform_async(record.id) if raw_form_data['email_address'].present?
         render json: record, serializer: CovidVaccine::V0::ExpandedRegistrationSerializer, status: :created
       end
 

--- a/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
+++ b/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
@@ -114,5 +114,13 @@ FactoryBot.define do
         }
       }
     end
+
+    trait :blank_email do
+      default_raw_options {
+        {
+          'email_address' => nil
+        }
+      }
+    end
   end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
The FE does not require email address. Previously the BE automatically kicks off an email confirmation job for all submissions. Updates the `ExpandedRegistrationController#create` action to only perform the `CovidVaccine::ExpandedRegistrationEmailJob` if an email is present in the submission. Added specs to confirm the other parts of the submission still work with a blank email.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22738

