### PR TITLE
added method back in

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
@@ -14,6 +14,10 @@ module ClaimsApi
       before_action :validate_json_format, if: -> { request.post? }
       before_action :verify_mpi
 
+      def fetch_aud
+        Settings.oidc.isolated_audience.claims
+      end
+
       protected
 
       def source_name

--- a/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
@@ -14,6 +14,8 @@ module ClaimsApi
       before_action :validate_json_format, if: -> { request.post? }
       before_action :verify_mpi
 
+      # fetch_audience: defines the audience used for oauth
+      # NOTE: required for oauth through claims_api to function
       def fetch_aud
         Settings.oidc.isolated_audience.claims
       end


### PR DESCRIPTION
## Description of change
Missed method definition during previous version breakout that is causing issues with oauth for v1 claims endpoints.

## Original issue(s)
https://lighthouseva.slack.com/archives/CT0G8GMS7/p1617802856052200