### PR TITLE
19061 Ability to save QR snapshot to DB

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -18,6 +18,8 @@ reports:
     region: region
     secret_access_key: secret
 
+db_encryption_key: f01ff8ebd1a2b053ad697ae1f0d86adb
+
 saml:
   cert_path: spec/support/certificates/ruby-saml.crt
   key_path: spec/support/certificates/ruby-saml.key

--- a/modules/health_quest/app/models/health_quest/questionnaire_response.rb
+++ b/modules/health_quest/app/models/health_quest/questionnaire_response.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'json_marshal/marshaller'
+
+module HealthQuest
+  ##
+  # An ActiveRecord object for modeling and persisting questionnaire response and user demographics data to the DB.
+  #
+  # @!attribute appointment_id
+  #   @return [String]
+  # @!attribute user_uuid
+  #   @return [String]
+  # @!attribute questionnaire_response_id
+  #   @return [String]
+  # @!attribute questionnaire_response_data
+  #   @return [String]
+  # @!attribute user_demographics_data
+  #   @return [String]
+  # @!attribute user
+  #   @return [User]
+  class QuestionnaireResponse < ApplicationRecord
+    attr_accessor :user
+
+    attr_encrypted :questionnaire_response_data,
+                   key: Settings.db_encryption_key,
+                   marshal: true,
+                   marshaler: JsonMarshal::Marshaller
+    attr_encrypted :user_demographics_data,
+                   key: Settings.db_encryption_key,
+                   marshal: true,
+                   marshaler: JsonMarshal::Marshaller
+
+    validates :questionnaire_response_data, presence: true
+
+    before_save :set_user_demographics
+
+    private
+
+    def set_user_demographics
+      demographics = {
+        first_name: user.first_name,
+        middle_name: user.middle_name,
+        last_name: user.last_name,
+        gender: user.gender,
+        address: user.address,
+        vas_contact_info: user.vet360_contact_info
+      }
+
+      self.user_demographics_data = demographics
+    end
+  end
+end

--- a/modules/health_quest/spec/models/questionnaire_response_spec.rb
+++ b/modules/health_quest/spec/models/questionnaire_response_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthQuest::QuestionnaireResponse do
+  subject { described_class.new }
+
+  let(:user) do
+    double(
+      'User',
+      icn: '1008596379V859838',
+      account_uuid: 'abc123',
+      uuid: '789defg',
+      first_name: 'Foo',
+      middle_name: 'Baz',
+      last_name: 'Bar',
+      gender: 'M',
+      address: '221B Baker Street',
+      vet360_contact_info: {}
+    )
+  end
+
+  describe 'object initialization' do
+    it 'responds to appointment_id' do
+      expect(subject.respond_to?(:appointment_id)).to eq(true)
+    end
+
+    it 'responds to user_uuid' do
+      expect(subject.respond_to?(:user_uuid)).to eq(true)
+    end
+
+    it 'responds to questionnaire_response_id' do
+      expect(subject.respond_to?(:questionnaire_response_id)).to eq(true)
+    end
+
+    it 'responds to questionnaire_response_data' do
+      expect(subject.respond_to?(:questionnaire_response_data)).to eq(true)
+    end
+
+    it 'responds to user_demographics_data' do
+      expect(subject.respond_to?(:user_demographics_data)).to eq(true)
+    end
+
+    it 'responds to user' do
+      expect(subject.respond_to?(:user)).to eq(true)
+    end
+  end
+
+  describe 'validations' do
+    it 'is not valid without questionnaire_response_data' do
+      subject.questionnaire_response_data = nil
+
+      expect(subject.valid?).to eq(false)
+    end
+
+    it 'is valid with questionnaire_response_data' do
+      subject.questionnaire_response_data = { 'foo' => 'bar' }
+
+      expect(subject.valid?).to eq(true)
+    end
+  end
+
+  describe 'encryption' do
+    before do
+      subject.user = user
+      subject.questionnaire_response_data = { 'foo' => 'bar' }
+      subject.save
+      subject.reload
+    end
+
+    it 'encrypts questionnaire_response_data' do
+      expect(subject.encrypted_questionnaire_response_data).to be_a(String)
+    end
+
+    it 'encrypts user_demographics_data' do
+      expect(subject.encrypted_user_demographics_data).to be_a(String)
+    end
+  end
+
+  describe 'before_save' do
+    before do
+      subject.user = user
+      subject.questionnaire_response_data = { 'foo' => 'bar' }
+      subject.save
+      subject.reload
+    end
+
+    it 'returns the user_demographics_data' do
+      hash = {
+        'first_name' => 'Foo',
+        'middle_name' => 'Baz',
+        'last_name' => 'Bar',
+        'gender' => 'M',
+        'address' => '221B Baker Street',
+        'vas_contact_info' => {}
+      }
+
+      expect(subject.user_demographics_data).to eq(hash)
+    end
+  end
+end

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -54,6 +54,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       expect(factory.respond_to?(:aggregated_data)).to eq(true)
       expect(factory.respond_to?(:patient)).to eq(true)
       expect(factory.respond_to?(:questionnaires)).to eq(true)
+      expect(factory.respond_to?(:questionnaire_response)).to eq(true)
       expect(factory.respond_to?(:save_in_progress)).to eq(true)
       expect(factory.respond_to?(:lighthouse_appointment_service)).to eq(true)
       expect(factory.respond_to?(:location_service)).to eq(true)
@@ -289,9 +290,14 @@ describe HealthQuest::QuestionnaireManager::Factory do
         item: []
       }
     end
+    let(:client_reply) do
+      double('FHIR::ClientReply', response: { code: '201' }, resource: double('Resource', id: '123abc'))
+    end
 
     it 'returns a ClientReply' do
       allow_any_instance_of(HealthQuest::Resource::Factory).to receive(:create).with(anything).and_return(client_reply)
+      allow_any_instance_of(HealthQuest::QuestionnaireResponse).to receive(:save)
+        .and_return(double('HealthQuest::QuestionnaireResponse'))
 
       expect(described_class.new(user).create_questionnaire_response(data)).to eq(client_reply)
     end


### PR DESCRIPTION
- Add the QuestionnaireResponse model and specs
- Questionnaire Manager saves QR and User demographics to DB upon QR creation

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Ability to save QR snapshot to DB
  - Add the QuestionnaireResponse model and specs
  - Questionnaire Manager saves QR and User demographics to DB upon QR creation
## Original issue(s)
department-of-veterans-affairs/va.gov-team#19061

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature flag
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests passing
- [x] Rubop passing