### PR TITLE
API-6192: Issue when multiple POA changes are submitted with the same headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Vets API
 
-
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Vets API
 
+
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/modules/claims_api/app/models/claims_api/power_of_attorney.rb
+++ b/modules/claims_api/app/models/claims_api/power_of_attorney.rb
@@ -23,10 +23,11 @@ module ClaimsApi
       primary_identifier[:id] = id if id.present?
       primary_identifier[:header_md5] = header_md5 if header_md5.present?
       primary_identifier[:md5] = md5 if md5.present?
-      poa = ClaimsApi::PowerOfAttorney.find_by(primary_identifier)
-      return nil if poa.present? && poa.source_data['name'] != source_name
+      poas = ClaimsApi::PowerOfAttorney.where(primary_identifier).order(:created_at)
+      poas = poas.select { |poa| poa.source_data['name'] == source_name }
+      return nil if poas.blank?
 
-      poa
+      poas.last
     end
 
     def sign_pdf


### PR DESCRIPTION
## Description of change
Current find for the "active" poa endpoint gets the first record with the same header_md5 in the database. This order isn't guaranteed, but very possible to be the incorrect record if there are several records with the same header_md5.

This change ensures the last record (according to create_at) is the one that is chosen if there are multiples.

## Original issue(s)
https://vajira.max.gov/browse/API-6192

## Things to know about this PR
All existing tests still pass.
