### PR TITLE
Api 6165 - Refactor to use serializer on submission create

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
+++ b/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
@@ -4,7 +4,7 @@ require 'json_marshal/marshaller'
 
 module AppealsApi
   class EvidenceSubmission < ApplicationRecord
-    belongs_to :supportable, polymorphic: true, optional: true
+    belongs_to :supportable, polymorphic: true
 
     attr_encrypted(:file_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
 

--- a/modules/appeals_api/app/serializers/appeals_api/evidence_submission_serializer.rb
+++ b/modules/appeals_api/app/serializers/appeals_api/evidence_submission_serializer.rb
@@ -30,7 +30,7 @@ module AppealsApi
 
     def details
       details = object.details.to_s
-      details = details[0..MAX_DETAIL_DISPLAY_LENGTH - 1] + '...' if details.length > MAX_DETAIL_DISPLAY_LENGTH
+      details = "#{details[0..MAX_DETAIL_DISPLAY_LENGTH - 1]}..." if details.length > MAX_DETAIL_DISPLAY_LENGTH
       details
     end
   end

--- a/modules/appeals_api/spec/factories/evidence_submissions.rb
+++ b/modules/appeals_api/spec/factories/evidence_submissions.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
   factory :evidence_submission, class: 'AppealsApi::EvidenceSubmission' do
     sequence(:id) { |n| n }
     association :supportable, factory: :notice_of_disagreement
+
+    trait :with_details do
+      details { SecureRandom.alphanumeric(150) }
+    end
   end
 end

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -7,7 +7,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
   include FixtureHelpers
 
   let!(:notice_of_disagreement) { create(:notice_of_disagreement) }
-  let(:evidence_submissions) { create_list(:evidence_submission, 3, supportable: notice_of_disagreement) }
+  let!(:evidence_submissions) { create_list(:evidence_submission, 3, supportable: notice_of_disagreement) }
   let(:path) { '/services/appeals/v1/decision_reviews/notice_of_disagreements/evidence_submissions/' }
 
   describe '#show' do
@@ -18,14 +18,15 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
     end
 
     it 'queries all evidence submissions for the nod' do
-      submissions = AppealsApi::EvidenceSubmissionSerializer.new(evidence_submissions).serializable_hash
-
       get "#{path}#{notice_of_disagreement.id}"
-
       body = JSON.parse(response.body)['data']
-      serialized = JSON.parse(submissions[:data].to_json)
-
-      expect(body).to match_array(serialized)
+      body.each do |submission|
+        expect(submission).to have_key('id')
+        expect(submission).to have_key('type')
+        expect(submission['attributes']['status']).to eq('pending')
+        expect(submission['attributes']['appealId']).to eq(notice_of_disagreement.id)
+        expect(submission['attributes']['appealType']).to eq('NoticeOfDisagreement')
+      end
     end
   end
 
@@ -40,44 +41,31 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
       allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
     end
 
-    context 'when nod_id parameter is not included' do
-      it 'returns submission attributes and location url' do
-        with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                      prefix: 'https://fake.s3.url/foo/',
-                      replacement: 'https://api.vets.gov/proxy/') do
-          double_setup
-          post(path, params: {})
-          json = JSON.parse(response.body)
-          expect(json['data']['attributes']).to have_key('id')
-          expect(json['data']['attributes']['status']).to eq('pending')
-          expect(json['data']['location']).to eq('https://api.vets.gov/proxy/uuid')
-        end
+    it 'returns submission attributes and location url' do
+      with_settings(Settings.modules_appeals_api.evidence_submissions.location,
+                    prefix: 'https://fake.s3.url/foo/',
+                    replacement: 'https://api.vets.gov/proxy/') do
+        double_setup
+        post(path, params: { nod_id: notice_of_disagreement.id })
+        body = JSON.parse(response.body)['data']
+        expect(body).to have_key('id')
+        expect(body).to have_key('type')
+        expect(body['attributes']['status']).to eq('pending')
+        expect(body['attributes']['appealId']).to eq(notice_of_disagreement.id)
+        expect(body['attributes']['appealType']).to eq('NoticeOfDisagreement')
+        expect(body['attributes']['location']).to eq('https://api.vets.gov/proxy/uuid')
       end
     end
 
-    context 'when nod_id parameter is included' do
-      it "returns saved submission with attributes 'appeal_id' and 'appeal_type'" do
+    context 'with no matching record' do
+      it 'raises an error' do
         with_settings(Settings.modules_appeals_api.evidence_submissions.location,
                       prefix: 'https://fake.s3.url/foo/',
                       replacement: 'https://api.vets.gov/proxy/') do
           double_setup
-          post(path, params: { nod_id: notice_of_disagreement.id })
-          json = JSON.parse(response.body)
-          expect(json['data']['attributes']['appeal_id']).to eq(notice_of_disagreement.id)
-          expect(json['data']['attributes']['appeal_type']).to eq('NoticeOfDisagreement')
-        end
-      end
-
-      context 'with no matching record' do
-        it 'raises an error' do
-          with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                        prefix: 'https://fake.s3.url/foo/',
-                        replacement: 'https://api.vets.gov/proxy/') do
-            double_setup
-            post(path, params: { nod_id: 1979 })
-            expect(response.status).to eq 404
-            expect(response.body).to include 'Record not found'
-          end
+          post(path, params: { nod_id: 1979 })
+          expect(response.status).to eq 404
+          expect(response.body).to include 'Record not found'
         end
       end
     end

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -6,8 +6,8 @@ require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmissionsController, type: :request do
   include FixtureHelpers
 
-  let!(:notice_of_disagreement) { create(:notice_of_disagreement) }
-  let!(:evidence_submissions) { create_list(:evidence_submission, 3, supportable: notice_of_disagreement) }
+  let(:notice_of_disagreement) { create(:notice_of_disagreement) }
+  let(:evidence_submissions) { create_list(:evidence_submission, 3, supportable: notice_of_disagreement) }
   let(:path) { '/services/appeals/v1/decision_reviews/notice_of_disagreements/evidence_submissions/' }
 
   describe '#show' do
@@ -22,7 +22,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
       body = JSON.parse(response.body)['data']
       body.each do |submission|
         expect(submission).to have_key('id')
-        expect(submission).to have_key('type')
+        expect(submission)['type'].to eq('evidenceSubmission')
         expect(submission['attributes']['status']).to eq('pending')
         expect(submission['attributes']['appealId']).to eq(notice_of_disagreement.id)
         expect(submission['attributes']['appealType']).to eq('NoticeOfDisagreement')

--- a/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
+++ b/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
@@ -6,39 +6,17 @@ require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 describe AppealsApi::EvidenceSubmissionSerializer do
   let(:evidence_submission) { create(:evidence_submission) }
   let(:rendered_hash) { described_class.new(evidence_submission).serializable_hash }
+  let(:notice_of_disagreement) { AppealsApi::NoticeOfDisagreement.find(evidence_submission.supportable_id) }
 
-  it 'serializes the NOD properly' do
-    expect(rendered_hash).to eq(
+  it 'serializes the evidence submission properly' do
+    expect(rendered_hash.keys.count).to be 9
+    expect(rendered_hash).to include(
       {
-        data: {
-          type: :evidenceSubmission,
-          id: evidence_submission.id.to_s,
-          attributes: {
-            status: evidence_submission.status
-          }
-        }
+        id: evidence_submission.id,
+        status: evidence_submission.status,
+        appeal_type: 'NoticeOfDisagreement',
+        appeal_id: notice_of_disagreement.id
       }
     )
-  end
-
-  it 'has the correct top level keys' do
-    expect(rendered_hash.keys.count).to be 1
-    expect(rendered_hash).to have_key :data
-  end
-
-  it 'has the correct data keys' do
-    expect(rendered_hash[:data].keys.count).to be 3
-    expect(rendered_hash[:data]).to have_key :type
-    expect(rendered_hash[:data]).to have_key :id
-    expect(rendered_hash[:data]).to have_key :attributes
-  end
-
-  it 'has the correct attribute keys' do
-    expect(rendered_hash[:data][:attributes].keys.count).to be 1
-    expect(rendered_hash[:data][:attributes]).to have_key :status
-  end
-
-  it 'has the correct type' do
-    expect(rendered_hash[:data][:type]).to eq :evidenceSubmission
   end
 end

--- a/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
+++ b/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
@@ -4,19 +4,24 @@ require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::EvidenceSubmissionSerializer do
-  let(:evidence_submission) { create(:evidence_submission) }
+  let(:evidence_submission) { create(:evidence_submission, :with_details) }
   let(:rendered_hash) { described_class.new(evidence_submission).serializable_hash }
   let(:notice_of_disagreement) { AppealsApi::NoticeOfDisagreement.find(evidence_submission.supportable_id) }
 
-  it 'serializes the evidence submission properly' do
-    expect(rendered_hash.keys.count).to be 9
-    expect(rendered_hash).to include(
-      {
-        id: evidence_submission.id,
-        status: evidence_submission.status,
-        appeal_type: 'NoticeOfDisagreement',
-        appeal_id: notice_of_disagreement.id
-      }
-    )
+  it 'includes id' do
+    expect(rendered_hash[:id]).to eq evidence_submission.id
+  end
+
+  it 'includes :appeal_type' do
+    expect(rendered_hash[:appeal_type]).to eq 'NoticeOfDisagreement'
+  end
+
+  it 'includes :appeal_id' do
+    expect(rendered_hash[:appeal_id]).to eq notice_of_disagreement.id
+  end
+
+  it "truncates :details value if longer than #{described_class::MAX_DETAIL_DISPLAY_LENGTH}" do
+    max_length_plus_ellipses = described_class::MAX_DETAIL_DISPLAY_LENGTH + 3
+    expect(rendered_hash[:details].length).to eq(max_length_plus_ellipses)
   end
 end


### PR DESCRIPTION
Refactored the serializer for our evidence submissions to include s3 location url, and additional custom methods to manage the response keys for supportable_type and supportable_id to read `appeal` instead of `supportable`. The change impacted both the rendering in the create and show endpoints.

Controller test updated
Serializer test updated

Ticket: https://vajira.max.gov/browse/API-6156