### PR TITLE
Adds helper rake task for facility id fixup

### DIFF
--- a/rakelib/covid_vaccine.rake
+++ b/rakelib/covid_vaccine.rake
@@ -57,4 +57,20 @@ namespace :covid_vaccine do
     end
     puts "Updated mapped facility info for #{count} records"
   end
+
+  desc 'Write mapped facility IDs to record for a specified batch'
+  task :map_facility_ids_for_batch, [:batch_id] => [:environment] do |_, args|
+    raise 'No batch_id provided' unless args[:batch_id]
+
+    batch_id = args[:batch_id]
+    count = 0
+    CovidVaccine::V0::ExpandedRegistrationSubmission.where(batch_id: batch_id).find_each do |submission|
+      resolver = CovidVaccine::V0::FacilityResolver.new
+      mapped_facility = resolver.resolve(submission)
+      submission.eligibility_info = { preferred_facility: mapped_facility }
+      submission.save!
+      count += 1
+    end
+    puts "Updated mapped facility info for #{count} records in batch #{batch_id}"
+  end
 end


### PR DESCRIPTION
## Description of change
Adds a rake task to run the facility fix up process for existing records in a batch,in case we need to do manual resubmission due to issues like in https://github.com/department-of-veterans-affairs/va.gov-team/issues/22841

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/22841

## Things to know about this PR

Tested locally
