### PR TITLE
fix Metrics/AbcSize violation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -491,6 +491,7 @@ Metrics/AbcSize:
     - 'modules/mobile/app/controllers/mobile/v0/messages_controller.rb'
     - 'modules/mobile/app/controllers/mobile/v0/push_notifications_controller.rb'
     - 'modules/mobile/app/models/mobile/v0/adapters/va_appointments.rb'
+    - 'modules/mobile/app/models/mobile/v0/adapters/claims_overview.rb'
     - 'modules/mobile/app/services/mobile/v0/appointments/proxy.rb'
     - 'modules/mobile/app/services/mobile/v0/claims/proxy.rb'
     - 'modules/mobile/app/workers/mobile/v0/pre_cache_appointments_job.rb'


### PR DESCRIPTION
Master broke due to a Metrics/AbcSize violation after [this PR](https://github.com/department-of-veterans-affairs/vets-api/commit/1ca8300e87858cb85ffedf737a83faa52d275322) was merged in. It looks like the branch wasn't updated with the latest master before merging