### PR TITLE
Remove rubocop:disable Metrics/AbcSize in mobile claims adapter

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/claims_overview.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/claims_overview.rb
@@ -12,7 +12,6 @@ module Mobile
 
         private
 
-        # rubocop:disable Metrics/AbcSize
         def parse_claim(entry)
           Mobile::V0::ClaimOverview.new(
             {
@@ -27,7 +26,6 @@ module Mobile
             }
           )
         end
-        # rubocop:enable Metrics/AbcSize
 
         def parse_appeal(entry)
           subtype = entry['type']


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Seems like briefly yesterday afternoon that cop was needed but now it's not (and is blocking other PRs).

## Original issue(s)
N/A

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
