### PR TITLE
set insecure-external-code-execution config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ registries:
 updates:
 - package-ecosystem: bundler
   directory: "/"
+  insecure-external-code-execution: allow
   schedule:
     interval: weekly
   ignore:


### PR DESCRIPTION
Setting config for dependabot Gemfile code execution 

"Dependabot refused to execute external code. 
Dependabot blocked external code required for this update. Please set insecure-external-code-execution: allow in the config if you trust all dependencies' supply chain."
