### PR TITLE
Add index to covid_vaccine_expanded_registration_submissions on batch_id

### DIFF
--- a/db/migrate/20210408191850_add_covid_vaccine_expanded_batch_id_index.rb
+++ b/db/migrate/20210408191850_add_covid_vaccine_expanded_batch_id_index.rb
@@ -1,0 +1,8 @@
+class AddCovidVaccineExpandedBatchIdIndex < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+  
+  def change
+    add_index :covid_vaccine_expanded_registration_submissions, :batch_id,
+      algorithm: :concurrently, name: :index_covid_vaccine_expanded_reg_submissions_on_batch_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_01_071242) do
+ActiveRecord::Schema.define(version: 2021_04_08_191850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -238,6 +238,7 @@ ActiveRecord::Schema.define(version: 2021_04_01_071242) do
     t.string "encrypted_form_data_iv"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["batch_id"], name: "index_covid_vaccine_expanded_reg_submissions_on_batch_id"
     t.index ["encrypted_eligibility_info_iv"], name: "index_covid_vaccine_expanded_on_el_iv", unique: true
     t.index ["encrypted_form_data_iv"], name: "index_covid_vaccine_expanded_on_form_iv", unique: true
     t.index ["encrypted_raw_form_data_iv"], name: "index_covid_vaccine_expanded_on_raw_iv", unique: true
@@ -685,10 +686,10 @@ ActiveRecord::Schema.define(version: 2021_04_01_071242) do
     t.datetime "checkout_time"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.text "services"
     t.string "id_type"
     t.string "loa"
     t.string "account_type"
+    t.text "services"
     t.uuid "idme_uuid"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -686,10 +686,10 @@ ActiveRecord::Schema.define(version: 2021_04_08_191850) do
     t.datetime "checkout_time"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "services"
     t.string "id_type"
     t.string "loa"
     t.string "account_type"
-    t.text "services"
     t.uuid "idme_uuid"
   end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Adds an index to the `covid_vaccine_expanded_registration_submissions` table on `batch_id` which is used in `CovidVaccine::V0::ExpandedRegistrationSubmission` queries.

## Original issue(s)
N/A

## Things to know about this PR
N/A

Testing planned: run queries on staging