### PR TITLE
API-6279 Prevent Repeated Okta Profile Fetching

### DIFF
--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -40,10 +40,7 @@ class OpenidApplicationController < ApplicationController
     profile = fetch_profile(token.identifiers.okta_uid) unless token.client_credentials_token? || !@session.nil?
 
     if @session.nil? && !profile.nil? && profile.attrs['last_login_type'] == 'ssoi'
-      token.payload['last_login_type'] = 'ssoi'
-      token.payload['icn'] = profile.attrs['icn']
-      token.payload['npi'] = profile.attrs['npi']
-      token.payload['vista_id'] = profile.attrs['VistaId']
+      populate_ssoi_token_payload(profile)
     end
 
     # issued for a client vs a user
@@ -64,6 +61,13 @@ class OpenidApplicationController < ApplicationController
     return false if @session.nil?
 
     @current_user = OpenidUser.find(@session.uuid)
+  end
+
+  def populate_ssoi_token_payload(profile)
+    token.payload['last_login_type'] = 'ssoi'
+    token.payload['icn'] = profile.attrs['icn']
+    token.payload['npi'] = profile.attrs['npi']
+    token.payload['vista_id'] = profile.attrs['VistaId']
   end
 
   def token_from_request

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -39,9 +39,7 @@ class OpenidApplicationController < ApplicationController
     @session = Session.find(token) unless token.client_credentials_token?
     profile = fetch_profile(token.identifiers.okta_uid) unless token.client_credentials_token? || !@session.nil?
 
-    if @session.nil? && !profile.nil? && profile.attrs['last_login_type'] == 'ssoi'
-      populate_ssoi_token_payload(profile)
-    end
+    populate_ssoi_token_payload(profile) if @session.nil? && !profile.nil? && profile.attrs['last_login_type'] == 'ssoi'
 
     # issued for a client vs a user
     if token.client_credentials_token? || token.ssoi_token?

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -100,18 +100,7 @@ class OpenidApplicationController < ApplicationController
     # all the classes used by our dependencies.
     Common::Exceptions::TokenValidationError.new(detail: error_detail_string)
   end
-
-  def mark_token_if_ssoi(profile)
-    if profile.attrs['last_login_type'] == 'ssoi'
-      token.payload['last_login_type'] = 'ssoi'
-      token.payload['icn'] = profile.attrs['icn']
-      token.payload['npi'] = profile.attrs['npi']
-      token.payload['vista_id'] = profile.attrs['VistaId']
-      return true
-    end
-    false
-  end
-
+  
   def establish_session(profile)
     ttl = token.payload['exp'] - Time.current.utc.to_i
     user_identity = OpenidUserIdentity.build_from_okta_profile(uuid: token.identifiers.uuid, profile: profile, ttl: ttl)

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -40,10 +40,10 @@ class OpenidApplicationController < ApplicationController
     profile = fetch_profile(token.identifiers.okta_uid) unless token.client_credentials_token? || !@session.nil?
 
     if @session.nil? && !profile.nil? && profile.attrs['last_login_type'] == 'ssoi'
-       token.payload['last_login_type'] = 'ssoi'
-       token.payload['icn'] = profile.attrs['icn']
-       token.payload['npi'] = profile.attrs['npi']
-       token.payload['vista_id'] = profile.attrs['VistaId']
+      token.payload['last_login_type'] = 'ssoi'
+      token.payload['icn'] = profile.attrs['icn']
+      token.payload['npi'] = profile.attrs['npi']
+      token.payload['vista_id'] = profile.attrs['VistaId']
     end
 
     # issued for a client vs a user
@@ -100,7 +100,7 @@ class OpenidApplicationController < ApplicationController
     # all the classes used by our dependencies.
     Common::Exceptions::TokenValidationError.new(detail: error_detail_string)
   end
-  
+
   def establish_session(profile)
     ttl = token.payload['exp'] - Time.current.utc.to_i
     user_identity = OpenidUserIdentity.build_from_okta_profile(uuid: token.identifiers.uuid, profile: profile, ttl: ttl)

--- a/spec/controllers/openid_application_controller_spec.rb
+++ b/spec/controllers/openid_application_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe OpenidApplicationController, type: :controller do
       end
 
       it 'permits access when token has allowed scopes' do
-        with_okta_configured do
+        with_okta_profile_configured do
           get :index
           expect(response).to be_ok
         end
@@ -113,7 +113,7 @@ RSpec.describe OpenidApplicationController, type: :controller do
       end
 
       it 'permits access to one action with the correct scope' do
-        with_okta_configured do
+        with_okta_profile_configured do
           get :index
           expect(response).to be_ok
         end
@@ -130,7 +130,7 @@ RSpec.describe OpenidApplicationController, type: :controller do
       end
 
       it 'permits access if at least one of the allowed scopes is provided' do
-        with_okta_configured do
+        with_okta_profile_configured do
           token_opts = { 'scp' => %w[email] }
           change_encoded_token_payload(token_opts)
 
@@ -140,7 +140,7 @@ RSpec.describe OpenidApplicationController, type: :controller do
       end
 
       it 'permits access if all the allowed scopes are provided' do
-        with_okta_configured do
+        with_okta_profile_configured do
           token_opts = { 'scp' => %w[email openid] }
           change_encoded_token_payload(token_opts)
 
@@ -187,7 +187,7 @@ RSpec.describe OpenidApplicationController, type: :controller do
       end
 
       it 'returns 200 and add the user to the session' do
-        with_okta_configured do
+        with_okta_profile_configured do
           request.headers['Authorization'] = 'Bearer FakeToken'
           get :index
           expect(response).to be_ok


### PR DESCRIPTION
## Description of change
With the addition of Lighthouse SSOi token validation support, it was identified that Okta profile fetching was occurring for every non-Client Credentials token validation request rather than previously where only the first time a token was used.

This PR updates the fetch profile to only occur when a session is nil and the token is not a client credentials token.

## Original issue(s)
- https://vajira.max.gov/browse/API-6279
- https://github.com/department-of-veterans-affairs/vets-api/pull/6359

## Things to know about this PR
- Future update to token validation will cache the fetch_profile response 
