### PR TITLE
supply target-branch for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
   insecure-external-code-execution: allow
   schedule:
     interval: weekly
+  target-branch: "test-dependabot-sidekiq-credentials"
   ignore:
     - dependency-name: "vets_json_schema"
     - dependency-name: "active_model_serializers"


### PR DESCRIPTION
## Description of change
This supplies a target-branch for dependabot to run against. Purely for testing if dependabot is setting enterprise.contribsys.com creds correctly.

