### PR TITLE
add to rubocop_todo for failing deploy

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -535,6 +535,7 @@ Metrics/AbcSize:
     - 'rakelib/in_progress_forms.rake'
     - 'rakelib/mvi.rake'
     - 'rakelib/swagger.rake'
+    - 'spec/controllers/v0/profile/communication_preferences_controller_spec.rb'
     - 'spec/lib/carma/client/client_spec.rb'
     - 'spec/lib/debt_management_center/debt_letter_downloader_spec.rb'
     - 'spec/lib/emis/support/emis_soap_response_examples.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -326,6 +326,7 @@ Metrics/AbcSize:
     - 'app/services/mhv_accounts_service.rb'
     - 'app/services/users/profile.rb'
     - 'app/services/users/services.rb'
+    - 'app/swagger/swagger/schemas/vet360/communication_permission.rb'
     - 'app/uploaders/evss_claim_document_uploader.rb'
     - 'app/workers/central_mail/submit_form4142_job.rb'
     - 'app/workers/central_mail/submit_saved_claim_job.rb'


### PR DESCRIPTION

## Description of change
This [PR branch](https://github.com/department-of-veterans-affairs/vets-api/commit/39ca5b6abe920a32063ee372044f6f319875dfac) didn’t have the latest master before merging in and introduced a rubocop failure. 

