### PR TITLE
Add missing fetch profile call

### DIFF
--- a/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
@@ -12,11 +12,8 @@ module VeteranVerification
     before_action { set_default_format_to_json }
 
     def authenticate_token
-      return false if token.blank?
-
-      # Not supported for Client Credentials tokens
-      return false if token.client_credentials_token?
-
+      return false if token.blank? || token.client_credentials_token? # Not supported for Client Credentials tokens
+      
       @session = Session.find(token)
       if @session.nil?
         profile = fetch_profile(token.identifiers.okta_uid)

--- a/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
@@ -18,7 +18,8 @@ module VeteranVerification
       return false if token.client_credentials_token?
 
       @session = Session.find(token)
-      establish_session if @session.nil?
+      profile = fetch_profile(token.identifiers.okta_uid) if @session.nil?
+      establish_session(profile) if @session.nil?
       return false if @session.nil?
 
       open_id = if Settings.vet_verification.mock_emis

--- a/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
@@ -22,9 +22,16 @@ module VeteranVerification
       end
       return false if @session.nil?
 
-      open_id = OpenidUser
-      open_id = MockOpenIdUser if Settings.vet_verification.mock_emis
+      open_id = get_open_id_user
       @current_user = open_id.find(@session.uuid)
+    end
+
+    def get_open_id_user
+      if Settings.vet_verification.mock_emis
+        MockOpenIdUser
+      else
+        OpenidUser
+      end
     end
 
     def set_default_format_to_json

--- a/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
@@ -18,8 +18,10 @@ module VeteranVerification
       return false if token.client_credentials_token?
 
       @session = Session.find(token)
-      profile = fetch_profile(token.identifiers.okta_uid) if @session.nil?
-      establish_session(profile) if @session.nil?
+      if @session.nil?
+        profile = fetch_profile(token.identifiers.okta_uid)
+        establish_session(profile)
+      end
       return false if @session.nil?
 
       open_id = if Settings.vet_verification.mock_emis

--- a/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
@@ -12,7 +12,9 @@ module VeteranVerification
     before_action { set_default_format_to_json }
 
     def authenticate_token
-      return false if token.blank? || token.client_credentials_token? # Not supported for Client Credentials tokens
+      # Not supported for Client Credentials tokens
+      return false if token.blank? || token.client_credentials_token?
+
       @session = Session.find(token)
       if @session.nil?
         profile = fetch_profile(token.identifiers.okta_uid)

--- a/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
@@ -13,7 +13,6 @@ module VeteranVerification
 
     def authenticate_token
       return false if token.blank? || token.client_credentials_token? # Not supported for Client Credentials tokens
-      
       @session = Session.find(token)
       if @session.nil?
         profile = fetch_profile(token.identifiers.okta_uid)
@@ -21,11 +20,8 @@ module VeteranVerification
       end
       return false if @session.nil?
 
-      open_id = if Settings.vet_verification.mock_emis
-                  MockOpenIdUser
-                else
-                  OpenidUser
-                end
+      open_id = OpenidUser
+      open_id = MockOpenIdUser if Settings.vet_verification.mock_emis
       @current_user = open_id.find(@session.uuid)
     end
 


### PR DESCRIPTION
## Description of change
The underlying `authenticate_token` method contained in the openid_application_controller.rb parent class was updated to fetch the Okta profile earlier to detect SSOi tokens.  The Veteran Verification API had overridden that method to utilize a mock-emis endpoint.

Update the Veteran Verification API contained `authenticate_token` method to similarly fetch the Okta profile if a session is not already established and pass that to the `establish_session` method.

## Original issue(s)
- https://github.com/department-of-veterans-affairs/vets-api/pull/6520