### PR TITLE
Api 6001/audit logging event sourcing

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/event_subscription.rb
+++ b/modules/appeals_api/app/models/appeals_api/event_subscription.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: event_subscriptions
+#
+#  id         :integer          not null, primary key
+#  callback   :string
+#  topic      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_event_subscriptions_on_topic_and_callback  (topic,callback) UNIQUE
+#
+
+class AppealsApi::EventSubscription < ApplicationRecord
+  def topic
+    self[:topic].to_sym
+  end
+
+  def callback
+    self[:callback].constantize
+  end
+end

--- a/modules/appeals_api/app/models/appeals_api/event_subscription.rb
+++ b/modules/appeals_api/app/models/appeals_api/event_subscription.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: event_subscriptions

--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -37,6 +37,7 @@ module AppealsApi
     )
 
     has_many :evidence_submissions, as: :supportable, dependent: :destroy
+    has_many :status_updates, as: :statusable, dependent: :destroy
 
     def pdf_structure(version)
       Object.const_get(

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -23,6 +23,7 @@ module AppealsApi
     validate :validate_hearing_type_selection, if: :pii_present?
 
     has_many :evidence_submissions, as: :supportable, dependent: :destroy
+    has_many :status_updates, as: :statusable, dependent: :destroy
 
     def pdf_structure(version)
       Object.const_get(

--- a/modules/appeals_api/app/models/appeals_api/status_update.rb
+++ b/modules/appeals_api/app/models/appeals_api/status_update.rb
@@ -3,6 +3,5 @@
 module AppealsApi
   class StatusUpdate < ApplicationRecord
     belongs_to :statusable, polymorphic: true, optional: true
-
   end
 end

--- a/modules/appeals_api/app/models/appeals_api/status_update.rb
+++ b/modules/appeals_api/app/models/appeals_api/status_update.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  class StatusUpdate < ApplicationRecord
+    belongs_to :statusable, polymorphic: true, optional: true
+
+  end
+end

--- a/modules/appeals_api/app/services/appeals_api/events/handler.rb
+++ b/modules/appeals_api/app/services/appeals_api/events/handler.rb
@@ -14,8 +14,7 @@ module AppealsApi
         @opts = opts
       end
 
-      def handle
-        # push log of event out?
+      def handle!
         AppealsApi::EventsWorker.perform_async(event_type, opts)
       end
 

--- a/modules/appeals_api/app/services/appeals_api/events/handler.rb
+++ b/modules/appeals_api/app/services/appeals_api/events/handler.rb
@@ -15,6 +15,7 @@ module AppealsApi
       end
 
       def handle
+        # push log of event out?
         AppealsApi::EventsWorker.perform_async(event_type, opts)
       end
 

--- a/modules/appeals_api/app/services/appeals_api/events/handler.rb
+++ b/modules/appeals_api/app/services/appeals_api/events/handler.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 module AppealsApi
   module Events
     class Handler
-
       def self.subscribe(topic_name, callback_name)
         AppealsApi::EventSubscription.find_or_create_by!(
           topic: topic_name,
-          callback: callback_name,
+          callback: callback_name
         )
       end
 

--- a/modules/appeals_api/app/services/appeals_api/events/status_updated.rb
+++ b/modules/appeals_api/app/services/appeals_api/events/status_updated.rb
@@ -4,26 +4,26 @@ module AppealsApi
 
       def initialize(opts)
         @opts = opts
-        return false unless has_required_keys?
+        raise InvalidKeys unless has_required_keys?
       end
 
       def hlr_status_updated
         AppealsApi::StatusUpdate.create!(
-          from: opts[:from],
-          to: opts[:to],
-          status_update_time: opts[:status_update_time],
-          appeal_id: opts[:appeal_id],
-          appeal_type: 'AppealsApi::HigherLevelReview',
+          from: opts['from'],
+          to: opts['to'],
+          status_update_time: opts['status_update_time'],
+          statusable_id: opts['statusable_id'],
+          statusable_type: 'AppealsApi::HigherLevelReview',
         )
       end
 
       def nod_status_updated
         AppealsApi::StatusUpdate.create!(
-          from: opts[:from],
-          to: opts[:to],
-          status_update_time: opts[:status_update_time],
-          appeal_id: opts[:appeal_id],
-          appeal_type: 'AppealsApi::NoticeOfDisagreement',
+          from: opts['from'],
+          to: opts['to'],
+          status_update_time: opts['status_update_time'],
+          statusable_id: opts['statusable_id'],
+          statusable_type: 'AppealsApi::NoticeOfDisagreement',
         )
       end
 
@@ -36,8 +36,11 @@ module AppealsApi
       end
 
       def required_keys
-        %i[from to status_update_time appeal_id]
+        %w[from to status_update_time statusable_id]
       end
     end
+
+    class InvalidKeys < StandardError; end
   end
 end
+

--- a/modules/appeals_api/app/services/appeals_api/events/status_updated.rb
+++ b/modules/appeals_api/app/services/appeals_api/events/status_updated.rb
@@ -1,0 +1,43 @@
+module AppealsApi
+  module Events
+    class StatusUpdated
+
+      def initialize(opts)
+        @opts = opts
+        return false unless has_required_keys?
+      end
+
+      def hlr_status_updated
+        AppealsApi::StatusUpdate.create!(
+          from: opts[:from],
+          to: opts[:to],
+          status_update_time: opts[:status_update_time],
+          appeal_id: opts[:appeal_id],
+          appeal_type: 'AppealsApi::HigherLevelReview',
+        )
+      end
+
+      def nod_status_updated
+        AppealsApi::StatusUpdate.create!(
+          from: opts[:from],
+          to: opts[:to],
+          status_update_time: opts[:status_update_time],
+          appeal_id: opts[:appeal_id],
+          appeal_type: 'AppealsApi::NoticeOfDisagreement',
+        )
+      end
+
+      private
+
+      attr_accessor :opts
+
+      def has_required_keys?
+        required_keys.all? { |k| opts.key?(k) }
+      end
+
+      def required_keys
+        %i[from to status_update_time appeal_id]
+      end
+    end
+  end
+end

--- a/modules/appeals_api/app/services/appeals_api/events/status_updated.rb
+++ b/modules/appeals_api/app/services/appeals_api/events/status_updated.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 module AppealsApi
   module Events
     class StatusUpdated
-
       def initialize(opts)
         @opts = opts
-        raise InvalidKeys unless has_required_keys?
+        raise InvalidKeys unless required_keys?
       end
 
       def hlr_status_updated
@@ -13,7 +14,7 @@ module AppealsApi
           to: opts['to'],
           status_update_time: opts['status_update_time'],
           statusable_id: opts['statusable_id'],
-          statusable_type: 'AppealsApi::HigherLevelReview',
+          statusable_type: 'AppealsApi::HigherLevelReview'
         )
       end
 
@@ -23,7 +24,7 @@ module AppealsApi
           to: opts['to'],
           status_update_time: opts['status_update_time'],
           statusable_id: opts['statusable_id'],
-          statusable_type: 'AppealsApi::NoticeOfDisagreement',
+          statusable_type: 'AppealsApi::NoticeOfDisagreement'
         )
       end
 
@@ -31,7 +32,7 @@ module AppealsApi
 
       attr_accessor :opts
 
-      def has_required_keys?
+      def required_keys?
         required_keys.all? { |k| opts.key?(k) }
       end
 
@@ -43,4 +44,3 @@ module AppealsApi
     class InvalidKeys < StandardError; end
   end
 end
-

--- a/modules/appeals_api/app/services/events/handler.rb
+++ b/modules/appeals_api/app/services/events/handler.rb
@@ -1,0 +1,26 @@
+module AppealsApi
+  module Events
+    class Handler
+
+      def self.subscribe(topic_name, callback_name)
+        AppealsApi::EventSubscription.find_or_create_by!(
+          topic: topic_name,
+          callback: callback_name,
+        )
+      end
+
+      def initialize(event_type:, opts:)
+        @event_type = event_type
+        @opts = opts
+      end
+
+      def handle
+        AppealsApi::EventsWorker.perform_async(event_type, opts)
+      end
+
+      private
+
+      attr_accessor :event_type, :opts
+    end
+  end
+end

--- a/modules/appeals_api/app/workers/appeals_api/events_worker.rb
+++ b/modules/appeals_api/app/workers/appeals_api/events_worker.rb
@@ -3,9 +3,17 @@ module AppealsApi
     include Sidekiq::Worker
 
     def perform(event_type, opts)
+      log_event(event_type)
+
       EventSubscription.where(topic: event_type).each do |subscription|
         subscription.callback.new(opts).send(event_type)
       end
+    end
+
+    private
+
+    def log_event(event_type)
+      Rails.logger.info("AppealsApi: Event triggered - #{event_type}, job started at #{Time.zone.now}")
     end
   end
 end

--- a/modules/appeals_api/app/workers/appeals_api/events_worker.rb
+++ b/modules/appeals_api/app/workers/appeals_api/events_worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AppealsApi
   class EventsWorker
     include Sidekiq::Worker

--- a/modules/appeals_api/app/workers/appeals_api/events_worker.rb
+++ b/modules/appeals_api/app/workers/appeals_api/events_worker.rb
@@ -1,0 +1,11 @@
+module AppealsApi
+  class EventsWorker
+    include Sidekiq::Worker
+
+    def perform(event_type, opts)
+      EventSubscription.where(topic: event_type).each do |subscription|
+        subscription.callback.new(opts).send(event_type)
+      end
+    end
+  end
+end

--- a/modules/appeals_api/config/initializers/event_subscriptions.rb
+++ b/modules/appeals_api/config/initializers/event_subscriptions.rb
@@ -1,4 +1,4 @@
 if ActiveRecord::Base.connected? && ActiveRecord::Base.connection.table_exists?("appeals_api_event_subscriptions")
-  AppealsApi::Events::Handler.subscribe(:hlr_status_updated, "AppealsApi::StatusUpdated")
-  AppealsApi::Events::Handler.subscribe(:nod_status_updated, "AppealsApi::StatusUpdated")
+  AppealsApi::Events::Handler.subscribe(:hlr_status_updated, "AppealsApi::Events::StatusUpdated")
+  AppealsApi::Events::Handler.subscribe(:nod_status_updated, "AppealsApi::Events::StatusUpdated")
 end

--- a/modules/appeals_api/config/initializers/event_subscriptions.rb
+++ b/modules/appeals_api/config/initializers/event_subscriptions.rb
@@ -1,0 +1,4 @@
+if ActiveRecord::Base.connected? && ActiveRecord::Base.connection.table_exists?("appeals_api_event_subscriptions")
+  AppealsApi::Events::Handler.subscribe(:hlr_status_updated, "AppealsApi::StatusUpdated")
+  AppealsApi::Events::Handler.subscribe(:nod_status_updated, "AppealsApi::StatusUpdated")
+end

--- a/modules/appeals_api/config/initializers/event_subscriptions.rb
+++ b/modules/appeals_api/config/initializers/event_subscriptions.rb
@@ -1,4 +1,6 @@
-if ActiveRecord::Base.connected? && ActiveRecord::Base.connection.table_exists?("appeals_api_event_subscriptions")
-  AppealsApi::Events::Handler.subscribe(:hlr_status_updated, "AppealsApi::Events::StatusUpdated")
-  AppealsApi::Events::Handler.subscribe(:nod_status_updated, "AppealsApi::Events::StatusUpdated")
+# frozen_string_literal: true
+
+if ActiveRecord::Base.connected? && ActiveRecord::Base.connection.table_exists?('appeals_api_event_subscriptions')
+  AppealsApi::Events::Handler.subscribe(:hlr_status_updated, 'AppealsApi::Events::StatusUpdated')
+  AppealsApi::Events::Handler.subscribe(:nod_status_updated, 'AppealsApi::Events::StatusUpdated')
 end

--- a/modules/appeals_api/spec/services/appeals_api/events/handler_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/events/handler_spec.rb
@@ -1,31 +1,31 @@
-require "rails_helper"
-require "sidekiq/testing"
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
 
 module AppealsApi
   module Events
     describe Handler do
-
-      describe ".subscribe" do
-        it "creates a record of the callback needed for the event" do
-          Handler.subscribe(:hlr_status_updated, "AppealsApi::StatusUpdated")
+      describe '.subscribe' do
+        it 'creates a record of the callback needed for the event' do
+          Handler.subscribe(:hlr_status_updated, 'AppealsApi::Events::StatusUpdated')
 
           event = EventSubscription.first
 
           expect(EventSubscription.count).to eq(1)
           expect(event.topic).to eq(:hlr_status_updated)
-          expect(event.callback).to eq(AppealsApi::StatusUpdated)
+          expect(event.callback).to eq(AppealsApi::Events::StatusUpdated)
         end
       end
 
-
-      describe "#handle" do
-        it "delegates to the correct event type" do
+      describe '#handle' do
+        it 'delegates to the correct event type' do
           Sidekiq::Testing.fake! do
             handler = Handler.new(event_type: :hlr_status_updated, opts: {})
-            handler.handle
+            handler.handle!
 
             expect(EventsWorker.jobs.size).to eq(1)
-            expect(EventsWorker.jobs.first["args"].first).to eq("hlr_status_updated")
+            expect(EventsWorker.jobs.first['args'].first).to eq('hlr_status_updated')
           end
         end
       end

--- a/modules/appeals_api/spec/services/appeals_api/events/handler_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/events/handler_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+require "sidekiq/testing"
+
+module AppealsApi
+  module Events
+    describe Handler do
+
+      describe ".subscribe" do
+        it "creates a record of the callback needed for the event" do
+          Handler.subscribe(:hlr_status_updated, "AppealsApi::StatusUpdated")
+
+          event = EventSubscription.first
+
+          expect(EventSubscription.count).to eq(1)
+          expect(event.topic).to eq(:hlr_status_updated)
+          expect(event.callback).to eq(AppealsApi::StatusUpdated)
+        end
+      end
+
+
+      describe "#handle" do
+        it "delegates to the correct event type" do
+          Sidekiq::Testing.fake! do
+            handler = Handler.new(event_type: :hlr_status_updated, opts: {})
+            handler.handle
+
+            expect(EventsWorker.jobs.size).to eq(1)
+            expect(EventsWorker.jobs.first["args"].first).to eq("hlr_status_updated")
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/appeals_api/spec/services/appeals_api/events/status_updated_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/events/status_updated_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 module AppealsApi
   module Events
     RSpec.describe StatusUpdated do

--- a/modules/appeals_api/spec/services/appeals_api/events/status_updated_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/events/status_updated_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  module Events
+    RSpec.describe StatusUpdated do
+      describe 'hlr_status_updated' do
+        it 'errors if the keys needed are missing' do
+          opts = {
+            'from' => 'pending',
+            'to' => 'submitted',
+            'status_update_time' => Time.zone.now
+          }
+
+          expect { AppealsApi::Events::StatusUpdated.new(opts).hlr_status_updated }.to raise_error(InvalidKeys)
+        end
+
+        it 'creates a status update' do
+          opts = {
+            'from' => 'pending',
+            'to' => 'submitted',
+            'status_update_time' => Time.zone.now,
+            'statusable_id' => 'id_of_status'
+          }
+
+          expect { AppealsApi::Events::StatusUpdated.new(opts).hlr_status_updated }.to change(
+            AppealsApi::StatusUpdate,
+            :count
+          ).by(1)
+        end
+      end
+
+      describe 'nod_status_updated' do
+        it 'errors if the keys needed are missing' do
+          opts = {
+            'from' => 'pending',
+            'to' => 'submitted',
+            'status_update_time' => Time.zone.now
+          }
+
+          expect { AppealsApi::Events::StatusUpdated.new(opts).nod_status_updated }.to raise_error(InvalidKeys)
+        end
+
+        it 'creates a status update' do
+          opts = {
+            'from' => 'pending',
+            'to' => 'submitted',
+            'status_update_time' => Time.zone.now,
+            'statusable_id' => 'id_of_status'
+          }
+
+          expect { AppealsApi::Events::StatusUpdated.new(opts).nod_status_updated }.to change(
+            AppealsApi::StatusUpdate,
+            :count
+          ).by(1)
+        end
+      end
+    end
+  end
+end

--- a/modules/appeals_api/spec/workers/appeals_api/events_worker_spec.rb
+++ b/modules/appeals_api/spec/workers/appeals_api/events_worker_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module AppealsApi
+  RSpec.describe EventsWorker, type: :job do
+    before do
+      AppealsApi::Events::Handler.subscribe(:test_subscription, 'TestSubscriptionEvent')
+    end
+
+    describe 'perform' do
+      it 'calls the correct callback' do
+        test_double = instance_double('TestSubscriptionEvent')
+        allow(test_double).to receive(:test_subscription)
+
+        stub_const('TestSubscriptionEvent', test_double)
+
+        allow(TestSubscriptionEvent).to receive(:new).and_return(test_double)
+
+        EventsWorker.new.perform(:test_subscription, {})
+
+        expect(test_double).to have_received(:test_subscription)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[API-6001](https://vajira.max.gov/browse/API-6001)

This PR adds functionality for Status Update audit logging, to track meta data around statuses changing in our API.

It does this by using an lightweight EventSourced model to decouple the event from the effect.

‼️ This PR is dependent on [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/6527) ‼️