### PR TITLE
Api 6346 Update Evidence submission create & show

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -5,34 +5,26 @@ module AppealsApi::V1
     module NoticeOfDisagreements
       class EvidenceSubmissionsController < AppealsApi::ApplicationController
         skip_before_action :authenticate
-        before_action :set_submission_attributes, if: -> { params[:nod_id] }
+        before_action :set_submission_attributes, only: :create
 
         def create
-          submission = AppealsApi::EvidenceSubmission.create(@submission_attributes)
-          signed_url = submission.get_location
+          upload = VBADocuments::UploadSubmission.create! consumer_name: 'appeals_api_nod_evidence_submission'
+          submission = AppealsApi::EvidenceSubmission.create! @submission_attributes.merge(upload_submission: upload)
 
-          render json: { data:
-                          {
-                            attributes:
-                              {
-                                status: submission.status,
-                                id: submission.id,
-                                appeal_id: submission.supportable_id,
-                                appeal_type: submission.supportable_type
-                              },
-                            location: signed_url
-                          } }
+          render json: submission,
+                 serializer: AppealsApi::EvidenceSubmissionSerializer,
+                 key_transform: :camel_lower,
+                 render_location: true
         end
 
         def show
-          submissions = AppealsApi::EvidenceSubmission.where(
-            supportable_id: params[:id],
-            supportable_type: 'AppealsApi::NoticeOfDisagreement'
-          )
+          submission = AppealsApi::EvidenceSubmission.find_by(guid: params[:id])
+          raise Common::Exceptions::RecordNotFound, params[:id] unless submission
 
-          serialized = AppealsApi::EvidenceSubmissionSerializer.new(submissions)
-
-          render json: serialized.serializable_hash
+          render json: submission,
+                 serializer: AppealsApi::EvidenceSubmissionSerializer,
+                 key_transform: :camel_lower,
+                 render_location: false
         end
 
         private
@@ -42,6 +34,7 @@ module AppealsApi::V1
           raise Common::Exceptions::RecordNotFound, params[:nod_id] unless @appeal
 
           @submission_attributes ||= {
+            source: request.headers['X-Consumer-Username'],
             supportable_id: params[:nod_id],
             supportable_type: 'NoticeOfDisagreement'
           }

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -36,7 +36,7 @@ module AppealsApi::V1
           @submission_attributes ||= {
             source: request.headers['X-Consumer-Username'],
             supportable_id: params[:nod_id],
-            supportable_type: 'NoticeOfDisagreement'
+            supportable_type: 'AppealsApi::NoticeOfDisagreement'
           }
         end
       end

--- a/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
+++ b/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
@@ -5,12 +5,10 @@ require 'json_marshal/marshaller'
 module AppealsApi
   class EvidenceSubmission < ApplicationRecord
     include SetGuid
-
-    self.ignored_columns = ["status"] # Temporary until migrations have run
-    belongs_to :supportable, polymorphic: true, optional: true
+    self.ignored_columns = ['status'] # Temporary until migrations have run
+    belongs_to :supportable, polymorphic: true
     belongs_to :upload_submission,
                class_name: 'VBADocuments::UploadSubmission',
-               foreign_key: 'upload_submission_id',
                dependent: :destroy
   end
 end

--- a/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
+++ b/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
@@ -4,30 +4,13 @@ require 'json_marshal/marshaller'
 
 module AppealsApi
   class EvidenceSubmission < ApplicationRecord
+    include SetGuid
+
+    self.ignored_columns = ["status"] # Temporary until migrations have run
     belongs_to :supportable, polymorphic: true, optional: true
-
-    attr_encrypted(:file_data, key: Settings.db_encryption_key, marshal: true, marshaler: JsonMarshal::Marshaller)
-
-    def get_location
-      rewrite_url(signed_url(id))
-    end
-
-    private
-
-    def rewrite_url(url)
-      rewritten = url.sub!(Settings.modules_appeals_api.evidence_submissions.location.prefix,
-                           Settings.modules_appeals_api.evidence_submissions.location.replacement)
-      raise 'Unable to provide document upload location' unless rewritten
-
-      rewritten
-    end
-
-    def signed_url(id)
-      s3 = Aws::S3::Resource.new(region: Settings.modules_appeals_api.s3.region,
-                                 access_key_id: Settings.modules_appeals_api.s3.aws_access_key_id,
-                                 secret_access_key: Settings.modules_appeals_api.s3.aws_secret_access_key)
-      obj = s3.bucket(Settings.modules_appeals_api.s3.bucket).object(id)
-      obj.presigned_url(:put, {})
-    end
+    belongs_to :upload_submission,
+               class_name: 'VBADocuments::UploadSubmission',
+               foreign_key: 'upload_submission_id',
+               dependent: :destroy
   end
 end

--- a/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
+++ b/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
@@ -10,5 +10,7 @@ module AppealsApi
     belongs_to :upload_submission,
                class_name: 'VBADocuments::UploadSubmission',
                dependent: :destroy
+
+    delegate :status, to: :upload_submission
   end
 end

--- a/modules/appeals_api/app/serializers/appeals_api/evidence_submission_serializer.rb
+++ b/modules/appeals_api/app/serializers/appeals_api/evidence_submission_serializer.rb
@@ -1,13 +1,45 @@
 # frozen_string_literal: true
 
-require 'fast_jsonapi'
+require_dependency 'common/exceptions'
 
 module AppealsApi
-  class EvidenceSubmissionSerializer
-    include FastJsonapi::ObjectSerializer
+  class EvidenceSubmissionSerializer < ActiveModel::Serializer
+    MAX_DETAIL_DISPLAY_LENGTH = 100
 
-    set_key_transform :camel_lower
-    attributes :status
-    set_type :evidenceSubmission
+    type 'evidence_submission'
+
+    attributes :id, :status, :code, :detail, :appeal_type, :appeal_id, :location, :created_at, :updated_at
+
+    def id
+      object.guid
+    end
+
+    def status
+      object.upload_submission.status
+    end
+
+    delegate :code, to: :object
+
+    def detail
+      details = object.detail.to_s
+      details = "#{details[0..MAX_DETAIL_DISPLAY_LENGTH - 1]}..." if details.length > MAX_DETAIL_DISPLAY_LENGTH
+      details
+    end
+
+    def appeal_type
+      object.supportable_type.to_s.demodulize
+    end
+
+    def appeal_id
+      object.supportable_id
+    end
+
+    def location
+      return nil unless @instance_options[:render_location]
+
+      object.upload_submission.get_location
+    rescue => e
+      raise Common::Exceptions::InternalServerError, e
+    end
   end
 end

--- a/modules/appeals_api/spec/factories/evidence_submissions.rb
+++ b/modules/appeals_api/spec/factories/evidence_submissions.rb
@@ -3,6 +3,12 @@
 FactoryBot.define do
   factory :evidence_submission, class: 'AppealsApi::EvidenceSubmission' do
     sequence(:id) { |n| n }
+    guid { SecureRandom.uuid }
     association :supportable, factory: :notice_of_disagreement
+    upload_submission { create(:upload_submission, guid: SecureRandom.uuid) } # set the guid to pass uniqueness check
+
+    trait :with_details do
+      details { SecureRandom.alphanumeric(150) }
+    end
   end
 end

--- a/modules/appeals_api/spec/factories/evidence_submissions.rb
+++ b/modules/appeals_api/spec/factories/evidence_submissions.rb
@@ -7,8 +7,12 @@ FactoryBot.define do
     association :supportable, factory: :notice_of_disagreement
     upload_submission { create(:upload_submission, guid: SecureRandom.uuid) } # set the guid to pass uniqueness check
 
-    trait :with_details do
-      details { SecureRandom.alphanumeric(150) }
+    trait :with_detail do
+      detail { SecureRandom.alphanumeric(150) }
+    end
+
+    trait :with_nod do
+      supportable { create(:notice_of_disagreement) }
     end
   end
 end

--- a/modules/appeals_api/spec/models/evidence_submission_spec.rb
+++ b/modules/appeals_api/spec/models/evidence_submission_spec.rb
@@ -5,17 +5,18 @@ require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::EvidenceSubmission, type: :model do
   let(:notice_of_disagreement) { create(:notice_of_disagreement) }
-  let(:evidence_submission) { notice_of_disagreement.evidence_submissions.create! }
+  let(:upload_submission) { create(:upload_submission) }
+  let(:evidence_submission) { create(:evidence_submission, supportable: notice_of_disagreement, upload_submission: upload_submission) }
 
-  xit 'responds to status' do
-    expect(evidence_submission.respond_to?(:status)).to eq(true)
-  end
-
-  xit 'responds to supportable' do
+  it 'responds to supportable' do
     expect(evidence_submission.respond_to?(:supportable)).to eq(true)
   end
 
-  xit 'has an association with the supportable' do
+  it 'has an association with the supportable' do
     expect(evidence_submission.supportable).to eq(notice_of_disagreement)
+  end
+
+  it 'has an association with the upload submission' do
+    expect(evidence_submission.upload_submission).to eq(upload_submission)
   end
 end

--- a/modules/appeals_api/spec/models/evidence_submission_spec.rb
+++ b/modules/appeals_api/spec/models/evidence_submission_spec.rb
@@ -6,7 +6,9 @@ require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 describe AppealsApi::EvidenceSubmission, type: :model do
   let(:notice_of_disagreement) { create(:notice_of_disagreement) }
   let(:upload_submission) { create(:upload_submission) }
-  let(:evidence_submission) { create(:evidence_submission, supportable: notice_of_disagreement, upload_submission: upload_submission) }
+  let(:evidence_submission) do
+    create :evidence_submission, supportable: notice_of_disagreement, upload_submission: upload_submission
+  end
 
   it 'responds to supportable' do
     expect(evidence_submission.respond_to?(:supportable)).to eq(true)

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -6,30 +6,10 @@ require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmissionsController, type: :request do
   include FixtureHelpers
 
-  let(:notice_of_disagreement) { create(:notice_of_disagreement) }
-  let(:evidence_submissions) { create_list(:evidence_submission, 3, supportable: notice_of_disagreement) }
+  let!(:notice_of_disagreement) { create(:notice_of_disagreement) }
   let(:path) { '/services/appeals/v1/decision_reviews/notice_of_disagreements/evidence_submissions/' }
 
-  xdescribe '#show' do
-    it 'successfully requests the evidence submissions' do
-      get "#{path}#{notice_of_disagreement.id}"
-
-      expect(response).to have_http_status(:ok)
-    end
-
-    it 'queries all evidence submissions for the nod' do
-      submissions = AppealsApi::EvidenceSubmissionSerializer.new(evidence_submissions).serializable_hash
-
-      get "#{path}#{notice_of_disagreement.id}"
-
-      body = JSON.parse(response.body)['data']
-      serialized = JSON.parse(submissions[:data].to_json)
-
-      expect(body).to match_array(serialized)
-    end
-  end
-
-  xdescribe '#create' do
+  describe '#create' do
     let(:double_setup) do
       s3_client = instance_double(Aws::S3::Resource)
       allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
@@ -40,46 +20,60 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
       allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
     end
 
-    context 'when nod_id parameter is not included' do
-      it 'returns submission attributes and location url' do
-        with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                      prefix: 'https://fake.s3.url/foo/',
-                      replacement: 'https://api.vets.gov/proxy/') do
-          double_setup
-          post(path, params: {})
-          json = JSON.parse(response.body)
-          expect(json['data']['attributes']).to have_key('id')
-          expect(json['data']['attributes']['status']).to eq('pending')
-          expect(json['data']['location']).to eq('https://api.vets.gov/proxy/uuid')
-        end
+    it 'returns submission attributes and location url' do
+      with_settings(Settings.vba_documents.location,
+                    prefix: 'https://fake.s3.url/foo/',
+                    replacement: 'https://api.vets.gov/proxy/') do
+        double_setup
+        post(path, params: { nod_id: notice_of_disagreement.id })
+        body = JSON.parse(response.body)['data']
+        expect(body).to have_key('id')
+        expect(body).to have_key('type')
+        expect(body['attributes']['status']).to eq('pending')
+        expect(body['attributes']['appealId']).to eq(notice_of_disagreement.id)
+        expect(body['attributes']['appealType']).to eq('NoticeOfDisagreement')
+        expect(body['attributes']['location']).to eq('https://api.vets.gov/proxy/uuid')
       end
     end
 
-    context 'when nod_id parameter is included' do
-      it "returns saved submission with attributes 'appeal_id' and 'appeal_type'" do
-        with_settings(Settings.modules_appeals_api.evidence_submissions.location,
+    context 'with no matching record' do
+      it 'raises an error' do
+        with_settings(Settings.vba_documents.location,
                       prefix: 'https://fake.s3.url/foo/',
                       replacement: 'https://api.vets.gov/proxy/') do
           double_setup
-          post(path, params: { nod_id: notice_of_disagreement.id })
-          json = JSON.parse(response.body)
-          expect(json['data']['attributes']['appeal_id']).to eq(notice_of_disagreement.id)
-          expect(json['data']['attributes']['appeal_type']).to eq('NoticeOfDisagreement')
+          post(path, params: { nod_id: 1979 })
+          expect(response.status).to eq 404
+          expect(response.body).to include 'Record not found'
         end
       end
+    end
+  end
 
-      context 'with no matching record' do
-        it 'raises an error' do
-          with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                        prefix: 'https://fake.s3.url/foo/',
-                        replacement: 'https://api.vets.gov/proxy/') do
-            double_setup
-            post(path, params: { nod_id: 1979 })
-            expect(response.status).to eq 404
-            expect(response.body).to include 'Record not found'
-          end
-        end
-      end
+  describe '#show' do
+    let!(:evidence_submissions) { create_list(:evidence_submission, 3, supportable: notice_of_disagreement) }
+
+    it 'successfully requests the evidence submission' do
+      get "#{path}#{evidence_submissions.sample.guid}"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns details for the evidence submission' do
+      es = evidence_submissions.sample
+      get "#{path}#{es.guid}"
+      submission = JSON.parse(response.body)['data']
+
+      expect(submission['id']).to eq es.guid
+      expect(submission['type']).to eq('evidenceSubmission')
+      expect(submission['attributes']['status']).to eq('pending')
+      expect(submission['attributes']['appealId']).to eq(notice_of_disagreement.id)
+      expect(submission['attributes']['appealType']).to eq('NoticeOfDisagreement')
+    end
+
+    it 'returns an error if record is not found' do
+      get "#{path}/bueller"
+      expect(response.status).to eq 404
+      expect(response.body).to include 'Record not found'
     end
   end
 end

--- a/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
+++ b/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
@@ -4,41 +4,23 @@ require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::EvidenceSubmissionSerializer do
-  let(:evidence_submission) { create(:evidence_submission) }
+  let(:evidence_submission) { create(:evidence_submission, :with_detail, :with_nod) }
   let(:rendered_hash) { described_class.new(evidence_submission).serializable_hash }
 
-  xit 'serializes the NOD properly' do
-    expect(rendered_hash).to eq(
-      {
-        data: {
-          type: :evidenceSubmission,
-          id: evidence_submission.id.to_s,
-          attributes: {
-            status: evidence_submission.status
-          }
-        }
-      }
-    )
+  it 'includes guid' do
+    expect(rendered_hash[:id]).to eq evidence_submission.guid
   end
 
-  xit 'has the correct top level keys' do
-    expect(rendered_hash.keys.count).to be 1
-    expect(rendered_hash).to have_key :data
+  it 'includes :appeal_type' do
+    expect(rendered_hash[:appeal_type]).to eq 'NoticeOfDisagreement'
   end
 
-  xit 'has the correct data keys' do
-    expect(rendered_hash[:data].keys.count).to be 3
-    expect(rendered_hash[:data]).to have_key :type
-    expect(rendered_hash[:data]).to have_key :id
-    expect(rendered_hash[:data]).to have_key :attributes
+  it 'includes :appeal_id' do
+    expect(rendered_hash[:appeal_id]).to eq evidence_submission.supportable.id
   end
 
-  xit 'has the correct attribute keys' do
-    expect(rendered_hash[:data][:attributes].keys.count).to be 1
-    expect(rendered_hash[:data][:attributes]).to have_key :status
-  end
-
-  xit 'has the correct type' do
-    expect(rendered_hash[:data][:type]).to eq :evidenceSubmission
+  it "truncates :detail value if longer than #{described_class::MAX_DETAIL_DISPLAY_LENGTH}" do
+    max_length_plus_ellipses = described_class::MAX_DETAIL_DISPLAY_LENGTH + 3
+    expect(rendered_hash[:detail].length).to eq(max_length_plus_ellipses)
   end
 end


### PR DESCRIPTION
## Description of change
Updates the EvidenceSubmission create & show endpoints to follow the research we've done with the Matsumoto team to talk to VBADocuments::UploadSubmission directly.

❗ ❗ ~Requires #6571 (db migrations)~  ❗ ❗ 

## Original issue(s)
https://vajira.max.gov/browse/API-6346
https://vajira.max.gov/browse/API-6221

## Things to know about this PR
Will need to follow up with other PRs to remove code that is no longer needed.
