### PR TITLE
Adding Email Notifications for VA Form 28-1900 (Chapter 31)

### DIFF
--- a/app/mailers/veteran_readiness_employment_mailer.rb
+++ b/app/mailers/veteran_readiness_employment_mailer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class VeteranReadinessEmploymentMailer < ApplicationMailer
+  def build(user, email_addr)
+    @submission_date = Time.current.in_time_zone('America/New_York').strftime('%m/%d/%Y')
+    template = File.read('app/mailers/views/veteran_readiness_employment.html.erb')
+
+    mail(
+      to: email_addr,
+      subject: 'VR&E Counseling Request Confirmation',
+      body: ERB.new(template).result(binding)
+    )
+  end
+end

--- a/app/mailers/views/veteran_readiness_employment.html.erb
+++ b/app/mailers/views/veteran_readiness_employment.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>
+      <b>Submitted Application</b></br>
+      Veteran's PID: <%= user.participant_id %></br>
+      Type of Form Submitted: 28-1900</br>
+      Submitted Date: <%= @submission_date %></br>
+    </p>
+    <p>Sent from: VA.gov</p>
+    <p><i>Note: This is an automated message sent from an unmonitored email account.</i></p>
+  </body>
+</html>

--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -10,6 +10,68 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
   # to all vets
   PERMITTED_OFFICE_LOCATIONS = %w[325].freeze
 
+  REGIONAL_OFFICE_EMAILS = {
+    '301' => 'VRC.VBABOS@va.gov',
+    '304' => 'VRE.VBAPRO@va.gov',
+    '306' => 'VRE.VBANYN@va.gov',
+    '307' => 'VRC.VBABUF@va.gov',
+    '308' => 'VRE.VBAHAR@va.gov',
+    '309' => 'vre.vbanew@va.gov',
+    '310' => 'VREBDD.VBAPHI@va.gov',
+    '311' => 'VRE.VBAPIT@va.gov',
+    '313' => 'VRE.VBABAL@va.gov',
+    '314' => 'VRE.VBAROA@va.gov',
+    '315' => 'VRE.VBAHUN@va.gov',
+    '316' => 'VRETMP.VBAATG@va.gov',
+    '317' => 'VRE281900.VBASPT@va.gov',
+    '318' => 'VRC.VBAWIN@va.gov',
+    '319' => 'VRC.VBACMS@va.gov',
+    '320' => 'VREAPPS.VBANAS@va.gov',
+    '321' => 'VRC.VBANOL@va.gov',
+    '322' => 'VRE.VBAMGY@va.gov',
+    '323' => 'VRE.VBAJAC@va.gov',
+    '325' => 'VRE.VBACLE@va.gov',
+    '326' => 'VRE.VBAIND@va.gov',
+    '327' => 'VRE.VBALOU@va.gov',
+    '328' => 'VAVBACHI.VRE@va.gov',
+    '329' => 'VRE.VBADET@va.gov',
+    '330' => 'VREApplications.VBAMIW@va.gov',
+    '331' => 'VRC.VBASTL@va.gov',
+    '333' => 'VRE.VBADES@va.gov',
+    '334' => 'VRE.VBALIN@va.gov',
+    '335' => 'VRC.VBASPL@va.gov',
+    '339' => 'VRE.VBADEN@va.gov',
+    '340' => 'VRC.VBAALB@va.gov',
+    '341' => 'VRE.VBASLC@va.gov',
+    '343' => 'VRC.VBAOAK@va.gov',
+    '344' => 'ROVRC.VBALAN@va.gov',
+    '345' => 'VRE.VBAPHO@va.gov',
+    '346' => 'VRE.VBASEA@va.gov',
+    '347' => 'VRE.VBABOI@va.gov',
+    '348' => 'VRE.VBAPOR@va.gov',
+    '349' => 'VREAPPS.VBAWAC@va.gov',
+    '350' => 'VRE.VBALIT@va.gov',
+    '351' => 'VREBDD.VBAMUS@va.gov',
+    '354' => 'VRE.VBAREN@va.gov',
+    '355' => 'MBVRE.VBASAJ@va.gov',
+    '358' => 'VRE.VBAMPI@va.gov',
+    '362' => 'VRE.VBAHOU@va.gov',
+    '372' => 'VRE.VBAWAS@va.gov',
+    '373' => 'VRE.VBAMAN@va.gov',
+    '377' => 'EBENAPPS.VBASDC@va.gov',
+    '402' => 'VRE.VBATOG@va.gov',
+    '405' => 'VRE.VBAMAN@va.gov',
+    '436' => 'VRC.VBAFHM@va.gov',
+    '437' => 'VRC.VBAFAR@va.gov',
+    '438' => 'VRC.VBAFAR@va.gov',
+    '442' => 'VRE.VBADEN@va.gov',
+    '452' => 'VRE.VBAWIC@va.gov',
+    '459' => 'VRC.VBAHON@va.gov',
+    '460' => 'VAVBA/WIM/RO/VR&E@vba.va.gov',
+    '463' => 'VRE.VBAANC@va.gov',
+    '000' => 'VRE.VBACO@va.gov'
+  }.freeze
+
   validate :veteran_information, on: :prepare_form_data
 
   def add_claimant_info(user)
@@ -33,6 +95,9 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
   def send_to_vre(user)
     prepare_form_data
     office_location = check_office_location
+
+    email_addr = REGIONAL_OFFICE_EMAILS[office_location] || 'VRE.VBACO@va.gov'
+    VeteranReadinessEmploymentMailer.build(user, email_addr).deliver_now if user.present?
 
     upload_to_vbms
 
@@ -68,7 +133,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     vet_info = parsed_form['veteranAddress']
 
     regional_office_response = service.routing.get_regional_office_by_zip_code(
-      vet_info['postalCode'], vet_info['country'], vet_info['state'], 'CP', parsed_form['veteranInformation']['ssn']
+      vet_info['postalCode'], vet_info['country'], vet_info['state'], 'VRE', parsed_form['veteranInformation']['ssn']
     )
 
     regional_office_response[:regional_office][:number]

--- a/spec/mailers/veteran_readiness_employment_mailer_spec.rb
+++ b/spec/mailers/veteran_readiness_employment_mailer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VeteranReadinessEmploymentMailer, type: [:mailer] do
+  include ActionView::Helpers::TranslationHelper
+  let(:user) { FactoryBot.create(:evss_user, :loa3) }
+  let(:email_addr) { 'foo@example.com' }
+  let(:current_date) { Time.current.in_time_zone('America/New_York').strftime('%m/%d/%Y') }
+
+  describe '#build' do
+    it 'includes all info' do
+      mailer = described_class.build(user, email_addr).deliver_now
+
+      expect(mailer.subject).to eq('VR&E Counseling Request Confirmation')
+      expect(mailer.to).to eq(['foo@example.com'])
+      expect(mailer.body.raw_source).to include(
+        'Submitted Application',
+        "Veteran's PID: #{user.participant_id}",
+        'Type of Form Submitted: 28-1900',
+        "Submitted Date: #{current_date}"
+      )
+    end
+  end
+end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
When a user submits a Form 28-1900 on VA.gov, an email needs to be sent to the office of Veteran Readiness and Employment (VR&E).  The regional office where the email should get sent is dependent upon the zip code that the user enters on the form.  

## Original issue(s)
department-of-veterans-affairs/va.gov-team#23024

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is an update (adding an email notification) to an existing form submission, so no new logging or settings have been added.  
<!-- Please describe testing done to verify the changes or any testing planned. -->
### Testing
- [x] Spec added
- [x] Staging testing planned