### PR TITLE
[API-6386] - Fix swagger example for "directDeposit.accountType"

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/forms/form_526_response_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_526_response_swagger.rb
@@ -937,8 +937,8 @@ module ClaimsApi
                 property :accountType do
                   key :type, :string
                   key :description, 'Veteran Account Type'
-                  key :example, 'Checking'
-                  key :enum, %w[Checking Savings]
+                  key :example, 'CHECKING'
+                  key :enum, %w[CHECKING SAVINGS]
                 end
 
                 property :accountNumber do

--- a/modules/claims_api/app/swagger/claims_api/forms/form_526_response_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/forms/form_526_response_swagger.rb
@@ -937,8 +937,8 @@ module ClaimsApi
                 property :accountType do
                   key :type, :string
                   key :description, 'Veteran Account Type'
-                  key :example, 'CHECKING'
-                  key :enum, %w[CHECKING SAVINGS]
+                  key :example, 'Checking'
+                  key :enum, %w[Checking Savings]
                 end
 
                 property :accountNumber do

--- a/modules/claims_api/config/schemas/526.json
+++ b/modules/claims_api/config/schemas/526.json
@@ -796,7 +796,7 @@
       "properties": {
         "accountType": {
           "type": "string",
-          "enum": ["Checking", "Savings"]
+          "enum": ["CHECKING", "SAVINGS"]
         },
         "accountNumber": {
           "minLength": 4,


### PR DESCRIPTION
## Description of change
Fixes the casing of the example values for POST Form 526 `directDeposit.accountType` attribute.

## Original issue(s)
[api-6386](https://vajira.max.gov/browse/API-6386)