### PR TITLE
update eligibilty_info check to use string instead of object key

### DIFF
--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
@@ -142,7 +142,7 @@ module CovidVaccine
           submission: id,
           submission_date: date
         )
-        raise Common::Exceptions::RecordNotFound, "#{self.class.name}:Error in MPI Lookup: #{error}"
+        raise Common::Exceptions::RecordNotFound.new(self.class.name.to_s, detail: "Error in MPI Lookup: #{error}")
       end
     end
   end

--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
@@ -13,7 +13,7 @@ module CovidVaccine
         # preferred facility will either be in eligibility_info, or raw_form_data. If its in neither one,
         # for the purposes of this register method we should not be fetching facilities and trying to reconcile;
         # instead we will set the state to :enrollment_out_of_band
-        facility = submission&.eligibility_info&.fetch(:preferred_facility, nil) ||
+        facility = submission&.eligibility_info&.fetch('preferred_facility', nil) ||
                    raw_form_data['preferred_facility'].delete_prefix('vha_')
         handle_no_facility_error(submission) if facility.blank?
 

--- a/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
+++ b/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
@@ -99,7 +99,7 @@ FactoryBot.define do
     end
 
     trait :eligibility_info do
-      eligibility_info { { 'preferred_facility': '516' } }
+      eligibility_info { { 'preferred_facility' => '516' } }
     end
 
     trait :spouse do


### PR DESCRIPTION
## Description of change
This PR:
* fixes a bug discovered when processing records where a lookup for the eligibility_info['preferred_facility'] was using an object (`:preferred_facility`) instead of a string (`'preferred_facility'`).
* Adds detail to the Exception raised when look up fails in MPI

The [test case factory trait](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb#L102) that injects the preferred_facility into eligibility_info has been updated

This path is tested with this test case: 
* https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb#L124

The test cases for the MPI lookup exceptions are:
* [Profile Not Found](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb#L180)
* [Facility Not Found](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb#L187)