### PR TITLE
fix bug with email vs email_address

### DIFF
--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
@@ -93,7 +93,7 @@ module CovidVaccine
           state: form_data['state_code'],
           zip_code: form_data['zip_code'],
           phone: form_data['phone'],
-          email: form_data['email'] || '',
+          email: form_data['email_address'] || '',
           sms_acknowledgement: form_data['sms_acknowledgement'] || false,
           sta3n: facility[0..2],
           sta6a: facility.length > 3 ? facility : ''

--- a/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
+++ b/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
           'character_of_service' => 'Honorable',
           'date_range' => { 'from' => '1980-03-XX', 'to' => '1984-01-XX' },
           'preferred_facility' => 'vha_516',
-          'email' => 'vets.gov.user+0@gmail.com',
+          'email_address' => 'vets.gov.user+0@gmail.com',
           'phone' => '808-555-1212',
           'sms_acknowledgement' => true,
           'address_line1' => '810 Vermont Avenue',
@@ -62,7 +62,7 @@ FactoryBot.define do
         character_of_service: 'Honorable',
         date_range: { 'from' => '1980-03-XX', 'to' => '1984-01-XX' },
         preferred_facility: 'vha_516',
-        email: 'vets.gov.user+0@gmail.com',
+        email_address: 'vets.gov.user+0@gmail.com',
         phone: '808-555-1212',
         sms_acknowledgement: false,
         address_line1: '810 Vermont Avenue',
@@ -93,7 +93,7 @@ FactoryBot.define do
     trait :blank_email do
       default_raw_options {
         {
-          'email' => nil
+          'email_address' => nil
         }
       }
     end


### PR DESCRIPTION

## Description of change
Fix bug where form system is sending `email_address` but code was using `email` and thus missing the email in submission

<!-- Please describe testing done to verify the changes or any testing planned. -->
tests have been updated to ensure email_address is the field name in test data