### PR TITLE
[6600] Adding account uuid to default rails logging

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,8 @@ Rails.application.configure do
     consumer_username: ->(request) { request.headers['X-Consumer-Username'] },
     consumer_custom_id: ->(request) { request.headers['X-Consumer-Custom-ID'] },
     credential_username: ->(request) { request.headers['X-Credential-Username'] },
-    csrf_token: ->(request) { request.headers['X-Csrf-Token'] }
+    csrf_token: ->(request) { request.headers['X-Csrf-Token'] },
+    account_id: ->(_request) { current_user&.account_uuid }
   }
 
   config.rails_semantic_logger.format = :json


### PR DESCRIPTION
## Description of change
This PR simply adds a default `account_uuid: 'some-account=uuid'` to every Rails logger event, set to `nil` if the current user is not yet authenticated.

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/6600

## Things to know about this PR
- Can only test this on production-like environments, so will need to test on staging, or a PR instance

## My testing
- I wasn't able to figure out how to test this on the deployed instance here, but I tried this locally (by moving the logger config over to the `development` environment), and I confirmed these changes did not break the logging
