### PR TITLE
Ensure source tracked

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews_controller.rb
@@ -78,7 +78,9 @@ class AppealsApi::V1::DecisionReviews::HigherLevelReviewsController < AppealsApi
 
   def new_higher_level_review
     @higher_level_review = AppealsApi::HigherLevelReview.new(
-      auth_headers: headers, form_data: @json_body
+      auth_headers: headers,
+      form_data: @json_body,
+      source: headers['X-Consumer-Username']
     )
 
     render_model_errors unless @higher_level_review.validate

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -34,7 +34,7 @@ module AppealsApi::V1
           raise Common::Exceptions::RecordNotFound, params[:nod_id] unless @appeal
 
           @submission_attributes ||= {
-            source: request.headers['X-Consumer-Username'],
+            source: params['headers']['X-Consumer-Username'],
             supportable_id: params[:nod_id],
             supportable_type: 'AppealsApi::NoticeOfDisagreement'
           }

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements_controller.rb
@@ -76,7 +76,11 @@ class AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController < Appeals
   end
 
   def new_notice_of_disagreement
-    @notice_of_disagreement = AppealsApi::NoticeOfDisagreement.new(auth_headers: headers, form_data: @json_body)
+    @notice_of_disagreement = AppealsApi::NoticeOfDisagreement.new(
+      auth_headers: headers,
+      form_data: @json_body,
+      source: headers['X-Consumer-Username']
+    )
     render_model_errors unless @notice_of_disagreement.validate
   end
 

--- a/modules/appeals_api/spec/requests/v1/higher_level_reviews_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/higher_level_reviews_controller_spec.rb
@@ -26,6 +26,8 @@ describe AppealsApi::V1::DecisionReviews::HigherLevelReviewsController, type: :r
     context 'creates an HLR and persists the data' do
       it 'with all headers' do
         post(path, params: @data, headers: @headers)
+        hlr = AppealsApi::HigherLevelReview.last
+        expect(hlr.source).to eq('va.gov')
         expect(parsed['data']['type']).to eq('higherLevelReview')
         expect(parsed['data']['attributes']['status']).to eq('pending')
       end

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
@@ -26,6 +26,9 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController, type:
     context 'creates an NOD and persists the data' do
       it 'with all headers' do
         post(path, params: @data, headers: @headers)
+        nod = AppealsApi::NoticeOfDisagreement.find_by(id: parsed['data']['id'])
+
+        expect(nod.source).to eq('va.gov')
         expect(parsed['data']['type']).to eq('noticeOfDisagreement')
         expect(parsed['data']['attributes']['status']).to eq('pending')
       end


### PR DESCRIPTION
## Description of change
We added `source` to our nod, hlr, and evidence submission models but never persisted the attribute upon creation. This is the fix.

## Original issue(s)
https://vajira.max.gov/browse/API-6414