### PR TITLE
reorganize user model methods (#18742)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,61 +62,10 @@ class User < Common::RedisStore
     pciu&.get_alternate_phone&.to_s
   end
 
-  def first_name
-    identity.first_name || (mhv_icn.present? ? mpi&.profile&.given_names&.first : nil)
-  end
+  # Identity getter methods
 
-  def first_name_mpi
-    mpi&.profile&.given_names&.first
-  end
-
-  def full_name_normalized
-    {
-      first: first_name&.capitalize,
-      middle: middle_name&.capitalize,
-      last: last_name&.capitalize,
-      suffix: va_profile&.normalized_suffix
-    }
-  end
-
-  def ssn_normalized
-    ssn&.gsub(/[^\d]/, '')
-  end
-
-  def middle_name
-    identity.middle_name || (mhv_icn.present? ? mpi&.profile&.given_names.to_a[1..-1]&.join(' ').presence : nil)
-  end
-
-  def last_name
-    identity.last_name || (mhv_icn.present? ? mpi&.profile&.family_name : nil)
-  end
-
-  def last_name_mpi
-    mpi&.profile&.family_name
-  end
-
-  def gender
-    identity.gender || (mhv_icn.present? ? mpi&.profile&.gender : nil)
-  end
-
-  def gender_mpi
-    mpi&.profile&.gender
-  end
-
-  def given_names
-    mpi_profile&.given_names
-  end
-
-  def historical_icns
-    mpi_profile&.historical_icns
-  end
-
-  def home_phone
-    mpi_profile&.home_phone
-  end
-
-  def normalized_suffix
-    mpi_profile&.normalized_suffix
+  def birls_id
+    identity&.birls_id || mpi&.birls_id
   end
 
   # Returns a Date string in iso8601 format, eg. '{year}-{month}-{day}'
@@ -132,8 +81,74 @@ class User < Common::RedisStore
       Rails.logger.info "[User] Cannot find birth date for User with uuid: #{uuid}"
       return nil
     end
-
     Formatters::DateFormatter.format_date(birth_date)
+  end
+
+  def first_name
+    identity.first_name || (mhv_icn.present? ? first_name_mpi : nil)
+  end
+
+  def full_name_normalized
+    {
+      first: first_name&.capitalize,
+      middle: middle_name&.capitalize,
+      last: last_name&.capitalize,
+      suffix: normalized_suffix
+    }
+  end
+
+  def gender
+    identity.gender || (mhv_icn.present? ? mpi&.profile&.gender : nil)
+  end
+
+  def icn
+    identity&.icn || mpi&.icn
+  end
+
+  def loa
+    identity&.loa || {}
+  end
+
+  def mhv_account_type
+    identity.mhv_account_type || MHVAccountTypeService.new(self).mhv_account_type
+  end
+
+  def mhv_correlation_id
+    identity.mhv_correlation_id || mpi.mhv_correlation_id
+  end
+
+  def middle_name
+    identity.middle_name || (mhv_icn.present? ? mpi&.profile&.given_names.to_a[1..-1]&.join(' ').presence : nil)
+  end
+
+  def last_name
+    identity.last_name || (mhv_icn.present? ? mpi&.profile&.family_name : nil)
+  end
+
+  def participant_id
+    identity&.participant_id || mpi&.participant_id
+  end
+
+  def sec_id
+    identity.sec_id || mpi_profile&.sec_id
+  end
+
+  def ssn
+    identity.ssn || (mhv_icn.present? ? mpi&.profile&.ssn : nil)
+  end
+
+  def ssn_normalized
+    ssn&.gsub(/[^\d]/, '')
+  end
+
+  def zip
+    identity.zip || (mhv_icn.present? ? mpi&.profile&.address&.postal_code : nil)
+  end
+
+  # MPI getter methods
+
+  def active_mhv_ids
+    mpi_profile&.active_mhv_ids
   end
 
   def address
@@ -147,25 +162,90 @@ class User < Common::RedisStore
     }
   end
 
-  def zip
-    identity.zip || (mhv_icn.present? ? mpi&.profile&.address&.postal_code : nil)
+  def edipi_mpi
+    mpi_profile&.edipi
   end
 
-  def ssn
-    identity.ssn || (mhv_icn.present? ? mpi&.profile&.ssn : nil)
+  def first_name_mpi
+    given_names&.first
+  end
+
+  def gender_mpi
+    mpi_profile&.gender
+  end
+
+  def given_names
+    mpi_profile&.given_names
+  end
+
+  def historical_icns
+    mpi_profile&.historical_icns
+  end
+
+  def home_phone
+    mpi_profile&.home_phone
+  end
+
+  def last_name_mpi
+    mpi_profile&.family_name
+  end
+
+  def mhv_account_state
+    return 'DEACTIVATED' if (mhv_ids.to_a - active_mhv_ids.to_a).any?
+    return 'MULTIPLE' if active_mhv_ids.to_a.size > 1
+    return 'NONE' if mhv_correlation_id.blank?
+
+    'OK'
+  end
+
+  def mhv_ids
+    mpi_profile&.mhv_ids
+  end
+
+  def mpi_profile_birth_date
+    return nil unless mpi_profile
+
+    if mpi_profile.birth_date.nil?
+      Rails.logger.info "[User] Cannot find birth date from MPI profile for User with uuid: #{uuid}"
+      return nil
+    end
+
+    mpi_profile.birth_date
+  end
+
+  def normalized_suffix
+    mpi_profile&.normalized_suffix
+  end
+
+  def sec_id_mpi
+    mpi_profile&.sec_id
   end
 
   def ssn_mpi
-    mpi&.profile&.ssn
+    mpi_profile&.ssn
   end
 
-  def active_mhv_ids
-    mpi_profile&.active_mhv_ids
+  def suffix
+    mpi_profile&.suffix
   end
 
-  def mhv_correlation_id
-    identity.mhv_correlation_id || mpi.mhv_correlation_id
+  def mpi_profile?
+    mpi_profile != nil
   end
+
+  def va_profile
+    mpi.profile
+  end
+
+  def va_profile_error
+    mpi.error
+  end
+
+  def va_profile_status
+    mpi.status
+  end
+
+  # MPI setter methods
 
   def set_mhv_ids(mhv_id)
     mpi_profile.mhv_ids = [mhv_id] + mhv_ids
@@ -173,22 +253,7 @@ class User < Common::RedisStore
     recache
   end
 
-  def mhv_account_type
-    identity.mhv_account_type || MHVAccountTypeService.new(self).mhv_account_type
-  end
-
-  def mhv_account_state
-    return 'DEACTIVATED' if (va_profile.mhv_ids.to_a - va_profile.active_mhv_ids.to_a).any?
-    return 'MULTIPLE' if va_profile.active_mhv_ids.to_a.size > 1
-    return 'NONE' if mhv_correlation_id.blank?
-
-    'OK'
-  end
-
-  def loa
-    identity&.loa || {}
-  end
-
+  # identity attributes
   delegate :multifactor, to: :identity, allow_nil: true
   delegate :authn_context, to: :identity, allow_nil: true
   delegate :mhv_icn, to: :identity, allow_nil: true
@@ -214,42 +279,6 @@ class User < Common::RedisStore
     loa3? && dslogon_edipi.present? ? dslogon_edipi : mpi&.edipi
   end
 
-  def edipi_mpi
-    mpi&.profile&.edipi
-  end
-
-  def sec_id
-    identity.sec_id || va_profile&.sec_id
-  end
-
-  def sec_id_mpi
-    mpi_profile&.sec_id
-  end
-
-  def icn
-    identity&.icn || mpi&.icn
-  end
-
-  def birls_id
-    identity&.birls_id || mpi&.birls_id
-  end
-
-  def participant_id
-    identity&.participant_id || mpi&.participant_id
-  end
-
-  def va_profile
-    mpi.profile
-  end
-
-  def va_profile_status
-    mpi.status
-  end
-
-  def va_profile_error
-    mpi.error
-  end
-
   # LOA1 no longer just means ID.me LOA1.
   # It could also be DSLogon or MHV NON PREMIUM users who have not yet done ID.me FICAM LOA3.
   # See also lib/saml/user_attributes/dslogon.rb
@@ -273,9 +302,9 @@ class User < Common::RedisStore
   end
 
   def ssn_mismatch?
-    return false unless loa3? && identity&.ssn && va_profile&.ssn
+    return false unless loa3? && identity&.ssn && ssn_mpi
 
-    identity.ssn != va_profile.ssn
+    identity.ssn != ssn_mpi
   end
 
   def can_access_user_profile?
@@ -290,7 +319,7 @@ class User < Common::RedisStore
   # User's profile contains a list of VHA facility-specific identifiers.
   # Facilities in the defined range are treating facilities
   def va_treatment_facility_ids
-    facilities = va_profile&.vha_facility_ids
+    facilities = mpi_profile&.vha_facility_ids
     facilities.to_a.select do |f|
       Settings.mhv.facility_range.any? { |range| f.to_i.between?(*range) } ||
         Settings.mhv.facility_specific.include?(f)
@@ -311,14 +340,6 @@ class User < Common::RedisStore
   def mhv_account
     @mhv_account ||= MHVAccount.find_or_initialize_by(user_uuid: uuid, mhv_correlation_id: mhv_correlation_id)
                                .tap { |m| m.user = self } # MHV account should not re-initialize use
-  end
-
-  def mhv_ids
-    mpi_profile&.mhv_ids
-  end
-
-  def suffix
-    mpi_profile&.suffix
   end
 
   def in_progress_forms
@@ -424,21 +445,6 @@ class User < Common::RedisStore
 
   def relationships
     @relationships ||= mpi_profile_relationships.map { |relationship| relationship_hash(relationship) }
-  end
-
-  def mpi_profile_birth_date
-    return nil unless mpi_profile
-
-    if mpi_profile.birth_date.nil?
-      Rails.logger.info "[User] Cannot find birth date from MPI profile for User with uuid: #{uuid}"
-      return nil
-    end
-
-    mpi_profile.birth_date
-  end
-
-  def mpi_profile?
-    mpi_profile != nil
   end
 
   private

--- a/modules/mobile/app/serializers/mobile/v0/user_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/user_serializer.rb
@@ -75,7 +75,7 @@ module Mobile
       end
 
       def self.facility(user, facility_id)
-        cerner_facility_ids = user.va_profile.cerner_facility_ids || []
+        cerner_facility_ids = user.cerner_facility_ids || []
         {
           facility_id: facility_id,
           is_cerner: cerner_facility_ids.include?(facility_id)
@@ -85,7 +85,7 @@ module Mobile
       attribute :health do |user|
         {
           facilities: user.va_treatment_facility_ids.map { |id| facility(user, id) },
-          is_cerner_patient: !user.va_profile.cerner_id.nil?
+          is_cerner_patient: !user.cerner_id.nil?
         }
       end
     end

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -758,7 +758,7 @@ RSpec.describe FormProfile, type: :model do
         'fullName' => {
           'first' => user.first_name&.capitalize,
           'last' => user.last_name&.capitalize,
-          'suffix' => user.va_profile[:suffix]
+          'suffix' => user.suffix
         },
         'ssn' => '796111863',
         'dob' => '1809-02-12'


### PR DESCRIPTION
## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Followup PR to #6433, this change contains the last removal of external `user.va_profile` method calls and reorders various User model getter and setter methods to flow alphabetically.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18740

## Things to know about this PR
No unit test changes were made, full test suite was performed as well as manual login/logout workflow tests.