### PR TITLE
Remove & update flipper personnel

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -666,7 +666,6 @@ flipper:
     - alastair@adhocteam.us
     - anna@adhoc.team
     - bill.ryan@adhocteam.us
-    - callen@governmentcio.com # Remove after Profile 2.0 UAT
     - cory.trimm@va.gov
     - cwheeler@governmentcio.com
     - dan.hinze@adhocteam.us
@@ -702,7 +701,6 @@ flipper:
     - ltran@thoughtworks.com
     - marisa.hoenig@thoughtworks.com
     - mark.greenburg@adhocteam.us
-    - matt.shea@adhocteam.us # Remove after Profile 2.0 UAT
     - mccurdy_devin@bah.com
     - mdewey@governmentcio.com
     - micah@adhocteam.us
@@ -726,7 +724,6 @@ flipper:
     - sonntag_adam@bah.com
     - ssuddath@governmentcio.com
     - stephen.barrs@va.gov
-    - tressa.furner@adhocteam.us # Remove after Profile 2.0 UAT
     - tony.williams@va.gov
     - travis.hilton@oddball.io
     - turner_desiree@bah.com

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -673,6 +673,7 @@ flipper:
     - delli-gatti_michael@bah.com
     - devinmccurdy@gmail.com
     - draju@governmentcio.com
+    - dror.matalon@va.gov
     - elder_joseph@bah.com
     - eric.buckley@adhocteam.us
     - erik@adhocteam.us

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -667,6 +667,7 @@ flipper:
     - anna@adhoc.team
     - bconley@governmentcio.com
     - bill.ryan@adhocteam.us
+    - callen@governmentcio.com # Remove after Profile 2.0 UAT
     - cory.trimm@va.gov
     - cwheeler@governmentcio.com
     - dan.hinze@adhocteam.us
@@ -687,6 +688,7 @@ flipper:
     - jennie.mcgibney@va.gov
     - jesse.cohn@adhocteam.us
     - jlinn@governmentcio.com
+    - joeyn414@gmail.com # Joe Niquette Oddball VSP Identity Team Sr Security Engineer
     - kabrown@thoughtworks.com
     - kadams@governmentcio.com
     - kam@adhocteam.us
@@ -694,12 +696,14 @@ flipper:
     - kenneth.santiago2010@gmail.com
     - kmircovich@governmentcio.com
     - lauren.alexanderson@va.gov
+    - lauren.ernest@adhocteam.us
     - lihan@adhocteam.us
     - lindsey.hattamer@oddball.io
     - lsanchez@governmentcio.com
     - ltran@thoughtworks.com
     - marisa.hoenig@thoughtworks.com
     - mark.greenburg@adhocteam.us
+    - matt.shea@adhocteam.us # Remove after Profile 2.0 UAT
     - mccurdy_devin@bah.com
     - mdewey@governmentcio.com
     - micah@adhocteam.us
@@ -724,17 +728,13 @@ flipper:
     - sonntag_adam@bah.com
     - ssuddath@governmentcio.com
     - stephen.barrs@va.gov
+    - tressa.furner@adhocteam.us # Remove after Profile 2.0 UAT
     - tony.williams@va.gov
     - travis.hilton@oddball.io
     - turner_desiree@bah.com
     - tze@adhocteam.us
     - zurbergram@gmail.com
     - zmorel@governmentcio.com
-    - callen@governmentcio.com # Remove after Profile 2.0 UAT
-    - matt.shea@adhocteam.us # Remove after Profile 2.0 UAT
-    - tressa.furner@adhocteam.us # Remove after Profile 2.0 UAT
-    - joeyn414@gmail.com # Joe Niquette Oddball VSP Identity Team Sr Security Engineer
-    - lauren.ernest@adhocteam.us
 
 bgs:
   application: ~

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -689,7 +689,6 @@ flipper:
     - kabrown@thoughtworks.com
     - kadams@governmentcio.com
     - kam@adhocteam.us
-    - keifer@oddball.io
     - kenneth.gary@va.gov
     - kenneth.santiago2010@gmail.com
     - kmircovich@governmentcio.com
@@ -713,10 +712,7 @@ flipper:
     - patrick@adhocteam.us
     - paul.phillips@thoughtworks.com
     - pherbert@thoughtworks.com
-    - philip.becker@oddball.io
     - regarr@gmail.com # Robin Garrison - AdHoc
-    - rian.fowler@adhoc.team
-    - rianfowler@outlook.com
     - roth_matthew@bah.com
     - ryan.thurlwell@va.gov
     - saman.moshafi@thoughtworks.com

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -672,7 +672,7 @@ flipper:
     - delli-gatti_michael@bah.com
     - devinmccurdy@gmail.com
     - draju@governmentcio.com
-    - dror.matalon@va.gov
+    - dror@matal.com
     - elder_joseph@bah.com
     - eric.buckley@adhocteam.us
     - erik@adhocteam.us


### PR DESCRIPTION
This removes folks from the flipper admin list who have left the platform and makes updates to include additional personnel. 
