### PR TITLE
Migration/add metadata to notice of disagreement

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_12_175709) do
+ActiveRecord::Schema.define(version: 2021_04_20_131905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 2021_04_12_175709) do
     t.string "code"
     t.string "detail"
     t.string "source"
+    t.jsonb "metadata"
   end
 
   create_table "appeals_api_status_updates", force: :cascade do |t|

--- a/modules/appeals_api/db/migrate/20210420131905_add_metadata_to_notice_of_disagreement.rb
+++ b/modules/appeals_api/db/migrate/20210420131905_add_metadata_to_notice_of_disagreement.rb
@@ -1,0 +1,5 @@
+class AddMetadataToNoticeOfDisagreement < ActiveRecord::Migration[6.0]
+  def change
+    add_column :appeals_api_notice_of_disagreements, :metadata, :jsonb
+  end
+end


### PR DESCRIPTION
## Description of change
In order to hold onto a notice of disagreement's `boardReviewOption` _(lane)_ after a PII purge, we are adding a column containing metadata in the form of a json blob. The review/lane option, among other data, will help validate evidence submissions.

related to: https://vajira.max.gov/browse/API-6166