### PR TITLE
add enum values to nodCreateInput docs

### DIFF
--- a/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
@@ -133,8 +133,17 @@ module AppealsApi::V1
 
               property :boardReviewOption do
                 key :type, :string
-                key :example, 'evidence_submission'
-                key :description, 'Type of Board Review NOD being requested'
+                key :example, 'hearing'
+                key :enum, %w[direct_review evidence_submission hearing]
+
+                key :description, 'The option selected for the NOD submission'
+              end
+
+              property :hearingTypePreference do
+                key :type, :string
+                key :example, 'video_conference'
+                key :enum, %w[virtual_hearing video_conference central_office]
+                key :description, "The type of hearing selected, required if 'hearing' is selected for boardReviewOption"
               end
 
               property :timezone do

--- a/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/schemas/notice_of_disagreements.rb
@@ -143,7 +143,8 @@ module AppealsApi::V1
                 key :type, :string
                 key :example, 'video_conference'
                 key :enum, %w[virtual_hearing video_conference central_office]
-                key :description, "The type of hearing selected, required if 'hearing' is selected for boardReviewOption"
+                key :description,
+                    "The type of hearing selected, required if 'hearing' is selected for boardReviewOption"
               end
 
               property :timezone do


### PR DESCRIPTION
[API-6486](https://vajira.max.gov/browse/API-6486)

This PR adds some missing values to the nodCreateInput schema documentation.