### PR TITLE
Migration/add board review option to notice of disagreement

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_12_175709) do
+ActiveRecord::Schema.define(version: 2021_04_20_131905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 2021_04_12_175709) do
     t.string "code"
     t.string "detail"
     t.string "source"
+    t.string "board_review_option"
   end
 
   create_table "appeals_api_status_updates", force: :cascade do |t|

--- a/modules/appeals_api/db/migrate/20210420131905_add_board_review_option_to_notice_of_disagreement.rb
+++ b/modules/appeals_api/db/migrate/20210420131905_add_board_review_option_to_notice_of_disagreement.rb
@@ -1,0 +1,5 @@
+class AddBoardReviewOptionToNoticeOfDisagreement < ActiveRecord::Migration[6.0]
+  def change
+    add_column :appeals_api_notice_of_disagreements, :board_review_option, :string
+  end
+end


### PR DESCRIPTION
In order to hold onto a notice of disagreement's boardReviewOption (lane) after a PII purge, we are adding a column containing this data. The review/lane option will help validate evidence submissions.

related to: https://vajira.max.gov/browse/API-6166