### PR TITLE
Skip CSRF check on KMI opt_out endpoint

### DIFF
--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
@@ -9,6 +9,7 @@ module CovidVaccine
       include IgnoreNotFound
 
       before_action :validate_raw_form_data, only: :create
+      skip_before_action :verify_authenticity_token, only: :opt_in, :opt_out, :create 
 
       def create
         raw_form_data = params[:registration].merge(attributes_from_user)

--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
@@ -9,7 +9,7 @@ module CovidVaccine
       include IgnoreNotFound
 
       before_action :validate_raw_form_data, only: :create
-      skip_before_action :verify_authenticity_token, only: :opt_in, :opt_out, :create 
+      skip_before_action :verify_authenticity_token, only: :opt_out
 
       def create
         raw_form_data = params[:registration].merge(attributes_from_user)


### PR DESCRIPTION
## Description of change
Disabled CSRF protection on the covid KMI opt_out endpoint which is triggered via an email opt out link. Working theory is that since it essentially triggers the API request immediately, there may be a race condition vs. getting the CSRF token during page load. 

However it's also the case that the frontend was not passing the CSRF token at all, as remedied here: https://github.com/department-of-veterans-affairs/vets-website/pull/16880
But there is little value in CSRF protection on this particular endpoint so it may be safest to disable it. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/23542

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
