### PR TITLE
[6412] Refactoring User model to remove MPI circular dependency

### DIFF
--- a/app/controllers/v0/profile/personal_informations_controller.rb
+++ b/app/controllers/v0/profile/personal_informations_controller.rb
@@ -21,7 +21,7 @@ module V0
       #   }
       #
       def show
-        response = MPIData.for_user(@current_user).profile
+        response = @current_user.mpi.profile
 
         handle_errors!(response)
 

--- a/app/models/mpi_data.rb
+++ b/app/models/mpi_data.rb
@@ -16,25 +16,28 @@ class MPIData < Common::RedisStore
   REDIS_CONFIG_KEY = :mpi_profile_response
   redis_config_key REDIS_CONFIG_KEY
 
-  # @return [User] the user to query MVI for.
-  attr_accessor :user
+  # @return [UserIdentity] the user identity object to query MVI for.
+  attr_accessor :user_identity
 
-  # Creates a new MPIData instance for a user.
+  # Creates a new MPIData instance for a user identity.
   #
-  # @param user [User] the user to query MVI for
+  # @param user [UserIdentity] the user identity to query MVI for
   # @return [MPIData] an instance of this class
-  def self.for_user(user)
-    MPIData.new(user: user)
+  def self.for_user(user_identity)
+    mvi = MPIData.new
+    mvi.user_identity = user_identity
+    mvi
   end
 
   # Queries MPI specifically to retrieve historical icn data.
   #
   # @param user [User] the user to query MVI for
   # @return [MPIData] an instance of this class
-  def self.historical_icn_for_user(user)
-    return nil unless user.loa3?
+  def self.historical_icn_for_user(user_identity)
+    return nil unless user_identity.loa3?
 
-    mpi_data_instance = MPIData.new(user: user)
+    mpi_data_instance = MPIData.new
+    mpi_data_instance.user_identity = user_identity
     mpi_data_instance.mvi_get_person_historical_icns
   end
 
@@ -98,7 +101,7 @@ class MPIData < Common::RedisStore
   #
   # @return [MPI::Models::MviProfile] patient 'golden record' data from MVI
   def profile
-    return nil unless user.loa3?
+    return nil unless user_identity.loa3?
 
     mvi_response&.profile
   end
@@ -107,7 +110,7 @@ class MPIData < Common::RedisStore
   #
   # @return [String] the status of the last MVI response
   def status
-    return MPI::Responses::FindProfileResponse::RESPONSE_STATUS[:not_authorized] unless user.loa3?
+    return MPI::Responses::FindProfileResponse::RESPONSE_STATUS[:not_authorized] unless user_identity.loa3?
 
     mvi_response.status
   end
@@ -116,7 +119,7 @@ class MPIData < Common::RedisStore
   #
   # @return [Common::Exceptions::BackendServiceException]
   def error
-    return Common::Exceptions::Unauthorized.new(source: self.class) unless user.loa3?
+    return Common::Exceptions::Unauthorized.new(source: self.class) unless user_identity.loa3?
 
     mvi_response.try(:error)
   end
@@ -128,7 +131,7 @@ class MPIData < Common::RedisStore
 
   # @return [String] Array representing the historical icn data for the user
   def mvi_get_person_historical_icns
-    mpi_profile = mpi_service.find_profile(user, search_type: MPI::Constants::CORRELATION_WITH_ICN_HISTORY)
+    mpi_profile = mpi_service.find_profile(user_identity, search_type: MPI::Constants::CORRELATION_WITH_ICN_HISTORY)
     mpi_profile&.profile&.historical_icns
   end
 
@@ -136,11 +139,11 @@ class MPIData < Common::RedisStore
   # call is made. The response is recached afterwards so the new ids can be accessed on the next call.
   #
   # @return [MPI::Responses::AddPersonResponse] the response returned from MPI Add Person call
-  def add_person
-    search_response = MPI::OrchSearchService.new.find_profile(user)
+  def add_person(user_identity)
+    search_response = MPI::OrchSearchService.new.find_profile(user_identity)
     if search_response.ok?
       @mvi_response = search_response
-      add_response = mpi_service.add_person(user)
+      add_response = mpi_service.add_person(user_identity)
       add_ids(add_response) if add_response.ok?
     else
       add_response = MPI::Responses::AddPersonResponse.with_failed_orch_search(
@@ -157,12 +160,12 @@ class MPIData < Common::RedisStore
     profile.birls_id = response.mvi_codes[:birls_id].presence
     profile.participant_id = response.mvi_codes[:participant_id].presence
 
-    cache(user.uuid, mvi_response) if mvi_response.cache?
+    cache(user_identity.uuid, mvi_response) if mvi_response.cache?
   end
 
   def response_from_redis_or_service
-    do_cached_with(key: user.uuid) do
-      mpi_service.find_profile(user)
+    do_cached_with(key: user_identity.uuid) do
+      mpi_service.find_profile(user_identity)
     rescue ArgumentError
       return nil
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@ class User < Common::RedisStore
   attribute :mhv_last_signed_in, Common::UTCTime # MHV audit logging
 
   delegate :email, to: :identity, allow_nil: true
+  delegate :loa3?, to: :identity, allow_nil: true
 
   # This delegated method is called with #account_uuid
   delegate :uuid, to: :account, prefix: true, allow_nil: true
@@ -71,22 +72,15 @@ class User < Common::RedisStore
 
   # Returns a Date string in iso8601 format, eg. '{year}-{month}-{day}'
   def birth_date
-    birth_date = nil
+    birth_date = identity.birth_date || birth_date_mpi
 
-    if identity.birth_date
-      birth_date =  identity.birth_date
-    elsif mhv_icn.present?
-      birth_date =  birth_date_mpi
-    end
-    if birth_date.nil?
-      Rails.logger.info "[User] Cannot find birth date for User with uuid: #{uuid}"
-      return nil
-    end
+    Rails.logger.info "[User] Cannot find birth date for User with uuid: #{uuid}" if birth_date.nil?
+
     Formatters::DateFormatter.format_date(birth_date)
   end
 
   def first_name
-    identity.first_name || (mhv_icn.present? ? first_name_mpi : nil)
+    identity.first_name || first_name_mpi
   end
 
   def full_name_normalized
@@ -99,7 +93,7 @@ class User < Common::RedisStore
   end
 
   def gender
-    identity.gender || (mhv_icn.present? ? mpi_profile&.gender : nil)
+    identity.gender || gender_mpi
   end
 
   def icn
@@ -119,11 +113,11 @@ class User < Common::RedisStore
   end
 
   def middle_name
-    identity.middle_name || (mhv_icn.present? ? mpi_profile&.given_names.to_a[1..-1]&.join(' ').presence : nil)
+    identity.middle_name || mpi&.profile&.given_names.to_a[1..-1]&.join(' ').presence
   end
 
   def last_name
-    identity.last_name || (mhv_icn.present? ? mpi_profile&.family_name : nil)
+    identity.last_name || last_name_mpi
   end
 
   def participant_id
@@ -135,7 +129,7 @@ class User < Common::RedisStore
   end
 
   def ssn
-    identity.ssn || (mhv_icn.present? ? mpi_profile&.ssn : nil)
+    identity.ssn || ssn_mpi
   end
 
   def ssn_normalized
@@ -143,7 +137,7 @@ class User < Common::RedisStore
   end
 
   def zip
-    identity.zip || (mhv_icn.present? ? mpi_profile&.address&.postal_code : nil)
+    identity.zip || mpi&.profile&.address&.postal_code
   end
 
   # MPI getter methods
@@ -264,7 +258,6 @@ class User < Common::RedisStore
   delegate :authn_context, to: :identity, allow_nil: true
   delegate :mhv_icn, to: :identity, allow_nil: true
   delegate :idme_uuid, to: :identity, allow_nil: true
-  delegate :dslogon_edipi, to: :identity, allow_nil: true
   delegate :common_name, to: :identity, allow_nil: true
   delegate :person_types, to: :identity, allow_nil: true
 
@@ -278,37 +271,12 @@ class User < Common::RedisStore
   delegate :cerner_id, to: :mpi
   delegate :cerner_facility_ids, to: :mpi
 
-  # mpi methods
-  delegate :add_person, to: :mpi, prefix: true
-
   # emis attributes
   delegate :military_person?, to: :veteran_status
   delegate :veteran?, to: :veteran_status
 
   def edipi
-    loa3? && dslogon_edipi.present? ? dslogon_edipi : edipi_mpi
-  end
-
-  # LOA1 no longer just means ID.me LOA1.
-  # It could also be DSLogon or MHV NON PREMIUM users who have not yet done ID.me FICAM LOA3.
-  # See also lib/saml/user_attributes/dslogon.rb
-  # See also lib/saml/user_attributes/mhv
-  def loa1?
-    loa[:current] == LOA::ONE
-  end
-
-  def loa2?
-    loa[:current] == LOA::TWO
-  end
-
-  # LOA3 no longer just means ID.me FICAM LOA3.
-  # It could also be DSLogon or MHV Premium users.
-  # It could also be DSLogon or MHV NON PREMIUM users who have done ID.me FICAM LOA3.
-  # Additionally, LOA3 does not automatically mean user has opted to have MFA.
-  # See also lib/saml/user_attributes/dslogon.rb
-  # See also lib/saml/user_attributes/mhv
-  def loa3?
-    loa[:current].try(:to_i) == LOA::THREE
+    loa3? && identity.edipi.present? ? identity.edipi : edipi_mpi
   end
 
   def ssn_mismatch?
@@ -318,7 +286,7 @@ class User < Common::RedisStore
   end
 
   def can_access_user_profile?
-    loa1? || loa2? || loa3?
+    loa[:current].present?
   end
 
   # True if the user has 1 or more treatment facilities, false otherwise
@@ -421,14 +389,8 @@ class User < Common::RedisStore
     false
   end
 
-  def can_mvi_proxy_add?
-    personal_info? && edipi.present? && icn_with_aaid.present? && search_token.present?
-  rescue # Default to false for any error
-    false
-  end
-
-  def personal_info?
-    first_name.present? && last_name.present? && ssn.present? && birth_date.present?
+  def mpi
+    @mpi ||= MPIData.for_user(identity)
   end
 
   # A user can have served in the military without being a veteran.  For example,
@@ -453,8 +415,13 @@ class User < Common::RedisStore
     @relationships ||= get_relationships_array
   end
 
-  def mpi
-    @mpi ||= MPIData.for_user(self)
+  def mpi_add_person
+    add_person_identity = identity
+    add_person_identity.edipi = edipi
+    add_person_identity.ssn = ssn
+    add_person_identity.icn_with_aaid = icn_with_aaid
+    add_person_identity.search_token = search_token
+    mpi.add_person(add_person_identity)
   end
 
   private

--- a/app/models/user_identity.rb
+++ b/app/models/user_identity.rb
@@ -33,12 +33,29 @@ class UserIdentity < Common::RedisStore
   attribute :mhv_icn # only needed by B/E not serialized in user_serializer
   attribute :mhv_correlation_id # this is the cannonical version of MHV Correlation ID, provided by MHV sign-in users
   attribute :mhv_account_type # this is only available for MHV sign-in users
-  attribute :dslogon_edipi # this is only available for dslogon users
+  attribute :edipi # this is only available for dslogon users
   attribute :sign_in, Hash # original sign_in (see sso_service#mergable_identity_attributes)
+  attribute :icn_with_aaid
+  attribute :search_token
 
   validates :uuid, presence: true
   validates :loa, presence: true
   validate  :loa_highest_present
+
+  # LOA3 no longer just means ID.me FICAM LOA3.
+  # It could also be DSLogon or MHV Premium users.
+  # It could also be DSLogon or MHV NON PREMIUM users who have done ID.me FICAM LOA3.
+  # Additionally, LOA3 does not automatically mean user has opted to have MFA.
+  # See also lib/saml/user_attributes/dslogon.rb
+  # See also lib/saml/user_attributes/mhv
+  def loa3?
+    loa[:current].try(:to_i) == LOA::THREE
+  end
+
+  with_options if: :loa3? do
+    validates :ssn, format: /\A\d{9}\z/, allow_blank: true
+    validates :gender, format: /\A(M|F)\z/, allow_blank: true
+  end
 
   private
 

--- a/lib/evss/disability_compensation_auth_headers.rb
+++ b/lib/evss/disability_compensation_auth_headers.rb
@@ -31,14 +31,13 @@ module EVSS
     end
 
     def gender
-      case @user.gender || @user.gender_mpi
+      case @user.gender
       when 'F'
         'FEMALE'
       when 'M'
         'MALE'
       else
-        Raven.extra_context(user_gender: @user.gender,
-                            mvi_gender: @user.gender_mpi)
+        Raven.extra_context(user_gender: @user.gender)
         raise Common::Exceptions::UnprocessableEntity,
               detail: 'Gender is required & must be "F" or "M"',
               source: self.class,

--- a/lib/mpi/messages/add_person_message.rb
+++ b/lib/mpi/messages/add_person_message.rb
@@ -16,7 +16,7 @@ module MPI
       SCHEMA_FILE_NAME = 'mpi_add_person_template.xml'
 
       def initialize(user)
-        raise ArgumentError, 'User missing attributes' unless user.can_mvi_proxy_add?
+        raise ArgumentError, 'User missing attributes' unless can_mvi_proxy_add?(user)
 
         @user = user
       end
@@ -30,6 +30,22 @@ module MPI
       end
 
       private
+
+      def can_mvi_proxy_add?(user)
+        personal_info?(user) &&
+          user.edipi.present? &&
+          user.icn_with_aaid.present? &&
+          user.search_token.present?
+      rescue # Default to false for any error
+        false
+      end
+
+      def personal_info?(user)
+        user.first_name.present? &&
+          user.last_name.present? &&
+          user.ssn.present? &&
+          user.birth_date.present?
+      end
 
       def build_content(user)
         current_time = Time.current

--- a/lib/mpi/orch_search_service.rb
+++ b/lib/mpi/orch_search_service.rb
@@ -14,31 +14,31 @@ module MPI
       ) { yield }
     end
 
-    def create_profile_message(user, search_type: MPI::Constants::CORRELATION_WITH_RELATIONSHIP_DATA)
-      unless user.valid? && user.edipi.present?
+    def create_profile_message(user_identity, search_type: MPI::Constants::CORRELATION_WITH_RELATIONSHIP_DATA)
+      unless user_identity.valid? && user_identity.edipi.present?
         raise Common::Exceptions::UnprocessableEntity.new(
           detail: 'User is invalid or missing edipi',
           source: 'OrchSearchService'
         )
       end
 
-      message_user_attributes(user, search_type)
+      message_user_attributes(user_identity, search_type)
     end
 
-    def message_user_attributes(user, search_type)
-      given_names = [user.first_name]
-      given_names.push user.middle_name unless user.middle_name.nil?
+    def message_user_attributes(user_identity, search_type)
+      given_names = [user_identity.first_name]
+      given_names.push user_identity.middle_name unless user_identity.middle_name.nil?
       profile = {
         given_names: given_names,
-        last_name: user.last_name,
-        birth_date: user.birth_date,
-        ssn: user.ssn,
-        gender: user.gender
+        last_name: user_identity.last_name,
+        birth_date: user_identity.birth_date,
+        ssn: user_identity.ssn,
+        gender: user_identity.gender
       }
       MPI::Messages::FindProfileMessage.new(
         profile,
         orch_search: true,
-        edipi: user.edipi,
+        edipi: user_identity.edipi,
         search_type: search_type
       ).to_xml
     end

--- a/lib/saml/user_attributes/dslogon.rb
+++ b/lib/saml/user_attributes/dslogon.rb
@@ -6,8 +6,7 @@ module SAML
   module UserAttributes
     class DSLogon < Base
       PREMIUM_LOAS = %w[2 3].freeze
-      DSLOGON_SERIALIZABLE_ATTRIBUTES = %i[first_name middle_name last_name gender ssn birth_date
-                                           dslogon_edipi].freeze
+      DSLOGON_SERIALIZABLE_ATTRIBUTES = %i[first_name middle_name last_name gender ssn birth_date edipi].freeze
 
       def first_name
         attributes['dslogon_fname']
@@ -35,7 +34,7 @@ module SAML
         attributes['dslogon_birth_date']
       end
 
-      def dslogon_edipi
+      def edipi
         attributes['dslogon_uuid']
       end
 

--- a/lib/saml/user_attributes/id_me.rb
+++ b/lib/saml/user_attributes/id_me.rb
@@ -49,8 +49,8 @@ module SAML
         existing_user_identity.mhv_account_type if existing_user_identity? && authn_context == 'myhealthevet_loa3'
       end
 
-      def dslogon_edipi
-        existing_user_identity.dslogon_edipi if existing_user_identity? && authn_context == 'dslogon_loa3'
+      def edipi
+        existing_user_identity.edipi if existing_user_identity? && authn_context == 'dslogon_loa3'
       end
 
       def sign_in
@@ -72,7 +72,7 @@ module SAML
         when 'myhealthevet_loa3'
           %i[mhv_icn mhv_account_type mhv_correlation_id sign_in]
         when 'dslogon_loa3'
-          %i[dslogon_edipi sign_in]
+          %i[edipi sign_in]
         else
           %i[sign_in]
         end

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -11,7 +11,7 @@ module SAML
       include Identity::Parsers::GCIds
       SERIALIZABLE_ATTRIBUTES = %i[email first_name middle_name last_name common_name zip gender ssn birth_date
                                    uuid idme_uuid sec_id mhv_icn mhv_correlation_id mhv_account_type
-                                   dslogon_edipi loa sign_in multifactor participant_id birls_id icn
+                                   edipi loa sign_in multifactor participant_id birls_id icn
                                    person_types].freeze
       INBOUND_AUTHN_CONTEXT = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password'
 
@@ -129,7 +129,7 @@ module SAML
         safe_attr('va_eauth_dslogonassurance')
       end
 
-      def dslogon_edipi
+      def edipi
         safe_attr('va_eauth_dodedipnid')&.split(',')&.first
       end
 

--- a/modules/claims_api/app/models/claims_api/veteran.rb
+++ b/modules/claims_api/app/models/claims_api/veteran.rb
@@ -29,8 +29,6 @@ module ClaimsApi
     delegate :birls_id, to: :mpi, allow_nil: true
     delegate :participant_id, to: :mpi, allow_nil: true
 
-    alias dslogon_edipi edipi
-
     def birth_date
       va_profile[:birth_date]
     end

--- a/modules/mobile/spec/request/user_request_spec.rb
+++ b/modules/mobile/spec/request/user_request_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe 'user', type: :request do
 
       context 'when user object birth_date is nil' do
         before do
-          allow_any_instance_of(IAMUserIdentity).to receive(:birth_date).and_return(nil)
+          iam_sign_in(FactoryBot.build(:iam_user, :no_birth_date))
           get '/mobile/v0/user', headers: iam_headers
         end
 

--- a/modules/openid_auth/app/controllers/openid_auth/v0/mpi_users_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v0/mpi_users_controller.rb
@@ -58,7 +58,7 @@ module OpenidAuth
           birth_date: user_attributes[:dob],
           ssn: user_attributes[:ssn],
           mhv_icn: user_attributes[:mhv_icn],
-          dslogon_edipi: user_attributes[:dslogon_edipi],
+          edipi: user_attributes[:edipi],
           loa:
           {
             current: user_attributes[:level_of_assurance].to_i,
@@ -78,7 +78,7 @@ module OpenidAuth
           birth_date: request.headers['x-va-dob'],
           ssn: request.headers['x-va-ssn'],
           mhv_icn: request.headers['x-va-mhv-icn'],
-          dslogon_edipi: request.headers['x-va-dslogon-edipi'],
+          edipi: request.headers['x-va-dslogon-edipi'],
           loa:
           {
             current: request.headers['x-va-level-of-assurance'].to_i,

--- a/modules/openid_auth/app/controllers/openid_auth/v0/okta_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v0/okta_controller.rb
@@ -31,7 +31,7 @@ module OpenidAuth
       def fetch_mvi_profile(user_attributes)
         user_identity = OpenidUserIdentity.new(
           birth_date: user_attributes[:dob],
-          dslogon_edipi: user_attributes[:dslogon_edipi],
+          edipi: user_attributes[:edipi],
           email: user_attributes[:user_email],
           first_name: user_attributes[:first_name],
           gender: user_attributes[:gender]&.chars&.first&.upcase,

--- a/modules/openid_auth/spec/requests/mpi_user_request_spec.rb
+++ b/modules/openid_auth/spec/requests/mpi_user_request_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe 'Return ICN for a User from MVI', type: :request, skip_emis: true
       let(:req_body) do
         {
           'idp_uuid' => 'ae9ff5f4e4b741389904087d94cd19b2',
-          'dslogon_edipi' => '7961223060',
+          'edipi' => '7961223060',
           'ssn' => '796122306',
           'level_of_assurance' => 3,
           'user_email' => 'test@123.com',

--- a/modules/openid_auth/spec/requests/validation_request_spec.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec.rb
@@ -100,7 +100,9 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
     }
   end
   let(:auth_header) { { 'Authorization' => "Bearer #{token}" } }
-  let(:user) { OpenidUser.new(build(:user_identity_attrs, :loa3)) }
+  let(:some_ttl) { 86_400 }
+  let(:identity) { OpenidUserIdentity.create(build(:user_identity_attrs, :loa3)) }
+  let(:user) { OpenidUser.build_from_identity(identity: identity, ttl: some_ttl) }
 
   context 'with valid responses' do
     before do

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -580,7 +580,7 @@ namespace :form526 do
     end
 
     def user_identity(icn:, edipi:)
-      OpenStruct.new mhv_icn: icn, dslogon_edipi: edipi
+      OpenStruct.new mhv_icn: icn, edipi: edipi
     end
 
     def edipi(auth_headers)

--- a/spec/factories/iam_users.rb
+++ b/spec/factories/iam_users.rb
@@ -70,6 +70,27 @@ FactoryBot.define do
       end
     end
 
+    trait :no_birth_date do
+      callback(:after_build, :after_stub, :after_create) do |user, _t|
+        user_identity = create(:iam_user_identity, birth_date: nil)
+        user.instance_variable_set(:@identity, user_identity)
+      end
+
+      after(:build) do
+        stub_mpi(
+          build(
+            :mvi_profile,
+            icn: '24811694708759028',
+            edipi: nil,
+            birls_id: '796121200',
+            participant_id: '796121200',
+            birth_date: nil,
+            vet360_id: '1'
+          )
+        )
+      end
+    end
+
     trait :no_vet360_id do
       callback(:after_build, :after_stub, :after_create) do |user, _t|
         user_identity = create(:iam_user_identity)

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -37,7 +37,7 @@ end
 
 FactoryBot.define do
   factory :mvi_profile, class: 'MPI::Models::MviProfile' do
-    given_names { Array.new(2) { Faker::Name.first_name } }
+    given_names { Array.new(1) { Faker::Name.first_name } }
     family_name { Faker::Name.last_name }
     suffix { Faker::Name.suffix }
     gender { %w[M F].sample }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
       multifactor { false }
       mhv_correlation_id { nil }
       mhv_account_type { nil }
-      dslogon_edipi { nil }
+      edipi { nil }
       va_patient { nil }
       search_token { nil }
       icn_with_aaid { nil }
@@ -63,7 +63,7 @@ FactoryBot.define do
                              multifactor: t.multifactor,
                              mhv_correlation_id: t.mhv_correlation_id,
                              mhv_account_type: t.mhv_account_type,
-                             dslogon_edipi: t.dslogon_edipi,
+                             edipi: t.edipi,
                              sign_in: t.sign_in,
                              common_name: t.common_name)
       user.instance_variable_set(:@identity, user_identity)

--- a/spec/lib/evss/disability_compensation_auth_headers_spec.rb
+++ b/spec/lib/evss/disability_compensation_auth_headers_spec.rb
@@ -20,7 +20,7 @@ describe EVSS::DisabilityCompensationAuthHeaders do
   # rubocop:enable all
 
   it 'raises an error if gender is not included' do
-    expect(Raven).to receive(:extra_context).with(user_gender: '', mvi_gender: nil)
+    expect(Raven).to receive(:extra_context).with(user_gender: '')
     expect { invalid_headers.add_headers(auth_headers) }.to raise_error(Common::Exceptions::UnprocessableEntity)
   end
 end

--- a/spec/lib/mpi/messages/add_person_message_spec.rb
+++ b/spec/lib/mpi/messages/add_person_message_spec.rb
@@ -91,16 +91,18 @@ describe MPI::Messages::AddPersonMessage do
     end
 
     context 'missing arguments' do
+      before { stub_mpi_not_found }
+
       let(:user) { build(:user, :loa3, user_hash) }
 
       let(:user_hash) do
         {
           first_name: 'MARK',
           last_name: 'WEBB',
-          middle_name: '',
+          middle_name: 'WEBBER',
           birth_date: '1950-10-04',
           ssn: nil,
-          dslogon_edipi: '1013590059'
+          edipi: '1013590059'
         }
       end
 

--- a/spec/lib/mpi/orch_search_service_spec.rb
+++ b/spec/lib/mpi/orch_search_service_spec.rb
@@ -15,7 +15,7 @@ describe MPI::OrchSearchService do
           middle_name: '',
           birth_date: '1950-10-04',
           ssn: '796104437',
-          dslogon_edipi: '1013590059'
+          edipi: '1013590059'
         }
       end
 

--- a/spec/lib/mpi/service_spec.rb
+++ b/spec/lib/mpi/service_spec.rb
@@ -308,8 +308,8 @@ describe MPI::Service do
     end
 
     context 'valid requests' do
-      it 'fetches profile when no mhv_icn exists but dslogon_edipi is present' do
-        allow(user).to receive(:dslogon_edipi).and_return('1025062341')
+      it 'fetches profile when no mhv_icn exists but edipi is present' do
+        allow(user).to receive(:edipi).and_return('1025062341')
 
         VCR.use_cassette('mpi/find_candidate/edipi_present') do
           expect(Raven).to receive(:tags_context).once.with(mvi_find_profile: 'edipi')

--- a/spec/lib/saml/dslogon_user_spec.rb
+++ b/spec/lib/saml/dslogon_user_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SAML::User do
 
       it 'has various important attributes' do
         expect(subject.to_hash).to eq(
-          dslogon_edipi: '1606997570',
+          edipi: '1606997570',
           birth_date: nil,
           first_name: nil,
           last_name: nil,
@@ -74,7 +74,7 @@ RSpec.describe SAML::User do
             ssn: nil,
             multifactor: true,
             authn_context: 'dslogon_multifactor',
-            dslogon_edipi: '1606997570'
+            edipi: '1606997570'
           )
         end
 
@@ -100,7 +100,7 @@ RSpec.describe SAML::User do
             birth_date: '1735-10-30',
             ssn: '111223333',
             zip: nil,
-            dslogon_edipi: '1606997570',
+            edipi: '1606997570',
             loa: { current: 3, highest: 3 },
             sign_in: { service_name: 'dslogon', account_type: '1' },
             sec_id: nil,
@@ -122,7 +122,7 @@ RSpec.describe SAML::User do
       it 'has various important attributes' do
         expect(subject.to_hash).to eq(
           birth_date: '1735-10-30',
-          dslogon_edipi: '1606997570',
+          edipi: '1606997570',
           first_name: 'Tristan',
           last_name: 'MHV',
           middle_name: '',
@@ -164,7 +164,7 @@ RSpec.describe SAML::User do
             ssn: '111223333',
             multifactor: true,
             authn_context: 'dslogon_multifactor',
-            dslogon_edipi: '1606997570'
+            edipi: '1606997570'
           )
         end
 

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe SAML::User do
           mhv_icn: nil,
           mhv_correlation_id: nil,
           mhv_account_type: nil,
-          dslogon_edipi: nil,
+          edipi: nil,
           uuid: '54e78de6140d473f87960f211be49c08',
           email: 'vets.gov.user+262@example.com',
           idme_uuid: '54e78de6140d473f87960f211be49c08',
@@ -144,7 +144,7 @@ RSpec.describe SAML::User do
           mhv_icn: nil,
           mhv_correlation_id: nil,
           mhv_account_type: nil,
-          dslogon_edipi: nil,
+          edipi: nil,
           uuid: '54e78de6140d473f87960f211be49c08',
           email: 'vets.gov.user+262@example.com',
           idme_uuid: '54e78de6140d473f87960f211be49c08',
@@ -185,7 +185,7 @@ RSpec.describe SAML::User do
           mhv_icn: '1008830476V316605',
           mhv_correlation_id: nil,
           mhv_account_type: nil,
-          dslogon_edipi: nil,
+          edipi: nil,
           uuid: '54e78de6140d473f87960f211be49c08',
           email: 'vets.gov.user+262@example.com',
           idme_uuid: '54e78de6140d473f87960f211be49c08',
@@ -216,7 +216,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: nil,
           authn_context: authn_context,
-          dslogon_edipi: nil,
+          edipi: nil,
           first_name: nil,
           last_name: nil,
           middle_name: nil,
@@ -258,7 +258,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: '1988-11-24',
           authn_context: authn_context,
-          dslogon_edipi: nil,
+          edipi: nil,
           first_name: 'ALEX',
           last_name: 'MAC',
           middle_name: nil,
@@ -295,7 +295,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: nil,
           authn_context: authn_context,
-          dslogon_edipi: nil,
+          edipi: nil,
           first_name: nil,
           last_name: nil,
           middle_name: nil,
@@ -338,7 +338,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: '1977-03-07',
           authn_context: authn_context,
-          dslogon_edipi: '2107307560',
+          edipi: '2107307560',
           first_name: 'TRISTAN',
           last_name: 'GPTESTSYSTWO',
           middle_name: nil,
@@ -382,7 +382,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: '1977-03-07',
           authn_context: authn_context,
-          dslogon_edipi: '2107307560',
+          edipi: '2107307560',
           first_name: 'TRISTAN',
           last_name: 'GPTESTSYSTWO',
           middle_name: nil,
@@ -630,7 +630,7 @@ RSpec.describe SAML::User do
 
         it 'de-duplicates values' do
           expect(subject.to_hash).to include(
-            dslogon_edipi: '0123456789'
+            edipi: '0123456789'
           )
         end
 
@@ -644,7 +644,7 @@ RSpec.describe SAML::User do
 
         it 'de-duplicates values' do
           expect(subject.to_hash).to include(
-            dslogon_edipi: nil
+            edipi: nil
           )
         end
 
@@ -663,7 +663,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: nil,
           authn_context: authn_context,
-          dslogon_edipi: '1606997570',
+          edipi: '1606997570',
           first_name: nil,
           last_name: nil,
           middle_name: nil,
@@ -701,7 +701,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: '1951-06-04',
           authn_context: authn_context,
-          dslogon_edipi: '2106798217',
+          edipi: '2106798217',
           first_name: 'BRANDIN',
           last_name: 'MILLER-NIETO',
           middle_name: 'BRANSON',
@@ -745,7 +745,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: '1956-07-10',
           authn_context: authn_context,
-          dslogon_edipi: '1005169255',
+          edipi: '1005169255',
           first_name: 'JOHNNIE',
           last_name: 'WEAVER',
           middle_name: 'LEONARD',
@@ -788,7 +788,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: '1956-07-10',
           authn_context: authn_context,
-          dslogon_edipi: '1005169255',
+          edipi: '1005169255',
           first_name: 'JOHNNIE',
           last_name: 'WEAVER',
           middle_name: 'LEONARD',
@@ -848,7 +848,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: '1946-10-20',
           authn_context: authn_context,
-          dslogon_edipi: '1606997570',
+          edipi: '1606997570',
           first_name: 'SOFIA',
           last_name: 'MCKIBBENS',
           middle_name: nil,
@@ -901,7 +901,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: '1982-05-23',
           authn_context: authn_context,
-          dslogon_edipi: nil,
+          edipi: nil,
           first_name: 'ZACK',
           last_name: 'DAYTMHV',
           middle_name: nil,
@@ -943,7 +943,7 @@ RSpec.describe SAML::User do
         expect(subject.to_hash).to eq(
           birth_date: '1969-04-07',
           authn_context: authn_context,
-          dslogon_edipi: '1320002060',
+          edipi: '1320002060',
           first_name: 'JERRY',
           last_name: 'GPKTESTNINE',
           middle_name: nil,

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe FormProfile, type: :model do
   let(:full_name) do
     {
       'first' => user.first_name&.capitalize,
+      'middle' => user.middle_name&.capitalize,
       'last' => user.last_name&.capitalize,
       'suffix' => user.suffix
     }
@@ -106,8 +107,8 @@ RSpec.describe FormProfile, type: :model do
       },
       'veteranInformation' => {
         'fullName' => {
-          'first' => 'Abraham',
-          'last' => 'Lincoln',
+          'first' => user.first_name.capitalize,
+          'last' => user.last_name.capitalize,
           'suffix' => 'Jr.'
         },
         'ssn' => '796111863',
@@ -274,6 +275,7 @@ RSpec.describe FormProfile, type: :model do
       },
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -289,6 +291,7 @@ RSpec.describe FormProfile, type: :model do
     {
       'claimantFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -309,6 +312,7 @@ RSpec.describe FormProfile, type: :model do
       },
       'applicantFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -343,6 +347,7 @@ RSpec.describe FormProfile, type: :model do
       },
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -366,6 +371,7 @@ RSpec.describe FormProfile, type: :model do
       },
       'relativeFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -385,6 +391,7 @@ RSpec.describe FormProfile, type: :model do
       },
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -406,6 +413,7 @@ RSpec.describe FormProfile, type: :model do
       },
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -427,6 +435,7 @@ RSpec.describe FormProfile, type: :model do
       },
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -449,6 +458,7 @@ RSpec.describe FormProfile, type: :model do
       'currentlyActiveDuty' => true,
       'relativeFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -470,6 +480,7 @@ RSpec.describe FormProfile, type: :model do
       'currentlyActiveDuty' => true,
       'relativeFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -482,6 +493,7 @@ RSpec.describe FormProfile, type: :model do
     {
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -512,6 +524,7 @@ RSpec.describe FormProfile, type: :model do
     {
       'fullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -619,6 +632,7 @@ RSpec.describe FormProfile, type: :model do
     {
       'veteranFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -641,6 +655,7 @@ RSpec.describe FormProfile, type: :model do
     {
       'claimantFullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -725,6 +740,7 @@ RSpec.describe FormProfile, type: :model do
       'serviceBranch' => 'Air Force',
       'fullName' => {
         'first' => user.first_name&.capitalize,
+        'middle' => user.middle_name&.capitalize,
         'last' => user.last_name&.capitalize,
         'suffix' => user.suffix
       },
@@ -1158,6 +1174,7 @@ RSpec.describe FormProfile, type: :model do
           {
             'claimantFullName' => {
               'first' => user.first_name&.capitalize,
+              'middle' => user.middle_name&.capitalize,
               'last' => user.last_name&.capitalize,
               'suffix' => user.suffix
             }

--- a/spec/models/mpi_data_spec.rb
+++ b/spec/models/mpi_data_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe MPIData, skip_mvi: true do
   let(:user) { build(:user, :loa3) }
-  let(:mvi) { MPIData.for_user(user) }
+  let(:mvi) { MPIData.for_user(user.identity) }
   let(:mvi_profile) { build(:mvi_profile) }
   let(:mvi_codes) do
     {
@@ -32,12 +32,12 @@ describe MPIData, skip_mvi: true do
 
   describe '.new' do
     it 'creates an instance with user attributes' do
-      expect(mvi.user).to eq(user)
+      expect(mvi.user_identity).to eq(user.identity)
     end
   end
 
   describe '.historical_icn_for_user' do
-    subject { MPIData.historical_icn_for_user(user) }
+    subject { MPIData.historical_icn_for_user(user.identity) }
 
     let(:mpi_profile) { build(:mpi_profile_response, :with_historical_icns) }
 
@@ -61,7 +61,7 @@ describe MPIData, skip_mvi: true do
   end
 
   describe '#mvi_get_person_historical_icns' do
-    subject { MPIData.new(user).mvi_get_person_historical_icns }
+    subject { MPIData.new(user.identity).mvi_get_person_historical_icns }
 
     let(:mpi_profile) { build(:mpi_profile_response, :with_historical_icns) }
 
@@ -74,14 +74,14 @@ describe MPIData, skip_mvi: true do
     end
   end
 
-  describe '#mpi_add_person' do
+  describe '#add_person' do
     context 'with a successful add' do
       it 'returns the successful response' do
         allow_any_instance_of(MPI::Service).to receive(:find_profile).and_return(profile_response)
         allow_any_instance_of(MPI::Service).to receive(:add_person).and_return(add_response)
         expect_any_instance_of(MPIData).to receive(:add_ids).once.and_call_original
         expect_any_instance_of(MPIData).to receive(:cache).once.and_call_original
-        response = user.mpi_add_person
+        response = mvi.add_person(user.identity)
         expect(response.status).to eq('OK')
       end
     end
@@ -89,7 +89,7 @@ describe MPIData, skip_mvi: true do
     context 'with a failed search' do
       it 'returns the failed search response' do
         allow_any_instance_of(MPI::Service).to receive(:find_profile).and_return(profile_response_error)
-        response = user.mpi_add_person
+        response = mvi.add_person(user.identity)
         expect_any_instance_of(MPI::Service).not_to receive(:add_person)
         expect(response.status).to eq('SERVER_ERROR')
       end
@@ -101,7 +101,7 @@ describe MPIData, skip_mvi: true do
         allow_any_instance_of(MPI::Service).to receive(:add_person).and_return(add_response_error)
         expect_any_instance_of(MPIData).not_to receive(:add_ids)
         expect_any_instance_of(MPIData).not_to receive(:cache)
-        response = user.mpi_add_person
+        response = mvi.add_person(user.identity)
         expect(response.status).to eq('SERVER_ERROR')
       end
     end
@@ -245,7 +245,7 @@ describe MPIData, skip_mvi: true do
   end
 
   describe '#add_ids' do
-    let(:mvi) { MPIData.for_user(user) }
+    let(:mvi) { MPIData.for_user(user.identity) }
     let(:response) do
       MPI::Responses::AddPersonResponse.new(
         status: 'OK',

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -152,7 +152,8 @@ RSpec.describe User, type: :model do
 
   describe '#ssn_mismatch?', :skip_mvi do
     let(:user) { build(:user, :loa3) }
-    let(:mvi_profile) { build(:mvi_profile, ssn: 'unmatched-ssn') }
+    let(:mvi_profile) { build(:mvi_profile, ssn: mismatched_ssn) }
+    let(:mismatched_ssn) { '918273384' }
 
     before do
       stub_mpi(mvi_profile)
@@ -163,7 +164,7 @@ RSpec.describe User, type: :model do
     end
 
     it 'returns false if user is not loa3?' do
-      allow(user).to receive(:loa3?).and_return(false)
+      allow(user.identity).to receive(:loa3?).and_return(false)
       expect(user).not_to be_loa3
       expect(user.ssn).to eq(user.ssn)
       expect(user.ssn_mpi).to be_falsey
@@ -175,7 +176,7 @@ RSpec.describe User, type: :model do
 
       it 'returns false' do
         expect(user).to be_loa3
-        expect(user.ssn).to be_falsey
+        expect(user.ssn).to eq(mismatched_ssn)
         expect(user.ssn_mpi).to be_truthy
         expect(user).not_to be_ssn_mismatch
       end
@@ -259,7 +260,7 @@ RSpec.describe User, type: :model do
     end
 
     it 'has nil edipi locally and from IDENTITY' do
-      expect(subject.identity.dslogon_edipi).to be_nil
+      expect(subject.identity.edipi).to be_nil
       expect(subject.edipi).to be_nil
     end
   end
@@ -380,13 +381,13 @@ RSpec.describe User, type: :model do
           expect(user.ssn).to be(user.identity.ssn)
         end
 
-        it 'fetches edipi from mvi when identity.dslogon_edipi is empty' do
-          expect(user.edipi).to be(user.edipi_mpi)
+        it 'fetches edipi from mvi when identity.edipi is empty' do
+          expect(user.edipi).to be(mvi_profile.edipi)
         end
 
-        it 'fetches edipi from identity.dslogon_edipi when available' do
-          user.identity.dslogon_edipi = '001001999'
-          expect(user.edipi).to be(user.identity.dslogon_edipi)
+        it 'fetches edipi from identity.edipi when available' do
+          user.identity.edipi = '001001999'
+          expect(user.edipi).to be(user.identity.edipi)
         end
 
         it 'has a vet360 id if one exists' do

--- a/spec/policies/mpi_policy_spec.rb
+++ b/spec/policies/mpi_policy_spec.rb
@@ -8,10 +8,13 @@ describe MPIPolicy do
   permissions :queryable? do
     let(:user) { build(:user, :loa3) }
 
+    before { stub_mpi_not_found }
+
     context 'with a user who has the required mvi attributes' do
       context 'where user has an icn, but not the required personal attributes' do
         it 'is queryable' do
           user.identity.attributes = {
+            icn: 'some-icn',
             ssn: nil,
             first_name: nil,
             last_name: nil,

--- a/spec/request/health_care_applications_request_spec.rb
+++ b/spec/request/health_care_applications_request_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'hca/service'
 
 RSpec.describe 'Health Care Application Integration', type: %i[request serializer] do
   let(:test_veteran) do

--- a/spec/support/mpi/find_candidate_multiple_match_response.xml
+++ b/spec/support/mpi/find_candidate_multiple_match_response.xml
@@ -65,7 +65,7 @@
             </livingSubjectId>
             <livingSubjectName>
               <value use="L">
-                <given>KENNETH</given>
+                <given>KENNETH DONALD</given>
                 <family>ANDREWS</family>
               </value>
               <semanticsText>Legal Name</semanticsText>


### PR DESCRIPTION

## Description of change
This change refactors the MPI service and user model so that the `UserIdentity` set of attributes is passed to the MPI service instead of the entire User model. This should help with circular dependencies where MPI needs fields on the `User` model that then require MPI.

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/6412

## Things to know about this PR
* There shouldn't be any functional changes with this PR


## Testing Done
* Logged in a user and confirmed that MPI is still called correctly and returns the expected profile
* Called the `AddPerson` route to update user information and confirmed that MPI is called correctly
