### PR TITLE
Set more appropriate log level for KMI MVI records not found

### DIFF
--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
@@ -142,7 +142,7 @@ module CovidVaccine
           submission: id,
           submission_date: date
         )
-        raise Common::Exceptions::RecordNotFound.new(self.class.name.to_s, detail: "Error in MPI Lookup: #{error}")
+        # raise Common::Exceptions::RecordNotFound.new(self.class.name.to_s, detail: "Error in MPI Lookup: #{error}")
       end
     end
   end

--- a/modules/covid_vaccine/spec/jobs/covid_vaccine/expanded_submission_job_spec.rb
+++ b/modules/covid_vaccine/spec/jobs/covid_vaccine/expanded_submission_job_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe CovidVaccine::ExpandedSubmissionJob, type: :worker do
 
     context 'without sufficient traits' do
       it 'raises exception for MVI lookup error' do
-        pending('temporarily quieting errors on MPI failures')
         expect_any_instance_of(CovidVaccine::V0::VetextService).not_to receive(:put_vaccine_registry)
         allow_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_profile_not_found)
         allow(Rails.logger).to receive(:error)
+        pending('temporarily quieting errors on MPI failures')
         expect(Rails.logger).to receive(:error).with('Record not found.')
         subject.perform(submission.id)
       end

--- a/modules/covid_vaccine/spec/jobs/covid_vaccine/expanded_submission_job_spec.rb
+++ b/modules/covid_vaccine/spec/jobs/covid_vaccine/expanded_submission_job_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe CovidVaccine::ExpandedSubmissionJob, type: :worker do
     end
 
     context 'without sufficient traits' do
-      pending('temporarily quieting errors on MPI failures')
       it 'raises exception for MVI lookup error' do
+        pending('temporarily quieting errors on MPI failures')
         expect_any_instance_of(CovidVaccine::V0::VetextService).not_to receive(:put_vaccine_registry)
         allow_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_profile_not_found)

--- a/modules/covid_vaccine/spec/jobs/covid_vaccine/expanded_submission_job_spec.rb
+++ b/modules/covid_vaccine/spec/jobs/covid_vaccine/expanded_submission_job_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe CovidVaccine::ExpandedSubmissionJob, type: :worker do
     end
 
     context 'without sufficient traits' do
+      pending('temporarily quieting errors on MPI failures')
       it 'raises exception for MVI lookup error' do
         expect_any_instance_of(CovidVaccine::V0::VetextService).not_to receive(:put_vaccine_registry)
         allow_any_instance_of(MPI::Service).to receive(:find_profile)
@@ -66,6 +67,7 @@ RSpec.describe CovidVaccine::ExpandedSubmissionJob, type: :worker do
       end
 
       it 'raises exception for MVI facility discrepancy error' do
+        pending('temporarily quieting errors on MPI failures')
         expect_any_instance_of(CovidVaccine::V0::VetextService).not_to receive(:put_vaccine_registry)
         allow_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_facility_not_found)

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb
@@ -178,20 +178,20 @@ describe CovidVaccine::V0::ExpandedRegistrationService do
 
       context 'without sufficient traits' do
         it 'does not register when lacking traits for MVI lookup' do
-          pending('temporarily quieting errors on MPI failures')    
           expect_any_instance_of(CovidVaccine::V0::VetextService).not_to receive(:put_vaccine_registry)
           allow_any_instance_of(MPI::Service).to receive(:find_profile)
             .and_return(mvi_profile_not_found)
+          pending('temporarily quieting errors on MPI failures')
           expect { subject.register(submission) }.to raise_error(Common::Exceptions::RecordNotFound)
         end
 
         it 'does not send data when facility does not match' do
-          pending('temporarily quieting errors on MPI failures')
           expect_any_instance_of(CovidVaccine::V0::VetextService).not_to receive(:put_vaccine_registry)
           allow_any_instance_of(MPI::Service).to receive(:find_profile)
             .and_return(mvi_facility_not_found)
           expect do
             subject.register(submission)
+          pending('temporarily quieting errors on MPI failures')
           end.to raise_error(Common::Exceptions::RecordNotFound)
         end
 

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb
@@ -177,8 +177,8 @@ describe CovidVaccine::V0::ExpandedRegistrationService do
       end
 
       context 'without sufficient traits' do
-        pending('temporarily quieting errors on MPI failures')
         it 'does not register when lacking traits for MVI lookup' do
+          pending('temporarily quieting errors on MPI failures')    
           expect_any_instance_of(CovidVaccine::V0::VetextService).not_to receive(:put_vaccine_registry)
           allow_any_instance_of(MPI::Service).to receive(:find_profile)
             .and_return(mvi_profile_not_found)

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb
@@ -190,8 +190,8 @@ describe CovidVaccine::V0::ExpandedRegistrationService do
           allow_any_instance_of(MPI::Service).to receive(:find_profile)
             .and_return(mvi_facility_not_found)
           expect do
+            pending('temporarily quieting errors on MPI failures')
             subject.register(submission)
-          pending('temporarily quieting errors on MPI failures')
           end.to raise_error(Common::Exceptions::RecordNotFound)
         end
 

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb
@@ -177,6 +177,7 @@ describe CovidVaccine::V0::ExpandedRegistrationService do
       end
 
       context 'without sufficient traits' do
+        pending('temporarily quieting errors on MPI failures')
         it 'does not register when lacking traits for MVI lookup' do
           expect_any_instance_of(CovidVaccine::V0::VetextService).not_to receive(:put_vaccine_registry)
           allow_any_instance_of(MPI::Service).to receive(:find_profile)
@@ -185,6 +186,7 @@ describe CovidVaccine::V0::ExpandedRegistrationService do
         end
 
         it 'does not send data when facility does not match' do
+          pending('temporarily quieting errors on MPI failures')
           expect_any_instance_of(CovidVaccine::V0::VetextService).not_to receive(:put_vaccine_registry)
           allow_any_instance_of(MPI::Service).to receive(:find_profile)
             .and_return(mvi_facility_not_found)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Comment out raising of an exception so we stop triggering a Sidekiq job to log a Sentry error every time a record is not found. Not finding a record is an expected and acceptable outcome. We want to know when it happens for evaluation purposes, but we don't need an error throw every time.

Tracking this [over here for now](https://github.com/department-of-veterans-affairs/va.gov-team/issues/23580).


## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
