### PR TITLE
Add secure messaging to service dictionary

### DIFF
--- a/modules/mobile/app/serializers/mobile/v0/user_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/user_serializer.rb
@@ -45,7 +45,8 @@ module Mobile
         directDepositBenefits: :evss,
         lettersAndDocuments: :evss,
         militaryServiceHistory: :emis,
-        userProfileUpdate: :vet360
+        userProfileUpdate: :vet360,
+        secureMessaging: :mhv_messaging
       }.freeze
 
       def self.filter_keys(value, keys)

--- a/modules/mobile/spec/request/user_request_spec.rb
+++ b/modules/mobile/spec/request/user_request_spec.rb
@@ -154,6 +154,7 @@ RSpec.describe 'user', type: :request do
             lettersAndDocuments
             militaryServiceHistory
             userProfileUpdate
+            secureMessaging
           ]
         )
       end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Adds secure messaging to the list of authorized/available services using the `mhv_messaging_policy` and updates specs.

User should only be authorized to use SM if they have a Premium MHV account.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#23139

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
