### PR TITLE
Create a shared FormAttachmentCreate controller spec

### DIFF
--- a/spec/controllers/concerns/form_attachment_create_spec.rb
+++ b/spec/controllers/concerns/form_attachment_create_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 shared_examples_for 'a FormAttachmentCreate controller' do |user_factory: nil|
   describe '::FORM_ATTACHMENT_MODEL' do
     it 'is a FormAttachment model' do

--- a/spec/controllers/concerns/form_attachment_create_spec.rb
+++ b/spec/controllers/concerns/form_attachment_create_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+shared_examples_for 'a FormAttachmentCreate controller' do |user_factory: nil|
+  describe '::FORM_ATTACHMENT_MODEL' do
+    it 'is a FormAttachment model' do
+      expect(described_class::FORM_ATTACHMENT_MODEL.ancestors).to include(FormAttachment)
+    end
+  end
+
+  describe '#create' do
+    let(:form_attachment_guid) { SecureRandom.uuid }
+    let(:form_attachment_model) { described_class::FORM_ATTACHMENT_MODEL }
+    let(:resource_name) { form_attachment_model.to_s.underscore.split('/').last }
+    let(:json_api_type) { form_attachment_model.name.remove('::').snakecase.pluralize }
+
+    before do
+      if user_factory
+        sign_in_as(
+          build(:user, user_factory)
+        )
+      end
+    end
+
+    it 'requires params.`resource_name`' do
+      empty_req_params = [nil, {}]
+      empty_req_params << { resource_name => {} }
+      empty_req_params.each do |params|
+        post(:create, params: params)
+
+        expect(response).to have_http_status(:bad_request)
+
+        response_body = JSON.parse(response.body)
+
+        expect(response_body['errors'].size).to eq(1)
+        expect(response_body['errors'][0]).to eq(
+          'title' => 'Missing parameter',
+          'detail' => "The required parameter \"#{resource_name}\", is missing",
+          'code' => '108',
+          'status' => '400'
+        )
+      end
+    end
+
+    def expect_form_attachment_creation(req_params:) # rubocop:disable Metrics/AbcSize
+      form_attachment = build(resource_name.to_sym, guid: form_attachment_guid)
+
+      expect(form_attachment_model).to receive(:new) do
+        expect(form_attachment).to receive(:set_file_data!).with(
+          req_params[resource_name][:file_data],
+          req_params[resource_name][:password]
+        )
+
+        expect(form_attachment).to receive(:save!) do
+          form_attachment.id = 99
+          form_attachment
+        end
+
+        form_attachment
+      end
+
+      expect(subject).to receive(:render).with(json: form_attachment).and_call_original # rubocop:disable RSpec/SubjectStub
+
+      form_attachment
+    end
+
+    it 'creates a FormAttachment' do
+      params = {}
+      params[resource_name] = { file_data: 'uploaded_document' }
+
+      expect_form_attachment_creation(req_params: params)
+      post(:create, params: params)
+
+      expect(response).to have_http_status(:ok)
+      expect(
+        JSON.parse(response.body)
+      ).to eq(
+        {
+          'data' => {
+            'id' => '99',
+            'type' => json_api_type,
+            'attributes' => {
+              'guid' => form_attachment_guid
+            }
+          }
+        }
+      )
+    end
+  end
+end

--- a/spec/controllers/v0/decision_review_evidences_controller_spec.rb
+++ b/spec/controllers/v0/decision_review_evidences_controller_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'controllers/concerns/form_attachment_create_spec'
+
+RSpec.describe V0::DecisionReviewEvidencesController, type: :controller do
+  it_behaves_like 'a FormAttachmentCreate controller', user_factory: :loa1
+end

--- a/spec/controllers/v0/hca_attachments_controller_spec.rb
+++ b/spec/controllers/v0/hca_attachments_controller_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'controllers/concerns/form_attachment_create_spec'
 
 RSpec.describe V0::HCAAttachmentsController, type: :controller do
+  it_behaves_like 'a FormAttachmentCreate controller'
+
   describe '#create' do
     it 'uploads an hca attachment' do
       post(:create, params: { hca_attachment: {

--- a/spec/controllers/v0/preneeds/preneed_attachments_controller_spec.rb
+++ b/spec/controllers/v0/preneeds/preneed_attachments_controller_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'controllers/concerns/form_attachment_create_spec'
 
 RSpec.describe V0::Preneeds::PreneedAttachmentsController, type: :controller do
+  it_behaves_like 'a FormAttachmentCreate controller'
+
   describe '#create' do
     it 'uploads a preneed attachment' do
       post(:create, params: { preneed_attachment: {

--- a/spec/controllers/v0/preneeds/preneed_attachments_controller_spec.rb
+++ b/spec/controllers/v0/preneeds/preneed_attachments_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'controllers/concerns/form_attachment_create_spec'
 
 RSpec.describe V0::Preneeds::PreneedAttachmentsController, type: :controller do
-  it_behaves_like 'a FormAttachmentCreate controller'
+  it_behaves_like 'a FormAttachmentCreate controller', attachment_factory: :preneed_attachment
 
   describe '#create' do
     it 'uploads a preneed attachment' do

--- a/spec/controllers/v0/upload_supporting_evidences_controller_spec.rb
+++ b/spec/controllers/v0/upload_supporting_evidences_controller_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'controllers/concerns/form_attachment_create_spec'
+
+RSpec.describe V0::UploadSupportingEvidencesController, type: :controller do
+  it_behaves_like 'a FormAttachmentCreate controller', user_factory: :loa1
+end

--- a/spec/controllers/v0/vic/supporting_documentation_attachments_controller_spec.rb
+++ b/spec/controllers/v0/vic/supporting_documentation_attachments_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'controllers/concerns/form_attachment_create_spec'
 
 RSpec.describe V0::VIC::SupportingDocumentationAttachmentsController, type: :controller do
-  it_behaves_like 'a FormAttachmentCreate controller'
+  it_behaves_like 'a FormAttachmentCreate controller', attachment_factory: :supporting_documentation_attachment
 
   describe '#create' do
     it 'uploads a supporting documentation attachment' do

--- a/spec/controllers/v0/vic/supporting_documentation_attachments_controller_spec.rb
+++ b/spec/controllers/v0/vic/supporting_documentation_attachments_controller_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'controllers/concerns/form_attachment_create_spec'
 
 RSpec.describe V0::VIC::SupportingDocumentationAttachmentsController, type: :controller do
+  it_behaves_like 'a FormAttachmentCreate controller'
+
   describe '#create' do
     it 'uploads a supporting documentation attachment' do
       post(:create, params: { supporting_documentation_attachment: {

--- a/spec/factories/decision_review_evidence_attachment.rb
+++ b/spec/factories/decision_review_evidence_attachment.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :decision_review_evidence_attachment
+end

--- a/spec/factories/supporting_evidence_attachment.rb
+++ b/spec/factories/supporting_evidence_attachment.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :supporting_evidence_attachment
+end

--- a/spec/request/decision_review_evidences_request_spec.rb
+++ b/spec/request/decision_review_evidences_request_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'DecisionReviewEvidencesontroller', type: :request do
+RSpec.describe 'Decision Review Evidences', type: :request do
   include SchemaMatchers
   let(:user) { build(:disabilities_compensation_user) }
 

--- a/spec/request/upload_supporting_evidence_request_spec.rb
+++ b/spec/request/upload_supporting_evidence_request_spec.rb
@@ -90,12 +90,12 @@ RSpec.describe 'Upload supporting evidence', type: :request do
     end
 
     context 'with invalid parameters' do
-      it 'returns a 500 with no parameters' do
+      it 'returns a 400 with no parameters' do
         post '/v0/upload_supporting_evidence', params: nil
         expect(response).to have_http_status(:bad_request)
       end
 
-      it 'returns a 500 with no file_data' do
+      it 'returns a 400 with no file_data' do
         post '/v0/upload_supporting_evidence', params: { supporting_evidence_attachment: {} }
         expect(response).to have_http_status(:bad_request)
       end


### PR DESCRIPTION
## Description of change
This PR creates a common controller test suite for all controllers that accept document uploads as form submission attachments.

- [x] Create a shared_example for `FormAttachmentCreate` (located in `app/controllers/concerns/form_attachment_create.rb`)
- [x] Updated `FormAttachmentCreate` inheriting controller specs to use the shared spec
  - `V0::HCAAttachmentsController`
  - `V0::UploadSupportingEvidencesController`
  - `V0::Preneeds::PreneedAttachmentsController`
  - `V0::VIC::SupportingDocumentationAttachmentsController`
  - `V0::DecisionReviewEvidencesController`
  - `V0::Form1010cg::AttachmentController` *added in next PR [#6661](https://github.com/department-of-veterans-affairs/vets-api/pull/6661)

## Original issue(s)
- [#21906](https://github.com/department-of-veterans-affairs/va.gov-team/issues/21906)

## Things to know about this PR
 | Next [#6661](https://github.com/department-of-veterans-affairs/vets-api/pull/6661)