### PR TITLE
Enables blue-green deployment for virtual agent

### DIFF
--- a/app/controllers/v0/virtual_agent_token_controller.rb
+++ b/app/controllers/v0/virtual_agent_token_controller.rb
@@ -40,7 +40,7 @@ module V0
     end
 
     def bearer_token
-      secret = Flipper.enabled?(:virtual_agent_bot_a) ? Settings.virtual_agent.webchat_secret_a : 'FAKE'
+      secret = Flipper.enabled?(:virtual_agent_bot_a) ? Settings.virtual_agent.webchat_secret_a : Settings.virtual_agent.webchat_secret_b
       @bearer_token ||= 'Bearer ' + secret
     end
 

--- a/app/controllers/v0/virtual_agent_token_controller.rb
+++ b/app/controllers/v0/virtual_agent_token_controller.rb
@@ -40,7 +40,8 @@ module V0
     end
 
     def bearer_token
-      @bearer_token ||= 'Bearer ' + Settings.virtual_agent.webchat_secret
+      secret = Flipper.enabled?(:virtual_agent_bot_a) ? Settings.virtual_agent.webchat_secret_a : 'FAKE'
+      @bearer_token ||= 'Bearer ' + secret
     end
 
     def service_exception_handler

--- a/app/controllers/v0/virtual_agent_token_controller.rb
+++ b/app/controllers/v0/virtual_agent_token_controller.rb
@@ -40,7 +40,11 @@ module V0
     end
 
     def bearer_token
-      secret = Flipper.enabled?(:virtual_agent_bot_a) ? Settings.virtual_agent.webchat_secret_a : Settings.virtual_agent.webchat_secret_b
+      secret = if Flipper.enabled?(:virtual_agent_bot_a)
+                 Settings.virtual_agent.webchat_secret_a
+               else
+                 Settings.virtual_agent.webchat_secret_b
+               end
       @bearer_token ||= 'Bearer ' + secret
     end
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -446,3 +446,8 @@ features:
     enable_in_development: true
     description: >
       Form 10182 Notice of Disagreement - Request a board appeal
+  virtual_agent_bot_a:
+    actor_type: user
+    enable_in_development: true
+    description: >
+      Points to Bot A

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -851,7 +851,8 @@ covid_vaccine:
       password: fake_password
 
 virtual_agent:
-  webchat_secret: fake_secret
+  webchat_secret_a: fake_secret_a
+  webchat_secret_b: fake_secret_b
 
 # Settings for notifications client
 vanotify:

--- a/spec/controllers/v0/virtual_agent_token_controller_spec.rb
+++ b/spec/controllers/v0/virtual_agent_token_controller_spec.rb
@@ -6,26 +6,23 @@ require 'support/controller_spec_helper'
 RSpec.describe V0::VirtualAgentTokenController, type: :controller do
   describe '#create' do
     context 'when external service is healthy' do
-      let(:recorded_token) do
-        'ew0KICAiYWxnIjogIlJTMjU2IiwNCiAgImtpZCI6ICJsY0oxTXFpNkdKYXdCZEw5Y0dieEt5S1R6OE0iLA0KICAieDV0IjogImxjSjFNcWk2' \
-        'R0phd0JkTDljR2J4S3lLVHo4TSIsDQogICJ0eXAiOiAiSldUIg0KfQ.ew0KICAiYm90IjogInZhYm90LWF6Y2N0b2xhYi1ib3QiLA0KICAic' \
-        '2l0ZSI6ICJ3b1ZDYXV2RzA2QSIsDQogICJjb252IjogIjdPajBBbzJ2bWxpTGZxRFZRZGpOME0tNiIsDQogICJuYmYiOiAxNjE1NTg0MDcyL' \
-        'A0KICAiZXhwIjogMTYxNTU4NzY3MiwNCiAgImlzcyI6ICJodHRwczovL2RpcmVjdGxpbmUuYm90ZnJhbWV3b3JrLmNvbS8iLA0KICAiYXVkI' \
-        'jogImh0dHBzOi8vZGlyZWN0bGluZS5ib3RmcmFtZXdvcmsuY29tLyINCn0.kqUZA7Awnh0gFDDvJN87Kl1wOUNZLjZaYMu14JWeK3tvF60g-' \
-        'iMsc3anM67hVC1hZ-WqJ4Aowm06LsYZ0ZF3baAFUi70r0B6s0-GMwtQ75V34Ee3vDp4u4t-wm2fFuMoGinJ-PBZPTAHV5QaOnkzVblEPL5L2' \
-        'PmIDDt_uFQ32aFuEdRpX02rKyhiD_Y5r_y0gSW3elUGvxVJTsKvl1qgY6WoGp6f_60HkTZOKr49lyqgz2Hfp0t_qHcpyI208aP1SpLzUpDSh' \
-        'MzZk-oyzGPlep8XDOTNl54nBL__q7NlZu8VMKxhX7IlBjchGcYzZXCD9w6ZfLgsJHp-ftB7HJUEug'
-      end
-
-      it 'returns a token' do
-        VCR.use_cassette('virtual_agent/webchat_token') do
-          post :create
+      context 'when virtual_agent_bot_a toggle is on' do
+        let(:recorded_token) do
+          'fake.token.bota'
         end
 
-        expect(response).to have_http_status(:ok)
+        it 'returns a token for Bot A' do
+          expect(Flipper).to receive(:enabled?).with(:virtual_agent_bot_a).and_return(true)
 
-        res = JSON.parse(response.body)
-        expect(res['token']).to eq(recorded_token)
+          VCR.use_cassette('virtual_agent/webchat_token_a') do
+            post :create
+          end
+
+          expect(response).to have_http_status(:ok)
+
+          res = JSON.parse(response.body)
+          expect(res['token']).to eq(recorded_token)
+        end
       end
     end
 

--- a/spec/controllers/v0/virtual_agent_token_controller_spec.rb
+++ b/spec/controllers/v0/virtual_agent_token_controller_spec.rb
@@ -14,7 +14,26 @@ RSpec.describe V0::VirtualAgentTokenController, type: :controller do
         it 'returns a token for Bot A' do
           expect(Flipper).to receive(:enabled?).with(:virtual_agent_bot_a).and_return(true)
 
-          VCR.use_cassette('virtual_agent/webchat_token_a') do
+          VCR.use_cassette('virtual_agent/webchat_token_a', :match_requests_on => [:headers, :uri, :method]) do
+            post :create
+          end
+
+          expect(response).to have_http_status(:ok)
+
+          res = JSON.parse(response.body)
+          expect(res['token']).to eq(recorded_token)
+        end
+      end
+
+      context 'when virtual_agent_bot_a toggle is off' do
+        let(:recorded_token) do
+          'fake.token.botb'
+        end
+
+        it 'returns a token for Bot B' do
+          expect(Flipper).to receive(:enabled?).with(:virtual_agent_bot_a).and_return(false)
+
+          VCR.use_cassette('virtual_agent/webchat_token_b', :match_requests_on => [:headers, :uri, :method]) do
             post :create
           end
 

--- a/spec/controllers/v0/virtual_agent_token_controller_spec.rb
+++ b/spec/controllers/v0/virtual_agent_token_controller_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe V0::VirtualAgentTokenController, type: :controller do
         end
 
         it 'returns a token for Bot A' do
-          expect(Flipper).to receive(:enabled?).with(:virtual_agent_bot_a).and_return(true)
+          allow(Flipper).to receive(:enabled?).with(:virtual_agent_bot_a).and_return(true)
 
-          VCR.use_cassette('virtual_agent/webchat_token_a', :match_requests_on => [:headers, :uri, :method]) do
+          VCR.use_cassette('virtual_agent/webchat_token_a', match_requests_on: %i[headers uri method]) do
             post :create
           end
 
@@ -31,9 +31,9 @@ RSpec.describe V0::VirtualAgentTokenController, type: :controller do
         end
 
         it 'returns a token for Bot B' do
-          expect(Flipper).to receive(:enabled?).with(:virtual_agent_bot_a).and_return(false)
+          allow(Flipper).to receive(:enabled?).with(:virtual_agent_bot_a).and_return(false)
 
-          VCR.use_cassette('virtual_agent/webchat_token_b', :match_requests_on => [:headers, :uri, :method]) do
+          VCR.use_cassette('virtual_agent/webchat_token_b', match_requests_on: %i[headers uri method]) do
             post :create
           end
 

--- a/spec/request/swagger_spec.rb
+++ b/spec/request/swagger_spec.rb
@@ -3241,7 +3241,7 @@ RSpec.describe 'the API documentation', type: %i[apivore request], order: :defin
     describe 'virtual agent' do
       describe 'POST v0/virtual_agent_token' do
         it 'returns webchat token' do
-          VCR.use_cassette('virtual_agent/webchat_token') do
+          VCR.use_cassette('virtual_agent/webchat_token_a') do
             expect(subject).to validate(:post, '/v0/virtual_agent_token', 200)
           end
         end

--- a/spec/support/vcr_cassettes/virtual_agent/webchat_token_a.yml
+++ b/spec/support/vcr_cassettes/virtual_agent/webchat_token_a.yml
@@ -16,7 +16,7 @@ http_interactions:
       Host:
       - directline.botframework.com
       Authorization:
-      - Bearer fake_secret
+      - Bearer fake_secret_a
   response:
     status:
       code: 200
@@ -47,7 +47,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"conversationId\": \"7Oj0Ao2vmliLfqDVQdjN0M-6\",\r\n  \"token\":
-        \"ew0KICAiYWxnIjogIlJTMjU2IiwNCiAgImtpZCI6ICJsY0oxTXFpNkdKYXdCZEw5Y0dieEt5S1R6OE0iLA0KICAieDV0IjogImxjSjFNcWk2R0phd0JkTDljR2J4S3lLVHo4TSIsDQogICJ0eXAiOiAiSldUIg0KfQ.ew0KICAiYm90IjogInZhYm90LWF6Y2N0b2xhYi1ib3QiLA0KICAic2l0ZSI6ICJ3b1ZDYXV2RzA2QSIsDQogICJjb252IjogIjdPajBBbzJ2bWxpTGZxRFZRZGpOME0tNiIsDQogICJuYmYiOiAxNjE1NTg0MDcyLA0KICAiZXhwIjogMTYxNTU4NzY3MiwNCiAgImlzcyI6ICJodHRwczovL2RpcmVjdGxpbmUuYm90ZnJhbWV3b3JrLmNvbS8iLA0KICAiYXVkIjogImh0dHBzOi8vZGlyZWN0bGluZS5ib3RmcmFtZXdvcmsuY29tLyINCn0.kqUZA7Awnh0gFDDvJN87Kl1wOUNZLjZaYMu14JWeK3tvF60g-iMsc3anM67hVC1hZ-WqJ4Aowm06LsYZ0ZF3baAFUi70r0B6s0-GMwtQ75V34Ee3vDp4u4t-wm2fFuMoGinJ-PBZPTAHV5QaOnkzVblEPL5L2PmIDDt_uFQ32aFuEdRpX02rKyhiD_Y5r_y0gSW3elUGvxVJTsKvl1qgY6WoGp6f_60HkTZOKr49lyqgz2Hfp0t_qHcpyI208aP1SpLzUpDShMzZk-oyzGPlep8XDOTNl54nBL__q7NlZu8VMKxhX7IlBjchGcYzZXCD9w6ZfLgsJHp-ftB7HJUEug\",\r\n
+        \"fake.token.bota\",\r\n
         \ \"expires_in\": 3600\r\n}"
   recorded_at: Fri, 12 Mar 2021 21:21:12 GMT
 recorded_with: VCR 6.0.0

--- a/spec/support/vcr_cassettes/virtual_agent/webchat_token_b.yml
+++ b/spec/support/vcr_cassettes/virtual_agent/webchat_token_b.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://directline.botframework.com/v3/directline/tokens/generate
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - directline.botframework.com
+      Authorization:
+      - Bearer fake_secret_b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '1026'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 00-af443688d87ad948bcb1a4e88acda829-b5146616833b3a4c-00
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Fri, 12 Mar 2021 21:21:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"conversationId\": \"7Oj0Ao2vmliLfqDVQdjN0M-6\",\r\n  \"token\":
+        \"fake.token.botb\",\r\n
+        \ \"expires_in\": 3600\r\n}"
+  recorded_at: Fri, 12 Mar 2021 21:21:12 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Creates a toggle to switch between two bots in each environment, using two different webchat secrets
- Added two values to `settings.yml`
- related devops PR to update secrets: https://github.com/department-of-veterans-affairs/devops/pull/9041

## Original issue(s)
department-of-veterans-affairs/va-virtual-agent#150

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
New feature flag, `virtual_agent_bot_a`

<!-- Please describe testing done to verify the changes or any testing planned. -->
Updated unit tests and did manual testing locally