### PR TITLE
Adds primary_eligibility attribute as part of enrollment_status on healthcare_applications_controller

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -96,10 +96,9 @@ class HealthCareApplication < ApplicationRecord
       )
 
       ee_data.slice(
-        :application_date,
-        :enrollment_date,
-        :preferred_facility,
-        :effective_date
+        :application_date, :enrollment_date,
+        :preferred_facility, :effective_date,
+        :primary_eligibility
       ).merge(parsed_status: parsed_status)
     else
       {

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe HealthCareApplication, type: :model do
         enrollment_date: nil,
         preferred_facility: '987 - CHEY6',
         ineligibility_reason: 'OTH',
-        effective_date: '2018-01-24T00:00:00.000-09:00'
+        effective_date: '2018-01-24T00:00:00.000-09:00',
+        primary_eligibility: 'SC LESS THAN 50%'
       }
     end
 
@@ -48,7 +49,8 @@ RSpec.describe HealthCareApplication, type: :model do
           enrollment_date: nil,
           preferred_facility: '987 - CHEY6',
           parsed_status: inelig_character_of_discharge,
-          effective_date: '2018-01-24T00:00:00.000-09:00'
+          effective_date: '2018-01-24T00:00:00.000-09:00',
+          primary_eligibility: 'SC LESS THAN 50%'
         )
       end
 

--- a/spec/request/health_care_applications_request_spec.rb
+++ b/spec/request/health_care_applications_request_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
       { application_date: '2018-01-24T00:00:00.000-06:00',
         enrollment_date: nil,
         preferred_facility: '987 - CHEY6',
-        parsed_status: inelig_character_of_discharge }
+        parsed_status: inelig_character_of_discharge,
+        primary_eligibility: 'SC LESS THAN 50%' }
     end
     let(:loa1_response) do
       { parsed_status: login_required }
@@ -116,6 +117,7 @@ RSpec.describe 'Health Care Application Integration', type: %i[request serialize
             enrollment_date: '2018-12-27T17:15:39.000-06:00',
             preferred_facility: '988 - DAYT20',
             effective_date: '2019-01-02T21:58:55.000-06:00',
+            primary_eligibility: 'SC LESS THAN 50%',
             parsed_status: enrolled
           }
         end


### PR DESCRIPTION
## Description of change
Adds `primary_eligibility` attribute as part of enrollment_status on `healthcare_applications_controller`

This is needed by VAOS direct scheduling to ensure we’re only allowing veterans and not spouses, caretakers, etc who might have recently received a vaccine from the VA.

## Original issue(s)
@grossb1 can you update with ticket number?
