### PR TITLE
23635 mobile clear appointments cache on cancel appointment

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
@@ -7,6 +7,8 @@ require 'mobile/v0/exceptions/validation_errors'
 module Mobile
   module V0
     class AppointmentsController < ApplicationController
+      after_action :clear_appointments_cache, only: :cancel
+      
       def index
         use_cache = params[:useCache] || true
         start_date = params[:startDate] || one_year_ago.iso8601
@@ -36,6 +38,10 @@ module Mobile
       end
 
       private
+      
+      def clear_appointments_cache
+        Mobile::V0::Appointment.clear_cache(@current_user)
+      end
 
       def one_year_ago
         (DateTime.now.utc.beginning_of_day - 1.year)

--- a/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/appointments_controller.rb
@@ -8,7 +8,7 @@ module Mobile
   module V0
     class AppointmentsController < ApplicationController
       after_action :clear_appointments_cache, only: :cancel
-      
+
       def index
         use_cache = params[:useCache] || true
         start_date = params[:startDate] || one_year_ago.iso8601
@@ -38,7 +38,7 @@ module Mobile
       end
 
       private
-      
+
       def clear_appointments_cache
         Mobile::V0::Appointment.clear_cache(@current_user)
       end

--- a/modules/mobile/app/models/mobile/v0/concerns/redis_caching.rb
+++ b/modules/mobile/app/models/mobile/v0/concerns/redis_caching.rb
@@ -25,7 +25,7 @@ module Mobile
             @redis.set(user.uuid, data.to_json)
             @redis.expire(user.uuid, @redis_ttl)
           end
-          
+
           def clear_cache(user)
             @redis.del(user.uuid)
           end

--- a/modules/mobile/app/models/mobile/v0/concerns/redis_caching.rb
+++ b/modules/mobile/app/models/mobile/v0/concerns/redis_caching.rb
@@ -25,6 +25,10 @@ module Mobile
             @redis.set(user.uuid, data.to_json)
             @redis.expire(user.uuid, @redis_ttl)
           end
+          
+          def clear_cache(user)
+            @redis.del(user.uuid)
+          end
         end
       end
     end

--- a/modules/mobile/spec/request/appointments_request_spec.rb
+++ b/modules/mobile/spec/request/appointments_request_spec.rb
@@ -524,6 +524,16 @@ RSpec.describe 'appointments', type: :request do
         end
       end
 
+      it 'clears the cache after a succesful cancel' do
+        VCR.use_cassette('appointments/put_cancel_appointment', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('appointments/get_cancel_reasons', match_requests_on: %i[method uri]) do
+            expect(Mobile::V0::Appointment).to receive(:clear_cache).once
+
+            put "/mobile/v0/appointments/cancel/#{cancel_id}", headers: iam_headers
+          end
+        end
+      end
+
       context 'when appointment can be cancelled but fails' do
         let(:cancel_id) do
           Mobile::V0::Appointment.encode_cancel_id(


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Adds a controller action after hook to clear the appointments cache when an appointment is cancelled.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#23635

