### PR TITLE
Pass string instead of boolean to VEText for expanded KMI vaccine interest

### DIFF
--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
@@ -103,7 +103,7 @@ module CovidVaccine
       def other_form_attributes(form_data)
         service_date_range = form_data['date_range'] ? form_data['date_range'].to_a.flatten.join(' ') : ''
         {
-          vaccine_interest: true,
+          vaccine_interest: 'INTERESTED',
           privacy_agreement_accepted: form_data['privacy_agreement_accepted'],
           last_branch_of_service: form_data['last_branch_of_service'] || '',
           service_date_range: service_date_range,


### PR DESCRIPTION
## Description of change
Classic KMI passes a string for the `vaccineInterest` attribute to VEText. This change aligns new SLA KMI with classic KMI by passing the string `'INTERESTED'` rather than `true` for all submissions. All submissions are considered interested in receiving a vaccine.

Separately, the VEText team will set all received SLA KMI submissions to `vaccineInterest = 'INTERESTED'` to complete the cleanup.