### PR TITLE
Rely on sidekiq retry and add logging for duplicate HLRPDFSubmitJob

### DIFF
--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -14,23 +14,23 @@ module AppealsApi
     include Sidekiq::MonitoredWorker
     include CentralMail::Utilities
 
-    def perform(higher_level_review_id, retries = 0)
+    def perform(higher_level_review_id)
       higher_level_review = AppealsApi::HigherLevelReview.find(higher_level_review_id)
 
       begin
-        @retries = retries
         stamped_pdf = AppealsApi::PdfConstruction::Generator.new(higher_level_review).generate
         higher_level_review.update!(status: 'submitting')
         upload_to_central_mail(higher_level_review, stamped_pdf)
         File.delete(stamped_pdf) if File.exist?(stamped_pdf)
       rescue => e
         higher_level_review.update!(status: 'error', code: e.class.to_s, detail: e.message)
+        Rails.logger.info("#{self.class} error: #{e}")
         raise
       end
     end
 
     def retry_limits_for_notification
-      [6, 10]
+      [2, 5]
     end
 
     def notify(retry_params)
@@ -57,8 +57,7 @@ module AppealsApi
       process_response(CentralMail::Service.new.upload(body), higher_level_review)
       log_submission(higher_level_review, metadata)
     rescue AppealsApi::UploadError => e
-      e.detail = "#{e.detail} (retry attempt #{@retries})"
-      retry_errors(e, higher_level_review)
+      handle_upload_error(higher_level_review, e)
     end
 
     def process_response(response, higher_level_review)
@@ -74,6 +73,26 @@ module AppealsApi
         .created_at
         .in_time_zone('Central Time (US & Canada)')
         .strftime('%Y-%m-%d %H:%M:%S')
+    end
+
+    def log_upload_error(higher_level_review, e)
+      Rails.logger.info("#{higher_level_review.class.to_s.gsub('::', ' ')}: Submission failure",
+                        'source' => higher_level_review.consumer_name,
+                        'consumer_id' => higher_level_review.consumer_id,
+                        'consumer_username' => higher_level_review.consumer_name,
+                        'uuid' => higher_level_review.uuid,
+                        'code' => e.code,
+                        'detail' => e.detail)
+    end
+
+    def handle_upload_error(higher_level_review, e)
+      if e.code == 'DOC201'
+        log_upload_error(higher_level_review, e)
+        higher_level_review.update(status: 'error', code: e.code, detail: e.detail)
+      else
+        log_upload_error(higher_level_review, e)
+        raise
+      end
     end
   end
 end

--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -15,7 +15,7 @@ module AppealsApi
         "
         The sidekiq job #{params['class']} has hit #{params['retry_count']} retries.
         \nError Type: #{params['error_class']} \n Error Message: \n #{params['error_message']} \n\n
-This job failed at: #{Time.zone.at(params['failed_at'])}, and was retried at: #{retried_at(params['retried_at'])}
+This job failed at: #{Time.zone.at(params['failed_at'])}, and #{retried_at(params['retried_at'])}
         "
       end
 
@@ -36,9 +36,9 @@ This job failed at: #{Time.zone.at(params['failed_at'])}, and was retried at: #{
       end
 
       def retried_at(retried_time)
-        return 'was not retried' unless retried_time
+        return 'was not retried.' unless retried_time
 
-        Time.zone.at(retried_time)
+        "was retried at: #{Time.zone.at(retried_time)}."
       end
 
       def slack_channel_id

--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -15,7 +15,7 @@ module AppealsApi
         "
         The sidekiq job #{params['class']} has hit #{params['retry_count']} retries.
         \nError Type: #{params['error_class']} \n Error Message: \n #{params['error_message']} \n\n
-This job failed at: #{Time.zone.at(params['failed_at'])}, and was retried at: #{Time.zone.at(params['retried_at'])}
+This job failed at: #{Time.zone.at(params['failed_at'])}, and was retried at: #{retried_at(params['retried_at'])}
         "
       end
 
@@ -33,6 +33,12 @@ This job failed at: #{Time.zone.at(params['failed_at'])}, and was retried at: #{
           'Content-type' => 'application/json; charset=utf-8',
           'Authorization' => "Bearer #{slack_api_token}"
         }
+      end
+
+      def retried_at(retried_time)
+        return 'was not retried' unless retried_time
+
+        Time.zone.at(retried_time)
       end
 
       def slack_channel_id

--- a/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
@@ -71,9 +71,18 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
 
     it 'puts the HLR into an error state' do
       expect(client_stub).to receive(:upload) { |_arg| faraday_response }
+      allow(AppealsApi::SidekiqRetryNotifier).to receive(:notify!).and_return(true)
       described_class.new.perform(higher_level_review.id)
       expect(higher_level_review.reload.status).to eq('error')
       expect(higher_level_review.code).to eq('DOC201')
+    end
+
+    it 'sends a retry notification' do
+      expect(client_stub).to receive(:upload) { |_arg| faraday_response }
+      allow(AppealsApi::SidekiqRetryNotifier).to receive(:notify!).and_return(true)
+      described_class.new.perform(higher_level_review.id)
+
+      expect(AppealsApi::SidekiqRetryNotifier).to have_received(:notify!)
     end
   end
 

--- a/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
       capture_body = arg
       faraday_response
     }
-    described_class.new.perform(higher_level_review.id)
+
+    expect { described_class.new.perform(higher_level_review.id) }.to raise_error(AppealsApi::UploadError)
     expect(capture_body).to be_a(Hash)
     expect(capture_body).to have_key('metadata')
     expect(capture_body).to have_key('document')
@@ -68,12 +69,11 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
       allow(faraday_response).to receive(:success?).and_return(false)
     end
 
-    it 'queues another job to retry the request' do
+    it 'puts the HLR into an error state' do
       expect(client_stub).to receive(:upload) { |_arg| faraday_response }
-      Timecop.freeze(Time.zone.now)
       described_class.new.perform(higher_level_review.id)
-      expect(described_class.jobs.last['at']).to eq(30.minutes.from_now.to_f)
-      Timecop.return
+      expect(higher_level_review.reload.status).to eq('error')
+      expect(higher_level_review.code).to eq('DOC201')
     end
   end
 
@@ -88,6 +88,7 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
 
       higher_level_review.reload
       expect(higher_level_review.status).to eq('error')
+      expect(higher_level_review.code).to eq('RuntimeError')
     end
   end
 


### PR DESCRIPTION
[API-6424](https://vajira.max.gov/browse/API-6424)

This PR:

HLRPDFSubmitJob is potentially sending duplicate requests to CentralMail. We _think_ that the reason is because we're both relying on CentralMail::Utilities#retry_errors, which manually schedules another job, and then some failure (for which no logging exists) then raises and is retried automatically by sidekiq.

This PR attempts to add some logging to both error states, and removes the dependency on CentralMail::Utilities.

Potential Issue - this change will mean that any UploadError due to upstream outages (DOC201) will need to manually be retried, as the HLR will be in 'error' state. (which is kinda what it's for anyway)

This issue will present for NOD as well, assuming this is the problem.

CC: @nathanbwright (co-authored)