### PR TITLE
API-6439: validate POA code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Vets API
 
-
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Vets API
 
+
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)

--- a/modules/claims_api/app/controllers/claims_api/v0/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/power_of_attorney_controller.rb
@@ -8,6 +8,7 @@ module ClaimsApi
       class PowerOfAttorneyController < ClaimsApi::V0::Forms::Base
         include ClaimsApi::DocumentValidations
         include ClaimsApi::EndpointDeprecation
+        include ClaimsApi::PoaVerification
 
         FORM_NUMBER = '2122'
 
@@ -16,6 +17,9 @@ module ClaimsApi
         # @return [JSON] Record in pending state
         def submit_form_2122
           validate_json_schema
+
+          poa_code = form_attributes.dig('serviceOrganization', 'poaCode')
+          validate_poa_code!(poa_code)
 
           power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(header_md5: header_md5,
                                                                                           source_name: source_name)

--- a/modules/claims_api/app/controllers/claims_api/v1/claims_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/claims_controller.rb
@@ -7,7 +7,7 @@ module ClaimsApi
     class ClaimsController < ApplicationController
       include ClaimsApi::PoaVerification
       before_action { permit_scopes %w[claim.read] }
-      before_action :verify_power_of_attorney_using_bgs_service, if: :header_request?
+      before_action :verify_power_of_attorney!, if: :header_request?
 
       def index
         claims = claims_service.all

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -21,7 +21,7 @@ module ClaimsApi
           permit_scopes %w[claim.write]
         end
         skip_before_action :validate_json_format, only: %i[upload_supporting_documents]
-        before_action :verify_power_of_attorney_using_bgs_service, if: :header_request?
+        before_action :verify_power_of_attorney!, if: :header_request?
 
         # POST to submit disability claim.
         #

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
@@ -12,7 +12,7 @@ module ClaimsApi
         before_action except: %i[schema] do
           permit_scopes %w[claim.write]
         end
-        before_action :verify_power_of_attorney_using_bgs_service, if: :header_request?
+        before_action :verify_power_of_attorney!, if: :header_request?
 
         FORM_NUMBER = '0966'
         ITF_TYPES = %w[compensation pension burial].freeze

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -8,6 +8,7 @@ module ClaimsApi
       class PowerOfAttorneyController < ClaimsApi::V1::Forms::Base
         include ClaimsApi::DocumentValidations
         include ClaimsApi::EndpointDeprecation
+        include ClaimsApi::PoaVerification
 
         before_action except: %i[schema] do
           permit_scopes %w[claim.write]
@@ -20,6 +21,10 @@ module ClaimsApi
         # @return [JSON] Record in pending state
         def submit_form_2122 # rubocop:disable Metrics/MethodLength
           validate_json_schema
+
+          poa_code = form_attributes.dig('serviceOrganization', 'poaCode')
+          validate_poa_code!(poa_code)
+          validate_poa_code_for_current_user!(poa_code) if header_request?
 
           power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(header_md5: header_md5,
                                                                                           source_name: source_name)

--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -6,14 +6,58 @@ module ClaimsApi
   module PoaVerification
     extend ActiveSupport::Concern
 
-    included do
-      def verify_power_of_attorney_using_bgs_service
+    included do # rubocop:disable Metrics/BlockLength
+      #
+      # Validate poa code provided exists in OGC dataset, that provided poa code is a valid/active poa code
+      # @param poa_code [String] poa code to validate
+      #
+      # @raise [Common::Exceptions::InvalidFieldValue] if provided poa code does not exist in OGC dataset
+      def validate_poa_code!(poa_code)
+        return if valid_poa_code?(poa_code)
+
+        raise ::Common::Exceptions::InvalidFieldValue.new('poaCode', poa_code)
+      end
+
+      #
+      # Validate poa code provided exists in OGC dataset, that provided poa code is a valid/active poa code
+      # @param poa_code [String] poa code to validate
+      #
+      # @return [Boolean] True if valid poa code, False if not
+      def valid_poa_code?(poa_code)
+        ::Veteran::Service::Representative.where('? = ANY(poa_codes)', poa_code).any?
+      end
+
+      #
+      # Validate poa code provided matches one of the poa codes associated with the @current_user
+      # @param poa_code [String] poa code to match to @current_user
+      #
+      # @raise [Common::Exceptions::InvalidFieldValue] if provided poa code is not associated with @current_user
+      def validate_poa_code_for_current_user!(poa_code)
+        return if valid_poa_code_for_current_user?(poa_code)
+
+        raise ::Common::Exceptions::InvalidFieldValue.new('poaCode', poa_code)
+      end
+
+      #
+      # Validate poa code provided matches one of the poa codes associated with the @current_user
+      # @param poa_code [String] poa code to match to @current_user
+      #
+      # @return [Boolean] True if valid poa code, False if not
+      def valid_poa_code_for_current_user?(poa_code)
+        representative = ::Veteran::Service::Representative.for_user(first_name: @current_user.first_name,
+                                                                     last_name: @current_user.last_name)
+        representative.poa_codes.include?(poa_code)
+      end
+
+      #
+      # Verify @current_user is a valid power of attorney for the Veteran being acted on
+      #
+      # @raise [Common::Exceptions::Unauthorized] if Veteran is not associated to one of the @current_user's poa codes
+      def verify_power_of_attorney!
         logged_in_representative_user = @current_user
         target_veteran_to_be_verified = target_veteran
         verify_representative_and_veteran(logged_in_representative_user, target_veteran_to_be_verified)
-      rescue # => e
-        # Need to eventually start logging poa error logs.
-        # log_message_to_sentry('PoA claims', :warning, body: e.message)
+      rescue
         raise ::Common::Exceptions::Unauthorized, detail: 'Cannot validate Power of Attorney'
       end
 

--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -46,6 +46,8 @@ module ClaimsApi
       def valid_poa_code_for_current_user?(poa_code)
         representative = ::Veteran::Service::Representative.for_user(first_name: @current_user.first_name,
                                                                      last_name: @current_user.last_name)
+        return false if representative.blank?
+
         representative.poa_codes.include?(poa_code)
       end
 

--- a/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
@@ -24,34 +24,47 @@ RSpec.describe 'Power of Attorney ', type: :request do
       expect(json_schema).to eq(JSON.parse(schema))
     end
 
-    it 'returns a successful response with all the data' do
-      post path, params: data, headers: headers
-      parsed = JSON.parse(response.body)
-      expect(parsed['data']['type']).to eq('claims_api_power_of_attorneys')
-      expect(parsed['data']['attributes']['status']).to eq('pending')
-    end
-
-    it 'returns the same successful response with all the data' do
-      post path, params: data, headers: headers
-      parsed = JSON.parse(response.body)
-      expect(parsed['data']['type']).to eq('claims_api_power_of_attorneys')
-      post path, params: data, headers: headers
-      newly_parsed = JSON.parse(response.body)
-      expect(newly_parsed['data']['id']).to eq(parsed['data']['id'])
-    end
-
     it 'returns a unsuccessful response without mpi' do
       allow_any_instance_of(ClaimsApi::Veteran).to receive(:mpi_record?).and_return(false)
       post path, params: data, headers: headers
       expect(response.status).to eq(400)
     end
 
-    it 'sets the source' do
-      post path, params: data, headers: headers
-      parsed = JSON.parse(response.body)
-      token = parsed['data']['id']
-      poa = ClaimsApi::PowerOfAttorney.find(token)
-      expect(poa.source_data['name']).to eq('Abe Lincoln')
+    context 'when poa code is valid' do
+      before do
+        Veteran::Service::Representative.new(poa_codes: ['074']).save!
+      end
+
+      it 'sets the source' do
+        post path, params: data, headers: headers
+        parsed = JSON.parse(response.body)
+        token = parsed['data']['id']
+        poa = ClaimsApi::PowerOfAttorney.find(token)
+        expect(poa.source_data['name']).to eq('Abe Lincoln')
+      end
+
+      it 'returns a successful response with all the data' do
+        post path, params: data, headers: headers
+        parsed = JSON.parse(response.body)
+        expect(parsed['data']['type']).to eq('claims_api_power_of_attorneys')
+        expect(parsed['data']['attributes']['status']).to eq('pending')
+      end
+
+      it 'returns the same successful response with all the data' do
+        post path, params: data, headers: headers
+        parsed = JSON.parse(response.body)
+        expect(parsed['data']['type']).to eq('claims_api_power_of_attorneys')
+        post path, params: data, headers: headers
+        newly_parsed = JSON.parse(response.body)
+        expect(newly_parsed['data']['id']).to eq(parsed['data']['id'])
+      end
+    end
+
+    context 'when poa code is not valid' do
+      it 'responds with invalid poa code message' do
+        post path, params: data, headers: headers
+        expect(response.status).to eq(400)
+      end
     end
 
     context 'validation' do


### PR DESCRIPTION
## Description of change
This change adds a check to ensure the poa code submitted to assign to a Veteran is found as active in the OGC dataset.
This change also adds a check, for the v1 representative flow only, to ensure the representative submitted the poa change request is associated with the poa_code they are submitting.

## Original issue(s)
https://vajira.max.gov/browse/API-6439

## Things to know about this PR
Existing tests broke with new functionality.
Modified existing tests to reflect change in response.
Added tests to cover new expectations.