### PR TITLE
Cris.shupp api 6651 duplicate uploads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,6 +130,7 @@ gem 'utf8-cleaner'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus'
 gem 'will_paginate'
+gem 'with_advisory_lock'
 
 group :development do
   gem 'benchmark-ips'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -912,6 +912,8 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     will_paginate (3.3.0)
+    with_advisory_lock (4.6.0)
+      activerecord (>= 4.2)
     xmldsig (0.3.2)
       nokogiri
     xmlenc (0.7.1)
@@ -1094,6 +1096,7 @@ DEPENDENCIES
   webrick (>= 1.6.1)
   websocket-extensions (>= 0.1.5)
   will_paginate
+  with_advisory_lock
   yard
 
 RUBY VERSION

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
         allow(client_stub).to receive(:upload).and_return(faraday_response)
         num_times = 7
         # Why 7?  That's the most times a duplicate ever occurred.  See the excel spreadsheet in the ticket!
-        # ¯\_(:-)_/¯
         temp_files = []
         num_times.times do
           temp_files << Tempfile.new

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -60,6 +60,59 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
   describe '#perform' do
     let(:upload) { FactoryBot.create(:upload_submission, :status_uploaded, consumer_name: 'test consumer') }
 
+    context 'duplicates' do
+      before(:context) do
+        @transaction_state = use_transactional_tests
+        # need all subprocesses to see the state of the DB.  Transactional isolation will hurt us here.
+        self.use_transactional_tests = false
+        @upload_model = VBADocuments::UploadSubmission.new
+        @upload_model.status = 'uploaded'
+        @upload_model.save!
+      end
+
+      after(:context) do
+        self.use_transactional_tests = @transaction_state
+        @upload_model.delete
+      end
+
+      # Put in as a response to https://vajira.max.gov/browse/API-6651
+      it 'does not send duplicates if called multiple times concurrently on the same guid' do
+        allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts_attachment }
+        allow(CentralMail::Service).to receive(:new) { client_stub }
+        allow(faraday_response).to receive(:status).and_return(200)
+        allow(faraday_response).to receive(:body).and_return('')
+        allow(faraday_response).to receive(:success?).and_return(true)
+        allow(client_stub).to receive(:upload).and_return(faraday_response)
+        num_times = 7
+        # Why 7?  That's the most times a duplicate ever occurred.  See the excel spreadsheet in the ticket!
+        # ¯\_(ツ)_/¯
+        temp_files = []
+        num_times.times do
+          temp_files << Tempfile.new
+        end
+        pids = []
+        num_times.times do |i|
+          # Why fork instead of threads?  We are testing the advisory lock under different processes just as sidekiq
+          # will run the jobs.
+          pids << fork do
+            response = described_class.new.perform(@upload_model.guid)
+            writing = response.to_s
+            temp_files[i].write(writing)
+            temp_files[i].close
+          end
+        end
+        pids.each { |pid| Process.waitpid(pid) } # wait for my children to complete
+        responses = []
+        temp_files.each do |tf|
+          responses << File.open(tf.path) do |f|
+            f.read
+          end
+        end
+        expect(responses.select { |e| e.eql?('true') }.length).to eq(1)
+        expect(responses.select { |e| e.eql?('false') }.length).to eq(num_times - 1)
+      end
+    end
+
     it 'parses and uploads a valid multipart payload' do
       allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
       allow(CentralMail::Service).to receive(:new) { client_stub }

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
         allow(client_stub).to receive(:upload).and_return(faraday_response)
         num_times = 7
         # Why 7?  That's the most times a duplicate ever occurred.  See the excel spreadsheet in the ticket!
-        # ¯\_(ツ)_/¯
+        # ¯\_(:-)_/¯
         temp_files = []
         num_times.times do
           temp_files << Tempfile.new
@@ -104,9 +104,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
         pids.each { |pid| Process.waitpid(pid) } # wait for my children to complete
         responses = []
         temp_files.each do |tf|
-          responses << File.open(tf.path) do |f|
-            f.read
-          end
+          responses << File.open(tf.path, &:read)
         end
         expect(responses.select { |e| e.eql?('true') }.length).to eq(1)
         expect(responses.select { |e| e.eql?('false') }.length).to eq(num_times - 1)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
We are adding in an application-level lock to ensure an upload submission never occurs more than once.

## Original issue(s)
https://vajira.max.gov/browse/API-6651

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
A detailed RSPEC test is being added that has sub-processes to test the application lock.  If the lock is removed the tests do fail!!