### PR TITLE
Remove unnecessary VAOS feature flags

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -136,30 +136,6 @@ features:
     enable_in_development: true
     description: >
       Allows veterans to directly schedule VA appointments
-  va_online_scheduling_vsp_appointment_list:
-    actor_type: user
-    description: >
-      Enables the use of VSP for VA appointment data and cancellation on list page
-  va_online_scheduling_vsp_appointment_new:
-    actor_type: user
-    description: >
-      Enables the use of VSP for creating a new VA appointment
-  va_online_scheduling_ccsp_appointment_list:
-    actor_type: user
-    description: >
-      Enables the use of CCSP for Community Care appointment data on list page
-  va_online_scheduling_ccsp_request_new:
-    actor_type: user
-    description: >
-      Enables the use of CCSP for making a new Community Care appointment request
-  va_online_scheduling_vsp_request_list:
-    actor_type: user
-    description: >
-      Enables the use of VSP for request data and cancellation on list page
-  va_online_scheduling_vsp_request_new:
-    actor_type: user
-    description: >
-      Enables the use of VSP for making a new VA appointment request
   va_online_scheduling_express_care_new:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Description of change
We created some feature flags in advance of work that has now been delayed for several years, so I think it makes sense to remove them.

Front end change: https://github.com/department-of-veterans-affairs/vets-website/pull/16948/files#diff-c2a50f0603156c6db59de7ab566a362de04d87684c55d2f2b0b6a68e9d901e79

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/23691

## Things to know about this PR
None of these flags are used on the BE.

