### PR TITLE
Migrate Pact tests to GitHub Actions

### DIFF
--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Setup Database
         run: bundle exec rake db:reset
 
+      - name: Migrate database
+        run: bundle exec rake db:schema:load db:migrate
+
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify
         env:

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -10,6 +10,9 @@ jobs:
       DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test?pool=4"
       DISABLE_BOOTSNAP: true
       RAILS_ENV: test
+      PGHOST: localhost
+      PGUSER: vets-api
+      LANG: en_US.UTF-8
       "Settings.test_database_url": "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test"
       "Settings.saml.cert_path": "spec/support/certificates/ruby-saml.crt"
       "Settings.saml.key_path": "spec/support/certificates/ruby-saml.key"

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -63,7 +63,7 @@ jobs:
         run: bundle install --path vendor/bundle
 
       - name: Setup Database
-        run: bundle exec rake db:create db:schema:load
+        run: bundle exec rake db:drop db:create db:schema:load db:migrate db:migrate:status
 
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -59,9 +59,6 @@ jobs:
       - name: Install dependencies (pdftk, poppler, imagemagick)
         run: sudo apt install imagemagick pdftk poppler-utils
 
-      - name: Bundle install
-        run: bundle install --path vendor/bundle
-
       - name: Setup Database
         run: bundle exec rake db:schema:load
 

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -7,7 +7,7 @@ jobs:
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
       CI: true
-      DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test?pool=4"
+      DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets-api-test?pool=4"
       DISABLE_BOOTSNAP: true
       RAILS_ENV: test
       PGHOST: localhost

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -1,26 +1,20 @@
 name: Pact Contract Tests
-on: [workflow_dispatch]
+on: [push]
 jobs:
   tests:
-    name: Pact Contract Tests
+    name: Test
     runs-on: ubuntu-16.04
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
-      CI: true
       DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets-api-test"
-      DISABLE_BOOTSNAP: true
       RAILS_ENV: test
       PGHOST: localhost
       PGUSER: vets-api
       PGPASSWORD: postgres
-      LANG: en_US.UTF-8
       "Settings.test_database_url": "postgis://vets-api:postgres@127.0.0.1:5432/vets-api-test"
       "Settings.saml.cert_path": "spec/support/certificates/ruby-saml.crt"
       "Settings.saml.key_path": "spec/support/certificates/ruby-saml.key"
       "Settings.binaries.clamdscan": "clamscan"
-      TERM: xterm-256color
-      GIT_COMMIT_SHA: ${{ github.sha }}
-      CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
 
     services:
       postgres:

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -1,5 +1,5 @@
 name: Pact Contract Tests
-on: [push]
+on: [workflow_dispatch]
 jobs:
   tests:
     name: Test

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -63,7 +63,7 @@ jobs:
         run: bundle install --path vendor/bundle
 
       - name: Setup Database
-        run: bundle exec rake db:create db:reset db:schema:load
+        run: bundle exec rake db:reset db:schema:load
 
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -63,7 +63,7 @@ jobs:
         run: bundle install --path vendor/bundle
 
       - name: Setup Database
-        run: bundle exec rake db:drop db:create db:schema:load db:reset db:migrate
+        run: bundle exec rake db:schema:load
 
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -7,7 +7,7 @@ jobs:
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
       CI: true
-      DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test?pool=4"
+      DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets-api-test?pool=4"
       DISABLE_BOOTSNAP: true
       RAILS_ENV: test
       PGHOST: localhost
@@ -27,7 +27,7 @@ jobs:
         image: postgis/postgis:11-2.5
         env:
           POSTGRES_USER: vets-api
-          POSTGRES_DB: vets_api_test
+          POSTGRES_DB: vets-api-test
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -27,7 +27,7 @@ jobs:
         image: postgis/postgis:11-2.5
         env:
           POSTGRES_USER: vets-api
-          POSTGRES_DB: vets_api_test
+          POSTGRES_DB: vets-api-test
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -63,7 +63,7 @@ jobs:
         run: bundle install --path vendor/bundle
 
       - name: Setup Database
-        run: bundle exec rake db:create db:schema:load
+        run: bundle exec rake db:create db:reset db:schema:load
 
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -2,9 +2,10 @@ name: Pact Contract Tests
 on: [push]
 jobs:
   tests:
-    name: Test
+    name: Pact Contract Tests
     runs-on: ubuntu-16.04
     env:
+      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
       DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets-api-test"
       RAILS_ENV: test
       PGHOST: localhost

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -63,7 +63,7 @@ jobs:
         run: bundle install --path vendor/bundle
 
       - name: Setup Database
-        run: bundle exec rake db:reset db:schema:load db:migrate
+        run: bundle exec rake db:reset db:schema:load db:setup
 
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -27,7 +27,7 @@ jobs:
         image: postgis/postgis:11-2.5
         env:
           POSTGRES_USER: vets-api
-          POSTGRES_DB: vets-api-test
+          POSTGRES_DB: vets_api_test
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -1,0 +1,49 @@
+name: Pact Contract Tests
+on: [push]
+jobs:
+  tests:
+    name: Test
+    runs-on: ubuntu-16.04
+    env:
+      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
+      CI: true
+      DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test?pool=4"
+      DISABLE_BOOTSNAP: true
+      RAILS_ENV: test
+      "Settings.test_database_url": "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test"
+      "Settings.saml.cert_path": "spec/support/certificates/ruby-saml.crt"
+      "Settings.saml.key_path": "spec/support/certificates/ruby-saml.key"
+      "Settings.binaries.clamdscan": "clamscan"
+      TERM: xterm-256color
+      GIT_COMMIT_SHA: ${{ github.sha }}
+      CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+
+    services:
+      postgres:
+        image: postgis/postgis:11-2.5
+        env:
+          POSTGRES_USER: vets-api
+          POSTGRES_DB: vets-api_test
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 15
+
+      redis:
+        image: circleci/redis:5.0-alpine
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Install System Packages (pdftk, poppler, imagemagick)
+        run: bundle install --path vendor/bundle
+
+      - name: Setup Database
+        run: bundle exec rake db:create db:schema:load
+
+      - name: Verify stable Pacts
+        run: bundle exec rake pact:verify

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -63,10 +63,7 @@ jobs:
         run: bundle install --path vendor/bundle
 
       - name: Setup Database
-        run: bundle exec rake db:reset
-
-      - name: Migrate database
-        run: bundle exec rake db:schema:load db:migrate
+        run: bundle exec rake db:create db:schema:load
 
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -12,6 +12,7 @@ jobs:
       RAILS_ENV: test
       PGHOST: localhost
       PGUSER: vets-api
+      PGPASSWORD: postgres
       LANG: en_US.UTF-8
       "Settings.test_database_url": "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test"
       "Settings.saml.cert_path": "spec/support/certificates/ruby-saml.crt"

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -27,7 +27,7 @@ jobs:
         image: postgis/postgis:11-2.5
         env:
           POSTGRES_USER: vets-api
-          POSTGRES_DB: vets-api_test
+          POSTGRES_DB: vets-api-test
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -63,7 +63,7 @@ jobs:
         run: bundle install --path vendor/bundle
 
       - name: Setup Database
-        run: bundle exec rake db:reset db:schema:load db:setup
+        run: bundle exec rake db:reset db:schema:load db:setup db:migrate
 
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -63,7 +63,7 @@ jobs:
         run: bundle install --path vendor/bundle
 
       - name: Setup Database
-        run: bundle exec rake db:reset db:schema:load db:setup db:migrate
+        run: bundle exec rake db:reset
 
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -5,16 +5,12 @@ jobs:
     name: Test
     runs-on: ubuntu-16.04
     env:
-      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
       DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets-api-test"
       RAILS_ENV: test
       PGHOST: localhost
       PGUSER: vets-api
       PGPASSWORD: postgres
       "Settings.test_database_url": "postgis://vets-api:postgres@127.0.0.1:5432/vets-api-test"
-      "Settings.saml.cert_path": "spec/support/certificates/ruby-saml.crt"
-      "Settings.saml.key_path": "spec/support/certificates/ruby-saml.key"
-      "Settings.binaries.clamdscan": "clamscan"
 
     services:
       postgres:

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -2,7 +2,7 @@ name: Pact Contract Tests
 on: [workflow_dispatch]
 jobs:
   tests:
-    name: Test
+    name: Pact Contract Tests
     runs-on: ubuntu-16.04
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -63,7 +63,7 @@ jobs:
         run: bundle install --path vendor/bundle
 
       - name: Setup Database
-        run: bundle exec rake db:drop db:create db:schema:load db:migrate db:migrate:status
+        run: bundle exec rake db:drop db:create db:schema:load db:reset db:migrate
 
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -39,7 +39,10 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Install System Packages (pdftk, poppler, imagemagick)
+      - name: Install dependencies (pdftk, poppler, imagemagick)
+        run: sudo apt install imagemagick pdftk poppler-utils
+
+      - name: Bundle install
         run: bundle install --path vendor/bundle
 
       - name: Setup Database

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -63,7 +63,7 @@ jobs:
         run: bundle install --path vendor/bundle
 
       - name: Setup Database
-        run: bundle exec rake db:reset db:schema:load
+        run: bundle exec rake db:reset db:schema:load db:migrate
 
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -7,14 +7,14 @@ jobs:
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
       CI: true
-      DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets-api-test?pool=4"
+      DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets-api-test"
       DISABLE_BOOTSNAP: true
       RAILS_ENV: test
       PGHOST: localhost
       PGUSER: vets-api
       PGPASSWORD: postgres
       LANG: en_US.UTF-8
-      "Settings.test_database_url": "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test"
+      "Settings.test_database_url": "postgis://vets-api:postgres@127.0.0.1:5432/vets-api-test"
       "Settings.saml.cert_path": "spec/support/certificates/ruby-saml.crt"
       "Settings.saml.key_path": "spec/support/certificates/ruby-saml.key"
       "Settings.binaries.clamdscan": "clamscan"

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -7,7 +7,7 @@ jobs:
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
       CI: true
-      DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets-api-test?pool=4"
+      DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test?pool=4"
       DISABLE_BOOTSNAP: true
       RAILS_ENV: test
       PGHOST: localhost
@@ -27,7 +27,7 @@ jobs:
         image: postgis/postgis:11-2.5
         env:
           POSTGRES_USER: vets-api
-          POSTGRES_DB: vets-api-test
+          POSTGRES_DB: vets_api_test
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -1,5 +1,5 @@
 name: Pact Contract Tests
-on: [push]
+on: [workflow_dispatch]
 jobs:
   tests:
     name: Pact Contract Tests

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -35,6 +35,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-gov-west-1"
+
+      - name: Get bot token from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /dsva-vagov/pact-broker/utility/PACT_BROKER_BASIC_AUTH_PASSWORD
+          env_variable_name: PACT_BROKER_BASIC_AUTH_PASSWORD
+
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -50,3 +63,6 @@ jobs:
 
       - name: Verify stable Pacts
         run: bundle exec rake pact:verify
+        env:
+          PACT_BROKER_BASIC_AUTH_USERNAME: pact-broker
+          PACT_BROKER_BASE_URL: https://dev.va.gov/_vfs/pact-broker/


### PR DESCRIPTION
## Description of change
This PR migrates the `pact:verify` rake task to GitHub Actions. Pact will be removed entirely from CircleCI in a separate PR.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/22374