### PR TITLE
Temporarily disable the flaky (on CI) covid schedule batch logging spec

### DIFF
--- a/modules/covid_vaccine/spec/jobs/covid_vaccine/scheduled_batch_job_spec.rb
+++ b/modules/covid_vaccine/spec/jobs/covid_vaccine/scheduled_batch_job_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe CovidVaccine::ScheduledBatchJob, type: :worker do
           end
         end
 
-        it 'logs its progress including an enrollment jid' do
+        # temporarily disabling this spec sometimes fails on CI
+        xit 'logs its progress including an enrollment jid' do
           with_settings(
             Settings.covid_vaccine.enrollment_service, { job_enabled: true }
           ) do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This spec fails sporadicaly during CI runs. Temporarily disabling while a solution to setup and tear down the spec correctly is researched.

## Original issue(s)
N/A
