### PR TITLE
Remove unique md5 requirement for POA records

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v0/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v0/forms/power_of_attorney_controller.rb
@@ -55,7 +55,7 @@ module ClaimsApi
           power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(id: params[:id],
                                                                                           source_name: source_name)
           power_of_attorney.set_file_data!(documents.first, params[:doc_type])
-          power_of_attorney.status = 'submitted'
+          power_of_attorney.status = ClaimsApi::PowerOfAttorney::SUBMITTED
           power_of_attorney.save!
           power_of_attorney.reload
           ClaimsApi::VBMSUploadJob.perform_async(power_of_attorney.id)

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -66,7 +66,7 @@ module ClaimsApi
           ClaimsApi::PoaUpdater.perform_async(@power_of_attorney.id) if header_request?
 
           @power_of_attorney.set_file_data!(documents.first, params[:doc_type])
-          @power_of_attorney.status = 'submitted'
+          @power_of_attorney.status = ClaimsApi::PowerOfAttorney::SUBMITTED
           @power_of_attorney.save!
           @power_of_attorney.reload
 

--- a/modules/claims_api/app/models/claims_api/power_of_attorney.rb
+++ b/modules/claims_api/app/models/claims_api/power_of_attorney.rb
@@ -13,17 +13,18 @@ module ClaimsApi
 
     PENDING = 'pending'
     UPDATED = 'updated'
+    SUBMITTED = 'submitted'
     ERRORED = 'errored'
 
-    before_validation :set_md5
-    validates :md5, uniqueness: true
+    before_save :set_md5
 
     def self.find_using_identifier_and_source(source_name:, id: nil, header_md5: nil, md5: nil)
       primary_identifier = {}
       primary_identifier[:id] = id if id.present?
       primary_identifier[:header_md5] = header_md5 if header_md5.present?
       primary_identifier[:md5] = md5 if md5.present?
-      poas = ClaimsApi::PowerOfAttorney.where(primary_identifier).order(:created_at)
+      # it's possible to have duplicate POAs, so be sure to return the most recently created match
+      poas = ClaimsApi::PowerOfAttorney.where(primary_identifier).order(created_at: :desc)
       poas = poas.select { |poa| poa.source_data['name'] == source_name }
       return nil if poas.blank?
 

--- a/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/power_of_attorney_request_spec.rb
@@ -49,15 +49,6 @@ RSpec.describe 'Power of Attorney ', type: :request do
         expect(parsed['data']['type']).to eq('claims_api_power_of_attorneys')
         expect(parsed['data']['attributes']['status']).to eq('pending')
       end
-
-      it 'returns the same successful response with all the data' do
-        post path, params: data, headers: headers
-        parsed = JSON.parse(response.body)
-        expect(parsed['data']['type']).to eq('claims_api_power_of_attorneys')
-        post path, params: data, headers: headers
-        newly_parsed = JSON.parse(response.body)
-        expect(newly_parsed['data']['id']).to eq(parsed['data']['id'])
-      end
     end
 
     context 'when poa code is not valid' do

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -60,17 +60,6 @@ RSpec.describe 'Power of Attorney ', type: :request do
             expect(parsed['data']['attributes']['status']).to eq('pending')
           end
         end
-
-        it 'returns the same successful response with all the data' do
-          with_okta_user(scopes) do |auth_header|
-            post path, params: data, headers: headers.merge(auth_header)
-            parsed = JSON.parse(response.body)
-            expect(parsed['data']['type']).to eq('claims_api_power_of_attorneys')
-            post path, params: data, headers: headers.merge(auth_header)
-            newly_parsed = JSON.parse(response.body)
-            expect(newly_parsed['data']['id']).to eq(parsed['data']['id'])
-          end
-        end
       end
 
       context 'when poa code is not associated with current user' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

### Background Context

We initially added the POA `status` to the md5 hash to make it pass validation for uniqueness via this flow:

- set to rep A
- set to rep B
- set back to rep A

However, this still fails on this workflow after a few go-rounds, since there's only a handful of status options it will have:

    set to rep A (with status `pending` -> 'updated`)
    set to rep B (with status `pending` -> `updated`)
    set back to rep A (with status `pending` -> failing on uniqueness going to `updated`)
    set back to rep B (with status `pending` -> failing on uniqueness going to `updated`)
    set back to rep A ( failing on uniqueness for `pending` and `updated`


Since the lookups can happen with just the header_md5, I'm not sure if the md5 is even needed at all now, but at least removing the uniqueness requirement avoids validation failures

## Original issue(s)
https://vajira.max.gov/browse/API-6192

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
