### PR TITLE
API-6116 Add evidence submission validation

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -39,7 +39,7 @@ module AppealsApi::V1
 
         def set_submission_attributes
           @submission_attributes ||= {
-            source: params['headers']['X-Consumer-Username'],
+            source: request.headers['X-Consumer-Username'],
             supportable_id: params[:nod_id],
             supportable_type: 'AppealsApi::NoticeOfDisagreement'
           }

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -4,11 +4,12 @@ module AppealsApi::V1
   module DecisionReviews
     module NoticeOfDisagreements
       class EvidenceSubmissionsController < AppealsApi::ApplicationController
+        include SentryLogging
+
+        class EvidenceSubmissionRequestValidatorError < StandardError; end
+
         skip_before_action :authenticate
         before_action :nod_id_present?, only: :create
-        before_action :set_notice_of_disagreement, only: :create
-        before_action :validate_nod_attributes, only: :create
-        before_action :set_submission_attributes, only: :create
 
         class InvalidReviewOption < StandardError
           def message
@@ -23,13 +24,20 @@ module AppealsApi::V1
         end
 
         def create
-          upload = VBADocuments::UploadSubmission.create! consumer_name: 'appeals_api_nod_evidence_submission'
-          submission = AppealsApi::EvidenceSubmission.create! @submission_attributes.merge(upload_submission: upload)
+          status, error = AppealsApi::EvidenceSubmissionRequestValidator.new(params[:nod_id],
+                                                                             params['headers']['X-VA-SSN']).call
 
-          render json: submission,
-                 serializer: AppealsApi::EvidenceSubmissionSerializer,
-                 key_transform: :camel_lower,
-                 render_location: true
+          if status == :ok
+            upload = VBADocuments::UploadSubmission.create! consumer_name: 'appeals_api_nod_evidence_submission'
+            submission = AppealsApi::EvidenceSubmission.create! submission_attributes.merge(upload_submission: upload)
+
+            render json: submission,
+                   serializer: AppealsApi::EvidenceSubmissionSerializer,
+                   key_transform: :camel_lower,
+                   render_location: true
+          else
+            render json: { errors: [log_error(error)] }, status: error[:title].to_sym
+          end
         end
 
         def show
@@ -45,31 +53,25 @@ module AppealsApi::V1
         private
 
         def nod_id_present?
-          raise Common::Exceptions::ParameterMissing, 'nod_id' unless params[:nod_id]
+          nod_id_missing_error unless params[:nod_id]
         end
 
-        def set_notice_of_disagreement
-          @notice_of_disagreement ||= AppealsApi::NoticeOfDisagreement.find_by(id: params[:nod_id])
-          raise Common::Exceptions::RecordNotFound, params[:nod_id] unless @notice_of_disagreement
+        def nod_id_missing_error
+          error = { title: 'bad_request', detail: I18n.t('appeals_api.errors.missing_nod_id') }
+          render json: { errors: [log_error(error)] }, status: :bad_request
         end
 
-        def validate_nod_attributes
-          raise InvalidReviewOption unless @notice_of_disagreement.accepts_evidence?
-          raise InvalidVeteranSSN unless ssn_match?
-        end
-
-        def ssn_match?
-          return unless @notice_of_disagreement.auth_headers
-
-          params['headers']['X-VA-SSN'] == @notice_of_disagreement.auth_headers['X-VA-SSN']
-        end
-
-        def set_submission_attributes
-          @submission_attributes ||= {
-            source: request.headers['X-Consumer-Username'],
+        def submission_attributes
+          {
+            source: params['headers']['X-Consumer-Username'],
             supportable_id: params[:nod_id],
             supportable_type: 'AppealsApi::NoticeOfDisagreement'
           }
+        end
+
+        def log_error(error_detail)
+          log_exception_to_sentry(EvidenceSubmissionRequestValidatorError.new(error_detail), {}, {}, :warn)
+          error_detail
         end
       end
     end

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -36,7 +36,8 @@ module AppealsApi::V1
                    key_transform: :camel_lower,
                    render_location: true
           else
-            render json: { errors: [log_error(error)] }, status: error[:title].to_sym
+            log_error(error)
+            render json: { errors: [error] }, status: error[:title].to_sym
           end
         end
 
@@ -58,7 +59,9 @@ module AppealsApi::V1
 
         def nod_id_missing_error
           error = { title: 'bad_request', detail: I18n.t('appeals_api.errors.missing_nod_id') }
-          render json: { errors: [log_error(error)] }, status: :bad_request
+          log_error(error)
+
+          render json: { errors: [error] }, status: :bad_request
         end
 
         def submission_attributes

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -11,21 +11,9 @@ module AppealsApi::V1
         skip_before_action :authenticate
         before_action :nod_id_present?, only: :create
 
-        class InvalidReviewOption < StandardError
-          def message
-            I18n.t('appeals_api.errors.no_evidence_submission_accepted')
-          end
-        end
-
-        class InvalidVeteranSSN < StandardError
-          def message
-            I18n.t('appeals_api.errors.invalid_submission_ssn')
-          end
-        end
-
         def create
           status, error = AppealsApi::EvidenceSubmissionRequestValidator.new(params[:nod_id],
-                                                                             params['headers']['X-VA-SSN']).call
+                                                                             request.headers['X-VA-SSN']).call
 
           if status == :ok
             upload = VBADocuments::UploadSubmission.create! consumer_name: 'appeals_api_nod_evidence_submission'
@@ -66,7 +54,7 @@ module AppealsApi::V1
 
         def submission_attributes
           {
-            source: params['headers']['X-Consumer-Username'],
+            source: request.headers['X-Consumer-Username'],
             supportable_id: params[:nod_id],
             supportable_type: 'AppealsApi::NoticeOfDisagreement'
           }

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -12,7 +12,13 @@ module AppealsApi::V1
 
         class InvalidReviewOption < StandardError
           def message
-            I18n.t('appeals_api.errors.invalid_evidence_submission_lane')
+            I18n.t('appeals_api.errors.no_evidence_submission_accepted')
+          end
+        end
+
+        class InvalidVeteranSSN < StandardError
+          def message
+            I18n.t('appeals_api.errors.invalid_submission_ssn')
           end
         end
 
@@ -49,7 +55,13 @@ module AppealsApi::V1
 
         def validate_nod_attributes
           raise InvalidReviewOption unless @notice_of_disagreement.accepts_evidence?
-          raise Common::Exceptions::Forbidden, I18n.t('appeals_api.errors.invalid_evidence_submission_ssn')
+          raise InvalidVeteranSSN unless ssn_match?
+        end
+
+        def ssn_match?
+          return unless @notice_of_disagreement.auth_headers
+
+          params['headers']['X-VA-SSN'] == @notice_of_disagreement.auth_headers['X-VA-SSN']
         end
 
         def set_submission_attributes

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -7,7 +7,7 @@ module AppealsApi::V1
         skip_before_action :authenticate
         before_action :nod_id_present?, only: :create
         before_action :set_notice_of_disagreement, only: :create
-        before_action :validate_board_review_option, only: :create
+        before_action :validate_nod_attributes, only: :create
         before_action :set_submission_attributes, only: :create
 
         class InvalidReviewOption < StandardError
@@ -47,8 +47,9 @@ module AppealsApi::V1
           raise Common::Exceptions::RecordNotFound, params[:nod_id] unless @notice_of_disagreement
         end
 
-        def validate_board_review_option
+        def validate_nod_attributes
           raise InvalidReviewOption unless @notice_of_disagreement.accepts_evidence?
+          raise Common::Exceptions::Forbidden, I18n.t('appeals_api.errors.invalid_evidence_submission_ssn')
         end
 
         def set_submission_attributes

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements_controller.rb
@@ -79,7 +79,8 @@ class AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController < Appeals
     @notice_of_disagreement = AppealsApi::NoticeOfDisagreement.new(
       auth_headers: headers,
       form_data: @json_body,
-      source: headers['X-Consumer-Username']
+      source: headers['X-Consumer-Username'],
+      board_review_option: @json_body['data']['attributes']['boardReviewOption']
     )
     render_model_errors unless @notice_of_disagreement.validate
   end

--- a/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
+++ b/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
@@ -6,7 +6,7 @@ module AppealsApi
   class EvidenceSubmission < ApplicationRecord
     include SetGuid
     self.ignored_columns = ['status'] # Temporary until migrations have run
-    belongs_to :supportable, polymorphic: true, optional: true
+    belongs_to :supportable, polymorphic: true
     belongs_to :upload_submission,
                class_name: 'VBADocuments::UploadSubmission',
                dependent: :destroy

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -91,7 +91,7 @@ module AppealsApi
       form_data&.dig('data', 'attributes', 'veteran', 'representativesName')
     end
 
-    def board_review_option
+    def board_review_value
       form_data&.dig('data', 'attributes', 'boardReviewOption')
     end
 
@@ -106,6 +106,10 @@ module AppealsApi
 
     def lob
       'BVA'
+    end
+
+    def accepts_evidence?
+      board_review_option == 'evidence_submission'
     end
 
     def update_status!(status:, code: nil, detail: nil)
@@ -128,7 +132,7 @@ module AppealsApi
     end
 
     def board_review_hearing_selected?
-      board_review_option == 'hearing'
+      board_review_value == 'hearing'
     end
 
     def includes_hearing_type_preference?

--- a/modules/appeals_api/app/services/appeals_api/evidence_submission_request_validator.rb
+++ b/modules/appeals_api/app/services/appeals_api/evidence_submission_request_validator.rb
@@ -9,17 +9,28 @@ module AppealsApi
 
     def call
       return [:error, record_not_found_error] unless notice_of_disagreement_exists?
-      return [:error, invalid_review_option_error] unless @notice_of_disagreement.accepts_evidence?
+      return [:error, invalid_review_option_error] unless evidence_accepted?
       return [:error, invalid_veteran_id_error] unless ssn_match?
 
       [:ok, {}]
     end
 
+    private
+
     def notice_of_disagreement_exists?
       @notice_of_disagreement ||= AppealsApi::NoticeOfDisagreement.find_by(id: @nod_id)
     end
 
-    private
+    def evidence_accepted?
+      @notice_of_disagreement.accepts_evidence?
+    end
+
+    def ssn_match?
+      # if PII expunged not validating for matching SSNs
+      return true unless @notice_of_disagreement.auth_headers
+
+      @request_ssn == @notice_of_disagreement.auth_headers['X-VA-SSN']
+    end
 
     def record_not_found_error
       { title: 'not_found', detail: I18n.t('appeals_api.errors.nod_not_found', id: @nod_id) }
@@ -31,13 +42,6 @@ module AppealsApi
 
     def invalid_veteran_id_error
       { title: 'unprocessable_entity', detail: I18n.t('appeals_api.errors.mismatched_ssns') }
-    end
-
-    def ssn_match?
-      # if PII expunged not validating for matching SSNs
-      return true unless @notice_of_disagreement.auth_headers
-
-      @request_ssn == @notice_of_disagreement.auth_headers['X-VA-SSN']
     end
   end
 end

--- a/modules/appeals_api/app/services/appeals_api/evidence_submission_request_validator.rb
+++ b/modules/appeals_api/app/services/appeals_api/evidence_submission_request_validator.rb
@@ -34,7 +34,8 @@ module AppealsApi
     end
 
     def ssn_match?
-      return unless @notice_of_disagreement.auth_headers
+      # if PII expunged not validating for matching SSNs
+      return true unless @notice_of_disagreement.auth_headers
 
       @request_ssn == @notice_of_disagreement.auth_headers['X-VA-SSN']
     end

--- a/modules/appeals_api/app/services/appeals_api/evidence_submission_request_validator.rb
+++ b/modules/appeals_api/app/services/appeals_api/evidence_submission_request_validator.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  class EvidenceSubmissionRequestValidator
+    def initialize(nod_id, request_ssn)
+      @nod_id = nod_id
+      @request_ssn = request_ssn
+    end
+
+    def call
+      return [:error, record_not_found_error] unless notice_of_disagreement_exists?
+      return [:error, invalid_review_option_error] unless @notice_of_disagreement.accepts_evidence?
+      return [:error, invalid_veteran_id_error] unless ssn_match?
+
+      [:ok, {}]
+    end
+
+    def notice_of_disagreement_exists?
+      @notice_of_disagreement ||= AppealsApi::NoticeOfDisagreement.find_by(id: @nod_id)
+    end
+
+    private
+
+    def record_not_found_error
+      { title: 'not_found', detail: I18n.t('appeals_api.errors.nod_not_found', id: @nod_id) }
+    end
+
+    def invalid_review_option_error
+      { title: 'unprocessable_entity', detail: I18n.t('appeals_api.errors.no_evidence_submission_accepted') }
+    end
+
+    def invalid_veteran_id_error
+      { title: 'unprocessable_entity', detail: I18n.t('appeals_api.errors.mismatched_ssns') }
+    end
+
+    def ssn_match?
+      return unless @notice_of_disagreement.auth_headers
+
+      @request_ssn == @notice_of_disagreement.auth_headers['X-VA-SSN']
+    end
+  end
+end

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/notice_of_disagreement/v1/form_data.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/notice_of_disagreement/v1/form_data.rb
@@ -39,15 +39,15 @@ module AppealsApi
         end
 
         def direct_review
-          board_review_option == 'direct_review' ? 1 : 'Off'
+          notice_of_disagreement.board_review_option == 'direct_review' ? 1 : 'Off'
         end
 
         def evidence_submission
-          board_review_option == 'evidence_submission' ? 1 : 'Off'
+          notice_of_disagreement.board_review_option == 'evidence_submission' ? 1 : 'Off'
         end
 
         def hearing
-          board_review_option == 'hearing' ? 1 : 'Off'
+          notice_of_disagreement.board_review_option == 'hearing' ? 1 : 'Off'
         end
 
         def extra_contestable_issues
@@ -120,10 +120,6 @@ module AppealsApi
 
         def header_field(key)
           notice_of_disagreement.auth_headers&.dig(key)
-        end
-
-        def board_review_option
-          notice_of_disagreement.form_data&.dig('data', 'attributes', 'boardReviewOption')
         end
       end
     end

--- a/modules/appeals_api/config/locales/en.yml
+++ b/modules/appeals_api/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   appeals_api:
       errors:
+        invalid_evidence_submission_lane: "Corresponding Notice of Disagreement 'boardReviewOption' must be 'evidence_submission'"
         contact_info_presence: "At least one must be included: '/data/attributes/veteran'"
         hearing_type_preference_inclusion: "If '/data/attributes/boardReviewOption' 'direct_review' or 'evidence_submission' is selected, '/data/attributes/hearingTypePreference' must not be selected"
         hearing_type_preference_missing: "If '/data/attributes/boardReviewOption' 'hearing' is selected, '/data/attributes/hearingTypePreference' must also be present"

--- a/modules/appeals_api/config/locales/en.yml
+++ b/modules/appeals_api/config/locales/en.yml
@@ -2,6 +2,7 @@ en:
   appeals_api:
       errors:
         invalid_evidence_submission_lane: "Corresponding Notice of Disagreement 'boardReviewOption' must be 'evidence_submission'"
+        invalid_evidence_submission_ssn: "Request header 'X-VA-SSN' does not match the associated Notice of Disagreement's SSN"
         contact_info_presence: "At least one must be included: '/data/attributes/veteran'"
         hearing_type_preference_inclusion: "If '/data/attributes/boardReviewOption' 'direct_review' or 'evidence_submission' is selected, '/data/attributes/hearingTypePreference' must not be selected"
         hearing_type_preference_missing: "If '/data/attributes/boardReviewOption' 'hearing' is selected, '/data/attributes/hearingTypePreference' must also be present"

--- a/modules/appeals_api/config/locales/en.yml
+++ b/modules/appeals_api/config/locales/en.yml
@@ -1,10 +1,11 @@
 en:
   appeals_api:
       errors:
-        no_evidence_submission_accepted: "Corresponding Notice of Disagreement 'boardReviewOption' must be 'evidence_submission'"
-        invalid_submission_ssn: "Request header 'X-VA-SSN' does not match the associated Notice of Disagreement's SSN"
         contact_info_presence: "At least one must be included: '/data/attributes/veteran'"
         hearing_type_preference_inclusion: "If '/data/attributes/boardReviewOption' 'direct_review' or 'evidence_submission' is selected, '/data/attributes/hearingTypePreference' must not be selected"
         hearing_type_preference_missing: "If '/data/attributes/boardReviewOption' 'hearing' is selected, '/data/attributes/hearingTypePreference' must also be present"
+        mismatched_ssns: "Request header 'X-VA-SSN' does not match the associated Notice of Disagreement's SSN"
+        missing_nod_id: 'Must supply a corresponding NOD id in order to submit evidence'
+        no_evidence_submission_accepted: "Corresponding Notice of Disagreement 'boardReviewOption' must be 'evidence_submission'"
         nod_not_found: "NoticeOfDisagreement with uuid %{id} not found."
         not_homeless_address_missing: "If not homeless, address must be provided: '/data/attributes/veteran/address'"

--- a/modules/appeals_api/config/locales/en.yml
+++ b/modules/appeals_api/config/locales/en.yml
@@ -1,8 +1,8 @@
 en:
   appeals_api:
       errors:
-        invalid_evidence_submission_lane: "Corresponding Notice of Disagreement 'boardReviewOption' must be 'evidence_submission'"
-        invalid_evidence_submission_ssn: "Request header 'X-VA-SSN' does not match the associated Notice of Disagreement's SSN"
+        no_evidence_submission_accepted: "Corresponding Notice of Disagreement 'boardReviewOption' must be 'evidence_submission'"
+        invalid_submission_ssn: "Request header 'X-VA-SSN' does not match the associated Notice of Disagreement's SSN"
         contact_info_presence: "At least one must be included: '/data/attributes/veteran'"
         hearing_type_preference_inclusion: "If '/data/attributes/boardReviewOption' 'direct_review' or 'evidence_submission' is selected, '/data/attributes/hearingTypePreference' must not be selected"
         hearing_type_preference_missing: "If '/data/attributes/boardReviewOption' 'hearing' is selected, '/data/attributes/hearingTypePreference' must also be present"

--- a/modules/appeals_api/spec/factories/evidence_submissions.rb
+++ b/modules/appeals_api/spec/factories/evidence_submissions.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :evidence_submission, class: 'AppealsApi::EvidenceSubmission' do
     sequence(:id) { |n| n }
     guid { SecureRandom.uuid }
+    association :supportable, factory: :notice_of_disagreement
     upload_submission { create(:upload_submission, guid: SecureRandom.uuid) } # set the guid to pass uniqueness check
 
     trait :with_detail do

--- a/modules/appeals_api/spec/factories/notice_of_disagreements.rb
+++ b/modules/appeals_api/spec/factories/notice_of_disagreements.rb
@@ -19,6 +19,9 @@ FactoryBot.define do
       updated_at { 8.days.ago }
       status { AppealsApi::NoticeOfDisagreement::COMPLETE_STATUSES.sample }
     end
+    trait :board_review_hearing do
+      board_review_option { 'hearing' }
+    end
   end
 
   factory :minimal_notice_of_disagreement, class: 'AppealsApi::NoticeOfDisagreement' do

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -6,13 +6,12 @@ require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 describe AppealsApi::NoticeOfDisagreement, type: :model do
   include FixtureHelpers
 
+  let(:auth_headers) { fixture_as_json 'valid_10182_headers.json' }
+  let(:form_data) { fixture_as_json 'valid_10182.json' }
   let(:notice_of_disagreement) do
     review_option = form_data['data']['attributes']['boardReviewOption']
     build(:notice_of_disagreement, form_data: form_data, auth_headers: auth_headers, board_review_option: review_option)
   end
-
-  let(:auth_headers) { fixture_as_json 'valid_10182_headers.json' }
-  let(:form_data) { fixture_as_json 'valid_10182.json' }
 
   describe '.build' do
     before { notice_of_disagreement.valid? }

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -6,13 +6,13 @@ require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 describe AppealsApi::NoticeOfDisagreement, type: :model do
   include FixtureHelpers
 
-  let(:notice_of_disagreement) { build(:notice_of_disagreement, form_data: form_data, auth_headers: auth_headers) }
+  let(:notice_of_disagreement) do
+    review_option = form_data['data']['attributes']['boardReviewOption']
+    build(:notice_of_disagreement, form_data: form_data, auth_headers: auth_headers, board_review_option: review_option)
+  end
 
-  let(:auth_headers) { default_auth_headers }
-  let(:form_data) { default_form_data }
-
-  let(:default_auth_headers) { fixture_as_json 'valid_10182_headers.json' }
-  let(:default_form_data) { fixture_as_json 'valid_10182.json' }
+  let(:auth_headers) { fixture_as_json 'valid_10182_headers.json' }
+  let(:form_data) { fixture_as_json 'valid_10182.json' }
 
   describe '.build' do
     before { notice_of_disagreement.valid? }
@@ -116,19 +116,21 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
 
     context 'when homeless and no address' do
       before do
-        veteran_data = default_form_data['data']['attributes']['veteran']
+        veteran_data = form_data['data']['attributes']['veteran']
         veteran_data['homeless'] = true
         veteran_data.delete('address')
       end
 
-      it do
-        expect(notice_of_disagreement.zip_code_5).to eq '00000'
-      end
+      it { expect(notice_of_disagreement.zip_code_5).to eq '00000' }
     end
   end
 
   describe '#lob' do
     it { expect(notice_of_disagreement.lob).to eq 'BVA' }
+  end
+
+  describe '#board_review_option' do
+    it { expect(notice_of_disagreement.board_review_option).to eq 'hearing' }
   end
 
   describe '#update_status!' do

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -14,15 +14,15 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
     context 'when corresponding notice of disagreement record not found' do
       it 'returns an error' do
         with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                      prefix: 'http://some.fakesite.com/path',
-                      replacement: 'http://another.fakesite.com/rewrittenpath') do
+                      prefix: 'https://fake.s3.url/foo/',
+                      replacement: 'https://api.vets.gov/proxy/') do
           s3_client = instance_double(Aws::S3::Resource)
           allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
           s3_bucket = instance_double(Aws::S3::Bucket)
           s3_object = instance_double(Aws::S3::Object)
           allow(s3_client).to receive(:bucket).and_return(s3_bucket)
           allow(s3_bucket).to receive(:object).and_return(s3_object)
-          allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
+          allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
           post(path, params: { nod_id: 1979, headers: headers })
 
           expect(response.status).to eq 404
@@ -34,15 +34,15 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
     context 'when corresponding notice of disagreement record found' do
       it "returns an error if nod 'boardReviewOption' is not 'evidence_submission'" do
         with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                      prefix: 'http://some.fakesite.com/path',
-                      replacement: 'http://another.fakesite.com/rewrittenpath') do
+                      prefix: 'https://fake.s3.url/foo/',
+                      replacement: 'https://api.vets.gov/proxy/') do
           s3_client = instance_double(Aws::S3::Resource)
           allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
           s3_bucket = instance_double(Aws::S3::Bucket)
           s3_object = instance_double(Aws::S3::Object)
           allow(s3_client).to receive(:bucket).and_return(s3_bucket)
           allow(s3_bucket).to receive(:object).and_return(s3_object)
-          allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
+          allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
           post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
 
           expect(response.status).to eq 422
@@ -53,19 +53,17 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
       context "when nod record 'auth_headers' are present" do
         it "returns an error if request 'headers['X-VA-SSN'] and NOD record SSNs do not match" do
           with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                        prefix: 'http://some.fakesite.com/path',
-                        replacement: 'http://another.fakesite.com/rewrittenpath') do
+                        prefix: 'https://fake.s3.url/foo/',
+                        replacement: 'https://api.vets.gov/proxy/') do
             s3_client = instance_double(Aws::S3::Resource)
             allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
             s3_bucket = instance_double(Aws::S3::Bucket)
             s3_object = instance_double(Aws::S3::Object)
             allow(s3_client).to receive(:bucket).and_return(s3_bucket)
             allow(s3_bucket).to receive(:object).and_return(s3_object)
-            allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
-
+            allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
             notice_of_disagreement.update(board_review_option: 'evidence_submission')
             headers['X-VA-SSN'] = '1111111111'
-
             post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
 
             expect(response.status).to eq 422
@@ -77,17 +75,16 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
       context "when nod record 'auth_headers' are not present" do
         # if PII expunged not validating for matching SSNs
         it 'creates the evidence submission and returns upload location' do
-          with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                        prefix: 'http://some.fakesite.com/path',
-                        replacement: 'http://another.fakesite.com/rewrittenpath') do
+          with_settings(Settings.vba_documents.location,
+                        prefix: 'https://fake.s3.url/foo/',
+                        replacement: 'https://api.vets.gov/proxy/') do
             s3_client = instance_double(Aws::S3::Resource)
             allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
             s3_bucket = instance_double(Aws::S3::Bucket)
             s3_object = instance_double(Aws::S3::Object)
             allow(s3_client).to receive(:bucket).and_return(s3_bucket)
             allow(s3_bucket).to receive(:object).and_return(s3_object)
-            allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
-
+            allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
             notice_of_disagreement.update(board_review_option: 'evidence_submission', auth_headers: nil)
             post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
 
@@ -97,25 +94,23 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
             expect(data['attributes']['status']).to eq('pending')
             expect(data['attributes']['appealId']).to eq(notice_of_disagreement.id)
             expect(data['attributes']['appealType']).to eq('NoticeOfDisagreement')
-            expect(data['attributes']['location']).to eq('http://another.fakesite.com/rewrittenpath/uuid')
+            expect(data['attributes']['location']).to eq('https://api.vets.gov/proxy/uuid')
           end
         end
       end
 
-
       it 'creates the evidence submission and returns upload location' do
-        with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                      prefix: 'http://some.fakesite.com/path',
-                      replacement: 'http://another.fakesite.com/rewrittenpath') do
+        with_settings(Settings.vba_documents.location,
+                      prefix: 'https://fake.s3.url/foo/',
+                      replacement: 'https://api.vets.gov/proxy/') do
           s3_client = instance_double(Aws::S3::Resource)
           allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
           s3_bucket = instance_double(Aws::S3::Bucket)
           s3_object = instance_double(Aws::S3::Object)
           allow(s3_client).to receive(:bucket).and_return(s3_bucket)
           allow(s3_bucket).to receive(:object).and_return(s3_object)
-          allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
-
-          notice_of_disagreement.update(board_review_option: 'evidence_submission')
+          allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
+          notice_of_disagreement.update!(board_review_option: 'evidence_submission')
           post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
 
           data = JSON.parse(response.body)['data']
@@ -124,23 +119,22 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
           expect(data['attributes']['status']).to eq('pending')
           expect(data['attributes']['appealId']).to eq(notice_of_disagreement.id)
           expect(data['attributes']['appealType']).to eq('NoticeOfDisagreement')
-          expect(data['attributes']['location']).to eq('http://another.fakesite.com/rewrittenpath/uuid')
+          expect(data['attributes']['location']).to eq('https://api.vets.gov/proxy/uuid')
         end
       end
     end
 
     it "returns an error when 'nod_id' parameter is missing" do
       with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                    prefix: 'http://some.fakesite.com/path',
-                    replacement: 'http://another.fakesite.com/rewrittenpath') do
+                    prefix: 'https://fake.s3.url/foo/',
+                    replacement: 'https://api.vets.gov/proxy/') do
         s3_client = instance_double(Aws::S3::Resource)
         allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
         s3_bucket = instance_double(Aws::S3::Bucket)
         s3_object = instance_double(Aws::S3::Object)
         allow(s3_client).to receive(:bucket).and_return(s3_bucket)
         allow(s3_bucket).to receive(:object).and_return(s3_object)
-        allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
-
+        allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
         post(path, params: { headers: headers })
 
         expect(response.status).to eq 400

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -23,11 +23,10 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
           allow(s3_client).to receive(:bucket).and_return(s3_bucket)
           allow(s3_bucket).to receive(:object).and_return(s3_object)
           allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
-
           post(path, params: { nod_id: 1979, headers: headers })
 
           expect(response.status).to eq 404
-          expect(response.body).to include 'Record not found'
+          expect(response.body).to include 'not found'
         end
       end
     end
@@ -44,10 +43,9 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
           allow(s3_client).to receive(:bucket).and_return(s3_bucket)
           allow(s3_bucket).to receive(:object).and_return(s3_object)
           allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
-
           post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
 
-          expect(response.status).to eq 500
+          expect(response.status).to eq 422
           expect(response.body).to include "'boardReviewOption' must be 'evidence_submission'"
         end
       end
@@ -65,11 +63,11 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
           allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
 
           notice_of_disagreement.update(board_review_option: 'evidence_submission')
-          headers['X-VA-SSN'] = "1111111111"
+          headers['X-VA-SSN'] = '1111111111'
 
           post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
 
-          expect(response.status).to eq 500
+          expect(response.status).to eq 422
           expect(response.body).to include "'X-VA-SSN' does not match"
         end
       end
@@ -90,7 +88,6 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
           post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
 
           data = JSON.parse(response.body)['data']
-
           expect(data).to have_key('id')
           expect(data).to have_key('type')
           expect(data['attributes']['status']).to eq('pending')
@@ -116,7 +113,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
         post(path, params: { headers: headers })
 
         expect(response.status).to eq 400
-        expect(response.body).to include 'Missing parameter'
+        expect(response.body).to include 'Must supply a corresponding NOD'
       end
     end
 

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -11,85 +11,93 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
   let(:path) { '/services/appeals/v1/decision_reviews/notice_of_disagreements/evidence_submissions/' }
 
   describe '#create' do
-    it "returns submission attributes including 'appealId'" do
-      with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                    prefix: 'http://some.fakesite.com/path',
-                    replacement: 'http://another.fakesite.com/rewrittenpath') do
-        s3_client = instance_double(Aws::S3::Resource)
-        allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
-        s3_bucket = instance_double(Aws::S3::Bucket)
-        s3_object = instance_double(Aws::S3::Object)
-        allow(s3_client).to receive(:bucket).and_return(s3_bucket)
-        allow(s3_bucket).to receive(:object).and_return(s3_object)
-        allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
-        notice_of_disagreement.update(board_review_option: 'evidence_submission')
-        post path, params: { nod_id: notice_of_disagreement.id }, headers: headers
+    context 'when corresponding notice of disagreement record not found' do
+      it 'returns an error' do
+        with_settings(Settings.modules_appeals_api.evidence_submissions.location,
+                      prefix: 'http://some.fakesite.com/path',
+                      replacement: 'http://another.fakesite.com/rewrittenpath') do
+          s3_client = instance_double(Aws::S3::Resource)
+          allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
+          s3_bucket = instance_double(Aws::S3::Bucket)
+          s3_object = instance_double(Aws::S3::Object)
+          allow(s3_client).to receive(:bucket).and_return(s3_bucket)
+          allow(s3_bucket).to receive(:object).and_return(s3_object)
+          allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
 
-        data = JSON.parse(response.body)['data']
-        expect(data).to have_key('id')
-        expect(data).to have_key('type')
-        expect(data['attributes']['status']).to eq('pending')
-        expect(data['attributes']['appealId']).to eq(notice_of_disagreement.id)
-        expect(data['attributes']['appealType']).to eq('NoticeOfDisagreement')
-        expect(data['attributes']['location']).to eq('http://another.fakesite.com/rewrittenpath/uuid')
-      end
-    end
+          post(path, params: { nod_id: 1979, headers: headers })
 
-    it 'returns an error when corresponding notice of disagreement not found' do
-      with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                    prefix: 'http://some.fakesite.com/path',
-                    replacement: 'http://another.fakesite.com/rewrittenpath') do
-        s3_client = instance_double(Aws::S3::Resource)
-        allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
-        s3_bucket = instance_double(Aws::S3::Bucket)
-        s3_object = instance_double(Aws::S3::Object)
-        allow(s3_client).to receive(:bucket).and_return(s3_bucket)
-        allow(s3_bucket).to receive(:object).and_return(s3_object)
-        allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
-        notice_of_disagreement.update(board_review_option: 'evidence_submission')
-        post path, params: { nod_id: 1979}, headers: headers
-      end
-
-      expect(response.status).to eq 404
-      expect(response.body).to include 'Record not found'
-    end
-
-    it "returns an error if nod 'boardReviewOption' is not 'evidence_submission'" do
-      with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                    prefix: 'http://some.fakesite.com/path',
-                    replacement: 'http://another.fakesite.com/rewrittenpath') do
-        s3_client = instance_double(Aws::S3::Resource)
-        allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
-        s3_bucket = instance_double(Aws::S3::Bucket)
-        s3_object = instance_double(Aws::S3::Object)
-        allow(s3_client).to receive(:bucket).and_return(s3_bucket)
-        allow(s3_bucket).to receive(:object).and_return(s3_object)
-        allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
-        post path, params: { nod_id: notice_of_disagreement.id }, headers: headers
-        expect(response.status).to eq 500
-        expect(response.body).to include "'boardReviewOption' must be 'evidence_submission'"
-      end
-    end
-
-    it 'raises an error if record is not found' do
-      with_settings(Settings.modules_appeals_api.evidence_submissions.location,
-                    prefix: 'http://some.fakesite.com/path',
-                    replacement: 'http://another.fakesite.com/rewrittenpath') do
-        s3_client = instance_double(Aws::S3::Resource)
-        allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
-        s3_bucket = instance_double(Aws::S3::Bucket)
-        s3_object = instance_double(Aws::S3::Object)
-        allow(s3_client).to receive(:bucket).and_return(s3_bucket)
-        allow(s3_bucket).to receive(:object).and_return(s3_object)
-        allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
-        post path, params: { nod_id: SecureRandom.uuid }
-
-        expect(response.status).to eq 404
-        expect(response.body).to include 'Record not found'
+          expect(response.status).to eq 404
+          expect(response.body).to include 'Record not found'
         end
+      end
     end
 
-    it 'creates the evidence submission and returns upload location' do
+    context 'when corresponding notice of disagreement record found' do
+      it "returns an error if nod 'boardReviewOption' is not 'evidence_submission'" do
+        with_settings(Settings.modules_appeals_api.evidence_submissions.location,
+                      prefix: 'http://some.fakesite.com/path',
+                      replacement: 'http://another.fakesite.com/rewrittenpath') do
+          s3_client = instance_double(Aws::S3::Resource)
+          allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
+          s3_bucket = instance_double(Aws::S3::Bucket)
+          s3_object = instance_double(Aws::S3::Object)
+          allow(s3_client).to receive(:bucket).and_return(s3_bucket)
+          allow(s3_bucket).to receive(:object).and_return(s3_object)
+          allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
+
+          post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
+
+          expect(response.status).to eq 500
+          expect(response.body).to include "'boardReviewOption' must be 'evidence_submission'"
+        end
+      end
+
+      it 'returns an error if request and NOD Veteran SSNs do not match' do
+        with_settings(Settings.modules_appeals_api.evidence_submissions.location,
+                      prefix: 'http://some.fakesite.com/path',
+                      replacement: 'http://another.fakesite.com/rewrittenpath') do
+          s3_client = instance_double(Aws::S3::Resource)
+          allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
+          s3_bucket = instance_double(Aws::S3::Bucket)
+          s3_object = instance_double(Aws::S3::Object)
+          allow(s3_client).to receive(:bucket).and_return(s3_bucket)
+          allow(s3_bucket).to receive(:object).and_return(s3_object)
+          allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
+
+          notice_of_disagreement.update(board_review_option: 'evidence_submission')
+          binding.pry
+          post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
+        end
+      end
+
+      it 'creates the evidence submission and returns upload location' do
+        with_settings(Settings.modules_appeals_api.evidence_submissions.location,
+                      prefix: 'http://some.fakesite.com/path',
+                      replacement: 'http://another.fakesite.com/rewrittenpath') do
+          s3_client = instance_double(Aws::S3::Resource)
+          allow(Aws::S3::Resource).to receive(:new).and_return(s3_client)
+          s3_bucket = instance_double(Aws::S3::Bucket)
+          s3_object = instance_double(Aws::S3::Object)
+          allow(s3_client).to receive(:bucket).and_return(s3_bucket)
+          allow(s3_bucket).to receive(:object).and_return(s3_object)
+          allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
+
+          notice_of_disagreement.update(board_review_option: 'evidence_submission')
+          post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
+
+          data = JSON.parse(response.body)['data']
+
+          expect(data).to have_key('id')
+          expect(data).to have_key('type')
+          expect(data['attributes']['status']).to eq('pending')
+          expect(data['attributes']['appealId']).to eq(notice_of_disagreement.id)
+          expect(data['attributes']['appealType']).to eq('NoticeOfDisagreement')
+          expect(data['attributes']['location']).to eq('http://another.fakesite.com/rewrittenpath/uuid')
+        end
+      end
+    end
+
+    it "returns an error when 'nod_id' parameter is missing" do
       with_settings(Settings.modules_appeals_api.evidence_submissions.location,
                     prefix: 'http://some.fakesite.com/path',
                     replacement: 'http://another.fakesite.com/rewrittenpath') do
@@ -100,17 +108,11 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
         allow(s3_client).to receive(:bucket).and_return(s3_bucket)
         allow(s3_bucket).to receive(:object).and_return(s3_object)
         allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
-        notice_of_disagreement.update(board_review_option: 'evidence_submission')
-        post path, params: { nod_id: notice_of_disagreement.id }, headers: headers
 
-        data = JSON.parse(response.body)['data']
+        post(path, params: { headers: headers })
 
-        expect(data).to have_key('id')
-        expect(data).to have_key('type')
-        expect(data['attributes']['status']).to eq('pending')
-        expect(data['attributes']['appealId']).to eq(notice_of_disagreement.id)
-        expect(data['attributes']['appealType']).to eq('NoticeOfDisagreement')
-        expect(data['attributes']['location']).to eq('http://another.fakesite.com/rewrittenpath/uuid')
+        expect(response.status).to eq 400
+        expect(response.body).to include 'Missing parameter'
       end
     end
 

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -52,7 +52,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
         end
       end
 
-      it 'returns an error if request and NOD Veteran SSNs do not match' do
+      it "returns an error if request 'headers['X-VA-SSN'] and NOD record SSNs do not match" do
         with_settings(Settings.modules_appeals_api.evidence_submissions.location,
                       prefix: 'http://some.fakesite.com/path',
                       replacement: 'http://another.fakesite.com/rewrittenpath') do
@@ -65,8 +65,12 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
           allow(s3_object).to receive(:presigned_url).and_return(+'http://some.fakesite.com/path/uuid')
 
           notice_of_disagreement.update(board_review_option: 'evidence_submission')
-          binding.pry
+          headers['X-VA-SSN'] = "1111111111"
+
           post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
+
+          expect(response.status).to eq 500
+          expect(response.body).to include "'X-VA-SSN' does not match"
         end
       end
 

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -23,7 +23,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
           allow(s3_client).to receive(:bucket).and_return(s3_bucket)
           allow(s3_bucket).to receive(:object).and_return(s3_object)
           allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
-          post(path, params: { nod_id: 1979, headers: headers })
+          post path, params: { nod_id: 1979 }, headers: headers
 
           expect(response.status).to eq 404
           expect(response.body).to include 'not found'
@@ -43,7 +43,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
           allow(s3_client).to receive(:bucket).and_return(s3_bucket)
           allow(s3_bucket).to receive(:object).and_return(s3_object)
           allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
-          post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
+          post path, params: { nod_id: notice_of_disagreement.id }, headers: headers
 
           expect(response.status).to eq 422
           expect(response.body).to include "'boardReviewOption' must be 'evidence_submission'"
@@ -64,7 +64,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
             allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
             notice_of_disagreement.update(board_review_option: 'evidence_submission')
             headers['X-VA-SSN'] = '1111111111'
-            post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
+            post path, params: { nod_id: notice_of_disagreement.id }, headers: headers
 
             expect(response.status).to eq 422
             expect(response.body).to include "'X-VA-SSN' does not match"
@@ -86,7 +86,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
             allow(s3_bucket).to receive(:object).and_return(s3_object)
             allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
             notice_of_disagreement.update(board_review_option: 'evidence_submission', auth_headers: nil)
-            post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
+            post path, params: { nod_id: notice_of_disagreement.id }, headers: headers
 
             data = JSON.parse(response.body)['data']
             expect(data).to have_key('id')
@@ -111,7 +111,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
           allow(s3_bucket).to receive(:object).and_return(s3_object)
           allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
           notice_of_disagreement.update!(board_review_option: 'evidence_submission')
-          post(path, params: { nod_id: notice_of_disagreement.id, headers: headers })
+          post path, params: { nod_id: notice_of_disagreement.id }, headers: headers
 
           data = JSON.parse(response.body)['data']
           expect(data).to have_key('id')
@@ -135,7 +135,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
         allow(s3_client).to receive(:bucket).and_return(s3_bucket)
         allow(s3_bucket).to receive(:object).and_return(s3_object)
         allow(s3_object).to receive(:presigned_url).and_return(+'https://fake.s3.url/foo/uuid')
-        post(path, params: { headers: headers })
+        post path, headers: headers
 
         expect(response.status).to eq 400
         expect(response.body).to include 'Must supply a corresponding NOD'

--- a/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
+++ b/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::EvidenceSubmissionSerializer do
-  let(:notice_of_disagreement) { create(:notice_of_disagreement) }
-  let(:evidence_submission) { create(:evidence_submission, :with_detail, supportable: notice_of_disagreement) }
+  let(:evidence_submission) { create(:evidence_submission, :with_detail) }
   let(:rendered_hash) { described_class.new(evidence_submission).serializable_hash }
 
   it 'includes guid' do

--- a/modules/appeals_api/spec/services/appeals_api/pdf_construction/notice_of_disagreement/v1/form_data_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/pdf_construction/notice_of_disagreement/v1/form_data_spec.rb
@@ -7,7 +7,7 @@ module AppealsApi
     module NoticeOfDisagreement
       module V1
         describe FormData do
-          let(:notice_of_disagreement) { build(:notice_of_disagreement) }
+          let(:notice_of_disagreement) { create(:notice_of_disagreement, :board_review_hearing) }
           let(:form_data) { described_class.new(notice_of_disagreement) }
 
           describe '#veteran_name' do


### PR DESCRIPTION
Step 1
In order to validate our nod evidence submissions, we need to persist a nod's board_review_option upon its creation in order to check that it's marked as evidence_submission.

Step 2
Validate the board_review_option for incoming evidence submission.

**Step 3 In Progress**
Validate agains NOD's Veteran SSN _if_ PII still available

---

This PR is a follow up to the recent addition of board_review_option to our nod model schema.

Relates to https://vajira.max.gov/browse/API-6166

Updates made to the multiple specs with the addition of the new NOD attribute.

Also includes fix for: https://vajira.max.gov/browse/API-6840