### PR TITLE
API-6718 - Update NOD header schema

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -32,19 +32,19 @@ module AppealsApi
     end
 
     def veteran_first_name
-      header_field_as_string 'X-VA-Veteran-First-Name'
+      header_field_as_string 'X-VA-First-Name'
     end
 
     def veteran_last_name
-      header_field_as_string 'X-VA-Veteran-Last-Name'
+      header_field_as_string 'X-VA-Last-Name'
     end
 
     def ssn
-      header_field_as_string 'X-VA-Veteran-SSN'
+      header_field_as_string 'X-VA-SSN'
     end
 
     def file_number
-      header_field_as_string 'X-VA-Veteran-File-Number'
+      header_field_as_string 'X-VA-File-Number'
     end
 
     def consumer_name

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/notice_of_disagreement/v1/form_data.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/notice_of_disagreement/v1/form_data.rb
@@ -11,19 +11,19 @@ module AppealsApi
         delegate :mailing_address, to: :notice_of_disagreement
 
         def veteran_name
-          name('Veteran')
+          name
         end
 
         def veteran_ssn
-          header_field_as_string('X-VA-Veteran-SSN')
+          header_field_as_string('X-VA-SSN')
         end
 
         def veteran_file_number
-          header_field_as_string('X-VA-Veteran-File-Number')
+          header_field_as_string('X-VA-File-Number')
         end
 
         def veteran_dob
-          dob 'Veteran'
+          dob
         end
 
         def homeless
@@ -60,7 +60,7 @@ module AppealsApi
 
         def signature
           # 180 characters is the max allowed by the Name field on the pdf
-          "#{veteran_name[0...180]}\n- Signed by digital authentication to api.va.gov"
+          "#{name[0...180]}\n- Signed by digital authentication to api.va.gov"
         end
 
         def date_signed
@@ -74,7 +74,7 @@ module AppealsApi
         end
 
         def stamp_text
-          "#{last_name('Veteran').truncate(35)} - #{veteran_ssn.last(4)}"
+          "#{last_name.truncate(35)} - #{veteran_ssn.last(4)}"
         end
 
         def representatives_name
@@ -87,31 +87,31 @@ module AppealsApi
 
         attr_accessor :notice_of_disagreement
 
-        def name(who)
-          initial = middle_initial(who)
+        def name
+          initial = middle_initial
           initial = "#{initial}." if initial.size.positive?
 
           [
-            first_name(who),
+            first_name,
             initial,
-            last_name(who)
+            last_name
           ].map(&:presence).compact.join(' ')
         end
 
-        def first_name(who)
-          header_field_as_string "X-VA-#{who}-First-Name"
+        def first_name
+          header_field_as_string 'X-VA-First-Name'
         end
 
-        def middle_initial(who)
-          header_field_as_string "X-VA-#{who}-Middle-Initial"
+        def middle_initial
+          header_field_as_string 'X-VA-Middle-Initial'
         end
 
-        def last_name(who)
-          header_field_as_string "X-VA-#{who}-Last-Name"
+        def last_name
+          header_field_as_string 'X-VA-Last-Name'
         end
 
-        def dob(who)
-          header_field_as_string "X-VA-#{who}-Birth-Date"
+        def dob
+          header_field_as_string 'X-VA-Birth-Date'
         end
 
         def header_field_as_string(key)

--- a/modules/appeals_api/app/swagger/appeals_api/v1/notice_of_disagreements_controller_swagger.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/notice_of_disagreements_controller_swagger.rb
@@ -84,7 +84,7 @@ class AppealsApi::V1::NoticeOfDisagreementsControllerSwagger
       end
 
       parameter do
-        key :name, 'X-VA-Veteran-File-Number'
+        key :name, 'X-VA-File-Number'
         key :in, :header
         key :required, false
         key :description, 'VA file number'
@@ -92,7 +92,7 @@ class AppealsApi::V1::NoticeOfDisagreementsControllerSwagger
       end
 
       parameter do
-        key :name, 'X-VA-Veteran-Birth-Date'
+        key :name, 'X-VA-Birth-Date'
         key :in, :header
         key :required, false
         key :description, 'The birth date of the Veteran referenced in the Notice of Disagreement.'
@@ -377,14 +377,14 @@ class AppealsApi::V1::NoticeOfDisagreementsControllerSwagger
       end
 
       parameter do
-        key :name, 'X-VA-Veteran-File-Number'
+        key :name, 'X-VA-File-Number'
         key :in, :header
         key :required, false
         key :description, 'VA file number'
       end
 
       parameter do
-        key :name, 'X-VA-Veteran-Birth-Date'
+        key :name, 'X-VA-Birth-Date'
         key :in, :header
         key :required, false
         key :description, 'The birth date of the Veteran referenced in the Notice of Disagreement.'

--- a/modules/appeals_api/config/schemas/10182_headers.json
+++ b/modules/appeals_api/config/schemas/10182_headers.json
@@ -9,20 +9,20 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "X-VA-Veteran-First-Name":      { "$ref": "#/definitions/nodCreateHeadersFirstName" },
-        "X-VA-Veteran-Middle-Initial":  { "$ref": "#/definitions/nodCreateHeadersMiddleInitial" },
-        "X-VA-Veteran-Last-Name":       { "$ref": "#/definitions/nodCreateHeadersLastName" },
-        "X-VA-Veteran-SSN":             { "$ref": "#/definitions/nodCreateHeadersSsn" },
-        "X-VA-Veteran-File-Number":     { "$ref": "#/definitions/nodCreateHeadersFileNumber" },
-        "X-VA-Veteran-Birth-Date":      { "$ref": "#/definitions/nodCreateHeadersBirthDate" },
+        "X-VA-First-Name":      { "$ref": "#/definitions/nodCreateHeadersFirstName" },
+        "X-VA-Middle-Initial":  { "$ref": "#/definitions/nodCreateHeadersMiddleInitial" },
+        "X-VA-Last-Name":       { "$ref": "#/definitions/nodCreateHeadersLastName" },
+        "X-VA-SSN":             { "$ref": "#/definitions/nodCreateHeadersSsn" },
+        "X-VA-File-Number":     { "$ref": "#/definitions/nodCreateHeadersFileNumber" },
+        "X-VA-Birth-Date":      { "$ref": "#/definitions/nodCreateHeadersBirthDate" },
         "X-Consumer-Username":          { "$ref": "#/definitions/nodCreateHeadersConsumerUsername"},
         "X-Consumer-ID":                { "$ref": "#/definitions/nodCreateHeadersConsumerId"}
       },
       "required": [
-        "X-VA-Veteran-First-Name",
-        "X-VA-Veteran-Last-Name",
-        "X-VA-Veteran-SSN",
-        "X-VA-Veteran-Birth-Date"
+        "X-VA-First-Name",
+        "X-VA-Last-Name",
+        "X-VA-SSN",
+        "X-VA-Birth-Date"
       ]
     },
 

--- a/modules/appeals_api/spec/fixtures/valid_10182_headers.json
+++ b/modules/appeals_api/spec/fixtures/valid_10182_headers.json
@@ -1,10 +1,10 @@
 {
-  "X-VA-Veteran-First-Name": "Jane",
-  "X-VA-Veteran-Middle-Initial": "Z",
-  "X-VA-Veteran-Last-Name": "Doe",
-  "X-VA-Veteran-SSN": "123456789",
-  "X-VA-Veteran-File-Number": "987654321",
-  "X-VA-Veteran-Birth-Date": "1969-12-31",
+  "X-VA-First-Name": "Jane",
+  "X-VA-Middle-Initial": "Z",
+  "X-VA-Last-Name": "Doe",
+  "X-VA-SSN": "123456789",
+  "X-VA-File-Number": "987654321",
+  "X-VA-Birth-Date": "1969-12-31",
   "X-Consumer-Username": "va.gov",
   "X-Consumer-ID": "some-guid"
 }

--- a/modules/appeals_api/spec/fixtures/valid_10182_headers_minimum.json
+++ b/modules/appeals_api/spec/fixtures/valid_10182_headers_minimum.json
@@ -1,8 +1,8 @@
 {
-  "X-VA-Veteran-First-Name": "Jane",
-  "X-VA-Veteran-Last-Name": "Doe",
-  "X-VA-Veteran-SSN": "123456789",
-  "X-VA-Veteran-Birth-Date": "1969-12-31",
+  "X-VA-First-Name": "Jane",
+  "X-VA-Last-Name": "Doe",
+  "X-VA-SSN": "123456789",
+  "X-VA-Birth-Date": "1969-12-31",
   "X-Consumer-Username": "va.gov",
   "X-Consumer-ID": "some-guid"
 }

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements_controller_spec.rb
@@ -39,7 +39,7 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController, type:
       end
 
       it 'fails when a required header is missing' do
-        post(path, params: @data, headers: @minimum_required_headers.except('X-VA-Veteran-SSN'))
+        post(path, params: @data, headers: @minimum_required_headers.except('X-VA-SSN'))
         expect(response.status).to eq(422)
         expect(parsed['errors']).to be_an Array
       end

--- a/modules/appeals_api/spec/services/appeals_api/pdf_construction/notice_of_disagreement/v1/form_data_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/pdf_construction/notice_of_disagreement/v1/form_data_spec.rb
@@ -80,9 +80,9 @@ module AppealsApi
 
             it 'truncates the signature if name is too long' do
               full_first_name = Faker::Lorem.characters(number: 99)
-              notice_of_disagreement.auth_headers['X-VA-Veteran-First-Name'] = full_first_name
+              notice_of_disagreement.auth_headers['X-VA-First-Name'] = full_first_name
               full_last_name = Faker::Lorem.characters(number: 99)
-              notice_of_disagreement.auth_headers['X-VA-Veteran-Last-Name'] = full_last_name
+              notice_of_disagreement.auth_headers['X-VA-Last-Name'] = full_last_name
 
               full_name = form_data.veteran_name
               expect(form_data.signature).to eq(
@@ -110,7 +110,7 @@ module AppealsApi
 
             it 'truncates the last name if too long' do
               full_last_name = 'AAAAAAAAAAbbbbbbbbbbCCCCCCCCCCdddddddddd'
-              notice_of_disagreement.auth_headers['X-VA-Veteran-Last-Name'] = full_last_name
+              notice_of_disagreement.auth_headers['X-VA-Last-Name'] = full_last_name
               expect(form_data.stamp_text).to eq 'AAAAAAAAAAbbbbbbbbbbCCCCCCCCCCdd... - 6789'
             end
           end


### PR DESCRIPTION
## Description of change
This updates the naming conventions (for the request headers) used in the NOD. Previously we were using `X-VA-Veteran-First-Name` instead of how the HLR is structured `X-VA-First-Name`.

## Original issue(s)
https://vajira.max.gov/browse/API-6718