### PR TITLE
21632 Fix get_facilities method

### DIFF
--- a/modules/health_quest/app/services/health_quest/questionnaire_manager/basic_questionnaire_manager_formatter.rb
+++ b/modules/health_quest/app/services/health_quest/questionnaire_manager/basic_questionnaire_manager_formatter.rb
@@ -15,6 +15,7 @@ module HealthQuest
     #   @return [Hash]
     class BasicQuestionnaireManagerFormatter
       ID_MATCHER = /([I2\-a-zA-Z0-9]+)\z/i.freeze
+      ORG_ID_MATCHER = /(^vha_\d{3,})/.freeze
 
       attr_reader :appointments, :hashed_organizations, :hashed_locations, :hashed_questionnaires
 
@@ -45,8 +46,8 @@ module HealthQuest
         appointments.each_with_object([]) do |appt, accumulator|
           location_id = appt_location_id(appt)
           location = hashed_locations[location_id]
-          quest_key = location.resource.identifier.last.value
-          org_key = location.resource.identifier.first.value
+          quest_key = location.resource.identifier.first.value
+          org_key = quest_key.match(ORG_ID_MATCHER)[1]
           org = hashed_organizations[org_key]
 
           next unless hashed_questionnaires.key?(quest_key)

--- a/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
+++ b/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
@@ -116,6 +116,7 @@ module HealthQuest
         return default_response if lighthouse_appointments.blank?
 
         concurrent_pgd_requests
+        @facilities = get_facilities
         return default_response if patient.blank? || questionnaires.blank?
 
         compose
@@ -186,7 +187,6 @@ module HealthQuest
         # rubocop:disable ThreadSafety/NewThread
         request_threads << Thread.new { @patient = get_patient.resource }
         request_threads << Thread.new { @organizations = get_organizations }
-        request_threads << Thread.new { @facilities = get_facilities }
         request_threads << Thread.new { @questionnaires = get_questionnaires.resource&.entry }
         request_threads << Thread.new { @questionnaire_responses = get_questionnaire_responses.resource&.entry }
         request_threads << Thread.new { @save_in_progress = get_save_in_progress }
@@ -291,7 +291,7 @@ module HealthQuest
       # @return [Array]
       #
       def get_facilities
-        list = locations.map { |loc| loc.resource.identifier.first.value }
+        list = organizations.map { |org| org.resource.identifier.last.value }
         facilities_ids = list.join(',')
 
         facilities_request.get(facilities_ids)

--- a/modules/health_quest/spec/services/questionnaire_manager/basic_questionnaire_manager_formatter_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/basic_questionnaire_manager_formatter_spec.rb
@@ -22,7 +22,7 @@ describe HealthQuest::QuestionnaireManager::BasicQuestionnaireManagerFormatter d
       'I2-LABC' => double(
         'Location',
         resource: double('Resource',
-                         identifier: [double('first', value: 'vha_442'), double('last', value: 'vha_442_3049')],
+                         identifier: [double('first', value: 'vha_442_3049')],
                          to_hash: { id: 'I2-LABC' })
       )
     }

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -155,7 +155,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       [
         double('FHIR::Location',
                resource: double('FHIR::Bundle',
-                                identifier: [double('first', value: 'vha_442'), double('last', value: 'vha_442_3049')],
+                                identifier: [double('first', value: 'vha_442_3049')],
                                 to_hash: { id: 'I2-LABC' }))
       ]
     end
@@ -234,7 +234,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       [
         double('FHIR::Location',
                resource: double('FHIR::Bundle',
-                                identifier: [double('first', value: 'vha_442'), double('last', value: 'vha_442_3049')],
+                                identifier: [double('first', value: 'vha_442_3049')],
                                 managingOrganization: double('Reference', reference: '/O/I2-OABC'),
                                 to_hash: { id: 'I2-LABC' }))
       ]
@@ -257,12 +257,19 @@ describe HealthQuest::QuestionnaireManager::Factory do
       [
         double('FHIR::Location',
                resource: double('FHIR::Bundle',
-                                identifier: [double('first', value: 'vha_442'), double('last', value: 'vha_442_3049')]))
+                                identifier: [double('first', value: 'vha_442_3049')]))
+      ]
+    end
+    let(:organizations) do
+      [
+        double('FHIR::Organization',
+               resource: double('Resource',
+                                identifier: [double('last', value: 'vha_442')]))
       ]
     end
 
     before do
-      allow_any_instance_of(subject).to receive(:locations).and_return(locations)
+      allow_any_instance_of(subject).to receive(:organizations).and_return(organizations)
       allow_any_instance_of(HealthQuest::Facilities::Request).to receive(:get).with(anything).and_return(facilities)
     end
 

--- a/modules/health_quest/spec/services/questionnaire_manager/transformer_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/transformer_spec.rb
@@ -203,7 +203,7 @@ describe HealthQuest::QuestionnaireManager::Transformer do
         'I2-LABC' => double(
           'Location',
           resource: double('Resource',
-                           identifier: [double('first', value: 'vha_442'), double('last', value: 'vha_442_3049')],
+                           identifier: [double('first', value: 'vha_442_3049')],
                            to_hash: { id: 'I2-LABC' })
         )
       }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Lighthouse Location resource no longer has the Organization key
- Use the Organization identifiers to retrieve the list of facilities
## Original issue(s)
department-of-veterans-affairs/va.gov-team#21632

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
- [x] Feature flag
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests passing
- [x] Rubocop passing 