### PR TITLE
bump aws-sdk-s3 to latest minor version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
     aws-sdk-kms (1.43.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.93.1)
+    aws-sdk-s3 (1.94.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the aws-sdk-s3 gem(default group) to the latest minor version. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-s3/CHANGELOG.md

## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 