### PR TITLE
bump octokit to latest minor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -559,7 +559,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    octokit (4.20.0)
+    octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     oj (3.11.5)


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the octokit gem(default group) to the latest minor version. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

https://github.com/octokit/octokit.rb/releases

## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 