### PR TITLE
Route 10-10CG submissions to new job

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -353,10 +353,6 @@ features:
     enable_in_development: true
     description: >
       Enables type ahead search functionality
-  async_10_10_cg_attachments:
-    actor_type: cookie_id
-    description: >
-      This will process attachments of 10-10CG submissions using sidekiq.
   multiple_address_10_10ez:
     actor_type: cookie_id
     description: >

--- a/spec/request/caregivers_assistance_claims_request_spec.rb
+++ b/spec/request/caregivers_assistance_claims_request_spec.rb
@@ -98,66 +98,25 @@ RSpec.describe 'Caregivers Assistance Claims', type: :request do
 
     timestamp = DateTime.parse('2020-03-09T06:48:59-04:00')
 
-    context 'when flipper :async_10_10_cg_attachments' do
-      context 'is enabled' do
-        before do
-          expect(Flipper).to receive(:enabled?).with(:async_10_10_cg_attachments).and_return(true)
-        end
-
-        after do
-          expect(Form1010cg::DeliverPdfToCARMAJob.jobs.size).to eq(1)
-        end
-
-        it 'can submit a valid submission', run_at: timestamp.iso8601 do
-          VCR.use_cassette 'mpi/find_candidate/valid', vcr_options do
-            VCR.use_cassette 'carma/auth/token/200', vcr_options do
-              VCR.use_cassette 'carma/submissions/create/201', vcr_options do
-                subject
-              end
-            end
+    it 'can submit a valid submission', run_at: timestamp.iso8601 do
+      VCR.use_cassette 'mpi/find_candidate/valid', vcr_options do
+        VCR.use_cassette 'carma/auth/token/200', vcr_options do
+          VCR.use_cassette 'carma/submissions/create/201', vcr_options do
+            subject
           end
-
-          expect(response.code).to eq('200')
-
-          res_body = JSON.parse(response.body)
-
-          expect(res_body['data']).to be_present
-          expect(res_body['data']['type']).to eq 'form1010cg_submissions'
-          expect(DateTime.parse(res_body['data']['attributes']['submittedAt'])).to eq timestamp
-          expect(res_body['data']['attributes']['confirmationNumber']).to eq 'aB935000000F3VnCAK'
         end
       end
 
-      context 'is disabled' do
-        before do
-          expect(Flipper).to receive(:enabled?).with(:async_10_10_cg_attachments).and_return(false)
-        end
+      expect(response.code).to eq('200')
 
-        after do
-          expect(Form1010cg::DeliverPdfToCARMAJob.jobs.size).to eq(0)
-        end
+      res_body = JSON.parse(response.body)
 
-        it 'can submit a valid submission', run_at: timestamp.iso8601 do
-          VCR.use_cassette 'mpi/find_candidate/valid', vcr_options do
-            VCR.use_cassette 'carma/auth/token/200', vcr_options do
-              VCR.use_cassette 'carma/submissions/create/201', vcr_options do
-                VCR.use_cassette 'carma/attachments/upload/201', vcr_options do
-                  subject
-                end
-              end
-            end
-          end
+      expect(res_body['data']).to be_present
+      expect(res_body['data']['type']).to eq 'form1010cg_submissions'
+      expect(DateTime.parse(res_body['data']['attributes']['submittedAt'])).to eq timestamp
+      expect(res_body['data']['attributes']['confirmationNumber']).to eq 'aB935000000F3VnCAK'
 
-          expect(response.code).to eq('200')
-
-          res_body = JSON.parse(response.body)
-
-          expect(res_body['data']).to be_present
-          expect(res_body['data']['type']).to eq 'form1010cg_submissions'
-          expect(DateTime.parse(res_body['data']['attributes']['submittedAt'])).to eq timestamp
-          expect(res_body['data']['attributes']['confirmationNumber']).to eq 'aB935000000F3VnCAK'
-        end
-      end
+      expect(Form1010cg::DeliverAttachmentsJob.jobs.size).to eq(1)
     end
   end
 

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -868,7 +868,7 @@ RSpec.describe Form1010cg::Service do
       expect { subject.process_claim! }.to raise_error(described_class::InvalidVeteranStatus)
     end
 
-    context 'when flipper :async_10_10_cg_attachments' do
+    context 'with valid state' do
       let(:expected) do
         {
           results: {
@@ -897,223 +897,17 @@ RSpec.describe Form1010cg::Service do
 
           carma_submission
         }
+        expect(subject).to receive(:submit_attachment_async)
       end
 
-      context 'is enabled' do
-        before do
-          expect(Flipper).to receive(:enabled?).with(:async_10_10_cg_attachments).and_return(true)
-          expect(subject).to receive(:submit_attachment_async)
-        end
+      it 'submits the claim to carma and returns a Form1010cg::Submission' do
+        result = subject.process_claim!
 
-        it 'submits the claim to carma and returns a Form1010cg::Submission' do
-          result = subject.process_claim!
-
-          expect(result).to be_a(Form1010cg::Submission)
-          expect(result.carma_case_id).to eq(expected[:results][:carma_case_id])
-          expect(result.accepted_at).to eq(expected[:results][:submitted_at])
-          expect(result.metadata).to eq(expected[:results][:metadata])
-        end
+        expect(result).to be_a(Form1010cg::Submission)
+        expect(result.carma_case_id).to eq(expected[:results][:carma_case_id])
+        expect(result.accepted_at).to eq(expected[:results][:submitted_at])
+        expect(result.metadata).to eq(expected[:results][:metadata])
       end
-
-      context 'is disabled' do
-        before do
-          expect(Flipper).to receive(:enabled?).with(:async_10_10_cg_attachments).and_return(false)
-          expect(subject).to receive(:submit_attachment)
-        end
-
-        it 'submits the claim to carma and returns a Form1010cg::Submission' do
-          result = subject.process_claim!
-
-          expect(result).to be_a(Form1010cg::Submission)
-          expect(result.carma_case_id).to eq(expected[:results][:carma_case_id])
-          expect(result.accepted_at).to eq(expected[:results][:submitted_at])
-          expect(result.metadata).to eq(expected[:results][:metadata])
-        end
-      end
-    end
-  end
-
-  describe '#submit_attachment' do
-    context 'raises error' do
-      it 'when submission is not present' do
-        expect { subject.submit_attachment }.to raise_error('requires a submission')
-      end
-
-      it 'when submission is not yet processed' do
-        subject.submission = double(carma_case_id: nil)
-        expect { subject.submit_attachment }.to raise_error('requires a processed submission')
-      end
-
-      it 'when submission already has attachments' do
-        subject.submission = double(carma_case_id: 'CAS_1234', attachments: [{ id: 'CAS_qwer' }])
-        expect { subject.submit_attachment }.to raise_error('submission already has attachments')
-      end
-    end
-
-    it 'submits the PDF version of submission to CARMA' do
-      document_type     = '10-10CG'
-      file_path         = 'tmp/my_file.pdf'
-      carma_attachment  = double
-      claim             = build(:caregivers_assistance_claim)
-
-      submission = Form1010cg::Submission.new(
-        carma_case_id: 'aB9350000000TjICAU',
-        accepted_at: '2020-06-26 13:30:59'
-      )
-
-      subject = described_class.new(claim, submission)
-
-      expect(subject.claim).to receive(:to_pdf).with(sign: true).and_return(file_path)
-
-      expect(CARMA::Models::Attachments).to receive(:new).with(
-        submission.carma_case_id,
-        claim.veteran_data['fullName']['first'],
-        claim.veteran_data['fullName']['last']
-      ).and_return(
-        carma_attachment
-      )
-
-      expect(carma_attachment).to receive(:add).with(document_type, file_path).and_return(carma_attachment)
-      expect(carma_attachment).to receive(:submit!).and_return(:ATTACHMENT_RESPONSE)
-      expect(carma_attachment).to receive(:to_hash).and_return(:attachments_as_hash)
-      expect(submission).to receive(:attachments=).with(:attachments_as_hash)
-
-      expect(File).to receive(:exist?).with(file_path).and_return(true)
-      expect(File).to receive(:delete).with(file_path)
-
-      expect(subject.submit_attachment).to eq(true)
-    end
-
-    it 'returns false when PDF generation fails' do
-      claim = build(:caregivers_assistance_claim)
-
-      submission = Form1010cg::Submission.new(
-        carma_case_id: 'aB9350000000TjICAU',
-        accepted_at: '2020-06-26 13:30:59'
-      )
-
-      subject = described_class.new(claim, submission)
-
-      expect(subject.claim).to receive(:to_pdf).and_raise('pdf generation failure')
-      expect(CARMA::Models::Attachments).not_to receive(:new)
-
-      expect(subject.submit_attachment).to eq(false)
-    end
-
-    it 'returns false when building Attachments fails' do
-      file_path = 'tmp/my_file.pdf'
-      claim     = build(:caregivers_assistance_claim)
-
-      submission = Form1010cg::Submission.new(
-        carma_case_id: 'aB9350000000TjICAU',
-        accepted_at: '2020-06-26 13:30:59'
-      )
-
-      subject = described_class.new(claim, submission)
-
-      expect(subject.claim).to receive(:to_pdf).and_return(file_path)
-
-      expect(CARMA::Models::Attachments).to receive(:new).and_raise('failure')
-
-      expect(File).to receive(:exist?).with(file_path).and_return(true)
-      expect(File).to receive(:delete).with(file_path)
-
-      expect(subject.submit_attachment).to eq(false)
-    end
-
-    it 'returns false when adding an attachment fails' do
-      document_type     = '10-10CG'
-      file_path         = 'tmp/my_file.pdf'
-      carma_attachment  = double
-      claim             = build(:caregivers_assistance_claim)
-
-      submission = Form1010cg::Submission.new(
-        carma_case_id: 'aB9350000000TjICAU',
-        accepted_at: '2020-06-26 13:30:59'
-      )
-
-      subject = described_class.new(claim, submission)
-
-      expect(subject.claim).to receive(:to_pdf).and_return(file_path)
-
-      expect(CARMA::Models::Attachments).to receive(:new).with(
-        submission.carma_case_id,
-        claim.veteran_data['fullName']['first'],
-        claim.veteran_data['fullName']['last']
-      ).and_return(
-        carma_attachment
-      )
-
-      expect(carma_attachment).to receive(:add).with(document_type, file_path).and_raise('failure')
-
-      expect(File).to receive(:exist?).with(file_path).and_return(true)
-      expect(File).to receive(:delete).with(file_path)
-
-      expect(subject.submit_attachment).to eq(false)
-    end
-
-    it 'returns false when submission fails' do
-      document_type     = '10-10CG'
-      file_path         = 'tmp/my_file.pdf'
-      carma_attachment  = double
-      claim             = build(:caregivers_assistance_claim)
-
-      submission = Form1010cg::Submission.new(
-        carma_case_id: 'aB9350000000TjICAU',
-        accepted_at: '2020-06-26 13:30:59'
-      )
-
-      subject = described_class.new(claim, submission)
-
-      expect(subject.claim).to receive(:to_pdf).and_return(file_path)
-
-      expect(CARMA::Models::Attachments).to receive(:new).with(
-        submission.carma_case_id,
-        claim.veteran_data['fullName']['first'],
-        claim.veteran_data['fullName']['last']
-      ).and_return(
-        carma_attachment
-      )
-
-      expect(carma_attachment).to receive(:add).with(document_type, file_path).and_return(carma_attachment)
-      expect(carma_attachment).to receive(:submit!).and_raise('bad request')
-
-      expect(File).to receive(:exist?).with(file_path).and_return(true)
-      expect(File).to receive(:delete).with(file_path)
-
-      expect(subject.submit_attachment).to eq(false)
-    end
-
-    it 'returns false when file is deleted from another source' do
-      document_type     = '10-10CG'
-      file_path         = 'tmp/my_file.pdf'
-      carma_attachment  = double
-      claim             = build(:caregivers_assistance_claim)
-
-      submission = Form1010cg::Submission.new(
-        carma_case_id: 'aB9350000000TjICAU',
-        accepted_at: '2020-06-26 13:30:59'
-      )
-
-      subject = described_class.new(claim, submission)
-
-      expect(subject.claim).to receive(:to_pdf).and_return(file_path)
-
-      expect(CARMA::Models::Attachments).to receive(:new).with(
-        submission.carma_case_id,
-        claim.veteran_data['fullName']['first'],
-        claim.veteran_data['fullName']['last']
-      ).and_return(
-        carma_attachment
-      )
-
-      expect(carma_attachment).to receive(:add).with(document_type, file_path).and_return(carma_attachment)
-      expect(carma_attachment).to receive(:submit!).and_raise('bad request')
-
-      expect(File).to receive(:exist?).with(file_path).and_return(false)
-      expect(File).not_to receive(:delete).with(file_path)
-
-      expect(subject.submit_attachment).to eq(false)
     end
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/23825

## Description of change
- Direct Form 10-10cg Submissions to use the new `Form1010cg::DeliverAttachmentsJob`.
- Remove `:async_10_10_cg_attachments` feature flag and logic
- Remove deprecated `Form1010cg::Service#submit_attachment` method.

## Original issue(s)
- Epic [#18347](https://app.zenhub.com/workspaces/vsa---caregiver-5fff0cfd1462b6000e320fc7/issues/department-of-veterans-affairs/va.gov-team/18347
)
## Things to know about this PR
- We will not remove the `Form1010cg::DeliverPdfToCARMAJob` just yet, so pending jobs in prod can be completed.

## Regression Tests
- [x] Vet, PC (simple - only req. fileds)
  - [x] Submission works
  - [x] PDF makes it to CARMA
- [x] Vet, PC, SC1, SC2 (kitchen sink - all fields)
  - [x] Submission works
  - [x] PDF makes it to CARMA
- [x] Vet, SC1
  - [x] Submission works
  - [x] PDF makes it to CARMA
- [x] ~Vet, SC1, SC2~ (did not test)
  - [ ] Submission works
  - [ ] PDF makes it to CARMA

