### PR TITLE
Revert "Bump ruby-saml from 1.11.0 to 1.12.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,7 +528,7 @@ GEM
       rake
     mini_magick (4.11.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.1)
+    mini_portile2 (2.5.0)
     minitest (5.14.4)
     msgpack (1.3.3)
     multi_json (1.15.0)
@@ -717,7 +717,7 @@ GEM
       hashie (>= 1.2.0, < 4.0)
       json (>= 1.7.5)
     retriable (3.1.2)
-    rexml (3.2.5)
+    rexml (3.2.4)
     rgeo (2.0.1)
     rgeo-activerecord (6.2.1)
       activerecord (>= 5.0)
@@ -778,7 +778,7 @@ GEM
       rubocop (>= 0.53.0)
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
-    ruby-saml (1.12.2)
+    ruby-saml (1.12.1)
       nokogiri (>= 1.10.5)
       rexml
     ruby-vips (2.0.17)


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#6672

Reverting because it updated REXML