### PR TITLE
bump aasm to latest minor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
   remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.0.3)
-    aasm (5.1.1)
+    aasm (5.2.0)
       concurrent-ruby (~> 1.0)
     actioncable (6.0.3.6)
       actionpack (= 6.0.3.6)


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the aasm gem (default group) to the latest minor version. Gems are being updated individually via separate PRs, in order to avoid issues if a roll back is needed.

https://github.com/aasm/aasm/blob/master/CHANGELOG.md

## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 