### PR TITLE
Remove ignores for CVE-2021-28965

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@
         steps:
             - run:
                 name: Audit bundled gems for CVE issues
-                command: bundle exec bundle-audit check --update --ignore CVE-2021-28965
+                command: bundle exec bundle-audit check --update
     security_check:
         steps:
             - run:

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -19,7 +19,7 @@ jobs:
         run: sudo apt install imagemagick pdftk poppler-utils
 
       - name: Run bundle-audit (checks gems for CVE issues)
-        run:  bundle exec bundle-audit check --update --ignore CVE-2021-28965
+        run:  bundle exec bundle-audit check --update
 
       - name: Run Rubocop
         run: bundle exec rubocop --parallel --format progress --format json --out rubocop.json

--- a/rakelib/security.rake
+++ b/rakelib/security.rake
@@ -14,7 +14,7 @@ task security: :environment do
 
   puts 'running bundle-audit to check for insecure dependencies...'
   exit!(1) unless ShellCommand.run('bundle-audit update')
-  audit_result = ShellCommand.run('bundle-audit check --ignore CVE-2021-28965')
+  audit_result = ShellCommand.run('bundle-audit check')
 
   puts "\n"
   if brakeman_result && audit_result


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
We added these ignores because upgrading to `rexml` 3.2.5 caused breaking changes to `ruby-saml` therefore broke login. After upgrading both `rexml` and `ruby-saml` that issue is now resolved and the CVE taken care of. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#24019


