### PR TITLE
Api 6411/status update event

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -179,7 +179,16 @@ module AppealsApi
     end
 
     def update_status!(status:, code: nil, detail: nil)
+      handler = Events::Handler.new(event_type: :hlr_status_updated, opts: {
+                                      from: self.status,
+                                      to: status,
+                                      status_update_time: Time.zone.now,
+                                      statusable_id: id
+                                    })
+
       update!(status: status, code: code, detail: detail)
+
+      handler.handle!
     end
 
     private

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -109,7 +109,16 @@ module AppealsApi
     end
 
     def update_status!(status:, code: nil, detail: nil)
+      handler = Events::Handler.new(event_type: :nod_status_updated, opts: {
+                                      from: self.status,
+                                      to: status,
+                                      status_update_time: Time.zone.now,
+                                      statusable_id: id
+                                    })
+
       update!(status: status, code: code, detail: detail)
+
+      handler.handle!
     end
 
     private

--- a/modules/appeals_api/spec/models/higher_level_review_spec.rb
+++ b/modules/appeals_api/spec/models/higher_level_review_spec.rb
@@ -370,5 +370,15 @@ describe AppealsApi::HigherLevelReview, type: :model do
       end.to raise_error(ActiveRecord::RecordInvalid,
                          'Validation failed: Status is not included in the list')
     end
+
+    it 'emits an event' do
+      handler = instance_double(AppealsApi::Events::Handler)
+      allow(AppealsApi::Events::Handler).to receive(:new).and_return(handler)
+      allow(handler).to receive(:handle!)
+
+      higher_level_review.update_status!(status: 'pending')
+
+      expect(handler).to have_received(:handle!)
+    end
   end
 end

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -152,5 +152,15 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
       end.to raise_error(ActiveRecord::RecordInvalid,
                          'Validation failed: Status is not included in the list')
     end
+
+    it 'emits an event' do
+      handler = instance_double(AppealsApi::Events::Handler)
+      allow(AppealsApi::Events::Handler).to receive(:new).and_return(handler)
+      allow(handler).to receive(:handle!)
+
+      notice_of_disagreement.update_status!(status: 'pending')
+
+      expect(handler).to have_received(:handle!)
+    end
   end
 end


### PR DESCRIPTION
[API-6411](https://vajira.max.gov/browse/API-6411)

This PR emits a status updated event in the [newly created](https://github.com/department-of-veterans-affairs/vets-api/pull/6731) `update_status!` interface for both NOD and HLR.

As a result, it's also dependent on that PR.

Potential Issues: As of right now, it seems that the module namespaced initializer isn't working as expected, and the EventSubscriptions are not being created locally. Will continue to investigate, this won't break any of the code that exists.