### PR TITLE
#18742 adds deprecation warnings for User va_profile methods

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,17 +237,17 @@ class User < Common::RedisStore
   def va_profile
     mpi.profile
   end
-  deprecate :va_profile, :none, 2021, 8
+  deprecate :va_profile, :none, 2021, 5
 
   def va_profile_error
     mpi.error
   end
-  deprecate :va_profile_error, :mpi_error, 2021, 8
+  deprecate :va_profile_error, :mpi_error, 2021, 5
 
   def va_profile_status
     mpi.status
   end
-  deprecate :va_profile_status, :mpi_status, 2021, 8
+  deprecate :va_profile_status, :mpi_status, 2021, 5
 
   # MPI setter methods
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ require 'va_profile/configuration'
 class User < Common::RedisStore
   include BetaSwitch
   include Authorization
+  extend Gem::Deprecate
 
   UNALLOCATED_SSN_PREFIX = '796' # most test accounts use this
 
@@ -236,14 +237,17 @@ class User < Common::RedisStore
   def va_profile
     mpi.profile
   end
+  deprecate :va_profile, :none, 2021, 8
 
   def va_profile_error
     mpi.error
   end
+  deprecate :va_profile_error, :mpi_error, 2021, 8
 
   def va_profile_status
     mpi.status
   end
+  deprecate :va_profile_status, :mpi_status, 2021, 8
 
   # MPI setter methods
 

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -48,7 +48,7 @@ module Users
       scaffold.account = account
       scaffold.profile = profile
       scaffold.vet360_contact_information = vet360_contact_information
-      scaffold.va_profile = va_profile
+      scaffold.va_profile = mpi_profile
       scaffold.veteran_status = veteran_status
       scaffold.in_progress_forms = in_progress_forms
       scaffold.prefills_available = prefills_available
@@ -101,7 +101,7 @@ module Users
       nil
     end
 
-    def va_profile
+    def mpi_profile
       status = user.mpi_status
 
       if status == RESPONSE_STATUS[:ok]

--- a/rakelib/mvi.rake
+++ b/rakelib/mvi.rake
@@ -38,7 +38,7 @@ middle_name="W" last_name="Smith" birth_date="1945-01-25" gender="M" ssn="555443
       )
 
       user.last_signed_in = Time.now.utc
-      pp user.va_profile
+      pp user.mpi.profile
     rescue => e
       puts "User query failed: #{e.message}"
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Adds deprecation notices to User `va_profile` methods in preparation for removal and removes last invocation of it from a rakefile. Also renames scaffolded User.va_profile getter method; the serialized `va_profile` will remain an attribute sent to the front end for the time being.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18742

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Manual testing of the deprecation notice and continuing functionality of the rakefile and serializer.