### PR TITLE
API-6628: Update docs to accept eSignature

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v0/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_526_controller_swagger.rb
@@ -213,7 +213,7 @@ module ClaimsApi
           key(
             :description,
             <<~X
-              Used to upload a completed, wet-signed 526 PDF to establish an original claim. Use this endpoint only after following the instructions in the POST /forms/526 endpoint to begin the claim submission.
+              Used to upload a completed, wet-signed (or e-signed) 526 PDF to establish an original claim. Use this endpoint only after following the instructions in the POST /forms/526 endpoint to begin the claim submission.
               <br/><br/>
               This endpoint works by accepting a document binary PDF as part of a multi-part payload (for example, attachment1, attachment2, attachment3). Each attachment should be encoded separately rather than encoding the whole payload together as with the Benefits Intake API.
               <br/><br/>

--- a/modules/claims_api/app/swagger/claims_api/v0/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v0/form_526_controller_swagger.rb
@@ -213,7 +213,7 @@ module ClaimsApi
           key(
             :description,
             <<~X
-              Used to upload a completed, wet-signed (or e-signed) 526 PDF to establish an original claim. Use this endpoint only after following the instructions in the POST /forms/526 endpoint to begin the claim submission.
+              Used to upload a completed, signed 526 PDF to establish an original claim. Use this endpoint only after following the instructions in the POST /forms/526 endpoint to begin the claim submission.
               <br/><br/>
               This endpoint works by accepting a document binary PDF as part of a multi-part payload (for example, attachment1, attachment2, attachment3). Each attachment should be encoded separately rather than encoding the whole payload together as with the Benefits Intake API.
               <br/><br/>

--- a/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
@@ -191,7 +191,7 @@ module ClaimsApi
           key(
             :description,
             <<~X
-              Used to upload a completed, wet-signed 526 PDF to establish an original claim. Use this endpoint only after following the instructions in the POST /forms/526 endpoint to begin the claim submission.
+              Used to upload a completed, wet-signed (or e-signed) 526 PDF to establish an original claim. Use this endpoint only after following the instructions in the POST /forms/526 endpoint to begin the claim submission.
               <br/><br/>
               This endpoint works by accepting a document binary PDF as part of a multi-part payload (for example, attachment1, attachment2, attachment3). Each attachment should be encoded separately rather than encoding the whole payload together as with the Benefits Intake API.
               <br/><br/>

--- a/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v1/form_526_controller_swagger.rb
@@ -191,7 +191,7 @@ module ClaimsApi
           key(
             :description,
             <<~X
-              Used to upload a completed, wet-signed (or e-signed) 526 PDF to establish an original claim. Use this endpoint only after following the instructions in the POST /forms/526 endpoint to begin the claim submission.
+              Used to upload a completed, signed 526 PDF to establish an original claim. Use this endpoint only after following the instructions in the POST /forms/526 endpoint to begin the claim submission.
               <br/><br/>
               This endpoint works by accepting a document binary PDF as part of a multi-part payload (for example, attachment1, attachment2, attachment3). Each attachment should be encoded separately rather than encoding the whole payload together as with the Benefits Intake API.
               <br/><br/>


### PR DESCRIPTION
## Description of change
Missed the PUT endpoint description. This should cover all places where a wet-signature was documented as required. Documentation should now present either a wet-signature or an e-signature as possible for pdf submissions.

## Original issue(s)
https://vajira.max.gov/browse/API-6628