### PR TITLE
conditional and rake task to kick off reprocess of stuck records

### DIFF
--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
@@ -20,8 +20,8 @@ module CovidVaccine
         # if records are > 24 hours old, we will send to VeText service without an ICN or facility match
         mpi_attributes = attributes_from_mpi(raw_form_data, facility[0..2], submission.id, submission.created_at)
         return if mpi_attributes.empty?
-        
-        if (submission.state != 'enrollment_complete') 
+
+        if submission.state != 'enrollment_complete'
           submission.created_at <= 1.day.ago ? submission.failed_enrollment! : submission.detected_enrollment!
         end
 

--- a/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
+++ b/modules/covid_vaccine/app/services/covid_vaccine/v0/expanded_registration_service.rb
@@ -20,8 +20,10 @@ module CovidVaccine
         # if records are > 24 hours old, we will send to VeText service without an ICN or facility match
         mpi_attributes = attributes_from_mpi(raw_form_data, facility[0..2], submission.id, submission.created_at)
         return if mpi_attributes.empty?
-
-        submission.created_at <= 1.day.ago ? submission.failed_enrollment! : submission.detected_enrollment!
+        
+        if (submission.state != 'enrollment_complete') 
+          submission.created_at <= 1.day.ago ? submission.failed_enrollment! : submission.detected_enrollment!
+        end
 
         vetext_attributes = transform_form_data(raw_form_data, facility, mpi_attributes)
         submit_and_save(vetext_attributes, submission)

--- a/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
+++ b/modules/covid_vaccine/spec/factories/expanded_registration_submissions.rb
@@ -90,10 +90,6 @@ FactoryBot.define do
       }
     end
 
-    # trait :enrollment_out_of_band do
-    #   state { 'enrollment_out_of_band' }
-    # end
-
     trait :blank_email do
       default_raw_options {
         {

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/expanded_registration_service_spec.rb
@@ -12,8 +12,9 @@ describe CovidVaccine::V0::ExpandedRegistrationService do
   let(:submission_non_us) { create(:covid_vax_expanded_registration, :unsubmitted, :non_us) }
   let(:submission_composite_facility) { create(:covid_vax_expanded_registration, :unsubmitted, :composite_facility) }
   let(:submission_eligibility_info) { create(:covid_vax_expanded_registration, :unsubmitted, :eligibility_info) }
-  let(:submission_enrollment_complete) { create(:covid_vax_expanded_registration, :unsubmitted, :state_enrollment_complete) }
-
+  let(:submission_enrollment_complete) do
+    create(:covid_vax_expanded_registration, :unsubmitted, :state_enrollment_complete)
+  end
 
   let(:mvi_profile) { build(:mvi_profile, { vha_facility_ids: %w[358 516 553 200HD 200IP 200MHV] }) }
   let(:mvi_profile_no_facility) { build(:mvi_profile) }
@@ -246,7 +247,7 @@ describe CovidVaccine::V0::ExpandedRegistrationService do
             expect(submission_enrollment_complete.reload.vetext_sid).to match(sid)
             expect(submission_enrollment_complete.reload.vetext_sid).to be_truthy
           end
-    
+
           it 'updates state to registered' do
             sid = SecureRandom.uuid
             allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
@@ -327,7 +328,7 @@ describe CovidVaccine::V0::ExpandedRegistrationService do
               expect(submission_enrollment_complete.reload.vetext_sid).to match(sid)
               expect(submission_enrollment_complete.reload.vetext_sid).to be_truthy
             end
-      
+
             it 'updates state to registered' do
               sid = SecureRandom.uuid
               allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)

--- a/rakelib/covid_vaccine.rake
+++ b/rakelib/covid_vaccine.rake
@@ -74,4 +74,14 @@ namespace :covid_vaccine do
     end
     puts "Updated mapped facility info for #{count} records in batch #{batch_id}"
   end
+
+  desc 'Reprocess records with state = enrollment_complete that have not been sent to vetext'
+  task reprocess_completed_records: [:environment] do |_task|
+    count = 0
+    CovidVaccine::V0::ExpandedRegistrationSubmission.where(state: 'enrollment_complete').find_each do |submission|
+      CovidVaccine::ExpandedSubmissionJob.perform_async(submission.id)
+      count += 1
+    end
+    puts "Processed #{count} records with state=enrollment_complete"
+  end
 end


### PR DESCRIPTION

## Description of change
This PR adds a rake task that can be invoked to reprocess records that are stuck with state=enrollment_complete.  A conditional check is also added to prevent attempts to make illegal state transitions. 

## Things to know about this PR
Test cases have been added that begin with state=enrollment_complete

The rake task will be manually invoked as needed to handle these rare cases.  