### PR TITLE
Fix bug with header parsing on EvidenceSubmission create

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -39,7 +39,7 @@ module AppealsApi::V1
 
         def set_submission_attributes
           @submission_attributes ||= {
-            source: params['headers']['X-Consumer-Username'],
+            source: request.headers['X-Consumer-Username'],
             supportable_id: params[:nod_id],
             supportable_type: 'AppealsApi::NoticeOfDisagreement'
           }


### PR DESCRIPTION
## Description of change
The specs were creating a `header` key on the params rather than actually sending them in as headers to the request. We then built the functionality of extracting the `source` from this incorrect key.

Updated to send the headers properly and extract the `source` from the request headers.

## Original issue(s)
https://vajira.max.gov/browse/API-6840