### PR TITLE
[23803] Bumping the Betamocks Gem version number to accomodate for la…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,10 +32,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/betamocks
-  revision: 460d72bc89f802e57f531bf0c726437815bf2be8
+  revision: d6ceb4cdd2f0b9c5d9bddf3cbda675892945349b
   branch: master
   specs:
-    betamocks (0.7.0)
+    betamocks (0.7.1)
       activesupport (>= 4.2)
       adler32
       faraday (>= 0.7.4, < 0.18)


### PR DESCRIPTION
…test Betamocks change

## Description of change
This PR just bumps the Betamocks version number in the Gemfile.lock to take advantage of the new Betamocks changes in https://github.com/department-of-veterans-affairs/betamocks/pull/22 . This change allows for an additional field in the services config file, `:optional_code_locator` to be defined, which can be used to mock different versions of a service call, even if the ID is the same. For example, adding `:optional_code_locator: 'modifyCode code="(MVI\.COMP1\.RMS|MVI\.COMP2)"'` to the MPI `services_config.yml` route definitions, will allow for us to mock both an `MVI.COMP1.RMS` MPI call, as well as an `MVI.COMP2` MPI call, even with the same `ICN` identifier

## Original issue(s)
department-of-veterans-affairs/va.gov-team/issues/23803

## Things to know about this PR
- If the `optional_code_locator` is not defined, behavior will remain unaffected
- If `optional_code_locator` is defined, the expected mocks will live in folders that are represented by the different field options. In the example above, mocks will live in `MVICOMP1RMS/` and `MVICOMP2/` directories. If a mock does not exist in these directories, then the existing mock will be used as a fallback