### PR TITLE
Use clinic friendly name for mobile VA appointments if available

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/va_appointments.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/va_appointments.rb
@@ -93,7 +93,7 @@ module Mobile
           facilities.add(facility_id) if facility_id
 
           details, type = parse_by_appointment_type(appointment_hash)
-          healthcare_service = healthcare_service(details, type)
+          healthcare_service = healthcare_service(appointment_hash, details, type)
           start_date_utc = start_date_utc(appointment_hash)
           time_zone = time_zone(facility_id)
           start_date_local = start_date_utc.in_time_zone(time_zone)
@@ -114,7 +114,7 @@ module Mobile
             cancel_id: cancel_id,
             comment: comment(details, type),
             facility_id: facility_id,
-            healthcare_service: healthcare_service(details, type),
+            healthcare_service: healthcare_service,
             location: location(details, type, facility_id),
             minutes_duration: minutes_duration(details, type),
             start_date_local: start_date_local,
@@ -202,8 +202,14 @@ module Mobile
           APPOINTMENT_TYPES[:va_video_connect_home]
         end
 
-        def healthcare_service(details, type)
-          va?(type) ? details.dig(:clinic, :name) : video_healthcare_service(details)
+        def healthcare_service(appointment_hash, details, type)
+          va?(type) ? va_clinic_name(appointment_hash, details) : video_healthcare_service(details)
+        end
+
+        def va_clinic_name(appointment_hash, details)
+          appointment_hash[:clinic_friendly_name].presence || details.dig(
+            :clinic, :name
+          )
         end
 
         def location_home(details, location)

--- a/modules/mobile/spec/models/adapters/va_appointments_adapter_spec.rb
+++ b/modules/mobile/spec/models/adapters/va_appointments_adapter_spec.rb
@@ -31,7 +31,7 @@ describe Mobile::V0::Adapters::VAAppointments do
     end
 
     it 'has a cancel id of the encoded cancel params' do
-      expect(booked_va[:cancel_id]).to eq('MzA4OzIwMjAxMTAzLjA5MDAwMDs0NDI7Q0hZIFBDIEtJTFBBVFJJQ0s=')
+      expect(booked_va[:cancel_id]).to eq('MzA4OzIwMjAxMTAzLjA5MDAwMDs0NDI7R3JlZW4gVGVhbSBDbGluaWMx')
     end
 
     it 'has a type of VA' do
@@ -43,7 +43,7 @@ describe Mobile::V0::Adapters::VAAppointments do
     end
 
     it 'has a healthcare_service that matches the clinic name' do
-      expect(booked_va[:healthcare_service]).to eq('CHY PC KILPATRICK')
+      expect(booked_va[:healthcare_service]).to eq('Green Team Clinic1')
     end
 
     it 'has a location with a name (address to be filled in by facilities api)' do
@@ -114,7 +114,7 @@ describe Mobile::V0::Adapters::VAAppointments do
     end
 
     it 'has a healthcare_service that matches the clinic name' do
-      expect(cancelled_va[:healthcare_service]).to eq('CHY PC KILPATRICK')
+      expect(cancelled_va[:healthcare_service]).to eq('Green Team Clinic1')
     end
 
     it 'has a location with a name (address to be filled in by facilities api)' do
@@ -403,6 +403,14 @@ describe Mobile::V0::Adapters::VAAppointments do
           }
         )
       end
+    end
+  end
+
+  context 'with a VA appointment that has a missing friendly name' do
+    let(:missing_friendly_name) { adapted_appointments[3] }
+
+    it 'uses the VDS clinic name' do
+      expect(missing_friendly_name[:healthcare_service]).to eq('CHY PC CASSIDY')
     end
   end
 end

--- a/modules/mobile/spec/support/fixtures/va_appointments.json
+++ b/modules/mobile/spec/support/fixtures/va_appointments.json
@@ -63,7 +63,7 @@
         "id": "202006051600983000030800000000000000",
         "start_date": "2020-11-05T16:00:00Z",
         "clinic_id": "308",
-        "clinic_friendly_name": "Green Team Clinic1",
+        "clinic_friendly_name": "",
         "facility_id": "983",
         "sta6aid": "983",
         "patient_icn": "1012845331V153043",


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Updates the mobile VA appointments adapter to use the clinic friendly name if available and default to the clinic name in the VDS object if not. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#24210

