### PR TITLE
API-6838 Response body charon errors

### DIFF
--- a/app/controllers/concerns/exception_handling.rb
+++ b/app/controllers/concerns/exception_handling.rb
@@ -35,8 +35,6 @@ module ExceptionHandling
           Common::Exceptions::Forbidden.new(detail: 'User does not have access to the requested resource')
         when ActionController::InvalidAuthenticityToken
           Common::Exceptions::Forbidden.new(detail: 'Invalid Authenticity Token')
-        when Common::Exceptions::TokenValidationError
-          Common::Exceptions::Unauthorized.new(detail: exception.detail)
         when ActionController::ParameterMissing
           Common::Exceptions::ParameterMissing.new(exception.param)
         when Common::Exceptions::BaseError, JsonSchema::JsonApiMissingAttribute

--- a/lib/common/exceptions/token_validation_error.rb
+++ b/lib/common/exceptions/token_validation_error.rb
@@ -8,14 +8,18 @@ module Common
     # Validation Error - an ActiveModel having validation errors, can be sent to this exception
     class TokenValidationError < BaseError
       attr_reader :detail
+      attr_reader :code
+      attr_reader :status
 
       def initialize(options = {})
+        @code = options[:code] || 401
         @detail = options[:detail]
         @source = options[:source]
+        @status = options[:status] || 401
       end
 
       def errors
-        Array(SerializableError.new(i18n_data.merge(detail: @detail, source: @source)))
+        Array(SerializableError.new(i18n_data.merge(code: @code, detail: @detail, source: @source, status: @status)))
       end
     end
   end

--- a/modules/openid_auth/README_V2.yml
+++ b/modules/openid_auth/README_V2.yml
@@ -71,9 +71,9 @@ paths:
                 properties:
                   data:
                     $ref: '#/components/schemas/ValidatedToken'
-        '404':
-          description: Auth service responded that data for token was not found
-        '502':
+        '401':
+          description: Auth service responded that data for token was not authorized
+        '500':
           description: Auth service responded with something other than the necessary information
 components:
   securitySchemes:

--- a/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
@@ -142,7 +142,7 @@ module OpenidAuth
                                   { params: { duz: duz, site: site } })
         response
       rescue => e
-        raise Common::Exceptions::TokenValidationError.new(detail: 'Failed validation with Charon.', status_code: 500)
+        raise Common::Exceptions::TokenValidationError.new(status: 500, code: 500, detail: 'Failed validation with Charon.')
       end
     end
   end

--- a/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
@@ -13,9 +13,6 @@ module OpenidAuth
         render json: validated_payload, serializer: OpenidAuth::ValidationSerializerV2
       rescue => e
         case e
-        when RestClient::ExceptionWithResponse
-          status_code = e.response.code >= 500 ? 503 : 401
-          render status: status_code
         when Common::Exceptions::TokenValidationError
           raise e
         else
@@ -140,8 +137,8 @@ module OpenidAuth
                                   { params: { duz: duz, site: site } })
         response.code == 200
       rescue => e
-        log_message_to_sentry('Failed validation with Charon', :error, body: e.message)
-        raise e
+        #TODO Parse the response.body.value
+        raise error_klass('Failed validation with Charon.')
       end
     end
   end

--- a/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
+++ b/modules/openid_auth/app/controllers/openid_auth/v2/validation_controller.rb
@@ -3,7 +3,7 @@
 require_dependency 'openid_auth/application_controller'
 require 'common/exceptions'
 require 'rest-client'
-
+require 'json'
 module OpenidAuth
   module V2
     class ValidationController < ApplicationController
@@ -137,8 +137,18 @@ module OpenidAuth
                                   { params: { duz: duz, site: site } })
         response.code == 200
       rescue => e
-        #TODO Parse the response.body.value
-        raise error_klass('Failed validation with Charon.')
+        msg = 'Failed validation with Charon.'
+        if e.is_a?(RestClient::ExceptionWithResponse)
+          if e.response.body
+            body = JSON.parse(e.response.body)
+            if body['message']
+              msg = body['message']
+            elsif body['status']
+              msg = body['status']
+            end
+          end
+        end
+        raise error_klass(msg)
       end
     end
   end

--- a/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
+++ b/modules/openid_auth/spec/requests/validation_request_spec_v2.rb
@@ -438,6 +438,31 @@ RSpec.describe 'Validated Token API endpoint', type: :request, skip_emis: true d
       end
     end
 
+    it 'v2 POST returns json response if 401 charon response' do
+      charon_response = instance_double(RestClient::Response, code: 401, body: JSON.parse('{"status": "401"}'))
+      with_ssoi_charon_configured do
+        allow(RestClient).to receive(:get).and_return(launch_with_sta3n_response, charon_response)
+        post '/internal/auth/v2/validation',
+             params: { aud: %w[https://example.com/xxxxxxservices/xxxxx] },
+             headers: auth_header
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it 'v2 POST returns json response if 500 charon response' do
+      charon_json = JSON.parse('{"status": "500","value": "-1"}')
+      charon_response = instance_double(RestClient::Response, code: 401, body: charon_json)
+      with_ssoi_charon_configured do
+        allow(RestClient).to receive(:get).and_return(launch_with_sta3n_response, charon_response)
+        post '/internal/auth/v2/validation',
+             params: { aud: %w[https://example.com/xxxxxxservices/xxxxx] },
+             headers: auth_header
+        expect(response).to have_http_status(:unauthorized)
+        binding.pry
+        expect(response.body).to be_a(String)
+      end
+    end
+
     it 'v2 POST returns 401 response if invalid user' do
       with_ssoi_charon_configured do
         allow(RestClient).to receive(:get).and_return(launch_with_wrong_sta3n_response)


### PR DESCRIPTION
## Description of change
As a follow up to earlier token validation PR's, this adds more details to the non-200 responses from the token validation service.

## Original issue(s)
- https://vajira.max.gov/browse/API-6838
- https://github.com/department-of-veterans-affairs/vets-api/pull/6705

## Things to know about this PR
To return both 401 and 500 responses from the token validation service, the Common::Exceptions::TokenValidationError error transform to the Common::Exceptions::Unauthorized error has been removed.

Rspec tests have been added for 200, 401, and 500 response types.  Additionally, existing tests for other 401 responses were confirmed working and a default 401 was set for the TokenValidationError response.