### PR TITLE
add versioning parameter to pdf submit job

### DIFF
--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -14,11 +14,11 @@ module AppealsApi
     include Sidekiq::MonitoredWorker
     include CentralMail::Utilities
 
-    def perform(higher_level_review_id)
+    def perform(higher_level_review_id, version = 'V1')
       higher_level_review = AppealsApi::HigherLevelReview.find(higher_level_review_id)
 
       begin
-        stamped_pdf = AppealsApi::PdfConstruction::Generator.new(higher_level_review).generate
+        stamped_pdf = AppealsApi::PdfConstruction::Generator.new(higher_level_review, version: version).generate
         higher_level_review.update_status!(status: 'submitting')
         upload_to_central_mail(higher_level_review, stamped_pdf)
         File.delete(stamped_pdf) if File.exist?(stamped_pdf)

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_pdf_submit_job.rb
@@ -14,13 +14,13 @@ module AppealsApi
     include Sidekiq::MonitoredWorker
     include CentralMail::Utilities
 
-    def perform(id, retries = 0)
+    def perform(id, retries = 0, version = 'V1')
       @retries = retries
       notice_of_disagreement = NoticeOfDisagreement.find(id)
 
       begin
         notice_of_disagreement.update_status!(status: 'submitting')
-        stamped_pdf = PdfConstruction::Generator.new(notice_of_disagreement).generate
+        stamped_pdf = PdfConstruction::Generator.new(notice_of_disagreement, version: version).generate
         upload_to_central_mail(notice_of_disagreement, stamped_pdf)
         File.delete(stamped_pdf) if File.exist?(stamped_pdf)
       rescue => e


### PR DESCRIPTION
[API-6894](https://vajira.max.gov/browse/API-6894)

This optional parameter for PDF submit job allows for multiple versions of pdf generation to occur