### PR TITLE
Api 6954/bug with swagger docs curl generation

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/docs/v1/docs_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/docs/v1/docs_controller.rb
@@ -8,6 +8,7 @@ class AppealsApi::Docs::V1::DocsController < ApplicationController
     AppealsApi::V1::NoticeOfDisagreementsControllerSwagger,
     AppealsApi::V1::Schemas::NoticeOfDisagreements,
     AppealsApi::V1::Schemas::HigherLevelReviews,
+    AppealsApi::V1::SecuritySchemeSwagger,
     AppealsApi::V1::SwaggerRoot
   ].freeze
 

--- a/modules/appeals_api/app/swagger/appeals_api/v1/notice_of_disagreements_controller_swagger.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/notice_of_disagreements_controller_swagger.rb
@@ -37,7 +37,7 @@ class AppealsApi::V1::NoticeOfDisagreementsControllerSwagger
       key :operationId, 'nodCreateRoot'
 
       security do
-        key :apiKey, []
+        key :apikey, []
       end
 
       parameter do
@@ -333,7 +333,7 @@ class AppealsApi::V1::NoticeOfDisagreementsControllerSwagger
       key :operationId, 'nodValidateSchema'
 
       security do
-        key :apiKey, []
+        key :apikey, []
       end
 
       parameter do

--- a/modules/appeals_api/app/swagger/appeals_api/v1/security_scheme_swagger.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/security_scheme_swagger.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  module V1
+    class SecuritySchemeSwagger
+      include Swagger::Blocks
+      swagger_component do
+        security_scheme :apikey do
+          key :type, :apiKey
+          key :name, :apikey
+          key :in, :header
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This PR should fix the issue with the fact that our example curl commands weren't getting generated properly (when you add an API Key).

To test you will need to have the developer portal running locally and point it at your local instance of vets-api.

## Original issue(s)
https://vajira.max.gov/browse/API-6954