### PR TITLE
Add PgHero Jobs

### DIFF
--- a/app/workers/pg_hero_clean_query_stats_job.rb
+++ b/app/workers/pg_hero_clean_query_stats_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class PgHeroCleanQueryStatsJob
+  include Sidekiq::Worker
+  include SentryLogging
+
+  def perform
+    PgHero.clean_query_stats
+  rescue => e
+    handle_errors(e)
+  end
+
+  def handle_errors(ex)
+    Rails.logger.error('PgHero Query Stat Cleanup Failed')
+    log_exception_to_sentry(ex)
+    raise ex
+  end
+end

--- a/app/workers/pg_hero_query_stats_job.rb
+++ b/app/workers/pg_hero_query_stats_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class PgHeroQueryStatsJob
+  include Sidekiq::Worker
+  include SentryLogging
+
+  def perform
+    PgHero.capture_query_stats
+  rescue => e
+    handle_errors(e)
+  end
+
+  def handle_errors(ex)
+    Rails.logger.error('PgHero Query Stat Capture Failed')
+    log_exception_to_sentry(ex)
+    raise ex
+  end
+end

--- a/config/sidekiq_scheduler.yml
+++ b/config/sidekiq_scheduler.yml
@@ -237,3 +237,11 @@ CovidVaccine::ExpandedSubmissionStateJob:
 VRE::CreateCh31SubmissionsReport:
   cron: "0 0 * * * America/New_York"
   description: "Send a daily report to the VRE team about Chapter 31 submissions"
+
+PgHeroQueryStatsJob:
+  cron: "0 8 * * * America/New_York"
+  description: captures PgHero query stats every day
+
+PgHeroCleanQueryStatsJob:
+  cron: "0 0 1,15 * *America/New_York"
+  description: Remove old PgHero query stats twice per month (1 and 15)

--- a/db/migrate/20210507122840_add_stats_extension.rb
+++ b/db/migrate/20210507122840_add_stats_extension.rb
@@ -1,0 +1,5 @@
+class AddStatsExtension < ActiveRecord::Migration[6.0]
+  def change
+    enable_extension 'pg_stat_statements'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_05_180038) do
+ActiveRecord::Schema.define(version: 2021_05_07_122840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
+  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,6 +2,7 @@ version: '3.4'
 services:
   postgres:
     image: mdillon/postgis:11-alpine
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all -c max_connections=200
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"

--- a/spec/jobs/pg_hero_clean_query_stats_job_spec.rb
+++ b/spec/jobs/pg_hero_clean_query_stats_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PgHeroCleanQueryStatsJob, type: :worker do
+  subject { described_class.new }
+
+  describe '#perform' do
+    let(:query_stat_count) { PgHero::QueryStats.count }
+    let(:old_query_stat_count) { PgHero::QueryStats.where('captured_at < ?', 14.days.ago).count }
+
+    context 'when it runs the query stat task' do
+      it 'deletes old records' do
+        subject.perform
+        expect(old_query_stat_count).to eq(0)
+      end
+
+      # cleanup
+      context 'when error occurs' do
+        before do
+          allow(PgHero).to receive(:clean_query_stats).and_raise(PgHero::Error)
+        end
+
+        it 'raises an exception when an error occurs' do
+          with_settings(Settings.sentry, dsn: 'T') do
+            expect(Raven).to receive(:capture_exception)
+            expect(Rails.logger).to receive(:error).at_least(:once)
+            expect { subject.perform }.to raise_error(PgHero::Error)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/pg_hero_query_stats_job_spec.rb
+++ b/spec/jobs/pg_hero_query_stats_job_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PgHeroQueryStatsJob, type: :worker do
+  subject { described_class.new }
+
+  describe '#perform' do
+    let(:query_stat_count) { PgHero::QueryStats.count }
+
+    context 'when it runs the query stat task' do
+      it 'records new query stats' do
+        subject.perform
+        expect(PgHero::QueryStats.count).to be >= query_stat_count
+      end
+    end
+
+    context 'when error occurs' do
+      before do
+        allow(PgHero).to receive(:capture_query_stats).and_raise(PgHero::Error)
+      end
+
+      it 'raises an exception when an error occurs' do
+        with_settings(Settings.sentry, dsn: 'T') do
+          expect(Raven).to receive(:capture_exception)
+          expect(Rails.logger).to receive(:error).at_least(:once)
+          expect { subject.perform }.to raise_error(PgHero::Error)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR adds two jobs related to PgHero. The first job invokes a rake task to track query stats over time and saves them to the database. The query stat job will run once per day. The cleanup job removes table data older than 14 days and will run twice per month. 

This also enables pg_stat_statements for the postgres docker container for running tests. This is needed for PgHero query stat capturing. (The config is [already enabled]( https://github.com/department-of-veterans-affairs/devops/blob/10a9b1a58c1789cb85ae4f3c19ef7db25292560f/terraform/environments/dsva-vagov-dev/main.tf#L267-L277) for our RDS db instances for every environment via terraform in the devops repo)

## Original issue(s)

department-of-veterans-affairs/va.gov-team#24250
