### PR TITLE
[6809] Adding ability to query MPI mock with different modify code va…

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -334,24 +334,28 @@
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: '(?:root="2.16.840.1.113883.4.1" )?extension="(\d{9})"(?: root="2.16.840.1.113883.4.1")?'
+      :optional_code_locator: 'modifyCode code="(MVI\.COMP1\.RMS|MVI\.COMP2)"'
   - :method: :post
     :path: <%= URI(Settings.mvi.url).path %>
     :file_path: "mvi/profile_icn"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'id extension="([V0-9]*)"(?: root="2.16.840.1.113883.4.349")'
+      :optional_code_locator: 'modifyCode code="(MVI\.COMP1\.RMS|MVI\.COMP2)"'
   - :method: :post
     :path: <%= URI(Settings.mvi.url).path %>
     :file_path: "mvi/profile_icn"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'id (?:root="2.16.840.1.113883.4.349" )extension="([V0-9]*)"'
+      :optional_code_locator: 'modifyCode code="(MVI\.COMP1\.RMS|MVI\.COMP2)"'
   - :method: :post
     :path: <%= URI(Settings.mvi.url).path %>
     :file_path: "mvi/profile_edipi"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: '(?:root="2.16.840.1.113883.3.42.10001.100001.12" )?extension="(\d{10})"(?: root="2.16.840.1.113883.3.42.10001.100001.12")?'
+      :optional_code_locator: 'modifyCode code="(MVI\.COMP1\.RMS|MVI\.COMP2)"'
 
 
 # EMIS


### PR DESCRIPTION
…lues



## Description of change
This PR allows us to utilize the new change in Betamocks that gives us the ability to mock multiple types of call for a single id. 
Specifically, we use this so that we can call the MPI service with the same ICN for two different `modifyCode` values: `MVI.COMP2` (or MPI with historical icn data), and `MVI.COMP1.RMS` (or MPI with relationship information)

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/6809

## Things to know about this PR
* This shouldn't actually change any functionality at the moment. Since new mock data has not yet been created to take advantage of this change, the fallback mechanism should just use the existing mock. 
