### PR TITLE
bump pg_query to latest major

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,6 +448,7 @@ GEM
       google-apis-core (~> 0.1)
       google-apis-discovery_v1 (~> 0.0)
       thor (>= 0.20, < 2.a)
+    google-protobuf (3.15.8)
     googleauth (0.16.1)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)
@@ -632,7 +633,8 @@ GEM
       ruby-rc4
       ttfunk
     pg (1.2.3)
-    pg_query (1.3.0)
+    pg_query (2.0.3)
+      google-protobuf (~> 3.15.5)
     pg_search (2.3.5)
       activerecord (>= 5.2)
       activesupport (>= 5.2)


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the pg_query gem (default group) to the latest major version. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

https://github.com/pganalyze/pg_query/blob/main/CHANGELOG.md

## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 
- [x] Reviewed PgHero locally 