### PR TITLE
API-7009: Migration - remove code and detail from evidence submissions table

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_07_122840) do
+ActiveRecord::Schema.define(version: 2021_05_10_202141) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -91,8 +91,6 @@ ActiveRecord::Schema.define(version: 2021_05_07_122840) do
     t.string "encrypted_file_data"
     t.string "encrypted_file_data_iv"
     t.string "source"
-    t.string "code"
-    t.string "detail"
     t.uuid "guid", null: false
     t.integer "upload_submission_id", null: false
     t.index ["guid"], name: "index_appeals_api_evidence_submissions_on_guid"

--- a/modules/appeals_api/db/migrate/20210510202141_remove_error_fields_from_evidence_submissions.rb
+++ b/modules/appeals_api/db/migrate/20210510202141_remove_error_fields_from_evidence_submissions.rb
@@ -1,0 +1,8 @@
+class RemoveErrorFieldsFromEvidenceSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      remove_column :appeals_api_evidence_submissions, :code, :string
+      remove_column :appeals_api_evidence_submissions, :detail, :string
+    end
+  end
+end


### PR DESCRIPTION
**Going to require a merge before this will pass - PR forthcoming**

We will be delegating `code` and `detail` to to `VBA::UploadSubmission`,  so dropping from our table

Ticket: https://vajira.max.gov/browse/API-7009