### PR TITLE
Api 6897/new v2 route matchers

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -3,7 +3,7 @@
 require 'json_schema/json_api_missing_attribute'
 require 'appeals_api/form_schemas'
 
-class AppealsApi::V1::DecisionReviews::HigherLevelReviewsController < AppealsApi::ApplicationController
+class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi::ApplicationController
   include AppealsApi::JsonFormatValidation
   include AppealsApi::StatusSimulation
 
@@ -23,7 +23,7 @@ class AppealsApi::V1::DecisionReviews::HigherLevelReviewsController < AppealsApi
 
   def create
     @higher_level_review.save
-    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, version: 'V2')
+    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, 'V2')
     render_higher_level_review
   end
 

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'json_schema/json_api_missing_attribute'
+require 'appeals_api/form_schemas'
+
+class AppealsApi::V1::DecisionReviews::HigherLevelReviewsController < AppealsApi::ApplicationController
+  include AppealsApi::JsonFormatValidation
+  include AppealsApi::StatusSimulation
+
+  skip_before_action :authenticate
+  before_action :validate_json_format, if: -> { request.post? }
+  before_action :validate_json_schema, only: %i[create validate]
+  before_action :new_higher_level_review, only: %i[create validate]
+  before_action :find_higher_level_review, only: %i[show]
+
+  FORM_NUMBER = '200996'
+  MODEL_ERROR_STATUS = 422
+  HEADERS = JSON.parse(
+    File.read(
+      AppealsApi::Engine.root.join('config/schemas/v2/200996_headers.json')
+    )
+  )['definitions']['hlrCreateParameters']['properties'].keys
+
+  def create
+    @higher_level_review.save
+    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, version: 'V2')
+    render_higher_level_review
+  end
+
+  def validate
+    render json: validation_success
+  end
+
+  def schema
+    render json: AppealsApi::JsonSchemaToSwaggerConverter.remove_comments(
+      AppealsApi::FormSchemas.new.schema(self.class::FORM_NUMBER)
+    )
+  end
+
+  def show
+    @higher_level_review = with_status_simulation(@higher_level_review) if status_requested_and_allowed?
+    render_higher_level_review
+  end
+
+  private
+
+  def validate_json_schema
+    validate_json_schema_for_headers
+    validate_json_schema_for_body
+  rescue JsonSchema::JsonApiMissingAttribute => e
+    render json: e.to_json_api, status: e.code
+  end
+
+  def validate_json_schema_for_headers
+    AppealsApi::FormSchemas.new.validate!("#{self.class::FORM_NUMBER}_HEADERS", headers)
+  end
+
+  def validate_json_schema_for_body
+    AppealsApi::FormSchemas.new.validate!(self.class::FORM_NUMBER, @json_body)
+  end
+
+  def validation_success
+    {
+      data: {
+        type: 'higherLevelReviewValidation',
+        attributes: {
+          status: 'valid'
+        }
+      }
+    }
+  end
+
+  def headers
+    HEADERS.reduce({}) do |acc, header_key|
+      header_value = request.headers[header_key]
+
+      header_value.nil? ? acc : acc.merge({ header_key => header_value })
+    end
+  end
+
+  def new_higher_level_review
+    @higher_level_review = AppealsApi::HigherLevelReview.new(
+      auth_headers: headers,
+      form_data: @json_body,
+      source: headers['X-Consumer-Username']
+    )
+
+    render_model_errors unless @higher_level_review.validate
+  end
+
+  def render_model_errors
+    render json: model_errors_to_json_api, status: MODEL_ERROR_STATUS
+  end
+
+  def model_errors_to_json_api
+    errors = @higher_level_review.errors.to_a.map do |error|
+      { status: MODEL_ERROR_STATUS, detail: error }
+    end
+
+    { errors: errors }
+  end
+
+  def find_higher_level_review
+    @id = params[:id]
+    @higher_level_review = AppealsApi::HigherLevelReview.find(@id)
+  rescue ActiveRecord::RecordNotFound
+    render_higher_level_review_not_found
+  end
+
+  def render_higher_level_review_not_found
+    render(
+      status: :not_found,
+      json: {
+        errors: [
+          { status: 404, detail: "HigherLevelReview with uuid #{@id.inspect} not found." }
+        ]
+      }
+    )
+  end
+
+  def render_higher_level_review
+    render json: AppealsApi::HigherLevelReviewSerializer.new(@higher_level_review).serializable_hash
+  end
+end

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -17,13 +17,13 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
   MODEL_ERROR_STATUS = 422
   HEADERS = JSON.parse(
     File.read(
-      AppealsApi::Engine.root.join('config/schemas/v2/200996_headers.json')
+      AppealsApi::Engine.root.join('config/schemas/v1/200996_headers.json')
     )
   )['definitions']['hlrCreateParameters']['properties'].keys
 
   def create
     @higher_level_review.save
-    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, 'V2')
+    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, 'V1')
     render_higher_level_review
   end
 

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module AppealsApi::V2
+  module DecisionReviews
+    module NoticeOfDisagreements
+      class EvidenceSubmissionsController < AppealsApi::ApplicationController
+        skip_before_action :authenticate
+
+        def create
+          render json: { message: 'V2 is not implemented yet' }, status: :not_implemented
+        end
+
+        def show
+          render json: { message: 'V2 is not implemented yet' }, status: :not_implemented
+        end
+      end
+    end
+  end
+end

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
@@ -1,25 +1,20 @@
 # frozen_string_literal: true
 
 class AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController < AppealsApi::ApplicationController
-
   skip_before_action :authenticate
-  before_action :not_implemented
+  before_action :not_implemented_error
 
-  def create
-  end
+  def create; end
 
-  def show
-  end
+  def show; end
 
-  def validate
-  end
+  def validate; end
 
-  def schema
-  end
+  def schema; end
 
   private
 
-  def not_implemented
+  def not_implemented_error
     render json: { message: 'V2 is not implemented yet' }, status: :not_implemented
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController < AppealsApi::ApplicationController
+
+  skip_before_action :authenticate
+  before_action :not_implemented
+
+  def create
+  end
+
+  def show
+  end
+
+  def validate
+  end
+
+  def schema
+  end
+
+  private
+
+  def not_implemented
+    render json: { message: 'V2 is not implemented yet' }, status: :not_implemented
+  end
+end

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -32,6 +32,33 @@ AppealsApi::Engine.routes.draw do
       end
     end
   end
+
+  namespace :v2, defaults: { format: 'json' } do
+    namespace :decision_reviews do
+      # namespace :higher_level_reviews do
+      #   get 'contestable_issues(/:benefit_type)', to: 'contestable_issues#index'
+      # end
+
+      resources :higher_level_reviews, only: %i[create show] do
+        collection do
+          get 'schema'
+          post 'validate'
+        end
+      end
+
+      namespace :notice_of_disagreements do
+        # get 'contestable_issues', to: 'contestable_issues#index'
+        resources :evidence_submissions, only: %i[create show]
+      end
+      resources :notice_of_disagreements do
+        collection do
+          get 'schema'
+          post 'validate'
+        end
+      end
+    end
+  end
+
   namespace :docs do
     namespace(:v0) { resources :api, only: [:index] }
     namespace :v1, defaults: { format: 'json' } do


### PR DESCRIPTION
[API-6897](https://vajira.max.gov/browse/API-6897)

This PR adds the new V2 routes, and adds non-implemented response for NOD. 

There are some unfinished pieces here which are relying on other PRs, such as a completed V2 schema.

I believe that I'll get dinged on coverage here, in which case I'll wait for the schema PR before continuing, because testing the HLR controller is impossible without it.

