### PR TITLE
bump liquid to latest major version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -521,7 +521,7 @@ GEM
       kramdown (~> 2.0)
     levenshtein-ffi (1.1.0)
       ffi (~> 1.9)
-    liquid (4.0.3)
+    liquid (5.0.1)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the liquid gem(default group) to the latest major version. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

https://github.com/Shopify/liquid/blob/master/History.md

## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 