### PR TITLE
v2 documentation

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/docs/v2/docs_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/docs/v2/docs_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AppealsApi::Docs::V2::DocsController < ApplicationController
+  skip_before_action(:authenticate)
+
+  SWAGGERED_CLASSES = [
+    AppealsApi::V2::SwaggerRoot
+  ].freeze
+
+  def decision_reviews
+    render json: decision_reviews_swagger_json
+  end
+
+  private
+
+  def decision_reviews_swagger_json
+    Swagger::Blocks.build_root_json(SWAGGERED_CLASSES)
+  end
+end

--- a/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
@@ -92,7 +92,7 @@ module AppealsApi
     end
 
     def decision_reviews_versions
-      if Settings.modules_appeals_api.documentation.path_enabled_flag
+      if v2_enabled?
         [
           decision_reviews_v1.merge({ status: VERSION_STATUS[:previous] }),
           decision_reviews_v2
@@ -122,6 +122,10 @@ module AppealsApi
         path: '/services/appeals/docs/v2/decision_reviews',
         healthcheck: '/services/appeals/v2/healthcheck'
       }
+    end
+
+    def v2_enabled?
+      Settings.modules_appeals_api.documentation.path_enabled_flag
     end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
@@ -11,15 +11,7 @@ module AppealsApi
     def decision_reviews
       render json: {
         meta: {
-          versions: [
-            {
-              version: '1.0.0',
-              internal_only: true,
-              status: VERSION_STATUS[:current],
-              path: '/services/appeals/docs/v1/decision_reviews',
-              healthcheck: '/services/appeals/v1/healthcheck'
-            }
-          ]
+          versions: decision_reviews_versions
         }
       }
     end
@@ -96,6 +88,39 @@ module AppealsApi
           status: healthy ? 'OK' : 'Unavailable',
           time: time
         }
+      }
+    end
+
+    def decision_reviews_versions
+      if Settings.modules_appeals_api.documentation.path_enabled_flag
+        [
+          decision_reviews_v1.merge({ status: VERSION_STATUS[:previous] }),
+          decision_reviews_v2
+        ]
+      else
+        [
+          decision_reviews_v1
+        ]
+      end
+    end
+
+    def decision_reviews_v1
+      {
+        version: '1.0.0',
+        internal_only: true,
+        status: VERSION_STATUS[:current],
+        path: '/services/appeals/docs/v1/decision_reviews',
+        healthcheck: '/services/appeals/v1/healthcheck'
+      }
+    end
+
+    def decision_reviews_v2
+      {
+        version: '2.0.0',
+        internal_only: true,
+        status: VERSION_STATUS[:current],
+        path: '/services/appeals/docs/v2/decision_reviews',
+        healthcheck: '/services/appeals/v1/healthcheck'
       }
     end
   end

--- a/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
@@ -94,7 +94,7 @@ module AppealsApi
     def decision_reviews_versions
       if v2_enabled?
         [
-          decision_reviews_v1.merge( { status: VERSION_STATUS[:previous] }),
+          decision_reviews_v1.merge({ status: VERSION_STATUS[:previous] }),
           decision_reviews_v2
         ]
       else

--- a/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
@@ -94,7 +94,7 @@ module AppealsApi
     def decision_reviews_versions
       if v2_enabled?
         [
-          decision_reviews_v1,
+          decision_reviews_v1.merge( { status: VERSION_STATUS[:previous] }),
           decision_reviews_v2
         ]
       else

--- a/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
@@ -94,7 +94,7 @@ module AppealsApi
     def decision_reviews_versions
       if v2_enabled?
         [
-          decision_reviews_v1.merge({ status: VERSION_STATUS[:previous] }),
+          decision_reviews_v1,
           decision_reviews_v2
         ]
       else

--- a/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
@@ -120,7 +120,7 @@ module AppealsApi
         internal_only: true,
         status: VERSION_STATUS[:current],
         path: '/services/appeals/docs/v2/decision_reviews',
-        healthcheck: '/services/appeals/v1/healthcheck'
+        healthcheck: '/services/appeals/v2/healthcheck'
       }
     end
   end

--- a/modules/appeals_api/app/swagger/appeals_api/v2/swagger_root.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v2/swagger_root.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module AppealsApi::V2::SwaggerRoot
+  include Swagger::Blocks
+
+  swagger_root do
+    key :openapi, '3.0.0'
+    info do
+      key :title, 'Decision Reviews'
+      key :version, '2.0.0'
+      key :description, ''
+      key :termsOfService, 'https://developer.va.gov/terms-of-service'
+      contact do
+        key :name, 'VA API Benefits Team'
+      end
+    end
+
+    url = ->(prefix = '') { "https://#{prefix}api.va.gov/services/appeals/{version}/decision_reviews" }
+
+    server description: 'VA.gov API sandbox environment', url: url['sandbox-'] do
+      variable(:version) { key :default, 'v2' }
+    end
+
+    server description: 'VA.gov API production environment', url: url[''] do
+      variable(:version) { key :default, 'v2' }
+    end
+
+    key :basePath, '/services/appeals/v2'
+    key :consumes, ['application/json']
+    key :produces, ['application/json']
+
+    security do
+      key :type, :apikey
+      key :name, :apikey
+      key :in, :header
+    end
+  end
+end

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -37,5 +37,9 @@ AppealsApi::Engine.routes.draw do
     namespace :v1, defaults: { format: 'json' } do
       get 'decision_reviews', to: 'docs#decision_reviews'
     end
+
+    namespace :v2, defaults: { format: 'json' } do
+      get 'decision_reviews', to: 'docs#decision_reviews'
+    end
   end
 end

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -5,8 +5,10 @@ AppealsApi::Engine.routes.draw do
   match '/decision_reviews/metadata', to: 'metadata#decision_reviews', via: [:get]
   match '/v0/healthcheck', to: 'metadata#healthcheck', via: [:get]
   match '/v1/healthcheck', to: 'metadata#healthcheck', via: [:get]
+  match '/v2/healthcheck', to: 'metadata#healthcheck', via: [:get]
   match '/v0/upstream_healthcheck', to: 'metadata#appeals_status_upstream_healthcheck', via: [:get]
   match '/v1/upstream_healthcheck', to: 'metadata#decision_reviews_upstream_healthcheck', via: [:get]
+  match '/v2/upstream_healthcheck', to: 'metadata#decision_reviews_upstream_healthcheck', via: [:get]
   match '/v0/appeals', to: 'v0/appeals#index', via: [:get]
 
   namespace :v1, defaults: { format: 'json' } do


### PR DESCRIPTION
[API-6900](https://vajira.max.gov/browse/API-6900)

This PR adds the ability for our docs endpoints to serve a V2 docset