### PR TITLE
Refactor code and detail delegation

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
+++ b/modules/appeals_api/app/models/appeals_api/evidence_submission.rb
@@ -13,5 +13,7 @@ module AppealsApi
 
     STATUSES = VBADocuments::UploadSubmission::ALL_STATUSES
     delegate :status, to: :upload_submission
+    delegate :code, to: :upload_submission
+    delegate :detail, to: :upload_submission
   end
 end

--- a/modules/appeals_api/app/serializers/appeals_api/evidence_submission_serializer.rb
+++ b/modules/appeals_api/app/serializers/appeals_api/evidence_submission_serializer.rb
@@ -10,14 +10,16 @@ module AppealsApi
 
     attributes :id, :status, :code, :detail, :appeal_type, :appeal_id, :location, :created_at, :updated_at
 
+    delegate :status, to: :object
+    delegate :code, to: :object
+
     def id
       object.guid
     end
 
-    delegate :status, to: :object
-    delegate :code, to: :object
-
     def detail
+      return unless object.detail
+
       details = object.detail.to_s
       details = "#{details[0..MAX_DETAIL_DISPLAY_LENGTH - 1]}..." if details.length > MAX_DETAIL_DISPLAY_LENGTH
       details

--- a/modules/appeals_api/spec/factories/evidence_submissions.rb
+++ b/modules/appeals_api/spec/factories/evidence_submissions.rb
@@ -6,13 +6,18 @@ FactoryBot.define do
     guid { SecureRandom.uuid }
     association :supportable, factory: :notice_of_disagreement
     upload_submission { create(:upload_submission, guid: SecureRandom.uuid) } # set the guid to pass uniqueness check
+  end
 
-    trait :with_detail do
-      detail { SecureRandom.alphanumeric(150) }
-    end
-
-    trait :with_code do
-      code { 404 }
-    end
+  factory :evidence_submission_with_error, class: 'AppealsApi::EvidenceSubmission' do
+    sequence(:id) { |n| n }
+    guid { SecureRandom.uuid }
+    association :supportable, factory: :notice_of_disagreement
+    upload_submission {
+      create(:upload_submission,
+             guid: SecureRandom.uuid,
+             status: 'error',
+             code: '404',
+             detail: SecureRandom.alphanumeric(150))
+    }
   end
 end

--- a/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/notice_of_disagreements/evidence_submissions_controller_spec.rb
@@ -131,7 +131,6 @@ describe AppealsApi::V1::DecisionReviews::NoticeOfDisagreements::EvidenceSubmiss
           es = evidence_submissions.sample
           status_simulation_headers = { 'Status-Simulation' => 'error' }
           get "#{path}#{es.guid}", headers: status_simulation_headers
-
           submission = JSON.parse(response.body)
           expect(submission.dig('data', 'attributes', 'status')).to eq('error')
         end

--- a/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
+++ b/modules/appeals_api/spec/serializers/evidence_submission_serializer_spec.rb
@@ -4,10 +4,8 @@ require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::EvidenceSubmissionSerializer do
-  let(:notice_of_disagreement) { create(:notice_of_disagreement) }
-  let(:evidence_submission) { create(:evidence_submission, :with_detail, :with_code) }
+  let(:evidence_submission) { create(:evidence_submission) }
   let(:rendered_hash) { described_class.new(evidence_submission).serializable_hash }
-  let(:path) { '/services/appeals/v1/decision_reviews/notice_of_disagreements/evidence_submissions/' }
 
   context 'when initialized with an object that cannot be called by the delegated attributes' do
     it 'raises an error' do
@@ -19,10 +17,6 @@ describe AppealsApi::EvidenceSubmissionSerializer do
     expect(rendered_hash[:id]).to eq evidence_submission.guid
   end
 
-  it 'includes :status' do
-    expect(rendered_hash[:status]).to eq evidence_submission.status
-  end
-
   it 'includes :appeal_type' do
     expect(rendered_hash[:appeal_type]).to eq 'NoticeOfDisagreement'
   end
@@ -31,24 +25,40 @@ describe AppealsApi::EvidenceSubmissionSerializer do
     expect(rendered_hash[:appeal_id]).to eq evidence_submission.supportable.id
   end
 
-  it 'includes :code' do
-    expect(rendered_hash[:code]).to eq evidence_submission.code
-  end
-
-  it "truncates :detail value if longer than #{described_class::MAX_DETAIL_DISPLAY_LENGTH}" do
-    max_length_plus_ellipses = described_class::MAX_DETAIL_DISPLAY_LENGTH + 3
-    expect(rendered_hash[:detail].length).to eq(max_length_plus_ellipses)
-  end
-
-  it 'includes :created_at' do
-    expect(rendered_hash[:created_at]).to eq evidence_submission.created_at
-  end
-
   it 'includes :updated_at' do
     expect(rendered_hash[:updated_at]).to eq evidence_submission.updated_at
   end
 
-  it 'does not include any extra attributes' do
-    expect(rendered_hash.keys).to eq(%i[id status code detail appeal_type appeal_id location created_at updated_at])
+  context 'with a successful status on parent upload' do
+    it 'includes :status' do
+      expect(rendered_hash[:status]).to eq evidence_submission.status
+    end
+
+    it 'includes :code with nil value' do
+      expect(rendered_hash[:code]).to be nil
+    end
+
+    it 'includes :detail with nil value' do
+      expect(rendered_hash[:detail]).to be nil
+    end
+  end
+
+  context "with 'error' status on parent upload" do
+    let(:submission_with_error) { create(:evidence_submission_with_error) }
+    let(:rendered_hash) { described_class.new(submission_with_error).serializable_hash }
+
+    it 'includes :status' do
+      expect(rendered_hash[:status]).to eq 'error'
+    end
+
+    it 'includes :code' do
+      expect(rendered_hash[:code]).to eq '404'
+    end
+
+    it "truncates :detail value if longer than #{described_class::MAX_DETAIL_DISPLAY_LENGTH}" do
+      max_length_plus_ellipses = described_class::MAX_DETAIL_DISPLAY_LENGTH + 3
+      expect(rendered_hash[:detail].length).to eq(max_length_plus_ellipses)
+      expect(submission_with_error.detail).to include rendered_hash[:detail][0, 100]
+    end
   end
 end


### PR DESCRIPTION
While testing, claims and appeals hit our #show endpoint and received a `status: error` but no `code` or `detail`.

This PR delegates `AppealsApi::EvidenceSubmission` `code` and `detail` to `VBADocuments::UploadSubmission` in both the model and serializer so that when serialized, or called, the attributes inherits from the associated vba upload record.

Dependent migration PR: https://github.com/department-of-veterans-affairs/vets-api/pull/6826

Ticket: https://vajira.max.gov/browse/API-7009