### PR TITLE
24402 rescue standard errors

### DIFF
--- a/app/controllers/v0/financial_status_reports_controller.rb
+++ b/app/controllers/v0/financial_status_reports_controller.rb
@@ -15,7 +15,7 @@ module V0
         service.get_pdf,
         type: 'application/pdf',
         filename: 'VA Form 5655 - Submitted',
-        disposition: 'inline'
+        disposition: 'attachment'
       )
     end
 

--- a/app/models/form_profiles/va_5655.rb
+++ b/app/models/form_profiles/va_5655.rb
@@ -40,7 +40,7 @@ class FormProfiles::VA5655 < FormProfile
     file_number =
       begin
         BGS::PeopleService.new(@user).find_person_by_participant_id[:file_nbr].presence || @user.ssn
-      rescue Savon::SOAPFault
+      rescue
         @user.ssn
       end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Rescue from the default StandardError
- Savon soap fault exception is too narrow and restrictive
- The user's social security needs to be returned if anything goes wrong
## Original issue(s)
department-of-veterans-affairs/va.gov-team#24402

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
