### PR TITLE
added feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -414,6 +414,11 @@ features:
     enable_in_development: true
     description: >
       Feature gates the dependency verification modal for updating the diaries service.
+  coe_access:
+    actor_type: user
+    enable_in_development: true
+    description: >
+      Feature gates the certificate of eligibility application
   form10182_nod:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/23958)

Now that we are farther along on the Certificate of Eligibility app we need to gate it and the pages that access it behind a feature toggle. This PR adds the code for the feature toggle to the back end.