### PR TITLE
[22732] adds message log when failing to look up edipi

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -280,7 +280,7 @@ class User < Common::RedisStore
   delegate :veteran?, to: :veteran_status
 
   def edipi
-    loa3? && dslogon_edipi.present? ? dslogon_edipi : mpi&.edipi
+    loa3? && dslogon_edipi.present? ? dslogon_edipi : edipi_mpi
   end
 
   # LOA1 no longer just means ID.me LOA1.

--- a/lib/evss/vso_search/service.rb
+++ b/lib/evss/vso_search/service.rb
@@ -31,6 +31,13 @@ module EVSS
       def request_headers(additional_headers)
         ssn = additional_headers.key?('va_eauth_pnid') ? additional_headers['va_eauth_pnid'] : @user.ssn
         edipi = additional_headers.key?('va_eauth_dodedipnid') ? additional_headers['va_eauth_dodedipnid'] : @user.edipi
+        if edipi.nil?
+          user_info = {
+            loa3: @user.loa3?,
+            mhv_icn: !@user.mhv_icn.nil?
+          }
+          log_message_to_sentry('Failed to find EDIPI, EVSS service call will not succeed', :warn, user_info)
+        end
 
         {
           'ssn' => ssn,


### PR DESCRIPTION
## Description of change
This change adds a new, temporary, Sentry logging call in the case of an EVSS `getCurrentInfo` call that is to be performed without the needed EDIPI. We suspect that the failure to produce an EDIPI is due to this method (`request_headers`) being called on a user that has either not been authenticated to LOA3 or is missing their mhv_icn.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22732

## Things to know about this PR
This PR should not change any existing functionality.
