### PR TITLE
Sort flags and add covid_vaccine_scheduling_frontend

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -63,8 +63,8 @@ features:
   covid_vaccine_registration_frontend_cta:
     actor_type: user
     description: >
-    Toggles the availability of the call-to-action prompt (cta) on "va.gov/health-care/covid-19-vaccine/"
-    leading to the frontend form on va.gov for the covid-19 vaccine sign-up
+      Toggles the availability of the call-to-action prompt (cta) on "va.gov/health-care/covid-19-vaccine/"
+      leading to the frontend form on va.gov for the covid-19 vaccine sign-up
   covid_vaccine_registration_frontend_enable_expanded_eligibility:
     actor_type: user
     description: "Toggles the 'continue' button to launch the new expanded eligibility VAFS app\n"

--- a/config/features.yml
+++ b/config/features.yml
@@ -108,26 +108,26 @@ features:
     enable_in_development: true
   facilities_ppms_suppress_community_care:
     actor_type: user
-    description: Hide ppms community care searches"
+    description: Hide ppms community care searches
   facilities_ppms_suppress_pharmacies:
     actor_type: user
-    description: Front End Flag to suppress the ability to search for pharmacies"
+    description: Front End Flag to suppress the ability to search for pharmacies
   facility_locator_lighthouse_covid_vaccine_query:
     actor_type: user
-    description: enable covid search/display"
+    description: enable covid search/display
     enable_in_development: true
   facility_locator_ppms_forced_unique_id:
     actor_type: user
-    description: Use an hexdigest for the ID on PPMS Place of Service Calls"
+    description: Use an hexdigest for the ID on PPMS Place of Service Calls
   facility_locator_ppms_legacy_urgent_care_to_pos_locator:
     actor_type: user
-    description: force the legacy urgent care path to use the new POS locator"
+    description: force the legacy urgent care path to use the new POS locator
   facility_locator_predictive_location_search:
     actor_type: user
-    description: Use predictive location search in the Facility Locator UI"
+    description: Use predictive location search in the Facility Locator UI
   facility_locator_pull_operating_status_from_lighthouse:
     actor_type: user
-    description: A fast and dirty way to get the operating status from lighthouse"
+    description: A fast and dirty way to get the operating status from lighthouse
     enable_in_development: true
   facility_locator_show_community_cares:
     actor_type: user
@@ -137,7 +137,7 @@ features:
     enable_in_development: true
   facility_locator_show_operational_hours_special_instructions:
     actor_type: user
-    description: Display new field operationalHoursSpecialInstructions for VA facilities"
+    description: Display new field operationalHoursSpecialInstructions for VA facilities
     enable_in_development: true
   find_forms_mvp_enhancement:
     actor_type: user

--- a/config/features.yml
+++ b/config/features.yml
@@ -1,5 +1,5 @@
 ---
-# Add a new feture toggle here to ensure that it is initialized in all environments.
+# Add a new feature toggle here to ensure that it is initialized in all environments.
 #
 # Features are enabled by default in the test environment and disabled by default in other environments.
 # To default a feature to enabled in development, set the `enable_in_development` key to true.
@@ -8,449 +8,360 @@
 #
 # The actor_type should be either `user` for features you want to be "sticky" for a logged in user (default)
 #  or `cookie_id` of you wish to use the Google Analytics id as the unique identifier.
+
+# Sorted using http://yaml-sorter.herokuapp.com/
+
 features:
   can_upload_10_10cg_poa:
     actor_type: cookie_id
-    description: Allows users to upload POA documentation when completing the 10-10CG.
-  pre_entry_covid19_screener:
-    actor_type: user
-    description: >
-      Toggle for the entire pre-entry covid 19 self-screener available at
-      /covid19screener and to be used by visitors to VHA facilities in lieu
-      of manual screening with a VHA employee.
-      This toggle is owned by Patrick B. and the rest of the CTO Health Products
-      team.
-  ch33_dd_profile:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Allows user to access chapter 33 benefits (direct deposit for education) in the front end
-  covid_vaccine_registration_frontend:
-    actor_type: user
-    description: >
-      Toggles the availability of the frontend form on va.gov for the covid-19 vaccine sign-up
-  covid_vaccine_registration_frontend_cta:
-    actor_type: user
-    description: >
-      Toggles the availability of the call-to-action prompt (cta) on "va.gov/health-care/covid-19-vaccine/" leading to the frontend form on va.gov for the covid-19 vaccine sign-up
-  covid_vaccine_registration_frontend_hide_auth:
-    actor_type: user
-    description: >
-      Toggles the availability of the sign-in button on the covid-19 vaccine sign-up form on va.gov.
-      Note: When this is enabled, the 'Sign in' button will be hidden
-  covid_vaccine_registration_frontend_enable_expanded_eligibility:
-    actor_type: user
-    description: >
-      Toggles the 'continue' button to launch the new expanded eligibility VAFS app
-  covid_vaccine_registration:
-    actor_type: user
-    description: >
-      Toggles availability of covid vaccine form API.
-  covid_vaccine_registration_expanded:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Toggles availability of covid vaccine expanded registration form API.
-  covid_volunteer_delivery:
-    actor_type: cookie_id
-    description: >
-      Toggles whether COVID Research volunteer submissions will be delivered to genISIS
-  dashboard_show_dashboard_2:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables The New My VA Dashboard 2.0
-  direct_deposit_vanotify:
-    actor_type: user
-    description: >
-      Send direct deposit emails using VaNotify service
-  facility_locator_show_operational_hours_special_instructions:
-    actor_type: user
-    enable_in_development: true
-    description: Display new field operationalHoursSpecialInstructions for VA facilities
-  facility_locator_show_community_cares:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      On https://www.va.gov/find-locations/ enable veterans to search for Community care by showing that option in the "Search for" box.
-      This toggle is owned by Rian
-  facility_locator_pull_operating_status_from_lighthouse:
-    actor_type: user
-    enable_in_development: true
-    description: A fast and dirty way to get the operating status from lighthouse
-  facility_locator_lighthouse_covid_vaccine_query:
-    actor_type: user
-    enable_in_development: true
-    description: enable covid search/display
-  facility_locator_ppms_legacy_urgent_care_to_pos_locator:
-    actor_type: user
-    description: force the legacy urgent care path to use the new POS locator
-  facility_locator_ppms_forced_unique_id:
-    actor_type: user
-    description: Use an hexdigest for the ID on PPMS Place of Service Calls
-  facilities_ppms_suppress_pharmacies:
-    actor_type: user
-    description: Front End Flag to suppress the ability to search for pharmacies
-  facility_locator_predictive_location_search:
-    actor_type: user
-    description: Use predictive location search in the Facility Locator UI
-  facilities_ppms_suppress_community_care:
-    actor_type: user
-    description: Hide ppms community care searches
-  profile_schema_forms:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables SchemaForm-based contact info edit forms on the VA.gov Veteran profile page
-  profile_show_receive_text_notifications:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      https://www.va.gov/profile/ show Receive Text Notifications
-  va_online_scheduling:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Allows veterans to view their VA and Community Care appointments
-  va_online_scheduling_cancel:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Allows veterans to cancel VA appointments
-  va_online_scheduling_requests:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Allows veterans to submit requests for VA appointments
-  va_online_scheduling_community_care:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Allows veterans to submit requests for Community Care appointments
-  va_online_scheduling_direct:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Allows veterans to directly schedule VA appointments
-  va_online_scheduling_express_care_new:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables Express Care request flow in VAOS
-  va_online_scheduling_provider_selection:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables the community care provider selection field
-  va_online_scheduling_cheetah:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables Project Cheetah discovery work
-  va_online_scheduling_homepage_refresh:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Set up toggle in anticipation of the next iteration of the homepage and appointment cards.
-  va_online_scheduling_facility_selection_v2_2:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Set up toggle in anticipation of the next iteration of facility selection, version 2.2.
-  va_online_scheduling_unenrolled_vaccine:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Toggle for unenrolled vaccine scheduling discovery work.
-  va_online_scheduling_vaos_service_requests:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Toggle for new vaos service requests.
-  va_online_scheduling_vaos_service_va_appointments:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Toggle for new vaos service va appointments.
-  va_online_scheduling_vaos_service_cc_appointments:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Toggle for new vaos service cc appointments.
-  va_global_downtime_notification:
-    actor_type: user
-    description: >
-      Enables global downtime notification- do not use in production
-  ssoe:
-    actor_type: cookie_id
-    enable_in_development: true
-    description: >
-      Enables ssoe, as opposed to saml authentication wrapped by id.me
-  form526_original_claims:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Allows veterans to access form526 as an original claims user. Owned by va-benefits-memorial-1 team.
-  form526_benefits_delivery_at_discharge:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Allows veterans to access the BDD flow in the 526 form. Owned by va-benefits-memorial-1 team.
-  new_va_forms_search:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Uses the new search algorithm
-  va_view_dependents_access:
-    actor_type: user
-    description: >
-      Allows us to gate the View/ Modify dependents content in a progressive rollout
-  ssoe_ebenefits_links:
-    actor_type: user
-    description: >
-      Enable eBenefits links to be proxied through eauth.va.gov, this allows users with SSOe sessions to stay logged in.
-  ssoe_inbound:
-    actor_type: cookie_id
-    enable_in_development: true
-    description: >
-      Enables automatic establishment/disconnection of vets-api session based on a user's SSOe session status
-  gibct_eyb_bottom_sheet:
-    actor_type: user
-    description: >
-      Panel that displays while the user is modifying inputs to give context to their currently estimated benefits until they reach the full your estimated benefits panel.
-  form996_higher_level_review:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Allows veterans request a higher-level review of an existing claim. Owned by va-benefits-memorial-1 team.
-  debt_letters_show_letters:
-    actor_type: user
-    description: >
-      Enables debt letters
-  show_financial_status_report_wizard:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables the Wizard for VA Form 5655 (Financial Status Report)
-  show_financial_status_report:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables VA Form 5655 (Financial Status Report)
-  show_edu_benefits_5495_wizard:
-    actor_type: user
-    description: >
-      This determines when the wizard should show up on the 5495 introduction page
-  show_edu_benefits_1995_wizard:
-    actor_type: user
-    description: >
-      This determines when the wizard should show up on the 1995 introduction page
-  show_edu_benefits_1990n_wizard:
-    actor_type: user
-    description: >
-      This determines when the wizard should show up on the 1990N introduction page
-  show_edu_benefits_0994_wizard:
-    actor_type: user
-    description: >
-      This determines when the wizard should show up on the 0994 introduction page
-  show_edu_benefits_5490_wizard:
-    actor_type: user
-    description: >
-      This determines when the wizard should show up on the 5490 introduction page
-  show_edu_benefits_1990_wizard:
-    actor_type: user
-    description: >
-      This determines when the wizard should show up on the 1990 introduction page
-  show_edu_benefits_1990e_wizard:
-    actor_type: user
-    description: >
-      This determines when the wizard should show up on the 1990e introduction page
-  get_help_ask_form:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables inquiry form for users to submit questions, suggestions, and complaints.
-  get_help_messages:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables secure messaging
-  show_healthcare_experience_questionnaire:
-    actor_type: cookie_id
-    enable_in_development: true
-    description: >
-      Enables showing the pre-appointment questionnaire feature.
-  show526_wizard:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      This determines when the wizard should show up on the form 526 intro page
-  show_new_get_medical_records_page:
-    actor_type: user
-    description: >
-      This will show the non-Cerner-user and Cerner-user content for the page /health-care/get-medical-records/
-  show_new_refill_track_prescriptions_page:
-    actor_type: user
-    description: >
-      This will show the non-Cerner-user and Cerner-user content for the page /health-care/refill-track-prescriptions/
-  show_new_schedule_view_appointments_page:
-    actor_type: user
-    description: >
-      This will show the non-Cerner-user and Cerner-user content for the page /health-care/schedule-view-va-appointments/
-  show_new_secure_messaging_page:
-    actor_type: user
-    description: >
-      This will show the non-Cerner-user and Cerner-user content for the page /health-care/secure-messaging/
-  show_new_view_test_lab_results_page:
-    actor_type: user
-    description: >
-      This will show the non-Cerner-user and Cerner-user content for the page /health-care/view-test-and-lab-results/
+    description: "Allows users to upload POA documentation when completing the 10-10CG."
   cerner_override_463:
     actor_type: user
-    description: >
-      This will show the Cerner facility 463 as `isCerner`.
+    description: "This will show the Cerner facility 463 as `isCerner`.\n"
   cerner_override_531:
     actor_type: user
-    description: >
-      This will show the Cerner facility 531 as `isCerner`.
+    description: "This will show the Cerner facility 531 as `isCerner`.\n"
   cerner_override_648:
     actor_type: user
-    description: >
-      This will show the Cerner facility 648 as `isCerner`.
+    description: "This will show the Cerner facility 648 as `isCerner`.\n"
   cerner_override_653:
     actor_type: user
-    description: >
-      This will show the Cerner facility 653 as `isCerner`.
+    description: "This will show the Cerner facility 653 as `isCerner`.\n"
   cerner_override_663:
     actor_type: user
-    description: >
-      This will show the Cerner facility 663 as `isCerner`.
+    description: "This will show the Cerner facility 663 as `isCerner`.\n"
   cerner_override_668:
     actor_type: user
-    description: >
-      This will show the Cerner facility 668 as `isCerner`.
+    description: "This will show the Cerner facility 668 as `isCerner`.\n"
   cerner_override_687:
     actor_type: user
-    description: >
-      This will show the Cerner facility 687 as `isCerner`.
+    description: "This will show the Cerner facility 687 as `isCerner`.\n"
   cerner_override_692:
     actor_type: user
-    description: >
-      This will show the Cerner facility 692 as `isCerner`.
+    description: "This will show the Cerner facility 692 as `isCerner`.\n"
   cerner_override_757:
     actor_type: user
-    description: >
-      This will show the Cerner facility 757 as `isCerner`.
-  gibct_school_ratings:
+    description: "This will show the Cerner facility 757 as `isCerner`.\n"
+  ch33_dd_profile:
     actor_type: user
-    description: >
-      Show/Hide the school ratings section of the Comparison Tool School Profile Page.
-  mobile_api:
-    actor_type: user
-    description: >
-      API endpoints consumed by the VA Mobile App (iOS/Android)
-  show_chapter_31:
-    actor_type: user
-    description: >
-      This will toggle between an eBenefits link and a VA.gov link for the VR&E chapter 31 form
-  request_locked_pdf_password:
-    actor_type: user
+    description: "Allows user to access chapter 33 benefits (direct deposit for education) in the front end\n"
     enable_in_development: true
-    description: >
-      Ask for a password when an encrypted PDF is detected before uploading
-  education_reports_cleanup:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Updates to the daily education reports to remove old data that isn't needed in the new fiscal year
-  search_typeahead_enabled:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enables type ahead search functionality
-  multiple_address_10_10ez:
-    actor_type: cookie_id
-    description: >
-      [Front-end only] When enabled, the 10-10EZ will collect a home and mailing address for the veteran vs only collecting a single, "permanent" address.
-  evss_upload_limit_150mb:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Allow user to upload files up to 150 MB in size (EVSS endpoint for 526 & CST)
-  find_forms_mvp_enhancement:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enhances Find A Forms MVP.
-  yellow_ribbon_mvp_enhancement:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enhances Yellow Ribbon MVP.
-  stem_automated_decision:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Add automated decision to 10203 application workflow
-  in_progress_form_custom_expiration:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enable/disable custom expiration dates for forms
-  search_representative:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Enable frontend application and cta for Search Representative application
-  dependents_management:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Manage dependent removal from view dependent page
-  subform_8940_4192:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Form 526 subforms for unemployability & connected employment information
-  spool_testing_error_1:
-    actor_type: user
-    description: >
-      Enables spool_file_events tracking rows to be used to prevent multiple spool files per RPO per date
-  spool_testing_error_2:
-    actor_type: user
-    description: >
-      Enables Slack notifications for CreateDailySpoolFiles
-  spool_testing_error_3:
-    actor_type: user
-    description: >
-      Enables email notifications for CreateDailySpoolFiles errors
-  dependency_verification:
-    actor_type: user
-    enable_in_development: true
-    description: >
-      Feature gates the dependency verification modal for updating the diaries service.
   coe_access:
     actor_type: user
+    description: "Feature gates the certificate of eligibility application\n"
     enable_in_development: true
-    description: >
-      Feature gates the certificate of eligibility application
+  covid_vaccine_registration:
+    actor_type: user
+    description: "Toggles availability of covid vaccine form API.\n"
+  covid_vaccine_registration_expanded:
+    actor_type: user
+    description: "Toggles availability of covid vaccine expanded registration form API.\n"
+    enable_in_development: true
+  covid_vaccine_registration_frontend:
+    actor_type: user
+    description: "Toggles the availability of the frontend form on va.gov for the covid-19 vaccine sign-up\n"
+  covid_vaccine_registration_frontend_cta:
+    actor_type: user
+    description: "Toggles the availability of the call-to-action prompt (cta) on \"va.gov/health-care/covid-19-vaccine/\" leading to the frontend form on va.gov for the covid-19 vaccine sign-up\n"
+  covid_vaccine_registration_frontend_enable_expanded_eligibility:
+    actor_type: user
+    description: "Toggles the 'continue' button to launch the new expanded eligibility VAFS app\n"
+  covid_vaccine_registration_frontend_hide_auth:
+    actor_type: user
+    description: "Toggles the availability of the sign-in button on the covid-19 vaccine sign-up form on va.gov. Note: When this is enabled, the 'Sign in' button will be hidden\n"
+  covid_vaccine_scheduling_frontend:
+    actor_type: user
+    description: "Toggles the availability of covid-19 vaccine scheduling links in the facility locator frontend"
+    enable_in_development: true
+  covid_volunteer_delivery:
+    actor_type: cookie_id
+    description: "Toggles whether COVID Research volunteer submissions will be delivered to genISIS\n"
+  dashboard_show_dashboard_2:
+    actor_type: user
+    description: "Enables The New My VA Dashboard 2.0\n"
+    enable_in_development: true
+  debt_letters_show_letters:
+    actor_type: user
+    description: "Enables debt letters\n"
+  dependency_verification:
+    actor_type: user
+    description: "Feature gates the dependency verification modal for updating the diaries service.\n"
+    enable_in_development: true
+  dependents_management:
+    actor_type: user
+    description: "Manage dependent removal from view dependent page\n"
+    enable_in_development: true
+  direct_deposit_vanotify:
+    actor_type: user
+    description: "Send direct deposit emails using VaNotify service\n"
+  education_reports_cleanup:
+    actor_type: user
+    description: "Updates to the daily education reports to remove old data that isn't needed in the new fiscal year\n"
+    enable_in_development: true
+  evss_upload_limit_150mb:
+    actor_type: user
+    description: "Allow user to upload files up to 150 MB in size (EVSS endpoint for 526 & CST)\n"
+    enable_in_development: true
+  facilities_ppms_suppress_community_care:
+    actor_type: user
+    description: "Hide ppms community care searches"
+  facilities_ppms_suppress_pharmacies:
+    actor_type: user
+    description: "Front End Flag to suppress the ability to search for pharmacies"
+  facility_locator_lighthouse_covid_vaccine_query:
+    actor_type: user
+    description: "enable covid search/display"
+    enable_in_development: true
+  facility_locator_ppms_forced_unique_id:
+    actor_type: user
+    description: "Use an hexdigest for the ID on PPMS Place of Service Calls"
+  facility_locator_ppms_legacy_urgent_care_to_pos_locator:
+    actor_type: user
+    description: "force the legacy urgent care path to use the new POS locator"
+  facility_locator_predictive_location_search:
+    actor_type: user
+    description: "Use predictive location search in the Facility Locator UI"
+  facility_locator_pull_operating_status_from_lighthouse:
+    actor_type: user
+    description: "A fast and dirty way to get the operating status from lighthouse"
+    enable_in_development: true
+  facility_locator_show_community_cares:
+    actor_type: user
+    description: "On https://www.va.gov/find-locations/ enable veterans to search for Community care by showing that option in the \"Search for\" box. This toggle is owned by Rian\n"
+    enable_in_development: true
+  facility_locator_show_operational_hours_special_instructions:
+    actor_type: user
+    description: "Display new field operationalHoursSpecialInstructions for VA facilities"
+    enable_in_development: true
+  find_forms_mvp_enhancement:
+    actor_type: user
+    description: "Enhances Find A Forms MVP.\n"
+    enable_in_development: true
   form10182_nod:
     actor_type: user
+    description: "Form 10182 Notice of Disagreement - Request a board appeal\n"
     enable_in_development: true
-    description: >
-      Form 10182 Notice of Disagreement - Request a board appeal
-  virtual_agent_bot_a:
+  form526_benefits_delivery_at_discharge:
     actor_type: user
+    description: "Allows veterans to access the BDD flow in the 526 form. Owned by va-benefits-memorial-1 team.\n"
     enable_in_development: true
-    description: >
-      Points to Bot A
-  virtual_agent_token:
+  form526_original_claims:
     actor_type: user
+    description: "Allows veterans to access form526 as an original claims user. Owned by va-benefits-memorial-1 team.\n"
     enable_in_development: true
-    description: >
-      Enables connection to webchat
+  form996_higher_level_review:
+    actor_type: user
+    description: "Allows veterans request a higher-level review of an existing claim. Owned by va-benefits-memorial-1 team.\n"
+    enable_in_development: true
+  get_help_ask_form:
+    actor_type: user
+    description: "Enables inquiry form for users to submit questions, suggestions, and complaints.\n"
+    enable_in_development: true
+  get_help_messages:
+    actor_type: user
+    description: "Enables secure messaging\n"
+    enable_in_development: true
+  gibct_eyb_bottom_sheet:
+    actor_type: user
+    description: "Panel that displays while the user is modifying inputs to give context to their currently estimated benefits until they reach the full your estimated benefits panel.\n"
+  gibct_school_ratings:
+    actor_type: user
+    description: "Show/Hide the school ratings section of the Comparison Tool School Profile Page.\n"
+  in_progress_form_custom_expiration:
+    actor_type: user
+    description: "Enable/disable custom expiration dates for forms\n"
+    enable_in_development: true
+  mobile_api:
+    actor_type: user
+    description: "API endpoints consumed by the VA Mobile App (iOS/Android)\n"
+  multiple_address_10_10ez:
+    actor_type: cookie_id
+    description: "[Front-end only] When enabled, the 10-10EZ will collect a home and mailing address for the veteran vs only collecting a single, \"permanent\" address.\n"
+  new_va_forms_search:
+    actor_type: user
+    description: "Uses the new search algorithm\n"
+    enable_in_development: true
+  pre_entry_covid19_screener:
+    actor_type: user
+    description: "Toggle for the entire pre-entry covid 19 self-screener available at /covid19screener and to be used by visitors to VHA facilities in lieu of manual screening with a VHA employee. This toggle is owned by Patrick B. and the rest of the CTO Health Products team.\n"
+  profile_schema_forms:
+    actor_type: user
+    description: "Enables SchemaForm-based contact info edit forms on the VA.gov Veteran profile page\n"
+    enable_in_development: true
+  profile_show_receive_text_notifications:
+    actor_type: user
+    description: "https://www.va.gov/profile/ show Receive Text Notifications\n"
+    enable_in_development: true
+  request_locked_pdf_password:
+    actor_type: user
+    description: "Ask for a password when an encrypted PDF is detected before uploading\n"
+    enable_in_development: true
+  search_representative:
+    actor_type: user
+    description: "Enable frontend application and cta for Search Representative application\n"
+    enable_in_development: true
+  search_typeahead_enabled:
+    actor_type: user
+    description: "Enables type ahead search functionality\n"
+    enable_in_development: true
   sharable_link:
     actor_type: user
+    description: "Toggles the availability of sharable links to deep link to content\n"
     enable_in_development: true
-    description: >
-      Toggles the availability of sharable links to deep link to content
+  show526_wizard:
+    actor_type: user
+    description: "This determines when the wizard should show up on the form 526 intro page\n"
+    enable_in_development: true
+  show_chapter_31:
+    actor_type: user
+    description: "This will toggle between an eBenefits link and a VA.gov link for the VR&E chapter 31 form\n"
+  show_edu_benefits_0994_wizard:
+    actor_type: user
+    description: "This determines when the wizard should show up on the 0994 introduction page\n"
+  show_edu_benefits_1990_wizard:
+    actor_type: user
+    description: "This determines when the wizard should show up on the 1990 introduction page\n"
+  show_edu_benefits_1990e_wizard:
+    actor_type: user
+    description: "This determines when the wizard should show up on the 1990e introduction page\n"
+  show_edu_benefits_1990n_wizard:
+    actor_type: user
+    description: "This determines when the wizard should show up on the 1990N introduction page\n"
+  show_edu_benefits_1995_wizard:
+    actor_type: user
+    description: "This determines when the wizard should show up on the 1995 introduction page\n"
+  show_edu_benefits_5490_wizard:
+    actor_type: user
+    description: "This determines when the wizard should show up on the 5490 introduction page\n"
+  show_edu_benefits_5495_wizard:
+    actor_type: user
+    description: "This determines when the wizard should show up on the 5495 introduction page\n"
+  show_financial_status_report:
+    actor_type: user
+    description: "Enables VA Form 5655 (Financial Status Report)\n"
+    enable_in_development: true
+  show_financial_status_report_wizard:
+    actor_type: user
+    description: "Enables the Wizard for VA Form 5655 (Financial Status Report)\n"
+    enable_in_development: true
+  show_healthcare_experience_questionnaire:
+    actor_type: cookie_id
+    description: "Enables showing the pre-appointment questionnaire feature.\n"
+    enable_in_development: true
+  show_new_get_medical_records_page:
+    actor_type: user
+    description: "This will show the non-Cerner-user and Cerner-user content for the page /health-care/get-medical-records/\n"
+  show_new_refill_track_prescriptions_page:
+    actor_type: user
+    description: "This will show the non-Cerner-user and Cerner-user content for the page /health-care/refill-track-prescriptions/\n"
+  show_new_schedule_view_appointments_page:
+    actor_type: user
+    description: "This will show the non-Cerner-user and Cerner-user content for the page /health-care/schedule-view-va-appointments/\n"
+  show_new_secure_messaging_page:
+    actor_type: user
+    description: "This will show the non-Cerner-user and Cerner-user content for the page /health-care/secure-messaging/\n"
+  show_new_view_test_lab_results_page:
+    actor_type: user
+    description: "This will show the non-Cerner-user and Cerner-user content for the page /health-care/view-test-and-lab-results/\n"
+  spool_testing_error_1:
+    actor_type: user
+    description: "Enables spool_file_events tracking rows to be used to prevent multiple spool files per RPO per date\n"
+  spool_testing_error_2:
+    actor_type: user
+    description: "Enables Slack notifications for CreateDailySpoolFiles\n"
+  spool_testing_error_3:
+    actor_type: user
+    description: "Enables email notifications for CreateDailySpoolFiles errors\n"
+  ssoe:
+    actor_type: cookie_id
+    description: "Enables ssoe, as opposed to saml authentication wrapped by id.me\n"
+    enable_in_development: true
+  ssoe_ebenefits_links:
+    actor_type: user
+    description: "Enable eBenefits links to be proxied through eauth.va.gov, this allows users with SSOe sessions to stay logged in.\n"
+  ssoe_inbound:
+    actor_type: cookie_id
+    description: "Enables automatic establishment/disconnection of vets-api session based on a user's SSOe session status\n"
+    enable_in_development: true
+  stem_automated_decision:
+    actor_type: user
+    description: "Add automated decision to 10203 application workflow\n"
+    enable_in_development: true
+  subform_8940_4192:
+    actor_type: user
+    description: "Form 526 subforms for unemployability & connected employment information\n"
+    enable_in_development: true
+  va_global_downtime_notification:
+    actor_type: user
+    description: "Enables global downtime notification- do not use in production\n"
+  va_online_scheduling:
+    actor_type: user
+    description: "Allows veterans to view their VA and Community Care appointments\n"
+    enable_in_development: true
+  va_online_scheduling_cancel:
+    actor_type: user
+    description: "Allows veterans to cancel VA appointments\n"
+    enable_in_development: true
+  va_online_scheduling_cheetah:
+    actor_type: user
+    description: "Enables Project Cheetah discovery work\n"
+    enable_in_development: true
+  va_online_scheduling_community_care:
+    actor_type: user
+    description: "Allows veterans to submit requests for Community Care appointments\n"
+    enable_in_development: true
+  va_online_scheduling_direct:
+    actor_type: user
+    description: "Allows veterans to directly schedule VA appointments\n"
+    enable_in_development: true
+  va_online_scheduling_express_care_new:
+    actor_type: user
+    description: "Enables Express Care request flow in VAOS\n"
+    enable_in_development: true
+  va_online_scheduling_facility_selection_v2_2:
+    actor_type: user
+    description: "Set up toggle in anticipation of the next iteration of facility selection, version 2.2.\n"
+    enable_in_development: true
+  va_online_scheduling_homepage_refresh:
+    actor_type: user
+    description: "Set up toggle in anticipation of the next iteration of the homepage and appointment cards.\n"
+    enable_in_development: true
+  va_online_scheduling_provider_selection:
+    actor_type: user
+    description: "Enables the community care provider selection field\n"
+    enable_in_development: true
+  va_online_scheduling_requests:
+    actor_type: user
+    description: "Allows veterans to submit requests for VA appointments\n"
+    enable_in_development: true
+  va_online_scheduling_unenrolled_vaccine:
+    actor_type: user
+    description: "Toggle for unenrolled vaccine scheduling discovery work.\n"
+    enable_in_development: true
+  va_online_scheduling_vaos_service_cc_appointments:
+    actor_type: user
+    description: "Toggle for new vaos service cc appointments.\n"
+    enable_in_development: true
+  va_online_scheduling_vaos_service_requests:
+    actor_type: user
+    description: "Toggle for new vaos service requests.\n"
+    enable_in_development: true
+  va_online_scheduling_vaos_service_va_appointments:
+    actor_type: user
+    description: "Toggle for new vaos service va appointments.\n"
+    enable_in_development: true
+  va_view_dependents_access:
+    actor_type: user
+    description: "Allows us to gate the View/ Modify dependents content in a progressive rollout\n"
+  virtual_agent_bot_a:
+    actor_type: user
+    description: "Points to Bot A\n"
+    enable_in_development: true
+  virtual_agent_token:
+    actor_type: user
+    description: "Enables connection to webchat\n"
+    enable_in_development: true
+  yellow_ribbon_mvp_enhancement:
+    actor_type: user
+    description: "Enhances Yellow Ribbon MVP.\n"
+    enable_in_development: true

--- a/config/features.yml
+++ b/config/features.yml
@@ -62,13 +62,17 @@ features:
     description: "Toggles the availability of the frontend form on va.gov for the covid-19 vaccine sign-up\n"
   covid_vaccine_registration_frontend_cta:
     actor_type: user
-    description: "Toggles the availability of the call-to-action prompt (cta) on \"va.gov/health-care/covid-19-vaccine/\" leading to the frontend form on va.gov for the covid-19 vaccine sign-up\n"
+    description: >
+    Toggles the availability of the call-to-action prompt (cta) on "va.gov/health-care/covid-19-vaccine/"
+    leading to the frontend form on va.gov for the covid-19 vaccine sign-up
   covid_vaccine_registration_frontend_enable_expanded_eligibility:
     actor_type: user
     description: "Toggles the 'continue' button to launch the new expanded eligibility VAFS app\n"
   covid_vaccine_registration_frontend_hide_auth:
     actor_type: user
-    description: "Toggles the availability of the sign-in button on the covid-19 vaccine sign-up form on va.gov. Note: When this is enabled, the 'Sign in' button will be hidden\n"
+    description: >
+      Toggles the availability of the sign-in button on the covid-19 vaccine sign-up form on va.gov.
+      Note: When this is enabled, the 'Sign in' button will be hidden
   covid_vaccine_scheduling_frontend:
     actor_type: user
     description: "Toggles the availability of covid-19 vaccine scheduling links in the facility locator frontend"
@@ -127,7 +131,9 @@ features:
     enable_in_development: true
   facility_locator_show_community_cares:
     actor_type: user
-    description: "On https://www.va.gov/find-locations/ enable veterans to search for Community care by showing that option in the \"Search for\" box. This toggle is owned by Rian\n"
+    description: >
+      On https://www.va.gov/find-locations/ enable veterans to search for Community care by showing that option
+      in the "Search for" box.
     enable_in_development: true
   facility_locator_show_operational_hours_special_instructions:
     actor_type: user
@@ -151,7 +157,8 @@ features:
     enable_in_development: true
   form996_higher_level_review:
     actor_type: user
-    description: "Allows veterans request a higher-level review of an existing claim. Owned by va-benefits-memorial-1 team.\n"
+    description: >
+      Allows veterans request a higher-level review of an existing claim. Owned by va-benefits-memorial-1 team.
     enable_in_development: true
   get_help_ask_form:
     actor_type: user
@@ -163,7 +170,9 @@ features:
     enable_in_development: true
   gibct_eyb_bottom_sheet:
     actor_type: user
-    description: "Panel that displays while the user is modifying inputs to give context to their currently estimated benefits until they reach the full your estimated benefits panel.\n"
+    description: >
+      Panel that displays while the user is modifying inputs to give context to their currently estimated benefits
+      until they reach the full your estimated benefits panel.
   gibct_school_ratings:
     actor_type: user
     description: "Show/Hide the school ratings section of the Comparison Tool School Profile Page.\n"
@@ -176,14 +185,19 @@ features:
     description: "API endpoints consumed by the VA Mobile App (iOS/Android)\n"
   multiple_address_10_10ez:
     actor_type: cookie_id
-    description: "[Front-end only] When enabled, the 10-10EZ will collect a home and mailing address for the veteran vs only collecting a single, \"permanent\" address.\n"
+    description: >
+      [Front-end only] When enabled, the 10-10EZ will collect a home and mailing address for the veteran
+      vs only collecting a single, "permanent" address.
   new_va_forms_search:
     actor_type: user
     description: "Uses the new search algorithm\n"
     enable_in_development: true
   pre_entry_covid19_screener:
     actor_type: user
-    description: "Toggle for the entire pre-entry covid 19 self-screener available at /covid19screener and to be used by visitors to VHA facilities in lieu of manual screening with a VHA employee. This toggle is owned by Patrick B. and the rest of the CTO Health Products team.\n"
+    description: >
+      Toggle for the entire pre-entry covid 19 self-screener available at /covid19screener and to be used by visitors
+      to VHA facilities in lieu of manual screening with a VHA employee.
+      This toggle is owned by Patrick B. and the rest of the CTO Health Products team.
   profile_schema_forms:
     actor_type: user
     description: "Enables SchemaForm-based contact info edit forms on the VA.gov Veteran profile page\n"

--- a/config/features.yml
+++ b/config/features.yml
@@ -14,52 +14,52 @@
 features:
   can_upload_10_10cg_poa:
     actor_type: cookie_id
-    description: "Allows users to upload POA documentation when completing the 10-10CG."
+    description: Allows users to upload POA documentation when completing the 10-10CG.
   cerner_override_463:
     actor_type: user
-    description: "This will show the Cerner facility 463 as `isCerner`.\n"
+    description: This will show the Cerner facility 463 as `isCerner`.
   cerner_override_531:
     actor_type: user
-    description: "This will show the Cerner facility 531 as `isCerner`.\n"
+    description: This will show the Cerner facility 531 as `isCerner`.
   cerner_override_648:
     actor_type: user
-    description: "This will show the Cerner facility 648 as `isCerner`.\n"
+    description: This will show the Cerner facility 648 as `isCerner`.
   cerner_override_653:
     actor_type: user
-    description: "This will show the Cerner facility 653 as `isCerner`.\n"
+    description: This will show the Cerner facility 653 as `isCerner`.
   cerner_override_663:
     actor_type: user
-    description: "This will show the Cerner facility 663 as `isCerner`.\n"
+    description: This will show the Cerner facility 663 as `isCerner`.
   cerner_override_668:
     actor_type: user
-    description: "This will show the Cerner facility 668 as `isCerner`.\n"
+    description: This will show the Cerner facility 668 as `isCerner`.
   cerner_override_687:
     actor_type: user
-    description: "This will show the Cerner facility 687 as `isCerner`.\n"
+    description: This will show the Cerner facility 687 as `isCerner`.
   cerner_override_692:
     actor_type: user
-    description: "This will show the Cerner facility 692 as `isCerner`.\n"
+    description: This will show the Cerner facility 692 as `isCerner`.
   cerner_override_757:
     actor_type: user
-    description: "This will show the Cerner facility 757 as `isCerner`.\n"
+    description: This will show the Cerner facility 757 as `isCerner`.
   ch33_dd_profile:
     actor_type: user
-    description: "Allows user to access chapter 33 benefits (direct deposit for education) in the front end\n"
+    description: Allows user to access chapter 33 benefits (direct deposit for education) in the front end
     enable_in_development: true
   coe_access:
     actor_type: user
-    description: "Feature gates the certificate of eligibility application\n"
+    description: Feature gates the certificate of eligibility application
     enable_in_development: true
   covid_vaccine_registration:
     actor_type: user
-    description: "Toggles availability of covid vaccine form API.\n"
+    description: Toggles availability of covid vaccine form API.
   covid_vaccine_registration_expanded:
     actor_type: user
-    description: "Toggles availability of covid vaccine expanded registration form API.\n"
+    description: Toggles availability of covid vaccine expanded registration form API.
     enable_in_development: true
   covid_vaccine_registration_frontend:
     actor_type: user
-    description: "Toggles the availability of the frontend form on va.gov for the covid-19 vaccine sign-up\n"
+    description: Toggles the availability of the frontend form on va.gov for the covid-19 vaccine sign-up
   covid_vaccine_registration_frontend_cta:
     actor_type: user
     description: >
@@ -67,7 +67,7 @@ features:
       leading to the frontend form on va.gov for the covid-19 vaccine sign-up
   covid_vaccine_registration_frontend_enable_expanded_eligibility:
     actor_type: user
-    description: "Toggles the 'continue' button to launch the new expanded eligibility VAFS app\n"
+    description: Toggles the 'continue' button to launch the new expanded eligibility VAFS app
   covid_vaccine_registration_frontend_hide_auth:
     actor_type: user
     description: >
@@ -75,59 +75,59 @@ features:
       Note: When this is enabled, the 'Sign in' button will be hidden
   covid_vaccine_scheduling_frontend:
     actor_type: user
-    description: "Toggles the availability of covid-19 vaccine scheduling links in the facility locator frontend"
+    description: Toggles the availability of covid-19 vaccine scheduling links in the facility locator frontend
     enable_in_development: true
   covid_volunteer_delivery:
     actor_type: cookie_id
-    description: "Toggles whether COVID Research volunteer submissions will be delivered to genISIS\n"
+    description: Toggles whether COVID Research volunteer submissions will be delivered to genISIS
   dashboard_show_dashboard_2:
     actor_type: user
-    description: "Enables The New My VA Dashboard 2.0\n"
+    description: Enables The New My VA Dashboard 2.0
     enable_in_development: true
   debt_letters_show_letters:
     actor_type: user
-    description: "Enables debt letters\n"
+    description: Enables debt letters
   dependency_verification:
     actor_type: user
-    description: "Feature gates the dependency verification modal for updating the diaries service.\n"
+    description: Feature gates the dependency verification modal for updating the diaries service.
     enable_in_development: true
   dependents_management:
     actor_type: user
-    description: "Manage dependent removal from view dependent page\n"
+    description: Manage dependent removal from view dependent page
     enable_in_development: true
   direct_deposit_vanotify:
     actor_type: user
-    description: "Send direct deposit emails using VaNotify service\n"
+    description: Send direct deposit emails using VaNotify service
   education_reports_cleanup:
     actor_type: user
-    description: "Updates to the daily education reports to remove old data that isn't needed in the new fiscal year\n"
+    description: Updates to the daily education reports to remove old data that isn't needed in the new fiscal year
     enable_in_development: true
   evss_upload_limit_150mb:
     actor_type: user
-    description: "Allow user to upload files up to 150 MB in size (EVSS endpoint for 526 & CST)\n"
+    description: Allow user to upload files up to 150 MB in size (EVSS endpoint for 526 & CST)
     enable_in_development: true
   facilities_ppms_suppress_community_care:
     actor_type: user
-    description: "Hide ppms community care searches"
+    description: Hide ppms community care searches"
   facilities_ppms_suppress_pharmacies:
     actor_type: user
-    description: "Front End Flag to suppress the ability to search for pharmacies"
+    description: Front End Flag to suppress the ability to search for pharmacies"
   facility_locator_lighthouse_covid_vaccine_query:
     actor_type: user
-    description: "enable covid search/display"
+    description: enable covid search/display"
     enable_in_development: true
   facility_locator_ppms_forced_unique_id:
     actor_type: user
-    description: "Use an hexdigest for the ID on PPMS Place of Service Calls"
+    description: Use an hexdigest for the ID on PPMS Place of Service Calls"
   facility_locator_ppms_legacy_urgent_care_to_pos_locator:
     actor_type: user
-    description: "force the legacy urgent care path to use the new POS locator"
+    description: force the legacy urgent care path to use the new POS locator"
   facility_locator_predictive_location_search:
     actor_type: user
-    description: "Use predictive location search in the Facility Locator UI"
+    description: Use predictive location search in the Facility Locator UI"
   facility_locator_pull_operating_status_from_lighthouse:
     actor_type: user
-    description: "A fast and dirty way to get the operating status from lighthouse"
+    description: A fast and dirty way to get the operating status from lighthouse"
     enable_in_development: true
   facility_locator_show_community_cares:
     actor_type: user
@@ -137,23 +137,23 @@ features:
     enable_in_development: true
   facility_locator_show_operational_hours_special_instructions:
     actor_type: user
-    description: "Display new field operationalHoursSpecialInstructions for VA facilities"
+    description: Display new field operationalHoursSpecialInstructions for VA facilities"
     enable_in_development: true
   find_forms_mvp_enhancement:
     actor_type: user
-    description: "Enhances Find A Forms MVP.\n"
+    description: Enhances Find A Forms MVP.
     enable_in_development: true
   form10182_nod:
     actor_type: user
-    description: "Form 10182 Notice of Disagreement - Request a board appeal\n"
+    description: Form 10182 Notice of Disagreement - Request a board appeal
     enable_in_development: true
   form526_benefits_delivery_at_discharge:
     actor_type: user
-    description: "Allows veterans to access the BDD flow in the 526 form. Owned by va-benefits-memorial-1 team.\n"
+    description: Allows veterans to access the BDD flow in the 526 form. Owned by va-benefits-memorial-1 team.
     enable_in_development: true
   form526_original_claims:
     actor_type: user
-    description: "Allows veterans to access form526 as an original claims user. Owned by va-benefits-memorial-1 team.\n"
+    description: Allows veterans to access form526 as an original claims user. Owned by va-benefits-memorial-1 team.
     enable_in_development: true
   form996_higher_level_review:
     actor_type: user
@@ -162,11 +162,11 @@ features:
     enable_in_development: true
   get_help_ask_form:
     actor_type: user
-    description: "Enables inquiry form for users to submit questions, suggestions, and complaints.\n"
+    description: Enables inquiry form for users to submit questions, suggestions, and complaints.
     enable_in_development: true
   get_help_messages:
     actor_type: user
-    description: "Enables secure messaging\n"
+    description: Enables secure messaging
     enable_in_development: true
   gibct_eyb_bottom_sheet:
     actor_type: user
@@ -175,14 +175,14 @@ features:
       until they reach the full your estimated benefits panel.
   gibct_school_ratings:
     actor_type: user
-    description: "Show/Hide the school ratings section of the Comparison Tool School Profile Page.\n"
+    description: Show/Hide the school ratings section of the Comparison Tool School Profile Page.
   in_progress_form_custom_expiration:
     actor_type: user
-    description: "Enable/disable custom expiration dates for forms\n"
+    description: Enable/disable custom expiration dates for forms
     enable_in_development: true
   mobile_api:
     actor_type: user
-    description: "API endpoints consumed by the VA Mobile App (iOS/Android)\n"
+    description: API endpoints consumed by the VA Mobile App (iOS/Android)
   multiple_address_10_10ez:
     actor_type: cookie_id
     description: >
@@ -190,7 +190,7 @@ features:
       vs only collecting a single, "permanent" address.
   new_va_forms_search:
     actor_type: user
-    description: "Uses the new search algorithm\n"
+    description: Uses the new search algorithm
     enable_in_development: true
   pre_entry_covid19_screener:
     actor_type: user
@@ -200,182 +200,182 @@ features:
       This toggle is owned by Patrick B. and the rest of the CTO Health Products team.
   profile_schema_forms:
     actor_type: user
-    description: "Enables SchemaForm-based contact info edit forms on the VA.gov Veteran profile page\n"
+    description: Enables SchemaForm-based contact info edit forms on the VA.gov Veteran profile page
     enable_in_development: true
   profile_show_receive_text_notifications:
     actor_type: user
-    description: "https://www.va.gov/profile/ show Receive Text Notifications\n"
+    description: https://www.va.gov/profile/ show Receive Text Notifications
     enable_in_development: true
   request_locked_pdf_password:
     actor_type: user
-    description: "Ask for a password when an encrypted PDF is detected before uploading\n"
+    description: Ask for a password when an encrypted PDF is detected before uploading
     enable_in_development: true
   search_representative:
     actor_type: user
-    description: "Enable frontend application and cta for Search Representative application\n"
+    description: Enable frontend application and cta for Search Representative application
     enable_in_development: true
   search_typeahead_enabled:
     actor_type: user
-    description: "Enables type ahead search functionality\n"
+    description: Enables type ahead search functionality
     enable_in_development: true
   sharable_link:
     actor_type: user
-    description: "Toggles the availability of sharable links to deep link to content\n"
+    description: Toggles the availability of sharable links to deep link to content
     enable_in_development: true
   show526_wizard:
     actor_type: user
-    description: "This determines when the wizard should show up on the form 526 intro page\n"
+    description: This determines when the wizard should show up on the form 526 intro page
     enable_in_development: true
   show_chapter_31:
     actor_type: user
-    description: "This will toggle between an eBenefits link and a VA.gov link for the VR&E chapter 31 form\n"
+    description: This will toggle between an eBenefits link and a VA.gov link for the VR&E chapter 31 form
   show_edu_benefits_0994_wizard:
     actor_type: user
-    description: "This determines when the wizard should show up on the 0994 introduction page\n"
+    description: This determines when the wizard should show up on the 0994 introduction page
   show_edu_benefits_1990_wizard:
     actor_type: user
-    description: "This determines when the wizard should show up on the 1990 introduction page\n"
+    description: This determines when the wizard should show up on the 1990 introduction page
   show_edu_benefits_1990e_wizard:
     actor_type: user
-    description: "This determines when the wizard should show up on the 1990e introduction page\n"
+    description: This determines when the wizard should show up on the 1990e introduction page
   show_edu_benefits_1990n_wizard:
     actor_type: user
-    description: "This determines when the wizard should show up on the 1990N introduction page\n"
+    description: This determines when the wizard should show up on the 1990N introduction page
   show_edu_benefits_1995_wizard:
     actor_type: user
-    description: "This determines when the wizard should show up on the 1995 introduction page\n"
+    description: This determines when the wizard should show up on the 1995 introduction page
   show_edu_benefits_5490_wizard:
     actor_type: user
-    description: "This determines when the wizard should show up on the 5490 introduction page\n"
+    description: This determines when the wizard should show up on the 5490 introduction page
   show_edu_benefits_5495_wizard:
     actor_type: user
-    description: "This determines when the wizard should show up on the 5495 introduction page\n"
+    description: This determines when the wizard should show up on the 5495 introduction page
   show_financial_status_report:
     actor_type: user
-    description: "Enables VA Form 5655 (Financial Status Report)\n"
+    description: Enables VA Form 5655 (Financial Status Report)
     enable_in_development: true
   show_financial_status_report_wizard:
     actor_type: user
-    description: "Enables the Wizard for VA Form 5655 (Financial Status Report)\n"
+    description: Enables the Wizard for VA Form 5655 (Financial Status Report)
     enable_in_development: true
   show_healthcare_experience_questionnaire:
     actor_type: cookie_id
-    description: "Enables showing the pre-appointment questionnaire feature.\n"
+    description: Enables showing the pre-appointment questionnaire feature.
     enable_in_development: true
   show_new_get_medical_records_page:
     actor_type: user
-    description: "This will show the non-Cerner-user and Cerner-user content for the page /health-care/get-medical-records/\n"
+    description: This will show the non-Cerner-user and Cerner-user content for the page /health-care/get-medical-records/
   show_new_refill_track_prescriptions_page:
     actor_type: user
-    description: "This will show the non-Cerner-user and Cerner-user content for the page /health-care/refill-track-prescriptions/\n"
+    description: This will show the non-Cerner-user and Cerner-user content for the page /health-care/refill-track-prescriptions/
   show_new_schedule_view_appointments_page:
     actor_type: user
-    description: "This will show the non-Cerner-user and Cerner-user content for the page /health-care/schedule-view-va-appointments/\n"
+    description: This will show the non-Cerner-user and Cerner-user content for the page /health-care/schedule-view-va-appointments/
   show_new_secure_messaging_page:
     actor_type: user
-    description: "This will show the non-Cerner-user and Cerner-user content for the page /health-care/secure-messaging/\n"
+    description: This will show the non-Cerner-user and Cerner-user content for the page /health-care/secure-messaging/
   show_new_view_test_lab_results_page:
     actor_type: user
-    description: "This will show the non-Cerner-user and Cerner-user content for the page /health-care/view-test-and-lab-results/\n"
+    description: This will show the non-Cerner-user and Cerner-user content for the page /health-care/view-test-and-lab-results/
   spool_testing_error_1:
     actor_type: user
-    description: "Enables spool_file_events tracking rows to be used to prevent multiple spool files per RPO per date\n"
+    description: Enables spool_file_events tracking rows to be used to prevent multiple spool files per RPO per date
   spool_testing_error_2:
     actor_type: user
-    description: "Enables Slack notifications for CreateDailySpoolFiles\n"
+    description: Enables Slack notifications for CreateDailySpoolFiles
   spool_testing_error_3:
     actor_type: user
-    description: "Enables email notifications for CreateDailySpoolFiles errors\n"
+    description: Enables email notifications for CreateDailySpoolFiles errors
   ssoe:
     actor_type: cookie_id
-    description: "Enables ssoe, as opposed to saml authentication wrapped by id.me\n"
+    description: Enables ssoe, as opposed to saml authentication wrapped by id.me
     enable_in_development: true
   ssoe_ebenefits_links:
     actor_type: user
-    description: "Enable eBenefits links to be proxied through eauth.va.gov, this allows users with SSOe sessions to stay logged in.\n"
+    description: Enable eBenefits links to be proxied through eauth.va.gov, this allows users with SSOe sessions to stay logged in.
   ssoe_inbound:
     actor_type: cookie_id
-    description: "Enables automatic establishment/disconnection of vets-api session based on a user's SSOe session status\n"
+    description: Enables automatic establishment/disconnection of vets-api session based on a user's SSOe session status
     enable_in_development: true
   stem_automated_decision:
     actor_type: user
-    description: "Add automated decision to 10203 application workflow\n"
+    description: Add automated decision to 10203 application workflow
     enable_in_development: true
   subform_8940_4192:
     actor_type: user
-    description: "Form 526 subforms for unemployability & connected employment information\n"
+    description: Form 526 subforms for unemployability & connected employment information
     enable_in_development: true
   va_global_downtime_notification:
     actor_type: user
-    description: "Enables global downtime notification- do not use in production\n"
+    description: Enables global downtime notification- do not use in production
   va_online_scheduling:
     actor_type: user
-    description: "Allows veterans to view their VA and Community Care appointments\n"
+    description: Allows veterans to view their VA and Community Care appointments
     enable_in_development: true
   va_online_scheduling_cancel:
     actor_type: user
-    description: "Allows veterans to cancel VA appointments\n"
+    description: Allows veterans to cancel VA appointments
     enable_in_development: true
   va_online_scheduling_cheetah:
     actor_type: user
-    description: "Enables Project Cheetah discovery work\n"
+    description: Enables Project Cheetah discovery work
     enable_in_development: true
   va_online_scheduling_community_care:
     actor_type: user
-    description: "Allows veterans to submit requests for Community Care appointments\n"
+    description: Allows veterans to submit requests for Community Care appointments
     enable_in_development: true
   va_online_scheduling_direct:
     actor_type: user
-    description: "Allows veterans to directly schedule VA appointments\n"
+    description: Allows veterans to directly schedule VA appointments
     enable_in_development: true
   va_online_scheduling_express_care_new:
     actor_type: user
-    description: "Enables Express Care request flow in VAOS\n"
+    description: Enables Express Care request flow in VAOS
     enable_in_development: true
   va_online_scheduling_facility_selection_v2_2:
     actor_type: user
-    description: "Set up toggle in anticipation of the next iteration of facility selection, version 2.2.\n"
+    description: Set up toggle in anticipation of the next iteration of facility selection, version 2.2.
     enable_in_development: true
   va_online_scheduling_homepage_refresh:
     actor_type: user
-    description: "Set up toggle in anticipation of the next iteration of the homepage and appointment cards.\n"
+    description: Set up toggle in anticipation of the next iteration of the homepage and appointment cards.
     enable_in_development: true
   va_online_scheduling_provider_selection:
     actor_type: user
-    description: "Enables the community care provider selection field\n"
+    description: Enables the community care provider selection field
     enable_in_development: true
   va_online_scheduling_requests:
     actor_type: user
-    description: "Allows veterans to submit requests for VA appointments\n"
+    description: Allows veterans to submit requests for VA appointments
     enable_in_development: true
   va_online_scheduling_unenrolled_vaccine:
     actor_type: user
-    description: "Toggle for unenrolled vaccine scheduling discovery work.\n"
+    description: Toggle for unenrolled vaccine scheduling discovery work.
     enable_in_development: true
   va_online_scheduling_vaos_service_cc_appointments:
     actor_type: user
-    description: "Toggle for new vaos service cc appointments.\n"
+    description: Toggle for new vaos service cc appointments.
     enable_in_development: true
   va_online_scheduling_vaos_service_requests:
     actor_type: user
-    description: "Toggle for new vaos service requests.\n"
+    description: Toggle for new vaos service requests.
     enable_in_development: true
   va_online_scheduling_vaos_service_va_appointments:
     actor_type: user
-    description: "Toggle for new vaos service va appointments.\n"
+    description: Toggle for new vaos service va appointments.
     enable_in_development: true
   va_view_dependents_access:
     actor_type: user
-    description: "Allows us to gate the View/ Modify dependents content in a progressive rollout\n"
+    description: Allows us to gate the View/ Modify dependents content in a progressive rollout
   virtual_agent_bot_a:
     actor_type: user
-    description: "Points to Bot A\n"
+    description: Points to Bot A
     enable_in_development: true
   virtual_agent_token:
     actor_type: user
-    description: "Enables connection to webchat\n"
+    description: Enables connection to webchat
     enable_in_development: true
   yellow_ribbon_mvp_enhancement:
     actor_type: user
-    description: "Enhances Yellow Ribbon MVP.\n"
+    description: Enhances Yellow Ribbon MVP.
     enable_in_development: true


### PR DESCRIPTION
## Description of change
Adds a feature flag that will be used to toggle the availability of covid-19 vaccine scheduling links in the facility locator frontend. Also sorts the feature flags using http://yaml-sorter.herokuapp.com/.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/22139


