### PR TITLE
Allow only some file types for NOD supporting evidence uploads

### DIFF
--- a/app/uploaders/decision_review_evidence_attachment_uploader.rb
+++ b/app/uploaders/decision_review_evidence_attachment_uploader.rb
@@ -8,6 +8,12 @@ class DecisionReviewEvidenceAttachmentUploader < CarrierWave::Uploader::Base
     1.byte...100.megabytes
   end
 
+  # Waiting on Lighthouse for the real allow list but this is my best guess
+  # based upon what EVSS accepts and then sends on to VBMS
+  def extension_allowlist
+    %w[pdf gif png tiff tif jpeg jpg bmp txt]
+  end
+
   def initialize(decision_review_guid)
     super
     @decision_review_guid = decision_review_guid

--- a/app/uploaders/decision_review_evidence_attachment_uploader.rb
+++ b/app/uploaders/decision_review_evidence_attachment_uploader.rb
@@ -8,10 +8,8 @@ class DecisionReviewEvidenceAttachmentUploader < CarrierWave::Uploader::Base
     1.byte...100.megabytes
   end
 
-  # Waiting on Lighthouse for the real allow list but this is my best guess
-  # based upon what EVSS accepts and then sends on to VBMS
   def extension_allowlist
-    %w[pdf gif png tiff tif jpeg jpg bmp txt]
+    %w[pdf]
   end
 
   def initialize(decision_review_guid)

--- a/spec/jobs/decision_review/submit_upload_spec.rb
+++ b/spec/jobs/decision_review/submit_upload_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DecisionReview::SubmitUpload, type: :job do
   end
 
   describe 'perform' do
-    let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/files/sm_file1.jpg', 'image/jpg') }
+    let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/files/doctors-note.pdf', 'application/pdf') }
     let(:appeal_submission) { create(:appeal_submission, :with_one_upload) }
     let(:appeal_submission_upload) { appeal_submission.appeal_submission_uploads.first }
 

--- a/spec/request/decision_review_evidences_request_spec.rb
+++ b/spec/request/decision_review_evidences_request_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe 'Decision Review Evidences', type: :request do
         expect(err['title']).to eq 'Unprocessable Entity'
         expect(err['detail']).to eq(I18n.t('errors.messages.min_size_error', min_size: '1 Byte'))
       end
+
+      it 'returns a 422  for a file that not an allowed type' do
+        post '/v0/decision_review_evidence',
+             params: { decision_review_evidence_attachment:
+                       { file_data: fixture_file_upload('spec/fixtures/files/saml_responses/loa1.xml', 'application/xml') } }
+        expect(response).to have_http_status(:unprocessable_entity)
+        err = JSON.parse(response.body)['errors'][0]
+        expect(err['title']).to eq 'Unprocessable Entity'
+        expect(err['detail']).to eq(
+          'You can’t upload "xml" files. The allowed file types are: pdf, gif, png, tiff, tif, jpeg, jpg, bmp, txt'
+          )
+      end
     end
 
     context 'with invalid parameters' do

--- a/spec/request/decision_review_evidences_request_spec.rb
+++ b/spec/request/decision_review_evidences_request_spec.rb
@@ -27,26 +27,17 @@ RSpec.describe 'Decision Review Evidences', type: :request do
     end
 
     context 'with valid encrypted parameters' do
-      it 'returns a 422  for a file that is too small' do
-        post '/v0/decision_review_evidence',
-             params: { decision_review_evidence_attachment:
-                       { file_data: fixture_file_upload('spec/fixtures/files/empty_file.txt') } }
-        expect(response).to have_http_status(:unprocessable_entity)
-        err = JSON.parse(response.body)['errors'][0]
-        expect(err['title']).to eq 'Unprocessable Entity'
-        expect(err['detail']).to eq(I18n.t('errors.messages.min_size_error', min_size: '1 Byte'))
-      end
-
       it 'returns a 422  for a file that not an allowed type' do
         post '/v0/decision_review_evidence',
              params: { decision_review_evidence_attachment:
-                       { file_data: fixture_file_upload('spec/fixtures/files/saml_responses/loa1.xml', 'application/xml') } }
+                       { file_data: fixture_file_upload('spec/fixtures/files/saml_responses/loa1.xml',
+                                                        'application/xml') } }
         expect(response).to have_http_status(:unprocessable_entity)
         err = JSON.parse(response.body)['errors'][0]
         expect(err['title']).to eq 'Unprocessable Entity'
         expect(err['detail']).to eq(
-          'You can’t upload "xml" files. The allowed file types are: pdf, gif, png, tiff, tif, jpeg, jpg, bmp, txt'
-          )
+          'You can’t upload "xml" files. The allowed file types are: pdf'
+        )
       end
     end
 


### PR DESCRIPTION
Allow only some file types for NOD supporting evidence uploads
## Original issue(s)
department-of-veterans-affairs/va.gov-team#24632
