### PR TITLE
[18741] removes sec_id_mpi method

### DIFF
--- a/app/models/gi_bill_feedback.rb
+++ b/app/models/gi_bill_feedback.rb
@@ -31,7 +31,7 @@ class GIBillFeedback < Common::RedisStore
       profile_data = {
         'active_ICN' => user.icn,
         'historical_ICN' => user.historical_icns,
-        'sec_ID' => user.sec_id_mpi
+        'sec_ID' => user.sec_id
       }
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -218,10 +218,6 @@ class User < Common::RedisStore
     mpi_profile&.normalized_suffix
   end
 
-  def sec_id_mpi
-    mpi_profile&.sec_id
-  end
-
   def ssn_mpi
     mpi_profile&.ssn
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -438,10 +438,6 @@ RSpec.describe User, type: :model do
           expect(user.active_mhv_ids).to be(mvi_profile.active_mhv_ids)
         end
 
-        it 'fetches sec_id from MPI' do
-          expect(user.sec_id_mpi).to be(mvi_profile.sec_id)
-        end
-
         it 'fetches suffix from MPI' do
           expect(user.suffix).to be(mvi_profile.suffix)
         end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Further cleanup/consolidation of User MPI getter methods, this change removes the `sec_id_mpi` method and replaces the one place that is called in the vets-api codebase with a `sec_id` call.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18741

## Things to know about this PR
Functionality should not change, unit tests updated to remove `sec_id_mpi` test.
