### PR TITLE
bump factory_bot_rails to the latest minor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,10 +350,10 @@ GEM
       tzinfo
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    factory_bot (6.1.0)
+    factory_bot (6.2.0)
       activesupport (>= 5.0.0)
-    factory_bot_rails (6.1.0)
-      factory_bot (~> 6.1.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
     faker (2.17.0)
       i18n (>= 1.6, < 2)


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the factory_bot_rails gem (dev/test group) to the latest minor version. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

https://github.com/thoughtbot/factory_bot_rails/blob/master/NEWS.md

## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 