### PR TITLE
bump parallel_tests to lastest minor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -614,7 +614,7 @@ GEM
       activerecord (>= 5.2)
       request_store (~> 1.1)
     parallel (1.20.1)
-    parallel_tests (3.6.0)
+    parallel_tests (3.7.0)
       parallel
     parser (3.0.1.1)
       ast (~> 2.4.1)


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the parallel_tests gem (dev/test group) to the latest minor version. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

https://github.com/grosser/parallel_tests/blob/master/CHANGELOG.md

## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 