### PR TITLE
bump bootsnap to latest patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       i18n
     benchmark-ips (2.8.4)
     bindex (0.8.1)
-    bootsnap (1.7.3)
+    bootsnap (1.7.5)
       msgpack (~> 1.0)
     brakeman (5.0.1)
     breakers (0.4.0)


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the bootsnap gem (dev/test group) to the latest patch version. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

https://github.com/Shopify/bootsnap/blob/master/CHANGELOG.md

## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 