### PR TITLE
bump super_diff to latest minor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -884,7 +884,7 @@ GEM
     statsd-instrument (2.6.0)
     strong_migrations (0.7.6)
       activerecord (>= 5)
-    super_diff (0.6.1)
+    super_diff (0.7.0)
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the super_diff gem (test group) to the latest minor version. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

https://github.com/mcmire/super_diff/blob/master/CHANGELOG.md

## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 