### PR TITLE
add deprecation ability

### DIFF
--- a/modules/appeals_api/app/controllers/concerns/appeals_api/header_modification.rb
+++ b/modules/appeals_api/app/controllers/concerns/appeals_api/header_modification.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  module HeaderModification
+    extend ActiveSupport::Concern
+
+    included do
+      V1_DEV_DOCS = 'https://developer.va.gov/explore/appeals/docs/decision_reviews?version=1.0.0'
+      V2_DEV_DOCS = 'https://developer.va.gov/explore/appeals/docs/decision_reviews?version=2.0.0'
+
+      def deprecate(response:, link: nil)
+        response.headers['Deprecation'] = 'true'
+        response.headers['Link'] = link if link.present?
+      end
+    end
+  end
+end

--- a/modules/appeals_api/spec/controllers/concerns/appeals_api/header_modification_spec.rb
+++ b/modules/appeals_api/spec/controllers/concerns/appeals_api/header_modification_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require 'rails_helper'

--- a/modules/appeals_api/spec/controllers/concerns/appeals_api/header_modification_spec.rb
+++ b/modules/appeals_api/spec/controllers/concerns/appeals_api/header_modification_spec.rb
@@ -1,0 +1,46 @@
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class FakeController < ApplicationController
+  include AppealsApi::HeaderModification
+end
+
+describe FakeController do
+  context "adding a 'Deprecation' header to the response" do
+    context "when a 'Response' object is not provided" do
+      it "An 'ArgumentError' is raised" do
+        expect { subject.deprecate }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when a 'Response' object is provided" do
+      it "adds a 'Deprecation' header to the response" do
+        response = ActionDispatch::Response.new
+        subject.deprecate(response: response)
+        expect(response.headers).to have_key('Deprecation')
+        expect(response.headers['Deprecation']).to eq('true')
+      end
+    end
+  end
+
+  context "adding a 'Link' header to the response" do
+    context "when a 'Link' is not provided" do
+      it "A 'Link' header is not added to the response" do
+        response = ActionDispatch::Response.new
+        subject.deprecate(response: response)
+        expect(response.headers).not_to have_key('Link')
+      end
+    end
+
+    context "when a 'Link' is provided" do
+      it "A 'Link' header is added to the response" do
+        response = ActionDispatch::Response.new
+        subject.deprecate(response: response, link: 'Hello World')
+        expect(response.headers).to have_key('Link')
+        expect(response.headers['Link']).to eq('Hello World')
+      end
+    end
+  end
+end


### PR DESCRIPTION
[API-7102](https://vajira.max.gov/browse/API-7102)

This PR adds a concern to allow us to deprecate routes in the AppealsApi namespace.