### PR TITLE
Api 4821/error types for hlr v2

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -17,9 +17,10 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
   MODEL_ERROR_STATUS = 422
   HEADERS = JSON.parse(
     File.read(
-      AppealsApi::Engine.root.join('config/schemas/v1/200996_headers.json')
+      AppealsApi::Engine.root.join('config/schemas/v2/200996_headers.json')
     )
   )['definitions']['hlrCreateParameters']['properties'].keys
+  SCHEMA_ERROR_TYPE = Common::Exceptions::DetailedSchemaErrors
 
   def create
     @higher_level_review.save
@@ -33,7 +34,10 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
 
   def schema
     render json: AppealsApi::JsonSchemaToSwaggerConverter.remove_comments(
-      AppealsApi::FormSchemas.new.schema(self.class::FORM_NUMBER)
+      AppealsApi::FormSchemas.new(
+        SCHEMA_ERROR_TYPE,
+        schema_version: 'v2'
+      ).schema(self.class::FORM_NUMBER)
     )
   end
 
@@ -52,11 +56,17 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
   end
 
   def validate_json_schema_for_headers
-    AppealsApi::FormSchemas.new.validate!("#{self.class::FORM_NUMBER}_HEADERS", headers)
+    AppealsApi::FormSchemas.new(
+      SCHEMA_ERROR_TYPE,
+      schema_version: 'v2'
+    ).validate!("#{self.class::FORM_NUMBER}_HEADERS", headers)
   end
 
   def validate_json_schema_for_body
-    AppealsApi::FormSchemas.new.validate!(self.class::FORM_NUMBER, @json_body)
+    AppealsApi::FormSchemas.new(
+      SCHEMA_ERROR_TYPE,
+      schema_version: 'v2'
+    ).validate!(self.class::FORM_NUMBER, @json_body)
   end
 
   def validation_success

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -23,7 +23,7 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
 
   def create
     @higher_level_review.save
-    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, version: 'V2')
+    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, 'V2')
     render_higher_level_review
   end
 

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -17,13 +17,13 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
   MODEL_ERROR_STATUS = 422
   HEADERS = JSON.parse(
     File.read(
-      AppealsApi::Engine.root.join('config/schemas/v1/200996_headers.json')
+      AppealsApi::Engine.root.join('config/schemas/v2/200996_headers.json')
     )
   )['definitions']['hlrCreateParameters']['properties'].keys
 
   def create
     @higher_level_review.save
-    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, 'V1')
+    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, version: 'V2')
     render_higher_level_review
   end
 

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -17,13 +17,13 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
   MODEL_ERROR_STATUS = 422
   HEADERS = JSON.parse(
     File.read(
-      AppealsApi::Engine.root.join('config/schemas/v2/200996_headers.json')
+      AppealsApi::Engine.root.join('config/schemas/v1/200996_headers.json')
     )
   )['definitions']['hlrCreateParameters']['properties'].keys
 
   def create
     @higher_level_review.save
-    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, 'V2')
+    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, 'V1')
     render_higher_level_review
   end
 

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -24,7 +24,7 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
 
   def create
     @higher_level_review.save
-    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, 'V1')
+    AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id, 'V2')
     render_higher_level_review
   end
 


### PR DESCRIPTION
[API-4821](https://vajira.max.gov/browse/API-4821)

This PR updates the HLR v2 controller to read in the v2 schema, as well as updates the error types to use the new DetailedSchemaError class

Note: This PR is dependent on [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/6875)