### PR TITLE
Enable Form 10-10cg Attachments Route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,7 @@ Rails.application.routes.draw do
     post 'caregivers_assistance_claims/download_pdf', to: 'caregivers_assistance_claims#download_pdf'
 
     namespace :form1010cg do
-      resources :attachments, only: :create unless Settings.vsp_environment == 'production'
+      resources :attachments, only: :create
     end
 
     resources :dependents_applications, only: %i[create show] do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Enable form 10-10cg attachment route in production.

## Original issue(s)
- Epic [#18347](https://app.zenhub.com/workspaces/vsa---caregiver-5fff0cfd1462b6000e320fc7/issues/department-of-veterans-affairs/va.gov-team/18347
)

## Things to know about this PR
- Security review: https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/260
