### PR TITLE
update SSOe SLO logout url

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,7 +25,7 @@ saml_ssoe:
   key_path: ~
   issuer: https://ssoe-sp-localhost.va.gov
   callback_url: http://localhost:3000/v1/sessions/callback
-  logout_url: https://int.eauth.va.gov/pkmslogout?filename=vagov-logout.html
+  logout_url: https://int.eauth.va.gov/slo/globallogout?appKey=https%253A%252F%252Fssoe-sp-dev.va.gov
   request_signing: false
   response_signing: false
   response_encryption: false

--- a/spec/controllers/v0/sessions_controller_spec.rb
+++ b/spec/controllers/v0/sessions_controller_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           it 'redirects' do
             get(:new, params: { type: :slo })
             expect(get(:new, params: { type: :slo }))
-              .to redirect_to('https://int.eauth.va.gov/pkmslogout?filename=vagov-logout.html')
+              .to redirect_to('https://int.eauth.va.gov/slo/globallogout?appKey=https%253A%252F%252Fssoe-sp-dev.va.gov')
           end
         end
       end
@@ -224,7 +224,7 @@ RSpec.describe V0::SessionsController, type: :controller do
           expect(cookies['vagov_session_dev']).not_to be_nil
           get(:new, params: { type: 'slo' })
           expect(response.location)
-            .to eq('https://int.eauth.va.gov/pkmslogout?filename=vagov-logout.html')
+            .to eq('https://int.eauth.va.gov/slo/globallogout?appKey=https%253A%252F%252Fssoe-sp-dev.va.gov')
 
           # these should be destroyed.
           expect(Session.find(token)).to be_nil

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe V1::SessionsController, type: :controller do
         context 'routes /v1/sessions/slo/new to SessionController#new' do
           it 'redirects' do
             expect(get(:new, params: { type: :slo }))
-              .to redirect_to('https://int.eauth.va.gov/pkmslogout?filename=vagov-logout.html')
+              .to redirect_to('https://int.eauth.va.gov/slo/globallogout?appKey=https%253A%252F%252Fssoe-sp-dev.va.gov')
           end
         end
       end
@@ -365,7 +365,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           expect(cookies['vagov_session_dev']).not_to be_nil
           get(:new, params: { type: 'slo' })
           expect(response.location)
-            .to eq('https://int.eauth.va.gov/pkmslogout?filename=vagov-logout.html')
+            .to eq('https://int.eauth.va.gov/slo/globallogout?appKey=https%253A%252F%252Fssoe-sp-dev.va.gov')
 
           # these should be destroyed.
           expect(Session.find(token)).to be_nil


### PR DESCRIPTION
## Description of change

Update SSOe logout URL by request of IAM.

## Original issue(s)

https://app.zenhub.com/workspaces/vsp-identity-5f5bab705a94c9001ba33734/issues/department-of-veterans-affairs/va.gov-team/20014

## Things to know about this PR

This change was requested by IAM. 