### PR TITLE
Decode HTML entities coming back from MHV on subject and body

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -71,7 +71,7 @@ class Message < Common::Base
 
   alias attachment? attachment
 
-  def initialize(attributes)
+  def initialize(attributes = {})
     super(attributes)
     self.subject = subject ? Nokogiri::HTML.parse(subject) : nil
     self.body = body ? Nokogiri::HTML.parse(body) : nil

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -71,6 +71,12 @@ class Message < Common::Base
 
   alias attachment? attachment
 
+  def initialize(attributes)
+    super(attributes)
+    self.subject = subject ? Nokogiri::HTML.parse(subject) : nil
+    self.body = body ? Nokogiri::HTML.parse(body) : nil
+  end
+
   ##
   # @note Default sort should be sent date in descending order
   #

--- a/spec/lib/sm/client/messages_spec.rb
+++ b/spec/lib/sm/client/messages_spec.rb
@@ -40,7 +40,7 @@ describe 'sm client' do
     it 'gets a message with id', :vcr do
       message = client.get_message(existing_message_id)
       expect(message.attributes[:id]).to eq(existing_message_id)
-      expect(message.attributes[:subject].strip).to eq('Release 16.2- SM last login')
+      expect(message.attributes[:subject].strip).to eq('Quote test: “test”')
     end
 
     it 'gets a message thread', :vcr do

--- a/spec/request/messages_request_spec.rb
+++ b/spec/request/messages_request_spec.rb
@@ -76,6 +76,9 @@ RSpec.describe 'Messages Integration', type: :request do
 
       expect(response).to be_successful
       expect(response.body).to be_a(String)
+      # It should decode html entities
+      expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('Quote test: “test”')
+      expect(JSON.parse(response.body)['data']['attributes']['body']).to eq("Einstein once said: “Profound quote contents here”. \n\nThat was supposed to show a regular quote but it didn’t display like it did in the compose form.\n\nLet’s try out more symbols here:\n\nSingle quote: ‘ contents’\nQuestion mark: ?\nColon: :\nDash: -\nLess than: <\nGreat then: >\nEquals: =\nAsterisk: *\nAnd symbol: &\nDollar symbol: $\nDivide symbol: %\nAt symbol: @\nParentheses: ( contents )\nBrackets: [ contents ]\nCurly braces: { contents }\nSemicolon: ;\nSlash: /\nPlus: +\nUp symbol: ^\nPound key: #\nExclamation: !")
       expect(response).to match_response_schema('message')
     end
 

--- a/spec/request/messages_request_spec.rb
+++ b/spec/request/messages_request_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Messages Integration', type: :request do
       # It should decode html entities
       expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('Quote test: “test”')
       # rubocop:disable Layout/LineLength
-      expect(JSON.parse(response.body)['data']['attributes']['body']).to eq(%q{Einstein once said: “Profound quote contents here”. \n\nThat was supposed to show a regular quote but it didn’t display like it did in the compose form.\n\nLet’s try out more symbols here:\n\nSingle quote: ‘ contents’\nQuestion mark: ?\nColon: :\nDash: -\nLess than: <\nGreat then: >\nEquals: =\nAsterisk: *\nAnd symbol: &\nDollar symbol: $\nDivide symbol: %\nAt symbol: @\nParentheses: ( contents )\nBrackets: [ contents ]\nCurly braces: { contents }\nSemicolon: ;\nSlash: /\nPlus: +\nUp symbol: ^\nPound key: #\nExclamation: !})
+      expect(JSON.parse(response.body)['data']['attributes']['body']).to eq("Einstein once said: “Profound quote contents here”. \n\nThat was supposed to show a regular quote but it didn’t display like it did in the compose form.\n\nLet’s try out more symbols here:\n\nSingle quote: ‘ contents’\nQuestion mark: ?\nColon: :\nDash: -\nLess than: <\nGreat then: >\nEquals: =\nAsterisk: *\nAnd symbol: &\nDollar symbol: $\nDivide symbol: %\nAt symbol: @\nParentheses: ( contents )\nBrackets: [ contents ]\nCurly braces: { contents }\nSemicolon: ;\nSlash: /\nPlus: +\nUp symbol: ^\nPound key: #\nExclamation: !")
       # rubocop:enable Layout/LineLength
       expect(response).to match_response_schema('message')
     end

--- a/spec/request/messages_request_spec.rb
+++ b/spec/request/messages_request_spec.rb
@@ -78,7 +78,9 @@ RSpec.describe 'Messages Integration', type: :request do
       expect(response.body).to be_a(String)
       # It should decode html entities
       expect(JSON.parse(response.body)['data']['attributes']['subject']).to eq('Quote test: “test”')
-      expect(JSON.parse(response.body)['data']['attributes']['body']).to eq("Einstein once said: “Profound quote contents here”. \n\nThat was supposed to show a regular quote but it didn’t display like it did in the compose form.\n\nLet’s try out more symbols here:\n\nSingle quote: ‘ contents’\nQuestion mark: ?\nColon: :\nDash: -\nLess than: <\nGreat then: >\nEquals: =\nAsterisk: *\nAnd symbol: &\nDollar symbol: $\nDivide symbol: %\nAt symbol: @\nParentheses: ( contents )\nBrackets: [ contents ]\nCurly braces: { contents }\nSemicolon: ;\nSlash: /\nPlus: +\nUp symbol: ^\nPound key: #\nExclamation: !")
+      # rubocop:disable Layout/LineLength
+      expect(JSON.parse(response.body)['data']['attributes']['body']).to eq(%q{Einstein once said: “Profound quote contents here”. \n\nThat was supposed to show a regular quote but it didn’t display like it did in the compose form.\n\nLet’s try out more symbols here:\n\nSingle quote: ‘ contents’\nQuestion mark: ?\nColon: :\nDash: -\nLess than: <\nGreat then: >\nEquals: =\nAsterisk: *\nAnd symbol: &\nDollar symbol: $\nDivide symbol: %\nAt symbol: @\nParentheses: ( contents )\nBrackets: [ contents ]\nCurly braces: { contents }\nSemicolon: ;\nSlash: /\nPlus: +\nUp symbol: ^\nPound key: #\nExclamation: !})
+      # rubocop:enable Layout/LineLength
       expect(response).to match_response_schema('message')
     end
 

--- a/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_with_id.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_with_id.yml
@@ -33,8 +33,7 @@ http_interactions:
       - Tue, 31 Jan 2017 21:30:45 GMT
     body:
       encoding: UTF-8
-      string: '{"id":573059,"category":"OTHER","subject":"Release 16.2- SM last login
-        ","body":"Patient reply again","attachment":false,"attachments":{"attachment":[]},"sentDate":"Mon,
+      string: '{"id":573059,"category":"OTHER","subject":"Quote test: &ldquo;test&rdquo;","body":"Einstein once said: &ldquo;Profound quote contents here&rdquo;. \n\nThat was supposed to show a regular quote but it didn&rsquo;t display like it did in the compose form.\n\nLet&rsquo;s try out more symbols here:\n\nSingle quote: &lsquo; contents&rsquo;\nQuestion mark: ?\nColon: :\nDash: -\nLess than: &lt;\nGreat then: &gt;\nEquals: =\nAsterisk: *\nAnd symbol: &amp;\nDollar symbol: $\nDivide symbol: %\nAt symbol: @\nParentheses: ( contents )\nBrackets: [ contents ]\nCurly braces: { contents }\nSemicolon: ;\nSlash: /\nPlus: +\nUp symbol: ^\nPound key: #\nExclamation: !","attachment":false,"attachments":{"attachment":[]},"sentDate":"Mon,
         11 Apr 2016 15:49:39 GMT","senderId":384939,"senderName":"MVIONE, TEST","recipientId":345468,"recipientName":"WORKLOAD
         CAPTURE_Mohammad","readReceipt":"READ"}'
     http_version: 


### PR DESCRIPTION
## Description of change
The MHV Secure Messaging API is returning message titles and subjects with HTML entities for certain symbols such as:
* Double quotes: `&ldquo;`
* Single quotes: `&lsquo;`
* Less than: `&lt;`
* Greater than: `&gt;`
* Ampersands: `&amp;`

This PR uses Nokogiri to parse a message's subject and body upon Message initialization.

For example: `"Subject &ldquo;Test&rdquo;"` is transformed to `Subject: “Test”`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#24625
