### PR TITLE
update nokogiri to address CVE's

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -556,7 +556,7 @@ GEM
     netrc (0.11.0)
     nio4r (2.5.7)
     no_proxy_fix (0.1.2)
-    nokogiri (1.11.3)
+    nokogiri (1.11.4)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     nori (2.6.0)


### PR DESCRIPTION
## Description of change

1.11.4 / 2021-05-14¶
Security¶
[CRuby] Vendored libxml2 upgraded to v2.9.12 which addresses:

CVE-2019-20388
CVE-2020-24977
CVE-2021-3517
CVE-2021-3518
CVE-2021-3537
CVE-2021-3541
Note that two additional CVEs were addressed upstream but are not relevant to this release. CVE-2021-3516 via xmllint is not present in Nokogiri, and CVE-2020-7595 has been patched in Nokogiri since v1.10.8 (see #1992).

Please see nokogiri/GHSA-7rrm-v45f-jp64 or #2233 for a more complete analysis of these CVEs and patches.

Dependencies¶
[CRuby] vendored libxml2 is updated from 2.9.10 to 2.9.12. (Note that 2.9.11 was skipped because it was superseded by 2.9.12 a few hours after its release.)


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
