### PR TITLE
Supporting Evidence Attachment Fix

### DIFF
--- a/app/workers/vbms/submit_dependents_pdf_job.rb
+++ b/app/workers/vbms/submit_dependents_pdf_job.rb
@@ -13,9 +13,10 @@ module VBMS
 
       raise Invalid686cClaim unless claim.valid?(:run_686_form_jobs)
 
-      url_prefix = Rails.env.production? ? '' : 'tmp'
       claim.persistent_attachments.each do |attachment|
-        claim.upload_to_vbms(path: url_prefix + attachment.file_url)
+        file_name = File.basename(attachment.file.url)
+        file_path = Common::FileHelpers.generate_temp_file(attachment.file.read, file_name)
+        claim.upload_to_vbms(path: file_path)
       end
 
       generate_pdf(claim, submittable_686, submittable_674)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
When submitting a dependency application (VA Form 21-686c) the user is able to attach additional documents as supporting evidence (marriage certificate, adoption decree, etc).  During integration testing, we noticed an error when uploading the supporting evidence attachments to VBMS.  This PR implements a fix which first generates a local temp file and then uploads that file to VBMS.  

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22758

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is a minor fix so no new logging or settings have been added.
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] Local testing
- [x] Staging testing planned
- [x] Partner integration testing planned