### PR TITLE
[API-7226] - Adds 404 logic to ClaimsApi veteran id endpoint prototype

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veteran_identifier_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veteran_identifier_controller.rb
@@ -14,8 +14,9 @@ module ClaimsApi
         raise ::Common::Exceptions::Unauthorized if request.headers['Authorization'].blank?
 
         validate_request
+        veteran = find_veteran(params)
 
-        render json: { id: ICN_FOR_TEST_USER }
+        render json: { id: veteran[:id] }
       end
 
       private
@@ -43,6 +44,34 @@ module ClaimsApi
         raise ::Common::Exceptions::InvalidFieldValue.new('birthdate', date_str)
       rescue ArgumentError
         raise ::Common::Exceptions::InvalidFieldValue.new('birthdate', date_str)
+      end
+
+      def find_veteran(params)
+        test_veteran_data = {
+          id: ICN_FOR_TEST_USER,
+          ssn: '796130115',
+          firstName: 'Tamara',
+          lastName: 'Ellis',
+          birthdate: '1967-06-19'
+        }
+
+        unless params[:ssn] == test_veteran_data[:ssn]
+          raise ::Common::Exceptions::ResourceNotFound.new(detail: 'Resource not found')
+        end
+
+        unless params[:firstName].casecmp?(test_veteran_data[:firstName])
+          raise ::Common::Exceptions::ResourceNotFound.new(detail: 'Resource not found')
+        end
+
+        unless params[:lastName].casecmp?(test_veteran_data[:lastName])
+          raise ::Common::Exceptions::ResourceNotFound.new(detail: 'Resource not found')
+        end
+
+        unless params[:birthdate] == test_veteran_data[:birthdate]
+          raise ::Common::Exceptions::ResourceNotFound.new(detail: 'Resource not found')
+        end
+
+        test_veteran_data
       end
     end
   end

--- a/modules/claims_api/app/swagger/claims_api/v2/veteran_identifier_controller_swagger.rb
+++ b/modules/claims_api/app/swagger/claims_api/v2/veteran_identifier_controller_swagger.rb
@@ -131,6 +131,42 @@ module ClaimsApi
               end
             end
           end
+
+          response 404 do
+            key :description, 'Resource not found'
+            content 'application/json' do
+              schema do
+                key :type, :object
+                key :required, [:errors]
+                property :errors do
+                  key :type, :array
+                  items do
+                    property :title do
+                      key :type, :string
+                      key :example, 'Resource not found'
+                    end
+
+                    property :detail do
+                      key :type, :string
+                      key :example, 'Resource not found'
+                      key :description, 'HTTP error detail'
+                    end
+
+                    property :code do
+                      key :type, :string
+                      key :example, '404'
+                    end
+
+                    property :status do
+                      key :type, :string
+                      key :example, '404'
+                      key :description, 'HTTP error code'
+                    end
+                  end
+                end
+              end
+            end
+          end
         end
       end
     end

--- a/modules/claims_api/spec/requests/v2/veteran_identifier_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veteran_identifier_request_spec.rb
@@ -16,11 +16,42 @@ RSpec.describe 'Veteran Identifier Endpoint', type: :request do
 
   describe 'Veteran Identifier' do
     context 'when auth header and body params are present' do
-      it 'returns an id' do
-        post path, params: data, headers: headers
-        icn = JSON.parse(response.body)['id']
-        expect(icn).to eq(ClaimsApi::V2::VeteranIdentifierController::ICN_FOR_TEST_USER)
-        expect(response.status).to eq(200)
+      context 'when body params match exactly' do
+        it 'returns an id' do
+          post path, params: data, headers: headers
+          icn = JSON.parse(response.body)['id']
+
+          expect(icn).to eq(ClaimsApi::V2::VeteranIdentifierController::ICN_FOR_TEST_USER)
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context 'when body params do not match exactly' do
+        context 'when first name is mixed-case' do
+          it 'returns an id' do
+            valid_data = data
+            valid_data[:firstName] = 'TaMAra'
+
+            post path, params: valid_data, headers: headers
+            icn = JSON.parse(response.body)['id']
+
+            expect(icn).to eq(ClaimsApi::V2::VeteranIdentifierController::ICN_FOR_TEST_USER)
+            expect(response.status).to eq(200)
+          end
+        end
+
+        context 'when last name is mixed-case' do
+          it 'returns an id' do
+            valid_data = data
+            valid_data[:lastName] = 'eLLiS'
+
+            post path, params: valid_data, headers: headers
+            icn = JSON.parse(response.body)['id']
+
+            expect(icn).to eq(ClaimsApi::V2::VeteranIdentifierController::ICN_FOR_TEST_USER)
+            expect(response.status).to eq(200)
+          end
+        end
       end
     end
 
@@ -39,6 +70,48 @@ RSpec.describe 'Veteran Identifier Endpoint', type: :request do
       it 'returns a 401 error code' do
         post path, params: data
         expect(response.status).to eq(401)
+      end
+    end
+
+    context 'when veteran cannot be found' do
+      context 'when ssn does not match' do
+        it 'returns a 404' do
+          invalid_data = data
+          invalid_data[:ssn] = '123456789'
+
+          post path, params: invalid_data, headers: headers
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context 'when first name does not match' do
+        it 'returns a 404' do
+          invalid_data = data
+          invalid_data[:firstName] = 'Random'
+
+          post path, params: invalid_data, headers: headers
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context 'when last name does not match' do
+        it 'returns a 404' do
+          invalid_data = data
+          invalid_data[:lastName] = 'Person'
+
+          post path, params: invalid_data, headers: headers
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context 'when birthdate does not match' do
+        it 'returns a 404' do
+          invalid_data = data
+          invalid_data[:birthdate] = '1970-01-01'
+
+          post path, params: invalid_data, headers: headers
+          expect(response.status).to eq(404)
+        end
       end
     end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Adds logic to the new `ClaimsApi` V2 veteran-id endpoint to return a 404 if the received data does not match the test veteran's data.

## Original issue(s)
[API-7226](https://vajira.max.gov/browse/API-7226)