### PR TITLE
[DRAFT/WIP] Add Additional Email Recipients to 686 Failure Email

### DIFF
--- a/app/mailers/dependents_application_failure_mailer.rb
+++ b/app/mailers/dependents_application_failure_mailer.rb
@@ -2,12 +2,21 @@
 
 class DependentsApplicationFailureMailer < ApplicationMailer
   def build(user)
+    opt = {}
+
+    opt[:to] = [
+      user.email,
+      'Jason.Wolf@va.gov',
+      'Kathleen.Crawford@va.gov'
+    ]
+
     template = File.read('app/mailers/views/dependents_application_failure.erb')
 
     mail(
-      to: user.email,
-      subject: t('dependency_claim_failure_mailer.subject'),
-      body: ERB.new(template).result(binding)
+      opt.merge(
+        subject: t('dependency_claim_failure_mailer.subject'),
+        body: ERB.new(template).result(binding)
+      )
     )
   end
 end

--- a/spec/mailers/dependents_application_failure_mailer_spec.rb
+++ b/spec/mailers/dependents_application_failure_mailer_spec.rb
@@ -5,13 +5,14 @@ require 'rails_helper'
 RSpec.describe DependentsApplicationFailureMailer, type: [:mailer] do
   include ActionView::Helpers::TranslationHelper
   let(:user) { FactoryBot.create(:evss_user, :loa3) }
+  let(:recipients) { [user.email, 'Jason.Wolf@va.gov', 'Kathleen.Crawford@va.gov'] }
 
   describe '#build' do
     it 'includes all info' do
       mailer = described_class.build(user).deliver_now
 
       expect(mailer.subject).to eq(t('dependency_claim_failure_mailer.subject'))
-      expect(mailer.to).to eq([user.email])
+      expect(mailer.to).to eq(recipients)
       expect(mailer.body.raw_source).to include(
         "Dear #{user.first_name} #{user.last_name}",
         "We're sorry. Something went wrong when we tried to submit your application to add or remove a dependent"


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
