### PR TITLE
API-7289 - Swagger updates

### DIFF
--- a/modules/appeals_api/app/swagger/appeals_api/v1/notice_of_disagreements_controller_swagger.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/notice_of_disagreements_controller_swagger.rb
@@ -695,10 +695,6 @@ class AppealsApi::V1::NoticeOfDisagreementsControllerSwagger
           end
         end
       end
-
-      security do
-        key :apikey, []
-      end
     end
   end
 

--- a/modules/appeals_api/app/swagger/appeals_api/v1/swagger_root.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/swagger_root.rb
@@ -31,11 +31,5 @@ module AppealsApi::V1::SwaggerRoot
     key :basePath, '/services/appeals/v1'
     key :consumes, ['application/json']
     key :produces, ['application/json']
-
-    security do
-      key :type, :apiKey
-      key :name, :apiKey
-      key :in, :header
-    end
   end
 end

--- a/modules/appeals_api/app/swagger/appeals_api/v2/swagger_root.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v2/swagger_root.rb
@@ -28,11 +28,5 @@ module AppealsApi::V2::SwaggerRoot
     key :basePath, '/services/appeals/v2'
     key :consumes, ['application/json']
     key :produces, ['application/json']
-
-    security do
-      key :type, :apikey
-      key :name, :apikey
-      key :in, :header
-    end
   end
 end


### PR DESCRIPTION
## Description of change
This PR makes it possible to remove the security block from a given endpoint and that makes the endpoint show up without an API key field on the front end. This is useful for the S3 endpoint (evidence submission upload) that doesn't use an API key.

## Original issue(s)
https://vajira.max.gov/browse/API-7289