### PR TITLE
bump fhir_client to latest patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,7 +373,7 @@ GEM
       activesupport (>= 4.2)
     fastimage (2.2.3)
     ffi (1.14.2)
-    fhir_client (4.0.5)
+    fhir_client (4.0.6)
       activesupport (>= 3)
       addressable (>= 2.3)
       fhir_dstu2_models (>= 1.0.10)


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the fhir_client gem (default group) to the latest patch version. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 