### PR TITLE
Converting the type parameter to separate Routes

### DIFF
--- a/modules/facilities_api/app/controllers/facilities_api/v1/ccp_controller.rb
+++ b/modules/facilities_api/app/controllers/facilities_api/v1/ccp_controller.rb
@@ -8,9 +8,31 @@ module FacilitiesApi
     # @param bbox - Bounding box in form "xmin,ymin,xmax,ymax" in Lat/Long coordinates
     # @param services - Optional specialty services filter
     def index
-      api_results = index_api_results
+      api_results = ppms_search
 
       render_json(V1::PPMS::ProviderSerializer, ppms_params, api_results)
+    end
+
+    def urgent_care
+      api_results = api.pos_locator(ppms_action_params)
+
+      render_json(V1::PPMS::ProviderSerializer, ppms_action_params, api_results)
+    end
+
+    def provider
+      api_results = if provider_urgent_care?
+                      api.pos_locator(ppms_action_params)
+                    else
+                      api.provider_locator(ppms_provider_params)
+                    end
+
+      render_json(V1::PPMS::ProviderSerializer, ppms_action_params, api_results)
+    end
+
+    def pharmacy
+      api_results = api.provider_locator(ppms_action_params.merge(specialties: ['3336C0003X']))
+
+      render_json(V1::PPMS::ProviderSerializer, ppms_action_params, api_results)
     end
 
     def specialties
@@ -24,10 +46,6 @@ module FacilitiesApi
     end
 
     private
-
-    def index_api_results
-      ppms_search
-    end
 
     def api
       @api ||= FacilitiesApi::V1::PPMS::Client.new
@@ -48,8 +66,20 @@ module FacilitiesApi
       )
     end
 
+    def ppms_action_params
+      params.permit(
+        :address,
+        :latitude,
+        :longitude,
+        :page,
+        :per_page,
+        :radius,
+        bbox: [],
+        specialties: []
+      )
+    end
+
     def ppms_provider_params
-      params.require(:type)
       params.require(:specialties)
       params.permit(
         :address,
@@ -75,11 +105,11 @@ module FacilitiesApi
     end
 
     def urgent_care?
-      provider_urgent_care? || ppms_params[:type] == 'urgent_care'
+      (ppms_params[:type] == 'provider' && provider_urgent_care?) || ppms_params[:type] == 'urgent_care'
     end
 
     def provider_urgent_care?
-      ppms_params[:type] == 'provider' && ppms_params[:specialties] == ['261QU0200X']
+      ppms_provider_params[:specialties] == ['261QU0200X']
     end
 
     def resource_path(options)

--- a/modules/facilities_api/config/routes.rb
+++ b/modules/facilities_api/config/routes.rb
@@ -3,7 +3,12 @@
 FacilitiesApi::Engine.routes.draw do
   namespace :v1, defaults: { format: 'json' } do
     resources :ccp, only: :index do
-      get 'specialties', on: :collection, to: 'ccp#specialties'
+      collection do
+        get 'urgent_care',  to: 'ccp#urgent_care'
+        get 'provider',     to: 'ccp#provider'
+        get 'pharmacy',     to: 'ccp#pharmacy'
+        get 'specialties',  to: 'ccp#specialties'
+      end
     end
     resources :va, only: %i[index show]
   end

--- a/modules/facilities_api/spec/requests/facilities_api/v1/ccp_request_spec.rb
+++ b/modules/facilities_api/spec/requests/facilities_api/v1/ccp_request_spec.rb
@@ -9,6 +9,10 @@ vcr_options = {
 }
 
 RSpec.describe 'FacilitiesApi::V1::Ccp', type: :request, team: :facilities, vcr: vcr_options do
+  before(:all) do
+    get facilities_api.v1_ccp_index_url
+  end
+
   let(:sha256) { 'bd2b84cc5c0aa3676090eacde32e99c7d668388e5fc5440e3c582aef419fc398' }
 
   let(:params) do
@@ -323,6 +327,208 @@ RSpec.describe 'FacilitiesApi::V1::Ccp', type: :request, team: :facilities, vcr:
 
         expect(response).to be_successful
       end
+    end
+  end
+
+  describe '#provider' do
+    context 'Missing specialties param' do
+      let(:params) do
+        {
+          latitude: 40.415217,
+          longitude: -74.057114,
+          radius: 200
+        }
+      end
+
+      it 'requires a specialty code' do
+        get '/facilities_api/v1/ccp/provider', params: params
+
+        bod = JSON.parse(response.body)
+
+        expect(bod).to include(
+          'errors' => [{
+            'title' => 'Missing parameter',
+            'detail' => 'The required parameter "specialties", is missing',
+            'code' => '108',
+            'status' => '400'
+          }]
+        )
+
+        expect(response).not_to be_successful
+      end
+    end
+
+    context 'specialties=261QU0200X' do
+      let(:params) do
+        {
+          latitude: 40.415217,
+          longitude: -74.057114,
+          radius: 200,
+          specialties: ['261QU0200X']
+        }
+      end
+
+      it 'returns a results from the pos_locator' do
+        get '/facilities_api/v1/ccp/provider', params: params
+
+        bod = JSON.parse(response.body)
+
+        sha256 = 'b09211e205d103edf949d2897dcbe489fb7bc3f2c73f203022b4d7b96e603d0d'
+
+        expect(bod['data']).to include(
+          {
+            'id' => sha256,
+            'type' => 'provider',
+            'attributes' => {
+              'accNewPatients' => 'false',
+              'address' => {
+                'street' => '5024 5TH AVE',
+                'city' => 'BROOKLYN',
+                'state' => 'NY',
+                'zip' => '11220-1909'
+              },
+              'caresitePhone' => '718-571-9251',
+              'email' => nil,
+              'fax' => nil,
+              'gender' => 'NotSpecified',
+              'lat' => 40.644795,
+              'long' => -74.011055,
+              'name' => 'CITY MD URGENT CARE',
+              'phone' => nil,
+              'posCodes' => '20',
+              'prefContact' => nil,
+              'uniqueId' => '1487993564'
+            }
+          }
+        )
+        expect(response).to be_successful
+      end
+    end
+
+    it 'returns a results from the provider_locator' do
+      get '/facilities_api/v1/ccp/provider', params: params
+
+      bod = JSON.parse(response.body)
+      expect(bod['data']).to include(
+        {
+          'id' => '6d4644e7db7491635849b23e20078f74cfcd2d0aeee6a77aca921f5540d03f33',
+          'type' => 'provider',
+          'attributes' => {
+            'accNewPatients' => 'true',
+            'address' => {
+              'street' => '176 RIVERSIDE AVE',
+              'city' => 'RED BANK',
+              'state' => 'NJ',
+              'zip' => '07701-1063'
+            },
+            'caresitePhone' => '732-219-6625',
+            'email' => nil,
+            'fax' => nil,
+            'gender' => 'Female',
+            'lat' => 40.35396,
+            'long' => -74.07492,
+            'name' => 'GESUALDI, AMY',
+            'phone' => nil,
+            'posCodes' => nil,
+            'prefContact' => nil,
+            'uniqueId' => '1154383230'
+          }
+        }
+      )
+
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#pharmacy' do
+    let(:params) do
+      {
+        latitude: 40.415217,
+        longitude: -74.057114,
+        radius: 200
+      }
+    end
+
+    it 'returns results from the pos_locator' do
+      get '/facilities_api/v1/ccp/pharmacy', params: params
+
+      bod = JSON.parse(response.body)
+
+      expect(bod['data'][0]).to match(
+        {
+          'id' => '1a2ec66b370936eccc980db2fcf4b094fc61a5329aea49744d538f6a9bab2569',
+          'type' => 'provider',
+          'attributes' => {
+            'accNewPatients' => 'false',
+            'address' => {
+              'street' => '2 BAYSHORE PLZ',
+              'city' => 'ATLANTIC HIGHLANDS',
+              'state' => 'NJ',
+              'zip' => '07716'
+            },
+            'caresitePhone' => '732-291-2900',
+            'email' => nil,
+            'fax' => nil,
+            'gender' => 'NotSpecified',
+            'lat' => 40.409114,
+            'long' => -74.041849,
+            'name' => 'BAYSHORE PHARMACY',
+            'phone' => nil,
+            'posCodes' => nil,
+            'prefContact' => nil,
+            'uniqueId' => '1225028293'
+          }
+        }
+      )
+
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#urgent_care' do
+    let(:params) do
+      {
+        latitude: 40.415217,
+        longitude: -74.057114,
+        radius: 200
+      }
+    end
+
+    it 'returns results from the pos_locator' do
+      get '/facilities_api/v1/ccp/urgent_care', params: params
+
+      bod = JSON.parse(response.body)
+
+      sha256 = 'b09211e205d103edf949d2897dcbe489fb7bc3f2c73f203022b4d7b96e603d0d'
+
+      expect(bod['data']).to include(
+        {
+          'id' => sha256,
+          'type' => 'provider',
+          'attributes' => {
+            'accNewPatients' => 'false',
+            'address' => {
+              'street' => '5024 5TH AVE',
+              'city' => 'BROOKLYN',
+              'state' => 'NY',
+              'zip' => '11220-1909'
+            },
+            'caresitePhone' => '718-571-9251',
+            'email' => nil,
+            'fax' => nil,
+            'gender' => 'NotSpecified',
+            'lat' => 40.644795,
+            'long' => -74.011055,
+            'name' => 'CITY MD URGENT CARE',
+            'phone' => nil,
+            'posCodes' => '20',
+            'prefContact' => nil,
+            'uniqueId' => '1487993564'
+          }
+        }
+      )
+
+      expect(response).to be_successful
     end
   end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Converting the `type` param into separate routes.

We scrub all of the params from logs so it's difficult to tell what `type` of search we are handling.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22183

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
