### PR TITLE
Disabling cache_classes in the test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
   config.action_view.cache_template_loading = true
 
   # Do not eager load code on boot. This avoids loading your whole application


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

The current rails template disables this if we are installing spring
This will make repeated test runs faster if your using spring but should
not effect your first run

[Rails test.rb Generator](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt#L12-L17)

[Discord Thread](https://dsva.slack.com/archives/CBU0KDSB1/p1620229594363700)
