### PR TITLE
Clean up lint checks in GHA

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -35,7 +35,6 @@ jobs:
     name: Test
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
-      CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
       CI: true
       DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test?pool=4"
       DISABLE_BOOTSNAP: true
@@ -71,21 +70,14 @@ jobs:
       - name: Setup Database
         run: bundle exec parallel_test -n 14 -e 'bundle exec rake db:reset'
 
-      - name: Setup Code Climate Reporting
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter before-build
-
       - name: Run Specs
         run: bundle exec parallel_rspec spec/ modules -n 14 -o '--color --tty'
 
-      - name: Publish Code Climate coverage
-        env:
-          GIT_COMMIT_SHA: ${{ github.sha }}
-        run: |
-          export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
-          ./cc-test-reporter after-build -t simplecov
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: Coverage Report
+          path: coverage
 
       - uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -3,10 +3,11 @@ on: [push]
 jobs:
   linting_and_security:
     name: Linting and Security
+
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
-      RAILS_ENV: test
-    runs-on: ubuntu-20.04
+
+    runs-on: ubuntu-20.04 # Doesn't run on self-hosted runners as there are SSL issues within the TIC
 
     steps:
       - uses: actions/checkout@v2
@@ -14,9 +15,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-
-      - name: Install System Packages (pdftk, poppler, imagemagick)
-        run: sudo apt install imagemagick pdftk poppler-utils
 
       - name: Run bundle-audit (checks gems for CVE issues)
         run:  bundle exec bundle-audit check --update
@@ -40,41 +38,40 @@ jobs:
 
   tests:
     name: Test
-    runs-on: asg
+
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
+      CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
       CI: true
       DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test?pool=4"
       DISABLE_BOOTSNAP: true
+      NODE_EXTRA_CA_CERTS: '/etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem' # Needed for self-hosted runners
       RAILS_ENV: test
-      "Settings.test_database_url": "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test"
+      "Settings.binaries.clamdscan": "clamscan"
       "Settings.saml.cert_path": "spec/support/certificates/ruby-saml.crt"
       "Settings.saml.key_path": "spec/support/certificates/ruby-saml.key"
-      "Settings.binaries.clamdscan": "clamscan"
+      "Settings.test_database_url": "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test"
       TERM: xterm-256color
-      GIT_COMMIT_SHA: ${{ github.sha }}
-      CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
-      ImageOS: ubuntu20
-      NODE_EXTRA_CA_CERTS: '/etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem' # Needed for self-hosted runners
+
+    runs-on: asg
 
     services:
       postgres:
         image: postgis/postgis:11-2.5
         env:
-          POSTGRES_USER: vets-api
           POSTGRES_DB: vets-api_test
+          POSTGRES_USER: vets-api
           POSTGRES_PASSWORD: postgres
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 15
         ports:
           - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 15
-
-      redis:
-        image: circleci/redis:5.0-alpine
 
     steps:
       - uses: actions/checkout@v2
 
       - uses: ruby/setup-ruby@v1
+        env:
+          ImageOS: ubuntu20
         with:
           bundler-cache: true
 
@@ -91,6 +88,8 @@ jobs:
         run: bundle exec parallel_rspec spec/ modules -n 14 -o '--color --tty'
 
       - name: Publish Code Climate coverage
+        env:
+          GIT_COMMIT_SHA: ${{ github.sha }}
         run: |
           export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
           ./cc-test-reporter after-build -t simplecov
@@ -100,6 +99,6 @@ jobs:
         if: always()
         with:
           check_name: Test Results
-          comment_on_pr: false
+          comment_mode: off
           files: log/*.xml
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -71,15 +71,19 @@ jobs:
         run: bundle exec parallel_test -n 14 -e 'bundle exec rake db:reset'
 
       - name: Run Specs
-        run: bundle exec parallel_rspec spec/ modules -n 14 -o '--color --tty'
+        run: |
+          bundle exec parallel_rspec spec/ modules -n 14 -o '--color --tty'
+          sed -i 's/"line"/"covered_percent"/g' coverage/.last_run.json
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v2
         if: always()
         with:
           name: Coverage Report
           path: coverage
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v2
         if: always()
         with:
           name: Test Results
@@ -114,3 +118,12 @@ jobs:
           comment_mode: off
           files: Test Results/*.xml
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Coverage Report
+        uses: devmasx/coverage-check-action@v1.2.0
+        if: hashFiles('Coverage Report/.last_run.json') != ''
+        with:
+          type: simplecov
+          result_path: Coverage Report/.last_run.json
+          min_coverage: 90
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -71,9 +71,7 @@ jobs:
         run: bundle exec parallel_test -n 14 -e 'bundle exec rake db:reset'
 
       - name: Run Specs
-        run: |
-          bundle exec parallel_rspec spec/ modules -n 14 -o '--color --tty'
-          sed -i 's/"line"/"covered_percent"/g' coverage/.last_run.json
+        run: bundle exec parallel_rspec spec/ modules -n 14 -o '--color --tty'
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v2
@@ -118,6 +116,9 @@ jobs:
           comment_mode: off
           files: Test Results/*.xml
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fix up coverage report to work with coverage-check-action
+        run: sed -i 's/"line"/"covered_percent"/g' 'Coverage Report/.last_run.json'
 
       - name: Publish Coverage Report
         uses: devmasx/coverage-check-action@v1.2.0

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -3,12 +3,9 @@ on: [push]
 jobs:
   linting_and_security:
     name: Linting and Security
-
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
-
     runs-on: ubuntu-20.04 # Doesn't run on self-hosted runners as there are SSL issues within the TIC
-
     steps:
       - uses: actions/checkout@v2
 
@@ -25,20 +22,17 @@ jobs:
       - name: Run Brakeman
         run:  bundle exec brakeman --ensure-latest --confidence-level=2 -o brakeman.json
 
-      - uses: duderman/rubocop-annotate-action@v0.1.0
+      - uses: actions/upload-artifact@v2
+        if: always()
         with:
-          path: rubocop.json
-        if: hashFiles('rubocop.json') != ''
-
-      - uses: devmasx/brakeman-linter-action@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          REPORT_PATH: brakeman.json
-        if: hashFiles('brakeman.json') != ''
+          name: Linting and Security Results
+          path: |
+            rubocop.json
+            brakeman.json
+          if-no-files-found: ignore
 
   tests:
     name: Test
-
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
       CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
@@ -52,7 +46,6 @@ jobs:
       "Settings.saml.key_path": "spec/support/certificates/ruby-saml.key"
       "Settings.test_database_url": "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test"
       TERM: xterm-256color
-
     runs-on: asg
 
     services:
@@ -94,11 +87,38 @@ jobs:
           export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
           ./cc-test-reporter after-build -t simplecov
 
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: Test Results
+          path: log/*.xml
+          if-no-files-found: ignore
+
+  publish_results:
+    name: Publish Results
+    if: always()
+    needs: [linting_and_security, tests]
+    runs-on: ubuntu-20.04 # Doesn't run on self-hosted runners as there are SSL issues within the TIC
+
+    steps:
+      - uses: actions/download-artifact@v2
+
+      - uses: duderman/rubocop-annotate-action@v0.1.0
+        with:
+          path: Linting and Security Results/rubocop.json
+        if: hashFiles('Linting and Security Results/rubocop.json') != ''
+
+      - uses: devmasx/brakeman-linter-action@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          REPORT_PATH: Linting and Security Results/brakeman.json
+        if: hashFiles('Linting and Security/brakeman.json') != ''
+
       - name: Publish Test Results
         uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1
         if: always()
         with:
           check_name: Test Results
           comment_mode: off
-          files: log/*.xml
+          files: Test Results/*.xml
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -37,8 +37,7 @@ jobs:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
       CI: true
       DATABASE_URL: "postgis://vets-api:postgres@127.0.0.1:5432/vets_api_test?pool=4"
-      DISABLE_BOOTSNAP: true
-      NODE_EXTRA_CA_CERTS: '/etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem' # Needed for self-hosted runners
+      NODE_EXTRA_CA_CERTS: '/etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem' # Needed for self-hosted runners (setup-ruby)
       RAILS_ENV: test
       "Settings.binaries.clamdscan": "clamscan"
       "Settings.saml.cert_path": "spec/support/certificates/ruby-saml.crt"

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -50,7 +50,6 @@ jobs:
       postgres:
         image: postgis/postgis:11-2.5
         env:
-          POSTGRES_DB: vets-api_test
           POSTGRES_USER: vets-api
           POSTGRES_PASSWORD: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 15

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -3,10 +3,11 @@ on: [pull_request]
 jobs:
   danger:
     name: Danger
+
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
-      RAILS_ENV: test
       DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     runs-on: ubuntu-20.04
 
     steps:
@@ -22,8 +23,8 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile') }}
           restore-keys: |
             ${{ runner.os }}-gems-
-      
-      - name: Bundle install
+
+      - name: Bundle Install
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,6 @@ ENV RAILS_ENV=$rails_env
 # only extra dev/build opts go here, common packages go in base 👆
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     git build-essential libxml2-dev libxslt-dev libpq-dev
-RUN curl -sSL -o /usr/local/bin/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 && \
-    chmod +x /usr/local/bin/cc-test-reporter && \
-    cc-test-reporter --version
 COPY --chown=vets-api:vets-api config/freshclam.conf docker-entrypoint.sh ./
 USER vets-api
 # XXX: this is tacky

--- a/Makefile
+++ b/Makefile
@@ -129,11 +129,7 @@ server:  ## Starts the server (natively)
 
 .PHONY: spec
 spec:  ## Runs spec tests
-ifeq ($(ENV_ARG), dev)
 	@$(BASH_DEV) "bin/rspec ${SPEC_PATH}"
-else
-	@$(BASH_TEST) "bin/rails spec:with_codeclimate_coverage"
-endif
 
 .PHONY: spec_parallel_setup
 spec_parallel_setup:  ## Setup the parallel test dbs. This resets the current test db, as well as the parallel test dbs
@@ -148,9 +144,7 @@ spec_parallel:  ## Runs spec tests in parallel
 ifeq ($(ENV_ARG), dev)
 	@$(BASH_DEV) "RAILS_ENV=test DISABLE_BOOTSNAP=true NOCOVERAGE=true bundle exec parallel_rspec ${SPEC_PATH}"
 else
-	@$(COMPOSE_TEST) $(BASH) -c "cc-test-reporter before-build"
 	@$(COMPOSE_TEST) $(BASH) -c "DISABLE_BOOTSNAP=true bundle exec parallel_rspec ${SPEC_PATH}"
-	@$(COMPOSE_TEST) $(BASH) -c "cc-test-reporter after-build -t simplecov"
 endif
 
 .PHONY: up

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/test_coverage)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/test_coverage)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0%201.0-lightgrey.svg)](LICENSE.md)
 
 This project provides common APIs for applications that live on VA.gov (formerly vets.gov APIs).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
-[![Maintainability](https://api.codeclimate.com/v1/badges/8576e1b71f64d9bcd3cb/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/maintainability)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0%201.0-lightgrey.svg)](LICENSE.md)
 
 This project provides common APIs for applications that live on VA.gov (formerly vets.gov APIs).

--- a/docs/setup/running_docker.md
+++ b/docs/setup/running_docker.md
@@ -27,7 +27,7 @@ but the following tasks have been aliased to speed development:
 
 ## Running tests
 
-- `make spec` - Run the entire test suite via the docker image (alias for `rspec spec`). Test coverage statistics are in `coverage/index.html` or in [CodeClimate](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/code)
+- `make spec` - Run the entire test suite via the docker image (alias for `rspec spec`). Test coverage statistics are in `coverage/index.html`.
 - `make guard` - Run the guard test server that reruns your tests after files are saved. Useful for TDD!
 
 ## Running tests in parallel

--- a/docs/setup/running_natively.md
+++ b/docs/setup/running_natively.md
@@ -16,7 +16,7 @@ they would be when running rails directly.
 
 ### Running tests
 
-- `bundle exec rake spec` - Run the entire test suite  ( for `rspec spec`). Test coverage statistics are in `coverage/index.html` or in [CodeClimate](https://codeclimate.com/github/department-of-veterans-affairs/vets-api/code)
+- `bundle exec rake spec` - Run the entire test suite  ( for `rspec spec`). Test coverage statistics are in `coverage/index.html`.
 - `make guard` - Run the guard test server that reruns your tests after files are saved. Useful for TDD!
 
 ### Running tests in parallel

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -1,31 +1,6 @@
 # frozen_string_literal: true
 
 desc 'Runs the continuous integration scripts'
-task ci: %i[lint security spec:with_codeclimate_coverage]
-
-task default: :ci
-
-desc 'run rspec tests and report results to CodeClimate'
-namespace :spec do
-  task with_codeclimate_coverage: :environment do
-    if ENV['CC_TEST_REPORTER_ID']
-      puts 'notifying CodeClimate of test run'
-      system('cc-test-reporter before-build')
-    end
-    exit_status = begin
-                    Rake::Task['spec'].invoke
-                  rescue SystemExit => e
-                    e.status
-                  else
-                    0
-                  end
-
-    if ENV['CC_TEST_REPORTER_ID']
-      puts 'reporting coverage to CodeClimate'
-      system('cc-test-reporter after-build -t simplecov')
-    end
-    exit exit_status
-  end
-end
+task ci: %i[lint security spec]
 
 $stdout.sync = false


### PR DESCRIPTION
- Alphabetize most yaml keys (leaving `name:` at the top, and `user` before `pass`).
- Removed unneeded system packages install for linting/security
- Moved some ENV vars into the specific step that needed it
- Removed redis (wasn't being used)
- Fix deprecation warning for `comment_on_pr` in Test Results action
- Looked into merging Danger workflow. We could but then everything would run twice because we'd need to add `pull_request` and `push` to our `on:` block.
- Move result publishing to its own job that runs on GH cloud runners since our self-hosted runners have SSL issues due to MITM cert.
- Remove Code Climate in favor of SimpleCov (GH artifacts and coverage report).