### PR TITLE
Remove Danger stage from Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,14 +86,6 @@ pipeline {
       }
     }
 
-    stage('Run Danger Bot') {
-      steps {
-        withCredentials([string(credentialsId: 'danger-github-api-token',    variable: 'DANGER_GITHUB_API_TOKEN')]) {
-          sh 'env=$RAILS_ENV make danger'
-        }
-      }
-    }
-
     stage('Review') {
       when { not { branch 'master' } }
 


### PR DESCRIPTION
## Description of change
Danger is now being ran as a Github action. Will no longer need to be ran on Jenkins.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#24197
