### PR TITLE
Add preferred_team attribute, update specs

### DIFF
--- a/app/models/triage_team.rb
+++ b/app/models/triage_team.rb
@@ -11,6 +11,7 @@ class TriageTeam < Common::Base
   attribute :triage_team_id, Integer
   attribute :name, String, sortable: { order: 'ASC', default: true }
   attribute :relation_type, String
+  attribute :preferred_team, Boolean
 
   def <=>(other)
     name <=> other.name

--- a/app/serializers/triage_team_serializer.rb
+++ b/app/serializers/triage_team_serializer.rb
@@ -8,4 +8,5 @@ class TriageTeamSerializer < ActiveModel::Serializer
   attribute :triage_team_id
   attribute :name
   attribute :relation_type
+  attribute :preferred_team
 end

--- a/modules/mobile/app/serializers/mobile/v0/triage_team_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/triage_team_serializer.rb
@@ -10,6 +10,7 @@ module Mobile
       attribute :triage_team_id
       attribute :name
       attribute :relation_type
+      attribute :preferred_team
     end
   end
 end

--- a/modules/mobile/spec/support/fixtures/triage_teams.json
+++ b/modules/mobile/spec/support/fixtures/triage_teams.json
@@ -2,16 +2,19 @@
 	{
 		"name": "Automation Triage",
 		"relation_type": "PATIENT",
-		"triage_team_id": 153463
+		"triage_team_id": 153463,
+		"preferred_team": true
 	},
 	{
 		"name": "Sustainment Team",
 		"relation_type": "PATIENT",
-		"triage_team_id": 333647
+		"triage_team_id": 333647,
+		"preferred_team": true
 	},
 	{
 		"name": "Vets.gov Testing_DAYT29",
 		"relation_type": "PATIENT",
-		"triage_team_id": 613586
+		"triage_team_id": 613586,
+		"preferred_team": false
 	}
 ]

--- a/spec/models/triage_team_spec.rb
+++ b/spec/models/triage_team_spec.rb
@@ -6,14 +6,16 @@ RSpec.describe TriageTeam do
   context 'with valid attributes' do
     subject { described_class.new(params) }
 
-    let(:params) { attributes_for :triage_team, triage_team_id: 100 }
+    let(:params) { attributes_for :triage_team, triage_team_id: 100, preferred_team: true }
     let(:other) { described_class.new(attributes_for(:triage_team, triage_team_id: 101)) }
 
     it 'populates attributes' do
-      expect(described_class.attribute_set.map(&:name)).to contain_exactly(:triage_team_id, :name, :relation_type)
+      expect(described_class.attribute_set.map(&:name)).to contain_exactly(:triage_team_id, :name, :relation_type,
+                                                                           :preferred_team)
       expect(subject.triage_team_id).to eq(params[:triage_team_id])
       expect(subject.name).to eq(params[:name])
       expect(subject.relation_type).to eq(params[:relation_type])
+      expect(subject.preferred_team).to eq(true)
     end
 
     it 'can be compared by name' do

--- a/spec/support/schemas/triage_team.json
+++ b/spec/support/schemas/triage_team.json
@@ -1,10 +1,24 @@
 {
-  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "required": ["triage_team_id", "name", "relation_type"],
+  "required": [
+    "triage_team_id",
+    "name",
+    "relation_type",
+    "preferred_team"
+  ],
   "properties": {
-    "triage_team_id": { "type": "integer" },
-    "name": { "type": "string" },
-    "relation_type": { "type": "string" }
+    "triage_team_id": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "relation_type": {
+      "type": "string"
+    },
+    "preferred_team": {
+      "type": "boolean"
+    }
   }
 }

--- a/spec/support/schemas_camelized/triage_team.json
+++ b/spec/support/schemas_camelized/triage_team.json
@@ -4,7 +4,8 @@
   "required": [
     "triageTeamId",
     "name",
-    "relationType"
+    "relationType",
+    "preferredTeam"
   ],
   "properties": {
     "triageTeamId": {
@@ -15,6 +16,9 @@
     },
     "relationType": {
       "type": "string"
+    },
+    "preferredTeam": {
+      "type": "boolean"
     }
   }
 }

--- a/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_triage_team_recipients.yml
+++ b/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_triage_team_recipients.yml
@@ -33,8 +33,8 @@ http_interactions:
       - Tue, 31 Jan 2017 21:20:38 GMT
     body:
       encoding: UTF-8
-      string: '{"triageTeam":[{"name":"Automation Triage","relationType":"PATIENT","triageTeamId":153463},{"name":"Sustainment
-        Team","relationType":"PATIENT","triageTeamId":333647},{"name":"Vets.gov Testing_DAYT29","relationType":"PATIENT","triageTeamId":613586}]}'
+      string: '{"triageTeam":[{"name":"Automation Triage","relationType":"PATIENT","triageTeamId":153463,"preferredTeam":true},{"name":"Sustainment
+ Team","relationType":"PATIENT","triageTeamId":333647,"preferredTeam":true},{"name":"Vets.gov Testing_DAYT29","relationType":"PATIENT","triageTeamId":613586,"preferredTeam":false}]}'
     http_version: 
   recorded_at: Tue, 31 Jan 2017 21:20:38 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Adds the `preferred_team` attribute to the TriageTeam model.  This attribute corresponds with the user preference on the MHV website which toggles whether the recipient/triage team displays in their contact list or not.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22933
