### PR TITLE
Add facility_locator_rails_engine feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -129,6 +129,10 @@ features:
     actor_type: user
     description: A fast and dirty way to get the operating status from lighthouse
     enable_in_development: true
+  facility_locator_rails_engine:
+    actor_type: user
+    description: Use rails engine routes for all Facility Locator API calls
+    enable_in_development: true
   facility_locator_show_community_cares:
     actor_type: user
     description: >


### PR DESCRIPTION
## Description of change
Adds a new feature flag to toggle the facility locator routes to use the new Rails engine.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/22701

