### PR TITLE
[24702] Adding fallback to BGS service when user.relationships is cal…

### DIFF
--- a/app/models/user_relationship.rb
+++ b/app/models/user_relationship.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class UserRelationship
+  attr_accessor :first_name, :last_name, :birth_date, :ssn,
+                :gender, :veteran_status, :participant_id, :icn
+
+  # Initializer with a single 'person' from a BGS get_dependents call
+  def self.from_bgs_dependent(bgs_dependent)
+    user_relationship = new
+    # Profile attributes
+    user_relationship.first_name = bgs_dependent['first_name']
+    user_relationship.last_name = bgs_dependent['last_name']
+    user_relationship.birth_date = Formatters::DateFormatter.format_date(bgs_dependent['date_of_birth'])
+    user_relationship.ssn = bgs_dependent['ssn']
+    user_relationship.gender = bgs_dependent['gender']
+    user_relationship.veteran_status = bgs_dependent['veteran_indicator'] == 'Y'
+    # ID attributes
+    user_relationship.participant_id = bgs_dependent['ptcpnt_id']
+    user_relationship
+  end
+
+  # Initializer with a single 'person' from an MPI response RelationshipHolder stanza
+  def self.from_mpi_relationship(mpi_relationship)
+    user_relationship = new
+    # Profile attributes
+    user_relationship.first_name = mpi_relationship.given_names&.first
+    user_relationship.last_name = mpi_relationship.family_name
+    user_relationship.birth_date = Formatters::DateFormatter.format_date(mpi_relationship.birth_date)
+    user_relationship.ssn = mpi_relationship.ssn
+    user_relationship.gender = mpi_relationship.gender
+    user_relationship.veteran_status = mpi_relationship.person_type_code == 'Veteran'
+    # ID attributes
+    user_relationship.icn = mpi_relationship.icn
+    user_relationship.participant_id = mpi_relationship.participant_id
+    user_relationship
+  end
+
+  # Sparse hash to serialize to frontend
+  def to_hash
+    {
+      first_name: first_name,
+      last_name: last_name,
+      birth_date: birth_date
+    }
+  end
+end

--- a/spec/models/user_relationship_spec.rb
+++ b/spec/models/user_relationship_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserRelationship, type: :model do
+  describe '.from_bgs_dependent' do
+    let(:user_relationship) { described_class.from_bgs_dependent(bgs_dependent) }
+    let(:bgs_dependent) do
+      {
+        'award_indicator' => 'N',
+        'city_of_birth' => 'WASHINGTON',
+        'current_relate_status' => '',
+        'date_of_birth' => '01/01/2000',
+        'date_of_death' => '',
+        'death_reason' => '',
+        'email_address' => 'Curt@email.com',
+        'first_name' => 'CURT',
+        'gender' => '',
+        'last_name' => 'WEBB-STER',
+        'middle_name' => '',
+        'proof_of_dependency' => 'Y',
+        'ptcpnt_id' => '32354974',
+        'related_to_vet' => 'N',
+        'relationship' => 'Child',
+        'ssn' => '500223351',
+        'ssn_verify_status' => '1',
+        'state_of_birth' => 'DC'
+      }
+    end
+
+    it 'creates a UserRelationship object with attributes from a BGS Dependent call' do
+      expect(user_relationship.first_name).to eq bgs_dependent['first_name']
+      expect(user_relationship.last_name).to eq bgs_dependent['last_name']
+      expect(user_relationship.birth_date).to eq Formatters::DateFormatter.format_date(bgs_dependent['date_of_birth'])
+      expect(user_relationship.ssn).to eq bgs_dependent['ssn']
+      expect(user_relationship.gender).to eq bgs_dependent['gender']
+      expect(user_relationship.veteran_status).to eq false
+      expect(user_relationship.participant_id).to eq bgs_dependent['ptcpnt_id']
+    end
+  end
+
+  describe '.from_mpi_relationship' do
+    let(:mpi_relationship) { build(:mpi_profile_relationship) }
+    let(:user_relationship) { described_class.from_mpi_relationship(mpi_relationship) }
+
+    it 'creates a UserRelationship object with attributes from an MPI Profile RelationshipHolder stanza' do
+      expect(user_relationship.first_name).to eq mpi_relationship.given_names.first
+      expect(user_relationship.last_name).to eq mpi_relationship.family_name
+      expect(user_relationship.birth_date).to eq Formatters::DateFormatter.format_date(mpi_relationship.birth_date)
+      expect(user_relationship.ssn).to eq mpi_relationship.ssn
+      expect(user_relationship.gender).to eq mpi_relationship.gender
+      expect(user_relationship.veteran_status).to eq false
+      expect(user_relationship.icn).to eq mpi_relationship.icn
+      expect(user_relationship.participant_id).to eq mpi_relationship.participant_id
+    end
+  end
+
+  describe '#to_hash' do
+    let(:mpi_relationship) { build(:mpi_profile_relationship) }
+    let(:user_relationship) { described_class.from_mpi_relationship(mpi_relationship) }
+    let(:user_relationship_hash) do
+      {
+        first_name: mpi_relationship.given_names.first,
+        last_name: mpi_relationship.family_name,
+        birth_date: Formatters::DateFormatter.format_date(mpi_relationship.birth_date)
+      }
+    end
+
+    it 'creates a spare hash of select attributes for frontend serialization' do
+      expect(user_relationship.to_hash).to eq user_relationship_hash
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -827,7 +827,7 @@ RSpec.describe User, type: :model do
 
         context 'and MPI Profile birth date does not exist' do
           before do
-            allow(user.mpi_profile).to receive(:birth_date).and_return nil
+            allow_any_instance_of(MPI::Models::MviProfile).to receive(:birth_date).and_return nil
           end
 
           it 'returns nil' do
@@ -863,41 +863,80 @@ RSpec.describe User, type: :model do
     let(:user) { described_class.new(build(:user_with_relationship)) }
 
     before do
-      allow(user.mpi_profile).to receive(:relationships).and_return([mpi_relationship])
+      allow_any_instance_of(MPI::Models::MviProfile).to receive(:relationships).and_return(mpi_relationship_array)
     end
 
     context 'when there are relationship entities in the MPI response' do
-      let(:mpi_relationship) do
-        build(:mpi_profile_relationship,
-              given_names: relationship_first_name,
-              family_name: relationship_last_name,
-              birth_date: relationship_birth_date,
-              person_type_code: relationship_person_type_code)
+      let(:mpi_relationship_array) { [mpi_relationship] }
+      let(:mpi_relationship) { build(:mpi_profile_relationship) }
+      let(:user_relationship_double) { double }
+      let(:expected_user_relationship_array) { [user_relationship_double] }
+
+      before do
+        allow(UserRelationship).to receive(:from_mpi_relationship)
+          .with(mpi_relationship).and_return(user_relationship_double)
       end
 
-      let(:relationship_first_name) { 'some-first-name' }
-      let(:relationship_last_name) { 'some-last-name' }
-      let(:relationship_birth_date) { '20100101' }
-      let(:relationship_person_type_code) { 'some-person-type-code' }
-      let(:expected_relationship_hash) do
-        {
-          first_name: relationship_first_name,
-          last_name: relationship_last_name,
-          birth_date: relationship_birth_date,
-          person_type_code: relationship_person_type_code
-        }
-      end
-
-      it 'returns a parsed array of hashes representing the different relationship entities' do
-        expect(user.relationships).to eq [expected_relationship_hash]
+      it 'returns an array of UserRelationship objects representing the relationship entities' do
+        expect(user.relationships).to eq expected_user_relationship_array
       end
     end
 
     context 'when there are not relationship entities in the MPI response' do
-      let(:mpi_relationship) { nil }
+      let(:mpi_relationship_array) { nil }
+      let(:bgs_dependent_response) { nil }
 
-      it 'returns an empty array' do
-        expect(user.relationships).to eq [nil]
+      before do
+        allow_any_instance_of(BGS::DependentService).to receive(:get_dependents).and_return(bgs_dependent_response)
+      end
+
+      it 'makes a call to the BGS for relationship information' do
+        expect_any_instance_of(BGS::DependentService).to receive(:get_dependents)
+        user.relationships
+      end
+
+      context 'when BGS relationship response contains information' do
+        let(:bgs_relationship_array) { [bgs_dependent] }
+        let(:bgs_dependent) do
+          {
+            'award_indicator' => 'N',
+            'city_of_birth' => 'WASHINGTON',
+            'current_relate_status' => '',
+            'date_of_birth' => '01/01/2000',
+            'date_of_death' => '',
+            'death_reason' => '',
+            'email_address' => 'Curt@email.com',
+            'first_name' => 'CURT',
+            'gender' => '',
+            'last_name' => 'WEBB-STER',
+            'middle_name' => '',
+            'proof_of_dependency' => 'Y',
+            'ptcpnt_id' => '32354974',
+            'related_to_vet' => 'N',
+            'relationship' => 'Child',
+            'ssn' => '500223351',
+            'ssn_verify_status' => '1',
+            'state_of_birth' => 'DC'
+          }
+        end
+        let(:bgs_dependent_response) { { 'persons' => [bgs_dependent] } }
+        let(:user_relationship_double) { double }
+        let(:expected_user_relationship_array) { [user_relationship_double] }
+
+        before do
+          allow(UserRelationship).to receive(:from_bgs_dependent)
+            .with(bgs_dependent).and_return(user_relationship_double)
+        end
+
+        it 'returns an array of UserRelationship objects representing the relationship entities' do
+          expect(user.relationships).to eq expected_user_relationship_array
+        end
+      end
+
+      context 'when BGS relationship response does not contain information' do
+        it 'returns an empty array' do
+          expect(user.relationships).to eq nil
+        end
       end
     end
   end


### PR DESCRIPTION
…led and MPI response has no relationship data

## Description of change
This change adds a call to the BGS dependent service to get information about a user's dependents when `user.relationships` is called and there is no relationship data from the saved MPI response (first we attempt to query MPI for relationship data, if that doesn't exist, we query BGS for relationship data)

## Original issue(s)
department-of-veterans-affairs/va.gov-team/issues/24702

## Things to know about this PR
- This shouldn't appear to have any functional impact on production at this point
- To test this, I added the line: `relationship: user.relationships` in the `profile` function of `models/profile.rb`, and logged in with user `vets.gov.user+36@gmail.com` (this user has a BGS mock with relationship data).
- Once that line is added, we can sign in and inspect the response from the call to `user`, there should be a `relationship` field with populated data
