### PR TITLE
[24862] makes User mpi and mpi_profile methods private

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -71,7 +71,7 @@ module V0
         saved_claim_id: saved_claim.id,
         auth_headers_json: auth_headers.to_json,
         form_json: saved_claim.to_submission_data(@current_user)
-      ) { |sub| sub.add_birls_ids @current_user.mpi&.profile&.birls_ids }
+      ) { |sub| sub.add_birls_ids @current_user.mpi_birls_id }
       submission.save! && submission
     rescue PG::NotNullViolation => e
       Rails.logger.error(

--- a/app/controllers/v0/profile/personal_informations_controller.rb
+++ b/app/controllers/v0/profile/personal_informations_controller.rb
@@ -7,22 +7,13 @@ module V0
 
       # Fetches the personal information for the current user.
       # Namely their gender and birth date.
-      #
-      # @return [Response] Sample response.body:
-      #   {
-      #     "data" => {
-      #       "id"         => "",
-      #       "type"       => "mvi_models_mvi_profiles",
-      #       "attributes" => {
-      #         "gender"     => "M",
-      #         "birth_date" => "1949-03-04"
-      #       }
-      #     }
-      #   }
-      #
       def show
-        response = @current_user.mpi.profile
-
+        response = OpenStruct.new({
+                                    'id': @current_user.account_uuid,
+                                    'type': 'mvi_models_mvi_profiles',
+                                    'gender': @current_user.gender_mpi,
+                                    'birth_date': @current_user.birth_date_mpi
+                                  })
         handle_errors!(response)
 
         render json: response, serializer: PersonalInformationSerializer
@@ -31,7 +22,7 @@ module V0
       private
 
       def handle_errors!(response)
-        raise_error! if response&.gender.blank? && response&.birth_date.blank?
+        raise_error! if response.gender.blank? && response.birth_date.blank?
 
         log_errors_for(response)
       end
@@ -44,15 +35,15 @@ module V0
       end
 
       def log_errors_for(response)
-        if response&.gender.nil? || response&.birth_date.nil?
+        if response.gender.nil? || response.birth_date.nil?
           log_message_to_sentry(
             'mpi missing data bug',
             :info,
             {
               response: response,
               params: params,
-              gender: response&.gender,
-              birth_date: response&.birth_date
+              gender: response.gender,
+              birth_date: response.birth_date
             },
             profile: 'pciu_profile'
           )

--- a/app/controllers/v0/profile/persons_controller.rb
+++ b/app/controllers/v0/profile/persons_controller.rb
@@ -23,9 +23,7 @@ module V0
       private
 
       def invalidate_mpi_cache
-        mvi_cache = @current_user.mpi
-        mvi_cache.mvi_response
-        mvi_cache.destroy
+        @current_user.invalidate_mpi_cache
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -296,11 +296,15 @@ class User < Common::RedisStore
   # User's profile contains a list of VHA facility-specific identifiers.
   # Facilities in the defined range are treating facilities
   def va_treatment_facility_ids
-    facilities = mpi_profile&.vha_facility_ids
-    facilities.to_a.select do |f|
+    facilities = vha_facility_ids
+    facilities.select do |f|
       Settings.mhv.facility_range.any? { |range| f.to_i.between?(*range) } ||
         Settings.mhv.facility_specific.include?(f)
     end
+  end
+
+  def vha_facility_ids
+    mpi_profile&.vha_facility_ids || []
   end
 
   def can_access_id_card?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -226,6 +226,16 @@ class User < Common::RedisStore
 
   # MPI setter methods
 
+  def mpi_add_person
+    add_person_identity = identity
+    add_person_identity.edipi = edipi
+    add_person_identity.ssn = ssn
+    add_person_identity.icn_with_aaid = icn_with_aaid
+    add_person_identity.search_token = search_token
+    mpi.user_identity = add_person_identity
+    mpi.add_person
+  end
+
   def set_mhv_ids(mhv_id)
     mpi_profile.mhv_ids = [mhv_id] + mhv_ids
     mpi_profile.active_mhv_ids = [mhv_id] + active_mhv_ids
@@ -382,10 +392,6 @@ class User < Common::RedisStore
     false
   end
 
-  def mpi
-    @mpi ||= MPIData.for_user(identity)
-  end
-
   # A user can have served in the military without being a veteran.  For example,
   # someone can be ex-military by having a discharge status higher than
   # 'Other Than Honorable'.
@@ -411,7 +417,7 @@ class User < Common::RedisStore
   private
 
   def mpi
-    @mpi ||= MPIData.for_user(self)
+    @mpi ||= MPIData.for_user(identity)
   end
 
   def mpi_profile

--- a/modules/health_quest/app/controllers/health_quest/v0/base_controller.rb
+++ b/modules/health_quest/app/controllers/health_quest/v0/base_controller.rb
@@ -25,7 +25,7 @@ module HealthQuest
           user_uuid: current_user&.uuid,
           user_icn: current_user&.icn,
           loa: current_user&.loa,
-          facilities: current_user&.mpi_profile&.vha_facility_ids || [],
+          facilities: current_user&.vha_facility_ids,
           controller_name: controller_name,
           controller_action: action_name,
           request_info: {

--- a/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
+++ b/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
@@ -425,7 +425,7 @@ module HealthQuest
           user_uuid: user&.uuid,
           user_icn: user&.icn,
           loa: user&.loa,
-          facilities: user&.mpi_profile&.vha_facility_ids || []
+          facilities: user&.vha_facility_ids
         }
       end
 

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -14,7 +14,7 @@ describe HealthQuest::QuestionnaireManager::Factory do
       account_uuid: 'abc123',
       uuid: '789defg',
       loa: 3,
-      mpi_profile: double('Facility', vha_facility_ids: ['1'])
+      vha_facility_ids: ['1']
     )
   end
   let(:session_store) { double('SessionStore', token: '123abc') }

--- a/rakelib/mvi.rake
+++ b/rakelib/mvi.rake
@@ -38,7 +38,7 @@ middle_name="W" last_name="Smith" birth_date="1945-01-25" gender="M" ssn="555443
       )
 
       user.last_signed_in = Time.now.utc
-      pp user.mpi_profile
+      pp MPIData.for_user(user).profile
     rescue => e
       puts "User query failed: #{e.message}"
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -308,6 +308,13 @@ RSpec.describe User, type: :model do
       end
     end
 
+    describe 'invalidate_mpi_cache' do
+      it 'clears the user mpi cache' do
+        expect_any_instance_of(MPIData).to receive(:destroy)
+        subject.invalidate_mpi_cache
+      end
+    end
+
     describe '#mpi_profile?' do
       context 'when user has mpi profile' do
         let(:mvi_profile) { build(:mvi_profile) }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This change removes the last few calls of the User model's `mpi` method and makes it private. It also returns the `mpi_profile` method to private as well and cleans up some testing surrounding these two changes.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#24862

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Affected unit specs update and manual login/logout workflow.