### PR TITLE
API-6614: Ensure upstream_healthcheck does not timeout for any upstream dependencies

### DIFF
--- a/modules/claims_api/config/initializers/okcomputer.rb
+++ b/modules/claims_api/config/initializers/okcomputer.rb
@@ -76,7 +76,9 @@ end
 
 class VbmsCheck < BaseCheck
   def check
-    response = Faraday::Connection.new.get(Settings.vbms.url) { |request| request.options.timeout = 20 }
+    connection = Faraday::Connection.new
+    connection.options.timeout = 10
+    response = connection.get(Settings.vbms.url)
     response.status == 200 ? process_success : process_failure
   rescue
     process_failure

--- a/modules/claims_api/config/initializers/okcomputer.rb
+++ b/modules/claims_api/config/initializers/okcomputer.rb
@@ -78,7 +78,7 @@ class VbmsCheck < BaseCheck
   def check
     connection = Faraday::Connection.new
     connection.options.timeout = 10
-    response = connection.get(Settings.vbms.url)
+    response = connection.get("#{Settings.vbms.url}/vbms-efolder-svc/upload-v1/eFolderUploadService?wsdl")
     response.status == 200 ? process_success : process_failure
   rescue
     process_failure


### PR DESCRIPTION
## Description of change
Attempts to ensure all healthcheck calls return a response instead of timing out. This helps us always know which upstream dependency is having issues.

## Original issue(s)
https://vajira.max.gov/browse/API-6614

## Things to know about this PR
WSDL path for the VBMS healthcheck was added due to base url check not working in production (though it worked fine in sandbox).
WSDL path addition allows healthcheck to work in both sandbox and production.