### PR TITLE
rolling back benchmark-ips gem because it is causing issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     bcp47 (0.3.3)
       i18n
-    benchmark-ips (2.9.0)
+    benchmark-ips (2.8.4)
     bindex (0.8.1)
     bootsnap (1.7.5)
       msgpack (~> 1.0)


### PR DESCRIPTION
## Description of change
Dependabot updated the benchmark-ips gem from 2.8.4 to 2.9.0 and it caused issues with running vets-api locally. Rolling back for now.