### PR TITLE
undefined method `mpi_icn' for #<ClaimsApi::Veteran:0x000055f83e6cf160>

### DIFF
--- a/modules/claims_api/app/models/claims_api/veteran.rb
+++ b/modules/claims_api/app/models/claims_api/veteran.rb
@@ -107,6 +107,12 @@ module ClaimsApi
       )
     end
 
+    def mpi_icn
+      return nil unless mpi
+
+      mpi.icn
+    end
+
     private
 
     def mpi_profile

--- a/modules/claims_api/app/models/claims_api/veteran.rb
+++ b/modules/claims_api/app/models/claims_api/veteran.rb
@@ -107,12 +107,6 @@ module ClaimsApi
       )
     end
 
-    def mpi_icn
-      return nil unless mpi
-
-      mpi.icn
-    end
-
     private
 
     def mpi_profile

--- a/modules/claims_api/spec/models/veteran/service/user_spec.rb
+++ b/modules/claims_api/spec/models/veteran/service/user_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Veteran::User do
+  context 'initialization' do
+    let(:user) do
+      ClaimsApi::Veteran.new(
+        uuid: '123456789',
+        ssn: '123456789',
+        first_name: 'Firstname',
+        last_name: 'Lastname',
+        va_profile: ClaimsApi::Veteran.build_profile('1970-01-01'),
+        last_signed_in: Time.now.utc
+      )
+    end
+
+    it 'initializes from a user' do
+      VCR.use_cassette('bgs/claimant_web_service/find_poa_by_participant_id') do
+        allow_any_instance_of(BGS::OrgWebService).to receive(:find_poa_history_by_ptcpnt_id)
+          .and_return({ person_poa_history: { person_poa: [{ begin_dt: Time.zone.now, legacy_poa_cd: '033' }] } })
+        veteran = Veteran::User.new(user)
+        expect(veteran.power_of_attorney.code).to eq('044')
+        expect(veteran.previous_power_of_attorney.code).to eq('033')
+      end
+    end
+
+    it 'does not bomb out if poa is missing' do
+      VCR.use_cassette('bgs/claimant_web_service/not_find_poa_by_participant_id') do
+        allow_any_instance_of(BGS::OrgWebService).to receive(:find_poa_history_by_ptcpnt_id)
+          .and_return({ person_poa_history: nil })
+        veteran = Veteran::User.new(user)
+        expect(veteran.power_of_attorney).to eq(nil)
+        expect(veteran.previous_power_of_attorney).to eq(nil)
+      end
+    end
+
+    it 'provides most recent previous poa' do
+      VCR.use_cassette('bgs/claimant_web_service/find_poa_by_participant_id') do
+        allow_any_instance_of(BGS::OrgWebService).to receive(:find_poa_history_by_ptcpnt_id)
+          .and_return({
+                        person_poa_history: {
+                          person_poa: [
+                            { begin_dt: Time.zone.now - 2.years, legacy_poa_cd: '233' },
+                            { begin_dt: Time.zone.now - 1.year, legacy_poa_cd: '133' },
+                            { begin_dt: Time.zone.now - 3.years, legacy_poa_cd: '333' }
+                          ]
+                        }
+                      })
+        veteran = Veteran::User.new(user)
+        expect(veteran.previous_power_of_attorney.code).to eq('133')
+      end
+    end
+  end
+end

--- a/modules/veteran/app/models/veteran/user.rb
+++ b/modules/veteran/app/models/veteran/user.rb
@@ -44,7 +44,7 @@ module Veteran
       external_key = "#{@user.first_name} #{@user.last_name}"
 
       @bgs_service ||= BGS::Services.new(
-        external_uid: @user.mpi.icn,
+        external_uid: @user.mpi_icn,
         external_key: external_key
       )
     end

--- a/modules/veteran/app/models/veteran/user.rb
+++ b/modules/veteran/app/models/veteran/user.rb
@@ -44,7 +44,7 @@ module Veteran
       external_key = "#{@user.first_name} #{@user.last_name}"
 
       @bgs_service ||= BGS::Services.new(
-        external_uid: @user.mpi_icn,
+        external_uid: @user.mpi.icn,
         external_key: external_key
       )
     end


### PR DESCRIPTION
## Description of change
Undefined method issue cropped up over the weekend, after a deploy on Friday it looks like.
I believe this was the culprit: https://github.com/department-of-veterans-affairs/vets-api/pull/6924

## Original issue(s)
http://sentry.vfs.va.gov/share/issue/bbb51c4a609043a5a9712a61067cb30a/

## Things to know about this PR
Ideally this should go out with today's deploy because it has rendered one of our endpoints completely broken :(