### PR TITLE
Feature flag for notifications triggered for connected accounts in lower environments

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -46,6 +46,10 @@ features:
     actor_type: user
     description: Feature gates the certificate of eligibility application
     enable_in_development: true
+  connected_applications_notif_service:
+    actor_type: cookie_id
+    description: Toggles whether or not to send a notification email when a user connects or disconnects an app from the VA Profile
+    enable_in_development: false
   covid_vaccine_registration:
     actor_type: user
     description: Toggles availability of covid vaccine form API.

--- a/config/features.yml
+++ b/config/features.yml
@@ -46,10 +46,6 @@ features:
     actor_type: user
     description: Feature gates the certificate of eligibility application
     enable_in_development: true
-  connected_applications_notif_service:
-    actor_type: cookie_id
-    description: Toggles whether or not to send a notification email when a user connects or disconnects an app from the VA Profile
-    enable_in_development: false
   covid_vaccine_registration:
     actor_type: user
     description: Toggles availability of covid vaccine form API.

--- a/modules/apps_api/lib/apps_api/notification_service.rb
+++ b/modules/apps_api/lib/apps_api/notification_service.rb
@@ -21,6 +21,7 @@ module AppsApi
 
     def handle_event(event_type, template)
       return 'not enabled for this environment' if @should_perform == false
+
       logs = get_events(event_type)
       logs.body.each do |event|
         parsed_hash = parse_event(event)

--- a/modules/apps_api/lib/apps_api/notification_service.rb
+++ b/modules/apps_api/lib/apps_api/notification_service.rb
@@ -16,7 +16,7 @@ module AppsApi
       @notify_client = VaNotify::Service.new(Settings.vanotify.services.lighthouse.api_key)
       @connection_event = 'app.oauth2.as.consent.grant'
       @disconnection_event = 'app.oauth2.as.consent.revoke'
-      @should_perform ||= Flipper.enabled?(:connected_applications_notif_service)
+      @should_perform = Flipper.enabled?(:connected_applications_notif_service)
     end
 
     def handle_event(event_type, template)

--- a/modules/apps_api/lib/apps_api/notification_service.rb
+++ b/modules/apps_api/lib/apps_api/notification_service.rb
@@ -16,7 +16,7 @@ module AppsApi
       @notify_client = VaNotify::Service.new(Settings.vanotify.services.lighthouse.api_key)
       @connection_event = 'app.oauth2.as.consent.grant'
       @disconnection_event = 'app.oauth2.as.consent.revoke'
-      @should_perform = Flipper.enabled?(:connected_applications_notif_service)
+      @should_perform = Settings.directory.notification_service_flag || false
     end
 
     def handle_event(event_type, template)

--- a/modules/apps_api/lib/apps_api/notification_service.rb
+++ b/modules/apps_api/lib/apps_api/notification_service.rb
@@ -20,7 +20,7 @@ module AppsApi
     end
 
     def handle_event(event_type, template)
-      return 'not enabled for this environment' if @should_perform == false
+      return 'not enabled for this environment' unless @should_perform
 
       logs = get_events(event_type)
       logs.body.each do |event|

--- a/modules/apps_api/lib/apps_api/notification_service.rb
+++ b/modules/apps_api/lib/apps_api/notification_service.rb
@@ -16,9 +16,11 @@ module AppsApi
       @notify_client = VaNotify::Service.new(Settings.vanotify.services.lighthouse.api_key)
       @connection_event = 'app.oauth2.as.consent.grant'
       @disconnection_event = 'app.oauth2.as.consent.revoke'
+      @should_perform ||= Flipper.enabled?(:connected_applications_notif_service)
     end
 
     def handle_event(event_type, template)
+      return 'not enabled for this environment' if @should_perform == false
       logs = get_events(event_type)
       logs.body.each do |event|
         parsed_hash = parse_event(event)

--- a/modules/apps_api/spec/lib/notification_service_spec.rb
+++ b/modules/apps_api/spec/lib/notification_service_spec.rb
@@ -129,7 +129,7 @@ describe AppsApi::NotificationService do
     # @notify_client ||= Notifications::Client.new(api_key, client_url)
     allow(Notifications::Client).to receive(:new).and_return(notification_client)
     allow(notification_client).to receive(:send_email).and_return(true)
-    allow(Flipper).to receive(:enabled?).with(:connected_applications_notif_service).and_return(true)
+    subject.instance_variable_set(:@should_perform, true)
   end
 
   describe '#initialize' do

--- a/modules/apps_api/spec/lib/notification_service_spec.rb
+++ b/modules/apps_api/spec/lib/notification_service_spec.rb
@@ -129,6 +129,7 @@ describe AppsApi::NotificationService do
     # @notify_client ||= Notifications::Client.new(api_key, client_url)
     allow(Notifications::Client).to receive(:new).and_return(notification_client)
     allow(notification_client).to receive(:send_email).and_return(true)
+    allow(Flipper).to receive(:enabled?).with(:connected_applications_notif_service).and_return(true)
   end
 
   describe '#initialize' do
@@ -141,6 +142,15 @@ describe AppsApi::NotificationService do
   end
 
   describe 'handle_event' do
+    it 'returns early if in testing or development' do
+      subject.instance_variable_set(:@should_perform, false)
+      response = subject.handle_event(
+        subject.instance_variable_get(:@connection_event),
+        subject.instance_variable_get(:@connection_template)
+      )
+      expect(response).to eql 'not enabled for this environment'
+    end
+
     it 'properly calls the okta service' do
       response = OpenStruct.new(
         {


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This PR prevents notifications being sent out when a user connects or disconnects an application from/to their VA Profile Connected Accounts. This feature was enabled for the lower environments for testing purposes, and is now causing rate limit warnings in Okta when large batches of zombie accounts/apps are being deleted in Okta. There's no need for emails to be sent in staging/testing so this feature can be disabled outside of Production without issue.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000
slack thread discussing the need for a feature flag in lower environments
https://lighthouseva.slack.com/archives/C01SABWSGRY/p1621863254056700
devops pr adding environment variable https://github.com/department-of-veterans-affairs/devops/pull/9222
## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Unit test has been added to `notification_service_spec.rb` to test for early return.