### PR TITLE
[22732] adds check for empty string to EVSS service request_headers

### DIFF
--- a/app/workers/education_form/process10203_submissions.rb
+++ b/app/workers/education_form/process10203_submissions.rb
@@ -100,8 +100,7 @@ module EducationForm
       service.get_current_info(auth_headers)['userPoaInfoAvailable']
     rescue => e
       log_exception_to_sentry(
-        Process10203EVSSError.new("Failed to retrieve VSOSearch data: #{e.message}"),
-        auth_headers
+        Process10203EVSSError.new("Failed to retrieve VSOSearch data: #{e.message}")
       )
       nil
     end

--- a/lib/evss/vso_search/service.rb
+++ b/lib/evss/vso_search/service.rb
@@ -36,7 +36,7 @@ module EVSS
             loa3: @user.loa3?,
             mhv_icn: !@user.mhv_icn.nil?,
             edipi_type: additional_headers['va_eauth_dodedipnid'].class,
-            edipi_length: additional_headers['va_eauth_dodedipnid'].class.length
+            edipi_length: additional_headers['va_eauth_dodedipnid']&.length
           }
           log_message_to_sentry('Failed to find EDIPI, EVSS service call will not succeed', :warn, user_info)
         end

--- a/lib/evss/vso_search/service.rb
+++ b/lib/evss/vso_search/service.rb
@@ -29,12 +29,14 @@ module EVSS
       private
 
       def request_headers(additional_headers)
-        ssn = additional_headers.key?('va_eauth_pnid') ? additional_headers['va_eauth_pnid'] : @user.ssn
-        edipi = additional_headers.key?('va_eauth_dodedipnid') ? additional_headers['va_eauth_dodedipnid'] : @user.edipi
+        ssn = additional_headers['va_eauth_pnid'].presence || @user.ssn
+        edipi = additional_headers['va_eauth_dodedipnid'].presence || @user.edipi
         if edipi.nil?
           user_info = {
             loa3: @user.loa3?,
-            mhv_icn: !@user.mhv_icn.nil?
+            mhv_icn: !@user.mhv_icn.nil?,
+            edipi_type: additional_headers['va_eauth_dodedipnid'].class,
+            edipi_length: additional_headers['va_eauth_dodedipnid'].class.length
           }
           log_message_to_sentry('Failed to find EDIPI, EVSS service call will not succeed', :warn, user_info)
         end

--- a/modules/veteran/app/models/veteran/user.rb
+++ b/modules/veteran/app/models/veteran/user.rb
@@ -42,7 +42,6 @@ module Veteran
 
     def bgs_service
       external_key = "#{@user.first_name} #{@user.last_name}"
-
       @bgs_service ||= BGS::Services.new(
         external_uid: @user.mpi_icn,
         external_key: external_key


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Fix to catch empty string `va_eauth_dodedipnid` headers that were being incorrectly used as a reference for a user's EDIPI; this is causing [500 errors](http://sentry.vfs.va.gov/organizations/vsp/issues/31328/?environment=production&project=3&query=is%3Aunresolved+message%3A%22EducationForm%3A%3AProcess10203EVSSError%22&statsPeriod=14d) to occur within EVSS when calls are made to their service with a blank EDIPI.

The `presence` method should check both for the existence of the appropriate header within the hash as well as the existence of a truthy value for that header.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22732

## Things to know about this PR
Some Sentry logging added to the EVSS service has been maintained; if the related errors stop occurring it will be removed.
