### PR TITLE
[6901] Adding ability to query MPI with a relationship object and ret…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -460,6 +460,8 @@ class User < Common::RedisStore
   private
 
   def get_relationships_array
+    return unless loa3?
+
     mpi_profile_relationships || bgs_relationships
   end
 

--- a/app/models/user_relationship.rb
+++ b/app/models/user_relationship.rb
@@ -43,4 +43,28 @@ class UserRelationship
       birth_date: birth_date
     }
   end
+
+  # Full MPI Profile object
+  def get_full_attributes
+    user_identity = build_user_identity
+    MPIData.for_user(user_identity)
+  end
+
+  private
+
+  def build_user_identity
+    UserIdentity.new(
+      first_name: first_name,
+      last_name: last_name,
+      birth_date: birth_date,
+      gender: gender,
+      ssn: ssn,
+      icn: icn,
+      mhv_icn: icn,
+      loa: {
+        current: LOA::THREE,
+        highest: LOA::THREE
+      }
+    )
+  end
 end

--- a/spec/models/user_relationship_spec.rb
+++ b/spec/models/user_relationship_spec.rb
@@ -70,4 +70,18 @@ RSpec.describe UserRelationship, type: :model do
       expect(user_relationship.to_hash).to eq user_relationship_hash
     end
   end
+
+  describe '#get_full_attributes' do
+    let(:mpi_relationship) { build(:mpi_profile_relationship) }
+    let(:user_relationship) { described_class.from_mpi_relationship(mpi_relationship) }
+    let(:mpi_object_double) { double }
+
+    before do
+      allow(MPIData).to receive(:for_user).and_return(mpi_object_double)
+    end
+
+    it 'returns an MPI profile for relationship attributes' do
+      expect(user_relationship.get_full_attributes).to eq mpi_object_double
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -866,66 +866,25 @@ RSpec.describe User, type: :model do
       allow_any_instance_of(MPI::Models::MviProfile).to receive(:relationships).and_return(mpi_relationship_array)
     end
 
-    context 'when there are relationship entities in the MPI response' do
-      let(:mpi_relationship_array) { [mpi_relationship] }
-      let(:mpi_relationship) { build(:mpi_profile_relationship) }
-      let(:user_relationship_double) { double }
-      let(:expected_user_relationship_array) { [user_relationship_double] }
+    context 'when user is not loa3' do
+      let(:user) { described_class.new(build(:user, :loa1)) }
+      let(:mpi_relationship_array) { [] }
 
-      before do
-        allow(UserRelationship).to receive(:from_mpi_relationship)
-          .with(mpi_relationship).and_return(user_relationship_double)
-      end
-
-      it 'returns an array of UserRelationship objects representing the relationship entities' do
-        expect(user.relationships).to eq expected_user_relationship_array
+      it 'returns nil' do
+        expect(user.relationships).to eq nil
       end
     end
 
-    context 'when there are not relationship entities in the MPI response' do
-      let(:mpi_relationship_array) { nil }
-      let(:bgs_dependent_response) { nil }
-
-      before do
-        allow_any_instance_of(BGS::DependentService).to receive(:get_dependents).and_return(bgs_dependent_response)
-      end
-
-      it 'makes a call to the BGS for relationship information' do
-        expect_any_instance_of(BGS::DependentService).to receive(:get_dependents)
-        user.relationships
-      end
-
-      context 'when BGS relationship response contains information' do
-        let(:bgs_relationship_array) { [bgs_dependent] }
-        let(:bgs_dependent) do
-          {
-            'award_indicator' => 'N',
-            'city_of_birth' => 'WASHINGTON',
-            'current_relate_status' => '',
-            'date_of_birth' => '01/01/2000',
-            'date_of_death' => '',
-            'death_reason' => '',
-            'email_address' => 'Curt@email.com',
-            'first_name' => 'CURT',
-            'gender' => '',
-            'last_name' => 'WEBB-STER',
-            'middle_name' => '',
-            'proof_of_dependency' => 'Y',
-            'ptcpnt_id' => '32354974',
-            'related_to_vet' => 'N',
-            'relationship' => 'Child',
-            'ssn' => '500223351',
-            'ssn_verify_status' => '1',
-            'state_of_birth' => 'DC'
-          }
-        end
-        let(:bgs_dependent_response) { { 'persons' => [bgs_dependent] } }
+    context 'when user is loa3' do
+      context 'when there are relationship entities in the MPI response' do
+        let(:mpi_relationship_array) { [mpi_relationship] }
+        let(:mpi_relationship) { build(:mpi_profile_relationship) }
         let(:user_relationship_double) { double }
         let(:expected_user_relationship_array) { [user_relationship_double] }
 
         before do
-          allow(UserRelationship).to receive(:from_bgs_dependent)
-            .with(bgs_dependent).and_return(user_relationship_double)
+          allow(UserRelationship).to receive(:from_mpi_relationship)
+            .with(mpi_relationship).and_return(user_relationship_double)
         end
 
         it 'returns an array of UserRelationship objects representing the relationship entities' do
@@ -933,9 +892,61 @@ RSpec.describe User, type: :model do
         end
       end
 
-      context 'when BGS relationship response does not contain information' do
-        it 'returns an empty array' do
-          expect(user.relationships).to eq nil
+      context 'when there are not relationship entities in the MPI response' do
+        let(:mpi_relationship_array) { nil }
+        let(:bgs_dependent_response) { nil }
+
+        before do
+          allow_any_instance_of(BGS::DependentService).to receive(:get_dependents).and_return(bgs_dependent_response)
+        end
+
+        it 'makes a call to the BGS for relationship information' do
+          expect_any_instance_of(BGS::DependentService).to receive(:get_dependents)
+          user.relationships
+        end
+
+        context 'when BGS relationship response contains information' do
+          let(:bgs_relationship_array) { [bgs_dependent] }
+          let(:bgs_dependent) do
+            {
+              'award_indicator' => 'N',
+              'city_of_birth' => 'WASHINGTON',
+              'current_relate_status' => '',
+              'date_of_birth' => '01/01/2000',
+              'date_of_death' => '',
+              'death_reason' => '',
+              'email_address' => 'Curt@email.com',
+              'first_name' => 'CURT',
+              'gender' => '',
+              'last_name' => 'WEBB-STER',
+              'middle_name' => '',
+              'proof_of_dependency' => 'Y',
+              'ptcpnt_id' => '32354974',
+              'related_to_vet' => 'N',
+              'relationship' => 'Child',
+              'ssn' => '500223351',
+              'ssn_verify_status' => '1',
+              'state_of_birth' => 'DC'
+            }
+          end
+          let(:bgs_dependent_response) { { 'persons' => [bgs_dependent] } }
+          let(:user_relationship_double) { double }
+          let(:expected_user_relationship_array) { [user_relationship_double] }
+
+          before do
+            allow(UserRelationship).to receive(:from_bgs_dependent)
+              .with(bgs_dependent).and_return(user_relationship_double)
+          end
+
+          it 'returns an array of UserRelationship objects representing the relationship entities' do
+            expect(user.relationships).to eq expected_user_relationship_array
+          end
+        end
+
+        context 'when BGS relationship response does not contain information' do
+          it 'returns an empty array' do
+            expect(user.relationships).to eq nil
+          end
         end
       end
     end


### PR DESCRIPTION
…urn a full MPI Data object

## Description of change
This PR adds a function on the UserRelationship object that will potentially query MPI with the user relationship attributes to return a full MPI data object

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/6901

## Things to know about this PR
- Nothing uses this functionality yet, so to test this you'll have to set a breakpoint somewhere in the user object. You should then be able to call `user.relationships` to get the relationships for the user, and then call `get_full_attributes` on one of the objects from that array. Test user `vets.gov.user+36@gmail.com` has BGS dependents mocked that can help with testing.

- To test this, I signed in with `vets.gov.user+36@gmail.com`, confirmed there were returned relationships with `user.relationships`, and then confirmed that I got back an MPI response when calling `user.relationships.first.get_full_attributes`
