### PR TITLE
API-6792: Internal Server Error when retrieving claims for John Doe in sandbox

### DIFF
--- a/app/models/mpi_data.rb
+++ b/app/models/mpi_data.rb
@@ -163,6 +163,8 @@ class MPIData < Common::RedisStore
   def response_from_redis_or_service
     do_cached_with(key: user.uuid) do
       mpi_service.find_profile(user)
+    rescue ArgumentError
+      return nil
     end
   end
 


### PR DESCRIPTION
## Description of change
find_profile raises an ArgumentError if the user doesnt have an ssn or birthdate. this was trickling up and resulting in a 500 response to the consumer.
there is quite a bit of logic in place that expects a simple nil response if the profile can't be found, this ensures that effect.

## Original issue(s)
https://vajira.max.gov/browse/API-6792

## Things to know about this PR
Tested locally using both John Doe (to ensure we receive a 400 response) and with Tamara Ellis to ensure everything still functions with someone who is in MPI.
