### PR TITLE
API-6823: SpecialIssueUpdater background job issue regarding no claims found

### DIFF
--- a/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
+++ b/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
@@ -24,7 +24,7 @@ module ClaimsApi
       validate_contention_id_structure(contention_id)
       service = bgs_service(user).contention
 
-      claims = service.find_contentions_by_ptcpnt_id(user['participant_id'])[:benefit_claims]
+      claims = service.find_contentions_by_ptcpnt_id(user['participant_id'])[:benefit_claims] || []
       claim = claim_from_contention_id(claims, contention_id)
       raise "Claim not found with contention: #{contention_id}" if claim.blank?
 


### PR DESCRIPTION
## Description of change
Error discovered in sentry. It seems the `find_contentions_by_ptcpnt_id` BGS can sometimes return nil instead of an empty array if no contentions are found.

## Original issue(s)
https://vajira.max.gov/browse/API-6823