### PR TITLE
API-6822: SpecialIssueUpdater background job issue with logging maximum failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Vets API
 
-
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0%201.0-lightgrey.svg)](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Vets API
 
+
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0%201.0-lightgrey.svg)](LICENSE.md)

--- a/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
+++ b/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
@@ -48,6 +48,21 @@ module ClaimsApi
       auto_claim.save
     end
 
+    # Passthru to allow calling from sidekiq_retries_exhausted section above
+    #
+    # @param auto_claim_id [Integer] Applied to that particular claim id if provided
+    # @param message [any] Anything in any format that explains the error
+    def self.log_exception_to_claim_record(auto_claim_id, message)
+      ClaimsApi::SpecialIssueUpdater.new.log_exception_to_claim_record(auto_claim_id, message)
+    end
+
+    # Passthru to allow calling from sidekiq_retries_exhausted section above
+    #
+    # @param e [StandardError] Error to be logged
+    def self.log_exception_to_sentry(e)
+      ClaimsApi::SpecialIssueUpdater.new.log_exception_to_sentry(e)
+    end
+
     # Service object to interface with BGS
     #
     # @param user [OpenStruct] Veteran to attach special issues to


### PR DESCRIPTION
## Description of change
Resolves issue with methods called from `sidekiq_retries_exhausted` within a sidekiq job. 

## Original issue(s)
https://vajira.max.gov/browse/API-6822

## Things to know about this PR
https://medium.com/appaloosa-store-engineering/make-a-failing-sidekiq-worker-call-a-method-after-a-specific-number-of-retries-709d7f2cb9f3
is where i got the idea to use class level methods for `sidekiq_retries_exhausted`