### PR TITLE
Add MPI id theft flag to user model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -273,6 +273,7 @@ class User < Common::RedisStore
   delegate :icn_with_aaid, to: :mpi
   delegate :vet360_id, to: :mpi
   delegate :search_token, to: :mpi
+  delegate :id_theft_flag, to: :mpi
   delegate :status, to: :mpi, prefix: true
   delegate :error, to: :mpi, prefix: true
   delegate :cerner_id, to: :mpi

--- a/lib/mpi/models/mvi_profile.rb
+++ b/lib/mpi/models/mvi_profile.rb
@@ -15,6 +15,7 @@ module MPI
 
       attribute :search_token, String
       attribute :relationships, Array[MviProfileRelationship]
+      attribute :id_theft_flag, Boolean
     end
   end
 end

--- a/lib/mpi/responses/profile_parser.rb
+++ b/lib/mpi/responses/profile_parser.rb
@@ -20,6 +20,8 @@ module MPI
       SUBJECT_XPATH = 'controlActProcess/subject'
       PATIENT_XPATH = 'registrationEvent/subject1/patient'
       STATUS_XPATH = 'statusCode/@code'
+      CONFIDENTIALITY_CODE_XPATH = 'confidentialityCode/@code'
+      ID_THEFT_INDICATOR = 'ID_THEFT^TRUE'
 
       PATIENT_PERSON_PREFIX = 'patientPerson/'
       RELATIONSHIP_PREFIX = 'relationshipHolder1/'
@@ -88,7 +90,8 @@ module MPI
         profile_ids_hash = create_mvi_profile_ids(patient, historical_icns)
         misc_hash = {
           search_token: locate_element(@original_body, 'id').attributes[:extension],
-          relationships: parse_relationships(patient.locate(PATIENT_RELATIONSHIP_XPATH))
+          relationships: parse_relationships(patient.locate(PATIENT_RELATIONSHIP_XPATH)),
+          id_theft_flag: parse_id_theft_flag(patient)
         }
 
         MPI::Models::MviProfile.new(profile_identity_hash.merge(profile_ids_hash).merge(misc_hash))
@@ -103,6 +106,11 @@ module MPI
         relationship_ids_hash = create_mvi_profile_ids(locate_element(relationship, RELATIONSHIP_PREFIX))
 
         MPI::Models::MviProfileRelationship.new(relationship_identity_hash.merge(relationship_ids_hash))
+      end
+
+      def parse_id_theft_flag(patient)
+        code = patient.locate_element(patient, CONFIDENTIALITY_CODE_XPATH)
+        code == ID_THEFT_INDICATOR
       end
 
       def create_mvi_profile_identity(person, person_prefix)

--- a/lib/mpi/responses/profile_parser.rb
+++ b/lib/mpi/responses/profile_parser.rb
@@ -109,7 +109,7 @@ module MPI
       end
 
       def parse_id_theft_flag(patient)
-        code = patient.locate_element(patient, CONFIDENTIALITY_CODE_XPATH)
+        code = locate_element(patient, CONFIDENTIALITY_CODE_XPATH)
         code == ID_THEFT_INDICATOR
       end
 

--- a/spec/lib/mpi/responses/profile_parser_spec.rb
+++ b/spec/lib/mpi/responses/profile_parser_spec.rb
@@ -29,7 +29,8 @@ describe MPI::Responses::ProfileParser do
           birls_ids: [],
           sec_id: nil,
           historical_icns: nil,
-          search_token: 'WSDOC1609131753362231779394902'
+          search_token: 'WSDOC1609131753362231779394902',
+          id_theft_flag: false
         )
       end
 
@@ -50,7 +51,8 @@ describe MPI::Responses::ProfileParser do
             birls_ids: [],
             sec_id: nil,
             historical_icns: nil,
-            search_token: 'WSDOC1609131753362231779394902'
+            search_token: 'WSDOC1609131753362231779394902',
+            id_theft_flag: false
           )
         end
 
@@ -82,7 +84,8 @@ describe MPI::Responses::ProfileParser do
               'UNK^NI^200DOD^USDOD^A',
               'UNK^PI^200CORP^USVBA^A'
             ],
-            search_token: 'WSDOC1609131753362231779394902'
+            search_token: 'WSDOC1609131753362231779394902',
+            id_theft_flag: false
           )
         end
 
@@ -113,7 +116,8 @@ describe MPI::Responses::ProfileParser do
               '1008714701^PN^200PROV^USDVA^A',
               '1100792239^PI^200MHS^USVHA^A'
             ],
-            search_token: 'WSDOC1908201553145951848240311'
+            search_token: 'WSDOC1908201553145951848240311',
+            id_theft_flag: false
           )
         end
 
@@ -161,7 +165,8 @@ describe MPI::Responses::ProfileParser do
           birls_ids: [],
           search_token: 'WSDOC2005221733165441605720989',
           person_type_code: 'Dependent',
-          relationships: [mpi_profile_relationship_component]
+          relationships: [mpi_profile_relationship_component],
+          id_theft_flag: false
         )
       end
 
@@ -286,7 +291,8 @@ describe MPI::Responses::ProfileParser do
           '123412345^PI^200BRLS^USVBA^A'
         ],
         search_token: 'WSDOC1611060614456041732180196',
-        person_type_code: 'Patient'
+        person_type_code: 'Patient',
+        id_theft_flag: false
       )
     end
 
@@ -309,7 +315,8 @@ describe MPI::Responses::ProfileParser do
         sec_id: nil,
         birls_id: nil,
         birls_ids: [],
-        search_token: 'WSDOC1609131753362231779394902'
+        search_token: 'WSDOC1609131753362231779394902',
+        id_theft_flag: false
       )
     end
 

--- a/spec/lib/mpi/service_spec.rb
+++ b/spec/lib/mpi/service_spec.rb
@@ -260,6 +260,16 @@ describe MPI::Service do
         end
       end
 
+      it 'fetches id_theft flag' do
+        allow(user).to receive(:mhv_icn).and_return('1012870264V741864')
+
+        VCR.use_cassette('mpi/find_candidate/valid_id_theft_flag') do
+          response = subject.find_profile(user)
+          expect(response.status).to eq('OK')
+          expect(response.profile['id_theft_flag']).to eq(true)
+        end
+      end
+
       it 'returns no errors' do
         allow(user).to receive(:mhv_icn).and_return('1008714701V416111^NI^200M^USVHA^P')
 

--- a/spec/lib/mpi/service_spec.rb
+++ b/spec/lib/mpi/service_spec.rb
@@ -39,7 +39,8 @@ describe MPI::Service do
         '1008714701^PN^200PROV^USDVA^A',
         '32383600^PI^200CORP^USVBA^L'
       ],
-      search_token: nil
+      search_token: nil,
+      id_theft_flag: false
     )
   end
 

--- a/spec/support/vcr_cassettes/mpi/find_candidate/valid_id_theft_flag.yml
+++ b/spec/support/vcr_cassettes/mpi/find_candidate/valid_id_theft_flag.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<MPI_URL>"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        CjxlbnY6RW52ZWxvcGUgeG1sbnM6c29hcGVuYz0iaHR0cDovL3NjaGVtYXMueG1sc29hcC5vcmcvc29hcC9lbmNvZGluZy8iIHhtbG5zOnhzZD0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiIHhtbG5zOmVudj0iaHR0cDovL3NjaGVtYXMueG1sc29hcC5vcmcvc29hcC9lbnZlbG9wZS8iIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiPgogIDxlbnY6SGVhZGVyLz4KICA8ZW52OkJvZHk+CiAgICA8aWRtOlBSUEFfSU4yMDEzMDVVVjAyIHhtbG5zOmlkbT0iaHR0cDovL3Zhd3cub2VkLm9pdC52YS5nb3YiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWHigJBpbnN0YW5jZSIgeHNpOnNjaGVtYUxvY2F0aW9uPSJ1cm46aGw34oCQb3JnOnYzIC4uLy4uL3NjaGVtYS9ITDdWMy9ORTIwMDgvbXVsdGljYWNoZXNjaGVtYXMvUFJQQV9JTjIwMTMwNVVWMDIueHNkIiB4bWxucz0idXJuOmhsN+KAkG9yZzp2MyIgSVRTVmVyc2lvbj0iWE1MXzEuMCI+CiAgICAgIDxpZCByb290PSIxLjIuODQwLjExNDM1MC4xLjEzLjAuMS43LjEuMSIgZXh0ZW5zaW9uPSIyMDBWR09WLWFjODk5NmFlLTBlY2UtNGZlMy1hNDVhLTc1YjYyYjk5MWViNCIvPgogICAgICA8Y3JlYXRpb25UaW1lIHZhbHVlPSIyMDE4MDIyMTIwMTkwMSIvPgogICAgICA8dmVyc2lvbkNvZGUgY29kZT0iNC4xIi8+CiAgICAgIDxpbnRlcmFjdGlvbklkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjEuNiIgZXh0ZW5zaW9uPSJQUlBBX0lOMjAxMzA1VVYwMiIvPgogICAgICA8cHJvY2Vzc2luZ0NvZGUgY29kZT0iVCIvPgogICAgICA8cHJvY2Vzc2luZ01vZGVDb2RlIGNvZGU9IlQiLz4KICAgICAgPGFjY2VwdEFja0NvZGUgY29kZT0iQUwiLz4KICAgICAgPHJlY2VpdmVyIHR5cGVDb2RlPSJSQ1YiPgogICAgICAgIDxkZXZpY2UgY2xhc3NDb2RlPSJERVYiIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAgICAgICAgICA8aWQgcm9vdD0iMS4yLjg0MC4xMTQzNTAuMS4xMy45OTkuMjM0IiBleHRlbnNpb249IjIwME0iLz4KICAgICAgICA8L2RldmljZT4KICAgICAgPC9yZWNlaXZlcj4KICAgICAgPHNlbmRlciB0eXBlQ29kZT0iU05EIj4KICAgICAgICA8ZGV2aWNlIGNsYXNzQ29kZT0iREVWIiBkZXRlcm1pbmVyQ29kZT0iSU5TVEFOQ0UiPgogICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMzQ5IiBleHRlbnNpb249IjIwMFZHT1YiLz4KICAgICAgICA8L2RldmljZT4KICAgICAgPC9zZW5kZXI+CiAgICAgIDxjb250cm9sQWN0UHJvY2VzcyBjbGFzc0NvZGU9IkNBQ1QiIG1vb2RDb2RlPSJFVk4iPgogICAgICAgIDxjb2RlIGNvZGU9IlBSUEFfVEUyMDEzMDVVVjAyIiBjb2RlU3lzdGVtPSIyLjE2Ljg0MC4xLjExMzg4My4xLjYiLz4KICAgICAgICA8cXVlcnlCeVBhcmFtZXRlcj4KICAgICAgICAgIDxxdWVyeUlkIHJvb3Q9IjEuMi44NDAuMTE0MzUwLjEuMTMuMjguMS4xOC41Ljk5OSIgZXh0ZW5zaW9uPSIxODIwNCIvPgogICAgICAgICAgPHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+CiAgICAgICAgICA8bW9kaWZ5Q29kZSBjb2RlPSJNVkkuQ09NUDEuUk1TIi8+CiAgICAgICAgICA8aW5pdGlhbFF1YW50aXR5IHZhbHVlPSIxIi8+CiAgICAgICAgICA8cGFyYW1ldGVyTGlzdD4KICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMzQ5IiBleHRlbnNpb249IjEwMTI4NzAyNjRWNzQxODY0Ii8+CiAgICAgICAgICA8L3BhcmFtZXRlckxpc3Q+CiAgICAgICAgPC9xdWVyeUJ5UGFyYW1ldGVyPgogICAgICA8L2NvbnRyb2xBY3RQcm9jZXNzPgogICAgPC9pZG06UFJQQV9JTjIwMTMwNVVWMDI+CiAgPC9lbnY6Qm9keT4KPC9lbnY6RW52ZWxvcGU+Cg==
+    headers:
+      Accept:
+      - text/xml;charset=UTF-8
+      Content-Type:
+      - text/xml;charset=UTF-8
+      User-Agent:
+      - Vets.gov Agent
+      Soapaction:
+      - PRPA_IN201305UV02
+      Date:
+      - Wed, 21 Feb 2018 20:19:01 GMT
+      Content-Length:
+      - '1888'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Backside-Transport:
+      - OK OK,OK OK
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 24 May 2021 23:52:46 GMT
+      Content-Type:
+      - text/xml
+      X-Global-Transaction-Id:
+      - f8ba531560ac3c4c08fa8091
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <env:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><env:Header/><env:Body><idm:PRPA_IN201306UV02 ITSVersion="XML_1.0" xsi:schemaLocation="urn:hl7-org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/PRPA_IN201306UV02.xsd" xmlns="urn:hl7-org:v3" xmlns:idm="http://vaww.oed.oit.va.gov"><id extension="WSDOC2105241952466650387697184" root="2.16.840.1.113883.4.349"/><creationTime value="20210524195246"/><versionCode code="4.1"/><interactionId extension="PRPA_IN201306UV02" root="2.16.840.1.113883.1.6"/><processingCode code="T"/><processingModeCode code="T"/><acceptAckCode code="NE"/><receiver typeCode="RCV"><device determinerCode="INSTANCE" classCode="DEV"><id extension="200VGOV" root="2.16.840.1.113883.4.349"/></device></receiver><sender typeCode="SND"><device determinerCode="INSTANCE" classCode="DEV"><id extension="200M" root="2.16.840.1.113883.4.349"/></device></sender><acknowledgement><typeCode code="AA"/><targetMessage><id extension="200VGOV-ac8996ae-0ece-4fe3-a45a-75b62b991eb4" root="1.2.840.114350.1.13.0.1.7.1.1"/></targetMessage></acknowledgement><controlActProcess classCode="CACT" moodCode="EVN"><code codeSystem="2.16.840.1.113883.1.6" code="PRPA_TE201306UV02"/><subject typeCode="SUBJ"><registrationEvent classCode="REG" moodCode="EVN"><id nullFlavor="NA"/><statusCode code="active"/><subject1 typeCode="SBJ"><patient classCode="PAT"><id extension="1012870264V741864^NI^200M^USVHA^P" root="2.16.840.1.113883.4.349"/><id extension="943590^PI^979^USVHA^A" root="2.16.840.1.113883.4.349"/><id extension="13408508^PI^200MHS^USVHA^A" root="2.16.840.1.113883.4.349"/><id extension="552151541^PI^989^USVHA^A" root="2.16.840.1.113883.4.349"/><id extension="666360333^PI^200BRLS^USVBA^A" root="2.16.840.1.113883.4.349"/><id extension="1320002070^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12"/><id extension="20411^PI^200VETS^USDVA^A" root="2.16.840.1.113883.4.349"/><id extension="1012870264^PN^200PROV^USDVA^A" root="2.16.840.1.113883.4.349"/><id extension="600152412^PI^200CORP^USVBA^A" root="2.16.840.1.113883.4.349"/><id extension="3f13a9f4fcc04102b90d13ef4e9370aa^PN^200VIDM^USDVA^A" root="2.16.840.1.113883.4.349"/><statusCode code="active"/><confidentialityCode code="ID_THEFT^TRUE"/><patientPerson><name use="L"><given>JHUN</given><family>GPKSYSNINETEST</family></name><administrativeGenderCode code="M"/><birthTime value="19790605"/><multipleBirthInd value="false"/><asOtherIDs classCode="SSN"><id extension="666360333" root="2.16.840.1.113883.4.1"/><scopingOrganization determinerCode="INSTANCE" classCode="ORG"><id root="1.2.840.114350.1.13.99997.2.3412"/></scopingOrganization></asOtherIDs><birthPlace><addr><city>ATLANTA</city><state>GA</state><country>USA</country></addr></birthPlace></patientPerson><subjectOf1><queryMatchObservation classCode="COND" moodCode="EVN"><code code="IHE_PDQ"/><value nullFlavor="NA" xsi:type="INT"/></queryMatchObservation></subjectOf1><subjectOf2 typeCode="SBJ"><administrativeObservation classCode="VERIF"><code codeSystem="2.16.840.1.113883.4.349" code="PERSON_TYPE" displayName="Person Type"/><value xsi:type="CD" code="PAT" displayName="Patient"/></administrativeObservation></subjectOf2></patient></subject1><custodian typeCode="CST"><assignedEntity classCode="ASSIGNED"><id root="2.16.840.1.113883.4.349"/></assignedEntity></custodian></registrationEvent></subject><queryAck><queryId extension="18204" root="1.2.840.114350.1.13.28.1.18.5.999"/><queryResponseCode code="OK"/><resultCurrentQuantity value="1"/></queryAck><queryByParameter><queryId extension="18204" root="1.2.840.114350.1.13.28.1.18.5.999"/><statusCode code="new"/><modifyCode code="MVI.COMP1.RMS"/><initialQuantity value="1"/><parameterList><id extension="1012870264V741864" root="2.16.840.1.113883.4.349"/></parameterList></queryByParameter></controlActProcess></idm:PRPA_IN201306UV02></env:Body></env:Envelope>
+  recorded_at: Wed, 21 Feb 2018 20:19:01 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Description of change
Adds the MPI identity theft flag to the MPI profile parser and from there to the user model.

The intent is that this flag can be used in scenarios like Mobile OAuth where we don't authenticate as frequently, to block user access. That change would come as a separate PR. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25057 describes some of the impetus

## Things to know about this PR

Tested with a staging user for whom we had the identity flag set in MPI's SQA environment. 
