### PR TITLE
API-7038 Update emailAddressText character limit from 44 to 100

### DIFF
--- a/modules/appeals_api/config/schemas/v2/200996.json
+++ b/modules/appeals_api/config/schemas/v2/200996.json
@@ -118,7 +118,7 @@
         "emailAddressText": {
           "type": "string",
           "format": "email",
-          "maxLength": 44
+          "maxLength": 100
         },
         "timezone": {
           "type": "string",


### PR DESCRIPTION
For the new hlr form, we are increasing the character limit for veteran email. The limit for v1 is currently 44 chars. After researching, it was discovered that:

~100 chars the font size reduces to 8pt

~110 chars, characters are cut off

Please see ticket and ticket comments for more details on how the 100-character limit was determined.

Ticket: https://vajira.max.gov/browse/API-7038