### PR TITLE
Rails 6.1 migrations and schema update

### DIFF
--- a/db/migrate/20210524134112_add_service_name_to_active_storage_blobs.active_storage.rb
+++ b/db/migrate/20210524134112_add_service_name_to_active_storage_blobs.active_storage.rb
@@ -1,0 +1,17 @@
+# This migration comes from active_storage (originally 20190112182829)
+class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
+
+  def up
+    unless column_exists?(:active_storage_blobs, :service_name)
+      add_column :active_storage_blobs, :service_name, :string, null: false
+
+      if configured_service = ActiveStorage::Blob.service.name
+        ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
+      end
+    end
+  end
+
+  def down
+    remove_column :active_storage_blobs, :service_name
+  end
+end

--- a/db/migrate/20210524134113_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20210524134113_create_active_storage_variant_records.active_storage.rb
@@ -1,0 +1,13 @@
+# This migration comes from active_storage (originally 20191206030411)
+class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
+
+  def change
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_10_202141) do
+ActiveRecord::Schema.define(version: 2021_05_24_134113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -53,7 +53,14 @@ ActiveRecord::Schema.define(version: 2021_05_10_202141) do
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
     t.datetime "created_at", null: false
+    t.string "service_name"
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "appeal_submission_uploads", force: :cascade do |t|
@@ -849,4 +856,5 @@ ActiveRecord::Schema.define(version: 2021_05_10_202141) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
## Description of change
This PR makes some necessary migrations for the Rails 6.1 upgrade. Some of the specs were failing with `NoMethodError (undefined method 'service_name' for #<ActiveStorage::Blob:0x0000558b5edfbeb8>)`. db migrations were needed for the ActiveStorage blobs (specifically to add the service_name column) Used the solution suggested [here](https://github.com/rails/rails/issues/40895#issuecomment-748811171)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#18862
department-of-veterans-affairs/va.gov-team#22271

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
