### PR TITLE
Api 7380/update generator to add versionsb

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews_controller.rb
@@ -82,7 +82,8 @@ class AppealsApi::V1::DecisionReviews::HigherLevelReviewsController < AppealsApi
     @higher_level_review = AppealsApi::HigherLevelReview.new(
       auth_headers: headers,
       form_data: @json_body,
-      source: headers['X-Consumer-Username']
+      source: headers['X-Consumer-Username'],
+      api_version: 'V1'
     )
 
     render_model_errors unless @higher_level_review.validate

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements_controller.rb
@@ -82,7 +82,8 @@ class AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController < Appeals
       auth_headers: headers,
       form_data: @json_body,
       source: headers['X-Consumer-Username'],
-      board_review_option: @json_body['data']['attributes']['boardReviewOption']
+      board_review_option: @json_body['data']['attributes']['boardReviewOption'],
+      api_version: 'V1'
     )
     render_model_errors unless @notice_of_disagreement.validate
   end

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -92,7 +92,8 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
     @higher_level_review = AppealsApi::HigherLevelReview.new(
       auth_headers: headers,
       form_data: @json_body,
-      source: headers['X-Consumer-Username']
+      source: headers['X-Consumer-Username'],
+      api_version: 'V2'
     )
 
     render_model_errors unless @higher_level_review.validate

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/generator.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/generator.rb
@@ -7,6 +7,7 @@ module AppealsApi
     class Generator
       def initialize(appeal, version: 'V1')
         @appeal = appeal
+        appeal.update(pdf_fill_version: version)
         @structure = appeal.pdf_structure(version)
       end
 

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/generator.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/generator.rb
@@ -7,7 +7,7 @@ module AppealsApi
     class Generator
       def initialize(appeal, version: 'V1')
         @appeal = appeal
-        appeal.update(pdf_fill_version: version)
+        appeal.update(pdf_version: version)
         @structure = appeal.pdf_structure(version)
       end
 


### PR DESCRIPTION
[API-7380](https://vajira.max.gov/browse/API-7380)

This PR adds the storage of pdf fill version and api versions to HLR/NOD. It's dependent on [this](https://github.com/department-of-veterans-affairs/vets-api/pull/7031) PR.

We'll add a backfilling PR that's dependent on this PR next.