### PR TITLE
[25234] Reducing log output for parallel specs to improve compatibili…

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,6 +1,5 @@
 --color
 --require spec_helper
---format progress
 <% if ENV['CI'] %>
 --format RspecJunitFormatter
 --out log/rspec<%= ENV['TEST_ENV_NUMBER'] %>.xml


### PR DESCRIPTION
…ty with Github Actions output

## Description of change
This PR reduces the logged output of a parallel spec run. This should make it so the Github Actions tab for the RSpec suite loads much more easily (doesn't hang for 3-5 minutes before being usable)

## Original issue(s)
department-of-veterans-affairs/va.gov-team/issues/25234

## Things to know about this PR
* Failed tests should still output the actual RSpec test failures

