### PR TITLE
[7047] Escaping HTML characters from relay state parameter for sessio…

### DIFF
--- a/app/controllers/v0/sessions_controller.rb
+++ b/app/controllers/v0/sessions_controller.rb
@@ -181,7 +181,7 @@ module V0
     end
 
     def saml_response_stats(saml_response)
-      type = JSON.parse(params[:RelayState] || '{}')['type']
+      type = html_escaped_relay_state['type']
       values = {
         'id' => saml_response.in_response_to,
         'authn' => saml_response.authn_context,
@@ -265,8 +265,12 @@ module V0
       end
     end
 
+    def html_escaped_relay_state
+      JSON.parse(CGI.unescapeHTML(params[:RelayState] || '{}'))
+    end
+
     def originating_request_id
-      JSON.parse(params[:RelayState] || '{}')['originating_request_id']
+      html_escaped_relay_state['originating_request_id']
     rescue
       'UNKNOWN'
     end

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -50,7 +50,7 @@ module V1
     end
 
     def saml_callback
-      set_sentry_context_for_callback if JSON.parse(params[:RelayState] || '{}')['type'] == 'mfa'
+      set_sentry_context_for_callback if html_escaped_relay_state['type'] == 'mfa'
       saml_response = SAML::Responses::Login.new(params[:SAMLResponse], settings: saml_settings)
       saml_response_stats(saml_response)
       raise_saml_error(saml_response) unless saml_response.valid?
@@ -350,8 +350,12 @@ module V1
       end
     end
 
+    def html_escaped_relay_state
+      JSON.parse(CGI.unescapeHTML(params[:RelayState] || '{}'))
+    end
+
     def originating_request_id
-      JSON.parse(params[:RelayState] || '{}')['originating_request_id']
+      html_escaped_relay_state['originating_request_id']
     rescue
       'UNKNOWN'
     end

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -26,7 +26,7 @@ module SAML
       @loa3_context = loa3_context
 
       if (params[:action] == 'saml_callback') && params[:RelayState].present?
-        @type = JSON.parse(params[:RelayState])['type']
+        @type = JSON.parse(CGI.unescapeHTML(params[:RelayState]))['type']
       end
       @query_params = {}
       @tracker = initialize_tracker(params)

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -38,7 +38,7 @@ module SAML
       @loa3_context = loa3_context
 
       if (params[:action] == 'saml_callback') && params[:RelayState].present?
-        @type = JSON.parse(params[:RelayState])['type']
+        @type = JSON.parse(CGI.unescapeHTML(params[:RelayState]))['type']
       end
       @query_params = {}
       @tracker = initialize_tracker(params)


### PR DESCRIPTION
…ns callback

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
We randomly started having authentication failures on local dev. It looks like this is happening because we're expecting to be able to parse an incoming param as JSON, but it has HTML characters in it. So we need to escape these characters first, and then we can parse the incoming param

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/7047

## Things to know about this PR
* Should be able to log in successfully
* Should be able to confirm that sentry context is getting set correctly when we are getting a SAML callback of type Multifactor Auth (this uses the relay state param to extract 'mfa')
