### PR TITLE
Api 7461 lighthouse ssoe token validation support

### DIFF
--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -138,7 +138,7 @@ class OpenidApplicationController < ApplicationController
                              Okta::UserProfile.new({ 'last_login_type' => profile['last_login_type'],
                                                      'SecID' => profile['SecID'], 'VistaId' => profile['VistaId'],
                                                      'npi' => profile['npi'], 'icn' => profile['icn'],
-                                                     'uuid' => profile['uuid']}))
+                                                     'uuid' => uuid(profile) }))
     @session.save && user_identity.save && @current_user.save
   end
 

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -132,7 +132,7 @@ class OpenidApplicationController < ApplicationController
   def establish_session(profile)
     ttl = token.payload['exp'] - Time.current.utc.to_i
 
-    user_identity = OpenidUserIdentity.build_from_okta_profile(uuid: uuid(profile), profile: profile, ttl: ttl)
+    user_identity = OpenidUserIdentity.build_from_okta_profile(uuid: token.identifiers.uuid, profile: profile, ttl: ttl)
     @current_user = OpenidUser.build_from_identity(identity: user_identity, ttl: ttl)
     @session = build_session(ttl,
                              Okta::UserProfile.new({ 'last_login_type' => profile['last_login_type'],

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -142,7 +142,8 @@ class OpenidApplicationController < ApplicationController
     @session.save && user_identity.save && @current_user.save
   end
 
-  # Helper method that uses the profile uuid set by SSOe but falls back to the token identifier uuid if unset
+  # Helper method that uses the profile uuid set by SSOe since the sub == ICN in that scenario
+  # but falls back to the token.identifiers.uuid
   def uuid(profile)
     profile['uuid'] || token.identifiers.uuid
   end

--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -131,13 +131,20 @@ class OpenidApplicationController < ApplicationController
 
   def establish_session(profile)
     ttl = token.payload['exp'] - Time.current.utc.to_i
-    user_identity = OpenidUserIdentity.build_from_okta_profile(uuid: token.identifiers.uuid, profile: profile, ttl: ttl)
+
+    user_identity = OpenidUserIdentity.build_from_okta_profile(uuid: uuid(profile), profile: profile, ttl: ttl)
     @current_user = OpenidUser.build_from_identity(identity: user_identity, ttl: ttl)
     @session = build_session(ttl,
                              Okta::UserProfile.new({ 'last_login_type' => profile['last_login_type'],
                                                      'SecID' => profile['SecID'], 'VistaId' => profile['VistaId'],
-                                                     'npi' => profile['npi'], 'icn' => profile['icn'] }))
+                                                     'npi' => profile['npi'], 'icn' => profile['icn'],
+                                                     'uuid' => profile['uuid']}))
     @session.save && user_identity.save && @current_user.save
+  end
+
+  # Helper method that uses the profile uuid set by SSOe but falls back to the token identifier uuid if unset
+  def uuid(profile)
+    profile['uuid'] || token.identifiers.uuid
   end
 
   def token
@@ -156,7 +163,7 @@ class OpenidApplicationController < ApplicationController
   end
 
   def build_session(ttl, profile)
-    session = Session.new(token: token.to_s, uuid: token.identifiers.uuid, profile: profile)
+    session = Session.new(token: token.to_s, uuid: uuid(profile), profile: profile)
     session.expire(ttl)
     session
   end

--- a/app/models/openid_user_identity.rb
+++ b/app/models/openid_user_identity.rb
@@ -10,12 +10,13 @@ class OpenidUserIdentity < ::UserIdentity
   redis_key :uuid
 
   # @param uuid [String] the UUID of the user, as they are known to the upstream identity provider.
+  #   uses the profile uuid set by SSOe but falls back to the token identifier uuid if unset
   # @param profile [Okta::UserProfile] the profile of the user, as they are known to okta.
   # @param ttl [Integer] the time to store the identity in redis.
   # @return [OpenidUserIdentity]
   def self.build_from_okta_profile(uuid:, profile:, ttl:)
     identity = new(
-      uuid: uuid,
+      uuid: profile['uuid'] || uuid,
       email: profile['email'],
       first_name: profile['firstName'],
       middle_name: profile['middleName'],

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -73,12 +73,16 @@ class Token
   end
 
   def identifiers
-    # Here the `sub` field is the same value as the `uuid` field from the original upstream ID.me
-    # SAML response. We use this as the primary identifier of the user because, despite openid user
+    # Here the `sub` field is the same value as the `login` field from the okta profile.
+    # In cases of direct saml-proxy integration with the IDP, the `sub` is
+    # the same value as the `uuid` field from the original upstream ID.me
+    # However in cases of SSOe, the `sub` is actually the `ICN` for the user
+    # We use this as the primary identifier of the user because, despite openid user
     # records being controlled by okta, we want to remain consistent with the va.gov SSO process
     # that consumes the SAML response directly, outside the openid flow.
     # Example of an upstream uuid for the user: cfa32244569841a090ad9d2f0524cf38
     # Example of an okta uid for the user: 00u2p9far4ihDAEX82p7
+    # Example of sub for SSOe: 1013062086V794840
     @identifiers ||= OpenStruct.new(
       uuid: payload['sub'],
       okta_uid: payload['uid']

--- a/lib/okta/user_profile.rb
+++ b/lib/okta/user_profile.rb
@@ -21,7 +21,7 @@ module Okta
         dl = DSLOGON_PREMIUM_LOAS.include?(@attrs['dslogon_assurance']) ? 3 : 1
         { current: dl, highest: dl }
       # SSOe combines LOA into a single field for all 3 login types
-      elsif %w(200DOD 200VIDM 200MHV).include?(@attrs['last_login_type'])
+      elsif %w[200DOD 200VIDM 200MHV].include?(@attrs['last_login_type'])
         { current: @attrs['loa']&.to_i, highest: @attrs['loa']&.to_i }
       else
         { current: @attrs['idme_loa']&.to_i, highest: @attrs['idme_loa']&.to_i }

--- a/lib/okta/user_profile.rb
+++ b/lib/okta/user_profile.rb
@@ -20,6 +20,9 @@ module Okta
       elsif @attrs['last_login_type'] == 'dslogon'
         dl = DSLOGON_PREMIUM_LOAS.include?(@attrs['dslogon_assurance']) ? 3 : 1
         { current: dl, highest: dl }
+      # SSOe combines LOA into a single field for all 3 login types
+      elsif ['200DOD', '200VIDM', '200MHV'].include?(@attrs['last_login_type'])
+        { current: @attrs['loa']&.to_i, highest: @attrs['loa']&.to_i }
       else
         { current: @attrs['idme_loa']&.to_i, highest: @attrs['idme_loa']&.to_i }
       end

--- a/lib/okta/user_profile.rb
+++ b/lib/okta/user_profile.rb
@@ -21,7 +21,7 @@ module Okta
         dl = DSLOGON_PREMIUM_LOAS.include?(@attrs['dslogon_assurance']) ? 3 : 1
         { current: dl, highest: dl }
       # SSOe combines LOA into a single field for all 3 login types
-      elsif ['200DOD', '200VIDM', '200MHV'].include?(@attrs['last_login_type'])
+      elsif %w(200DOD 200VIDM 200MHV).include?(@attrs['last_login_type'])
         { current: @attrs['loa']&.to_i, highest: @attrs['loa']&.to_i }
       else
         { current: @attrs['idme_loa']&.to_i, highest: @attrs['idme_loa']&.to_i }

--- a/spec/models/openid_user_identity_spec.rb
+++ b/spec/models/openid_user_identity_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe OpenidUserIdentity, type: :model do
         okta_response = okta_service.user('00u1zlqhuo3yLa2Xs2p7')
         profile = Okta::UserProfile.new(okta_response.body['profile'])
         identity = OpenidUserIdentity.build_from_okta_profile(uuid: 'abc123', profile: profile, ttl: some_ttl)
+        expect(identity.uuid).to eq('abc123')
+        expect(identity.first_name).to eq('KELLY')
+        expect(identity.last_name).to eq('CARROLL')
+        expect(identity.middle_name).to eq('D')
+        expect(identity.gender).to be_nil
+        expect(identity.loa).to eq(loa_three)
+      end
+    end
+
+    it 'is compatible with the okta profile that includes uuid (ssoe)' do
+      with_okta_profile_with_uuid_configured do
+        okta_response = okta_service.user('00u1zlqhuo3yLa2Xs2p7')
+        profile = Okta::UserProfile.new(okta_response.body['profile'])
+        identity = OpenidUserIdentity.build_from_okta_profile(uuid: 'abc123', profile: profile, ttl: some_ttl)
+        expect(identity.uuid).to eq('ae9ff5f4e4b741389904087d94cd19b2')
         expect(identity.first_name).to eq('KELLY')
         expect(identity.last_name).to eq('CARROLL')
         expect(identity.middle_name).to eq('D')

--- a/spec/support/okta_users_helpers.rb
+++ b/spec/support/okta_users_helpers.rb
@@ -40,14 +40,14 @@ end
 
 def with_okta_profile_with_uuid_configured(&block)
   with_settings(
-      Settings.oidc,
-      auth_server_metadata_url: 'https://example.com/oauth2/default/.well-known/openid-configuration',
-      issuer: 'https://example.com/oauth2/default',
-      issuer_prefix: 'https://example.com/oauth2',
-      audience: 'api://default',
-      base_api_url: 'https://example.com/',
-      base_api_token: 'token'
-  ) do
+    Settings.oidc,
+    auth_server_metadata_url: 'https://example.com/oauth2/default/.well-known/openid-configuration',
+    issuer: 'https://example.com/oauth2/default',
+    issuer_prefix: 'https://example.com/oauth2',
+    audience: 'api://default',
+    base_api_url: 'https://example.com/',
+    base_api_token: 'token'
+    ) do
     with_settings(Settings.oidc.isolated_audience, default: 'api://default') do
       VCR.use_cassette('okta/metadata-ssoe') do
         yield block

--- a/spec/support/okta_users_helpers.rb
+++ b/spec/support/okta_users_helpers.rb
@@ -47,7 +47,7 @@ def with_okta_profile_with_uuid_configured(&block)
     audience: 'api://default',
     base_api_url: 'https://example.com/',
     base_api_token: 'token'
-    ) do
+  ) do
     with_settings(Settings.oidc.isolated_audience, default: 'api://default') do
       VCR.use_cassette('okta/metadata-ssoe') do
         yield block

--- a/spec/support/okta_users_helpers.rb
+++ b/spec/support/okta_users_helpers.rb
@@ -38,6 +38,24 @@ def with_okta_profile_configured(&block)
   end
 end
 
+def with_okta_profile_with_uuid_configured(&block)
+  with_settings(
+      Settings.oidc,
+      auth_server_metadata_url: 'https://example.com/oauth2/default/.well-known/openid-configuration',
+      issuer: 'https://example.com/oauth2/default',
+      issuer_prefix: 'https://example.com/oauth2',
+      audience: 'api://default',
+      base_api_url: 'https://example.com/',
+      base_api_token: 'token'
+  ) do
+    with_settings(Settings.oidc.isolated_audience, default: 'api://default') do
+      VCR.use_cassette('okta/metadata-ssoe') do
+        yield block
+      end
+    end
+  end
+end
+
 def vcr_cassette(open_id_cassette, &block)
   VCR.use_cassette('okta/metadata') do
     VCR.use_cassette(open_id_cassette) do

--- a/spec/support/vcr_cassettes/okta/metadata-ssoe.yml
+++ b/spec/support/vcr_cassettes/okta/metadata-ssoe.yml
@@ -1,0 +1,194 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://example.com/oauth2/default/.well-known/openid-configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - SSWS <OKTA_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 13 Nov 2018 01:59:08 GMT
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      Content-Type:
+      - application/json;charset=UTF-8
+      X-Okta-Request-Id:
+      - W@ov7KhiirzWZ3wxk4ekxQAAFH4
+      P3p:
+      - CP="HONK"
+      X-Rate-Limit-Limit:
+      - '10000'
+      X-Rate-Limit-Remaining:
+      - '9999'
+      X-Rate-Limit-Reset:
+      - '1542074408'
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000
+      X-Robots-Tag:
+      - none
+      Set-Cookie:
+      - JSESSIONID=B8E5790E66E44F49B5DB0068DF81EFD9; Path=/; Secure; HttpOnly
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"issuer":"https://example.com/oauth2/default","authorization_endpoint":"https://example.com/oauth2/default/v1/authorize","token_endpoint":"https://example.com/oauth2/default/v1/token","userinfo_endpoint":"https://example.com/oauth2/default/v1/userinfo","registration_endpoint":"https://example.com/oauth2/v1/clients","jwks_uri":"https://example.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["launch/patient","openid","profile","email","address","phone","offline_access"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://example.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://example.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://example.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"]}'
+    http_version: 
+  recorded_at: Tue, 13 Nov 2018 01:59:08 GMT
+- request:
+    method: get
+    uri: https://example.com/oauth2/default/v1/keys
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - SSWS <OKTA_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 13 Nov 2018 01:59:08 GMT
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      Content-Type:
+      - application/json;charset=UTF-8
+      X-Okta-Request-Id:
+      - W@ov7Ep1DmzgoRmpjpcStQAAFjI
+      P3p:
+      - CP="HONK"
+      X-Rate-Limit-Limit:
+      - '10000'
+      X-Rate-Limit-Remaining:
+      - '9998'
+      X-Rate-Limit-Reset:
+      - '1542074408'
+      Cache-Control:
+      - max-age=5965338, must-revalidate
+      Expires:
+      - Mon, 21 Jan 2019 03:01:26 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000
+      X-Robots-Tag:
+      - none
+      Set-Cookie:
+      - JSESSIONID=0C63F982615E816FF04BB85C7447FEBC; Path=/; Secure; HttpOnly
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"keys":[{"kty":"RSA","alg":"RS256","kid":"1Z0tNc4Hxs_n7ySgwb6YT8JgWpq0wezqupEg136FZHU","use":"sig","e":"AQAB","n":"0i4GWoXmMg8pn3jJbv7oabdQKxiV43CKIwY05LaSRdXxE0XcsFEXLe58tcEV_1afM3ey4KuHcSYk22En6nl2uGkFGZ_bU0ckrb8bqZ09Adr9Vwogat0QcOfHvqxaCJI6kOqtCX46iP11ViqW6oVHP--exfNPazQE5NyKO6l4VPZ68fpMX82Z_YBB_xdoYkTwM_LuCv2jDpFlumZt539sv7EbhxAL1tq8bjIVH-3tfJB8Hpar8AfzTrcoA8V61qi3JfipU9Bupuex379rf5LNnSh-dvbd98ZIhQKA2yp5nk9gEGKoEuTd-FlqLXs2q2Lr-BlbPDQVkNWClXJICznu_Q"},{"kty":"RSA","alg":"RS256","kid":"8ngL7RPjudB40hF1ALOrxMAn_O7dwljoFohYxcZmLds","use":"sig","e":"AQAB","n":"mTOj331L7Bc3aHolSLR_Vh752zfG3q49NogKuw3eEIgfemQl91CRoOa6yq3aI25Mp15VeuQeVC2YtIM3Uh3Ctvh6ZCcr2UiVFvToIkrETNdJOXwRdo-1Az3Txl-ik_VN55SIYcQN2UcHSD6CM4_icntg4M6uRdylLVPjkmcfhjcHd_NNRgCZGX40N2azg-491vWIpoTVx9jpZjQv_XChTViLRU0F2d9hjg79qqP09r2Pz56dcyr3p0XKUIcYG9WTcUxNlPFdb-vmZ7T4zY49OcTqNIWlM79-XPMgZ7b1HrLnz0Z6iDcVfiDBI2WVCNS_ut00DPs6UIOE94xdav1M0w"}]}'
+    http_version: 
+  recorded_at: Tue, 13 Nov 2018 01:59:09 GMT
+- request:
+    method: get
+    uri: https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - SSWS <OKTA_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 13 Nov 2018 01:59:10 GMT
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      X-Okta-Request-Id:
+      - W@ov7srI2BDv@Fqf0Z7D3gAACgU
+      P3p:
+      - CP="HONK"
+      X-Rate-Limit-Limit:
+      - '2000'
+      X-Rate-Limit-Remaining:
+      - '1999'
+      X-Rate-Limit-Reset:
+      - '1542074410'
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000
+      Set-Cookie:
+      - JSESSIONID=F1DCE568599152B5B46246BC2DC8FCB7; Path=/; Secure; HttpOnly
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"00u1zlqhuo3yLa2Xs2p7","status":"ACTIVE","created":"2018-09-06T20:33:22.000Z","activated":"2018-09-06T20:33:22.000Z","statusChanged":"2018-09-06T20:33:22.000Z","lastLogin":"2018-11-13T01:58:12.000Z","lastUpdated":"2018-11-13T01:58:11.000Z","passwordChanged":null,"profile":{"lastName":"CARROLL","gender":"F","secondEmail":null,"login":"1013062086V794840","uuid":"ae9ff5f4e4b741389904087d94cd19b2","ssn":"123456789","last_login_type":"http://idmanagement.gov/ns/assurance/loa/3","firstName":"KELLY","icn":"1013062086V794840","idme_loa":"3","mobilePhone":null,"dob":"1998-01-23","middleName":"D","email":"vets.gov.user+20@gmail.com","loa":3},"credentials":{"provider":{"type":"FEDERATION","name":"FEDERATION"}},"_links":{"suspend":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/lifecycle/suspend","method":"POST"},"resetPassword":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/lifecycle/reset_password","method":"POST"},"changeRecoveryQuestion":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/credentials/change_recovery_question","method":"POST"},"self":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7"},"deactivate":{"href":"https://example.com/api/v1/users/00u1zlqhuo3yLa2Xs2p7/lifecycle/deactivate","method":"POST"}}}'
+    http_version: 
+  recorded_at: Tue, 13 Nov 2018 01:59:10 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Description of change
Adding 2 small changes to support Lighthouse SSOe integration.

1. Adds support for `profile['uuid']` with fallback to the `token.identifiers.uuid`
2. Updates the `derived_loa` method to handle when SSOe traits are used to populate the profile

## Original issue(s)
https://vajira.max.gov/browse/API-7461

## Things to know about this PR
Behavior should 100% reverse compatible with non-SSOe logins.  Redis cache entries are based on the uuid so different IDP uses will not result in multiple cache entries as long as the same underlying login method is used.
