### PR TITLE
[API-6821] - Only allow "PUT /forms/526" to function on "pending" claims

### DIFF
--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -65,7 +65,7 @@ module ClaimsApi
 
     def self.pending?(id)
       query = where(id: id)
-      query.exists? ? query.first : false
+      query.exists? && query.first.evss_id.nil? ? query.first : false
     end
 
     def self.evss_id_by_token(token)

--- a/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
@@ -293,5 +293,15 @@ RSpec.describe 'Disability Claims ', type: :request do
       auto_claim.reload
       expect(auto_claim.supporting_documents.count).to eq(count + 2)
     end
+
+    context 'when a claim is already established' do
+      let(:auto_claim) { create(:auto_established_claim, :status_established) }
+
+      it 'returns a 404 error because only pending claims are allowed' do
+        allow_any_instance_of(ClaimsApi::SupportingDocumentUploader).to receive(:store!)
+        put "/services/claims/v0/forms/526/#{auto_claim.id}", params: binary_params, headers: headers
+        expect(response.status).to eq(404)
+      end
+    end
   end
 end

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -476,5 +476,18 @@ RSpec.describe 'Disability Claims ', type: :request do
         expect(response.status).to eq(404)
       end
     end
+
+    context 'when a claim is already established' do
+      let(:auto_claim) { create(:auto_established_claim, :status_established) }
+
+      it 'returns a 404 error because only pending claims are allowed' do
+        with_okta_user(scopes) do |auth_header|
+          allow_any_instance_of(ClaimsApi::SupportingDocumentUploader).to receive(:store!)
+          put("/services/claims/v1/forms/526/#{auto_claim.id}",
+              params: binary_params, headers: headers.merge(auth_header))
+          expect(response.status).to eq(404)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Restrict `PUT /forms/526` endpoint in v0 and v1 to only work with pending claims.

## Original issue(s)
[API-6821](https://vajira.max.gov/browse/API-6821)
