### PR TITLE
API-6820: SpecialIssueUpdater background job issue regarding contentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Vets API
 
-
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0%201.0-lightgrey.svg)](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Vets API
 
+
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0%201.0-lightgrey.svg)](LICENSE.md)

--- a/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
+++ b/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
@@ -83,7 +83,8 @@ module ClaimsApi
       claims.each do |claim|
         next if claim[:contentions].blank?
 
-        contention = claim[:contentions].find { |c| matches_contention?(contention_id, c) }
+        contentions = claim[:contentions].is_a?(Hash) ? [claim[:contentions]] : claim[:contentions]
+        contention = contentions.find { |c| matches_contention?(contention_id, c) }
         return claim if contention.present?
       end
     end
@@ -123,7 +124,8 @@ module ClaimsApi
     def existing_contentions(claim, contention_id, special_issues)
       return [] if claim[:contentions].blank?
 
-      claim[:contentions].map do |contention|
+      contentions = claim[:contentions].is_a?(Hash) ? [claim[:contentions]] : claim[:contentions]
+      contentions.map do |contention|
         si = matches_contention?(contention_id, contention) ? special_issues : []
         {
           clm_id: claim[:clm_id],

--- a/modules/claims_api/spec/workers/special_issue_updater_spec.rb
+++ b/modules/claims_api/spec/workers/special_issue_updater_spec.rb
@@ -66,52 +66,101 @@ RSpec.describe ClaimsApi::SpecialIssueUpdater, type: :job do
 
     context 'when a matching contention is found' do
       context 'when contention does not have existing special issues' do
-        let(:claim_id) { '600200323' }
-        let(:claim) do
-          {
-            jrn_dt: '2020-08-17T10:44:43-05:00',
-            bnft_clm_tc: '130DPNEBNADJ',
-            bnft_clm_tn: 'eBenefits Dependency Adjustment',
-            claim_rcvd_dt: '2020-08-17T00:00:00-05:00',
-            clm_id: claim_id,
-            contentions: [
-              {
+        context 'when multiple contentions exist for claim' do
+          let(:claim_id) { '600200323' }
+          let(:claim) do
+            {
+              jrn_dt: '2020-08-17T10:44:43-05:00',
+              bnft_clm_tc: '130DPNEBNADJ',
+              bnft_clm_tn: 'eBenefits Dependency Adjustment',
+              claim_rcvd_dt: '2020-08-17T00:00:00-05:00',
+              clm_id: claim_id,
+              contentions: [
+                {
+                  clm_id: contention_id[:claim_id],
+                  cntntn_id: '999111',
+                  clsfcn_id: contention_id[:code],
+                  clmnt_txt: contention_id[:name]
+                },
+                {
+                  clm_id: '321',
+                  cntntn_id: '123456',
+                  clsfcn_id: '333',
+                  clmnt_txt: 'different-name-here'
+                }
+              ],
+              lc_stt_rsn_tc: 'OPEN',
+              lc_stt_rsn_tn: 'Open',
+              lctn_id: '322',
+              non_med_clm_desc: 'eBenefits Dependency Adjustment',
+              prirty: '0',
+              ptcpnt_id_clmnt: '600036156',
+              ptcpnt_id_vet: '600036156',
+              ptcpnt_suspns_id: '600276939',
+              soj_lctn_id: '347'
+            }
+          end
+          let(:claims) { { benefit_claims: [claim] } }
+
+          it 'all special issues provided are appended to payload' do
+            expected_claim_options = claim.dup
+            special_issues_payload = special_issues.map { |si| { spis_tc: si } }
+            expected_claim_options[:contentions] = [
+              { clm_id: claim_id, cntntn_id: '999111', special_issues: special_issues_payload },
+              { clm_id: claim_id, cntntn_id: '123456', special_issues: [] }
+            ]
+            expect_any_instance_of(BGS::ContentionService).to receive(:manage_contentions).with(expected_claim_options)
+
+            subject.new.perform(user, contention_id, special_issues, claim_record.id)
+          end
+
+          it 'stores bgs exceptions correctly' do
+            expect_any_instance_of(BGS::ContentionService).to receive(:manage_contentions)
+              .and_raise(BGS::ShareError.new('failed', 500))
+
+            subject.new.perform(user, contention_id, special_issues, claim_record.id)
+            expect(ClaimsApi::AutoEstablishedClaim.find(claim_record.id).bgs_special_issue_responses.count).to eq(1)
+          end
+        end
+
+        context 'when a single contention exists for claim' do
+          let(:claim_id) { '600200323' }
+          let(:claim) do
+            {
+              jrn_dt: '2020-08-17T10:44:43-05:00',
+              bnft_clm_tc: '130DPNEBNADJ',
+              bnft_clm_tn: 'eBenefits Dependency Adjustment',
+              claim_rcvd_dt: '2020-08-17T00:00:00-05:00',
+              clm_id: claim_id,
+              contentions: {
                 clm_id: contention_id[:claim_id],
                 cntntn_id: '999111',
                 clsfcn_id: contention_id[:code],
                 clmnt_txt: contention_id[:name]
-              }
-            ],
-            lc_stt_rsn_tc: 'OPEN',
-            lc_stt_rsn_tn: 'Open',
-            lctn_id: '322',
-            non_med_clm_desc: 'eBenefits Dependency Adjustment',
-            prirty: '0',
-            ptcpnt_id_clmnt: '600036156',
-            ptcpnt_id_vet: '600036156',
-            ptcpnt_suspns_id: '600276939',
-            soj_lctn_id: '347'
-          }
-        end
-        let(:claims) { { benefit_claims: [claim] } }
+              },
+              lc_stt_rsn_tc: 'OPEN',
+              lc_stt_rsn_tn: 'Open',
+              lctn_id: '322',
+              non_med_clm_desc: 'eBenefits Dependency Adjustment',
+              prirty: '0',
+              ptcpnt_id_clmnt: '600036156',
+              ptcpnt_id_vet: '600036156',
+              ptcpnt_suspns_id: '600276939',
+              soj_lctn_id: '347'
+            }
+          end
+          let(:claims) { { benefit_claims: [claim] } }
 
-        it 'all special issues provided are appended to payload' do
-          expected_claim_options = claim.dup
-          special_issues_payload = special_issues.map { |si| { spis_tc: si } }
-          expected_claim_options[:contentions] = [
-            { clm_id: claim_id, cntntn_id: '999111', special_issues: special_issues_payload }
-          ]
-          expect_any_instance_of(BGS::ContentionService).to receive(:manage_contentions).with(expected_claim_options)
+          it 'all special issues provided are appended to payload' do
+            expected_claim_options = claim.dup
+            special_issues_payload = special_issues.map { |si| { spis_tc: si } }
+            expected_claim_options[:contentions] = [
+              { clm_id: claim_id, cntntn_id: '999111', special_issues: special_issues_payload }
+            ]
+            expect_any_instance_of(BGS::ContentionService).to receive(:manage_contentions).with(expected_claim_options)
 
-          subject.new.perform(user, contention_id, special_issues, claim_record.id)
-        end
-
-        it 'stores bgs exceptions correctly' do
-          expect_any_instance_of(BGS::ContentionService).to receive(:manage_contentions)
-            .and_raise(BGS::ShareError.new('failed', 500))
-
-          subject.new.perform(user, contention_id, special_issues, claim_record.id)
-          expect(ClaimsApi::AutoEstablishedClaim.find(claim_record.id).bgs_special_issue_responses.count).to eq(1)
+            subject.new.perform(user, contention_id, special_issues, claim_record.id)
+          end
         end
       end
 


### PR DESCRIPTION
## Description of change
If a single contention is present on a claim, the object is a hash. If multiple contentions are present on a claim, the object is an array. This change should fix the "single contention on a claim" scenario.

## Original issue(s)
https://vajira.max.gov/browse/API-6820

## Things to know about this PR
Add spec to test for single contention situation.