### PR TITLE
API-7421 Add representative name character limits and email to schema

### DIFF
--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
@@ -10,7 +10,7 @@ module AppealsApi
 
         delegate :first_name, :middle_initial, :last_name, :number_and_street, :city, :state_code,
                  :country_code, :file_number, :zip_code_5, :insurance_policy_number, :contestable_issues, :birth_mm,
-                 :birth_dd, :birth_yyyy, :date_signed_mm, :date_signed_dd, :date_signed_yyyy, :rep_email,
+                 :birth_dd, :birth_yyyy, :date_signed_mm, :date_signed_dd, :date_signed_yyyy,
                  to: :higher_level_review
 
         def first_three_ssn

--- a/modules/appeals_api/config/schemas/v2/200996.json
+++ b/modules/appeals_api/config/schemas/v2/200996.json
@@ -81,7 +81,7 @@
       "properties": {
         "name":  { "$ref": "#/definitions/hlrCreateRepresentativeName" },
         "phone": { "$ref": "#/definitions/hlrCreatePhone" },
-        "emailAddressText": {
+        "email": {
           "type": "string",
           "format": "email",
           "maxLength": 100

--- a/modules/appeals_api/config/schemas/v2/200996.json
+++ b/modules/appeals_api/config/schemas/v2/200996.json
@@ -80,7 +80,12 @@
       "type": "object",
       "properties": {
         "name":  { "$ref": "#/definitions/hlrCreateRepresentativeName" },
-        "phone": { "$ref": "#/definitions/hlrCreatePhone" }
+        "phone": { "$ref": "#/definitions/hlrCreatePhone" },
+        "emailAddressText": {
+          "type": "string",
+          "format": "email",
+          "maxLength": 100
+        }
       },
       "additionalProperties": false,
       "required": [ "name", "phone" ]
@@ -89,8 +94,8 @@
     "hlrCreateRepresentativeName": {
       "type": "object",
       "properties": {
-        "firstName": { "type": "string"},
-        "lastName":  { "type": "string"}
+        "firstName": { "type": "string", "maxLength": 30 },
+        "lastName":  { "type": "string", "maxLength": 40 }
       },
       "required": [ "firstName", "lastName" ]
     },


### PR DESCRIPTION
1. Discovered how many autosized characters fit for representative first and last names (takes into account the potential future digital rep signature)
2. Entered limits in schema
3. Added representative email to schema
4. Added rep email character limit to schema (same as veteran email length)

Ticket: https://vajira.max.gov/browse/API-7421