### PR TITLE
[7075] Fix recent regression that broke MPI AddPerson calls by not pr…

### DIFF
--- a/app/models/mpi_data.rb
+++ b/app/models/mpi_data.rb
@@ -139,10 +139,11 @@ class MPIData < Common::RedisStore
   # call is made. The response is recached afterwards so the new ids can be accessed on the next call.
   #
   # @return [MPI::Responses::AddPersonResponse] the response returned from MPI Add Person call
-  def add_person(user_identity)
+  def add_person
     search_response = MPI::OrchSearchService.new.find_profile(user_identity)
     if search_response.ok?
       @mvi_response = search_response
+      update_user_identity_with_orch_search(search_response.profile)
       add_response = mpi_service.add_person(user_identity)
       add_ids(add_response) if add_response.ok?
     else
@@ -154,6 +155,20 @@ class MPIData < Common::RedisStore
   end
 
   private
+
+  def update_user_identity_with_orch_search(search_response_profile)
+    user_identity.icn_with_aaid = search_response_profile.icn_with_aaid
+    user_identity.edipi = search_response_profile.edipi
+    user_identity.search_token = search_response_profile.search_token
+
+    first_name, *middle_name = search_response_profile.given_names
+    user_identity.first_name = first_name
+    user_identity.middle_name = middle_name&.join(' ').presence
+    user_identity.last_name = search_response_profile.family_name
+    user_identity.gender = search_response_profile.gender
+    user_identity.ssn = search_response_profile.ssn
+    user_identity.birth_date = search_response_profile.birth_date
+  end
 
   def add_ids(response)
     # set new ids in the profile and recache the response

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -422,7 +422,8 @@ class User < Common::RedisStore
     add_person_identity.ssn = ssn
     add_person_identity.icn_with_aaid = icn_with_aaid
     add_person_identity.search_token = search_token
-    mpi.add_person(add_person_identity)
+    mpi.user_identity = add_person_identity
+    mpi.add_person
   end
 
   private

--- a/spec/factories/user_identities.rb
+++ b/spec/factories/user_identities.rb
@@ -13,6 +13,11 @@ FactoryBot.define do
     ssn { '796111863' }
     mhv_icn { nil }
     mhv_account_type { nil }
+    icn_with_aaid { nil }
+    edipi { nil }
+    search_token { nil }
+    multifactor { false }
+    idme_uuid { nil }
 
     sign_in do
       {


### PR DESCRIPTION
…operly updating user identity with orchestrated search MPI response

## Description of change
This PR properly updates the UserIdentity structure when an Orchestrated Search from MPI is queried, then calls MPI AddPerson with the updated profile information. Previously we had introduced a PR that was breaking AddPerson calls, because we were not using the `search_token` from the Orchestrated Search response, this meant we were using a `search_token` from a previous MPI query, and it was timing out before the AddPerson call was completed

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/7075

## Things to know about this PR
- Confirmed that standard login is unaffected with this change
- It's difficult to test AddPerson functionality on local/staging, but but spec coverage isn't bad. Should at least confirm that this does not regress things further
