### PR TITLE
add Cameron and Riley to flipper admin

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -693,6 +693,7 @@ flipper:
     - alastair@adhocteam.us
     - anna@adhoc.team
     - bill.ryan@adhocteam.us
+    - cameron@oddball.io
     - cory.trimm@va.gov
     - cwheeler@governmentcio.com
     - dan.hinze@adhocteam.us
@@ -742,6 +743,7 @@ flipper:
     - paul.phillips@thoughtworks.com
     - pherbert@thoughtworks.com
     - regarr@gmail.com # Robin Garrison - AdHoc
+    - riley.anderson@oddball.io
     - roth_matthew@bah.com
     - ryan.thurlwell@va.gov
     - saman.moshafi@thoughtworks.com


### PR DESCRIPTION
## Description of change
Adds Cameron Testerman and Riley Anderson to flipper admin list.

