### PR TITLE
[7090] Changing SOAP library response parser from body to request_bod…

### DIFF
--- a/lib/common/client/middleware/response/soap_parser.rb
+++ b/lib/common/client/middleware/response/soap_parser.rb
@@ -8,7 +8,7 @@ module Common
           def on_complete(env)
             case env.status
             when 200
-              doc = parse_doc(env.body)
+              doc = parse_doc(env.request_body)
               if doc_includes_error?(doc)
                 log_error_details(env)
                 raise Common::Client::Errors::HTTPError.new('SOAP service returned internal server error', 500)


### PR DESCRIPTION
…y to satisfy new Faraday requirements

## Description of change
I think the latest Faraday upgrade changed the behavior of how our SOAP responses are expected to be parsed. This change fixed MPI response on local dev. I'm not sure what other services may be impacted or how, but this at least fixed that use case, apparently 

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/7090

## Things to know about this PR
- This is certainly not exhaustive, will need to investigate how other services are impacted
- In my testing, I logged in, confirmed the MPI mock service was called and properly parsed
