### PR TITLE
Uses id theft flag to block mobile session refresh

### DIFF
--- a/app/models/iam_user_identity.rb
+++ b/app/models/iam_user_identity.rb
@@ -44,7 +44,8 @@ class IAMUserIdentity < ::UserIdentity
       iam_mhv_id: valid_mhv_id(iam_profile[:fediam_mhv_ien]),
       last_name: iam_profile[:family_name],
       loa: { current: loa_level, highest: loa_level },
-      middle_name: iam_profile[:middle_name]
+      middle_name: iam_profile[:middle_name],
+      sign_in: { service_name: "oauth_#{iam_auth_n_type}", account_type: iam_profile[:fediamassur_level] }
     )
 
     StatsD.increment('iam_ssoe_oauth.auth_type', tags: ["type:#{iam_auth_n_type}"])

--- a/app/models/mpi_data.rb
+++ b/app/models/mpi_data.rb
@@ -97,6 +97,11 @@ class MPIData < Common::RedisStore
   # @return [Array[String]] the the list of Cerner facility ids
   delegate :cerner_facility_ids, to: :profile
 
+  # Identity theft flag
+  #
+  # @return [Boolean] presence or absence of identity theft flag
+  delegate :id_theft_flag, to: :profile
+
   # The profile returned from the MVI service. Either returned from cached response in Redis or the MVI service.
   #
   # @return [MPI::Models::MviProfile] patient 'golden record' data from MVI

--- a/lib/iam_ssoe_oauth/session_manager.rb
+++ b/lib/iam_ssoe_oauth/session_manager.rb
@@ -46,8 +46,10 @@ module IAMSSOeOAuth
       Rails.logger.info('IAMUser create_user_session: introspect succeeded')
 
       user_identity = build_identity(iam_profile)
-      build_session(@access_token, user_identity)
-      build_user(user_identity)
+      session = build_session(@access_token, user_identity)
+      user = build_user(user_identity)
+      validate_user(user)
+      persist(session, user)
     rescue Common::Exceptions::Unauthorized => e
       Rails.logger.error('IAMUser create user session: unauthorized', error: e.message)
       StatsD.increment('iam_ssoe_oauth.inactive_session')
@@ -65,7 +67,7 @@ module IAMSSOeOAuth
 
     def build_session(access_token, user_identity)
       @session = IAMSession.new(token: access_token, uuid: user_identity.uuid)
-      @session.save
+      @session
     rescue => e
       Rails.logger.error('IAMUser create user session: build session failed', error: e.message)
       raise e
@@ -74,7 +76,6 @@ module IAMSSOeOAuth
     def build_user(user_identity)
       user = IAMUser.build_from_user_identity(user_identity)
       user.last_signed_in = Time.now.utc
-      user.save
 
       StatsD.set('iam_ssoe_oauth.users', user.uuid, sample_rate: 1.0)
       Rails.logger.info('IAMUser create user session: success', uuid: user.uuid)
@@ -83,6 +84,15 @@ module IAMSSOeOAuth
     rescue => e
       Rails.logger.error('IAMUser create user session: build user failed', error: e.message)
       raise e
+    end
+
+    def persist(session, user)
+      session.save && user.save
+      user
+    end
+
+    def validate_user(user)
+      raise Common::Exceptions::Unauthorized, detail: 'User record global deny flag' if user.id_theft_flag
     end
 
     def iam_ssoe_service

--- a/lib/iam_ssoe_oauth/session_manager.rb
+++ b/lib/iam_ssoe_oauth/session_manager.rb
@@ -67,7 +67,6 @@ module IAMSSOeOAuth
 
     def build_session(access_token, user_identity)
       @session = IAMSession.new(token: access_token, uuid: user_identity.uuid)
-      @session
     rescue => e
       Rails.logger.error('IAMUser create user session: build session failed', error: e.message)
       raise e

--- a/modules/mobile/spec/controllers/application_controller_spec.rb
+++ b/modules/mobile/spec/controllers/application_controller_spec.rb
@@ -144,6 +144,18 @@ RSpec.describe Mobile::ApplicationController, type: :controller do
           get :index
         end
       end
+
+      context 'with a user with id theft flag set' do
+        before { FactoryBot.create(:iam_user, :id_theft_flag) }
+
+        it 'returns unauthorized' do
+          VCR.use_cassette('iam_ssoe_oauth/introspect_active') do
+            get :index
+          end
+          expect(response).to have_http_status(:unauthorized)
+          expect(error_detail).to eq('User record global deny flag')
+        end
+      end
     end
   end
 end

--- a/spec/factories/iam_users.rb
+++ b/spec/factories/iam_users.rb
@@ -110,5 +110,26 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :id_theft_flag do
+      callback(:after_build, :after_stub, :after_create) do |user, _t|
+        user_identity = create(:iam_user_identity)
+        user.instance_variable_set(:@identity, user_identity)
+      end
+
+      after(:build) do
+        stub_mpi(
+          build(
+            :mvi_profile,
+            icn: '24811694708759028',
+            edipi: '1005079124',
+            birls_id: '796121200',
+            participant_id: '796121200',
+            birth_date: '1970-08-12T00:00:00+00:00'.to_date.to_s,
+            id_theft_flag: true
+          )
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Uses the id_theft_flag attribute set in MPI (and newly available in user record) to prevent mobile OAuth sessions from being established. 

This is warranted for mobile because otherwise flagged users would be able to continue using the OAuth long-lived session refresh mechanism for up to 45 days. This is not an issue for SAML-based auth on VA.gov because re-authentication is required every time a session expire, and authentication is blocked by the id theft flag. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25057

## Things to know about this PR
* I plan to re-test this but it will require the IAM team to remove then re-add the id theft flag for a user so we can log in to the app, block them, and then make sure session refresh is blocked. 

