### PR TITLE
[7028] Logging message to Sentry if MPI request is missing necessary …

### DIFF
--- a/app/models/mpi_data.rb
+++ b/app/models/mpi_data.rb
@@ -6,12 +6,14 @@ require 'mpi/orch_search_service'
 require 'common/models/redis_store'
 require 'common/models/concerns/cache_aside'
 require 'mpi/constants'
+require 'sentry_logging'
 
 # Facade for MVI. User model delegates MVI correlation id and VA profile (golden record) methods to this class.
 # When a profile is requested from one of the delegates it is returned from either a cached response in Redis
 # or from the MVI SOAP service.
 class MPIData < Common::RedisStore
   include Common::CacheAside
+  include SentryLogging
 
   REDIS_CONFIG_KEY = :mpi_profile_response
   redis_config_key REDIS_CONFIG_KEY
@@ -166,7 +168,8 @@ class MPIData < Common::RedisStore
   def response_from_redis_or_service
     do_cached_with(key: user_identity.uuid) do
       mpi_service.find_profile(user_identity)
-    rescue ArgumentError
+    rescue ArgumentError => e
+      log_message_to_sentry("[MPI Data] Request error: #{e.message}", :warn)
       return nil
     end
   end


### PR DESCRIPTION
…data

## Description of change
This PR just adds a message to Sentry if there are missing fields in an MPI request. We should probably catch these kinds of issues upstream but it's possible we could have cached the MPI response, so a user would be able to access it even if we temporarily didn't have access to certain data.

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/7028

## Things to know about this PR
- Sentry warning will have form like this: `[MPI Data] Request error: required values are missing for keys: [:birth_date, :ssn]`

- I confirmed this message was raised when a user with incomplete Identity data signed in
