### PR TITLE
Derives multifactor correctly for mobile OAuth

### DIFF
--- a/app/models/iam_user_identity.rb
+++ b/app/models/iam_user_identity.rb
@@ -11,6 +11,7 @@ class IAMUserIdentity < ::UserIdentity
 
   PREMIUM_LOAS = [2, 3].freeze
   UPGRADE_AUTH_TYPES = %w[DSL MHV].freeze
+  MULTIFACTOR_AUTH_TYPES = %w[IDME].freeze
 
   redis_store REDIS_CONFIG[:iam_user_identity][:namespace]
   redis_ttl REDIS_CONFIG[:iam_user_identity][:each_ttl]
@@ -45,6 +46,7 @@ class IAMUserIdentity < ::UserIdentity
       last_name: iam_profile[:family_name],
       loa: { current: loa_level, highest: loa_level },
       middle_name: iam_profile[:middle_name],
+      multifactor: multifactor?(loa_level, iam_auth_n_type),
       sign_in: { service_name: "oauth_#{iam_auth_n_type}", account_type: iam_profile[:fediamassur_level] }
     )
 
@@ -54,8 +56,8 @@ class IAMUserIdentity < ::UserIdentity
     identity
   end
 
-  def multifactor
-    loa[:current]&.to_int == LOA::THREE
+  def self.multifactor?(loa_level, auth_type)
+    loa_level == LOA::THREE && MULTIFACTOR_AUTH_TYPES.include?(auth_type)
   end
 
   def set_expire

--- a/modules/mobile/spec/request/payment_information_request_spec.rb
+++ b/modules/mobile/spec/request/payment_information_request_spec.rb
@@ -116,6 +116,17 @@ RSpec.describe 'payment_information', type: :request do
         end
       end
     end
+
+    context 'with a user without multifactor' do
+      before do
+        iam_sign_in(FactoryBot.build(:iam_user, :no_multifactor))
+      end
+
+      it 'returns forbidden' do
+        get '/mobile/v0/payment-information/benefits', headers: iam_headers
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
   end
 
   describe 'PUT /mobile/v0/payment-information' do

--- a/spec/factories/iam_introspection_responses.rb
+++ b/spec/factories/iam_introspection_responses.rb
@@ -139,4 +139,67 @@ FactoryBot.define do
 
     initialize_with { attributes }
   end
+
+  factory :idme_loa3_introspection_payload, class: Hash do
+    fediamtransaction_id { '5eWibth5T4By92LinZBrcRi+dMHCkde5bhzwwVeOmPI' }
+    fediam_is_delegate { 'false' }
+    fediam_birls_number { '796121200' }
+    birthdate { '1970-08-12' }
+    fediamss_issue_instant { '2020-08-05T21:48:38Z' }
+    fediam_mviicn { '1008596379V859838' }
+    fediam_street { '1700 University Boulevard' }
+    fediamsecid { '0000028114' }
+    client_id { 'VAMobile' }
+    fediam_country { 'NOT_FOUND' }
+    fediam_gender { 'MALE' }
+    exp { 1_596_667_726 }
+    code_challenge { 'tDKCgVeM7b8X2Mw7ahEeSPPFxr7TGPc25IV5ex0PvHI' }
+    fediam_street1 { '1700 University Boulevard' }
+    fediam_do_dedipn_id { '1005079124' }
+    fediam_gc_id {
+      '1008596379V859838^NI^200M^USVHA^P|796121200^PI^200BRLS^USVBA^A|0000028114^PN^200PROV^USDVA^A|' \
+      '1005079124^NI^200DOD^USDOD^A|32331150^PI^200CORP^USVBA^A|85c50aa76934460c8736f687a6a30546^PN^200VIDM^USDVA^A|' \
+      '2810777^PI^200CORP^USVBA^A|32324397^PI^200CORP^USVBA^A|19798466a4b143748e664482c6b6b81b^PN^200VIDM^USDVA^A|' \
+      '796121200^AN^200CORP^USVBA^'
+    }
+    active { true }
+    fediamauth_n_type { 'IDME' }
+    fediam_not_on_or_after { '2020-08-05T21:53:42Z' }
+    aud { 'VAMobile' }
+    fediam_mcid { 'WSSOE2008051748411450069042554' }
+    fediamidsource { 'ssoe' }
+    fediam_vaafi_proof_authority { 'FICAM' }
+    phone_number { '(858)335-0190' }
+    tokens_generated_by { 'OAuth AZN Code Flow' }
+    fediamissuer { 'https://int.eauth.va.gov/isam/sps/saml20idp/saml20' }
+    fediamproofing_auth { 'FICAM' }
+    fediam_authentication_method { 'http://idmanagement.gov/ns/assurance/loa/3' }
+    fediamam_eai_xattr_session_lifetime { '1596667722' }
+    fediam_suffix { 'NOT_FOUND' }
+    sub { '0000028114' }
+    fediam_mhvien { 'NOT_FOUND' }
+    fediam_authentication_instant { '2020-08-05T21:48:42Z' }
+    token_type { 'bearer' }
+    fediam_common_name { 'va.api.user+idme.008@gmail.com' }
+    scope { 'openid' }
+    fediam_postal_code { '78665' }
+    fediam_vaafi_csp_id { '200VIDM_19798466a4b143748e664482c6b6b81b' }
+    fediam_pn_id { '796121200' }
+    fediam_pn_id_type { 'SSN' }
+    iat { 1_596_664_126 }
+    email { 'va.api.user+idme.008@gmail.com' }
+    code_challenge_method { 'S256' }
+    given_name { 'GREG' }
+    middle_name { 'A' }
+    fediamassur_level { '3' }
+    fediam_not_before { '2020-08-05T21:43:42Z' }
+    fediam_prefix { 'NOT_FOUND' }
+    fediam_state { 'TX' }
+    fediam_city { 'Round Rock' }
+    fediam_pid { '32331150,2810777,32324397' }
+    family_name { 'ANDERSON' }
+    username { '0000028114' }
+
+    initialize_with { attributes }
+  end
 end

--- a/spec/factories/iam_users.rb
+++ b/spec/factories/iam_users.rb
@@ -131,5 +131,12 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :no_multifactor do
+      callback(:after_build, :after_stub, :after_create) do |user, _t|
+        user_identity = create(:iam_user_identity, multifactor: false)
+        user.instance_variable_set(:@identity, user_identity)
+      end
+    end
   end
 end

--- a/spec/models/iam_user_identity_spec.rb
+++ b/spec/models/iam_user_identity_spec.rb
@@ -3,13 +3,31 @@
 require 'rails_helper'
 
 RSpec.describe IAMUserIdentity, type: :model do
+  let(:idme_attrs) { build(:idme_loa3_introspection_payload) }
   let(:dslogon_attrs) { build(:dslogon_level2_introspection_payload) }
   let(:mhv_attrs) { build(:mhv_premium_introspection_payload) }
+
+  context 'for an ID.me user' do
+    it 'returns LOA3 for a premium assurance level' do
+      id = described_class.build_from_iam_profile(idme_attrs)
+      expect(id.loa[:current]).to eq(3)
+    end
+
+    it 'returns multifactor as true' do
+      id = described_class.build_from_iam_profile(idme_attrs)
+      expect(id.multifactor).to be(true)
+    end
+  end
 
   context 'for a DSLogon user' do
     it 'returns LOA3 for a premium assurance level' do
       id = described_class.build_from_iam_profile(dslogon_attrs)
       expect(id.loa[:current]).to eq(3)
+    end
+
+    it 'returns multifactor as false' do
+      id = described_class.build_from_iam_profile(dslogon_attrs)
+      expect(id.multifactor).to be(false)
     end
   end
 
@@ -17,6 +35,11 @@ RSpec.describe IAMUserIdentity, type: :model do
     it 'returns LOA3 for a premium assurance level' do
       id = described_class.build_from_iam_profile(mhv_attrs)
       expect(id.loa[:current]).to eq(3)
+    end
+
+    it 'returns multifactor as false' do
+      id = described_class.build_from_iam_profile(mhv_attrs)
+      expect(id.multifactor).to be(false)
     end
   end
 


### PR DESCRIPTION
## Description of change
Mobile OAuth is not brokered through ID.me, so MHV/DSL credentials
by definition to not have multifactor authentication present. This
change ensures that that attribute is derived correctly for all
credential types available for OAuth.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/20190

## Things to know about this PR

@kreek I noticed that `authorized_services` for payment is derived only from "can access evss" and not also "can access ppiu" - so it's now inaccurate in this case. The payment controller itself is correctly authorized. Do we want to make `authorized_services` smarter so it can check both of those policies?
