### PR TITLE
Ability to find locations by org

### DIFF
--- a/modules/health_quest/app/services/health_quest/shared/options_builder.rb
+++ b/modules/health_quest/app/services/health_quest/shared/options_builder.rb
@@ -52,8 +52,8 @@ module HealthQuest
             date: appointment_dates,
             location: clinic_id
           },
-          location: { _id: location_ids },
-          organization: { _id: organization_ids },
+          location: { _id: location_ids, organization: org_id },
+          organization: { _id: organization_ids, identifier: organization_identifier },
           questionnaire_response: {
             subject: appointment_reference,
             source: user.icn,
@@ -79,6 +79,24 @@ module HealthQuest
       #
       def organization_ids
         @organization_ids ||= filters&.fetch(:_id, nil)
+      end
+
+      ##
+      # Get the list of locations for an organization from the filters.
+      #
+      # @return [String]
+      #
+      def org_id
+        @org_id ||= filters&.fetch(:organization, nil)
+      end
+
+      ##
+      # Get the organization identifier from the filters.
+      #
+      # @return [String]
+      #
+      def organization_identifier
+        @organization_identifier ||= filters&.fetch(:identifier, nil)
       end
 
       ##

--- a/modules/health_quest/spec/services/shared/options_builder_spec.rb
+++ b/modules/health_quest/spec/services/shared/options_builder_spec.rb
@@ -79,11 +79,27 @@ describe HealthQuest::Shared::OptionsBuilder do
     end
   end
 
+  describe '#org_id' do
+    let(:filters) { loc_filter.merge!(organization: '456def').with_indifferent_access }
+
+    it 'has an org_id' do
+      expect(options_builder.org_id).to eq('456def')
+    end
+  end
+
   describe '#organization_ids' do
     let(:filters) { org_filter.merge!(_id: '123abc,456def').with_indifferent_access }
 
     it 'has a organization_ids' do
       expect(options_builder.organization_ids).to eq('123abc,456def')
+    end
+  end
+
+  describe '#organization_identifier' do
+    let(:filters) { org_filter.merge!(identifier: '123abc').with_indifferent_access }
+
+    it 'has an organization_identifier' do
+      expect(options_builder.organization_identifier).to eq('123abc')
     end
   end
 
@@ -127,7 +143,7 @@ describe HealthQuest::Shared::OptionsBuilder do
       let(:filters) { loc_filter.merge!(_id: '123abc,456def').with_indifferent_access }
 
       it 'has relevant keys' do
-        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[_id])
+        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[_id organization])
       end
     end
 
@@ -135,7 +151,7 @@ describe HealthQuest::Shared::OptionsBuilder do
       let(:filters) { org_filter.merge!(_id: '123abc,456def').with_indifferent_access }
 
       it 'has relevant keys' do
-        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[_id])
+        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[_id identifier])
       end
     end
   end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->
- Provides the ability for the vets-api to query FHIR Location resources which belong to an Organization
- Example local routes which are now functional: `http://localhost:3000/health_quest/v0/organizations?identifier=vha_688` and `http://localhost:3000/health_quest/v0/locations?organization=I2-YCRI7L52BYQL63ZFALGWIWF2WU000000`
## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25530

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec passing 