### PR TITLE
25428 decompose the registry method

### DIFF
--- a/modules/health_quest/app/services/health_quest/shared/options_builder.rb
+++ b/modules/health_quest/app/services/health_quest/shared/options_builder.rb
@@ -64,7 +64,8 @@ module HealthQuest
         {
           patient: user.icn,
           date: appointment_dates,
-          location: clinic_id
+          location: clinic_id,
+          _count: resource_count
         }
       end
 
@@ -76,7 +77,8 @@ module HealthQuest
       def location_registry
         {
           _id: location_ids,
-          organization: org_id
+          organization: org_id,
+          _count: resource_count
         }
       end
 
@@ -88,7 +90,8 @@ module HealthQuest
       def organization_registry
         {
           _id: organization_ids,
-          identifier: organization_identifier
+          identifier: organization_identifier,
+          _count: resource_count
         }
       end
 
@@ -101,7 +104,8 @@ module HealthQuest
         {
           subject: appointment_reference,
           source: user.icn,
-          authored: resource_created_date
+          authored: resource_created_date,
+          _count: resource_count
         }
       end
 
@@ -112,7 +116,8 @@ module HealthQuest
       #
       def questionnaire_registry
         {
-          'context-type-value': context_type_value
+          'context-type-value': context_type_value,
+          _count: resource_count
         }
       end
 
@@ -205,6 +210,15 @@ module HealthQuest
       #
       def context_type_value
         @context_type_value ||= filters&.fetch(:'context-type-value', nil)
+      end
+
+      ##
+      # Get the resource count from the filters.
+      #
+      # @return [String]
+      #
+      def resource_count
+        @resource_count ||= filters&.fetch(:_count, nil)
       end
 
       private

--- a/modules/health_quest/app/services/health_quest/shared/options_builder.rb
+++ b/modules/health_quest/app/services/health_quest/shared/options_builder.rb
@@ -47,19 +47,72 @@ module HealthQuest
       #
       def registry
         {
-          appointment: {
-            patient: user.icn,
-            date: appointment_dates,
-            location: clinic_id
-          },
-          location: { _id: location_ids, organization: org_id },
-          organization: { _id: organization_ids, identifier: organization_identifier },
-          questionnaire_response: {
-            subject: appointment_reference,
-            source: user.icn,
-            authored: resource_created_date
-          },
-          questionnaire: { 'context-type-value': context_type_value }
+          appointment: appointment_registry,
+          location: location_registry,
+          organization: organization_registry,
+          questionnaire_response: questionnaire_response_registry,
+          questionnaire: questionnaire_registry
+        }
+      end
+
+      ##
+      # The configuration for the appointment registry.
+      #
+      # @return [Hash]
+      #
+      def appointment_registry
+        {
+          patient: user.icn,
+          date: appointment_dates,
+          location: clinic_id
+        }
+      end
+
+      ##
+      # The configuration for the location registry.
+      #
+      # @return [Hash]
+      #
+      def location_registry
+        {
+          _id: location_ids,
+          organization: org_id
+        }
+      end
+
+      ##
+      # The configuration for the organization registry.
+      #
+      # @return [Hash]
+      #
+      def organization_registry
+        {
+          _id: organization_ids,
+          identifier: organization_identifier
+        }
+      end
+
+      ##
+      # The configuration for the questionnaire response registry.
+      #
+      # @return [Hash]
+      #
+      def questionnaire_response_registry
+        {
+          subject: appointment_reference,
+          source: user.icn,
+          authored: resource_created_date
+        }
+      end
+
+      ##
+      # The configuration for the questionnaire registry.
+      #
+      # @return [Hash]
+      #
+      def questionnaire_registry
+        {
+          'context-type-value': context_type_value
         }
       end
 

--- a/modules/health_quest/spec/services/shared/options_builder_spec.rb
+++ b/modules/health_quest/spec/services/shared/options_builder_spec.rb
@@ -103,6 +103,14 @@ describe HealthQuest::Shared::OptionsBuilder do
     end
   end
 
+  describe '#resource_count' do
+    let(:filters) { org_filter.merge!(_count: '30').with_indifferent_access }
+
+    it 'has a resource_count' do
+      expect(options_builder.resource_count).to eq('30')
+    end
+  end
+
   describe '#appointment_reference' do
     let(:filters) { qr_filter.merge!(subject: '123').with_indifferent_access }
 
@@ -118,7 +126,7 @@ describe HealthQuest::Shared::OptionsBuilder do
 
       it 'has relevant keys' do
         expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys)
-          .to eq(%i[patient date location])
+          .to eq(%i[patient date location _count])
       end
     end
 
@@ -127,7 +135,7 @@ describe HealthQuest::Shared::OptionsBuilder do
 
       it 'has relevant keys' do
         expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys)
-          .to eq(%i[subject source authored])
+          .to eq(%i[subject source authored _count])
       end
     end
 
@@ -135,7 +143,8 @@ describe HealthQuest::Shared::OptionsBuilder do
       let(:filters) { q_filter.merge!('context-type-value': '123').with_indifferent_access }
 
       it 'has relevant keys' do
-        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[context-type-value])
+        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys)
+          .to eq(%i[context-type-value _count])
       end
     end
 
@@ -143,7 +152,7 @@ describe HealthQuest::Shared::OptionsBuilder do
       let(:filters) { loc_filter.merge!(_id: '123abc,456def').with_indifferent_access }
 
       it 'has relevant keys' do
-        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[_id organization])
+        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[_id organization _count])
       end
     end
 
@@ -151,7 +160,7 @@ describe HealthQuest::Shared::OptionsBuilder do
       let(:filters) { org_filter.merge!(_id: '123abc,456def').with_indifferent_access }
 
       it 'has relevant keys' do
-        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[_id identifier])
+        expect(options_builder.registry[filters.delete(:resource_name).to_sym].keys).to eq(%i[_id identifier _count])
       end
     end
   end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->
- Break the registry methods hash into their own relevant hashes
- Making it easy to add other parameters to the registries
- Seeing the potential to extract registries into their own objects in the future
- Add the ability to change the resource count
## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25428

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec test suite passing