### PR TITLE
Updated constraints on the appointment show endpoint to allow the '.'…

### DIFF
--- a/modules/vaos/config/routes.rb
+++ b/modules/vaos/config/routes.rb
@@ -5,7 +5,7 @@ VAOS::Engine.routes.draw do
     resources :appointments, only: %i[index create] do
       put 'cancel', on: :collection
     end
-    get '/appointments/:type/:id', to: 'appointments#show', type: /va/
+    get '/appointments/:type/:id', to: 'appointments#show', type: /va/, constraints: { id: /[a-zA-Z0-9.]+/ }
     resources :appointment_requests, only: %i[index create update show] do
       resources :messages, only: %i[index create]
     end

--- a/modules/vaos/spec/request/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/appointments_request_spec.rb
@@ -172,22 +172,22 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
       context 'shows single appointment' do
         it 'returns single appointment based on appointment id' do
           VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method uri]) do
-            get '/vaos/v0/appointments/va/202006031600983000030800000000000000', params: params
+            get '/vaos/v0/appointments/va/202006031600983000030800000000000000.aaaaaa', params: params
             expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
-            expect(JSON.parse(response.body)['data']['id']).to eq('202006031600983000030800000000000000')
+            expect(JSON.parse(response.body)['data']['id']).to eq('202006031600983000030800000000000000.aaaaaa')
             expect(response).to match_response_schema('vaos/va_appointment')
           end
         end
 
         it 'returns single appointment based on appointment id when camel-inflected' do
           VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method uri]) do
-            get '/vaos/v0/appointments/va/202006031600983000030800000000000000',
+            get '/vaos/v0/appointments/va/202006031600983000030800000000000000.aaaaaa',
                 params: params,
                 headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
-            expect(JSON.parse(response.body)['data']['id']).to eq('202006031600983000030800000000000000')
+            expect(JSON.parse(response.body)['data']['id']).to eq('202006031600983000030800000000000000.aaaaaa')
             expect(response).to match_camelized_response_schema('vaos/va_appointment')
           end
         end

--- a/modules/vaos/spec/services/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/appointment_service_spec.rb
@@ -181,6 +181,8 @@ describe VAOS::AppointmentService do
 
   describe '#show_appointment of type va' do
     context 'returns single appointment' do
+      let(:id) { '202006031600983000030800000000000000.aaaaaa' }
+
       it 'with a 200 success' do
         VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method uri]) do
           response = subject.get_appointment(id)

--- a/spec/support/vcr_cassettes/vaos/appointments/show_appointment.yml
+++ b/spec/support/vcr_cassettes/vaos/appointments/show_appointment.yml
@@ -1,63 +1,64 @@
 ---
 http_interactions:
-- request:
-    method: get
-    uri: https://veteran.apps.va.gov/appointments/v1/patients/1012845331V153043/appointments/202006031600983000030800000000000000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Vets.gov Agent
-      Referer:
-      - https://api.va.gov
-      X-Vamf-Jwt:
-      - eyJhbGciOiJSUzUxMiJ9.eyJsYXN0TmFtZSI6Ik1vcnJpc29uIiwic3ViIjoiMTAxMjg0NTMzMVYxNTMwNDMiLCJhdXRoZW50aWNhdGVkIjp0cnVlLCJhdXRoZW50aWNhdGlvbkF1dGhvcml0eSI6Imdvdi52YS52YW9zIiwiaWRUeXBlIjoiSUNOIiwiZ2VuZGVyIjoiRkVNQUxFIiwiaXNzIjoiZ292LnZhLnZhbWYudXNlcnNlcnZpY2UudjIiLCJ2YW1mLmF1dGgucmVzb3VyY2VzIjpbIl4uKihcLyk_c2l0ZVtzXT9cLyhkZm4tKT85ODRcL3BhdGllbnRbc10_XC81NTIxNjEwNTBcL2FwcG9pbnRtZW50cyhcLy4qKT8kIiwiXi4qKFwvKT9zaXRlW3NdP1wvKGRmbi0pPzk4M1wvcGF0aWVudFtzXT9cLzcyMTY2OTFcL2FwcG9pbnRtZW50cyhcLy4qKT8kIiwiXi4qKFwvKT9wYXRpZW50W3NdP1wvKElDTlwvKT8xMDEyODQ1MzMxVjE1MzA0MyhcLy4qKT8kIl0sImRhdGVPZkJpcnRoIjoiMTk1MzA0MDEiLCJ2ZXJzaW9uIjoyLjEsImVkaXBpZCI6IjEyNTk4OTc5NzgiLCJ2aXN0YUlkcyI6W3sicGF0aWVudElkIjoiNTUyMTYxMDUwIiwic2l0ZUlkIjoiOTg0In0seyJwYXRpZW50SWQiOiI3MjE2NjkxIiwic2l0ZUlkIjoiOTgzIn1dLCJzc24iOiI3OTYwNjE5NzYiLCJmaXJzdE5hbWUiOiJKdWR5Iiwic3RhZmZEaXNjbGFpbWVyQWNjZXB0ZWQiOnRydWUsIm5iZiI6MTYxMDY0NzQxOCwic3N0IjoxNjEwNjQ3NTk4LCJwYXRpZW50Ijp7ImZpcnN0TmFtZSI6Ikp1ZHkiLCJsYXN0TmFtZSI6Ik1vcnJpc29uIiwiZ2VuZGVyIjoiRkVNQUxFIiwiaWNuIjoiMTAxMjg0NTMzMVYxNTMwNDMiLCJkb2IiOiIxOTUzLTA0LTAxIiwiZGF0ZU9mQmlydGgiOiIxOTUzLTA0LTAxIiwic3NuIjoiNzk2MDYxOTc2In0sImRvYiI6IjE5NTMwNDAxIiwidmFtZi5hdXRoLnJvbGVzIjpbInZldGVyYW4iXSwicmlnaHRPZkFjY2Vzc0FjY2VwdGVkIjp0cnVlLCJleHAiOjE2MTA2NDg0OTgsImp0aSI6ImJkNjA2YzcxLWNmODgtNDdhMi1hNWY3LTFiY2I2NjVmMmI1OCIsImxvYSI6Mn0.HqQTeWy8Fd63QvvoR5KvP4QIRSNLqelTTaVzETUU36vGbjuJTVFgr7cdVaQ1XPDzGiJwxXKTWq_kMwzP7h9rEKODbciP1Wl72yj3J3p8spsSg81Slr6Xnrsi_fK4_I2GTUxAjCt50CFCDOOH7pPE6DpCf9_2nAUFQnYL4YBOrzFxuQ2yqGiUovKckVGp-j4ZFM1rWIEPwDCGsDd69YJlMi1qhooGTIxozXzm2PxApiSWVwp3CzD1PQOMpejfS6j3l6AR6SRhhZOP-9EssoRSBmwP7t8HjacGq08He5ba3C8AD1NGruhzAtO1_y93Ty1myv-M4BVp0Mszmzw7W9js0Q
-      X-Request-Id:
-      - ''
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 14 Jan 2021 18:06:41 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '593'
-      Server:
-      - openresty
-      X-Vamf-Version:
-      - 1.23.0
-      B3:
-      - '048345211d50b863-36ecd8a0c72b74e2-0'
-      Access-Control-Allow-Headers:
-      - x-vamf-jwt
-      X-Vamf-Build:
-      - 8118a26
-      X-Vamf-Timestamp:
-      - '2020-11-24T14:50:36+0000'
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET,OPTIONS
-      Access-Control-Max-Age:
-      - '3600'
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: '{"id":"202006031600983000030800000000000000","startDate":"2020-06-03T16:00:00Z","clinicId":"308","clinicFriendlyName":"Green
-        Team Clinic1","facilityId":"983","sta6aid":"983","stationName":"CHYSHR-Cheyenne
-        VA Medical Center","locationName":"CHY PC KILPATRICK","patientIcn":"1012845331V153043","communityCare":false,"vdsAppointments":[{"id":"308;20200603.100000","appointmentLength":"20","appointmentTime":"2020-06-03T16:00:00Z","clinic":{"name":"CHY
-        PC KILPATRICK","askForCheckIn":false,"facilityCode":"983"},"patientId":"7216691","type":"SERVICE
-        CONNECTED","currentStatus":"NO ACTION TAKEN"}]}'
-  recorded_at: Thu, 14 Jan 2021 18:06:41 GMT
+  - request:
+      method: get
+      uri: https://veteran.apps.va.gov/appointments/v1/patients/1012845331V153043/appointments/202006031600983000030800000000000000.aaaaaa
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Referer:
+          - https://api.va.gov
+        X-Vamf-Jwt:
+          - eyJhbGciOiJSUzUxMiJ9.eyJsYXN0TmFtZSI6Ik1vcnJpc29uIiwic3ViIjoiMTAxMjg0NTMzMVYxNTMwNDMiLCJhdXRoZW50aWNhdGVkIjp0cnVlLCJhdXRoZW50aWNhdGlvbkF1dGhvcml0eSI6Imdvdi52YS52YW9zIiwiaWRUeXBlIjoiSUNOIiwiZ2VuZGVyIjoiRkVNQUxFIiwiaXNzIjoiZ292LnZhLnZhbWYudXNlcnNlcnZpY2UudjIiLCJ2YW1mLmF1dGgucmVzb3VyY2VzIjpbIl4uKihcLyk_c2l0ZVtzXT9cLyhkZm4tKT85ODRcL3BhdGllbnRbc10_XC81NTIxNjEwNTBcL2FwcG9pbnRtZW50cyhcLy4qKT8kIiwiXi4qKFwvKT9zaXRlW3NdP1wvKGRmbi0pPzk4M1wvcGF0aWVudFtzXT9cLzcyMTY2OTFcL2FwcG9pbnRtZW50cyhcLy4qKT8kIiwiXi4qKFwvKT9wYXRpZW50W3NdP1wvKElDTlwvKT8xMDEyODQ1MzMxVjE1MzA0MyhcLy4qKT8kIl0sImRhdGVPZkJpcnRoIjoiMTk1MzA0MDEiLCJ2ZXJzaW9uIjoyLjEsImVkaXBpZCI6IjEyNTk4OTc5NzgiLCJ2aXN0YUlkcyI6W3sicGF0aWVudElkIjoiNTUyMTYxMDUwIiwic2l0ZUlkIjoiOTg0In0seyJwYXRpZW50SWQiOiI3MjE2NjkxIiwic2l0ZUlkIjoiOTgzIn1dLCJzc24iOiI3OTYwNjE5NzYiLCJmaXJzdE5hbWUiOiJKdWR5Iiwic3RhZmZEaXNjbGFpbWVyQWNjZXB0ZWQiOnRydWUsIm5iZiI6MTYxMDY0NzQxOCwic3N0IjoxNjEwNjQ3NTk4LCJwYXRpZW50Ijp7ImZpcnN0TmFtZSI6Ikp1ZHkiLCJsYXN0TmFtZSI6Ik1vcnJpc29uIiwiZ2VuZGVyIjoiRkVNQUxFIiwiaWNuIjoiMTAxMjg0NTMzMVYxNTMwNDMiLCJkb2IiOiIxOTUzLTA0LTAxIiwiZGF0ZU9mQmlydGgiOiIxOTUzLTA0LTAxIiwic3NuIjoiNzk2MDYxOTc2In0sImRvYiI6IjE5NTMwNDAxIiwidmFtZi5hdXRoLnJvbGVzIjpbInZldGVyYW4iXSwicmlnaHRPZkFjY2Vzc0FjY2VwdGVkIjp0cnVlLCJleHAiOjE2MTA2NDg0OTgsImp0aSI6ImJkNjA2YzcxLWNmODgtNDdhMi1hNWY3LTFiY2I2NjVmMmI1OCIsImxvYSI6Mn0.HqQTeWy8Fd63QvvoR5KvP4QIRSNLqelTTaVzETUU36vGbjuJTVFgr7cdVaQ1XPDzGiJwxXKTWq_kMwzP7h9rEKODbciP1Wl72yj3J3p8spsSg81Slr6Xnrsi_fK4_I2GTUxAjCt50CFCDOOH7pPE6DpCf9_2nAUFQnYL4YBOrzFxuQ2yqGiUovKckVGp-j4ZFM1rWIEPwDCGsDd69YJlMi1qhooGTIxozXzm2PxApiSWVwp3CzD1PQOMpejfS6j3l6AR6SRhhZOP-9EssoRSBmwP7t8HjacGq08He5ba3C8AD1NGruhzAtO1_y93Ty1myv-M4BVp0Mszmzw7W9js0Q
+        X-Request-Id:
+          - ""
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Thu, 14 Jan 2021 18:06:41 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - "593"
+        Server:
+          - openresty
+        X-Vamf-Version:
+          - 1.23.0
+        B3:
+          - "048345211d50b863-36ecd8a0c72b74e2-0"
+        Access-Control-Allow-Headers:
+          - x-vamf-jwt
+        X-Vamf-Build:
+          - 8118a26
+        X-Vamf-Timestamp:
+          - "2020-11-24T14:50:36+0000"
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Allow-Methods:
+          - GET,OPTIONS
+        Access-Control-Max-Age:
+          - "3600"
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains; preload
+      body:
+        encoding: UTF-8
+        string:
+          '{"id":"202006031600983000030800000000000000.aaaaaa","startDate":"2020-06-03T16:00:00Z","clinicId":"308","clinicFriendlyName":"Green
+          Team Clinic1","facilityId":"983","sta6aid":"983","stationName":"CHYSHR-Cheyenne
+          VA Medical Center","locationName":"CHY PC KILPATRICK","patientIcn":"1012845331V153043","communityCare":false,"vdsAppointments":[{"id":"308;20200603.100000","appointmentLength":"20","appointmentTime":"2020-06-03T16:00:00Z","clinic":{"name":"CHY
+          PC KILPATRICK","askForCheckIn":false,"facilityCode":"983"},"patientId":"7216691","type":"SERVICE
+          CONNECTED","currentStatus":"NO ACTION TAKEN"}]}'
+    recorded_at: Thu, 14 Jan 2021 18:06:41 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
… character

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

This work is to address an issue where the `id` url parameter was being truncated if it contained a period and additional chars on the appointment show endpoint:

e.g. id: 20190305111111.aaaaaa -> 20190305111111 : incorrect
e.g. id: 20190305111111.aaaaaa -> 20190305111111.aaaaaa: correct


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Tests have been updated to reflect this change