### PR TITLE
Health care check in feature flip name space

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -392,7 +392,7 @@ features:
     actor_type: user
     description: Form 10203 updates in support of Isakson and Roe legislation
     enable_in_development: true
-  enable_check_in_experience:
+  check_in_experience_enabled:
       actor_type: user
       description: Enables the health care check-in experiences
       enable_in_development: true

--- a/config/features.yml
+++ b/config/features.yml
@@ -393,6 +393,6 @@ features:
     description: Form 10203 updates in support of Isakson and Roe legislation
     enable_in_development: true
   check_in_experience_enabled:
-      actor_type: user
-      description: Enables the health care check-in experiences
-      enable_in_development: true
+    actor_type: user
+    description: Enables the health care check-in experiences
+    enable_in_development: true


### PR DESCRIPTION
## Description of change
After discussing feature flips with our team, we want to namespace our flips. This PR renames our flip, to begin with `check-in`

## Original issue(s)
- [Spike](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25214)
- [Product Outline](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/checkin/product/product-outline.md)

