### PR TITLE
API-7341 - HLR v2 statuses

### DIFF
--- a/modules/appeals_api/app/models/concerns/appeals_api/hlr_status.rb
+++ b/modules/appeals_api/app/models/concerns/appeals_api/hlr_status.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
+require 'appeals_api/central_mail_updater'
+
 module AppealsApi
   module HlrStatus
     extend ActiveSupport::Concern
 
-    STATUSES = %w[pending submitting submitted processing error uploaded received success expired].freeze
+    V1_STATUSES = %w[pending submitting submitted processing error uploaded received success expired].freeze
+
+    V2_INTERNAL_STATUSES = %w[pending submitting submitted].freeze
+    V2_STATUSES = [*V2_INTERNAL_STATUSES, *CentralMailUpdater::CENTRAL_MAIL_STATUSES].uniq.freeze
+
+    # used primarly for reporting
+    STATUSES = [*V1_STATUSES, *V2_STATUSES].uniq.freeze
 
     RECEIVED_OR_PROCESSING = %w[received processing].freeze
     COMPLETE_STATUSES = %w[success error].freeze
@@ -13,7 +21,16 @@ module AppealsApi
       scope :received_or_processing, -> { where status: RECEIVED_OR_PROCESSING }
       scope :incomplete_statuses, -> { where.not status: COMPLETE_STATUSES }
 
-      validates :status, inclusion: { in: STATUSES }
+      def versioned_statuses
+        case api_version
+        when 'V2'
+          V2_STATUSES
+        else
+          V1_STATUSES
+        end
+      end
+
+      validates :status, inclusion: { in: ->(appeal) { appeal.versioned_statuses } }
     end
   end
 end

--- a/modules/appeals_api/app/models/concerns/appeals_api/hlr_status.rb
+++ b/modules/appeals_api/app/models/concerns/appeals_api/hlr_status.rb
@@ -15,7 +15,7 @@ module AppealsApi
     STATUSES = [*V1_STATUSES, *V2_STATUSES].uniq.freeze
 
     RECEIVED_OR_PROCESSING = %w[received processing].freeze
-    COMPLETE_STATUSES = %w[success error].freeze
+    COMPLETE_STATUSES = %w[success caseflow error].freeze
 
     included do
       scope :received_or_processing, -> { where status: RECEIVED_OR_PROCESSING }

--- a/modules/appeals_api/app/services/appeals_api/central_mail_updater.rb
+++ b/modules/appeals_api/app/services/appeals_api/central_mail_updater.rb
@@ -37,6 +37,8 @@ module AppealsApi
       'Processing Error' => { status: 'error', code: 'DOC202' }
     }.freeze
 
+    V2_HLR_CENTRAL_STATUS_ATTRIBUTES = NOD_CENTRAL_STATUS_ATTRIBUTES
+
     CENTRAL_MAIL_STATUS = Struct.new(:id, :status, :error_message) do
       delegate :present?, to: :id
 
@@ -101,7 +103,11 @@ module AppealsApi
     def central_mail_status_lookup(appeal)
       case appeal
       when AppealsApi::NoticeOfDisagreement then NOD_CENTRAL_STATUS_ATTRIBUTES
-      when AppealsApi::HigherLevelReview then HLR_CENTRAL_STATUS_ATTRIBUTES
+      when AppealsApi::HigherLevelReview
+        case appeal.api_version
+        when 'V2' then V2_HLR_CENTRAL_STATUS_ATTRIBUTES
+        else HLR_CENTRAL_STATUS_ATTRIBUTES
+        end
       end
     end
   end

--- a/modules/appeals_api/app/swagger/appeals_api/v1/schemas/higher_level_reviews.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/schemas/higher_level_reviews.rb
@@ -18,7 +18,7 @@ module AppealsApi::V1
 
         schema :hlrStatus do
           key :type, :string
-          key :enum, AppealsApi::HlrStatus::STATUSES
+          key :enum, AppealsApi::HlrStatus::V1_STATUSES
         end
 
         schema :errorWithTitleAndDetail do

--- a/modules/appeals_api/app/swagger/appeals_api/v2/api_description.md
+++ b/modules/appeals_api/app/swagger/appeals_api/v2/api_description.md
@@ -14,7 +14,7 @@ To gain access to the decision reviews API you must [request an API Key](/apply)
 
 Use the correct GET endpoint to check the appeal’s submission status. The endpoint returns the current status of the submission to VA but not the status of the appeal in the AMA process.
 
-### Notice of Disagreement (NOD) Submission Statuses
+### Higher Level Review (HLR) Submission Statuses
 
 The submission statuses begin with pending and end with caseflow.
 
@@ -26,21 +26,6 @@ The submission statuses begin with pending and end with caseflow.
 | processing   | Indicates intake has begun, the Intake, Conversion and Mail Handling Services (ICMHS) group is processing the appeal data. |
 | success   | The centralized mail portal, Digital Mail Handling System (DHMS), has received the data. |
 | caseflow   | Final status. The data is in the caseflow system and the Appeals Status API can be used to check the status of the appeal in the AMA process. |
-| error   | An error occurred. See the error code and message for further information. |
-
-### Higher Level Review (HLR) Submission Statuses
-
-The submission statuses begin with pending and end with success.
-
-| Status      | What it means |
-| ---        |     ---     |
-| pending      | Initial status of the submission when no supporting documents have been uploaded. |
-| submitting   | Data is transferring to upstream systems but is not yet complete. |
-| submitted   | A submitted status means the data was successfully transferred to the central mail portal. A submitted status is confirmation from the central mail portal that they have received the PDF, but the data is not yet being processed. The Date of Receipt is set when this status is achieved.Submitted is the final status in the sandbox environment. |
-| uploaded   | This status has been deprecated and is no longer in use. |
-| received   | A received status is confirmation from the Central Mail Portal that they have received the PDF, but the data is not yet being processed. The Date of Receipt is set when this status is achieved.<br /><br />Received is the final status in the sandbox environment. |
-| processing   | Indicates intake has begun, the Intake, Conversion and Mail Handling Services (ICMHS) group is processing the appeal data. |
-| success   | The centralized mail portal, Digital Mail Handling System (DHMS), has received the data. |
 | error   | An error occurred. See the error code and message for further information. |
 
 #### Status Simulation

--- a/modules/appeals_api/app/swagger/appeals_api/v2/schemas/higher_level_reviews.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v2/schemas/higher_level_reviews.rb
@@ -18,7 +18,7 @@ module AppealsApi::V2
 
         schema :hlrStatus do
           key :type, :string
-          key :enum, AppealsApi::HlrStatus::STATUSES
+          key :enum, AppealsApi::HlrStatus::V2_STATUSES
         end
 
         schema :errorWithTitleAndDetail do

--- a/modules/appeals_api/app/swagger/appeals_api/v2/swagger_root.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v2/swagger_root.rb
@@ -4,7 +4,7 @@ module AppealsApi::V2::SwaggerRoot
   include Swagger::Blocks
 
   read_file = ->(path) { File.read(AppealsApi::Engine.root.join(*path)) }
-  read_file_from_same_dir = ->(filename) { read_file.call(['app', 'swagger', 'appeals_api', 'v1', filename]) }
+  read_file_from_same_dir = ->(filename) { read_file.call(['app', 'swagger', 'appeals_api', 'v2', filename]) }
 
   swagger_root do
     key :openapi, '3.0.0'

--- a/modules/appeals_api/spec/factories/higher_level_reviews.rb
+++ b/modules/appeals_api/spec/factories/higher_level_reviews.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     end
     trait :completed_a_week_ago do
       updated_at { 8.days.ago }
-      status { AppealsApi::HigherLevelReview::COMPLETE_STATUSES.sample }
+      status { 'success' }
     end
   end
 

--- a/modules/appeals_api/spec/lib/decision_review_report_spec.rb
+++ b/modules/appeals_api/spec/lib/decision_review_report_spec.rb
@@ -19,6 +19,7 @@ describe AppealsApi::DecisionReviewReport do
     subject = described_class.new(from: 5.days.ago, to: Time.now.utc)
 
     expect(subject.hlr_by_status_and_count).to eq({
+      'caseflow' => 0,
       'error' => 1,
       'expired' => 0,
       'pending' => 0,

--- a/modules/appeals_api/spec/models/concerns/appeals_api/hlr_status_spec.rb
+++ b/modules/appeals_api/spec/models/concerns/appeals_api/hlr_status_spec.rb
@@ -12,9 +12,16 @@ describe AppealsApi::HlrStatus, type: :concern do
       expect(local_statuses).to include(*additional_statuses)
     end
 
-    it 'includes the expected statuses' do
-      statuses = %w[pending submitting submitted processing error uploaded received success expired]
-      expect(described_class::STATUSES).to eq(statuses)
+    context 'statuses' do
+      it 'includes the V1 expected statuses' do
+        statuses = %w[pending submitting submitted processing error uploaded received success expired]
+        expect(described_class::V1_STATUSES).to eq(statuses)
+      end
+
+      it 'includes the V2 expected statuses' do
+        statuses = %w[pending submitting submitted success processing error caseflow]
+        expect(described_class::V2_STATUSES).to eq(statuses)
+      end
     end
   end
 end

--- a/modules/appeals_api/spec/requests/v1/docs_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/docs_controller_spec.rb
@@ -34,7 +34,7 @@ describe AppealsApi::Docs::V1::DocsController, type: :request do
     end
 
     it 'HLR statuses match model (if this test fails, has there been a version change?)' do
-      expect(json['components']['schemas']['hlrStatus']['enum']).to eq AppealsApi::HigherLevelReview::STATUSES
+      expect(json['components']['schemas']['hlrStatus']['enum']).to eq AppealsApi::HigherLevelReview::V1_STATUSES
     end
   end
 end

--- a/modules/appeals_api/spec/services/appeals_api/central_mail_updater_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/central_mail_updater_spec.rb
@@ -42,6 +42,18 @@ describe AppealsApi::CentralMailUpdater do
       hlr.reload
       expect(hlr.status).to eq('success')
     end
+
+    it 'hlr V2 accepts VBMS Complete and maps it to caseflow' do
+      hlr = create(:higher_level_review)
+      hlr.update!(api_version: 'V2')
+      central_mail_response[0][:uuid] = hlr.id
+      allow(faraday_response).to receive(:body).at_least(:once).and_return([central_mail_response].to_json)
+
+      subject.call([hlr])
+      hlr.reload
+      expect(hlr.api_version).to eq('V2')
+      expect(hlr.status).to eq('caseflow')
+    end
   end
 
   context 'when verifying status structures' do


### PR DESCRIPTION
## Description of change
This PR adds support for the HLR model to have two different sets of statuses depending on the `api_version`.

## Original issue(s)
https://vajira.max.gov/browse/API-7341