### PR TITLE
25623 fetch locations by _id param

### DIFF
--- a/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
+++ b/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
@@ -242,7 +242,8 @@ module HealthQuest
       end
 
       ##
-      # Gets a list of Locations from the `lighthouse_appointments` array.
+      # Gets a list of Locations from the `lighthouse_appointments` array
+      # with a single request using the `_id` param
       #
       # @return [Array] a list of Locations
       #
@@ -256,11 +257,10 @@ module HealthQuest
             acc[location_id] << appt
           end
 
-        location_references.each_with_object([]) do |(k, _v), accumulator|
-          loc = location_service.get(k)
+        clinic_identifiers = location_references&.keys&.join(',')
+        location_response = location_service.search(_id: clinic_identifiers, _count: '100')
 
-          accumulator << loc
-        end
+        location_response&.resource&.entry
       end
 
       ##

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -217,15 +217,15 @@ describe HealthQuest::QuestionnaireManager::Factory do
                                 ]))
       ]
     end
-    let(:location) { double('FHIR::Location', resource: OpenStruct.new) }
+    let(:location) { double('FHIR::ClientReply', resource: double('FHIR::Bundle', entry: ['my_location'])) }
 
     before do
       allow_any_instance_of(subject).to receive(:lighthouse_appointments).and_return(appointments)
-      allow_any_instance_of(HealthQuest::Resource::Factory).to receive(:get).with(anything).and_return(location)
+      allow_any_instance_of(HealthQuest::Resource::Factory).to receive(:search).with(anything).and_return(location)
     end
 
     it 'returns an array of locations' do
-      expect(described_class.manufacture(user).get_locations).to eq([location])
+      expect(described_class.manufacture(user).get_locations).to eq(['my_location'])
     end
   end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Fetch all locations for a users appointments in one request using the `_id` param.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#25623

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x]  RSpec tests passing