### PR TITLE
Fix 10-10CG PDF download (file reference) bug

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -32,7 +32,7 @@ module V0
         # Brakeman will raise a warning if we use a claim's method or attribute in the source file name.
         # Use an arbitrary uuid for the source file name and don't use the return value of claim#to_pdf
         # as the source_file_path (to prevent changes in the the filename creating a vunerability in the future).
-        source_file_path = @claim.to_pdf(SecureRandom.uuid, sign: false)
+        source_file_path = PdfFill::Filler.fill_form(@claim, SecureRandom.uuid, sign: false)
         client_file_name = file_name_for_pdf(@claim.veteran_data)
         file_contents    = File.read(source_file_path)
 

--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -6,7 +6,6 @@ module V0
     AUDITOR = ::Form1010cg::Auditor.new
 
     skip_before_action :authenticate
-    skip_before_action :verify_authenticity_token
 
     before_action :record_submission_attempt, only: :create
     before_action :initialize_claim

--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -6,6 +6,7 @@ module V0
     AUDITOR = ::Form1010cg::Auditor.new
 
     skip_before_action :authenticate
+    skip_before_action :verify_authenticity_token
 
     before_action :record_submission_attempt, only: :create
     before_action :initialize_claim
@@ -31,11 +32,7 @@ module V0
         # Brakeman will raise a warning if we use a claim's method or attribute in the source file name.
         # Use an arbitrary uuid for the source file name and don't use the return value of claim#to_pdf
         # as the source_file_path (to prevent changes in the the filename creating a vunerability in the future).
-        uuid = SecureRandom.uuid
-
-        @claim.to_pdf(uuid, sign: false)
-
-        source_file_path = Rails.root.join 'tmp', 'pdfs', "10-10CG_#{uuid}.pdf"
+        source_file_path = @claim.to_pdf(SecureRandom.uuid, sign: false)
         client_file_name = file_name_for_pdf(@claim.veteran_data)
         file_contents    = File.read(source_file_path)
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->
Fixes: department-of-veterans-affairs/va.gov-team#24989

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Breakman (`Brakeman -t FileAccess`) will not allow us to use an attribute (or return value of a method) of an instance that was built with user-provided params, as a file name sent in the response.

To avoid the breakman warning, we interpreted the file path. This resulted in errors reading the file because PDF Fill will provide a different name for PDFs that have an "extras" file (`{guid}_final.pdf` instead of `{guid}.pdf`).

This change allows us to get the file name from PDF Fill while also not violating the breakman warning.

## Original issue(s)
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/24989
- Related Slack Threads:
  - https://dsva.slack.com/archives/CBU0KDSB1/p1595341676422700
  - https://dsva.slack.com/archives/CBU0KDSB1/p1601653841002800 

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
