### PR TITLE
add default country code for HLR v2

### DIFF
--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
@@ -126,7 +126,7 @@ module AppealsApi
         end
 
         def rep_country_code
-          higher_level_review.rep_phone_data&.dig('countryCode')
+          higher_level_review.rep_phone_data&.dig('countryCode') || '1'
         end
 
         def soc_opt_in

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
@@ -33,29 +33,41 @@ module AppealsApi
           higher_level_review.veteran_homeless? ? 1 : 'Off'
         end
 
+        def veteran_phone_extension
+          ext = higher_level_review.veteran_phone_data&.dig('phoneNumberExt')
+
+          return '' if veteran_country_code != '1' || ext.blank?
+
+          "x#{ext}"
+        end
+
         def veteran_phone_area_code
-          return if higher_level_review.veteran_phone_data&.dig('countryCode') != '1'
+          return if veteran_country_code != '1'
 
           higher_level_review.veteran_phone_data&.dig('areaCode')
         end
 
         def veteran_phone_prefix
-          return if higher_level_review.veteran_phone_data&.dig('countryCode') != '1'
+          return if veteran_country_code != '1'
 
           higher_level_review.veteran_phone_data&.dig('phoneNumber')&.first(3)
         end
 
         def veteran_phone_line_number
-          return if higher_level_review.veteran_phone_data&.dig('countryCode') != '1'
+          return if veteran_country_code != '1'
 
           higher_level_review.veteran_phone_data.dig('phoneNumber')&.last(4)
         end
 
         def veteran_phone_international_number
-          return if higher_level_review.veteran_phone_data&.dig('countryCode') == '1'
+          return if veteran_country_code == '1'
 
           higher_level_review.veteran_phone_number.presence ||
             'USE PHONE ON FILE'
+        end
+
+        def veteran_country_code
+          higher_level_review.veteran_phone_data&.dig('countryCode')
         end
 
         def veteran_email

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_fields.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_fields.rb
@@ -165,12 +165,14 @@ module AppealsApi
             year: "form1[0].#subform[#{subform}].DOByear[#{offset}]" }
         end
 
+        # rubocop:disable Metrics/MethodLength
         def boxes
           { first_name: { at: [3, 560], width: 195 },
             last_name: { at: [230, 560], width: 293 },
             number_and_street: { at: [29, 462], width: 512 },
             city: { at: [200, 441], width: 307 },
             veteran_email: { at: [8, 335], width: 513 },
+            veteran_phone_extension: { at: [220, 378], width: 50, height: 10 },
             rep_first_name: { at: [11, 586], width: 195 },
             rep_last_name: { at: [225, 586], width: 293 },
             rep_email: { at: [11, 525], width: 513 },
@@ -188,6 +190,7 @@ module AppealsApi
             rep_signature_last_name: { at: [226, 229], width: 293 },
             rep_signature: { at: [-4, 201], width: 369, height: 18 } }
         end
+        # rubocop:enable Metrics/MethodLength
       end
     end
   end

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/structure.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/structure.rb
@@ -150,6 +150,7 @@ module AppealsApi
             whiteout_line pdf, :number_and_street
             whiteout_line pdf, :city
             whiteout_line pdf, :veteran_email
+            whiteout_line pdf, :veteran_phone_extension
             pdf.start_new_page
 
             whiteout_line pdf, :rep_first_name

--- a/modules/appeals_api/config/schemas/v2/200996.json
+++ b/modules/appeals_api/config/schemas/v2/200996.json
@@ -98,7 +98,7 @@
         "countryCode":     { "type": "string", "pattern": "^[0-9]+$" },
         "areaCode":        { "type": "string", "pattern": "^[2-9][0-9]{2}$" },
         "phoneNumber":     { "type": "string", "pattern": "^[0-9]{1,14}$" },
-        "phoneNumberExt":  { "type": "string", "pattern": "^[a-zA-Z0-9]{1,10}$" }
+        "phoneNumberExt":  { "type": "string", "pattern": "^[0-9]{1,10}$" }
       },
       "required": [
         "areaCode",

--- a/modules/appeals_api/spec/services/appeals_api/pdf_construction/higher_level_review/v2/form_data_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/pdf_construction/higher_level_review/v2/form_data_spec.rb
@@ -7,16 +7,28 @@ module AppealsApi
     module HigherLevelReview
       module V2
         describe FormData do
-          let(:higher_level_review) { build(:higher_level_review) }
-          let(:form_data) { described_class.new(higher_level_review) }
-
           describe '#stamp_text' do
+            let(:higher_level_review) { build(:higher_level_review) }
+            let(:form_data) { described_class.new(higher_level_review) }
+
             it { expect(form_data.stamp_text).to eq('Doe - 6789') }
 
             it 'truncates the last name if too long' do
               full_last_name = 'AAAAAAAAAAbbbbbbbbbbCCCCCCCCCCdddddddddd'
               higher_level_review.auth_headers['X-VA-Last-Name'] = full_last_name
               expect(form_data.stamp_text).to eq 'AAAAAAAAAAbbbbbbbbbbCCCCCCCCCCdd... - 6789'
+            end
+          end
+
+          describe '#rep_country_code' do
+            it 'defaults to 1 if countryCode is blank' do
+              higher_level_review = build_stubbed(:higher_level_review)
+              form_data = described_class.new(higher_level_review)
+              allow(higher_level_review).to receive(:rep_phone_data).and_return(
+                { 'areaCode' => '555', 'phoneNumber' => '8001111', 'phoneNumberExt' => '2' }
+              )
+
+              expect(form_data.rep_country_code).to eq('1')
             end
           end
         end


### PR DESCRIPTION
[API-7578](https://vajira.max.gov/browse/API-7578)

This PR adds a default countryCode for HLR v2 if it doesn't exist

The ticket lists adding a requirement for countryCode on the schema, but I'm not sure if requiring a value and then providing a default makes sense. Will discuss in standup