### PR TITLE
25637 Fetch organizations by id param

### DIFF
--- a/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
+++ b/modules/health_quest/app/services/health_quest/questionnaire_manager/factory.rb
@@ -265,6 +265,7 @@ module HealthQuest
 
       ##
       # Returns an array of Organizations from the Health API for the `locations` array
+      # with a single request using the `_id` param
       #
       # @return [Array] a list of Organizations
       #
@@ -278,11 +279,10 @@ module HealthQuest
             acc[org_id] << loc
           end
 
-        org_references.each_with_object([]) do |(k, _v), accumulator|
-          org = organization_service.get(k)
+        facility_identifiers = org_references&.keys&.join(',')
+        org_response = organization_service.search(_id: facility_identifiers, _count: '100')
 
-          accumulator << org
-        end
+        org_response&.resource&.entry
       end
 
       ##

--- a/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
+++ b/modules/health_quest/spec/services/questionnaire_manager/factory_spec.rb
@@ -239,15 +239,23 @@ describe HealthQuest::QuestionnaireManager::Factory do
                                 to_hash: { id: 'I2-LABC' }))
       ]
     end
+    let(:organization) { double('FHIR::ClientReply', resource: double('FHIR::Bundle', entry: ['my_org'])) }
 
     before do
       allow_any_instance_of(subject).to receive(:locations).and_return(locations)
-      allow_any_instance_of(HealthQuest::Resource::Factory).to receive(:get)
-        .with(anything).and_return(default_organization)
+      allow_any_instance_of(HealthQuest::Resource::Factory).to receive(:search)
+        .with(anything).and_return(organization)
     end
 
     it 'returns an array of organizations' do
-      expect(described_class.manufacture(user).get_organizations).to eq([default_organization])
+      expect(described_class.manufacture(user).get_organizations).to eq(['my_org'])
+    end
+
+    it 'search receives the correct set of arguments' do
+      expect_any_instance_of(HealthQuest::Resource::Factory).to receive(:search)
+        .with({ _id: 'I2-OABC', _count: '100' }).once
+
+      described_class.manufacture(user).get_organizations
     end
   end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Fetch all organizations for a given set of locations for a users appointments in one request using the `_id` param.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#25637

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests passing