### PR TITLE
[24622] removes user.va_profile methods

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -230,21 +230,6 @@ class User < Common::RedisStore
     mpi_profile != nil
   end
 
-  def va_profile
-    mpi.profile
-  end
-  deprecate :va_profile, :none, 2021, 5
-
-  def va_profile_error
-    mpi.error
-  end
-  deprecate :va_profile_error, :mpi_error, 2021, 5
-
-  def va_profile_status
-    mpi.status
-  end
-  deprecate :va_profile_status, :mpi_status, 2021, 5
-
   # MPI setter methods
 
   def set_mhv_ids(mhv_id)


### PR DESCRIPTION
## Description of change
The `user.va_profile` methods as an abstraction of `user.mpi` have been deprecated in favor of direct User model getter methods, more information about this decision can be found [here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/e4401eb1ab6478ac386117e714694789639a97e0/docs/adr/0007-remove-user-model-va-profile.md)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#24622

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Unit tests were double checked for `va_profile` calls, manual authentication workflow testing.
