### PR TITLE
rswag: creation_date can be null

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v1/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v1/swagger.json
@@ -418,7 +418,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "1226d1d2-0182-477b-b88c-52c9009ff09d",
+                    "id": "64d409c8-f060-405e-9d94-d5835817ac09",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": 600118851,
@@ -467,11 +467,11 @@
                       "status": "Initial review",
                       "supporting_documents": [
                         {
-                          "id": "dc110154-d593-4b90-b648-f579bf059316",
+                          "id": "d5e4d75b-b139-4ac0-9378-a0750b169f90",
                           "type": "claim_supporting_document",
                           "md5": "d927c7e283b3158a54822a493d06181d",
                           "filename": "extras.pdf",
-                          "uploaded_at": "2021-06-03T20:34:22.899Z"
+                          "uploaded_at": "2021-06-07T16:06:22.794Z"
                         }
                       ]
                     }
@@ -2133,7 +2133,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "a802e427-3a8d-4515-9bdc-e2ad2a20f9fe",
+                    "id": "b08b7a21-6e0b-411a-b00a-7c2e68150b1d",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -2151,13 +2151,13 @@
                       "current_phase_back": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-03T20:34:23.363Z",
+                      "updated_at": "2021-06-07T16:06:23.143Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
 
                       ],
-                      "token": "a802e427-3a8d-4515-9bdc-e2ad2a20f9fe",
+                      "token": "b08b7a21-6e0b-411a-b00a-7c2e68150b1d",
                       "status": "pending",
                       "flashes": [
                         "Hardship",
@@ -3772,7 +3772,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "0b0efc82-d60d-4865-a2ec-b9cd4ad52490",
+                    "id": "f32c78b7-9834-4cdb-a325-60afd40e2bab",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -3790,13 +3790,13 @@
                       "current_phase_back": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-03T20:34:23.608Z",
+                      "updated_at": "2021-06-07T16:06:23.407Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
 
                       ],
-                      "token": "0b0efc82-d60d-4865-a2ec-b9cd4ad52490",
+                      "token": "f32c78b7-9834-4cdb-a325-60afd40e2bab",
                       "status": "pending",
                       "flashes": [
                         "Hardship",
@@ -5782,7 +5782,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "3fb25b17-5ecc-48e0-ad50-7a43cf696d68",
+                    "id": "e310afb4-55a6-47c7-b1af-24877e90cd20",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -5796,7 +5796,7 @@
                       "decision_letter_sent": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-03T20:34:24.282Z",
+                      "updated_at": "2021-06-07T16:06:24.134Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
@@ -5805,7 +5805,7 @@
                       "status": "pending",
                       "supporting_documents": [
                         {
-                          "id": "3b2156f1-59ad-4334-b912-a47f6ef105f6",
+                          "id": "6d460934-8d20-410b-9066-83b302d0e558",
                           "type": "claim_supporting_document",
                           "md5": null,
                           "filename": null,
@@ -6646,11 +6646,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "183042",
+                    "id": "184000",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creation_date": "2020-06-05T11:24:28.000-05:00",
-                      "expiration_date": "2021-06-05T11:24:28.000-05:00",
+                      "creation_date": null,
+                      "expiration_date": "2021-08-04T11:11:14.000-05:00",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -6681,14 +6681,16 @@
                           "type": "object",
                           "additionalProperties": false,
                           "required": [
-                            "creation_date",
                             "expiration_date",
                             "type",
                             "status"
                           ],
                           "properties": {
                             "creation_date": {
-                              "type": "string",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "format": "date",
                               "description": "Date the Intent to File was received at the VA"
                             },
@@ -7630,11 +7632,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "4fdf8ff5-1ed7-49e8-8a79-d84de9701521",
+                    "id": "70325312-2f4a-476d-89a4-7ff1ef59a349",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "pending",
-                      "date_request_accepted": "2021-06-03",
+                      "date_request_accepted": "2021-06-07",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"
@@ -8313,11 +8315,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "b047df34-c94f-4415-9c3c-65d69b4f2388",
+                    "id": "3a6ff927-5d3d-4b1a-8231-2aa69c2604ed",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "submitted",
-                      "date_request_accepted": "2021-06-03",
+                      "date_request_accepted": "2021-06-07",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"
@@ -8606,11 +8608,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "4d0e8ab0-c53c-4201-b49e-3022c46ac730",
+                    "id": "0c533d1f-401a-42a5-86b9-0cc4d9c33aa3",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "submitted",
-                      "date_request_accepted": "2021-06-03",
+                      "date_request_accepted": "2021-06-07",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"

--- a/spec/support/schemas/claims_api/forms/intent_to_file/active.json
+++ b/spec/support/schemas/claims_api/forms/intent_to_file/active.json
@@ -16,10 +16,10 @@
         "attributes": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["creation_date", "expiration_date", "type", "status"],
+          "required": ["expiration_date", "type", "status"],
           "properties": {
             "creation_date": {
-              "type": "string",
+              "type": ["string", "null"],
               "format": "date",
               "description": "Date the Intent to File was received at the VA"
             },


### PR DESCRIPTION
## Description of change
Appears that the creation_date field in the 0966/active response can be null.
Updated the spec and re-generated openapi documentation.