### PR TITLE
Mobile Vet360LinkingJob fix

### DIFF
--- a/modules/mobile/app/controllers/mobile/application_controller.rb
+++ b/modules/mobile/app/controllers/mobile/application_controller.rb
@@ -58,11 +58,11 @@ module Mobile
     end
 
     def link_user_with_vets360
-      account_uuid = @current_user.account_uuid
+      uuid = @current_user.uuid
 
-      unless vet360_linking_locked?(account_uuid)
-        lock_vets360_linking(account_uuid)
-        jid = Mobile::V0::Vet360LinkingJob.perform_async(@current_user)
+      unless vet360_linking_locked?(uuid)
+        lock_vets360_linking(uuid)
+        jid = Mobile::V0::Vet360LinkingJob.perform_async(uuid)
         Rails.logger.info('Mobile Vet360 account link job id', { job_id: jid })
       end
     end

--- a/modules/mobile/app/workers/mobile/v0/vet360_linking_job.rb
+++ b/modules/mobile/app/workers/mobile/v0/vet360_linking_job.rb
@@ -9,16 +9,18 @@ module Mobile
 
       sidekiq_options(retry: false)
 
-      def perform(current_user)
-        Mobile::V0::Profile::SyncUpdateService.new(current_user).await_vet360_account_link
+      def perform(uuid)
+        user = IAMUser.find(uuid)
+        result = Mobile::V0::Profile::SyncUpdateService.new(user).await_vet360_account_link
         Rails.logger.info('Mobile Vet360 account linking succeeded for user with uuid',
-                          { user_uuid: current_user.account_uuid })
+                          { user_uuid: uuid, transaction_id: result.transaction_id })
       rescue => e
         Rails.logger.error('Mobile Vet360 account linking failed for user with uuid',
-                           { user_uuid: current_user.account_uuid, error: e })
+                           { user_uuid: uuid })
+        raise e
       ensure
         redis = Redis::Namespace.new(REDIS_CONFIG[:mobile_vets360_account_link_lock][:namespace], redis: Redis.current)
-        redis.del(current_user.account_uuid)
+        redis.del(uuid)
       end
     end
   end

--- a/modules/mobile/spec/support/vcr_cassettes/profile/init_vet360_id_status_400.yml
+++ b/modules/mobile/spec/support/vcr_cassettes/profile/init_vet360_id_status_400.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "https://int.vet360.va.gov/contact-information-hub/cuf/contact-information/v1/2.16.840.1.113883.4.349/1000123456V123456%5ENI%5E200M%5EUSVHA"
+    body:
+      encoding: UTF-8
+      string: '{"bio":{"sourceDate":"2018-04-09T17:52:03Z"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Cufsystemname:
+      - VETSGOV
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Date:
+      - Wed, 25 Apr 2018 17:17:07 GMT
+      Expires:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      X-Ua-Compatible:
+      - IE-edge,chrome=1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+        "messages": [
+          {
+            "code":"PERS101",
+            "key":"vet360Id.NotNull",
+            "severity":"ERROR",
+            "text":"The vet360Id cannot be null."
+          }
+        ],
+        "txAuditId":"3773cd41-0958-4bbe-a035-16ae353cde03",
+        "status":"REJECTED"
+      }'
+    http_version:
+  recorded_at: Wed, 25 Apr 2018 17:17:06 GMT
+recorded_with: VCR 3.0.3

--- a/modules/mobile/spec/workers/vet360_linking_spec.rb
+++ b/modules/mobile/spec/workers/vet360_linking_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Mobile::V0::Vet360LinkingJob, type: :job do
   end
 
   context 'when linking fails' do
-    it 'logs the completed transaction id that linked an account with vet360' do
+    it 'logs the failure with the user uuid' do
       VCR.use_cassette('profile/init_vet360_id_status_400') do
         allow(Rails.logger).to receive(:error)
         expect { subject.perform(user.uuid) }.to raise_error(Common::Exceptions::BackendServiceException)

--- a/modules/mobile/spec/workers/vet360_linking_spec.rb
+++ b/modules/mobile/spec/workers/vet360_linking_spec.rb
@@ -15,13 +15,31 @@ RSpec.describe Mobile::V0::Vet360LinkingJob, type: :job do
 
   let(:user) { FactoryBot.build(:iam_user, :no_vet360_id) }
 
-  it 'Returns a completed transaction for linking an account with vet360' do
-    VCR.use_cassette('profile/init_vet360_id_status_complete') do
-      VCR.use_cassette('profile/init_vet360_id_status_incomplete') do
-        VCR.use_cassette('profile/init_vet360_id_success') do
-          expect(Rails.logger).not_to receive(:error)
-          subject.perform(user)
+  context 'when linking succeeds' do
+    it 'logs the completed transaction id that linked an account with vet360' do
+      VCR.use_cassette('profile/init_vet360_id_status_complete') do
+        VCR.use_cassette('profile/init_vet360_id_status_incomplete') do
+          VCR.use_cassette('profile/init_vet360_id_success') do
+            allow(Rails.logger).to receive(:info)
+            subject.perform(user.uuid)
+            expect(Rails.logger).to have_received(:info).with(
+              'Mobile Vet360 account linking succeeded for user with uuid',
+              { user_uuid: user.uuid, transaction_id: 'd8951c96-5b8c-42ea-9fbe-e656941b7236' }
+            )
+          end
         end
+      end
+    end
+  end
+
+  context 'when linking fails' do
+    it 'logs the completed transaction id that linked an account with vet360' do
+      VCR.use_cassette('profile/init_vet360_id_status_400') do
+        allow(Rails.logger).to receive(:error)
+        expect { subject.perform(user.uuid) }.to raise_error(Common::Exceptions::BackendServiceException)
+        expect(Rails.logger).to have_received(:error).with(
+          'Mobile Vet360 account linking failed for user with uuid', user_uuid: '3097e489-ad75-5746-ab1a-e0aabc1b426a'
+        )
       end
     end
   end


### PR DESCRIPTION
## Description of change
Fixes the `Mobile::V0::Vet360LinkingJob` by having it take a `user.uuid` rather than user object. Added a spec for the error case.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25789

