### PR TITLE
API-6697 Differentiate between v1 and v2 header fixtures

### DIFF
--- a/modules/appeals_api/spec/factories/higher_level_reviews.rb
+++ b/modules/appeals_api/spec/factories/higher_level_reviews.rb
@@ -50,7 +50,7 @@ FactoryBot.define do
   factory :higher_level_review_v2, class: 'AppealsApi::HigherLevelReview' do
     id { SecureRandom.uuid }
     auth_headers do
-      JSON.parse File.read "#{::Rails.root}/modules/appeals_api/spec/fixtures/valid_200996_headers.json"
+      JSON.parse File.read "#{::Rails.root}/modules/appeals_api/spec/fixtures/valid_200996_headers_v2.json"
     end
     form_data do
       JSON.parse File.read "#{::Rails.root}/modules/appeals_api/spec/fixtures/valid_200996_v2.json"
@@ -60,7 +60,7 @@ FactoryBot.define do
   factory :extra_higher_level_review_v2, class: 'AppealsApi::HigherLevelReview' do
     id { SecureRandom.uuid }
     auth_headers do
-      JSON.parse File.read "#{::Rails.root}/modules/appeals_api/spec/fixtures/valid_200996_headers.json"
+      JSON.parse File.read "#{::Rails.root}/modules/appeals_api/spec/fixtures/valid_200996_headers_v2.json"
     end
     form_data do
       JSON.parse File.read "#{::Rails.root}/modules/appeals_api/spec/fixtures/valid_200996_v2_extra.json"

--- a/modules/appeals_api/spec/fixtures/valid_200996_headers_v2.json
+++ b/modules/appeals_api/spec/fixtures/valid_200996_headers_v2.json
@@ -1,0 +1,11 @@
+{
+  "X-VA-SSN": "123456789",
+  "X-VA-First-Name": "Jane",
+  "X-VA-Middle-Initial": "Z",
+  "X-VA-Last-Name": "Doe",
+  "X-VA-Birth-Date": "1969-12-31",
+  "X-VA-File-Number": "987654321",
+  "X-VA-Insurance-Policy-Number": "987654321123456789",
+  "X-Consumer-Username": "va.gov",
+  "X-Consumer-ID": "some-guid"
+}


### PR DESCRIPTION
HLR v2 no longer requires the Veteran Service Number to be passed through the headers and printed on the form.

Our spec files and factories for HLR v2 were using the HLR v1 header fixtures, which worked, but continued one continued to pass in the veteran service number, making the distinction between the two expectations confusing.

A fixture file for valid v2 headers has been added, with the veteran service number removed.

Ticket: https://vajira.max.gov/browse/API-6697