### PR TITLE
[22732] adds user to EVSS VSOSearch service instantiation

### DIFF
--- a/app/workers/education_form/process10203_submissions.rb
+++ b/app/workers/education_form/process10203_submissions.rb
@@ -58,15 +58,15 @@ module EducationForm
     # Otherwise check submission data and EVSS data to see if submission can be marked as PROCESSED
     def process_user_submissions(user_submissions)
       user_submissions.each do |user_uuid, submissions|
-        user = User.find(user_uuid)
         auth_headers = submissions.last.education_stem_automated_decision.auth_headers
+        account = Account.find_by(idme_uuid: user_uuid)
 
         claim_ids = submissions.map(&:id).join(', ')
         log_info "EDIPI available for process STEM claim ids=#{claim_ids}: #{auth_headers&.key?('va_eauth_dodedipnid')}"
 
         gi_bill_status = get_gi_bill_status(auth_headers)
         # only check EVSS if poa wasn't set on submit
-        poa = submissions.last.education_stem_automated_decision.poa || get_user_poa_status(user, auth_headers)
+        poa = submissions.last.education_stem_automated_decision.poa || get_user_poa_status(account, auth_headers)
 
         if gi_bill_status == {} || gi_bill_status.remaining_entitlement.blank?
           submissions.each do |submission|
@@ -92,11 +92,11 @@ module EducationForm
     end
 
     # Retrieve poa status fromEVSS VSOSearch for a user
-    def get_user_poa_status(user, auth_headers)
+    def get_user_poa_status(account, auth_headers)
       return nil if auth_headers.nil?
       return nil unless auth_headers.key?('va_eauth_dodedipnid')
 
-      service = EVSS::VSOSearch::Service.new(user, auth_headers)
+      service = EVSS::VSOSearch::Service.new(nil, auth_headers, account)
       service.get_current_info(auth_headers)['userPoaInfoAvailable']
     rescue => e
       log_exception_to_sentry(

--- a/app/workers/education_form/process10203_submissions.rb
+++ b/app/workers/education_form/process10203_submissions.rb
@@ -57,16 +57,16 @@ module EducationForm
     #   by EducationForm::CreateDailySpoolFiles
     # Otherwise check submission data and EVSS data to see if submission can be marked as PROCESSED
     def process_user_submissions(user_submissions)
-      user_submissions.each_value do |submissions|
+      user_submissions.each do |user_uuid, submissions|
+        user = User.find(user_uuid)
         auth_headers = submissions.last.education_stem_automated_decision.auth_headers
 
         claim_ids = submissions.map(&:id).join(', ')
         log_info "EDIPI available for process STEM claim ids=#{claim_ids}: #{auth_headers&.key?('va_eauth_dodedipnid')}"
 
         gi_bill_status = get_gi_bill_status(auth_headers)
-
         # only check EVSS if poa wasn't set on submit
-        poa = submissions.last.education_stem_automated_decision.poa || get_user_poa_status(auth_headers)
+        poa = submissions.last.education_stem_automated_decision.poa || get_user_poa_status(user, auth_headers)
 
         if gi_bill_status == {} || gi_bill_status.remaining_entitlement.blank?
           submissions.each do |submission|
@@ -92,11 +92,11 @@ module EducationForm
     end
 
     # Retrieve poa status fromEVSS VSOSearch for a user
-    def get_user_poa_status(auth_headers)
+    def get_user_poa_status(user, auth_headers)
       return nil if auth_headers.nil?
       return nil unless auth_headers.key?('va_eauth_dodedipnid')
 
-      service = EVSS::VSOSearch::Service.new(nil, auth_headers)
+      service = EVSS::VSOSearch::Service.new(user, auth_headers)
       service.get_current_info(auth_headers)['userPoaInfoAvailable']
     rescue => e
       log_exception_to_sentry(

--- a/lib/evss/service.rb
+++ b/lib/evss/service.rb
@@ -9,8 +9,9 @@ module EVSS
     include Common::Client::Concerns::Monitoring
     STATSD_KEY_PREFIX = 'api.evss'
 
-    def initialize(user = nil, auth_headers = nil)
+    def initialize(user = nil, auth_headers = nil, account = nil)
       @user = user
+      @account = account
       if auth_headers.nil?
         @headers = EVSS::AuthHeaders.new(user)
         @transaction_id = @headers.transaction_id

--- a/lib/evss/vso_search/service.rb
+++ b/lib/evss/vso_search/service.rb
@@ -29,7 +29,7 @@ module EVSS
       private
 
       def request_headers(additional_headers)
-        edipi = additional_headers['va_eauth_dodedipnid'].presence || @account.edipi
+        edipi = additional_headers['va_eauth_dodedipnid'].presence || @account&.edipi
         ssn = additional_headers['va_eauth_pnid'].presence || @user.ssn
         {
           'ssn' => ssn,

--- a/lib/evss/vso_search/service.rb
+++ b/lib/evss/vso_search/service.rb
@@ -29,8 +29,8 @@ module EVSS
       private
 
       def request_headers(additional_headers)
+        edipi = additional_headers['va_eauth_dodedipnid'].presence || @account.edipi
         ssn = additional_headers['va_eauth_pnid'].presence || @user.ssn
-        edipi = additional_headers['va_eauth_dodedipnid'].presence || @user.edipi
         {
           'ssn' => ssn,
           'edipi' => edipi,

--- a/lib/evss/vso_search/service.rb
+++ b/lib/evss/vso_search/service.rb
@@ -31,16 +31,6 @@ module EVSS
       def request_headers(additional_headers)
         ssn = additional_headers['va_eauth_pnid'].presence || @user.ssn
         edipi = additional_headers['va_eauth_dodedipnid'].presence || @user.edipi
-        if edipi.nil?
-          user_info = {
-            loa3: @user.loa3?,
-            mhv_icn: !@user.mhv_icn.nil?,
-            edipi_type: additional_headers['va_eauth_dodedipnid'].class,
-            edipi_length: additional_headers['va_eauth_dodedipnid']&.length
-          }
-          log_message_to_sentry('Failed to find EDIPI, EVSS service call will not succeed', :warn, user_info)
-        end
-
         {
           'ssn' => ssn,
           'edipi' => edipi,

--- a/spec/jobs/education_form/process10203_submissions_spec.rb
+++ b/spec/jobs/education_form/process10203_submissions_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe EducationForm::Process10203Submissions, type: :model, form: :educ
   let(:evss_user) { create(:evss_user) }
   let(:evss_user2) { create(:evss_user, uuid: '87ebe3da-36a3-4c92-9a73-61e9d700f6ea') }
   let(:evss_response_with_poa) { OpenStruct.new(body: get_fixture('json/evss_with_poa')) }
+  let!(:account) { create(:account, uuid: evss_user.account_uuid) }
 
   context 'scheduling' do
     before do

--- a/spec/lib/evss/vso_search/service_spec.rb
+++ b/spec/lib/evss/vso_search/service_spec.rb
@@ -5,7 +5,8 @@ require 'evss/vso_search/service'
 
 describe EVSS::VSOSearch::Service do
   let(:user) { create(:evss_user) }
-  let(:service) { described_class.new(user) }
+  let(:account) { user.account }
+  let(:service) { described_class.new(user, nil, account) }
   let(:response) { OpenStruct.new(body: get_fixture('json/evss_with_poa')) }
 
   def it_returns_valid_payload(method, form = nil)
@@ -26,6 +27,17 @@ describe EVSS::VSOSearch::Service do
 
     it 'handles errors' do
       it_handles_errors(:get_current_info, response.body)
+    end
+
+    it 'uses passed in user account data if auth_headers are missing' do
+      headers = {
+        'Authorization' => 'Token token=PUBLICDEMO123',
+        'Content-Type' => 'application/json',
+        'edipi' => '1007697216',
+        'ssn' => '796043735'
+      }
+      expect(service).to receive(:perform).with(:post, 'getCurrentInfo', '', headers).and_return(response)
+      service.send(*[:get_current_info, {}].compact)
     end
 
     it 'sets the correct base headers and empty string for post body' do


### PR DESCRIPTION
## Description of change
This PR changes the EVSS service instantiation to properly take a user as an argument so that the user's attribute values will be available as backup values in the event that `additional_headers' is missing an attribute value. It is a quick & partial reversal of [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/5793/files) that changed the EVSS service from being instantiated with a `User` instance to using authentication_headers.

For further information related to this change, see my writeup in the linked issue thread.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22732

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Unit tests passed, manual testing of EVSS::VSOSearch service creation with only backup user object to confirm backup functionality is working.