### PR TITLE
Adds spec for additional error case from MHV API

### DIFF
--- a/lib/common/client/middleware/response/mhv_errors.rb
+++ b/lib/common/client/middleware/response/mhv_errors.rb
@@ -15,6 +15,7 @@ module Common
           #
           def on_complete(env)
             return if env.success?
+            return unless env[:body].is_a?(Hash)
 
             env[:body]['code'] = env[:body].delete('errorCode')
             env[:body]['detail'] = env[:body].delete('message')

--- a/spec/support/vcr_cassettes/mhv_account_type_service/error_empty_body.yml
+++ b/spec/support/vcr_cassettes/mhv_account_type_service/error_empty_body.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<MHV_HOST>/mhv-api/patient/v1/session"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Apptoken:
+      - "<APP_TOKEN>"
+      Mhvcorrelationid:
+      - '5052774'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 08 Jun 2021 22:54:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      X-Amzn-Requestid:
+      - 0df60629-18b6-4b8a-a270-00b556fa6357
+      X-Amzn-Remapped-Content-Length:
+      - '0'
+      X-Amz-Apigw-Id:
+      - AoM-xGXEvHMFV3w=
+      X-Amzn-Remapped-Date:
+      - Tue, 08 Jun 2021 22:54:35 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Tue, 08 Jun 2021 22:54:35 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
While looking at this issue in Sentry: http://sentry.vfs.va.gov/organizations/vsp/issues/44/?environment=staging&project=3&query=is%3Aunresolved+mobile&statsPeriod=14d

I noticed that the MHV client middleware was unable to handle one response from MHV - a 400 with no message body. The upshot of this is the same - that we can't get an MHV account type for this user - but this avoids us writing a spec against an internal error in the client implementation - that `string not matched` was coming from the mhv_errors middleware, trying to treat an empty string as a Hash. 

This seems to happen in staging because of garbage MHV IDs in MPI, so I don't know if it's essential to fix but seems like it will help with diagnosability. 



## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
