### PR TITLE
API-6698 Remove claimant method from form_data hlr v2

### DIFF
--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
@@ -24,11 +24,7 @@ module AppealsApi
         def last_four_ssn
           ssn.last(4)
         end
-
-        def claimant_type(index)
-          index == 4 ? 1 : 'Off'
-        end
-
+        
         def veteran_homeless
           higher_level_review.veteran_homeless? ? 1 : 'Off'
         end

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
@@ -24,7 +24,7 @@ module AppealsApi
         def last_four_ssn
           ssn.last(4)
         end
-        
+
         def veteran_homeless
           higher_level_review.veteran_homeless? ? 1 : 'Off'
         end


### PR DESCRIPTION
Not yet supporting claimant on HLR v2. Removed a method in form_data referencing the attribute.

Ticket: https://vajira.max.gov/browse/API-6698