### PR TITLE
Removes obsolete call to MHVLoggingService

### DIFF
--- a/modules/mobile/app/controllers/mobile/messaging_controller.rb
+++ b/modules/mobile/app/controllers/mobile/messaging_controller.rb
@@ -25,8 +25,6 @@ module Mobile
     end
 
     def authenticate_client
-      # TODO: is this audit service call still needed?
-      MHVLoggingService.login(current_user)
       client.authenticate if client.session.expired?
     end
 


### PR DESCRIPTION

## Description of change
Call to MHVLoggingService from mobile-specific messaging
controller was not working and also not needed, so removing it.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25819

## Things to know about this PR


<!-- Please describe testing done to verify the changes or any testing planned. -->
