### PR TITLE
API-7873 Handle row number constants in hlr v2 structure

### DIFF
--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_fields.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_fields.rb
@@ -4,9 +4,6 @@ module AppealsApi
   module PdfConstruction
     module HigherLevelReview::V2
       class FormFields
-        FIRST_PAGE_ISSUES_ROW_COUNT = 7
-        SECOND_PAGE_ISSUES_ROW_COUNT = 6
-
         def middle_initial
           'form1[0].#subform[2].Veteran_Middle_Initial1[0]'
         end
@@ -170,6 +167,9 @@ module AppealsApi
 
         # rubocop:disable Metrics/MethodLength
         def boxes
+          number_of_issues_on_second_pg = Structure::NUMBER_OF_ISSUES_SECOND_PAGE
+          number_of_issues_on_first_pg = Structure::NUMBER_OF_ISSUES_FIRST_PAGE
+
           { first_name: { at: [3, 560], width: 195 },
             last_name: { at: [230, 560], width: 293 },
             number_and_street: { at: [29, 462], width: 512 },
@@ -182,16 +182,16 @@ module AppealsApi
             rep_international_number: { at: [275, 555], width: 195 },
             rep_domestic_ext: { at: [225, 555], width: 50 },
             issues_pg1: [].tap do |n|
-              FIRST_PAGE_ISSUES_ROW_COUNT.times { |i| n << { at: [-3, 320 - (46.5 * i)], width: 369, height: 43 } }
+              number_of_issues_on_first_pg.times { |i| n << { at: [-3, 320 - (46.5 * i)], width: 369, height: 43 } }
             end,
             issues_pg2: [].tap do |n|
-              SECOND_PAGE_ISSUES_ROW_COUNT.times { |i| n << { at: [-3, 675 - (46.5 * i)], width: 369, height: 43 } }
+              number_of_issues_on_second_pg.times { |i| n << { at: [-3, 675 - (46.5 * i)], width: 369, height: 43 } }
             end,
             soc_date_pg1: [].tap do |n|
-              FIRST_PAGE_ISSUES_ROW_COUNT.times { |i| n << { at: [375, 315 - (46.5 * i)], width: 160, height: 15 } }
+              number_of_issues_on_first_pg.times { |i| n << { at: [375, 315 - (46.5 * i)], width: 160, height: 15 } }
             end,
             soc_date_pg2: [].tap do |n|
-              SECOND_PAGE_ISSUES_ROW_COUNT.times { |i| n << { at: [380, 670 - (46.5 * i)], width: 160, height: 15 } }
+              number_of_issues_on_second_pg.times { |i| n << { at: [380, 670 - (46.5 * i)], width: 160, height: 15 } }
             end,
             signature: { at: [-3, 329], width: 369, height: 18 },
             # The rest aren't currently used, but kept for if/when we need them

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/structure.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/structure.rb
@@ -6,8 +6,9 @@ module AppealsApi
   module PdfConstruction
     module HigherLevelReview::V2
       class Structure
-        MAX_NUMBER_OF_ISSUES_ON_MAIN_FORM = 13
-        NUMBER_OF_ISSUES_PER_PAGE = 7
+        NUMBER_OF_ISSUES_FIRST_PAGE = 7
+        NUMBER_OF_ISSUES_SECOND_PAGE = 6
+        MAX_NUMBER_OF_ISSUES_ON_MAIN_FORM = (NUMBER_OF_ISSUES_FIRST_PAGE + NUMBER_OF_ISSUES_SECOND_PAGE).freeze
 
         def initialize(higher_level_review)
           @higher_level_review = higher_level_review
@@ -199,7 +200,7 @@ module AppealsApi
 
         def fill_contestable_issues_text(pdf)
           issues = form_data.contestable_issues.take(MAX_NUMBER_OF_ISSUES_ON_MAIN_FORM)
-          issues.first(NUMBER_OF_ISSUES_PER_PAGE).each_with_index do |issue, i|
+          issues.first(NUMBER_OF_ISSUES_FIRST_PAGE).each_with_index do |issue, i|
             if (text = issue.dig('attributes', 'issue')&.presence)
               pdf.text_box text, default_text_opts.merge(form_fields.boxes[:issues_pg1][i])
               pdf.text_box form_data.soc_date_text(issue), default_text_opts.merge(form_fields.boxes[:soc_date_pg1][i])
@@ -207,7 +208,7 @@ module AppealsApi
           end
           pdf.start_new_page # Always start a new page even if there are no issues so other text can insert properly
 
-          issues.drop(NUMBER_OF_ISSUES_PER_PAGE).each_with_index do |issue, i|
+          issues.drop(NUMBER_OF_ISSUES_FIRST_PAGE).each_with_index do |issue, i|
             if (text = issue.dig('attributes', 'issue')&.presence)
               pdf.text_box text, default_text_opts.merge(form_fields.boxes[:issues_pg2][i])
               pdf.text_box form_data.soc_date_text(issue), default_text_opts.merge(form_fields.boxes[:soc_date_pg2][i])


### PR DESCRIPTION
While wiring up the contestable issues soc date printing, it was pointed out that we would be better off using constants for number of rows in a column on each the first and second pages of contestable issues. Additionally, these constants should be managed by the hlr v2 `structure` file.

Ticket: https://vajira.max.gov/browse/API-7873