### PR TITLE
increase Caseflow timeout

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -410,7 +410,7 @@ caseflow:
   mock: true
   app_token: PUBLICDEMO123
   host: https://dsva-appeals-certification-dev-1895622301.us-gov-west-1.elb.amazonaws.com
-  timeout: 40
+  timeout: 60
 
 vic:
   url: https://some.fakesite.com

--- a/spec/lib/caseflow/configuration_spec.rb
+++ b/spec/lib/caseflow/configuration_spec.rb
@@ -19,7 +19,7 @@ describe Caseflow::Configuration do
   describe '.read_timeout' do
     context 'when Settings.caseflow.timeout is set' do
       it 'uses the setting' do
-        expect(Caseflow::Configuration.instance.read_timeout).to eq(40)
+        expect(Caseflow::Configuration.instance.read_timeout).to eq(60)
       end
     end
   end

--- a/spec/lib/decision_review/configuration_spec.rb
+++ b/spec/lib/decision_review/configuration_spec.rb
@@ -7,7 +7,7 @@ describe DecisionReview::Configuration do
   describe '.read_timeout' do
     context 'when Settings.caseflow.timeout is set' do
       it 'uses the setting' do
-        expect(DecisionReview::Configuration.instance.read_timeout).to eq(40)
+        expect(DecisionReview::Configuration.instance.read_timeout).to eq(60)
       end
     end
   end


### PR DESCRIPTION
## Description of change
Obviously the right solution is for Caseflow to return results faster, but I'm increasing the timeout in the meantime.  I think it's preferable from our user's standpoint to wait for a result than it is to show them some sort of error message.

It seems that the more issues a user has the slower caseflow returns a result.  Or, to put this in human terms this disproportionately affects our more disabled users. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25914

## Things to know about this PR
This timeout is used by both lighthouse and va.gov for caseflow-related timeouts.  