### PR TITLE
Api 7661/refactor hlr convenience methods

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -7,6 +7,10 @@ module AppealsApi
   class HigherLevelReview < ApplicationRecord
     include HlrStatus
 
+    def formatter
+      AppealsApi::HigherLevelReview::Formatter.new(self)
+    end
+
     def self.past?(date)
       date < Time.zone.today
     end
@@ -39,9 +43,9 @@ module AppealsApi
     has_many :evidence_submissions, as: :supportable, dependent: :destroy
     has_many :status_updates, as: :statusable, dependent: :destroy
 
-    def pdf_structure(version)
+    def pdf_structure
       Object.const_get(
-        "AppealsApi::PdfConstruction::HigherLevelReview::#{version.upcase}::Structure"
+        "AppealsApi::PdfConstruction::HigherLevelReview::#{self.pdf_version.upcase}::Structure"
       ).new(self)
     end
 

--- a/modules/appeals_api/app/models/appeals_api/higher_level_review/contestable_issue.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review/contestable_issue.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AppealsApi::HigherLevelReview::ContestableIssue
+  def initialize(issue)
+    @issue = issue
+  end
+
+  def decision_date
+    AppealsApi::HigherLevelReview::Date.new(decision_date_string)
+  end
+
+  def decision_date_string
+    issue.dig('attributes', 'decisionDate').to_s
+  end
+
+  def text
+    issue.dig('attributes', 'issue')
+  end
+
+  delegate :[], to: :issue
+
+  def text_exists?
+    text.present?
+  end
+
+  private
+
+  attr_reader :issue
+end

--- a/modules/appeals_api/app/models/appeals_api/higher_level_review/contestable_issue.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review/contestable_issue.rb
@@ -6,11 +6,23 @@ class AppealsApi::HigherLevelReview::ContestableIssue
   end
 
   def decision_date
+    return unless decision_date_string
+
     AppealsApi::HigherLevelReview::Date.new(decision_date_string)
   end
 
   def decision_date_string
     issue.dig('attributes', 'decisionDate').to_s
+  end
+
+  def soc_date
+    return unless soc_date_string
+
+    AppealsApi::HigherLevelReview::Date.new(soc_date_string)
+  end
+
+  def soc_date_string
+    issue.dig('attributes', 'socDate')
   end
 
   def text

--- a/modules/appeals_api/app/models/appeals_api/higher_level_review/date.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review/date.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  class HigherLevelReview::Date
+    def initialize(date)
+      @raw_date = date
+      @date = date_from_string(date)
+    end
+
+    def day
+      date.strftime('%d')
+    end
+
+    def month
+      date.strftime('%m')
+    end
+
+    def year
+      date.strftime('%Y')
+    end
+
+    def formatted_date
+      "#{month}/#{day}/#{year}"
+    end
+
+    def in_the_past?
+      date < Time.zone.today
+    end
+
+    attr_reader :raw_date
+
+    def valid?
+      !!date
+    end
+
+    private
+
+    attr_reader :date
+
+    def date_from_string(date)
+      return date.to_date if time?
+
+      date.match(/\d{4}-\d{2}-\d{2}/) && Date.parse(date)
+    rescue ArgumentError
+      nil
+    end
+
+    def time?
+      raw_date.instance_of?(Time) || raw_date.instance_of?(ActiveSupport::TimeWithZone)
+    end
+  end
+end

--- a/modules/appeals_api/app/models/appeals_api/higher_level_review/date.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review/date.rb
@@ -19,8 +19,8 @@ module AppealsApi
       date.strftime('%Y')
     end
 
-    def formatted_date
-      "#{month}/#{day}/#{year}"
+    def formatted_date(formatter: '/')
+      "#{month}#{formatter}#{day}#{formatter}#{year}"
     end
 
     def in_the_past?

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -25,9 +25,9 @@ module AppealsApi
     has_many :evidence_submissions, as: :supportable, dependent: :destroy
     has_many :status_updates, as: :statusable, dependent: :destroy
 
-    def pdf_structure(version)
+    def pdf_structure
       Object.const_get(
-        "AppealsApi::PdfConstruction::NoticeOfDisagreement::#{version.upcase}::Structure"
+        "AppealsApi::PdfConstruction::NoticeOfDisagreement::#{pdf_version.upcase}::Structure"
       ).new(self)
     end
 

--- a/modules/appeals_api/app/models/concerns/appeals_api/higher_level_reviews/formatter.rb
+++ b/modules/appeals_api/app/models/concerns/appeals_api/higher_level_reviews/formatter.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  module HigherLevelReviews
+    class Formatter
+      def initialize(higher_level_review)
+        @higher_level_review = higher_level_review
+      end
+
+      def birth_date
+        AppealsApi::HigherLevelReview::Date.new(
+          higher_level_review.auth_headers.dig('X-VA-Birth-Date')
+        )
+      end
+
+      def date_signed
+        AppealsApi::HigherLevelReview::Date.new(veterans_local_time)
+      end
+
+      def contestable_issues
+        issues = higher_level_review.form_data.dig('included') || []
+
+        issues.map do |issue|
+          AppealsApi::HigherLevelReview::ContestableIssue.new(issue)
+        end
+      end
+
+      private
+
+      attr_accessor :higher_level_review
+
+      def version
+        higher_level_review.pdf_version
+      end
+
+      def veterans_local_time
+        timezone = higher_level_review.form_data&.dig(
+          'data', 'attributes', 'veteran', 'timezone'
+        ).presence&.strip
+
+        if timezone
+          Time.now.in_time_zone(timezone)
+        else
+          Time.now.utc
+        end
+      end
+    end
+  end
+end

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/generator.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/generator.rb
@@ -8,7 +8,7 @@ module AppealsApi
       def initialize(appeal, version: 'V1')
         @appeal = appeal
         appeal.update(pdf_version: version)
-        @structure = appeal.pdf_structure(version)
+        @structure = appeal.pdf_structure
       end
 
       def generate

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/pages/v1/additional_issues.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/pages/v1/additional_issues.rb
@@ -34,7 +34,7 @@ module AppealsApi
             issues = []
 
             form_data.contestable_issues.drop(MAX_ISSUES_ON_FIRST_PAGE).map do |issue|
-              issues << "Issue: #{issue['attributes']['issue']} - Decision Date: #{issue['attributes']['decisionDate']}"
+              issues << "Issue: #{issue.text} - Decision Date: #{issue.decision_date.raw_date}"
             end
 
             # keep parity between original HLR and new generator

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/pages/v2/additional_issues.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/pages/v2/additional_issues.rb
@@ -40,7 +40,8 @@ module AppealsApi
               header = ['A. Specific Issue(s)', 'B. Date of Decision', 'C. SOC/SSOC Date']
 
               data = form_data.contestable_issues.drop(max_issues_on_form).map do |issue|
-                [issue['attributes']['issue'], issue['attributes']['decisionDate'], form_data.soc_date_formatted(issue)]
+                [issue['attributes']['issue'], issue['attributes']['decisionDate'],
+                 issue.soc_date&.formatted_date(formatter: '-')]
               end
 
               data.unshift(header)

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v1/form_data.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v1/form_data.rb
@@ -27,15 +27,15 @@ module AppealsApi
         end
 
         def birth_month
-          higher_level_review.birth_mm
+          higher_level_review.birth_date.month
         end
 
         def birth_day
-          higher_level_review.birth_dd
+          higher_level_review.birth_date.day
         end
 
         def birth_year
-          higher_level_review.birth_yyyy
+          higher_level_review.birth_date.year
         end
 
         delegate :file_number, to: :higher_level_review

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v1/structure.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v1/structure.rb
@@ -58,7 +58,7 @@ module AppealsApi
             form_fields.conference_2_to_430 => form_data.informal_conference_times('1400-1630 ET'),
             form_fields.rep_name_and_phone_number => form_data.rep_name_and_phone_number,
             form_fields.signature => form_data.signature,
-            form_fields.date_signed => form_data.date_signed
+            form_fields.date_signed => form_data.date_signed.formatted_date
           }
 
           fill_contestable_issues!(options)

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v1/structure.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v1/structure.rb
@@ -118,8 +118,8 @@ module AppealsApi
         def fill_contestable_issues!(options)
           form_issues = form_data.contestable_issues.take(MAX_NUMBER_OF_ISSUES_ON_MAIN_FORM)
           form_issues.each_with_index do |issue, index|
-            options[form_fields.contestable_issue_fields_array[index]] = issue['attributes']['issue']
-            options[form_fields.issue_decision_date_fields_array[index]] = issue['attributes']['decisionDate']
+            options[form_fields.contestable_issue_fields_array[index]] = issue.text
+            options[form_fields.issue_decision_date_fields_array[index]] = issue.decision_date.raw_date
           end
 
           options

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
@@ -9,8 +9,7 @@ module AppealsApi
         end
 
         delegate :first_name, :middle_initial, :last_name, :number_and_street, :city, :state_code,
-                 :country_code, :file_number, :zip_code_5, :insurance_policy_number, :contestable_issues, :birth_mm,
-                 :birth_dd, :birth_yyyy, :date_signed_mm, :date_signed_dd, :date_signed_yyyy,
+                 :country_code, :file_number, :zip_code_5, :insurance_policy_number, :contestable_issues,
                  to: :higher_level_review
 
         def first_three_ssn
@@ -165,6 +164,30 @@ module AppealsApi
 
         def stamp_text
           "#{last_name.truncate(35)} - #{ssn.last(4)}"
+        end
+
+        def birth_mm
+          higher_level_review.birth_date.month
+        end
+
+        def birth_yyyy
+          higher_level_review.birth_date.year
+        end
+
+        def birth_dd
+          higher_level_review.birth_date.day
+        end
+
+        def date_signed_mm
+          higher_level_review.date_signed.month
+        end
+
+        def date_signed_yyyy
+          higher_level_review.date_signed.year
+        end
+
+        def date_signed_dd
+          higher_level_review.date_signed.day
         end
 
         private

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/form_data.rb
@@ -140,22 +140,10 @@ module AppealsApi
           higher_level_review.soc_opt_in ? 1 : 'Off'
         end
 
-        def soc_date(issue)
-          issue['attributes']&.dig('socDate')
-        end
-
-        def soc_date_formatted(issue)
-          date = soc_date(issue)
-          return '' unless date
-
-          Date.parse(date).strftime('%m-%d-%Y')
-        end
-
         def soc_date_text(issue)
-          date = soc_date(issue)
-          return '' unless date
+          return '' unless issue.soc_date_string
 
-          "SOC/SSOC Date: #{soc_date_formatted(issue)}"
+          "SOC/SSOC Date: #{issue.soc_date.formatted_date(formatter: '-')}"
         end
 
         def signature

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/structure.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/higher_level_review/v2/structure.rb
@@ -189,10 +189,9 @@ module AppealsApi
           form_issues = form_data.contestable_issues.take(MAX_NUMBER_OF_ISSUES_ON_MAIN_FORM)
           form_issues.each_with_index do |issue, index|
             date_fields = form_fields.issue_decision_date_fields(index)
-            date = Date.parse(issue['attributes']['decisionDate'])
-            options[date_fields[:month]] = date.strftime '%m'
-            options[date_fields[:day]] = date.strftime '%d'
-            options[date_fields[:year]] = date.strftime '%Y'
+            options[date_fields[:month]] = issue.decision_date.month
+            options[date_fields[:day]] = issue.decision_date.day
+            options[date_fields[:year]] = issue.decision_date.year
           end
           options
         end
@@ -200,16 +199,16 @@ module AppealsApi
         def fill_contestable_issues_text(pdf)
           issues = form_data.contestable_issues.take(MAX_NUMBER_OF_ISSUES_ON_MAIN_FORM)
           issues.first(NUMBER_OF_ISSUES_PER_PAGE).each_with_index do |issue, i|
-            if (text = issue.dig('attributes', 'issue')&.presence)
-              pdf.text_box text, default_text_opts.merge(form_fields.boxes[:issues_pg1][i])
+            if issue.text_exists?
+              pdf.text_box issue.text, default_text_opts.merge(form_fields.boxes[:issues_pg1][i])
               pdf.text_box form_data.soc_date_text(issue), default_text_opts.merge(form_fields.boxes[:soc_date_pg1][i])
             end
           end
           pdf.start_new_page # Always start a new page even if there are no issues so other text can insert properly
 
           issues.drop(NUMBER_OF_ISSUES_PER_PAGE).each_with_index do |issue, i|
-            if (text = issue.dig('attributes', 'issue')&.presence)
-              pdf.text_box text, default_text_opts.merge(form_fields.boxes[:issues_pg2][i])
+            if issue.text_exists?
+              pdf.text_box issue.text, default_text_opts.merge(form_fields.boxes[:issues_pg2][i])
               pdf.text_box form_data.soc_date_text(issue), default_text_opts.merge(form_fields.boxes[:soc_date_pg2][i])
             end
           end

--- a/modules/appeals_api/spec/models/higher_level_review_spec.rb
+++ b/modules/appeals_api/spec/models/higher_level_review_spec.rb
@@ -86,19 +86,19 @@ describe AppealsApi::HigherLevelReview, type: :model do
   end
 
   describe '#birth_mm' do
-    subject { higher_level_review.birth_mm }
+    subject { higher_level_review.birth_date.month }
 
     it('matches header') { is_expected.to eq auth_headers['X-VA-Birth-Date'][5..6] }
   end
 
   describe '#birth_dd' do
-    subject { higher_level_review.birth_dd }
+    subject { higher_level_review.birth_date.day }
 
     it('matches header') { is_expected.to eq auth_headers['X-VA-Birth-Date'][8..9] }
   end
 
   describe '#birth_yyyy' do
-    subject { higher_level_review.birth_yyyy }
+    subject { higher_level_review.birth_date.year }
 
     it('matches header') { is_expected.to eq auth_headers['X-VA-Birth-Date'][0..3] }
   end
@@ -178,13 +178,19 @@ describe AppealsApi::HigherLevelReview, type: :model do
   end
 
   describe '#contestable_issues' do
-    subject { higher_level_review.contestable_issues }
+    subject { higher_level_review.contestable_issues.to_json }
 
-    it('matches json') { is_expected.to eq form_data['included'] }
+    # ISSUE HAS AN EXTRA KEY
+
+    it 'matches json' do
+      issues = form_data['included'].map { |issue| AppealsApi::HigherLevelReview::ContestableIssue.new(issue) }.to_json
+
+      expect(subject).to eq(issues)
+    end
   end
 
   describe '#date_signed' do
-    subject { higher_level_review.date_signed }
+    subject { higher_level_review.date_signed.formatted_date }
 
     it('matches json') do
       expect(subject).to eq(

--- a/modules/appeals_api/spec/models/higher_level_review_spec.rb
+++ b/modules/appeals_api/spec/models/higher_level_review_spec.rb
@@ -180,8 +180,6 @@ describe AppealsApi::HigherLevelReview, type: :model do
   describe '#contestable_issues' do
     subject { higher_level_review.contestable_issues.to_json }
 
-    # ISSUE HAS AN EXTRA KEY
-
     it 'matches json' do
       issues = form_data['included'].map { |issue| AppealsApi::HigherLevelReview::ContestableIssue.new(issue) }.to_json
 

--- a/modules/appeals_api/spec/services/appeals_api/pdf_construction/higher_level_review/v1/form_data_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/pdf_construction/higher_level_review/v1/form_data_spec.rb
@@ -70,21 +70,30 @@ module AppealsApi
 
             describe '#birth_mm' do
               it do
-                expect(higher_level_review).to receive(:birth_mm)
+                date = AppealsApi::HigherLevelReview::Date.new(Time.zone.now)
+                expect(higher_level_review).to receive(:birth_date).and_return(date)
+                expect(date).to receive(:month)
+
                 form_data.birth_month
               end
             end
 
             describe '#birth_dd' do
               it do
-                expect(higher_level_review).to receive(:birth_dd)
+                date = AppealsApi::HigherLevelReview::Date.new(Time.zone.now)
+                expect(higher_level_review).to receive(:birth_date).and_return(date)
+                expect(date).to receive(:day)
+
                 form_data.birth_day
               end
             end
 
             describe '#birth_yyyy' do
               it do
-                expect(higher_level_review).to receive(:birth_yyyy)
+                date = AppealsApi::HigherLevelReview::Date.new(Time.zone.now)
+                expect(higher_level_review).to receive(:birth_date).and_return(date)
+                expect(date).to receive(:year)
+
                 form_data.birth_year
               end
             end


### PR DESCRIPTION
[API-7661](https://vajira.max.gov/browse/API-7661)

This PR attempts to begin refactoring how we reference `form_data` on an appeal. Right now we do a lot of post processing directly on the model, and have scattered references across the API to internal structured data.

This is an attempt to clean it up, and is a draft of a potential pattern for future iterations of refactor.