### PR TITLE
API-4183 - Clean up invalid json error

### DIFF
--- a/modules/appeals_api/app/controllers/concerns/appeals_api/json_format_validation.rb
+++ b/modules/appeals_api/app/controllers/concerns/appeals_api/json_format_validation.rb
@@ -19,12 +19,12 @@ module AppealsApi
         render_body_is_not_a_hash_error request.body.string
       end
 
-      def render_body_is_not_a_hash_error(body)
+      def render_body_is_not_a_hash_error(_)
         status = 422
         error = {
           status: status,
-          detail: "The request body isn't a JSON object: #{body.inspect}",
-          source: false
+          detail: "The request body isn't a JSON object",
+          source: nil
         }
         render status: status, json: { errors: [error] }
       end

--- a/modules/appeals_api/spec/requests/v1/higher_level_reviews_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v1/higher_level_reviews_controller_spec.rb
@@ -84,7 +84,7 @@ describe AppealsApi::V1::DecisionReviews::HigherLevelReviewsController, type: :r
           body = JSON.parse(response.body)
           expect(response.status).to eq 422
           expect(body['errors']).to be_an Array
-          expect(body.dig('errors', 0, 'detail')).to eq "The request body isn't a JSON object: #{json}"
+          expect(body.dig('errors', 0, 'detail')).to eq "The request body isn't a JSON object"
         end
       end
 
@@ -96,7 +96,7 @@ describe AppealsApi::V1::DecisionReviews::HigherLevelReviewsController, type: :r
           body = JSON.parse(response.body)
           expect(response.status).to eq 422
           expect(body['errors']).to be_an Array
-          expect(body.dig('errors', 0, 'detail')).to eq "The request body isn't a JSON object: #{json}"
+          expect(body.dig('errors', 0, 'detail')).to eq "The request body isn't a JSON object"
         end
       end
     end

--- a/modules/appeals_api/spec/requests/v2/higher_level_reviews_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v2/higher_level_reviews_controller_spec.rb
@@ -84,7 +84,7 @@ describe AppealsApi::V2::DecisionReviews::HigherLevelReviewsController, type: :r
           body = JSON.parse(response.body)
           expect(response.status).to eq 422
           expect(body['errors']).to be_an Array
-          expect(body.dig('errors', 0, 'detail')).to eq "The request body isn't a JSON object: #{json}"
+          expect(body.dig('errors', 0, 'detail')).to eq "The request body isn't a JSON object"
         end
       end
 
@@ -96,7 +96,7 @@ describe AppealsApi::V2::DecisionReviews::HigherLevelReviewsController, type: :r
           body = JSON.parse(response.body)
           expect(response.status).to eq 422
           expect(body['errors']).to be_an Array
-          expect(body.dig('errors', 0, 'detail')).to eq "The request body isn't a JSON object: #{json}"
+          expect(body.dig('errors', 0, 'detail')).to eq "The request body isn't a JSON object"
         end
       end
     end


### PR DESCRIPTION
## Description of change
Instead of returning the entire invalid json body, return the text that states the body is invalid.

## Original issue(s)
https://vajira.max.gov/browse/API-4183