### PR TITLE
Allow download of pre-filled 10-10CG PDF with invalid data

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -27,22 +27,18 @@ module V0
     # If we were unable to submit the user's claim digitally, we allow them to the download
     # the 10-10CG PDF, pre-filled with their data, for them to mail in.
     def download_pdf
-      if @claim.valid?
-        # Brakeman will raise a warning if we use a claim's method or attribute in the source file name.
-        # Use an arbitrary uuid for the source file name and don't use the return value of claim#to_pdf
-        # as the source_file_path (to prevent changes in the the filename creating a vunerability in the future).
-        source_file_path = PdfFill::Filler.fill_form(@claim, SecureRandom.uuid, sign: false)
-        client_file_name = file_name_for_pdf(@claim.veteran_data)
-        file_contents    = File.read(source_file_path)
+      # Brakeman will raise a warning if we use a claim's method or attribute in the source file name.
+      # Use an arbitrary uuid for the source file name and don't use the return value of claim#to_pdf
+      # as the source_file_path (to prevent changes in the the filename creating a vunerability in the future).
+      source_file_path = PdfFill::Filler.fill_form(@claim, SecureRandom.uuid, sign: false)
+      client_file_name = file_name_for_pdf(@claim.veteran_data)
+      file_contents    = File.read(source_file_path)
 
-        File.delete(source_file_path)
+      File.delete(source_file_path)
 
-        auditor.record(:pdf_download)
+      auditor.record(:pdf_download)
 
-        send_data file_contents, filename: client_file_name, type: 'application/pdf', disposition: 'attachment'
-      else
-        raise(Common::Exceptions::ValidationErrors, @claim)
-      end
+      send_data file_contents, filename: client_file_name, type: 'application/pdf', disposition: 'attachment'
     end
 
     private

--- a/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
+++ b/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
 
     it_behaves_like '10-10CG request with missing param: caregivers_assistance_claim', :download_pdf
     it_behaves_like '10-10CG request with missing param: form', :download_pdf
-    it_behaves_like '10-10CG request with invalid form data', :download_pdf
+    # it_behaves_like '10-10CG request with invalid form data', :download_pdf
 
     it 'generates a filled out 10-10CG and sends file as response', run_at: '2017-07-25 00:00:00 -0400' do
       form_data = get_fixture('pdf_fill/10-10CG/simple').to_json

--- a/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
+++ b/spec/controllers/v0/caregivers_assistance_claims_controller_spec.rb
@@ -308,7 +308,6 @@ RSpec.describe V0::CaregiversAssistanceClaimsController, type: :controller do
 
     it_behaves_like '10-10CG request with missing param: caregivers_assistance_claim', :download_pdf
     it_behaves_like '10-10CG request with missing param: form', :download_pdf
-    # it_behaves_like '10-10CG request with invalid form data', :download_pdf
 
     it 'generates a filled out 10-10CG and sends file as response', run_at: '2017-07-25 00:00:00 -0400' do
       form_data = get_fixture('pdf_fill/10-10CG/simple').to_json

--- a/spec/request/caregivers_assistance_claims_request_spec.rb
+++ b/spec/request/caregivers_assistance_claims_request_spec.rb
@@ -129,8 +129,6 @@ RSpec.describe 'Caregivers Assistance Claims', type: :request do
       File.delete(response_pdf) if File.exist?(response_pdf)
     end
 
-    it_behaves_like 'any invalid submission', endpoint: '/v0/caregivers_assistance_claims/download_pdf'
-
     it 'returns a completed PDF', run_at: '2017-07-25 00:00:00 -0400' do
       form_data = get_fixture('pdf_fill/10-10CG/simple').to_json
       claim     = build(:caregivers_assistance_claim, form: form_data)

--- a/spec/request/caregivers_assistance_claims_request_spec.rb
+++ b/spec/request/caregivers_assistance_claims_request_spec.rb
@@ -14,67 +14,6 @@ RSpec.describe 'Caregivers Assistance Claims', type: :request do
   let(:build_valid_form_submission) { -> { VetsJsonSchema::EXAMPLES['10-10CG'].clone } }
   let(:get_schema) { -> { VetsJsonSchema::SCHEMAS['10-10CG'].clone } }
 
-  shared_examples_for 'any invalid submission' do |endpoint:|
-    it 'requires a namespace of caregivers_assistance_claim' do
-      body = {}
-      post endpoint, params: body, headers: headers
-
-      expect(response).to have_http_status(:bad_request)
-
-      res_body = JSON.parse(response.body)
-
-      expect(res_body['errors'].count).to eq(1)
-      expect(res_body['errors'][0]['title']).to eq('Missing parameter')
-      expect(res_body['errors'][0]['detail']).to eq('The required parameter "caregivers_assistance_claim", is missing')
-    end
-
-    it 'prevents attributes undefined in schema from being submitted' do
-      body = { caregivers_assistance_claim: { form: JSON(anAttrNotInSchema: 'some value') } }.to_json
-      post endpoint, params: body, headers: headers
-
-      expect(response.code).to eq('422')
-
-      res_body = JSON.parse(response.body)
-
-      bad_attr_error = res_body['errors'].find { |error| error['title'].include?('anAttrNotInSchema') }
-
-      expect(bad_attr_error).to be_present
-      expect(res_body['errors'][0]['title']).to include("Form The property '#/' contains additional properties")
-      expect(res_body['errors'][0]['detail']).to be_present
-      expect(res_body['errors'][0]['code']).to eq('100')
-      expect(res_body['errors'][0]['source']['pointer']).to eq('data/attributes/form')
-      expect(res_body['errors'][0]['status']).to eq('422')
-    end
-
-    it 'provides formatted errors when missing required property' do
-      form_data = build_valid_form_submission.call
-      required_property = get_schema.call['required'][0]
-
-      form_data.delete(required_property)
-
-      body = { caregivers_assistance_claim: { form: form_data.to_json } }.to_json
-      post endpoint, params: body, headers: headers
-
-      expect(response.code).to eq('422')
-
-      res_body = JSON.parse(response.body)
-
-      expect(res_body['errors'].length).to eq(1)
-
-      schema_error = res_body['errors'][0]
-
-      expect(schema_error['title']).to include(
-        "Form The property '#/' did not contain a required property of '#{required_property}'"
-      )
-      expect(schema_error['detail']).to include(
-        "form - The property '#/' did not contain a required property of '#{required_property}'"
-      )
-      expect(schema_error['code']).to eq('100')
-      expect(schema_error['source']['pointer']).to eq('data/attributes/form')
-      expect(schema_error['status']).to eq('422')
-    end
-  end
-
   describe 'POST /v0/caregivers_assistance_claims' do
     subject do
       post endpoint, params: body, headers: headers
@@ -93,8 +32,6 @@ RSpec.describe 'Caregivers Assistance Claims', type: :request do
         match_requests_on: %i[method uri host path]
       }
     end
-
-    it_behaves_like 'any invalid submission', endpoint: '/v0/caregivers_assistance_claims'
 
     timestamp = DateTime.parse('2020-03-09T06:48:59-04:00')
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Allow users to download the prefilled 10-10cg PDF, even if their data is not valid against the schema.

## Original issue(s)
- Fixes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14287

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
