### PR TITLE
25916 mobile fix pre cache claims error handling

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/claims_overview_errors.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/claims_overview_errors.rb
@@ -17,7 +17,7 @@ module Mobile
           if error.respond_to?(:details)
             error.details
           elsif error.respond_to?(:errors)
-            error.errors.to_json
+            error.errors.as_json
           else
             error.message
           end

--- a/modules/mobile/app/models/mobile/v0/adapters/claims_overview_errors.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/claims_overview_errors.rb
@@ -7,8 +7,20 @@ module Mobile
         def parse(error, failed_service)
           {
             service: failed_service,
-            error_details: defined?(error.details) ? error.details : error.errors.to_json
+            error_details: error_details(error)
           }
+        end
+
+        private
+
+        def error_details(error)
+          if error.respond_to?(:details)
+            error.details
+          elsif error.respond_to?(:errors)
+            error.errors.to_json
+          else
+            error.message
+          end
         end
       end
     end

--- a/modules/mobile/spec/request/claims_and_appeals_overview_request_spec.rb
+++ b/modules/mobile/spec/request/claims_and_appeals_overview_request_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe 'claims and appeals overview', type: :request do
 
   after(:all) { VCR.configure { |c| c.cassette_library_dir = @original_cassette_dir } }
 
+  describe '#index is polled an unauthorized user' do
+    it 'and not user returns a 401 status' do
+      get '/mobile/v0/claims-and-appeals-overview'
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
   describe 'GET /v0/claims-and-appeals-overview' do
     before { iam_sign_in }
 
@@ -182,17 +189,6 @@ RSpec.describe 'claims and appeals overview', type: :request do
             expect(response.parsed_body.dig('meta', 'errors')[0]['service']).to eq('claims')
             expect(response.parsed_body.dig('meta', 'errors')[1]['service']).to eq('appeals')
             expect(response.body).to match_json_schema('claims_and_appeals_overview_response')
-          end
-        end
-      end
-    end
-
-    describe '#index is polled without user sign in' do
-      it 'and not user returns a 500 status' do
-        VCR.use_cassette('claims/claims') do
-          VCR.use_cassette('appeals/appeals') do
-            get '/mobile/v0/claims-and-appeals-overview', headers: iam_headers
-            expect(response).to have_http_status(:internal_server_error)
           end
         end
       end

--- a/modules/mobile/spec/workers/pre_cache_claims_and_appeals_job_spec.rb
+++ b/modules/mobile/spec/workers/pre_cache_claims_and_appeals_job_spec.rb
@@ -41,11 +41,35 @@ RSpec.describe Mobile::V0::PreCacheClaimsAndAppealsJob, type: :job do
       end
     end
 
-    context 'with any errors' do
-      it 'does not cache the appointments' do
+    context 'with a HTTP error' do
+      it 'does not cache the claims' do
         VCR.use_cassette('claims/claims_with_errors') do
           VCR.use_cassette('appeals/appeals') do
             expect(Mobile::V0::ClaimOverview.get_cached(user)).to be_nil
+            subject.perform(user.uuid)
+            expect(Mobile::V0::ClaimOverview.get_cached(user)).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'when a NoMethodError error occurs' do
+      it 'does not cache the claims' do
+        VCR.use_cassette('claims/claims') do
+          VCR.use_cassette('appeals/appeals') do
+            allow_any_instance_of(IAMUser).to receive(:loa).and_raise(NoMethodError)
+            subject.perform(user.uuid)
+            expect(Mobile::V0::ClaimOverview.get_cached(user)).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'when a Faraday::ClientError error occurs' do
+      it 'does not cache the claims' do
+        VCR.use_cassette('claims/claims') do
+          VCR.use_cassette('appeals/appeals') do
+            allow_any_instance_of(EVSS::BaseService).to receive(:get).and_raise(Faraday::ClientError)
             subject.perform(user.uuid)
             expect(Mobile::V0::ClaimOverview.get_cached(user)).to be_nil
           end


### PR DESCRIPTION
## Description of change
Fixes claims and appointments error message parsing. Adds specs for each case. Removes some duplication in the claims request specs.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25916

