### PR TITLE
bump oj to latest patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -572,7 +572,7 @@ GEM
     octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.11.5)
+    oj (3.11.6)
     okcomputer (1.18.4)
     olive_branch (4.0.0)
       multi_json


### PR DESCRIPTION
## Description of change
As part of the gem update series, this PR updates the oj gem (default group) to the latest patch version. Gems are being updated individually (separate PRs), in order to avoid issues if a roll back is needed.

https://github.com/ohler55/oj/blob/develop/CHANGELOG.md

## Testing Completed
- [x] CI make target passing locally 
- [x] Reviewed gem change log updates 