### PR TITLE
Api 7871/update email report

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -196,6 +196,22 @@ modules_appeals_api:
   notice_of_disagreement_pii_expunge_enabled: true
   notice_of_disagreement_updater_enabled: true
   reports:
+    daily_decision_review:
+      enabled: false
+      recipients:
+        - drew.fisher@adhocteam.us
+        - jack.schuss@oddball.io
+        - kelly@adhocteam.us
+        - laura.trager@adhocteam.us
+        - nathan.wright@oddball.io
+    weekly_decision_review:
+      enabled: false
+      recipients:
+        - drew.fisher@adhocteam.us
+        - jack.schuss@oddball.io
+        - kelly@adhocteam.us
+        - laura.trager@adhocteam.us
+        - nathan.wright@oddball.io
     decision_review:
       enabled: false
       recipients:

--- a/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
+++ b/modules/appeals_api/app/views/appeals_api/decision_review_mailer/mailer.html.erb
@@ -52,7 +52,7 @@
     <br />
     <hr />
 
-    <%= render partial: 'appeal_table', locals: { appeal_name: 'Evidence submissions', appeal_status_and_count: @report.evidence_submission_by_status_and_count, faulty_appeals: @report.faulty_evidence_submission } %>
+    <%= render partial: 'appeal_table', locals: { appeal_name: 'NOD Evidence submissions', appeal_status_and_count: @report.evidence_submission_by_status_and_count, faulty_appeals: @report.faulty_evidence_submission } %>
 
   </body>
 </html>


### PR DESCRIPTION
## Description of change
This PR add "NOD" to the evidence submission report and splits out the email recipients into two sections for daily and weekly reports (the actual functionality cannot be added yet until the devops [PR](https://github.com/department-of-veterans-affairs/devops/pull/9409) gets merged/applied).

## Original issue(s)
https://vajira.max.gov/browse/API-7871