### PR TITLE
fix retry monitoring

### DIFF
--- a/lib/sidekiq/retry_monitoring.rb
+++ b/lib/sidekiq/retry_monitoring.rb
@@ -13,6 +13,8 @@ module Sidekiq
     private
 
     def should_notify?(worker, job)
+      return false unless job['retry_count']
+
       # retry_count is incremented after all middlewares are called
 
       worker.is_a?(Sidekiq::MonitoredWorker) &&


### PR DESCRIPTION
[API-8002](https://vajira.max.gov/browse/API-8002)

Sidekiq provides a nil value on the first retry check. We don't want to add +1 to 0 retries, so we return false early.