### PR TITLE
API-7871 - Weekly and daily email report

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -212,14 +212,6 @@ modules_appeals_api:
         - kelly@adhocteam.us
         - laura.trager@adhocteam.us
         - nathan.wright@oddball.io
-    decision_review:
-      enabled: false
-      recipients:
-        - drew.fisher@adhocteam.us
-        - jack.schuss@oddball.io
-        - kelly@adhocteam.us
-        - laura.trager@adhocteam.us
-        - nathan.wright@oddball.io
     daily_error:
       enabled: false
       recipients:

--- a/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
+++ b/modules/appeals_api/app/mailers/appeals_api/decision_review_mailer.rb
@@ -4,7 +4,7 @@ require 'appeals_api/decision_review_report'
 
 module AppealsApi
   class DecisionReviewMailer < ApplicationMailer
-    def build(date_from:, date_to:, friendly_duration: '')
+    def build(date_from:, date_to:, recipients:, friendly_duration: '')
       @report = DecisionReviewReport.new(from: date_from, to: date_to)
       @friendly_duration = friendly_duration
       @friendly_env = (Settings.vsp_environment || Rails.env).titleize
@@ -30,10 +30,6 @@ module AppealsApi
         'decision_review_mailer',
         'mailer.html.erb'
       )
-    end
-
-    def recipients
-      Settings.modules_appeals_api.reports.decision_review.recipients
     end
   end
 end

--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_daily.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_daily.rb
@@ -9,13 +9,17 @@ module AppealsApi
     sidekiq_options retry: 11
 
     def perform(to: Time.zone.now, from: (to.monday? ? 3.days.ago.beginning_of_day : 1.day.ago.beginning_of_day))
-      DecisionReviewMailer.build(date_from: from, date_to: to, friendly_duration: 'Daily').deliver_now if enabled?
+      recipients = Settings.modules_appeals_api.reports.daily_decision_review.recipients
+      if enabled?
+        DecisionReviewMailer.build(date_from: from, date_to: to, friendly_duration: 'Daily',
+                                   recipients: recipients).deliver_now
+      end
     end
 
     private
 
     def enabled?
-      Settings.modules_appeals_api.reports.decision_review.enabled
+      Settings.modules_appeals_api.reports.daily_decision_review.enabled
     end
   end
 end

--- a/modules/appeals_api/app/workers/appeals_api/decision_review_report_weekly.rb
+++ b/modules/appeals_api/app/workers/appeals_api/decision_review_report_weekly.rb
@@ -9,13 +9,17 @@ module AppealsApi
     sidekiq_options retry: 16
 
     def perform(to: Time.zone.now, from: 1.week.ago.beginning_of_day)
-      DecisionReviewMailer.build(date_from: from, date_to: to, friendly_duration: 'Weekly').deliver_now if enabled?
+      recipients = Settings.modules_appeals_api.reports.weekly_decision_review.recipients
+      if enabled?
+        DecisionReviewMailer.build(date_from: from, date_to: to, friendly_duration: 'Weekly',
+                                   recipients: recipients).deliver_now
+      end
     end
 
     private
 
     def enabled?
-      Settings.modules_appeals_api.reports.decision_review.enabled
+      Settings.modules_appeals_api.reports.weekly_decision_review.enabled
     end
   end
 end

--- a/modules/appeals_api/spec/mailers/decision_review_mailer_spec.rb
+++ b/modules/appeals_api/spec/mailers/decision_review_mailer_spec.rb
@@ -5,7 +5,18 @@ require 'rails_helper'
 RSpec.describe AppealsApi::DecisionReviewMailer, type: [:mailer] do
   describe '#build' do
     subject do
-      described_class.build(date_from: 7.days.ago, date_to: Time.zone.now, friendly_duration: 'duration').deliver_now
+      described_class.build(date_from: 7.days.ago, date_to: Time.zone.now, friendly_duration: 'duration',
+                            recipients: recipients).deliver_now
+    end
+
+    let(:recipients) do
+      %w[
+        kelly@adhocteam.us
+        laura.trager@adhocteam.us
+        drew.fisher@adhocteam.us
+        jack.schuss@oddball.io
+        nathan.wright@oddball.io
+      ]
     end
 
     it 'sends the email' do
@@ -16,15 +27,7 @@ RSpec.describe AppealsApi::DecisionReviewMailer, type: [:mailer] do
 
     it 'sends to the right people' do
       with_settings(Settings, vsp_environment: 'spartacus') do
-        expect(subject.to).to match_array(
-          %w[
-            kelly@adhocteam.us
-            laura.trager@adhocteam.us
-            drew.fisher@adhocteam.us
-            jack.schuss@oddball.io
-            nathan.wright@oddball.io
-          ]
-        )
+        expect(subject.to).to match_array(recipients)
       end
     end
   end

--- a/modules/appeals_api/spec/workers/decision_review_report_daily_spec.rb
+++ b/modules/appeals_api/spec/workers/decision_review_report_daily_spec.rb
@@ -5,15 +5,23 @@ require 'rails_helper'
 describe AppealsApi::DecisionReviewReportDaily, type: :job do
   describe '#perform' do
     it 'sends mail' do
-      with_settings(Settings.modules_appeals_api.reports.decision_review, enabled: true) do
+      with_settings(Settings.modules_appeals_api.reports.daily_decision_review, enabled: true) do
         Timecop.freeze
         date_to = Time.zone.now
         date_from = date_to.monday? ? 3.days.ago : 1.day.ago
+        recipients = %w[
+          drew.fisher@adhocteam.us
+          jack.schuss@oddball.io
+          kelly@adhocteam.us
+          laura.trager@adhocteam.us
+          nathan.wright@oddball.io
+        ]
 
         expect(AppealsApi::DecisionReviewMailer).to receive(:build).once.with(
           date_from: date_from.beginning_of_day,
           date_to: date_to,
-          friendly_duration: 'Daily'
+          friendly_duration: 'Daily',
+          recipients: recipients
         ).and_return(double.tap do |mailer|
           expect(mailer).to receive(:deliver_now).once
         end)

--- a/modules/appeals_api/spec/workers/decision_review_report_weekly_spec.rb
+++ b/modules/appeals_api/spec/workers/decision_review_report_weekly_spec.rb
@@ -5,15 +5,23 @@ require 'rails_helper'
 describe AppealsApi::DecisionReviewReportWeekly, type: :job do
   describe '#perform' do
     it 'sends mail' do
-      with_settings(Settings.modules_appeals_api.reports.decision_review, enabled: true) do
+      with_settings(Settings.modules_appeals_api.reports.weekly_decision_review, enabled: true) do
         Timecop.freeze
         date_to = Time.zone.now
         date_from = 1.week.ago.beginning_of_day
+        recipients = %w[
+          drew.fisher@adhocteam.us
+          jack.schuss@oddball.io
+          kelly@adhocteam.us
+          laura.trager@adhocteam.us
+          nathan.wright@oddball.io
+        ]
 
         expect(AppealsApi::DecisionReviewMailer).to receive(:build).once.with(
           date_from: date_from,
           date_to: date_to,
-          friendly_duration: 'Weekly'
+          friendly_duration: 'Weekly',
+          recipients: recipients
         ).and_return(double.tap do |mailer|
           expect(mailer).to receive(:deliver_now).once
         end)


### PR DESCRIPTION
## Description of change
This PR changes the `DecisionReviewMailer` class to take in the list of recipients so that we can have separate lists of recipients for the daily and weekly reports. It depends on the changes from this [PR](https://github.com/department-of-veterans-affairs/devops/pull/9409) being active in each of the envs **before** merging!

## Original issue(s)
https://vajira.max.gov/browse/API-7871
