### PR TITLE
Update security properties for claims v1 swagger

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v1/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v1/swagger.json
@@ -25,6 +25,24 @@
   ],
   "components": {
     "securitySchemes": {
+      "bearer_token": {
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "productionOauth": {
+        "type": "oauth2",
+        "description": "This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://api.va.gov/oauth2/authorization",
+            "tokenUrl": "https://api.va.gov/oauth2/token",
+            "scopes": {
+              "claim.read": "Retrieve claim data",
+              "claim.write": "Submit claim data"
+            }
+          }
+        }
+      },
       "sandboxOauth": {
         "type": "oauth2",
         "description": "This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)",
@@ -51,8 +69,18 @@
         "operationId": "findClaims",
         "security": [
           {
+            "productionOauth": [
+              "claim.read"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -376,8 +404,18 @@
         "operationId": "findClaimById",
         "security": [
           {
+            "productionOauth": [
+              "claim.read"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -436,7 +474,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "bef09308-579b-4a7f-8bc6-0ecd035cacac",
+                    "id": "f2a1eedf-e037-496f-a13e-96c62f847f9c",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": 600118851,
@@ -485,11 +523,11 @@
                       "status": "Initial review",
                       "supporting_documents": [
                         {
-                          "id": "229c807f-00ea-4707-afb7-70bd59ef8938",
+                          "id": "166a083f-34ed-44ed-a337-f329ab53f2e8",
                           "type": "claim_supporting_document",
                           "md5": "d927c7e283b3158a54822a493d06181d",
                           "filename": "extras.pdf",
-                          "uploaded_at": "2021-06-14T22:32:08.868Z"
+                          "uploaded_at": "2021-06-16T15:51:28.649Z"
                         }
                       ]
                     }
@@ -849,13 +887,6 @@
           "Disability"
         ],
         "operationId": "get526JsonSchema",
-        "security": [
-          {
-            "sandboxOauth": [
-              "claim.read"
-            ]
-          }
-        ],
         "description": "Returns a single 526 schema to automatically generate a form. Using this GET endpoint allows users to download our current validations.\n",
         "responses": {
           "200": {
@@ -2124,9 +2155,20 @@
         "operationId": "post526Claim",
         "security": [
           {
+            "productionOauth": [
+              "claim.read",
+              "claim.write"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read",
               "claim.write"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -2176,7 +2218,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "b4530cdf-f4bd-4ff1-862b-06149fb3f0b8",
+                    "id": "0db4fcbe-7881-4cc2-93c5-cd62c6fef1c0",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -2194,13 +2236,13 @@
                       "current_phase_back": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-14T22:32:09.394Z",
+                      "updated_at": "2021-06-16T15:51:28.971Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
 
                       ],
-                      "token": "b4530cdf-f4bd-4ff1-862b-06149fb3f0b8",
+                      "token": "0db4fcbe-7881-4cc2-93c5-cd62c6fef1c0",
                       "status": "pending",
                       "flashes": [
                         "Hardship",
@@ -3794,9 +3836,20 @@
         "operationId": "upload526Attachment",
         "security": [
           {
+            "productionOauth": [
+              "claim.read",
+              "claim.write"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read",
               "claim.write"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -3855,7 +3908,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "1e07d752-fc2b-434a-b626-f5af3cb911eb",
+                    "id": "45c18f76-794d-4a7e-88f2-e07ff45c48a9",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -3873,13 +3926,13 @@
                       "current_phase_back": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-14T22:32:09.776Z",
+                      "updated_at": "2021-06-16T15:51:29.276Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
 
                       ],
-                      "token": "1e07d752-fc2b-434a-b626-f5af3cb911eb",
+                      "token": "45c18f76-794d-4a7e-88f2-e07ff45c48a9",
                       "status": "pending",
                       "flashes": [
                         "Hardship",
@@ -4262,9 +4315,20 @@
         "operationId": "post526ClaimValidate",
         "security": [
           {
+            "productionOauth": [
+              "claim.read",
+              "claim.write"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read",
               "claim.write"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -5830,9 +5894,20 @@
         "operationId": "upload526Attachments",
         "security": [
           {
+            "productionOauth": [
+              "claim.read",
+              "claim.write"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read",
               "claim.write"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -5891,7 +5966,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "5cd04a26-1987-4474-8783-608e606b11ae",
+                    "id": "94d8eb96-7987-4b16-8ae6-ce220bf8d2e9",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -5905,7 +5980,7 @@
                       "decision_letter_sent": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-14T22:32:10.667Z",
+                      "updated_at": "2021-06-16T15:51:29.919Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
@@ -5914,7 +5989,7 @@
                       "status": "pending",
                       "supporting_documents": [
                         {
-                          "id": "346c4da6-8539-4cff-8776-0d485a8d3ee8",
+                          "id": "cc9f9267-e5f2-4d59-9ed5-36726e2e1190",
                           "type": "claim_supporting_document",
                           "md5": null,
                           "filename": null,
@@ -6271,13 +6346,6 @@
           "Intent to File"
         ],
         "operationId": "get0966JsonSchema",
-        "security": [
-          {
-            "sandboxOauth": [
-              "claim.read"
-            ]
-          }
-        ],
         "description": "Returns a single 0966 JSON schema to auto generate a form.",
         "responses": {
           "200": {
@@ -6336,9 +6404,20 @@
         "operationId": "post0966itf",
         "security": [
           {
+            "productionOauth": [
+              "claim.read",
+              "claim.write"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read",
               "claim.write"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -6698,8 +6777,18 @@
         "operationId": "active0966itf",
         "security": [
           {
+            "productionOauth": [
+              "claim.read"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -7012,9 +7101,20 @@
         "operationId": "validate0966itf",
         "security": [
           {
+            "productionOauth": [
+              "claim.read",
+              "claim.write"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read",
               "claim.write"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -7288,13 +7388,6 @@
           "Power of Attorney"
         ],
         "operationId": "get2122JsonSchema",
-        "security": [
-          {
-            "sandboxOauth": [
-              "claim.read"
-            ]
-          }
-        ],
         "description": "Returns schema to automatically generate a POA form.",
         "responses": {
           "200": {
@@ -7702,9 +7795,20 @@
         "operationId": "post2122",
         "security": [
           {
+            "productionOauth": [
+              "claim.read",
+              "claim.write"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read",
               "claim.write"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -7754,11 +7858,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "800c41de-39a1-4e8d-ad0d-7b2a945fa9e7",
+                    "id": "dbe2409f-f48f-4ab5-b7a9-fda0fdff34e9",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "pending",
-                      "date_request_accepted": "2021-06-14",
+                      "date_request_accepted": "2021-06-16",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"
@@ -8384,9 +8488,20 @@
         "operationId": "upload2122Attachment",
         "security": [
           {
+            "productionOauth": [
+              "claim.read",
+              "claim.write"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read",
               "claim.write"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -8445,11 +8560,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "3ff1d1af-9d6b-469e-904e-296cb10795ec",
+                    "id": "8e700d7b-6e93-4478-8bb4-e1a3e1434fa4",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "submitted",
-                      "date_request_accepted": "2021-06-14",
+                      "date_request_accepted": "2021-06-16",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"
@@ -8678,8 +8793,18 @@
         "operationId": "get2122poa",
         "security": [
           {
+            "productionOauth": [
+              "claim.read"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -8738,11 +8863,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "d5622bde-4c91-42db-8811-59636e698e5e",
+                    "id": "53868f9a-ea44-4ede-ae5b-b145018ca138",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "submitted",
-                      "date_request_accepted": "2021-06-14",
+                      "date_request_accepted": "2021-06-16",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"
@@ -8957,8 +9082,18 @@
         "operationId": "getActive2122Poa",
         "security": [
           {
+            "productionOauth": [
+              "claim.read"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],
@@ -9263,9 +9398,20 @@
         "operationId": "validate2122poa",
         "security": [
           {
+            "productionOauth": [
+              "claim.read",
+              "claim.write"
+            ]
+          },
+          {
             "sandboxOauth": [
               "claim.read",
               "claim.write"
+            ]
+          },
+          {
+            "bearer_token": [
+
             ]
           }
         ],

--- a/modules/claims_api/app/swagger/claims_api/v1/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v1/swagger.json
@@ -25,11 +25,19 @@
   ],
   "components": {
     "securitySchemes": {
-      "bearer_token": {
-        "type": "http",
-        "name": "token",
-        "scheme": "bearer",
-        "bearer_format": "JWT"
+      "sandboxOauth": {
+        "type": "oauth2",
+        "description": "This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://sandbox-api.va.gov/oauth2/authorization",
+            "tokenUrl": "https://sandbox-api.va.gov/oauth2/token",
+            "scopes": {
+              "claim.read": "Retrieve claim data",
+              "claim.write": "Submit claim data"
+            }
+          }
+        }
       }
     }
   },
@@ -43,8 +51,8 @@
         "operationId": "findClaims",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read"
             ]
           }
         ],
@@ -368,8 +376,8 @@
         "operationId": "findClaimById",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read"
             ]
           }
         ],
@@ -428,7 +436,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "f9540c74-45f4-457f-a6b4-8f77a1ed4469",
+                    "id": "bef09308-579b-4a7f-8bc6-0ecd035cacac",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": 600118851,
@@ -477,11 +485,11 @@
                       "status": "Initial review",
                       "supporting_documents": [
                         {
-                          "id": "fa3943c8-de88-4e62-8bae-22d479e79549",
+                          "id": "229c807f-00ea-4707-afb7-70bd59ef8938",
                           "type": "claim_supporting_document",
                           "md5": "d927c7e283b3158a54822a493d06181d",
                           "filename": "extras.pdf",
-                          "uploaded_at": "2021-06-09T20:38:04.232Z"
+                          "uploaded_at": "2021-06-14T22:32:08.868Z"
                         }
                       ]
                     }
@@ -843,8 +851,8 @@
         "operationId": "get526JsonSchema",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read"
             ]
           }
         ],
@@ -2116,8 +2124,9 @@
         "operationId": "post526Claim",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read",
+              "claim.write"
             ]
           }
         ],
@@ -2167,7 +2176,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "f314c103-ec1a-4e29-9b12-a4f21fba0d04",
+                    "id": "b4530cdf-f4bd-4ff1-862b-06149fb3f0b8",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -2185,13 +2194,13 @@
                       "current_phase_back": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-09T20:38:04.630Z",
+                      "updated_at": "2021-06-14T22:32:09.394Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
 
                       ],
-                      "token": "f314c103-ec1a-4e29-9b12-a4f21fba0d04",
+                      "token": "b4530cdf-f4bd-4ff1-862b-06149fb3f0b8",
                       "status": "pending",
                       "flashes": [
                         "Hardship",
@@ -3785,8 +3794,9 @@
         "operationId": "upload526Attachment",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read",
+              "claim.write"
             ]
           }
         ],
@@ -3845,7 +3855,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "600bf193-e8c6-43f5-ae3d-bde6d49aa83a",
+                    "id": "1e07d752-fc2b-434a-b626-f5af3cb911eb",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -3863,13 +3873,13 @@
                       "current_phase_back": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-09T20:38:04.888Z",
+                      "updated_at": "2021-06-14T22:32:09.776Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
 
                       ],
-                      "token": "600bf193-e8c6-43f5-ae3d-bde6d49aa83a",
+                      "token": "1e07d752-fc2b-434a-b626-f5af3cb911eb",
                       "status": "pending",
                       "flashes": [
                         "Hardship",
@@ -4252,8 +4262,9 @@
         "operationId": "post526ClaimValidate",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read",
+              "claim.write"
             ]
           }
         ],
@@ -5819,8 +5830,9 @@
         "operationId": "upload526Attachments",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read",
+              "claim.write"
             ]
           }
         ],
@@ -5879,7 +5891,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "4205c8b5-caa1-40be-b260-1cdddd59940e",
+                    "id": "5cd04a26-1987-4474-8783-608e606b11ae",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -5893,7 +5905,7 @@
                       "decision_letter_sent": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-09T20:38:05.718Z",
+                      "updated_at": "2021-06-14T22:32:10.667Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
@@ -5902,7 +5914,7 @@
                       "status": "pending",
                       "supporting_documents": [
                         {
-                          "id": "5d62dd07-5ed1-4ee6-ab8d-f25fb392e845",
+                          "id": "346c4da6-8539-4cff-8776-0d485a8d3ee8",
                           "type": "claim_supporting_document",
                           "md5": null,
                           "filename": null,
@@ -6261,8 +6273,8 @@
         "operationId": "get0966JsonSchema",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read"
             ]
           }
         ],
@@ -6324,8 +6336,9 @@
         "operationId": "post0966itf",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read",
+              "claim.write"
             ]
           }
         ],
@@ -6685,8 +6698,8 @@
         "operationId": "active0966itf",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read"
             ]
           }
         ],
@@ -6999,8 +7012,9 @@
         "operationId": "validate0966itf",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read",
+              "claim.write"
             ]
           }
         ],
@@ -7276,8 +7290,8 @@
         "operationId": "get2122JsonSchema",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read"
             ]
           }
         ],
@@ -7688,8 +7702,9 @@
         "operationId": "post2122",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read",
+              "claim.write"
             ]
           }
         ],
@@ -7739,11 +7754,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "5833750e-25e0-449b-b587-da0e446919b2",
+                    "id": "800c41de-39a1-4e8d-ad0d-7b2a945fa9e7",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "pending",
-                      "date_request_accepted": "2021-06-09",
+                      "date_request_accepted": "2021-06-14",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"
@@ -8369,8 +8384,9 @@
         "operationId": "upload2122Attachment",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read",
+              "claim.write"
             ]
           }
         ],
@@ -8429,11 +8445,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "b85564e5-ca08-4052-bc49-60f1bf0bdeae",
+                    "id": "3ff1d1af-9d6b-469e-904e-296cb10795ec",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "submitted",
-                      "date_request_accepted": "2021-06-09",
+                      "date_request_accepted": "2021-06-14",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"
@@ -8662,8 +8678,8 @@
         "operationId": "get2122poa",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read"
             ]
           }
         ],
@@ -8722,11 +8738,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "d1240997-e997-4cab-8c8b-e4e64dfa03ea",
+                    "id": "d5622bde-4c91-42db-8811-59636e698e5e",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "submitted",
-                      "date_request_accepted": "2021-06-09",
+                      "date_request_accepted": "2021-06-14",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"
@@ -8941,8 +8957,8 @@
         "operationId": "getActive2122Poa",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read"
             ]
           }
         ],
@@ -9247,8 +9263,9 @@
         "operationId": "validate2122poa",
         "security": [
           {
-            "bearer_token": [
-
+            "sandboxOauth": [
+              "claim.read",
+              "claim.write"
             ]
           }
         ],

--- a/modules/claims_api/spec/requests/v1/rswag_claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_claims_request_spec.rb
@@ -9,7 +9,7 @@ describe 'EVSS Claims management', swagger_doc: 'v1/swagger.json' do  # rubocop:
     get 'Find all benefits claims for a Veteran' do
       tags 'Claims'
       operationId 'findClaims'
-      security [ {sandboxOauth: ['claim.read']} ]
+      security [{ sandboxOauth: ['claim.read'] }]
       produces 'application/json'
       index_description = 'Uses the Veteran’s metadata in headers to retrieve all claims for that Veteran. '
       index_description += 'An authenticated Veteran making a request with this endpoint will return their own claims'
@@ -136,7 +136,7 @@ describe 'EVSS Claims management', swagger_doc: 'v1/swagger.json' do  # rubocop:
     get 'Find Claim by ID' do
       tags 'Claims'
       operationId 'findClaimById'
-      security [ {sandboxOauth: ['claim.read']} ]
+      security [{ sandboxOauth: ['claim.read'] }]
       produces 'application/json'
 
       parameter name: :id, in: :path, type: :string, description: 'The ID of the claim being requested'

--- a/modules/claims_api/spec/requests/v1/rswag_claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_claims_request_spec.rb
@@ -9,7 +9,7 @@ describe 'EVSS Claims management', swagger_doc: 'v1/swagger.json' do  # rubocop:
     get 'Find all benefits claims for a Veteran' do
       tags 'Claims'
       operationId 'findClaims'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read']} ]
       produces 'application/json'
       index_description = 'Uses the Veteran’s metadata in headers to retrieve all claims for that Veteran. '
       index_description += 'An authenticated Veteran making a request with this endpoint will return their own claims'
@@ -136,7 +136,7 @@ describe 'EVSS Claims management', swagger_doc: 'v1/swagger.json' do  # rubocop:
     get 'Find Claim by ID' do
       tags 'Claims'
       operationId 'findClaimById'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read']} ]
       produces 'application/json'
 
       parameter name: :id, in: :path, type: :string, description: 'The ID of the claim being requested'

--- a/modules/claims_api/spec/requests/v1/rswag_claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_claims_request_spec.rb
@@ -9,7 +9,11 @@ describe 'EVSS Claims management', swagger_doc: 'v1/swagger.json' do  # rubocop:
     get 'Find all benefits claims for a Veteran' do
       tags 'Claims'
       operationId 'findClaims'
-      security [{ sandboxOauth: ['claim.read'] }]
+      security [
+        { productionOauth: ['claim.read'] },
+        { sandboxOauth: ['claim.read'] },
+        { bearer_token: [] }
+      ]
       produces 'application/json'
       index_description = 'Uses the Veteran’s metadata in headers to retrieve all claims for that Veteran. '
       index_description += 'An authenticated Veteran making a request with this endpoint will return their own claims'
@@ -136,7 +140,11 @@ describe 'EVSS Claims management', swagger_doc: 'v1/swagger.json' do  # rubocop:
     get 'Find Claim by ID' do
       tags 'Claims'
       operationId 'findClaimById'
-      security [{ sandboxOauth: ['claim.read'] }]
+      security [
+        { productionOauth: ['claim.read'] },
+        { sandboxOauth: ['claim.read'] },
+        { bearer_token: [] }
+      ]
       produces 'application/json'
 
       parameter name: :id, in: :path, type: :string, description: 'The ID of the claim being requested'

--- a/modules/claims_api/spec/requests/v1/rswag_disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_disability_compensation_request_spec.rb
@@ -10,7 +10,7 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
       deprecated true
       tags 'Disability'
       operationId 'get526JsonSchema'
-      security [ {sandboxOauth: ['claim.read']} ]
+      security [{ sandboxOauth: ['claim.read'] }]
       produces 'application/json'
       get_schema_description = <<~VERBIAGE
         Returns a single 526 schema to automatically generate a form. Using this GET endpoint allows users to download our current validations.
@@ -43,7 +43,7 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
     post 'Submits form 526' do
       tags 'Disability'
       operationId 'post526Claim'
-      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
+      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
       consumes 'application/json'
       produces 'application/json'
       post_description = <<~VERBIAGE
@@ -226,7 +226,7 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
     put 'Upload a 526 document' do
       tags 'Disability'
       operationId 'upload526Attachment'
-      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
+      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
       consumes 'multipart/form-data'
       produces 'application/json'
       put_description = <<~VERBIAGE
@@ -416,7 +416,7 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
       deprecated true
       tags 'Disability'
       operationId 'post526ClaimValidate'
-      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
+      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
       consumes 'application/json'
       produces 'application/json'
       validate_description = <<~VERBIAGE
@@ -567,7 +567,7 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
     post 'Upload documents supporting a 526 claim' do
       tags 'Disability'
       operationId 'upload526Attachments'
-      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
+      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
       consumes 'multipart/form-data'
       produces 'application/json'
       put_description = <<~VERBIAGE

--- a/modules/claims_api/spec/requests/v1/rswag_disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_disability_compensation_request_spec.rb
@@ -10,7 +10,7 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
       deprecated true
       tags 'Disability'
       operationId 'get526JsonSchema'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read']} ]
       produces 'application/json'
       get_schema_description = <<~VERBIAGE
         Returns a single 526 schema to automatically generate a form. Using this GET endpoint allows users to download our current validations.
@@ -43,7 +43,7 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
     post 'Submits form 526' do
       tags 'Disability'
       operationId 'post526Claim'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
       consumes 'application/json'
       produces 'application/json'
       post_description = <<~VERBIAGE
@@ -226,7 +226,7 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
     put 'Upload a 526 document' do
       tags 'Disability'
       operationId 'upload526Attachment'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
       consumes 'multipart/form-data'
       produces 'application/json'
       put_description = <<~VERBIAGE
@@ -416,7 +416,7 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
       deprecated true
       tags 'Disability'
       operationId 'post526ClaimValidate'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
       consumes 'application/json'
       produces 'application/json'
       validate_description = <<~VERBIAGE
@@ -567,7 +567,7 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
     post 'Upload documents supporting a 526 claim' do
       tags 'Disability'
       operationId 'upload526Attachments'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
       consumes 'multipart/form-data'
       produces 'application/json'
       put_description = <<~VERBIAGE

--- a/modules/claims_api/spec/requests/v1/rswag_disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_disability_compensation_request_spec.rb
@@ -10,7 +10,6 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
       deprecated true
       tags 'Disability'
       operationId 'get526JsonSchema'
-      security [{ sandboxOauth: ['claim.read'] }]
       produces 'application/json'
       get_schema_description = <<~VERBIAGE
         Returns a single 526 schema to automatically generate a form. Using this GET endpoint allows users to download our current validations.
@@ -43,7 +42,11 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
     post 'Submits form 526' do
       tags 'Disability'
       operationId 'post526Claim'
-      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
+      security [
+        { productionOauth: ['claim.read', 'claim.write'] },
+        { sandboxOauth: ['claim.read', 'claim.write'] },
+        { bearer_token: [] }
+      ]
       consumes 'application/json'
       produces 'application/json'
       post_description = <<~VERBIAGE
@@ -226,7 +229,11 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
     put 'Upload a 526 document' do
       tags 'Disability'
       operationId 'upload526Attachment'
-      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
+      security [
+        { productionOauth: ['claim.read', 'claim.write'] },
+        { sandboxOauth: ['claim.read', 'claim.write'] },
+        { bearer_token: [] }
+      ]
       consumes 'multipart/form-data'
       produces 'application/json'
       put_description = <<~VERBIAGE
@@ -416,7 +423,11 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
       deprecated true
       tags 'Disability'
       operationId 'post526ClaimValidate'
-      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
+      security [
+        { productionOauth: ['claim.read', 'claim.write'] },
+        { sandboxOauth: ['claim.read', 'claim.write'] },
+        { bearer_token: [] }
+      ]
       consumes 'application/json'
       produces 'application/json'
       validate_description = <<~VERBIAGE
@@ -567,7 +578,11 @@ describe 'Disability Claims', swagger_doc: 'v1/swagger.json' do # rubocop:disabl
     post 'Upload documents supporting a 526 claim' do
       tags 'Disability'
       operationId 'upload526Attachments'
-      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
+      security [
+        { productionOauth: ['claim.read', 'claim.write'] },
+        { sandboxOauth: ['claim.read', 'claim.write'] },
+        { bearer_token: [] }
+      ]
       consumes 'multipart/form-data'
       produces 'application/json'
       put_description = <<~VERBIAGE

--- a/modules/claims_api/spec/requests/v1/rswag_intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_intent_to_file_request_spec.rb
@@ -10,7 +10,7 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
       deprecated true
       tags 'Intent to File'
       operationId 'get0966JsonSchema'
-      security [ {sandboxOauth: ['claim.read']} ]
+      security [{ sandboxOauth: ['claim.read'] }]
       produces 'application/json'
       description 'Returns a single 0966 JSON schema to auto generate a form.'
       let(:Authorization) { 'Bearer token' }
@@ -39,7 +39,7 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
     post 'Submit form 0966 Intent to File.' do
       tags 'Intent to File'
       operationId 'post0966itf'
-      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
+      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
       consumes 'application/json'
       produces 'application/json'
       post_description = <<~VERBIAGE
@@ -201,7 +201,7 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
     get 'Returns last active 0966 Intent to File form submission.' do
       tags 'Intent to File'
       operationId 'active0966itf'
-      security [ {sandboxOauth: ['claim.read']} ]
+      security [{ sandboxOauth: ['claim.read'] }]
       produces 'application/json'
       description 'Returns the last active 0966 form for a Veteran.'
 
@@ -367,7 +367,7 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
       deprecated true
       tags 'Intent to File'
       operationId 'validate0966itf'
-      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
+      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
       consumes 'application/json'
       produces 'application/json'
       validate_description = <<~VERBIAGE

--- a/modules/claims_api/spec/requests/v1/rswag_intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_intent_to_file_request_spec.rb
@@ -10,7 +10,7 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
       deprecated true
       tags 'Intent to File'
       operationId 'get0966JsonSchema'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read']} ]
       produces 'application/json'
       description 'Returns a single 0966 JSON schema to auto generate a form.'
       let(:Authorization) { 'Bearer token' }
@@ -39,7 +39,7 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
     post 'Submit form 0966 Intent to File.' do
       tags 'Intent to File'
       operationId 'post0966itf'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
       consumes 'application/json'
       produces 'application/json'
       post_description = <<~VERBIAGE
@@ -201,7 +201,7 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
     get 'Returns last active 0966 Intent to File form submission.' do
       tags 'Intent to File'
       operationId 'active0966itf'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read']} ]
       produces 'application/json'
       description 'Returns the last active 0966 form for a Veteran.'
 
@@ -367,7 +367,7 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
       deprecated true
       tags 'Intent to File'
       operationId 'validate0966itf'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
       consumes 'application/json'
       produces 'application/json'
       validate_description = <<~VERBIAGE

--- a/modules/claims_api/spec/requests/v1/rswag_intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_intent_to_file_request_spec.rb
@@ -10,7 +10,6 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
       deprecated true
       tags 'Intent to File'
       operationId 'get0966JsonSchema'
-      security [{ sandboxOauth: ['claim.read'] }]
       produces 'application/json'
       description 'Returns a single 0966 JSON schema to auto generate a form.'
       let(:Authorization) { 'Bearer token' }
@@ -39,7 +38,11 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
     post 'Submit form 0966 Intent to File.' do
       tags 'Intent to File'
       operationId 'post0966itf'
-      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
+      security [
+        { productionOauth: ['claim.read', 'claim.write'] },
+        { sandboxOauth: ['claim.read', 'claim.write'] },
+        { bearer_token: [] }
+      ]
       consumes 'application/json'
       produces 'application/json'
       post_description = <<~VERBIAGE
@@ -201,7 +204,11 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
     get 'Returns last active 0966 Intent to File form submission.' do
       tags 'Intent to File'
       operationId 'active0966itf'
-      security [{ sandboxOauth: ['claim.read'] }]
+      security [
+        { productionOauth: ['claim.read'] },
+        { sandboxOauth: ['claim.read'] },
+        { bearer_token: [] }
+      ]
       produces 'application/json'
       description 'Returns the last active 0966 form for a Veteran.'
 
@@ -367,7 +374,11 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
       deprecated true
       tags 'Intent to File'
       operationId 'validate0966itf'
-      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
+      security [
+        { productionOauth: ['claim.read', 'claim.write'] },
+        { sandboxOauth: ['claim.read', 'claim.write'] },
+        { bearer_token: [] }
+      ]
       consumes 'application/json'
       produces 'application/json'
       validate_description = <<~VERBIAGE

--- a/modules/claims_api/spec/requests/v1/rswag_power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_power_of_attorney_request_spec.rb
@@ -10,7 +10,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
       deprecated true
       tags 'Power of Attorney'
       operationId 'get2122JsonSchema'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read']} ]
       produces 'application/json'
       description 'Returns schema to automatically generate a POA form.'
       let(:Authorization) { 'Bearer token' }
@@ -38,7 +38,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     post 'Submit a POA form.' do
       tags 'Power of Attorney'
       operationId 'post2122'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
       consumes 'application/json'
       produces 'application/json'
       post_description = <<~VERBIAGE
@@ -188,7 +188,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     put 'Upload a signed 21-22 document.' do
       tags 'Power of Attorney'
       operationId 'upload2122Attachment'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
       consumes 'multipart/form-data'
       produces 'application/json'
       put_description = <<~VERBIAGE
@@ -342,7 +342,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     get 'Check POA status by ID.' do
       tags 'Power of Attorney'
       operationId 'get2122poa'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read']} ]
       produces 'application/json'
       description 'Based on ID, returns a 21-22 submission and current status.'
 
@@ -488,7 +488,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     get 'Check active POA status.' do
       tags 'Power of Attorney'
       operationId 'getActive2122Poa'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read']} ]
       produces 'application/json'
       active_description = <<~VERBIAGE
         Returns the last active POA for a Veteran.
@@ -628,7 +628,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
       deprecated true
       tags 'Power of Attorney'
       operationId 'validate2122poa'
-      security [bearer_token: []]
+      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
       consumes 'application/json'
       produces 'application/json'
       validation_description = <<~VERBIAGE

--- a/modules/claims_api/spec/requests/v1/rswag_power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_power_of_attorney_request_spec.rb
@@ -10,7 +10,6 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
       deprecated true
       tags 'Power of Attorney'
       operationId 'get2122JsonSchema'
-      security [{ sandboxOauth: ['claim.read'] }]
       produces 'application/json'
       description 'Returns schema to automatically generate a POA form.'
       let(:Authorization) { 'Bearer token' }
@@ -38,7 +37,11 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     post 'Submit a POA form.' do
       tags 'Power of Attorney'
       operationId 'post2122'
-      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
+      security [
+        { productionOauth: ['claim.read', 'claim.write'] },
+        { sandboxOauth: ['claim.read', 'claim.write'] },
+        { bearer_token: [] }
+      ]
       consumes 'application/json'
       produces 'application/json'
       post_description = <<~VERBIAGE
@@ -188,7 +191,11 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     put 'Upload a signed 21-22 document.' do
       tags 'Power of Attorney'
       operationId 'upload2122Attachment'
-      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
+      security [
+        { productionOauth: ['claim.read', 'claim.write'] },
+        { sandboxOauth: ['claim.read', 'claim.write'] },
+        { bearer_token: [] }
+      ]
       consumes 'multipart/form-data'
       produces 'application/json'
       put_description = <<~VERBIAGE
@@ -342,7 +349,11 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     get 'Check POA status by ID.' do
       tags 'Power of Attorney'
       operationId 'get2122poa'
-      security [{ sandboxOauth: ['claim.read'] }]
+      security [
+        { productionOauth: ['claim.read'] },
+        { sandboxOauth: ['claim.read'] },
+        { bearer_token: [] }
+      ]
       produces 'application/json'
       description 'Based on ID, returns a 21-22 submission and current status.'
 
@@ -488,7 +499,11 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     get 'Check active POA status.' do
       tags 'Power of Attorney'
       operationId 'getActive2122Poa'
-      security [{ sandboxOauth: ['claim.read'] }]
+      security [
+        { productionOauth: ['claim.read'] },
+        { sandboxOauth: ['claim.read'] },
+        { bearer_token: [] }
+      ]
       produces 'application/json'
       active_description = <<~VERBIAGE
         Returns the last active POA for a Veteran.
@@ -628,7 +643,11 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
       deprecated true
       tags 'Power of Attorney'
       operationId 'validate2122poa'
-      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
+      security [
+        { productionOauth: ['claim.read', 'claim.write'] },
+        { sandboxOauth: ['claim.read', 'claim.write'] },
+        { bearer_token: [] }
+      ]
       consumes 'application/json'
       produces 'application/json'
       validation_description = <<~VERBIAGE

--- a/modules/claims_api/spec/requests/v1/rswag_power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_power_of_attorney_request_spec.rb
@@ -10,7 +10,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
       deprecated true
       tags 'Power of Attorney'
       operationId 'get2122JsonSchema'
-      security [ {sandboxOauth: ['claim.read']} ]
+      security [{ sandboxOauth: ['claim.read'] }]
       produces 'application/json'
       description 'Returns schema to automatically generate a POA form.'
       let(:Authorization) { 'Bearer token' }
@@ -38,7 +38,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     post 'Submit a POA form.' do
       tags 'Power of Attorney'
       operationId 'post2122'
-      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
+      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
       consumes 'application/json'
       produces 'application/json'
       post_description = <<~VERBIAGE
@@ -188,7 +188,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     put 'Upload a signed 21-22 document.' do
       tags 'Power of Attorney'
       operationId 'upload2122Attachment'
-      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
+      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
       consumes 'multipart/form-data'
       produces 'application/json'
       put_description = <<~VERBIAGE
@@ -342,7 +342,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     get 'Check POA status by ID.' do
       tags 'Power of Attorney'
       operationId 'get2122poa'
-      security [ {sandboxOauth: ['claim.read']} ]
+      security [{ sandboxOauth: ['claim.read'] }]
       produces 'application/json'
       description 'Based on ID, returns a 21-22 submission and current status.'
 
@@ -488,7 +488,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
     get 'Check active POA status.' do
       tags 'Power of Attorney'
       operationId 'getActive2122Poa'
-      security [ {sandboxOauth: ['claim.read']} ]
+      security [{ sandboxOauth: ['claim.read'] }]
       produces 'application/json'
       active_description = <<~VERBIAGE
         Returns the last active POA for a Veteran.
@@ -628,7 +628,7 @@ describe 'Power of Attorney', swagger_doc: 'v1/swagger.json' do  # rubocop:disab
       deprecated true
       tags 'Power of Attorney'
       operationId 'validate2122poa'
-      security [ {sandboxOauth: ['claim.read', 'claim.write']} ]
+      security [{ sandboxOauth: ['claim.read', 'claim.write'] }]
       consumes 'application/json'
       produces 'application/json'
       validation_description = <<~VERBIAGE

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -106,7 +106,7 @@ RSpec.configure do |config|
         securitySchemes: {
           sandboxOauth: {
             type: :oauth2,
-            description: 'This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)'
+            description: 'This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)',
             flows: {
               authorizationCode: {
                 authorizationUrl: 'https://sandbox-api.va.gov/oauth2/authorization',

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -104,11 +104,19 @@ RSpec.configure do |config|
       ],
       components: {
         securitySchemes: {
-          bearer_token: {
-            type: :http,
-            name: :token,
-            scheme: :bearer,
-            bearer_format: :JWT
+          sandboxOauth: {
+            type: :oauth2,
+            description: 'This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)'
+            flows: {
+              authorizationCode: {
+                authorizationUrl: 'https://sandbox-api.va.gov/oauth2/authorization',
+                tokenUrl: 'https://sandbox-api.va.gov/oauth2/token',
+                scopes: {
+                  'claim.read': 'Retrieve claim data',
+                  'claim.write': 'Submit claim data'
+                }
+              }
+            }
           }
         }
       },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -104,6 +104,24 @@ RSpec.configure do |config|
       ],
       components: {
         securitySchemes: {
+          bearer_token: {
+            type: :http,
+            scheme: :bearer
+          },
+          productionOauth: {
+            type: :oauth2,
+            description: 'This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)',
+            flows: {
+              authorizationCode: {
+                authorizationUrl: 'https://api.va.gov/oauth2/authorization',
+                tokenUrl: 'https://api.va.gov/oauth2/token',
+                scopes: {
+                  'claim.read': 'Retrieve claim data',
+                  'claim.write': 'Submit claim data'
+                }
+              }
+            }
+          },
           sandboxOauth: {
             type: :oauth2,
             description: 'This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)',


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

This updates the [security definitions](https://swagger.io/docs/specification/authentication/oauth2/) in claims v1 swagger to properly reflect that it's using OAuth for authentication.

## Original issue(s)
https://vajira.max.gov/browse/API-7860

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
In and of itself, this doesn't give us anything extra within swagger ui. The developer portal doesn't currently have the OAuth flow implemented from swagger ui, and even when using https://editor.swagger.io/, I don't think that it'll redirect properly.

<img width="451" alt="Screen Shot 2021-06-14 at 8 07 07 PM" src="https://user-images.githubusercontent.com/13280995/121981256-f36dbe00-cd52-11eb-8541-df049bbc021d.png">

This will require dev work on the portal and registering the portal as a valid OAuth consumer for in-browser requests to work properly. TBD if that's a route us or other teams are interested in pursuing, but this lays the groundwork for that.
<!-- Please describe testing done to verify the changes or any testing planned. -->
