### PR TITLE
Adds metrics and logging for OAuth sessions

### DIFF
--- a/app/models/iam_user_identity.rb
+++ b/app/models/iam_user_identity.rb
@@ -50,8 +50,6 @@ class IAMUserIdentity < ::UserIdentity
       sign_in: { service_name: "oauth_#{iam_auth_n_type}", account_type: iam_profile[:fediamassur_level] }
     )
 
-    StatsD.increment('iam_ssoe_oauth.auth_type', tags: ["type:#{iam_auth_n_type}"])
-
     identity.set_expire
     identity
   end

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -235,6 +235,11 @@ StatsD.increment('iam_ssoe_oauth.inactive_session', 0)
 
 StatsD.increment('iam_ssoe_oauth.auth_type', 0)
 
+%w[IDME MHV DSL].each do |cred|
+  StatsD.increment('iam_ssoe_oauth.session', 0, tags: ['type:new', "credential:#{cred}"])
+  StatsD.increment('iam_ssoe_oauth.session', 0, tags: ['type:refresh', "credential:#{cred}"])
+end
+
 # init VEText Push Notifications
 VEText::Service.extend StatsD::Instrument
 VEText::Service.statsd_count_success :register,

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -233,11 +233,9 @@ StatsD.increment('iam_ssoe_oauth.create_user_session.success', 0)
 StatsD.increment('iam_ssoe_oauth.create_user_session.failure', 0)
 StatsD.increment('iam_ssoe_oauth.inactive_session', 0)
 
-StatsD.increment('iam_ssoe_oauth.auth_type', 0)
-
 %w[IDME MHV DSL].each do |cred|
-  StatsD.increment('iam_ssoe_oauth.session', 0, tags: ['type:new', "credential:#{cred}"])
-  StatsD.increment('iam_ssoe_oauth.session', 0, tags: ['type:refresh', "credential:#{cred}"])
+  StatsD.increment(IAMSSOeOAuth::SessionManager::STATSD_OAUTH_SESSION_KEY, 0, tags: ['type:new', "credential:#{cred}"])
+  StatsD.increment(IAMSSOeOAuth::SessionManager::STATSD_OAUTH_SESSION_KEY, 0, tags: ['type:refresh', "credential:#{cred}"])
 end
 
 # init VEText Push Notifications

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -235,7 +235,8 @@ StatsD.increment('iam_ssoe_oauth.inactive_session', 0)
 
 %w[IDME MHV DSL].each do |cred|
   StatsD.increment(IAMSSOeOAuth::SessionManager::STATSD_OAUTH_SESSION_KEY, 0, tags: ['type:new', "credential:#{cred}"])
-  StatsD.increment(IAMSSOeOAuth::SessionManager::STATSD_OAUTH_SESSION_KEY, 0, tags: ['type:refresh', "credential:#{cred}"])
+  StatsD.increment(IAMSSOeOAuth::SessionManager::STATSD_OAUTH_SESSION_KEY, 0,
+                   tags: ['type:refresh', "credential:#{cred}"])
 end
 
 # init VEText Push Notifications

--- a/modules/mobile/app/controllers/mobile/application_controller.rb
+++ b/modules/mobile/app/controllers/mobile/application_controller.rb
@@ -4,7 +4,6 @@ module Mobile
   class ApplicationController < ActionController::API
     include ExceptionHandling
     include Headers
-    include Instrumentation
     include Pundit
     include SentryLogging
     include SentryControllerLogging
@@ -78,6 +77,12 @@ module Mobile
 
     def vet360_linking_locked?(account_uuid)
       !vets360_link_redis_lock.get(account_uuid).nil?
+    end
+
+    def append_info_to_payload(payload)
+      super
+      payload[:session] = Session.obscure_token(access_token) if access_token
+      payload[:user_uuid] = current_user.uuid if current_user.present?
     end
   end
 end

--- a/modules/mobile/app/controllers/mobile/application_controller.rb
+++ b/modules/mobile/app/controllers/mobile/application_controller.rb
@@ -49,7 +49,7 @@ module Mobile
     end
 
     def access_token
-      @access_token ||= request.headers['Authorization'].gsub(ACCESS_TOKEN_REGEX, '')
+      @access_token ||= request.headers['Authorization']&.gsub(ACCESS_TOKEN_REGEX, '')
     end
 
     def raise_unauthorized(detail)
@@ -81,7 +81,7 @@ module Mobile
 
     def append_info_to_payload(payload)
       super
-      payload[:session] = Session.obscure_token(access_token) if access_token
+      payload[:session] = Session.obscure_token(access_token) if access_token.present?
       payload[:user_uuid] = current_user.uuid if current_user.present?
     end
   end

--- a/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
+++ b/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
@@ -38,6 +38,51 @@ describe 'IAMSSOeOAuth::SessionManager' do
         expect(@user.last_signed_in).to be_a_kind_of(Time)
       end
     end
+
+    context 'with newly-authenticated token' do
+      let(:dslogon_attrs) do
+        build(:dslogon_level2_introspection_payload, fediam_authentication_instant: Time.current.utc.iso8601,
+                                                     iat: (Time.current + 5.minutes).strftime('%s').to_i)
+      end
+
+      it 'increments the new OAuth session metric' do
+        allow_any_instance_of(IAMSSOeOAuth::Service).to receive(:post_introspect).and_return(dslogon_attrs)
+        allow(StatsD).to receive(:increment)
+        @user = session_manager.find_or_create_user
+        expect(StatsD).to have_received(:increment).with('iam_ssoe_oauth.session',
+                                                         tags: ['type:new', 'credential:DSL'])
+      end
+    end
+
+    context 'with refreshed token' do
+      let(:idme_attrs) do
+        build(:idme_loa3_introspection_payload, fediam_authentication_instant: Time.current.utc.iso8601,
+                                                iat: (Time.current + 1.hour).strftime('%s').to_i)
+      end
+
+      it 'increments the new OAuth session metric' do
+        allow_any_instance_of(IAMSSOeOAuth::Service).to receive(:post_introspect).and_return(idme_attrs)
+        allow(StatsD).to receive(:increment)
+        @user = session_manager.find_or_create_user
+        expect(StatsD).to have_received(:increment).with('iam_ssoe_oauth.session',
+                                                         tags: ['type:refresh', 'credential:IDME'])
+      end
+    end
+
+    context 'with unparseable timestamps' do
+      let(:mhv_attrs) do
+        build(:mhv_premium_introspection_payload, fediam_authentication_instant: Time.current.utc.iso8601,
+                                                  iat: 'garbage')
+      end
+
+      it 'increments the new OAuth session metric and defaults to refresh type' do
+        allow_any_instance_of(IAMSSOeOAuth::Service).to receive(:post_introspect).and_return(mhv_attrs)
+        allow(StatsD).to receive(:increment)
+        @user = session_manager.find_or_create_user
+        expect(StatsD).to have_received(:increment).with('iam_ssoe_oauth.session',
+                                                         tags: ['type:refresh', 'credential:MHV'])
+      end
+    end
   end
 
   describe '#logout' do


### PR DESCRIPTION
## Description of change
Adds logging of obscured token and user info when new token is
presented. Adds obscured token to request logging. Adds statsd metrics
for new vs. refresh tokens for use in alerting.

More or less follows the approach used in VA.gov:
* Log a bunch of user info when session is first established. I'm open to not logging the secid directly but VA.gov does log ICN and I believe SECID as well. These are linkable PII but considered fair game for logging. 
* Log user UUID and obscured token in payload of each request.

I also reworked the statsd metric to allow us to distinguish between token issued immediately after authenticating vs. refresh tokens so we can define some alerts, and combined the credential type metric with that one. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25580
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25118

## Things to know about this PR
* Does add linkable PII - namely SECID - to logging on initial session establishment and on each refresh.

