### PR TITLE
 Vets Api '/v2/facilties' does not accept []= query parameters fix

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/facilities_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/facilities_controller.rb
@@ -4,7 +4,9 @@ module VAOS
   module V2
     class FacilitiesController < VAOS::V0::BaseController
       def index
-        response = mobile_facility_service.get_facilities(facility_params)
+        response = mobile_facility_service.get_facilities(ids: ids,
+                                                          children: children,
+                                                          type: type)
         render json: VAOS::V2::FacilitiesSerializer.new(response[:data], meta: response[:meta])
       end
 
@@ -14,13 +16,17 @@ module VAOS
         VAOS::V2::MobileFacilityService.new(current_user)
       end
 
-      def facility_params
-        params.require(:ids)
-        params.permit(
-          :ids,
-          :children,
-          :type
-        )
+      def ids
+        ids = params.require(:ids)
+        ids.is_a?(Array) ? ids.to_csv(row_sep: nil) : ids
+      end
+
+      def children
+        params[:children]
+      end
+
+      def type
+        params[:type]
       end
     end
   end

--- a/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
+++ b/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
@@ -255,7 +255,7 @@ paths:
       operationId: getFacilities
       parameters:
         - in: query
-          name: types
+          name: type
           schema:
             type: string
           description: Not implemented and will be ignored if present.

--- a/modules/vaos/app/services/vaos/v2/mobile_facility_service.rb
+++ b/modules/vaos/app/services/vaos/v2/mobile_facility_service.rb
@@ -6,11 +6,11 @@ require 'common/client/errors'
 module VAOS
   module V2
     class MobileFacilityService < VAOS::SessionService
-      def get_facilities(query_params, pagination_params = {})
+      def get_facilities(ids:, children: nil, type: nil, pagination_params: {})
         params = {
-          ids: query_params[:ids],
-          children: query_params[:children],
-          types: query_params[:types]
+          ids: ids,
+          children: children,
+          type: type
         }.merge(page_params(pagination_params)).compact
         with_monitoring do
           options = { params_encoder: Faraday::FlatParamsEncoder }

--- a/modules/vaos/spec/request/v2/facilities_request_spec.rb
+++ b/modules/vaos/spec/request/v2/facilities_request_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe 'facilities', type: :request do
         end
       end
 
+      context 'on successful query for a facility given multiple facilities in array form' do
+        it 'returns facility details' do
+          VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_200', match_requests_on: %i[method uri]) do
+            get '/vaos/v2/facilities?ids[]=983&ids[]=984', headers: inflection_header
+            # expect(response).to have_http_status(:ok)
+            # expect(response.body).to be_a(String)
+            # expect(response).to match_camelized_response_schema('vaos/v2/get_facilities', { strict: false })
+          end
+        end
+      end
+
       context 'on successful query for a facility and children' do
         it 'returns facility details' do
           VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_with_children_200',

--- a/modules/vaos/spec/request/v2/facilities_request_spec.rb
+++ b/modules/vaos/spec/request/v2/facilities_request_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe 'facilities', type: :request do
         it 'returns facility details' do
           VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_200', match_requests_on: %i[method uri]) do
             get '/vaos/v2/facilities?ids[]=983&ids[]=984', headers: inflection_header
-            # expect(response).to have_http_status(:ok)
-            # expect(response.body).to be_a(String)
-            # expect(response).to match_camelized_response_schema('vaos/v2/get_facilities', { strict: false })
+            expect(response).to have_http_status(:ok)
+            expect(JSON.parse(response.body)['data'].size).to eq(2)
+            expect(response).to match_camelized_response_schema('vaos/v2/get_facilities', { strict: false })
           end
         end
       end

--- a/modules/vaos/spec/services/v2/mobile_facility_service_spec.rb
+++ b/modules/vaos/spec/services/v2/mobile_facility_service_spec.rb
@@ -53,10 +53,7 @@ describe VAOS::V2::MobileFacilityService do
       it 'returns a configuration' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_200',
                          match_requests_on: %i[method uri]) do
-          params = {
-            ids: %w[688]
-          }
-          response = subject.get_facilities(params)
+          response = subject.get_facilities(ids: '688')
           expect(response[:data].size).to eq(1)
         end
       end
@@ -66,11 +63,7 @@ describe VAOS::V2::MobileFacilityService do
       it 'returns a configuration' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_with_children_200',
                          match_requests_on: %i[method uri]) do
-          params = {
-            ids: %w[688],
-            children: true
-          }
-          response = subject.get_facilities(params)
+          response = subject.get_facilities(ids: '688', children: true)
           expect(response[:data].size).to eq(8)
         end
       end
@@ -80,7 +73,7 @@ describe VAOS::V2::MobileFacilityService do
       it 'raises a backend exception' do
         VCR.use_cassette('vaos/v2/mobile_facility/get_facilities_400',
                          match_requests_on: %i[method uri]) do
-          expect { subject.get_facilities({}) }.to raise_error(
+          expect { subject.get_facilities(ids: nil) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
         end
@@ -91,10 +84,7 @@ describe VAOS::V2::MobileFacilityService do
       it 'raises a backend exception' do
         VCR.use_cassette('vaos/v2/mobile_facility/get_facilities_500',
                          match_requests_on: %i[method uri]) do
-          params = {
-            ids: %w[688]
-          }
-          expect { subject.get_facilities(params) }.to raise_error(
+          expect { subject.get_facilities(ids: '688') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
         end

--- a/spec/support/schemas_camelized/vaos/v2/get_facilities.json
+++ b/spec/support/schemas_camelized/vaos/v2/get_facilities.json
@@ -96,7 +96,7 @@
                 }
               },
               "hoursOfOperation": {
-                "type": "array",
+                "type": ["array", null],
                 "items": {
                   "type": "object",
                   "properties": {
@@ -191,7 +191,7 @@
                 ]
               },
               "operatingStatus": {
-                "type": "object",
+                "type": ["object", null],
                 "properties": {
                   "code": {
                     "type": ["string", null]

--- a/spec/support/vcr_cassettes/vaos/v2/mobile_facility_service/get_facilities_200.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/mobile_facility_service/get_facilities_200.yml
@@ -120,4 +120,117 @@ http_interactions:
           } ]
         }
   recorded_at: Thu, 20 May 2021 20:55:14 GMT
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/facilities/v2/facilities?ids=983,984&pageSize=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ca5fd0d6-3fd7-4025-b1cc-c4953c6c45a8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 16 Jun 2021 22:19:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2065'
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 2.5.2
+      B3:
+      - 5669b658c1627ca2-b1e66bdcd2127f66-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - cc1bce1
+      X-Vamf-Timestamp:
+      - '2021-05-30T22:09:53+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "data" : [ {
+            "id" : "983",
+            "vistaSite" : "983",
+            "vastParent" : "983",
+            "type" : "va_facilities",
+            "name" : "Cheyenne VA Medical Center",
+            "classification" : "VA Medical Center (VAMC)",
+            "timezone" : {
+              "zoneId" : "America/Denver",
+              "abbreviation" : "MDT"
+            },
+            "lat" : 39.744507,
+            "long" : -104.830956,
+            "website" : "https://www.denver.va.gov/locations/directions.asp",
+            "phone" : {
+              "main" : "307-778-7550",
+              "fax" : "307-778-7381",
+              "pharmacy" : "866-420-6337",
+              "afterHours" : "307-778-7550",
+              "patientAdvocate" : "307-778-7550 x7517",
+              "mentalHealthClinic" : "307-778-7349",
+              "enrollmentCoordinator" : "307-778-7550 x7579"
+            },
+            "physicalAddress" : {
+              "type" : "physical",
+              "line" : [ "2360 East Pershing Boulevard" ],
+              "city" : "Cheyenne",
+              "state" : "WY",
+              "postalCode" : "82001-5356"
+            },
+            "mobile" : false,
+            "healthService" : [ "Audiology", "Cardiology", "DentalServices", "EmergencyCare", "Gastroenterology", "Gynecology", "MentalHealthCare", "Nutrition", "Ophthalmology", "Optometry", "Orthopedics", "Podiatry", "PrimaryCare", "SpecialtyCare", "UrgentCare", "Urology", "WomensHealth" ],
+            "operatingStatus" : {
+              "code" : "NORMAL"
+            }
+          }, {
+            "id" : "984",
+            "vistaSite" : "984",
+            "vastParent" : "984",
+            "type" : "va_health_facility",
+            "name" : "Dayton VA Medical Center",
+            "classification" : "VA Medical Center (VAMC)",
+            "website" : "https://www.dayton.va.gov/locations/directions.asp",
+            "phone" : {
+              "main" : "937-268-6511"
+            },
+            "physicalAddress" : {
+              "type" : "physical",
+              "line" : [ "4100 West Third Street" ],
+              "city" : "Dayton",
+              "state" : "OH",
+              "postalCode" : "45428-9000"
+            },
+            "healthService" : [ "Audiology", "Cardiology", "DentalServices", "Dermatology", "Gastroenterology", "Gynecology", "MentalHealthCare", "Nutrition", "Ophthalmology", "Optometry", "Orthopedics", "Podiatry", "PrimaryCare", "SpecialtyCare", "Urology", "WomensHealth" ]
+          } ]
+        }
+  recorded_at: Wed, 16 Jun 2021 22:19:12 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Updated v2 facilities controller to accept []= query parameters. Added tests and VCR Cassettes interactions where multiple facility ids were passed in.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#26178


