### PR TITLE
empty slot hash is dropped from post appointment request object

### DIFF
--- a/modules/vaos/app/models/vaos/v2/appointment_form.rb
+++ b/modules/vaos/app/models/vaos/v2/appointment_form.rb
@@ -25,7 +25,7 @@ module VAOS
       def params
         raise Common::Exceptions::ValidationErrors, self unless valid?
 
-        attributes.compact.merge(patient_icn: @user.icn)
+        attributes.merge(patient_icn: @user.icn, slot: slot.empty? ? nil : slot).compact
       end
     end
   end

--- a/modules/vaos/spec/factories/v2/appointment_forms.rb
+++ b/modules/vaos/spec/factories/v2/appointment_forms.rb
@@ -39,5 +39,10 @@ FactoryBot.define do
         ]
       end
     end
+
+    trait :with_empty_slot_hash do
+      eligible
+      slot { {} }
+    end
   end
 end

--- a/modules/vaos/spec/models/v2/appointment_form_spec.rb
+++ b/modules/vaos/spec/models/v2/appointment_form_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe VAOS::V2::AppointmentForm, type: :model do
+  let(:user) { build(:user, :vaos) }
+
+  describe 'valid object' do
+    subject { build(:appointment_form_v2, :eligible, user: user) }
+
+    it 'validates presence of required attributes' do
+      expect(subject).to be_valid
+    end
+
+    it 'params returns expected fields' do
+      params = subject.params
+      expect(params[:kind]).to be('cc')
+      expect(params[:status]).to be('proposed')
+      expect(params[:location_id]).to be('983')
+      expect(params[:reason]).to be('Testing')
+      expect(params[:contact]).to be_a(Hash)
+      expect(params[:service_type]).to be('CCPOD')
+      expect(params[:requested_periods]).to be_a(Array)
+    end
+  end
+
+  describe 'with empty slot hash' do
+    subject { build(:appointment_form_v2, :with_empty_slot_hash, user: user) }
+
+    it 'validates presence of required attributes' do
+      expect(subject).to be_valid
+    end
+
+    it 'drops empty slot hash' do
+      params = subject.params
+      expect(params.key?('slot')).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

vaos service does not accept an empty object for the `slot` field in the post appointment request body.  The code has been updated to drop an empty `slot` object from the request body, should it exist

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Tests were added to verify that an empty `slot` object is dropped from the request