### PR TITLE
add identity team members to flipper admin

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -697,6 +697,7 @@ search_click_tracking:
 flipper:
   admin_user_emails:
     - adewitt@thoughtworks.com
+    - agarcia@clarityinnovates.com
     - alastair@adhocteam.us
     - anna@adhoc.team
     - bill.ryan@adhocteam.us
@@ -722,6 +723,7 @@ flipper:
     - jesse.cohn@adhocteam.us
     - jlinn@governmentcio.com
     - joeyn414@gmail.com # Joe Niquette Oddball VSP Identity Team Sr Security Engineer
+    - john.bramley@adhocteam.us
     - jwolf@governmentcio.com # Jason Wolf Product Manager for GCIO
     - kabrown@thoughtworks.com
     - kadams@governmentcio.com
@@ -764,6 +766,7 @@ flipper:
     - stephen.barrs@va.gov
     - tony.williams@va.gov
     - travis.hilton@oddball.io
+    - trevor.bosaw@oddball.io
     - turner_desiree@bah.com
     - tze@adhocteam.us
     - zurbergram@gmail.com


### PR DESCRIPTION
specifically being added for ssoe purposes

Adding new flipper admins for Identity SSOe purposes.
