### PR TITLE
Add bin/rspec back

### DIFF
--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+begin
+  load File.expand_path('spring', __dir__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,16 +1,18 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-if !defined?(Spring) && [nil, 'development', 'test'].include?(ENV['RAILS_ENV'])
-  gem 'bundler'
+# This file loads Spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require 'rubygems'
   require 'bundler'
 
-  # Load Spring without loading other gems in the Gemfile, for speed.
-  Bundler.locked_gems&.specs&.find { |spec| spec.name == 'spring' }&.tap do |spring|
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
+  if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', spring.version
     require 'spring/binstub'
-  rescue Gem::LoadError
-    # Ignore when Spring is not installed.
   end
 end


### PR DESCRIPTION
The binned rspec had spring support. We want to keep this as it makes our test suite faster.