### PR TITLE
[26326] Sidekiq Stats Instrumentation Fix

### DIFF
--- a/lib/sidekiq_stats_instrumentation/client_middleware.rb
+++ b/lib/sidekiq_stats_instrumentation/client_middleware.rb
@@ -5,7 +5,7 @@
 module SidekiqStatsInstrumentation
   class ClientMiddleware
     def call(worker_class, _job, _queue, _redis_pool)
-      klass = worker_class
+      klass = Object.const_get(worker_class.to_s)
       queue_name = klass.get_sidekiq_options['queue']
       worker_name = klass.name.gsub('::', '_')
       StatsD.increment "shared.sidekiq.#{queue_name}.#{worker_name}.enqueue"


### PR DESCRIPTION
## Description of change
When ClientMiddleware was being called for EVSS::DisabilityCompensationForm::SubmitUploads, it was passed as a `String` instead of a class. This fix ensures that whatever is passed when the middleware is called will be handled appropriately, regardless if that is an actual `Class` or string.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#26326

