### PR TITLE
API-7861 Add swagger-ui for claims endpoints

### DIFF
--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Rswag::Ui.configure do |c|
+  c.swagger_endpoint '/services/claims/docs/v1/api', 'Claims API V1 Docs'
+  c.swagger_endpoint '/services/claims/docs/v0/api', 'Claims API V0 Docs'
+end

--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rswag'
+
 Rswag::Ui.configure do |c|
   c.swagger_endpoint '/services/claims/docs/v1/api', 'Claims API V1 Docs'
   c.swagger_endpoint '/services/claims/docs/v0/api', 'Claims API V0 Docs'

--- a/modules/claims_api/config/routes.rb
+++ b/modules/claims_api/config/routes.rb
@@ -69,6 +69,8 @@ ClaimsApi::Engine.routes.draw do
   end
 
   namespace :docs do
+    mount Rswag::Ui::Engine => 'swagger'
+
     namespace :v0 do
       get 'api', to: 'api#index'
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

Display swagger-ui for interactions with claims api.
Should display at the following url: `{root_url, localhost, env, etc}/services/claims/docs/swagger`

## Original issue(s)
https://vajira.max.gov/browse/API-7861

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
This initially caused a breakage in deploys due to the following error showing up in [logs](http://grafana.vfs.va.gov/explore?orgId=1&left=%5B%221624397956921%22,%221624399756921%22,%22Loki%20(Dev)%22,%7B%22expr%22:%22%7Bapp%3D%5C%22vets-api-server%5C%22%7D%20%7C%3D%20%5C%22Rswag%5C%22%22%7D,%7B%7D%5D):
```log
21:40:12 web.1       |   /srv/vets-api/src/config/initializers/rswag-ui.rb:3:in `<main>'
21:40:12 web.1       | NameError: uninitialized constant Rswag
21:40:12 web.1       | bundler: failed to load command: puma (/usr/local/bundle/bin/puma)
21:40:12 web.1       | [8] ! Unable to load application: NameError: uninitialized constant Rswag
```

I added in a [require 'rswag' statement](https://github.com/department-of-veterans-affairs/vets-api/compare/master...dh-api-7861?expand=1#diff-3d68bb66c130475a29e7fe075061504624cee30831373c4536d8934ca7570e28R3) in the offending file and checked by running `bundle exec rails console -e production` and `bundle exec rails server -e production`. The error seemed to no longer show up, where before it did in both cases.
