### PR TITLE
Refactor error handling for FSR PDF downloads

### DIFF
--- a/app/controllers/v0/financial_status_reports_controller.rb
+++ b/app/controllers/v0/financial_status_reports_controller.rb
@@ -6,6 +6,8 @@ module V0
   class FinancialStatusReportsController < ApplicationController
     before_action { authorize :debt, :access? }
 
+    rescue_from ::DebtManagementCenter::FinancialStatusReportService::FSRNotFoundInRedis, with: :render_not_found
+
     def create
       render json: service.submit_financial_status_report(fsr_form)
     end
@@ -20,6 +22,10 @@ module V0
     end
 
     private
+
+    def render_not_found
+      render json: nil, status: :not_found
+    end
 
     def full_name
       %i[first middle last]

--- a/app/controllers/v0/financial_status_reports_controller.rb
+++ b/app/controllers/v0/financial_status_reports_controller.rb
@@ -7,7 +7,11 @@ module V0
     before_action { authorize :debt, :access? }
 
     def create
-      render json: service.submit_financial_status_report(fsr_form)
+      render(
+        json: service.submit_financial_status_report(
+          fsr_form
+        )
+      )
     end
 
     def download_pdf

--- a/app/controllers/v0/financial_status_reports_controller.rb
+++ b/app/controllers/v0/financial_status_reports_controller.rb
@@ -7,11 +7,7 @@ module V0
     before_action { authorize :debt, :access? }
 
     def create
-      render(
-        json: service.submit_financial_status_report(
-          fsr_form
-        )
-      )
+      render json: service.submit_financial_status_report(fsr_form)
     end
 
     def download_pdf

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -80,7 +80,7 @@ development: &defaults
     each_ttl: 2592000
   financial_status_report:
     namespace: financial_status_report
-    each_ttl: 1800
+    each_ttl: 1800 # 30 minutes
   pciu_address_dependencies:
     namespace: pciu-address-dependencies
     each_ttl: 604800

--- a/lib/debt_management_center/financial_status_report_downloader.rb
+++ b/lib/debt_management_center/financial_status_report_downloader.rb
@@ -5,7 +5,7 @@ require 'uri'
 
 module DebtManagementCenter
   class FinancialStatusReportDownloader
-    class FilenetIdNotFoundError < StandardError; end
+    class FilenetIdNotProvided < StandardError; end
 
     def initialize(financial_status_report)
       @financial_status_report = financial_status_report
@@ -14,7 +14,7 @@ module DebtManagementCenter
     def download_pdf
       id = @financial_status_report.filenet_id
 
-      raise FilenetIdNotFoundError if id.blank?
+      raise FilenetIdNotProvided if id.blank?
 
       uri = URI.parse(
         "#{Settings.dmc.url}financial-status-report/documentstream?objectId=#{id}"
@@ -26,8 +26,6 @@ module DebtManagementCenter
       request_headers.each { |header, value| request[header] = value }
       response = http.request(request)
       response.body
-    rescue FilenetIdNotFoundError
-      raise_filenet_id_not_found_error
     end
 
     private
@@ -38,13 +36,6 @@ module DebtManagementCenter
         client_id: Settings.dmc.client_id,
         client_secret: Settings.dmc.client_secret
       }
-    end
-
-    def raise_filenet_id_not_found_error
-      raise Common::Exceptions::ServiceError.new(
-        detail: 'Filenet ID not present in the user FSR from Redis.',
-        source: 'Debt Management, financial_status_report_downloader.'
-      )
     end
   end
 end

--- a/lib/debt_management_center/financial_status_report_downloader.rb
+++ b/lib/debt_management_center/financial_status_report_downloader.rb
@@ -5,7 +5,7 @@ require 'uri'
 
 module DebtManagementCenter
   class FinancialStatusReportDownloader
-    class FilenetIdNotProvided < StandardError; end
+    class FilenetIdNotPresent < StandardError; end
 
     def initialize(financial_status_report)
       @financial_status_report = financial_status_report
@@ -14,7 +14,7 @@ module DebtManagementCenter
     def download_pdf
       id = @financial_status_report.filenet_id
 
-      raise FilenetIdNotProvided if id.blank?
+      raise FilenetIdNotPresent if id.blank?
 
       uri = URI.parse(
         "#{Settings.dmc.url}financial-status-report/documentstream?objectId=#{id}"

--- a/lib/debt_management_center/models/financial_status_report.rb
+++ b/lib/debt_management_center/models/financial_status_report.rb
@@ -7,6 +7,7 @@ module DebtManagementCenter
     redis_key :uuid
 
     validates :uuid, presence: true
+    validates :filenet_id, presence: true
 
     attribute :uuid
     attribute :filenet_id

--- a/lib/debt_management_center/responses/financial_status_report_response.rb
+++ b/lib/debt_management_center/responses/financial_status_report_response.rb
@@ -6,10 +6,14 @@ module DebtManagementCenter
   class FinancialStatusReportResponse
     attr_reader :status, :filenet_id
 
-    def initialize(res)
-      @res = res
-      @status = @res['status']
-      @filenet_id = @res['identifier']
+    def initialize(response_body)
+      @response_body = response_body
+      @status = @response_body['status']
+      @filenet_id = @response_body['identifier']
+    end
+
+    def to_h
+      { response_body: @response_body }
     end
   end
 end

--- a/spec/controllers/v0/financial_status_reports_controller_spec.rb
+++ b/spec/controllers/v0/financial_status_reports_controller_spec.rb
@@ -5,6 +5,7 @@ require 'support/stub_financial_status_report'
 require 'support/financial_status_report_helpers'
 
 RSpec.describe V0::FinancialStatusReportsController, type: :controller do
+  let(:service_class) { DebtManagementCenter::FinancialStatusReportService }
   let(:valid_form_data) { get_fixture('dmc/fsr_submission') }
   let(:user) { build(:user, :loa3) }
   let(:filenet_id) { '93631483-E9F9-44AA-BB55-3552376400D8' }
@@ -14,6 +15,23 @@ RSpec.describe V0::FinancialStatusReportsController, type: :controller do
   end
 
   describe '#create' do
+    context 'when service raises FSRNotFoundInRedis' do
+      before do
+        expect_any_instance_of(service_class).to receive(
+          :submit_financial_status_report
+        ).and_raise(
+          service_class::FSRNotFoundInRedis
+        )
+      end
+
+      it 'renders 404' do
+        post(:create, params: valid_form_data)
+        expect(response.status).to eq(404)
+        expect(response.header['Content-Type']).to include('application/json')
+        expect(JSON.parse(response.body)).to eq(nil)
+      end
+    end
+
     it 'submits a financial status report' do
       VCR.use_cassette('dmc/submit_fsr') do
         VCR.use_cassette('bgs/people_service/person_data') do

--- a/spec/lib/debt_management_center/financial_status_report_downloader_spec.rb
+++ b/spec/lib/debt_management_center/financial_status_report_downloader_spec.rb
@@ -5,19 +5,49 @@ require 'debt_management_center/financial_status_report_downloader'
 require 'debt_management_center/models/financial_status_report'
 
 RSpec.describe DebtManagementCenter::FinancialStatusReportDownloader do
-  subject { described_class.new(financial_status_report) }
+  subject { described_class.new(fsr) }
 
   let(:user) { build(:user, :loa3) }
-  let(:filenet_id) { 'ABCD-1234' }
-  let(:financial_status_report) do
-    report_params = { REDIS_CONFIG[:financial_status_report][:namespace] => user.uuid }
-    financial_status_report = DebtManagementCenter::FinancialStatusReport.new(report_params)
-    financial_status_report.update(filenet_id: filenet_id, uuid: user.uuid)
-    financial_status_report
-  end
+  let(:filenet_id) { 'ABCD-1234' } # Must match cassette
+  let(:fsr_params) { { REDIS_CONFIG[:financial_status_report][:namespace] => user.uuid } }
+  let(:fsr) { DebtManagementCenter::FinancialStatusReport.new(fsr_params) }
 
   describe '#download_pdf' do
+    context 'with an missing filenet id' do
+      it 'raises an error' do
+        subject = described_class.new(fsr)
+        expect { subject.download_pdf }.to raise_error do |error|
+          expect(error).to be_instance_of(described_class::FilenetIdNotProvided)
+        end
+      end
+    end
+
+    context 'with an nil filenet id' do
+      before { fsr.update(filenet_id: nil, uuid: user.uuid) }
+
+      it 'raises an error' do
+        expect { subject.download_pdf }.to raise_error do |error|
+          expect(error).to be_instance_of(described_class::FilenetIdNotProvided)
+        end
+      end
+    end
+
+    context 'with an empty filenet id' do
+      before { fsr.update(filenet_id: '', uuid: user.uuid) }
+
+      it 'raises an error' do
+        subject = described_class.new(fsr)
+        expect { subject.download_pdf }.to raise_error do |error|
+          expect(error).to be_instance_of(described_class::FilenetIdNotProvided)
+        end
+      end
+    end
+
     context 'with a valid filenet id' do
+      before do
+        fsr.update(filenet_id: filenet_id, uuid: user.uuid)
+      end
+
       it 'downloads the pdf' do
         VCR.use_cassette('dmc/download_pdf') do
           expect(subject.download_pdf.force_encoding('ASCII-8BIT')).to eq(

--- a/spec/lib/debt_management_center/financial_status_report_downloader_spec.rb
+++ b/spec/lib/debt_management_center/financial_status_report_downloader_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DebtManagementCenter::FinancialStatusReportDownloader do
       it 'raises an error' do
         subject = described_class.new(fsr)
         expect { subject.download_pdf }.to raise_error do |error|
-          expect(error).to be_instance_of(described_class::FilenetIdNotProvided)
+          expect(error).to be_instance_of(described_class::FilenetIdNotPresent)
         end
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe DebtManagementCenter::FinancialStatusReportDownloader do
 
       it 'raises an error' do
         expect { subject.download_pdf }.to raise_error do |error|
-          expect(error).to be_instance_of(described_class::FilenetIdNotProvided)
+          expect(error).to be_instance_of(described_class::FilenetIdNotPresent)
         end
       end
     end
@@ -38,7 +38,7 @@ RSpec.describe DebtManagementCenter::FinancialStatusReportDownloader do
       it 'raises an error' do
         subject = described_class.new(fsr)
         expect { subject.download_pdf }.to raise_error do |error|
-          expect(error).to be_instance_of(described_class::FilenetIdNotProvided)
+          expect(error).to be_instance_of(described_class::FilenetIdNotPresent)
         end
       end
     end

--- a/spec/lib/debt_management_center/financial_status_report_service_spec.rb
+++ b/spec/lib/debt_management_center/financial_status_report_service_spec.rb
@@ -5,6 +5,10 @@ require 'debt_management_center/financial_status_report_service'
 require 'support/financial_status_report_helpers'
 
 RSpec.describe DebtManagementCenter::FinancialStatusReportService, type: :service do
+  it 'inherits SentryLogging' do
+    expect(described_class.ancestors).to include(SentryLogging)
+  end
+
   describe '#submit_financial_status_report' do
     let(:valid_form_data) { get_fixture('dmc/fsr_submission') }
     let(:user) { build(:user, :loa3) }
@@ -38,11 +42,55 @@ RSpec.describe DebtManagementCenter::FinancialStatusReportService, type: :servic
         end
       end
     end
+
+    context 'when saving FSR fails' do
+      subject { described_class.new(user) }
+
+      before do
+        expect_any_instance_of(SentryLogging).to receive(:log_exception_to_sentry) do |_self, arg_1, arg_2|
+          expect(arg_1).to be_instance_of(ActiveModel::ValidationError)
+          expect(arg_1.message).to eq('Validation failed: Filenet can\'t be blank')
+          expect(arg_2).to eq(
+            {
+              fsr_attributes: {
+                uuid: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef',
+                filenet_id: nil
+              },
+              fsr_response: {
+                response_body: {
+                  'status' => 'Document created successfully and uploaded to File Net.'
+                }
+              }
+            }
+          )
+        end
+      end
+
+      it 'logs to sentry' do
+        VCR.use_cassette('dmc/submit_fsr') do
+          VCR.use_cassette('bgs/people_service/person_data') do
+            res = subject.submit_financial_status_report(valid_form_data)
+            expect(res[:status]).to eq('Document created successfully and uploaded to File Net.')
+          end
+        end
+      end
+    end
   end
 
   describe '#get_pdf' do
     let(:filenet_id) { 'ABCD-1234' }
     let(:user) { build(:user, :loa3) }
+
+    context 'when FSR is missing from redis' do
+      it 'raises an error' do
+        VCR.use_cassette('bgs/people_service/person_data') do
+          service = described_class.new(user)
+          expect { service.get_pdf }.to raise_error do |error|
+            expect(error).to be_instance_of(described_class::FSRNotFoundInRedis)
+          end
+        end
+      end
+    end
 
     context 'with logged in user' do
       it 'downloads the pdf' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR refactors the error handling of downloading a persisted FSR's PDF. It stops using the [broken](https://github.com/department-of-veterans-affairs/va.gov-team/issues/24402#issuecomment-866900423) `Common::Exceptions::BackendServiceException`, and instead logs an exception to sentry with additional context.

## Original issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/24402

## Things to know about this PR
- When an FSR form is submitted, the `filenet_id` returned from DMC should be persisted. If it's not persisted, when the user attempts to download the PDF, the corresponding service will raise an error for the missing attribute. When this error is raised, it will raise a Type error and the original exception is lost ([details here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/24402#issuecomment-866900423)).

- In all VCR cassettes and mocks, there is no `filenet_id` property in the response from DMC. Once I can produce more detailed errors (with this PR), I will follow up with fixtures that contain an expected `filenet_id`.