### PR TITLE
Sanitize edipi in iam user identity

### DIFF
--- a/app/models/iam_user_identity.rb
+++ b/app/models/iam_user_identity.rb
@@ -8,6 +8,7 @@ require 'sentry_logging'
 #
 class IAMUserIdentity < ::UserIdentity
   extend SentryLogging
+  extend Identity::Parsers::GCIdsHelper
 
   PREMIUM_LOAS = [2, 3].freeze
   UPGRADE_AUTH_TYPES = %w[DSL MHV].freeze
@@ -40,7 +41,7 @@ class IAMUserIdentity < ::UserIdentity
       expiration_timestamp: iam_profile[:exp],
       first_name: iam_profile[:given_name],
       icn: iam_profile[:fediam_mviicn],
-      iam_edipi: iam_profile[:fediam_do_dedipn_id],
+      iam_edipi: sanitize_edipi(iam_profile[:fediam_do_dedipn_id]),
       iam_sec_id: iam_profile[:fediamsecid],
       iam_mhv_id: valid_mhv_id(iam_profile[:fediam_mhv_ien]),
       last_name: iam_profile[:family_name],

--- a/spec/models/iam_user_identity_spec.rb
+++ b/spec/models/iam_user_identity_spec.rb
@@ -73,4 +73,18 @@ RSpec.describe IAMUserIdentity, type: :model do
       expect(id.iam_mhv_id).to be_nil
     end
   end
+
+  context 'with a user who has a found EDIPI' do
+    it 'returns edipi number' do
+      id = described_class.build_from_iam_profile(idme_attrs)
+      expect(id.iam_edipi).to eq('1005079124')
+    end
+  end
+
+  context 'with a user who has a not found EDIPI' do
+    it 'returns nil' do
+      id = described_class.build_from_iam_profile(mhv_attrs)
+      expect(id.iam_edipi).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Fixes an issue where the EMIS military history service is returning a `MIS-ERR-005 EDIPI_BAD_FORMAT EDIPI incorrectly formatted` error due to IAMUsers (via IAMUserIdentity) not parsing EDIPI as 'NOT_FOUND' as nil.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#26486
