### PR TITLE
Created Check for service history null dates

### DIFF
--- a/app/models/emis_redis/military_information.rb
+++ b/app/models/emis_redis/military_information.rb
@@ -329,6 +329,14 @@ module EMISRedis
       end.call
     end
 
+    # @return [Array<EMIS::Models::MilitaryServiceEpisode>] Cached
+    #  array of veteran's military service episodes sorted by begin_date
+    def service_episodes_by_begin_date
+      @service_episodes_by_date ||= lambda do
+        military_service_episodes.sort_by { |ep| ep.begin_date || Time.zone.today + 3650 }
+      end.call
+    end
+
     # @return [Array<Hash>] Veteran's military service episodes sorted by date
     #  in hash format including data about branch of service, date range,
     #  and personnel category codes

--- a/app/models/emis_redis/military_information_v2.rb
+++ b/app/models/emis_redis/military_information_v2.rb
@@ -267,6 +267,14 @@ module EMISRedis
       end.call
     end
 
+    # @return [Array<EMIS::Models::MilitaryServiceEpisode>] Cached
+    #  array of veteran's military service episodes sorted by begin_date
+    def service_episodes_by_begin_date
+      @service_episodes_by_date ||= lambda do
+        military_service_episodes.sort_by { |ep| ep.begin_date || Time.zone.today + 3650 }
+      end.call
+    end
+
     # @return [Array<Hash>] Veteran's military service episodes sorted by date
     #  in hash format including data about branch of service, date range,
     #  and personnel category codes

--- a/modules/veteran_verification/spec/models/service_history_episode_spec.rb
+++ b/modules/veteran_verification/spec/models/service_history_episode_spec.rb
@@ -24,7 +24,7 @@ describe VeteranVerification::ServiceHistoryEpisode, skip_emis: true do
       VCR.use_cassette('emis/get_deployment_v2/valid') do
         VCR.use_cassette('emis/get_military_service_episodes_v2/valid_multiple_episodes') do
           result = described_class.for_user(user)
-          expect(result.length).to eq(1)
+          expect(result.length).to eq(2)
           expect(result[0][:first_name]).to eq('abraham')
           expect(result[0][:last_name]).to eq('lincoln')
           expect(result[0][:branch_of_service]).to eq('Army National Guard')
@@ -34,17 +34,17 @@ describe VeteranVerification::ServiceHistoryEpisode, skip_emis: true do
       end
     end
 
-    it 'returns service history and deploys when there are multiple episodes' do
+    it 'returns service history and deploys when there are multiple episodes and end date null' do
       VCR.use_cassette('emis/get_deployment_v2/valid') do
         VCR.use_cassette('emis/get_military_service_episodes_v2/valid_multiple_episodes_end_date_null') do
           result = described_class.for_user(user)
-          puts result.to_json
           expect(result.length).to eq(2)
           expect(result[0][:branch_of_service]).to eq('Army National Guard')
           expect(result[0][:pay_grade]).to eq('W04')
-          expect(result[0][:deployments]).length.to eq(0)
+          expect(result[0][:deployments].length).to eq(0)
           expect(result[1][:branch_of_service]).to eq('Army National Guard')
           expect(result[1][:pay_grade]).to eq('W04')
+          expect(result[1][:deployments].length).to eq(3)
         end
       end
     end

--- a/modules/veteran_verification/spec/models/service_history_episode_spec.rb
+++ b/modules/veteran_verification/spec/models/service_history_episode_spec.rb
@@ -24,12 +24,27 @@ describe VeteranVerification::ServiceHistoryEpisode, skip_emis: true do
       VCR.use_cassette('emis/get_deployment_v2/valid') do
         VCR.use_cassette('emis/get_military_service_episodes_v2/valid_multiple_episodes') do
           result = described_class.for_user(user)
-          expect(result.length).to eq(2)
-          expect(result[1][:branch_of_service]).to eq('Army National Guard')
-          expect(result[1][:pay_grade]).to eq('W04')
+          expect(result.length).to eq(1)
+          expect(result[0][:first_name]).to eq('abraham')
+          expect(result[0][:last_name]).to eq('lincoln')
           expect(result[0][:branch_of_service]).to eq('Army National Guard')
           expect(result[0][:pay_grade]).to eq('W04')
           expect(result[0][:deployments][0][:location]).to eq('AX1')
+        end
+      end
+    end
+
+    it 'returns service history and deploys when there are multiple episodes' do
+      VCR.use_cassette('emis/get_deployment_v2/valid') do
+        VCR.use_cassette('emis/get_military_service_episodes_v2/valid_multiple_episodes_end_date_null') do
+          result = described_class.for_user(user)
+          puts result.to_json
+          expect(result.length).to eq(2)
+          expect(result[0][:branch_of_service]).to eq('Army National Guard')
+          expect(result[0][:pay_grade]).to eq('W04')
+          expect(result[0][:deployments]).length.to eq(0)
+          expect(result[1][:branch_of_service]).to eq('Army National Guard')
+          expect(result[1][:pay_grade]).to eq('W04')
         end
       end
     end

--- a/modules/veteran_verification/spec/models/service_history_episode_spec.rb
+++ b/modules/veteran_verification/spec/models/service_history_episode_spec.rb
@@ -25,9 +25,11 @@ describe VeteranVerification::ServiceHistoryEpisode, skip_emis: true do
         VCR.use_cassette('emis/get_military_service_episodes_v2/valid_multiple_episodes') do
           result = described_class.for_user(user)
           expect(result.length).to eq(2)
+          expect(result[1][:branch_of_service]).to eq('Army National Guard')
+          expect(result[1][:pay_grade]).to eq('W04')
           expect(result[0][:branch_of_service]).to eq('Army National Guard')
           expect(result[0][:pay_grade]).to eq('W04')
-          expect(result[1][:deployments][0][:location]).to eq('AX1')
+          expect(result[0][:deployments][0][:location]).to eq('AX1')
         end
       end
     end

--- a/spec/support/vcr_cassettes/emis/get_military_service_episodes_v2/valid_multiple_episodes_end_date_null.yml
+++ b/spec/support/vcr_cassettes/emis/get_military_service_episodes_v2/valid_multiple_episodes_end_date_null.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://vaausvrsapp81.aac.va.gov/VIERSService/eMIS/v2/MilitaryInformationService
+    body:
+      encoding: ASCII-8BIT
+      string: |2
+
+        <soap:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:v1="http://viers.va.gov/cdi/CDI/commonService/v2" xmlns:v12="http://viers.va.gov/cdi/eMIS/RequestResponse/v2" xmlns:v13="http://viers.va.gov/cdi/eMIS/commonService/v2" xmlns:v11="http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v2">
+          <soap:Header>
+            <v1:inputHeaderInfo>
+              <v1:userId>vets.gov</v1:userId>
+              <v1:sourceSystemName>vets.gov</v1:sourceSystemName>
+              <v1:transactionId>9eac7549-8c2e-4f83-8a5a-b33d326b0a6e</v1:transactionId>
+            </v1:inputHeaderInfo>
+          </soap:Header>
+          <soap:Body>
+            <v11:eMISserviceEpisodeRequest>
+              <v12:edipiORicn>
+                <v13:edipiORicnValue>1007697216</v13:edipiORicnValue>
+                <v13:inputType>EDIPI</v13:inputType>
+              </v12:edipiORicn>
+            </v11:eMISserviceEpisodeRequest>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Accept:
+      - text/xml;charset=UTF-8
+      Content-Type:
+      - application/soap+xml;charset=UTF-8
+      User-Agent:
+      - Vets.gov Agent
+      Soapaction:
+      - http://viers.va.gov/cdi/eMIS/getMilitaryServiceEpisodes/v2
+      Date:
+      - Wed, 27 Nov 2019 19:29:58 GMT
+      Content-Length:
+      - '949'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Nov 2019 19:30:00 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Content-Length:
+      - '2246'
+      Cache-Control:
+      - max-age=0, no-store
+      Content-Type:
+      - application/soap+xml;charset=utf-8
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?> <NS1:Envelope xmlns:NS1="http://www.w3.org/2003/05/soap-envelope"> <NS1:Header> <NS2:essResponseCode xmlns:NS2="http://va.gov/ess/message/v1">Success</NS2:essResponseCode> <NS3:inputHeaderInfo xmlns:NS3="http://viers.va.gov/cdi/CDI/commonService/v2"> <NS3:userId>vets.gov</NS3:userId> <NS3:sourceSystemName>vets.gov</NS3:sourceSystemName> <NS3:transactionId>9eac7549-8c2e-4f83-8a5a-b33d326b0a6e</NS3:transactionId> </NS3:inputHeaderInfo> </NS1:Header> <NS1:Body> <NS4:eMISserviceEpisodeResponse xmlns:NS4="http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v2"> <NS5:militaryServiceEpisode xmlns:NS5="http://viers.va.gov/cdi/eMIS/RequestResponse/v2"> <NS6:edipi xmlns:NS6="http://viers.va.gov/cdi/eMIS/commonService/v2">1007697216</NS6:edipi> <NS7:keyData xmlns:NS7="http://viers.va.gov/cdi/eMIS/commonService/v2"> <NS7:personnelOrganizationCode>51</NS7:personnelOrganizationCode> <NS7:personnelCategoryTypeCode>N</NS7:personnelCategoryTypeCode> <NS7:personnelSegmentIdentifier>1</NS7:personnelSegmentIdentifier> </NS7:keyData> <NS8:militaryServiceEpisodeData xmlns:NS8="http://viers.va.gov/cdi/eMIS/commonService/v2"> <NS8:serviceEpisodeStartDate>2010-02-02</NS8:serviceEpisodeStartDate> <NS8:serviceEpisodeEndDate>2016-12-01</NS8:serviceEpisodeEndDate> <NS8:serviceEpisodeTerminationReason>S</NS8:serviceEpisodeTerminationReason> <NS8:branchOfServiceCode>A</NS8:branchOfServiceCode> <NS8:dischargeCharacterOfServiceCode>B</NS8:dischargeCharacterOfServiceCode> <NS8:personnelStatusChangeTransactionTypeCode>343</NS8:personnelStatusChangeTransactionTypeCode> <NS8:narrativeReasonForSeparationCode>999</NS8:narrativeReasonForSeparationCode> <NS8:narrativeReasonForSeparationTxt>UNKNOWN</NS8:narrativeReasonForSeparationTxt> <NS8:mgadLossCategoryCode>11</NS8:mgadLossCategoryCode> <NS8:payPlanCode>MW</NS8:payPlanCode> <NS8:payGradeCode>04</NS8:payGradeCode> <NS8:serviceRankNameCode>CW4</NS8:serviceRankNameCode> <NS8:serviceRankNameTxt>Chief Warrant Officer</NS8:serviceRankNameTxt> <NS8:payGradeDate>2010-02-02</NS8:payGradeDate> <NS8:activeDutyServiceAgreementQuantity>1</NS8:activeDutyServiceAgreementQuantity> </NS8:militaryServiceEpisodeData> </NS5:militaryServiceEpisode> <NS5:militaryServiceEpisode xmlns:NS5="http://viers.va.gov/cdi/eMIS/RequestResponse/v2"> <NS6:edipi xmlns:NS6="http://viers.va.gov/cdi/eMIS/commonService/v2">1007697216</NS6:edipi> <NS7:keyData xmlns:NS7="http://viers.va.gov/cdi/eMIS/commonService/v2"> <NS7:personnelOrganizationCode>51</NS7:personnelOrganizationCode> <NS7:personnelCategoryTypeCode>N</NS7:personnelCategoryTypeCode> <NS7:personnelSegmentIdentifier>1</NS7:personnelSegmentIdentifier> </NS7:keyData> <NS8:militaryServiceEpisodeData xmlns:NS8="http://viers.va.gov/cdi/eMIS/commonService/v2"> <NS8:serviceEpisodeStartDate>2002-02-02</NS8:serviceEpisodeStartDate> <NS8:serviceEpisodeTerminationReason>S</NS8:serviceEpisodeTerminationReason> <NS8:branchOfServiceCode>A</NS8:branchOfServiceCode> <NS8:dischargeCharacterOfServiceCode>B</NS8:dischargeCharacterOfServiceCode> <NS8:personnelStatusChangeTransactionTypeCode>343</NS8:personnelStatusChangeTransactionTypeCode> <NS8:narrativeReasonForSeparationCode>999</NS8:narrativeReasonForSeparationCode> <NS8:narrativeReasonForSeparationTxt>UNKNOWN</NS8:narrativeReasonForSeparationTxt> <NS8:mgadLossCategoryCode>11</NS8:mgadLossCategoryCode> <NS8:payPlanCode>MW</NS8:payPlanCode> <NS8:payGradeCode>04</NS8:payGradeCode> <NS8:serviceRankNameCode>CW4</NS8:serviceRankNameCode> <NS8:serviceRankNameTxt>Chief Warrant Officer</NS8:serviceRankNameTxt> <NS8:payGradeDate>2002-02-02</NS8:payGradeDate> <NS8:activeDutyServiceAgreementQuantity>1</NS8:activeDutyServiceAgreementQuantity> </NS8:militaryServiceEpisodeData> </NS5:militaryServiceEpisode> </NS4:eMISserviceEpisodeResponse> </NS1:Body> </NS1:Envelope>
+    http_version: 
+  recorded_at: Wed, 27 Nov 2019 19:29:59 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
# Description

Veteran Verification service history endpoint will take into consideration episode end_dates that are null. If they are null, deployments with a start date closes to their own will be matched with them.

## Things to consider

Some test user behavior may change because of this PR. Some users that threw 500 errors on the service history endpoint will now have valid data. Also, the logic may order the array of service episodes or deployment in a different order, but they should remain equivalent.

## Testing 

User `va.api.user+idme.028@gmail.com` before the change

```json
500 
```

User `va.api.user+idme.028@gmail.com` before the change

```json
{
  "data": [
    {
      "id": "75f7f8c0-8412-58ea-8eb8-8062e2675c35",
      "type": "service_history_episodes",
      "attributes": {
        "first_name": "Sam",
        "last_name": "Gardner",
        "branch_of_service": "Navy",
        "start_date": "1989-04-03",
        "end_date": "1993-04-02",
        "pay_grade": "E05",
        "discharge_status": "honorable",
        "separation_reason": "COMPLETION OF REQUIRED ACTIVE SERVICE",
        "deployments": []
      }
    },
    {
      "id": "4fddd402-1d31-51b8-a63d-e1d9acac1284",
      "type": "service_history_episodes",
      "attributes": {
        "first_name": "Sam",
        "last_name": "Gardner",
        "branch_of_service": "Navy Reserve",
        "start_date": "1993-04-03",
        "end_date": "1997-04-30",
        "pay_grade": "E05",
        "discharge_status": "honorable",
        "separation_reason": "COMPLETION OF REQUIRED ACTIVE SERVICE",
        "deployments": []
      }
    },
    {
      "id": "fb089b6d-63d1-521e-b6eb-387186e1231b",
      "type": "service_history_episodes",
      "attributes": {
        "first_name": "Sam",
        "last_name": "Gardner",
        "branch_of_service": "Army National Guard",
        "start_date": "2007-03-15",
        "end_date": null,
        "pay_grade": "E07",
        "discharge_status": "unknown",
        "separation_reason": "NOT APPLICABLE",
        "deployments": [
          {
            "start_date": "2017-12-05",
            "end_date": "2018-08-28",
            "location": "AX1"
          },
          {
            "start_date": "2016-12-01",
            "end_date": "2016-12-31",
            "location": "NN9"
          },
          {
            "start_date": "2011-12-01",
            "end_date": "2011-12-31",
            "location": "AX1"
          },
          {
            "start_date": "2011-01-20",
            "end_date": "2011-11-04",
            "location": "KWT"
          }
        ]
      }
    }
  ]
}
```