### PR TITLE
Flipper - Adding new email prior to company email change on July 12th

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -772,6 +772,7 @@ flipper:
     - tze@adhocteam.us
     - zurbergram@gmail.com
     - zmorel@governmentcio.com
+    - zachary.morel@gcio.com
 
 bgs:
   application: ~


### PR DESCRIPTION
## Description of change
GCIO is changing it's email for it's employees. I'd like to be ready when that happens.