### PR TITLE
Api 8264/slack auth borken

### DIFF
--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -46,7 +46,7 @@ This job failed at: #{Time.zone.at(params['failed_at'])}, and #{retried_at(param
       end
 
       def slack_api_token
-        Settings.modules_appeals_api.slack.api_token
+        Settings.modules_appeals_api.slack.api_key
       end
     end
   end

--- a/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
+++ b/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
@@ -18,7 +18,7 @@ module AppealsApi
       end
 
       it 'sends a network request' do
-        with_settings(Settings.modules_appeals_api.slack, api_token: 'api token',
+        with_settings(Settings.modules_appeals_api.slack, api_key: 'api token',
                                                           appeals_channel_id: 'slack channel id') do
           body = {
             text: SidekiqRetryNotifier.message_text(params),


### PR DESCRIPTION
[API-8264](https://vajira.max.gov/browse/API-8264)

This PR renames a key name to reflect what is actually in the devops repo. 