### PR TITLE
deprecate v1 HLR

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews_controller.rb
@@ -6,6 +6,7 @@ require 'appeals_api/form_schemas'
 class AppealsApi::V1::DecisionReviews::HigherLevelReviewsController < AppealsApi::ApplicationController
   include AppealsApi::JsonFormatValidation
   include AppealsApi::StatusSimulation
+  include AppealsApi::HeaderModification
 
   skip_before_action(:authenticate)
   before_action :validate_json_format, if: -> { request.post? }
@@ -22,22 +23,27 @@ class AppealsApi::V1::DecisionReviews::HigherLevelReviewsController < AppealsApi
   )['definitions']['hlrCreateParameters']['properties'].keys
 
   def create
+    deprecate(response: response, link: AppealsApi::HeaderModification::RELEASE_NOTES_LINK, sunset: sunset_date)
+
     @higher_level_review.save
     AppealsApi::HigherLevelReviewPdfSubmitJob.perform_async(@higher_level_review.id)
     render_higher_level_review
   end
 
   def validate
+    deprecate(response: response, link: AppealsApi::HeaderModification::RELEASE_NOTES_LINK, sunset: sunset_date)
     render json: validation_success
   end
 
   def schema
+    deprecate(response: response, link: AppealsApi::HeaderModification::RELEASE_NOTES_LINK, sunset: sunset_date)
     render json: AppealsApi::JsonSchemaToSwaggerConverter.remove_comments(
       AppealsApi::FormSchemas.new.schema(self.class::FORM_NUMBER)
     )
   end
 
   def show
+    deprecate(response: response, link: AppealsApi::HeaderModification::RELEASE_NOTES_LINK, sunset: sunset_date)
     @higher_level_review = with_status_simulation(@higher_level_review) if status_requested_and_allowed?
     render_higher_level_review
   end
@@ -121,5 +127,9 @@ class AppealsApi::V1::DecisionReviews::HigherLevelReviewsController < AppealsApi
 
   def render_higher_level_review
     render json: AppealsApi::HigherLevelReviewSerializer.new(@higher_level_review).serializable_hash
+  end
+
+  def sunset_date
+    Date.new(2022, 1, 31)
   end
 end

--- a/modules/appeals_api/app/controllers/concerns/appeals_api/header_modification.rb
+++ b/modules/appeals_api/app/controllers/concerns/appeals_api/header_modification.rb
@@ -7,10 +7,12 @@ module AppealsApi
     included do
       V1_DEV_DOCS = 'https://developer.va.gov/explore/appeals/docs/decision_reviews?version=1.0.0'
       V2_DEV_DOCS = 'https://developer.va.gov/explore/appeals/docs/decision_reviews?version=2.0.0'
+      RELEASE_NOTES_LINK = 'https://developer.va.gov/release-notes/appeals'
 
-      def deprecate(response:, link: nil)
+      def deprecate(response:, link: nil, sunset: nil)
         response.headers['Deprecation'] = 'true'
         response.headers['Link'] = link if link.present?
+        response.headers['Sunset'] = sunset if sunset.present?
       end
     end
   end


### PR DESCRIPTION
[API-8154](https://vajira.max.gov/browse/API-8154)

This PR adds deprecation headers to the HLR v1 endpoints, with a link to the release notes and a sunset date
(2022-01-31)