### PR TITLE
[7311] Reducing number of queries that Flipper calls when the Feature…

### DIFF
--- a/app/controllers/v0/feature_toggles_controller.rb
+++ b/app/controllers/v0/feature_toggles_controller.rb
@@ -21,9 +21,10 @@ module V0
 
         # returning both camel and snakecase for uniformity on FE
         FLIPPER_FEATURE_CONFIG['features'].collect do |feature_name, values|
+          flipper_enabled = Flipper.enabled?(feature_name, actor(values['actor_type']))
           features << { name: feature_name.camelize(:lower),
-                        value: Flipper.enabled?(feature_name, actor(values['actor_type'])) }
-          features << { name: feature_name, value: Flipper.enabled?(feature_name, actor(values['actor_type'])) }
+                        value: flipper_enabled }
+          features << { name: feature_name, value: flipper_enabled }
         end
       end
 


### PR DESCRIPTION
…TogglesController is called

## Description of change
This change just saves a `Flipper.enabled?` function call so it can be called multiple times without a query in the `FeatureTogglesController`

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/7311

## Things to know about this PR
- Shouldn't have any impact on prod
- This was tested by signing into localhost and confirming that `feature_toggles` endpoint was successfully called and returned expected data.
