### PR TITLE
26500 Add statsd to feature caching

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -138,7 +138,7 @@ StatsD.increment(Form1010cg::Auditor.metrics.submission.failure.client.data, 0)
 StatsD.increment(Form1010cg::Auditor.metrics.submission.failure.client.qualification, 0)
 StatsD.increment(Form1010cg::Auditor.metrics.pdf_download, 0)
 
-# init form 526 - disability compenstation
+# init form 526 - disability compensation
 StatsD.increment("#{EVSS::Service::STATSD_KEY_PREFIX}.submit_form526.total", 0)
 StatsD.increment("#{EVSS::Service::STATSD_KEY_PREFIX}.submit_form526.fail", 0)
 
@@ -168,6 +168,14 @@ ActiveSupport::Notifications.subscribe('process_action.action_controller') do |_
           "status:#{payload[:status]}"]
   StatsD.measure('api.request.db_runtime', payload[:db_runtime].to_i, tags: tags)
   StatsD.measure('api.request.view_runtime', payload[:view_runtime].to_i, tags: tags)
+end
+
+# Flipper features cache stats
+Flipper.adapter.instrumenter.subscribe(/cache_.*\.active_support/) do |name, start, finish, id, payload|
+  hit_or_miss = payload[:hit] ? 'cache_hit' : 'cache_miss'
+
+  StatsD.increment("cache.#{hit_or_miss}.#{id}", 1)
+  StatsD.measure(name, finish - start)
 end
 
 # init gibft


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- Adding StatsD to ActiveSupport caching on the Flipper adapter so that we can pull data on cache hit/miss statistics for the MemoryStore cache currently used by the FeatureToggles functionality in production environments.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#26500

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
