### PR TITLE
24945 change sorting of daily summary report email

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ PATH
 
 GEM
   remote: https://rubygems.org/
+  remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.1.0)
     aasm (5.2.0)
@@ -343,6 +344,7 @@ GEM
     e2mmap (0.1.0)
     ecma-re-validator (0.3.0)
       regexp_parser (~> 2.0)
+    einhorn (0.8.2)
     encryptor (3.0.0)
     erubi (1.10.0)
     et-orbi (1.2.4)
@@ -844,6 +846,13 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    sidekiq-ent (2.2.2)
+      einhorn (>= 0.7.4)
+      sidekiq (>= 6.1.1)
+      sidekiq-pro (>= 5.1.1)
+    sidekiq-pro (5.2.1)
+      connection_pool (>= 2.2.3)
+      sidekiq (>= 6.1.0)
     sidekiq-scheduler (3.1.0)
       e2mmap
       redis (>= 3, < 5)
@@ -1096,6 +1105,8 @@ DEPENDENCIES
   sentry-raven
   shrine
   sidekiq (< 7)
+  sidekiq-ent!
+  sidekiq-pro!
   sidekiq-scheduler (~> 3.1)
   simplecov
   slack-notify

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,6 @@ PATH
 
 GEM
   remote: https://rubygems.org/
-  remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.1.0)
     aasm (5.2.0)
@@ -344,7 +343,6 @@ GEM
     e2mmap (0.1.0)
     ecma-re-validator (0.3.0)
       regexp_parser (~> 2.0)
-    einhorn (0.8.2)
     encryptor (3.0.0)
     erubi (1.10.0)
     et-orbi (1.2.4)
@@ -846,13 +844,6 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sidekiq-ent (2.2.2)
-      einhorn (>= 0.7.4)
-      sidekiq (>= 6.1.1)
-      sidekiq-pro (>= 5.1.1)
-    sidekiq-pro (5.2.1)
-      connection_pool (>= 2.2.3)
-      sidekiq (>= 6.1.0)
     sidekiq-scheduler (3.1.0)
       e2mmap
       redis (>= 3, < 5)
@@ -1105,8 +1096,6 @@ DEPENDENCIES
   sentry-raven
   shrine
   sidekiq (< 7)
-  sidekiq-ent!
-  sidekiq-pro!
   sidekiq-scheduler (~> 3.1)
   simplecov
   slack-notify

--- a/app/workers/vre/create_ch31_submissions_report.rb
+++ b/app/workers/vre/create_ch31_submissions_report.rb
@@ -5,6 +5,10 @@ module VRE
     require 'csv'
     include Sidekiq::Worker
 
+    def initialize
+      @time = Time.zone.now
+    end
+
     def updated_at_range
       (@time - 24.hours)..(@time - 1.second)
     end
@@ -18,7 +22,6 @@ module VRE
     end
 
     def perform
-      @time = Time.zone.now
       submitted_claims = get_claims_submitted_in_range
       Ch31SubmissionsReportMailer.build(submitted_claims).deliver_now
     end

--- a/app/workers/vre/create_ch31_submissions_report.rb
+++ b/app/workers/vre/create_ch31_submissions_report.rb
@@ -16,9 +16,7 @@ module VRE
     def get_claims_submitted_in_range
       SavedClaim::VeteranReadinessEmploymentClaim.where(
         updated_at: updated_at_range
-      )
-
-      # .sort_by{ |claim| claim.parsed_form['veteranInformation']['regionalOffice'] }
+      ).sort_by { |claim| claim.parsed_form['veteranInformation']['regionalOffice'] }
     end
 
     def perform

--- a/app/workers/vre/create_ch31_submissions_report.rb
+++ b/app/workers/vre/create_ch31_submissions_report.rb
@@ -13,12 +13,13 @@ module VRE
       SavedClaim::VeteranReadinessEmploymentClaim.where(
         updated_at: updated_at_range
       )
+
+      # .sort_by{ |claim| claim.parsed_form['veteranInformation']['regionalOffice'] }
     end
 
     def perform
       @time = Time.zone.now
       submitted_claims = get_claims_submitted_in_range
-
       Ch31SubmissionsReportMailer.build(submitted_claims).deliver_now
     end
   end

--- a/spec/factories/veteran_readiness_employment_claim.rb
+++ b/spec/factories/veteran_readiness_employment_claim.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
   factory :veteran_readiness_employment_claim, class: SavedClaim::VeteranReadinessEmploymentClaim do
     form_id { '28-1900' }
 
+    transient do
+      regional_office { '317 - St. Petersburg' }
+    end
+
     form {
       {
         'useEva' => true,
@@ -43,7 +47,7 @@ FactoryBot.define do
           'pid' => '600036503',
           'edipi' => '1005354478',
           'vet360ID' => nil,
-          'regionalOffice' => '317 - St. Petersburg'
+          'regionalOffice' => regional_office
         }
       }.to_json
     }

--- a/spec/workers/vre/create_ch31_submissions_report_spec.rb
+++ b/spec/workers/vre/create_ch31_submissions_report_spec.rb
@@ -10,8 +10,8 @@ describe VRE::CreateCh31SubmissionsReport do
 
     it 'sorts them by Regional Office' do
       expected = [vre_claim2.id, vre_claim3.id, vre_claim1.id]
-      result = described_class.new.get_claims_submitted_in_range.ids
-      expect(result).to contain_exactly(expected)
+      result = described_class.new.get_claims_submitted_in_range.map(&:id)
+      expect(result).to eq(expected)
     end
   end
 end

--- a/spec/workers/vre/create_ch31_submissions_report_spec.rb
+++ b/spec/workers/vre/create_ch31_submissions_report_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe VRE::CreateCh31SubmissionsReport do
+  describe '#perform' do
+
+    let(:vre_claim1) { create :veteran_readiness_employment_claim, regional_office: '377 - San Diego', updated_at: 3.minutes.ago }
+    let(:vre_claim2) { create :veteran_readiness_employment_claim, regional_office: '349 - Waco', updated_at: 2.minutes.ago }
+    let(:vre_claim3) { create :veteran_readiness_employment_claim, regional_office: '351 - Muskogee', updated_at: 1.minutes.ago }
+
+    it 'sorts them by Regional Office' do
+      claims = [vre_claim2, vre_claim3, vre_claim1]
+      # expect_any_instance_of(Ch31SubmissionsReportMailer).to receive(:build).with(contain_exactly(claims))
+
+      new_thing = described_class.new
+      result = new_thing.get_claims_submitted_in_range
+      expected =
+
+      expect(result).to eq(expected)
+
+      # described_class.new.perform
+    end
+  end
+end

--- a/spec/workers/vre/create_ch31_submissions_report_spec.rb
+++ b/spec/workers/vre/create_ch31_submissions_report_spec.rb
@@ -4,9 +4,15 @@ require 'rails_helper'
 
 describe VRE::CreateCh31SubmissionsReport do
   describe '#get_claims_submitted_in_range' do
-    let!(:vre_claim1) { create :veteran_readiness_employment_claim, regional_office: '377 - San Diego', updated_at: 3.minutes.ago }
-    let!(:vre_claim2) { create :veteran_readiness_employment_claim, regional_office: '349 - Waco', updated_at: 2.minutes.ago }
-    let!(:vre_claim3) { create :veteran_readiness_employment_claim, regional_office: '351 - Muskogee', updated_at: 1.minutes.ago }
+    let!(:vre_claim1) do
+      create :veteran_readiness_employment_claim, regional_office: '377 - San Diego', updated_at: 3.minutes.ago
+    end
+    let!(:vre_claim2) do
+      create :veteran_readiness_employment_claim, regional_office: '349 - Waco', updated_at: 2.minutes.ago
+    end
+    let!(:vre_claim3) do
+      create :veteran_readiness_employment_claim, regional_office: '351 - Muskogee', updated_at: 1.minute.ago
+    end
 
     it 'sorts them by Regional Office' do
       expected = [vre_claim2.id, vre_claim3.id, vre_claim1.id]

--- a/spec/workers/vre/create_ch31_submissions_report_spec.rb
+++ b/spec/workers/vre/create_ch31_submissions_report_spec.rb
@@ -4,22 +4,14 @@ require 'rails_helper'
 
 describe VRE::CreateCh31SubmissionsReport do
   describe '#perform' do
-
-    let(:vre_claim1) { create :veteran_readiness_employment_claim, regional_office: '377 - San Diego', updated_at: 3.minutes.ago }
-    let(:vre_claim2) { create :veteran_readiness_employment_claim, regional_office: '349 - Waco', updated_at: 2.minutes.ago }
-    let(:vre_claim3) { create :veteran_readiness_employment_claim, regional_office: '351 - Muskogee', updated_at: 1.minutes.ago }
+    let!(:vre_claim1) { create :veteran_readiness_employment_claim, regional_office: '377 - San Diego', updated_at: 3.minutes.ago }
+    let!(:vre_claim2) { create :veteran_readiness_employment_claim, regional_office: '349 - Waco', updated_at: 2.minutes.ago }
+    let!(:vre_claim3) { create :veteran_readiness_employment_claim, regional_office: '351 - Muskogee', updated_at: 1.minutes.ago }
 
     it 'sorts them by Regional Office' do
-      claims = [vre_claim2, vre_claim3, vre_claim1]
-      # expect_any_instance_of(Ch31SubmissionsReportMailer).to receive(:build).with(contain_exactly(claims))
-
-      new_thing = described_class.new
-      result = new_thing.get_claims_submitted_in_range
-      expected =
-
-      expect(result).to eq(expected)
-
-      # described_class.new.perform
+      expected = [vre_claim2.id, vre_claim3.id, vre_claim1.id]
+      result = described_class.new.get_claims_submitted_in_range.ids
+      expect(result).to contain_exactly(expected)
     end
   end
 end

--- a/spec/workers/vre/create_ch31_submissions_report_spec.rb
+++ b/spec/workers/vre/create_ch31_submissions_report_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe VRE::CreateCh31SubmissionsReport do
-  describe '#perform' do
+  describe '#get_claims_submitted_in_range' do
     let!(:vre_claim1) { create :veteran_readiness_employment_claim, regional_office: '377 - San Diego', updated_at: 3.minutes.ago }
     let!(:vre_claim2) { create :veteran_readiness_employment_claim, regional_office: '349 - Waco', updated_at: 2.minutes.ago }
     let!(:vre_claim3) { create :veteran_readiness_employment_claim, regional_office: '351 - Muskogee', updated_at: 1.minutes.ago }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This PR alters the order (from `created_at` ASC using SQL to `regionalOffice` using `sort_by` since the form data is encrypted) of the Veteran Readiness Employment Claims that is provided to the Ch31 Submissions Report.

## Original issue(s)
department-of-veterans-affairs/va.gov-team/issues/24945

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
There is a new spec to describe the new functionality.