### PR TITLE
Remove feature flag: spool_testing_error_1 

### DIFF
--- a/app/workers/education_form/create_daily_spool_files.rb
+++ b/app/workers/education_form/create_daily_spool_files.rb
@@ -88,32 +88,28 @@ module EducationForm
         filename = "#{region_id}_#{Time.zone.now.strftime('%m%d%Y_%H%M%S')}_vetsgov.spl"
         spool_file_event = SpoolFileEvent.build_event(region_id, filename)
 
-        if Flipper.enabled?(:spool_testing_error_1) && spool_file_event.successful_at.present?
-          log_info("A spool file for #{region_id} on #{Time.zone.now.strftime('%m%d%Y')} was already created")
-        else
-          log_submissions(records, filename)
-          # create the single textual spool file
-          contents = records.map(&:text).join(EducationForm::WINDOWS_NOTEPAD_LINEBREAK)
+        log_submissions(records, filename)
+        # create the single textual spool file
+        contents = records.map(&:text).join(EducationForm::WINDOWS_NOTEPAD_LINEBREAK)
 
-          begin
-            writer.write(contents, filename)
+        begin
+          writer.write(contents, filename)
 
-            # track and update the records as processed once the file has been successfully written
-            track_submissions(region_id)
+          # track and update the records as processed once the file has been successfully written
+          track_submissions(region_id)
 
-            records.each { |r| r.record.update(processed_at: Time.zone.now) }
-            spool_file_event.update(number_of_submissions: records.count, successful_at: Time.zone.now)
-          rescue => e
-            StatsD.increment("#{STATSD_FAILURE_METRIC}.#{region_id}")
-            attempt_msg = if spool_file_event.retry_attempt.zero?
-                            'initial attempt'
-                          else
-                            "attempt #{spool_file_event.retry_attempt}"
-                          end
-            exception = DailySpoolFileError.new("Error creating #{filename} during #{attempt_msg}.\n\n#{e}")
-            log_exception(exception, region)
-            next
-          end
+          records.each { |r| r.record.update(processed_at: Time.zone.now) }
+          spool_file_event.update(number_of_submissions: records.count, successful_at: Time.zone.now)
+        rescue => e
+          StatsD.increment("#{STATSD_FAILURE_METRIC}.#{region_id}")
+          attempt_msg = if spool_file_event.retry_attempt.zero?
+                          'initial attempt'
+                        else
+                          "attempt #{spool_file_event.retry_attempt}"
+                        end
+          exception = DailySpoolFileError.new("Error creating #{filename} during #{attempt_msg}.\n\n#{e}")
+          log_exception(exception, region)
+          next
         end
       end
     ensure

--- a/config/features.yml
+++ b/config/features.yml
@@ -282,9 +282,6 @@ features:
   show_new_view_test_lab_results_page:
     actor_type: user
     description: This will show the non-Cerner-user and Cerner-user content for the page /health-care/view-test-and-lab-results/
-  spool_testing_error_1:
-    actor_type: user
-    description: Enables spool_file_events tracking rows to be used to prevent multiple spool files per RPO per date
   spool_testing_error_2:
     actor_type: user
     description: Enables Slack notifications for CreateDailySpoolFiles

--- a/spec/jobs/education_form/create_daily_spool_files_spec.rb
+++ b/spec/jobs/education_form/create_daily_spool_files_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
       end
 
       it 'skips observed holidays' do
-        expect(Flipper).to receive(:enabled?).with(:spool_testing_error_1).and_return(false).at_least(:once)
         expect(Flipper).to receive(:enabled?).with(:spool_testing_error_2).and_return(false).at_least(:once)
 
         possible_runs.each do |day, should_run|
@@ -222,7 +221,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
 
       before do
         expect(Rails.env).to receive('development?').twice.and_return(true)
-        expect(Flipper).to receive(:enabled?).with(:spool_testing_error_1).twice.and_return(true)
         expect(Flipper).to receive(:enabled?).with(:spool_testing_error_2).and_return(false).at_least(:once)
       end
 
@@ -249,7 +247,6 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, type: :model, form: :educat
       before do
         expect(Rails.env).to receive('development?').once.and_return(true)
         expect(Flipper).to receive(:enabled?).with(:spool_testing_error_3).and_return(false).at_least(:once)
-        expect(Flipper).to receive(:enabled?).with(:spool_testing_error_1).and_return(true).at_least(:once)
         expect(Flipper).to receive(:enabled?).with(:spool_testing_error_2).and_return(false).at_least(:once)
       end
 


### PR DESCRIPTION
## Description of change
Removed `spool_testing_error_1` feature flag.  This feature was only used to manually cause an error state for testing on staging.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22044

## Things to know about this PR
- Tested locally and QA reviewed.
