### PR TITLE
adjustments to thresold and messages

### DIFF
--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_upload_status_updater.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_upload_status_updater.rb
@@ -20,7 +20,11 @@ module AppealsApi
     end
 
     def retry_limits_for_notification
-      [2, 5]
+      if Settings.vsp_environment == 'production'
+        [3]
+      else
+        [2, 4]
+      end
     end
 
     def notify(retry_params)

--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_upload_status_updater.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_upload_status_updater.rb
@@ -21,9 +21,9 @@ module AppealsApi
 
     def retry_limits_for_notification
       if Settings.vsp_environment == 'production'
-        [3]
-      else
         [2, 4]
+      else
+        [3]
       end
     end
 

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_upload_status_updater.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_upload_status_updater.rb
@@ -20,7 +20,11 @@ module AppealsApi
     end
 
     def retry_limits_for_notification
-      [2, 5]
+      if Settings.vsp_environment == 'production'
+        [3]
+      else
+        [2, 4]
+      end
     end
 
     def notify(retry_params)

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_upload_status_updater.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_upload_status_updater.rb
@@ -21,9 +21,9 @@ module AppealsApi
 
     def retry_limits_for_notification
       if Settings.vsp_environment == 'production'
-        [3]
-      else
         [2, 4]
+      else
+        [3]
       end
     end
 

--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -13,7 +13,8 @@ module AppealsApi
 
       def message_text(params)
         "
-        The sidekiq job #{params['class']} has hit #{params['retry_count']} retries.
+        ENVIRONMENT: #{Settings.vsp_environment}
+        The sidekiq job #{params['class']} has hit #{params['retry_count'] + 1} retries.
         \nError Type: #{params['error_class']} \n Error Message: \n #{params['error_message']} \n\n
 This job failed at: #{Time.zone.at(params['failed_at'])}, and #{retried_at(params['retried_at'])}
         "

--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -13,7 +13,7 @@ module AppealsApi
 
       def message_text(params)
         "
-        ENVIRONMENT: #{Settings.vsp_environment}
+        ENVIRONMENT: #{Settings.vsp_environment} \n
         The sidekiq job #{params['class']} has hit #{params['retry_count'] + 1} retries.
         \nError Type: #{params['error_class']} \n Error Message: \n #{params['error_message']} \n\n
 This job failed at: #{Time.zone.at(params['failed_at'])}, and #{retried_at(params['retried_at'])}


### PR DESCRIPTION
[API-8396](https://vajira.max.gov/browse/API-8396)

This PR makes a few adjustments to the sidekiq retry notifier message and thresholds.

For the StatusUpdater job for both HLR and NOD, it was a bit noisy in the lower environments, so we've changed the thresholds to reflect that.

Additionally the message has been updated to be more accurate regarding the retry, and the environment was added.