### PR TITLE
Added Jim and Candy to flipper toggles

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -701,6 +701,7 @@ flipper:
     - alastair@adhocteam.us
     - anna@adhoc.team
     - bill.ryan@adhocteam.us
+    - clark@governmentcio.com # Designer on GCIO
     - cameron@oddball.io
     - cory.trimm@va.gov
     - cwheeler@governmentcio.com
@@ -718,6 +719,7 @@ flipper:
     - hshin@thoughtworks.com
     - jacob.gacek@thoughtworks.com
     - jbalboni@gmail.com
+    - james.adams2@va.gov # Jim Adams designer on GCIO
     - jeff@adhocteam.us
     - jennie.mcgibney@va.gov
     - jesse.cohn@adhocteam.us


### PR DESCRIPTION
Jim and Candy are designers on our team and often run research sessions with Veterans. It would be helpful to get them added to the flipper list of admin emails so they can add participants in a pinch if they need to. This PR adds them to the list.