### PR TITLE
API-8244: SpecialIssueUpdater Background Job Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Vets API
 
-
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0%201.0-lightgrey.svg)](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Vets API
 
+
 [![Build Status](http://jenkins.vfs.va.gov/buildStatus/icon?job=testing/vets-api/master)](http://jenkins.vfs.va.gov/job/builds/job/vets-api/)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/department-of-veterans-affairs/vets-api)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0%201.0-lightgrey.svg)](LICENSE.md)

--- a/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
+++ b/modules/claims_api/app/workers/claims_api/special_issue_updater.rb
@@ -87,6 +87,8 @@ module ClaimsApi
         contention = contentions.find { |c| matches_contention?(contention_id, c) }
         return claim if contention.present?
       end
+
+      nil
     end
 
     # Generate expected payload for updating special issues through BGS


### PR DESCRIPTION
## Description of change
Unexpected error was noticed in sentry with regards to our background job to update special issues for a claim submission.
This appears to be happening in the situation where the Veteran has more than one contention but none of them match the particular claims that was submitted.

## Original issue(s)
https://vajira.max.gov/browse/API-8244

## Things to know about this PR
No new tests are present because there was already an existing test for this exact situation. It was unfortunately already "passing" because it simply detected if an exception was raised (which causes the job to be queued back up).
