### PR TITLE
2685 providing explicit prefetch routes for safari

### DIFF
--- a/modules/check_in/config/routes.rb
+++ b/modules/check_in/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 CheckIn::Engine.routes.draw do
+  match '/check_in/v0/*path', to: 'application#cors_preflight', via: [:options]
+
   namespace :v0, defaults: { format: :json } do
     resources :patient_check_ins, only: %i[show create]
   end

--- a/modules/health_quest/config/routes.rb
+++ b/modules/health_quest/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 HealthQuest::Engine.routes.draw do
+  match '/health_quest/v0/*path', to: 'application#cors_preflight', via: [:options]
+
   namespace :v0, defaults: { format: :json } do
     resources :lighthouse_appointments, only: %i[index show]
     resources :locations, only: %i[index show]


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
All latest browsers, mobile, and desktop alike implement a DNS prefetch feature which looks for links on a web page and attempt to resolve the DNS for those URLs via pre-flight calls to those server resources. The Safari mobile and desktop browsers seem to make these pre-flight calls without closing the connection to the server even though the request/response cycle has successfully completed.

This story attempts to provide a fix for the issue by explicitly catching the calls to the health_quest and check_in modules in their individual route files.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#2685

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec tests passing
- [x] Rubocop passing