### PR TITLE
adds Identity team as TUD module codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,3 +45,6 @@ spec/support/*/check_in/ @department-of-veterans-affairs/vsa-healthcare-health-q
 modules/facilities_api @department-of-veterans-affairs/vsa-facilities-backend @department-of-veterans-affairs/backend-review-group
 spec/support/*/facilities @department-of-veterans-affairs/vsa-facilities-backend @department-of-veterans-affairs/backend-review-group
 spec/support/*/lighthouse @department-of-veterans-affairs/vsa-facilities-backend @department-of-veterans-affairs/backend-review-group
+
+# test user dashboard product
+modules/test_user_dashboard @department-of-veterans-affairs/vsp-identity


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Adds the Identity team as codeowners for the `test_user_dashboard` module within vets-api