### PR TITLE
API-6719: Ensures new power of attorney has authorization to update Veteran's address

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -47,7 +47,7 @@ module ClaimsApi
 
           # This job only occurs when a Veteran submits a PoA request, they are not required to submit a document.
           ClaimsApi::PoaUpdater.perform_async(power_of_attorney.id) unless header_request?
-          if enable_vmbs_access?
+          if enable_vbms_access?
             ClaimsApi::VBMSUpdater.perform_async(power_of_attorney.id,
                                                  target_veteran.participant_id)
           end
@@ -130,7 +130,7 @@ module ClaimsApi
 
         private
 
-        def enable_vmbs_access?
+        def enable_vbms_access?
           form_attributes['recordConsent'] && form_attributes['consentLimits'].blank?
         end
 

--- a/modules/claims_api/app/workers/claims_api/vbms_updater.rb
+++ b/modules/claims_api/app/workers/claims_api/vbms_updater.rb
@@ -17,8 +17,12 @@ module ClaimsApi
         participant_id: participant_id,
         poa_code: poa_form.form_data.dig('serviceOrganization', 'poaCode'),
         allow_poa_access: 'y',
-        allow_poa_c_add: 'y'
+        allow_poa_c_add: allow_address_change?(poa_form) ? 'y' : 'n'
       )
+    end
+
+    def allow_address_change?(poa_form)
+      poa_form.form_data['consentAddressChange']
     end
   end
 end

--- a/modules/claims_api/spec/workers/vbms_updater_spec.rb
+++ b/modules/claims_api/spec/workers/vbms_updater_spec.rb
@@ -16,10 +16,37 @@ RSpec.describe ClaimsApi::VBMSUpdater, type: :job do
     headers
   end
 
-  it 'updates a the BIRLS record for a qualifying POA submittal' do
-    poa = create_poa
-    create_mock_lighthouse_service
-    subject.new.perform(poa.id, user.participant_id)
+  context 'when address change is present and allowed' do
+    let(:allow_poa_c_add) { 'y' }
+    let(:consent_address_change) { true }
+
+    it 'updates a the BIRLS record for a qualifying POA submittal' do
+      poa = create_poa
+      create_mock_lighthouse_service
+      subject.new.perform(poa.id, user.participant_id)
+    end
+  end
+
+  context 'when address change is present and not allowed' do
+    let(:allow_poa_c_add) { 'n' }
+    let(:consent_address_change) { false }
+
+    it 'updates a the BIRLS record for a qualifying POA submittal' do
+      poa = create_poa
+      create_mock_lighthouse_service
+      subject.new.perform(poa.id, user.participant_id)
+    end
+  end
+
+  context 'when address change is not present' do
+    let(:allow_poa_c_add) { 'n' }
+    let(:consent_address_change) { nil }
+
+    it 'updates a the BIRLS record for a qualifying POA submittal' do
+      poa = create_poa
+      create_mock_lighthouse_service
+      subject.new.perform(poa.id, user.participant_id)
+    end
   end
 
   private
@@ -27,13 +54,21 @@ RSpec.describe ClaimsApi::VBMSUpdater, type: :job do
   def create_poa
     poa = create(:power_of_attorney)
     poa.auth_headers = auth_headers
+    if consent_address_change.present?
+      poa.form_data = poa.form_data.merge('consentAddressChange' => consent_address_change)
+    end
     poa.save
     poa
   end
 
   def create_mock_lighthouse_service
     corporate_update_stub = BGS::Services.new(external_uid: 'uid', external_key: 'key').corporate_update
-    expect(corporate_update_stub).to receive(:update_poa_access)
+    expect(corporate_update_stub).to receive(:update_poa_access).with(
+      participant_id: user.participant_id,
+      poa_code: '074',
+      allow_poa_access: 'y',
+      allow_poa_c_add: allow_poa_c_add
+    )
     service_double = instance_double('BGS::Services')
     expect(service_double).to receive(:corporate_update).and_return(corporate_update_stub)
     expect(BGS::Services).to receive(:new).and_return(service_double)


### PR DESCRIPTION
## Description of change
Allows a power of attorney (poa change submitted through claims api) to change the address of that Veteran within VBMS.

## Original issue(s)
https://vajira.max.gov/browse/API-6719