### PR TITLE
[API-8289] - ClaimsApi prevent burial ITF submission from Veteran

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
@@ -22,6 +22,7 @@ module ClaimsApi
         # @return [JSON] Response from BGS
         def submit_form_0966
           validate_json_schema
+          check_for_invalid_burial_submission! if form_type == 'burial'
 
           bgs_response = bgs_service.intent_to_file.insert_intent_to_file(intent_to_file_options)
           render json: bgs_response,
@@ -62,17 +63,10 @@ module ClaimsApi
 
         private
 
-        def participant_claimant_id
-          error_detail = "Veteran cannot file for type 'burial'"
-          raise ::Common::Exceptions::Forbidden, detail: error_detail if veteran_submitting_burial_itf?
-
-          target_veteran.participant_id
-        end
-
         def intent_to_file_options
           {
             intent_to_file_type_code: ClaimsApi::IntentToFile::ITF_TYPES[form_type],
-            participant_claimant_id: form_attributes['participant_claimant_id'] || participant_claimant_id,
+            participant_claimant_id: form_attributes['participant_claimant_id'] || target_veteran.participant_id,
             participant_vet_id: form_attributes['participant_vet_id'] || target_veteran.participant_id,
             received_date: Time.zone.now.strftime('%Y-%m-%dT%H:%M:%S%:z'),
             submitter_application_icn_type_code: ClaimsApi::IntentToFile::SUBMITTER_CODE,
@@ -110,8 +104,20 @@ module ClaimsApi
           }
         end
 
+        def check_for_invalid_burial_submission!
+          error_detail = "Veteran cannot file for type 'burial'"
+          raise ::Common::Exceptions::Forbidden, detail: error_detail if veteran_submitting_burial_itf?
+
+          error_detail = 'unknown claimaint id'
+          raise ::Common::Exceptions::Forbidden, detail: error_detail unless request_includes_claimant_id?
+        end
+
         def veteran_submitting_burial_itf?
           form_type == 'burial' && !header_request?
+        end
+
+        def request_includes_claimant_id?
+          form_attributes['participant_claimant_id'].present?
         end
       end
     end

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
@@ -63,10 +63,10 @@ module ClaimsApi
         private
 
         def participant_claimant_id
-          return target_veteran.participant_id unless form_type == 'burial'
-          return target_veteran.participant_id unless header_request?
+          error_detail = "Veteran cannot file for type 'burial'"
+          raise ::Common::Exceptions::Forbidden, detail: error_detail if veteran_submitting_burial_itf?
 
-          raise ::Common::Exceptions::Forbidden, detail: "Representative cannot file for type 'burial'"
+          target_veteran.participant_id
         end
 
         def intent_to_file_options
@@ -108,6 +108,10 @@ module ClaimsApi
               }
             }
           }
+        end
+
+        def veteran_submitting_burial_itf?
+          form_type == 'burial' && !header_request?
         end
       end
     end

--- a/modules/claims_api/app/swagger/claims_api/v1/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v1/swagger.json
@@ -496,7 +496,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "06dc7a0d-e389-41de-ad7d-68afb0534941",
+                    "id": "df521e1d-8703-40b9-9adc-cfe818169494",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": 600118851,
@@ -545,11 +545,11 @@
                       "status": "Initial review",
                       "supporting_documents": [
                         {
-                          "id": "abda5cda-4da2-47ca-83c0-0c8815b5d3c3",
+                          "id": "cd28ce19-749c-439a-9ab3-22f78b65305d",
                           "type": "claim_supporting_document",
                           "md5": "d927c7e283b3158a54822a493d06181d",
                           "filename": "extras.pdf",
-                          "uploaded_at": "2021-06-29T22:13:49.692Z"
+                          "uploaded_at": "2021-07-01T20:38:00.199Z"
                         }
                       ]
                     }
@@ -2262,7 +2262,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "9a40794e-e02a-4ca2-9421-aede38fc1be1",
+                    "id": "eeb7d16a-fb3a-4848-9f97-5c9f07f2fc9e",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -2280,13 +2280,13 @@
                       "current_phase_back": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-29T22:13:50.108Z",
+                      "updated_at": "2021-07-01T20:38:00.716Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
 
                       ],
-                      "token": "9a40794e-e02a-4ca2-9421-aede38fc1be1",
+                      "token": "eeb7d16a-fb3a-4848-9f97-5c9f07f2fc9e",
                       "status": "pending",
                       "flashes": [
                         "Hardship",
@@ -3963,7 +3963,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "47c5692e-907b-42ec-93b8-4b35891d7ff8",
+                    "id": "2e67f6c2-f88d-4383-8d25-254e37a2801a",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -3981,13 +3981,13 @@
                       "current_phase_back": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-29T22:13:50.569Z",
+                      "updated_at": "2021-07-01T20:38:01.093Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
 
                       ],
-                      "token": "47c5692e-907b-42ec-93b8-4b35891d7ff8",
+                      "token": "2e67f6c2-f88d-4383-8d25-254e37a2801a",
                       "status": "pending",
                       "flashes": [
                         "Hardship",
@@ -6065,7 +6065,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "132c8138-c135-4c79-ac45-2ac00c3197c3",
+                    "id": "02adf3bb-2ab5-460d-9cac-1457769a98a5",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -6079,7 +6079,7 @@
                       "decision_letter_sent": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-06-29T22:13:51.349Z",
+                      "updated_at": "2021-07-01T20:38:01.875Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
@@ -6088,7 +6088,7 @@
                       "status": "pending",
                       "supporting_documents": [
                         {
-                          "id": "787ad6c6-3546-490d-9fbd-e8e64933ea98",
+                          "id": "5e8d3945-f92e-4795-8bca-5e3aeb201085",
                           "type": "claim_supporting_document",
                           "md5": null,
                           "filename": null,
@@ -6737,7 +6737,7 @@
                   "errors": [
                     {
                       "title": "Forbidden",
-                      "detail": "Representative cannot file for type 'burial'",
+                      "detail": "Veteran cannot file for type 'burial'",
                       "code": "403",
                       "status": "403"
                     }
@@ -8045,11 +8045,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "1d4e2532-778a-4316-a603-50012cd75a06",
+                    "id": "88c0f827-906d-4a14-832d-60ac338e8fea",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "pending",
-                      "date_request_accepted": "2021-06-29",
+                      "date_request_accepted": "2021-07-01",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"
@@ -8758,11 +8758,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "40e0e88d-fd02-4b75-a3d5-da05cb419b24",
+                    "id": "a7dee9f7-513b-4859-91eb-2e6bf3f6ae0b",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "submitted",
-                      "date_request_accepted": "2021-06-29",
+                      "date_request_accepted": "2021-07-01",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"
@@ -9083,11 +9083,11 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "2658068a-3eec-4640-9f5f-9eff677cbc20",
+                    "id": "42e1db55-8ff2-4c2e-b64d-c7815241ecae",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "submitted",
-                      "date_request_accepted": "2021-06-29",
+                      "date_request_accepted": "2021-07-01",
                       "representative": {
                         "service_organization": {
                           "poa_code": "074"

--- a/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
@@ -66,12 +66,35 @@ RSpec.describe 'Intent to file', type: :request do
       end
     end
 
-    it "returns a 403 when veteran is submitting for 'burial'" do
-      with_okta_user(scopes) do |auth_header|
-        VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file') do
-          data[:data][:attributes] = { type: 'burial' }
-          post path, params: data.to_json, headers: auth_header
-          expect(response.status).to eq(403)
+    describe "'burial' submission" do
+      it "returns a 403 when veteran is submitting for 'burial'" do
+        with_okta_user(scopes) do |auth_header|
+          VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file') do
+            data[:data][:attributes] = { type: 'burial' }
+            post path, params: data.to_json, headers: auth_header
+            expect(response.status).to eq(403)
+          end
+        end
+      end
+
+      it "returns a 403 when 'participant claimant id' is not provided" do
+        with_okta_user(scopes) do |auth_header|
+          VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file') do
+            data[:data][:attributes] = { type: 'burial' }
+            post path, params: data.to_json, headers: headers.merge(auth_header)
+            expect(response.status).to eq(403)
+          end
+        end
+      end
+
+      it "returns a 200 if the veteran is not the submitter and 'participant claimant id' is provided" do
+        with_okta_user(scopes) do |auth_header|
+          VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file') do
+            data[:attributes] = extra
+            data[:attributes][:type] = 'burial'
+            post path, params: data.to_json, headers: headers.merge(auth_header)
+            expect(response.status).to eq(200)
+          end
         end
       end
     end

--- a/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/intent_to_file_request_spec.rb
@@ -66,11 +66,11 @@ RSpec.describe 'Intent to file', type: :request do
       end
     end
 
-    it 'posts a 403 when a representative who doesn\'t have an MPI account tries to post type "burial"' do
+    it "returns a 403 when veteran is submitting for 'burial'" do
       with_okta_user(scopes) do |auth_header|
         VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file') do
           data[:data][:attributes] = { type: 'burial' }
-          post path, params: data.to_json, headers: headers.merge(auth_header)
+          post path, params: data.to_json, headers: auth_header
           expect(response.status).to eq(403)
         end
       end

--- a/modules/claims_api/spec/requests/v1/rswag_intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_intent_to_file_request_spec.rb
@@ -145,6 +145,9 @@ describe 'Intent to file', swagger_doc: 'v1/swagger.json' do # rubocop:disable R
             stub_mpi
 
             with_okta_user(scopes) do
+              expect_any_instance_of(
+                ClaimsApi::V1::Forms::IntentToFileController
+              ).to receive(:veteran_submitting_burial_itf?).and_return(true)
               VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file') do
                 submit_request(example.metadata)
               end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Adds logic to prevent case where Veteran would be submitting an ITF for their own burial.

## Original issue(s)
[API-8289](https://vajira.max.gov/browse/API-8289)