### PR TITLE
API-8413: Prevent user matching multiple accredited representatives from using system

### DIFF
--- a/lib/bgs/power_of_attorney_verifier.rb
+++ b/lib/bgs/power_of_attorney_verifier.rb
@@ -20,14 +20,13 @@ module BGS
     end
 
     def verify(user)
-      veteran_poa_code = current_poa_code
       reps = Veteran::Service::Representative.all_for_user(first_name: user.first_name,
-                                                           last_name: user.last_name,
-                                                           poa_code: veteran_poa_code)
+                                                           last_name: user.last_name)
       raise ::Common::Exceptions::Unauthorized, detail: 'VSO Representative Not Found' if reps.blank?
       raise ::Common::Exceptions::Unauthorized, detail: 'Ambiguous VSO Representative Results' if reps.count > 1
 
       rep = reps.first
+      veteran_poa_code = current_poa_code
       unless matches(veteran_poa_code, rep)
         Rails.logger.info("POA code of #{rep.poa_codes.join(', ')} not valid for veteran code #{veteran_poa_code}")
         raise ::Common::Exceptions::Unauthorized, detail: "Power of Attorney code doesn't match Veteran's"

--- a/lib/bgs/power_of_attorney_verifier.rb
+++ b/lib/bgs/power_of_attorney_verifier.rb
@@ -20,15 +20,17 @@ module BGS
     end
 
     def verify(user)
-      rep = Veteran::Service::Representative.for_user(first_name: user.first_name, last_name: user.last_name)
-      if rep.present?
-        veteran_poa_code = current_poa_code
-        unless matches(veteran_poa_code, rep)
-          Rails.logger.info("POA code of #{rep.poa_codes.join(', ')} not valid for veteran code #{veteran_poa_code}")
-          raise Common::Exceptions::Unauthorized, detail: "Power of Attorney code doesn't match Veteran's"
-        end
-      else
-        raise Common::Exceptions::Unauthorized, detail: 'VSO Representative Not Found'
+      veteran_poa_code = current_poa_code
+      reps = Veteran::Service::Representative.all_for_user(first_name: user.first_name,
+                                                           last_name: user.last_name,
+                                                           poa_code: veteran_poa_code)
+      raise ::Common::Exceptions::Unauthorized, detail: 'VSO Representative Not Found' if reps.blank?
+      raise ::Common::Exceptions::Unauthorized, detail: 'Ambiguous VSO Representative Results' if reps.count > 1
+
+      rep = reps.first
+      unless matches(veteran_poa_code, rep)
+        Rails.logger.info("POA code of #{rep.poa_codes.join(', ')} not valid for veteran code #{veteran_poa_code}")
+        raise ::Common::Exceptions::Unauthorized, detail: "Power of Attorney code doesn't match Veteran's"
       end
     end
 

--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -54,10 +54,12 @@ module ClaimsApi
       #
       # @return [Boolean] True if valid poa code, False if not
       def valid_poa_code_for_current_user?(poa_code)
-        representative = ::Veteran::Service::Representative.for_user(first_name: @current_user.first_name,
-                                                                     last_name: @current_user.last_name,
-                                                                     poa_code: poa_code)
-        representative.present?
+        reps = ::Veteran::Service::Representative.all_for_user(first_name: @current_user.first_name,
+                                                               last_name: @current_user.last_name)
+        return false if reps.blank?
+        raise ::Common::Exceptions::Unauthorized, detail: 'Ambiguous VSO Representative Results' if reps.count > 1
+
+        reps.first.poa_codes.include?(poa_code)
       end
 
       #

--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -55,10 +55,9 @@ module ClaimsApi
       # @return [Boolean] True if valid poa code, False if not
       def valid_poa_code_for_current_user?(poa_code)
         representative = ::Veteran::Service::Representative.for_user(first_name: @current_user.first_name,
-                                                                     last_name: @current_user.last_name)
-        return false if representative.blank?
-
-        representative.poa_codes.include?(poa_code)
+                                                                     last_name: @current_user.last_name,
+                                                                     poa_code: poa_code)
+        representative.present?
       end
 
       #

--- a/modules/veteran/app/models/veteran/service/representative.rb
+++ b/modules/veteran/app/models/veteran/service/representative.rb
@@ -19,26 +19,39 @@ module Veteran
 
       validates :poa_codes, presence: true
 
-      # rubocop:disable Lint/DuplicateBranch
-      def self.for_user(first_name:, last_name:, ssn: nil, dob: nil)
+      def self.all_for_user(first_name:, last_name:, ssn: nil, dob: nil, poa_code: nil)
         reps = where('lower(first_name) = ? AND lower(last_name) = ?', first_name.downcase, last_name.downcase)
-        reps.each do |rep|
-          if matching_ssn(rep, ssn) && matching_date_of_birth(rep, dob)
-            return rep
-          elsif rep.ssn.blank? && rep.dob.blank?
-            return rep
-          end
+
+        reps.select do |rep|
+          matching_ssn(rep, ssn) &&
+            matching_date_of_birth(rep, dob) &&
+            matching_poa_code(rep, poa_code)
         end
-        nil
       end
-      # rubocop:enable Lint/DuplicateBranch
+
+      def self.for_user(first_name:, last_name:, ssn: nil, dob: nil, poa_code: nil)
+        reps = all_for_user(first_name: first_name, last_name: last_name, ssn: ssn, dob: dob, poa_code: poa_code)
+        return nil if reps.blank?
+
+        reps.first
+      end
 
       def self.matching_ssn(rep, ssn)
+        return true if ssn.blank?
+
         rep.ssn.present? && rep.ssn == ssn
       end
 
       def self.matching_date_of_birth(rep, birth_date)
+        return true if birth_date.blank?
+
         rep.dob.present? && rep.dob == birth_date
+      end
+
+      def self.matching_poa_code(rep, poa_code)
+        return true if poa_code.blank?
+
+        rep.poa_codes.present? && rep.poa_codes.include?(poa_code)
       end
     end
   end

--- a/modules/veteran/app/models/veteran/service/representative.rb
+++ b/modules/veteran/app/models/veteran/service/representative.rb
@@ -19,6 +19,15 @@ module Veteran
 
       validates :poa_codes, presence: true
 
+      #
+      # Find all representatives that matches the provided search criteria
+      # @param first_name: [String] First name to search for, ignoring case
+      # @param last_name: [String] Last name to search for, ignoring case
+      # @param ssn: nil [String] SSN to search for
+      # @param dob: nil [String] Date of birth to search for
+      # @param poa_code: nil [String] POA code to search for
+      #
+      # @return [Array(Veteran::Service::Representative)] All representatives found using the submitted search criteria
       def self.all_for_user(first_name:, last_name:, ssn: nil, dob: nil, poa_code: nil)
         reps = where('lower(first_name) = ? AND lower(last_name) = ?', first_name.downcase, last_name.downcase)
 
@@ -29,6 +38,15 @@ module Veteran
         end
       end
 
+      #
+      # Find first representative that matches the provided search criteria
+      # @param first_name: [String] First name to search for, ignoring case
+      # @param last_name: [String] Last name to search for, ignoring case
+      # @param ssn: nil [String] SSN to search for
+      # @param dob: nil [String] Date of birth to search for
+      # @param poa_code: nil [String] POA code to search for
+      #
+      # @return [Veteran::Service::Representative] First representative record found using the submitted search criteria
       def self.for_user(first_name:, last_name:, ssn: nil, dob: nil, poa_code: nil)
         reps = all_for_user(first_name: first_name, last_name: last_name, ssn: ssn, dob: dob, poa_code: poa_code)
         return nil if reps.blank?
@@ -36,18 +54,39 @@ module Veteran
         reps.first
       end
 
+      #
+      # Determine if representative ssn matches submitted ssn search query
+      # @note Assumes that the consumer did not submit an ssn value if the value is blank
+      # @param rep [Veteran::Service::Representative] Representative to match soon with
+      # @param ssn [String] Submitted ssn to match against representative
+      #
+      # @return [Boolean] True if matches, false if not
       def self.matching_ssn(rep, ssn)
         return true if ssn.blank?
 
         rep.ssn.present? && rep.ssn == ssn
       end
 
+      #
+      # Determine if representative dob matches submitted birth_date search query
+      # @note Assumes that the consumer did not submit a birth_date value if the value is blank
+      # @param rep [Veteran::Service::Representative] Representative to match soon with
+      # @param birth_date [String] Submitted birth_date to match against representative
+      #
+      # @return [Boolean] True if matches, false if not
       def self.matching_date_of_birth(rep, birth_date)
         return true if birth_date.blank?
 
         rep.dob.present? && rep.dob == birth_date
       end
 
+      #
+      # Determine if representative poa_codes contains submitted poa_code search query
+      # @note Assumes that the consumer did not submit a poa_code value if the value is blank
+      # @param rep [Veteran::Service::Representative] Representative to match soon with
+      # @param poa_code [String] Submitted poa_code to match against representative
+      #
+      # @return [Boolean] True if matches, false if not
       def self.matching_poa_code(rep, poa_code)
         return true if poa_code.blank?
 

--- a/modules/veteran/app/models/veteran/service/representative.rb
+++ b/modules/veteran/app/models/veteran/service/representative.rb
@@ -25,16 +25,14 @@ module Veteran
       # @param last_name: [String] Last name to search for, ignoring case
       # @param ssn: nil [String] SSN to search for
       # @param dob: nil [String] Date of birth to search for
-      # @param poa_code: nil [String] POA code to search for
       #
       # @return [Array(Veteran::Service::Representative)] All representatives found using the submitted search criteria
-      def self.all_for_user(first_name:, last_name:, ssn: nil, dob: nil, poa_code: nil)
+      def self.all_for_user(first_name:, last_name:, ssn: nil, dob: nil)
         reps = where('lower(first_name) = ? AND lower(last_name) = ?', first_name.downcase, last_name.downcase)
 
         reps.select do |rep|
           matching_ssn(rep, ssn) &&
-            matching_date_of_birth(rep, dob) &&
-            matching_poa_code(rep, poa_code)
+            matching_date_of_birth(rep, dob)
         end
       end
 
@@ -44,11 +42,10 @@ module Veteran
       # @param last_name: [String] Last name to search for, ignoring case
       # @param ssn: nil [String] SSN to search for
       # @param dob: nil [String] Date of birth to search for
-      # @param poa_code: nil [String] POA code to search for
       #
       # @return [Veteran::Service::Representative] First representative record found using the submitted search criteria
-      def self.for_user(first_name:, last_name:, ssn: nil, dob: nil, poa_code: nil)
-        reps = all_for_user(first_name: first_name, last_name: last_name, ssn: ssn, dob: dob, poa_code: poa_code)
+      def self.for_user(first_name:, last_name:, ssn: nil, dob: nil)
+        reps = all_for_user(first_name: first_name, last_name: last_name, ssn: ssn, dob: dob)
         return nil if reps.blank?
 
         reps.first
@@ -78,19 +75,6 @@ module Veteran
         return true if birth_date.blank?
 
         rep.dob.present? && rep.dob == birth_date
-      end
-
-      #
-      # Determine if representative poa_codes contains submitted poa_code search query
-      # @note Assumes that the consumer did not submit a poa_code value if the value is blank
-      # @param rep [Veteran::Service::Representative] Representative to match soon with
-      # @param poa_code [String] Submitted poa_code to match against representative
-      #
-      # @return [Boolean] True if matches, false if not
-      def self.matching_poa_code(rep, poa_code)
-        return true if poa_code.blank?
-
-        rep.poa_codes.present? && rep.poa_codes.include?(poa_code)
       end
     end
   end

--- a/spec/lib/bgs/power_of_attorney_verifier_spec.rb
+++ b/spec/lib/bgs/power_of_attorney_verifier_spec.rb
@@ -78,7 +78,7 @@ describe BGS::PowerOfAttorneyVerifier do
       expect do
         BGS::PowerOfAttorneyVerifier.new(user).verify(identity)
       end.to raise_error(Common::Exceptions::Unauthorized)
-    end    
+    end
   end
 
   it 'raises an exception if representative not found' do

--- a/spec/lib/bgs/power_of_attorney_verifier_spec.rb
+++ b/spec/lib/bgs/power_of_attorney_verifier_spec.rb
@@ -40,7 +40,7 @@ describe BGS::PowerOfAttorneyVerifier do
   end
 
   context 'when multiple representatives have the same name' do
-    it 'does not raise an exception if poa matches' do
+    it 'raises an exception if poa matches' do
       FactoryBot.create(
         :representative,
         representative_id: '1234',
@@ -57,7 +57,7 @@ describe BGS::PowerOfAttorneyVerifier do
       )
       expect do
         BGS::PowerOfAttorneyVerifier.new(user).verify(identity)
-      end.not_to raise_error
+      end.to raise_error(Common::Exceptions::Unauthorized)
     end
 
     it 'raises an exception if poa does not matches' do

--- a/spec/lib/bgs/power_of_attorney_verifier_spec.rb
+++ b/spec/lib/bgs/power_of_attorney_verifier_spec.rb
@@ -39,6 +39,48 @@ describe BGS::PowerOfAttorneyVerifier do
     end.to raise_error(Common::Exceptions::Unauthorized)
   end
 
+  context 'when multiple representatives have the same name' do
+    it 'does not raise an exception if poa matches' do
+      FactoryBot.create(
+        :representative,
+        representative_id: '1234',
+        poa_codes: ['A1Q'],
+        first_name: identity.first_name,
+        last_name: identity.last_name
+      )
+      FactoryBot.create(
+        :representative,
+        representative_id: '5678',
+        poa_codes: ['B1Q'],
+        first_name: identity.first_name,
+        last_name: identity.last_name
+      )
+      expect do
+        BGS::PowerOfAttorneyVerifier.new(user).verify(identity)
+      end.not_to raise_error
+    end
+
+    it 'raises an exception if poa does not matches' do
+      FactoryBot.create(
+        :representative,
+        representative_id: '1234',
+        poa_codes: ['A1Q'],
+        first_name: identity.first_name,
+        last_name: identity.last_name
+      )
+      FactoryBot.create(
+        :representative,
+        representative_id: '5678',
+        poa_codes: ['A1Q'],
+        first_name: identity.first_name,
+        last_name: identity.last_name
+      )
+      expect do
+        BGS::PowerOfAttorneyVerifier.new(user).verify(identity)
+      end.to raise_error(Common::Exceptions::Unauthorized)
+    end    
+  end
+
   it 'raises an exception if representative not found' do
     expect do
       BGS::PowerOfAttorneyVerifier.new(user).verify(identity)


### PR DESCRIPTION
## Description of change
We noticed an issue that can occur if a user is an accredited representative (not the Veteran themself) but has the same first and last name as another representative. A while back I was discovered there is at least one instance of duplicate first and last names within our current OGC data-set.

We've discussed alternative methods for matching a user to OGC data with the maintainers of OGC but unfortunately they dont store ssn or birthdate information. (and dont have any plan to in the near future)

This code change has the following effect:
In the small instances that an accredited representative both has the same first and last name, our system will respond with unauthorized to both users with the following message:
"Ambiguous VSO Representative Results"

## Original issue(s)
https://vajira.max.gov/browse/API-8413