### PR TITLE
API-8438 - Update status job error threshold in lower envs

### DIFF
--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_upload_status_updater.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_upload_status_updater.rb
@@ -23,7 +23,7 @@ module AppealsApi
       if Settings.vsp_environment == 'production'
         [2, 4]
       else
-        [3]
+        [5]
       end
     end
 

--- a/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_upload_status_updater.rb
+++ b/modules/appeals_api/app/workers/appeals_api/notice_of_disagreement_upload_status_updater.rb
@@ -23,7 +23,7 @@ module AppealsApi
       if Settings.vsp_environment == 'production'
         [2, 4]
       else
-        [3]
+        [5]
       end
     end
 


### PR DESCRIPTION
## Description of change
This error notification was firing off more than we wanted for the lower envs. Upping the threshold to try to quiet it down somewhat.

## Original issue(s)
https://vajira.max.gov/browse/API-8438