### PR TITLE
update schema with lighthouse changes

### DIFF
--- a/lib/decision_review/schemas/NOD_create_request_body_schema.json
+++ b/lib/decision_review/schemas/NOD_create_request_body_schema.json
@@ -68,7 +68,7 @@
         "homeless":            { "type": "boolean" },
         "address":             { "$ref": "#/definitions/nodCreateAddress" },
         "phone":               { "$ref": "#/definitions/nodCreatePhone" },
-        "emailAddressText":    { "$ref": "#/definitions/nodCreateEmail", "minLength": 5, "maxLength": 120 },
+        "emailAddressText":    { "$ref": "#/definitions/nodCreateEmail"},
         "representativesName": { "type": "string", "maxLength": 120 }
       },
       "required": ["homeless",  "phone", "emailAddressText"],
@@ -110,6 +110,8 @@
 
     "nodCreateEmail": {
       "type": "string",
+      "minLength": 6,
+      "maxLength": 255,
       "format": "email"
     },
 


### PR DESCRIPTION
## Description of change
[Lighthouse is updating](https://github.com/department-of-veterans-affairs/vets-api/pull/7353/files) its schema to allow for longer email addresses so we can too. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#21757

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
