### PR TITLE
update sql for InProgressForms to allow either case

### DIFF
--- a/app/models/in_progress_form.rb
+++ b/app/models/in_progress_form.rb
@@ -12,10 +12,16 @@ class InProgressForm < ApplicationRecord
   attr_accessor :skip_exipry_update
 
   RETURN_URL_SQL = "CAST(metadata -> 'returnUrl' AS text)"
-  scope :has_attempted_submit, -> { where("(metadata -> 'submission' ->> 'hasAttemptedSubmit')::boolean") }
+  scope :has_attempted_submit, lambda {
+                                 where("(metadata -> 'submission' ->> 'hasAttemptedSubmit')::boolean or "\
+                                       "(metadata -> 'submission' ->> 'has_attempted_submit')::boolean")
+                               }
   scope :has_errors,           -> { where("(metadata -> 'submission' -> 'errors') IS NOT NULL") }
   scope :has_no_errors,        -> { where.not("(metadata -> 'submission' -> 'errors') IS NOT NULL") }
-  scope :has_error_message,    -> { where("(metadata -> 'submission' -> 'errorMessage')::text !='false'") }
+  scope :has_error_message,    lambda {
+                                 where("(metadata -> 'submission' -> 'errorMessage')::text !='false' or "\
+                                       "(metadata -> 'submission' -> 'error_message')::text !='false' ")
+                               }
   # the double quotes in return_url are part of the value
   scope :return_url, ->(url) { where(%( #{RETURN_URL_SQL} = ? ), '"' + url + '"') }
 


### PR DESCRIPTION
## Description of change
it seems that InProgressForm metadata can be in either case (snake or camel), depending on how old it is, update sql to reflect this. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
