### PR TITLE
[17794] Add Sidekiq Retry Queue Size to Grafana

### DIFF
--- a/app/workers/sidekiq_stats_job.rb
+++ b/app/workers/sidekiq_stats_job.rb
@@ -21,6 +21,9 @@ class SidekiqStatsJob
     working = Sidekiq::ProcessSet.new.select { |p| p[:busy] == 1 }.count
     StatsD.gauge 'shared.sidekiq.stats.working', working
 
+    retry_size = Sidekiq::RetrySet.new.size
+    StatsD.gauge 'shared.sidekiq.stats.retry_size', retry_size
+
     info.queues.each do |name, size|
       StatsD.gauge "shared.sidekiq.#{name}.size", size
     end


### PR DESCRIPTION
## Description of change
Adds a new gauge to StatsD to report the retry queue size.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#17794

