### PR TITLE
add rack session config 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -70,7 +70,6 @@ module VetsAPI
     config.middleware.use OliveBranch::Middleware, inflection_header: 'X-Key-Inflection'
     config.middleware.use StatsdMiddleware
     config.middleware.use Rack::Attack
-    config.middleware.use Rack::Session::Cookie, key: 'rack.session', secret: Settings.rack.cookie_secret
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Flash
     config.middleware.insert_after ActionDispatch::Cookies,

--- a/config/application.rb
+++ b/config/application.rb
@@ -70,6 +70,7 @@ module VetsAPI
     config.middleware.use OliveBranch::Middleware, inflection_header: 'X-Key-Inflection'
     config.middleware.use StatsdMiddleware
     config.middleware.use Rack::Attack
+    config.middleware.use Rack::Session::Cookie, key: 'rack.session', secret: Settings.rack.cookie_secret
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Flash
     config.middleware.insert_after ActionDispatch::Cookies,

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,7 +7,6 @@ require 'sidekiq/error_tag'
 require 'sidekiq/semantic_logging'
 require 'sidekiq/set_request_id'
 require 'sidekiq/set_request_attributes'
-require 'sidekiq/web'
 
 Rails.application.reloader.to_prepare do
   Sidekiq::Enterprise.unique! if Rails.env.production?

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -10,9 +10,6 @@ require 'sidekiq/set_request_attributes'
 require 'sidekiq/web'
 
 Rails.application.reloader.to_prepare do
-  # Turn off Sidekiq's sessions, which overwrite the main Rails app's session
-  # after the first request
-  Sidekiq::Web.disable(:sessions)
   Sidekiq::Enterprise.unique! if Rails.env.production?
 
   Sidekiq.configure_server do |config|

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,8 +7,12 @@ require 'sidekiq/error_tag'
 require 'sidekiq/semantic_logging'
 require 'sidekiq/set_request_id'
 require 'sidekiq/set_request_attributes'
+require 'sidekiq/web'
 
 Rails.application.reloader.to_prepare do
+  # Turn off Sidekiq's sessions, which overwrite the main Rails app's session
+  # after the first request
+  Sidekiq::Web.set :sessions, false
   Sidekiq::Enterprise.unique! if Rails.env.production?
 
   Sidekiq.configure_server do |config|

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1047,3 +1047,6 @@ check_in:
     mock: false
     key_path: ~
     timeout: 30
+
+rack:
+  cookie_secret: ~

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -165,3 +165,6 @@ check_in:
     mock: false
     key_path: ~
     timeout: 30
+
+rack:
+  cookie_secret: "xxxxx"


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
adds Rack::Session::Cookie to config in order to persist the rack session 

[Devops PR](https://github.com/department-of-veterans-affairs/devops/pull/9533) with updated settings 
