### PR TITLE
Replace the mobile appointment facility and appointment type statsd metrics with log lines

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/va_appointments.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/va_appointments.rb
@@ -73,11 +73,7 @@ module Mobile
           end
 
           facilities.each do |facility_id|
-            StatsD.increment(
-              'mobile.appointments.facilities',
-              tags: ["facility_id:#{facility_id}"],
-              sample_rate: 1.0
-            )
+            Rails.logger.info('metric.mobile.appointment.facility', facility_id: facility_id)
           end
 
           [appointments, facilities]
@@ -127,9 +123,7 @@ module Mobile
             vetext_id: vetext_id(appointment_hash, start_date_local)
           }
 
-          StatsD.increment(
-            'mobile.appointments.type', tags: ["type:#{type}"], sample_rate: 0.1
-          )
+          Rails.logger.info('metric.mobile.appointment.type', type: type)
 
           model = Mobile::V0::Appointment.new(adapted_hash)
           facilities.add(model.id_for_address)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
To reduce the load on prometheus replace the statsd calls that collect facility and appointment type metrics in the mobile va appointment adapter with log lines. CloudWatch will then become the data source for those Grafana dashboards.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27058
