### PR TITLE
Kevin.cranmer/api 8294 s3 file remover bug

### DIFF
--- a/modules/vba_documents/app/workers/vba_documents/upload_remover.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_remover.rb
@@ -20,11 +20,13 @@ module VBADocuments
 
       VBADocuments::UploadSubmission.where(REMOVAL_QUERY, EXPIRATION_TIME.ago).find_each do |upload|
         Rails.logger.info('VBADocuments: Cleaning up s3: ' + upload.inspect)
-        break unless store.object(upload.guid).exists?
+        puts "-----\nUpload:#{upload.created_at}\n------\n"
+        next unless store.object(upload.guid).exists?
 
         store.delete(upload.guid)
         upload.update(s3_deleted: true)
       end
+      puts "\n\n\n\n"
     end
 
     def store

--- a/modules/vba_documents/app/workers/vba_documents/upload_remover.rb
+++ b/modules/vba_documents/app/workers/vba_documents/upload_remover.rb
@@ -20,13 +20,11 @@ module VBADocuments
 
       VBADocuments::UploadSubmission.where(REMOVAL_QUERY, EXPIRATION_TIME.ago).find_each do |upload|
         Rails.logger.info('VBADocuments: Cleaning up s3: ' + upload.inspect)
-        puts "-----\nUpload:#{upload.created_at}\n------\n"
         next unless store.object(upload.guid).exists?
 
         store.delete(upload.guid)
         upload.update(s3_deleted: true)
       end
-      puts "\n\n\n\n"
     end
 
     def store

--- a/modules/vba_documents/spec/factories/upload_submissions.rb
+++ b/modules/vba_documents/spec/factories/upload_submissions.rb
@@ -42,7 +42,7 @@ FactoryBot.define do
     detail { 'abc' * 500 }
     guid { '60719ee0-44fe-40ca-9b03-755fdb8c7884' }
   end
-  
+
   factory :upload_submission_manually_removed, class: 'VBADocuments::UploadSubmission' do
     guid { 'f7027a14-6abd-4087-b397-3d84d445f4c2' }
     status { 'received' }

--- a/modules/vba_documents/spec/factories/upload_submissions.rb
+++ b/modules/vba_documents/spec/factories/upload_submissions.rb
@@ -42,4 +42,11 @@ FactoryBot.define do
     detail { 'abc' * 500 }
     guid { '60719ee0-44fe-40ca-9b03-755fdb8c7884' }
   end
+  
+  factory :upload_submission_manually_removed, class: 'VBADocuments::UploadSubmission' do
+    guid { 'f7027a14-6abd-4087-b397-3d84d445f4c2' }
+    status { 'received' }
+    consumer_id { 'f7027a14-6abd-4087-b397-3d84d445f4c2' }
+    consumer_name { 'adhoc' }
+  end
 end

--- a/modules/vba_documents/spec/jobs/upload_remover_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_remover_spec.rb
@@ -60,7 +60,10 @@ RSpec.describe VBADocuments::UploadRemover, type: :job do
     end
 
     describe 'when a record was manually removed from s3' do
-      let(:upload_manually_removed) { FactoryBot.create(:upload_submission_manually_removed, status: 'received', s3_deleted: nil, created_at: 11.days.ago) }
+      let(:upload_manually_removed) do
+        FactoryBot.create(:upload_submission_manually_removed, status: 'received', s3_deleted: nil,
+                                                               created_at: 11.days.ago)
+      end
       let(:upload_old) { FactoryBot.create(:upload_submission, status: 'received', created_at: 12.days.ago) }
 
       it 'still removes other records older than 10 days' do
@@ -72,7 +75,7 @@ RSpec.describe VBADocuments::UploadRemover, type: :job do
           allow(@objstore).to receive(:object).with(upload_old.guid).and_return(s3_object_old)
           allow(s3_object_old).to receive(:exists?).and_return(true)
           expect(@objstore).to receive(:delete).with(upload_old.guid)
-          expect(@objstore).to_not receive(:delete).with(upload_manually_removed.guid)
+          expect(@objstore).not_to receive(:delete).with(upload_manually_removed.guid)
           described_class.new.perform
           upload_old.reload
           expect(upload_old.s3_deleted).to be_truthy


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
A job is repeatedly ran to clear out old files from our S3 storage. If someone were to manually remove a file from S3 and they forgot to check the s3_deleted flag to 'true', then the loop to remove old files would 'break' instead of moving to the 'next' file. This PR allows the upload remover job to move past these manually removed files and still remove other old files.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000
[API 8294](https://vajira.max.gov/browse/API-8294)

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
rspec test has been included inside ./modules/vba_documents/spec/jobs/upload_remover_spec.rb

<!-- Please describe testing done to verify the changes or any testing planned. -->
The new rspec test fails before the change. After the change, the test passes.
