### PR TITLE
[6165] Changing Flipper adapter to in-memory version

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 require 'flipper'
-require 'flipper/adapters/active_record'
 require 'active_support/cache'
-require 'flipper/adapters/active_support_cache_store'
+require 'flipper/adapters/memory'
 require 'flipper/action_patch'
 require 'flipper/configuration_patch'
 require 'flipper/instrumentation/event_subscriber'
@@ -13,12 +12,8 @@ FLIPPER_FEATURE_CONFIG = YAML.safe_load(File.read(Rails.root.join('config', 'fea
 Rails.application.reloader.to_prepare do
   Flipper.configure do |config|
     config.default do
-      activerecord_adapter = Flipper::Adapters::ActiveRecord.new
-      cache = ActiveSupport::Cache::MemoryStore.new
-      # Flipper settings will be stored in postgres and cached in memory for 1 minute in production/staging
-      cached_adapter = Flipper::Adapters::ActiveSupportCacheStore.new(activerecord_adapter, cache, expires_in: 1.minute)
-      adapter = Rails.env.development? || Rails.env.test? ? activerecord_adapter : cached_adapter
-      instrumented = Flipper::Adapters::Instrumented.new(adapter, instrumenter: ActiveSupport::Notifications)
+      memory_adapter = Flipper::Adapters::Memory.new
+      instrumented = Flipper::Adapters::Instrumented.new(memory_adapter, instrumenter: ActiveSupport::Notifications)
       # pass adapter to handy DSL instance
       Flipper.new(instrumented, instrumenter: ActiveSupport::Notifications)
     end

--- a/spec/controllers/v0/feature_toggles_controller_spec.rb
+++ b/spec/controllers/v0/feature_toggles_controller_spec.rb
@@ -59,18 +59,20 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
       json_data = JSON.parse(response.body)
 
       expect(json_data['data']['features'].first['value']).to be true
-      expect(json_data['data']['features'].first['name']).to eq(@feature_name)
-      expect(json_data['data']['features'].count).to eq(1)
+      expect(json_data['data']['features'].first['name']).to eq(@feature_name.camelize(:lower))
+      expect(json_data['data']['features'].second['name']).to eq(@feature_name)
+      expect(json_data['data']['features'].count).to eq(2)
     end
 
-    it 'keeps flags in format recieved' do
+    it 'returns both camelized and snake-case feature names' do
       get :index, params: { features: @feature_name.camelize }
       expect(response).to have_http_status(:ok)
       json_data = JSON.parse(response.body)
 
       expect(json_data['data']['features'].first['value']).to be true
-      expect(json_data['data']['features'].first['name']).to eq(@feature_name.camelize)
-      expect(json_data['data']['features'].count).to eq(1)
+      expect(json_data['data']['features'].first['name']).to eq(@feature_name.camelize(:lower))
+      expect(json_data['data']['features'].second['name']).to eq(@feature_name.snakecase)
+      expect(json_data['data']['features'].count).to eq(2)
     end
 
     it 'returns false for nonexistant flags' do
@@ -98,7 +100,7 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
 
       expect(json_data['data']['features'].first['name']).to eq(@feature_name)
       expect(json_data['data']['features'].first['value']).to be true
-      expect(json_data['data']['features'].count).to eq(1)
+      expect(json_data['data']['features'].count).to eq(2)
     end
   end
 end


### PR DESCRIPTION

## Description of change
This PR transitions the Flipper adapter to use the in-memory adapter. This shouldn't be a problem, because although the features yaml has grown to over a hundred features, we are still only saving an extra ~400 lines in memory. Given the immense size of the application itself, I don't see how this could be a problem whatsoever

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/6165

## Things to know about this PR
- This PR represents the backend `feature_toggles` route being optimized to about as fast as it will ever be
- I also changed the `feature_toggles` route with the `features` param to more closely  match the non-parameter version of the route. This means if you call `feature_toggles` with one or more specific `features`, it'll return an attribute array with two elements: the snake-case version of the feature, and the camelized version of the feature.


