### PR TITLE
25790 dependent verification listing adjustment

### DIFF
--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -38,11 +38,21 @@ module BGS
     end
 
     def normalize_dependency_decisions(dependency_decisions)
-      dependency_decisions.delete_if do |dependency_decision|
+      set1 = dependency_decisions.delete_if do |dependency_decision|
         !dependency_decision.has_key?(:award_effective_date) ||
-        dependency_decision[:award_effective_date].future? ||
-        dependency_decision[:dependency_status_type] == 'NAWDDEP'
+        dependency_decision[:award_effective_date].future?
       end
+
+      set2 = set1.group_by { |dependency_decision| dependency_decision[:person_id] }
+
+      final = []
+
+      set2.each_value do |array|
+        latest = array.max_by { |dd| dd[:award_effective_date] }
+        final << latest if latest[:dependency_status_type] != 'NAWDDEP'
+      end
+
+      final
     end
   end
 end

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -11,8 +11,8 @@ module BGS
           award_type: 'CPL'
         }
       )
-
-      diaries[:dependency_decs][:dependency_dec] = normalize_dependency_decisions(diaries)
+      dependency_decisions = diaries[:dependency_decs][:dependency_dec]
+      diaries[:dependency_decs][:dependency_dec] = normalize_dependency_decisions(dependency_decisions)
 
       return empty_response(diaries) if diaries[:diaries].blank?
 

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -39,8 +39,8 @@ module BGS
 
     def normalize_dependency_decisions(dependency_decisions)
       dependency_decisions.delete_if do |dependency_decision|
-        !dependency_decision.has_key?(:award_effective_date)
-        # dependency_decision[:award_effective_date].future?
+        !dependency_decision.has_key?(:award_effective_date) ||
+        dependency_decision[:award_effective_date].future?
         # || dependency_decision[:dependency_status_type] == 'NAWDDEP'
       end
     end

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -39,7 +39,7 @@ module BGS
 
     def normalize_dependency_decisions(dependency_decisions)
       set1 = dependency_decisions.delete_if do |dependency_decision|
-        !dependency_decision.has_key?(:award_effective_date) ||
+        !dependency_decision.key?(:award_effective_date) ||
         dependency_decision[:award_effective_date].future?
       end
 

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -40,6 +40,8 @@ module BGS
     def normalize_dependency_decisions(diaries)
       diaries[:dependency_decs][:dependency_dec].delete_if do |dep_dec|
         !dep_dec.has_key?(:award_effective_date)
+        # dep_dec[:award_effective_date].future?
+        # || dep_dec[:dependency_status_type] == 'NAWDDEP'
       end
     end
   end

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -11,10 +11,10 @@ module BGS
           award_type: 'CPL'
         }
       )
+      return empty_response(diaries) if diaries[:diaries].blank?
+
       dependency_decisions = diaries[:dependency_decs][:dependency_dec]
       diaries[:dependency_decs][:dependency_dec] = normalize_dependency_decisions(dependency_decisions)
-
-      return empty_response(diaries) if diaries[:diaries].blank?
 
       standard_response(diaries)
     rescue => e

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -40,7 +40,7 @@ module BGS
     def normalize_dependency_decisions(dependency_decisions)
       set1 = dependency_decisions.delete_if do |dependency_decision|
         !dependency_decision.key?(:award_effective_date) ||
-        dependency_decision[:award_effective_date].future?
+          dependency_decision[:award_effective_date].future?
       end
 
       set2 = set1.group_by { |dependency_decision| dependency_decision[:person_id] }

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -40,8 +40,8 @@ module BGS
     def normalize_dependency_decisions(dependency_decisions)
       dependency_decisions.delete_if do |dependency_decision|
         !dependency_decision.has_key?(:award_effective_date) ||
-        dependency_decision[:award_effective_date].future?
-        # || dependency_decision[:dependency_status_type] == 'NAWDDEP'
+        dependency_decision[:award_effective_date].future? ||
+        dependency_decision[:dependency_status_type] == 'NAWDDEP'
       end
     end
   end

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -37,11 +37,11 @@ module BGS
       }
     end
 
-    def normalize_dependency_decisions(diaries)
-      diaries[:dependency_decs][:dependency_dec].delete_if do |dep_dec|
-        !dep_dec.has_key?(:award_effective_date)
-        # dep_dec[:award_effective_date].future?
-        # || dep_dec[:dependency_status_type] == 'NAWDDEP'
+    def normalize_dependency_decisions(dependency_decisions)
+      dependency_decisions.delete_if do |dependency_decision|
+        !dependency_decision.has_key?(:award_effective_date)
+        # dependency_decision[:award_effective_date].future?
+        # || dependency_decision[:dependency_status_type] == 'NAWDDEP'
       end
     end
   end

--- a/app/services/bgs/dependency_verification_service.rb
+++ b/app/services/bgs/dependency_verification_service.rb
@@ -12,6 +12,8 @@ module BGS
         }
       )
 
+      diaries[:dependency_decs][:dependency_dec] = normalize_dependency_decisions(diaries)
+
       return empty_response(diaries) if diaries[:diaries].blank?
 
       standard_response(diaries)
@@ -33,6 +35,12 @@ module BGS
         dependency_decs: diaries.dig(:dependency_decs, :dependency_dec),
         diaries: diaries.dig(:diaries, :diary)
       }
+    end
+
+    def normalize_dependency_decisions(diaries)
+      diaries[:dependency_decs][:dependency_dec].delete_if do |dep_dec|
+        !dep_dec.has_key?(:award_effective_date)
+      end
     end
   end
 end

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -4,43 +4,9 @@ require 'rails_helper'
 
 RSpec.describe BGS::DependencyVerificationService do
   let(:user) { FactoryBot.create(:evss_user, :loa3) }
-  let(:payload_keys) do
-    %i[
-      award_event_id
-      award_type
-      begin_award_event_id
-      beneficiary_id
-      decision_id
-      dependency_decision_id
-      first_name
-      full_name
-      last_name
-      modified_action
-      modified_by
-      modified_location
-      modified_process
-      person_id
-      social_security_number
-      sort_date
-      sort_order_number
-      veteran_id
-      veteran_indicator
-    ]
-  end
 
   describe '#read_diaries' do
-    it 'returns diary information given a user\'s participant_id' do
-      VCR.use_cassette('bgs/diaries_service/read_diaries') do
-        allow(user).to receive(:participant_id).and_return('13014883')
-        service = BGS::DependencyVerificationService.new(user)
-        diaries = service.read_diaries
-
-        expect(diaries[:dependency_decs].size).to be > 2
-        expect(diaries[:dependency_decs].first.keys).to eq(payload_keys)
-      end
-    end
-
-    it 'returns dependency decisions that all contain :award_effective_date key' do
+    xit 'returns dependency decisions that all contain :award_effective_date key' do
       VCR.use_cassette('bgs/diaries_service/read_diaries') do
         allow(user).to receive(:participant_id).and_return('13014883')
         service = BGS::DependencyVerificationService.new(user)

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -43,10 +43,23 @@ RSpec.describe BGS::DependencyVerificationService do
       end
     end
 
-    xit 'should not include more than one dependecy decision per person_id' do
+    it 'should not include any dependency decisions that are NAWDDEP' do
+      VCR.use_cassette('bgs/diaries_service/read_diaries') do
+        allow(user).to receive(:participant_id).and_return('13014883')
+        service = BGS::DependencyVerificationService.new(user)
+        dependency_decisions = service.read_diaries[:dependency_decs]
+
+        result = dependency_decisions.none? do |dependency_decision|
+          dependency_decision[:dependency_status_type] == 'NAWDDEP'
+        end
+
+        expected = true
+
+        expect(result).to eq expected
+      end
     end
 
-    xit 'should not include any dependency decisions that are NAWDDEP' do
+    xit 'should not include more than one dependecy decision per person_id' do
     end
 
     it 'returns an empty response when it cannot find records' do

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BGS::DependencyVerificationService do
   let(:user) { FactoryBot.create(:evss_user, :loa3) }
 
   describe '#read_diaries' do
-    xit 'returns dependency decisions that all contain :award_effective_date key' do
+    it 'returns dependency decisions that all contain :award_effective_date key' do
       VCR.use_cassette('bgs/diaries_service/read_diaries') do
         allow(user).to receive(:participant_id).and_return('13014883')
         service = BGS::DependencyVerificationService.new(user)

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe BGS::DependencyVerificationService do
       end
     end
 
-    it 'should not include any dependency decisions that are NAWDDEP' do
+    it 'does not include any dependency decisions that are NAWDDEP' do
       VCR.use_cassette('bgs/diaries_service/read_diaries') do
         allow(user).to receive(:participant_id).and_return('13014883')
         service = BGS::DependencyVerificationService.new(user)
@@ -59,13 +59,13 @@ RSpec.describe BGS::DependencyVerificationService do
       end
     end
 
-    it 'should not include more than one dependecy decision per person_id' do
+    it 'does not include more than one dependecy decision per person_id' do
       VCR.use_cassette('bgs/diaries_service/read_diaries') do
         allow(user).to receive(:participant_id).and_return('13014883')
         service = BGS::DependencyVerificationService.new(user)
         dependency_decisions = service.read_diaries[:dependency_decs]
 
-        person_ids = dependency_decisions.map{ |e| e[:person_id] }
+        person_ids = dependency_decisions.pluck(:person_id)
         result = person_ids == person_ids.uniq
 
         expected = true

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -59,7 +59,19 @@ RSpec.describe BGS::DependencyVerificationService do
       end
     end
 
-    fit 'should not include more than one dependecy decision per person_id' do
+    it 'should not include more than one dependecy decision per person_id' do
+      VCR.use_cassette('bgs/diaries_service/read_diaries') do
+        allow(user).to receive(:participant_id).and_return('13014883')
+        service = BGS::DependencyVerificationService.new(user)
+        dependency_decisions = service.read_diaries[:dependency_decs]
+
+        person_ids = dependency_decisions.map{ |e| e[:person_id] }
+        result = person_ids == person_ids.uniq
+
+        expected = true
+
+        expect(result).to eq expected
+      end
     end
 
     it 'returns an empty response when it cannot find records' do

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BGS::DependencyVerificationService do
         dependency_decisions = service.read_diaries[:dependency_decs]
 
         result = dependency_decisions.all? do |dependency_decision|
-          dependency_decision.has_key?(:award_effective_date)
+          dependency_decision.key?(:award_effective_date)
         end
 
         expected = true

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe BGS::DependencyVerificationService do
       end
     end
 
-    it 'should not include any dependency decisions that are in the future' do
+    it 'does not include any dependency decisions that are in the future' do
       VCR.use_cassette('bgs/diaries_service/read_diaries') do
         allow(user).to receive(:participant_id).and_return('13014883')
         service = BGS::DependencyVerificationService.new(user)

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe BGS::DependencyVerificationService do
       end
     end
 
-    xit 'should not include any dependency decisions that are in the future' do
+    it 'should not include any dependency decisions that are in the future' do
       VCR.use_cassette('bgs/diaries_service/read_diaries') do
         allow(user).to receive(:participant_id).and_return('13014883')
         service = BGS::DependencyVerificationService.new(user)
 
-        Timecop.freeze(Time.now - 50.years)
+        Timecop.freeze(Time.local(1990))
 
         dependency_decisions = service.read_diaries[:dependency_decs]
 

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe BGS::DependencyVerificationService do
         allow(user).to receive(:participant_id).and_return('13014883')
         service = BGS::DependencyVerificationService.new(user)
 
-        Timecop.freeze(Time.local(1990))
+        Timecop.freeze(Time.zone.local(1990))
 
         dependency_decisions = service.read_diaries[:dependency_decs]
 

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -56,6 +56,33 @@ RSpec.describe BGS::DependencyVerificationService do
       end
     end
 
+    xit 'should not include any dependency decisions that are in the future' do
+      VCR.use_cassette('bgs/diaries_service/read_diaries') do
+        allow(user).to receive(:participant_id).and_return('13014883')
+        service = BGS::DependencyVerificationService.new(user)
+
+        Timecop.freeze(Time.now - 50.years)
+
+        dependency_decisions = service.read_diaries[:dependency_decs]
+
+        result = dependency_decisions.all? do |dependency_decision|
+          dependency_decision[:award_effective_date]&.past?
+        end
+
+        expected = true
+
+        expect(result).to eq expected
+
+        Timecop.return
+      end
+    end
+
+    xit 'should not include more than one dependecy decision per person_id' do
+    end
+
+    xit 'should not include any dependency decisions that are NAWDDEP' do
+    end
+
     it 'returns an empty response when it cannot find records' do
       VCR.use_cassette('bgs/diaries_service/read_empty_diaries') do
         allow(user).to receive(:participant_id).and_return('123')

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe BGS::DependencyVerificationService do
       end
     end
 
-    xit 'should not include more than one dependecy decision per person_id' do
+    fit 'should not include more than one dependecy decision per person_id' do
     end
 
     it 'returns an empty response when it cannot find records' do

--- a/spec/services/bgs/dependency_verification_service_spec.rb
+++ b/spec/services/bgs/dependency_verification_service_spec.rb
@@ -40,6 +40,22 @@ RSpec.describe BGS::DependencyVerificationService do
       end
     end
 
+    it 'returns dependency decisions that all contain :award_effective_date key' do
+      VCR.use_cassette('bgs/diaries_service/read_diaries') do
+        allow(user).to receive(:participant_id).and_return('13014883')
+        service = BGS::DependencyVerificationService.new(user)
+        dependency_decisions = service.read_diaries[:dependency_decs]
+
+        result = dependency_decisions.all? do |dependency_decision|
+          dependency_decision.has_key?(:award_effective_date)
+        end
+
+        expected = true
+
+        expect(result).to eq expected
+      end
+    end
+
     it 'returns an empty response when it cannot find records' do
       VCR.use_cassette('bgs/diaries_service/read_empty_diaries') do
         allow(user).to receive(:participant_id).and_return('123')


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
The changes in this code will filter the BGS diaries' dependency_decisions in order to:
- remove duplicate dependents
- remove dependents that are not on award
- remove dependents from being displayed based on award decisions that are in the future

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25790

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
1. Removed, was an old example that made two assertions:
    1. That the first dependency decision (the veteran) had exact keys included, which were different from the dependents.
      a. this was removed since the queried veteran was filtered out and never needed in the first place
   2. That the total dependency decisions was greater than two.
     a. This was arbitrary as there were 4 or 5 in the fixture data.
2. four new examples were added that covered:
```
BGS::DependencyVerificationService
  #read_diaries
    returns dependency decisions that all contain :award_effective_date key
    does not include any dependency decisions that are in the future
    does not include more than one dependecy decision per person_id
    does not include any dependency decisions that are NAWDDEP
```