### PR TITLE
27114 ch31 report find_each bug

### DIFF
--- a/app/mailers/views/ch31_submissions_report.html.erb
+++ b/app/mailers/views/ch31_submissions_report.html.erb
@@ -7,7 +7,7 @@
     <th style="white-space:nowrap; text-align:left; width:15%">Type of Form</th>
     <th style="white-space:nowrap; text-align:left; width:5%">Total</th>
   </tr>
-  <% @submitted_claims.find_each.with_index do |claim, index|
+  <% @submitted_claims.each.with_index do |claim, index|
         parsed_form = claim.parsed_form
   %>
   <tr>

--- a/spec/mailers/ch31_submissions_report_mailer_spec.rb
+++ b/spec/mailers/ch31_submissions_report_mailer_spec.rb
@@ -16,9 +16,7 @@ RSpec.describe Ch31SubmissionsReportMailer, type: %i[mailer aws_helpers] do
       let(:time) { Time.zone.now }
 
       let(:submitted_claims) do
-        SavedClaim::VeteranReadinessEmploymentClaim.where(
-          updated_at: (time - 24.hours)..(time - 1.second)
-        )
+        VRE::CreateCh31SubmissionsReport.new.get_claims_submitted_in_range
       end
 
       let(:mail) { described_class.build(submitted_claims).deliver_now }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Switches `spec/mailers/ch31_submissions_report_mailer_spec.rb` so that the `submitted_claims` helper used is not a duplicate (and outdated) implementation of the logic inside `VRE::CreateCh31SubmissionsReport#get_claims_submitted_in_range`, which is the method responsible for generating the object passed to `Ch31SubmissionsReportMailer`. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/27114

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
The spec that should have failed during https://github.com/department-of-veterans-affairs/vets-api/pull/7320's CI was altered to now rely on the preparatory class and pass the same type of object used in production. Once I got that to fail, I just fixed the bug.