### PR TITLE
[26884] Tud notes logic

### DIFF
--- a/modules/test_user_dashboard/app/controllers/test_user_dashboard/tud_accounts_controller.rb
+++ b/modules/test_user_dashboard/app/controllers/test_user_dashboard/tud_accounts_controller.rb
@@ -4,9 +4,20 @@ require_dependency 'test_user_dashboard/application_controller'
 
 module TestUserDashboard
   class TudAccountsController < ApplicationController
+    include ActionView::Helpers::SanitizeHelper
+
     def index
       tud_accounts = TudAccount.all
       render json: tud_accounts
+    end
+
+    def update
+      tud_account = TudAccount.find(params[:id])
+      sanitized_notes = sanitize params[:notes]
+      tud_account.update!(notes: sanitized_notes)
+      render json: tud_account
+    rescue ActiveRecord::RecordNotFound => e
+      render json: { error: e }
     end
   end
 end

--- a/modules/test_user_dashboard/app/serializers/test_user_dashboard/tud_account_serializer.rb
+++ b/modules/test_user_dashboard/app/serializers/test_user_dashboard/tud_account_serializer.rb
@@ -4,7 +4,7 @@ module TestUserDashboard
   class TudAccountSerializer < ActiveModel::Serializer
     attributes :id, :account_uuid, :first_name, :middle_name, :last_name, :gender,
                :birth_date, :ssn, :phone, :email, :password, :available, :checkout_time,
-               :id_type, :loa, :account_type, :services
+               :id_type, :loa, :account_type, :services, :notes
 
     def available
       object.available?

--- a/modules/test_user_dashboard/config/routes.rb
+++ b/modules/test_user_dashboard/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 TestUserDashboard::Engine.routes.draw do
-  resources :tud_accounts
+  resources :tud_accounts, only: %i[index update]
 end

--- a/modules/test_user_dashboard/spec/requests/tud_accounts_request_spec.rb
+++ b/modules/test_user_dashboard/spec/requests/tud_accounts_request_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe 'Test User Dashboard', type: :request do
 
   describe '#update' do
     let(:tud_account) { create(:tud_account, id: '123') }
-    let(:bad_notes) { 'Test note string goes here.' }
+    let(:notes) { 'Test note string goes here.' }
 
     it 'updates the tud account notes field' do
       allow(TestUserDashboard::TudAccount).to receive(:find).and_return(tud_account)
-      put('/test_user_dashboard/tud_accounts/123', params: { notes: bad_notes }, headers: headers)
+      put('/test_user_dashboard/tud_accounts/123', params: { notes: notes }, headers: headers)
 
       expect(response).to have_http_status(:ok)
       expect(tud_account.notes).to eq('Test note string goes here.')

--- a/modules/test_user_dashboard/spec/requests/tud_accounts_request_spec.rb
+++ b/modules/test_user_dashboard/spec/requests/tud_accounts_request_spec.rb
@@ -32,4 +32,26 @@ RSpec.describe 'Test User Dashboard', type: :request do
       end
     end
   end
+
+  describe '#update' do
+    let(:tud_account) { create(:tud_account, id: '123') }
+
+    it 'sanitizes the submitted notes' do
+      allow(TestUserDashboard::TudAccount).to receive(:find).and_return(tud_account)
+
+      rsa_private = OpenSSL::PKey::RSA.new 2048
+      rsa_public = rsa_private.public_key
+      pub_key = Base64.encode64(rsa_public.to_der)
+      token = JWT.encode 'test', rsa_private, 'RS256'
+
+      post('/test_user_dashboard/tud_accounts/123',
+           params: { notes: 'DROP TABLE test_user_dashboard_tud_accounts;' },
+           headers: {
+             'JWT' => token,
+             'PK' => pub_key
+           })
+
+      expect(response.status).to eq 200
+    end
+  end
 end

--- a/modules/test_user_dashboard/spec/requests/tud_accounts_request_spec.rb
+++ b/modules/test_user_dashboard/spec/requests/tud_accounts_request_spec.rb
@@ -3,10 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe 'Test User Dashboard', type: :request do
+  let(:rsa_private) { OpenSSL::PKey::RSA.new 2048 }
+  let(:rsa_public) { rsa_private.public_key }
+  let(:pub_key) { Base64.encode64(rsa_public.to_der) }
+  let(:token) { JWT.encode 'test', rsa_private, 'RS256' }
+  let(:headers) { { 'JWT' => token, 'PK' => pub_key } }
+
   describe '#index' do
     context 'without any authentication headers' do
       it 'refuses the request' do
-        get '/test_user_dashboard/tud_accounts'
+        get('/test_user_dashboard/tud_accounts')
 
         expect(response.status).to eq 403
         expect(response.content_type).to eq 'text/html'
@@ -15,19 +21,9 @@ RSpec.describe 'Test User Dashboard', type: :request do
 
     context 'with valid authentication headers' do
       it 'accepts the request and returns a response' do
-        rsa_private = OpenSSL::PKey::RSA.new 2048
-        rsa_public = rsa_private.public_key
-        pub_key = Base64.encode64(rsa_public.to_der)
-        token = JWT.encode 'test', rsa_private, 'RS256'
+        get('/test_user_dashboard/tud_accounts', params: '', headers: headers)
 
-        get('/test_user_dashboard/tud_accounts',
-            params: '',
-            headers: {
-              'JWT' => token,
-              'PK' => pub_key
-            })
-
-        expect(response.status).to eq 200
+        expect(response).to have_http_status(:ok)
         expect(response.content_type).to eq 'application/json; charset=utf-8'
       end
     end
@@ -35,23 +31,14 @@ RSpec.describe 'Test User Dashboard', type: :request do
 
   describe '#update' do
     let(:tud_account) { create(:tud_account, id: '123') }
+    let(:bad_notes) { 'Test note string goes here.' }
 
-    it 'sanitizes the submitted notes' do
+    it 'updates the tud account notes field' do
       allow(TestUserDashboard::TudAccount).to receive(:find).and_return(tud_account)
+      put('/test_user_dashboard/tud_accounts/123', params: { notes: bad_notes }, headers: headers)
 
-      rsa_private = OpenSSL::PKey::RSA.new 2048
-      rsa_public = rsa_private.public_key
-      pub_key = Base64.encode64(rsa_public.to_der)
-      token = JWT.encode 'test', rsa_private, 'RS256'
-
-      post('/test_user_dashboard/tud_accounts/123',
-           params: { notes: 'DROP TABLE test_user_dashboard_tud_accounts;' },
-           headers: {
-             'JWT' => token,
-             'PK' => pub_key
-           })
-
-      expect(response.status).to eq 200
+      expect(response).to have_http_status(:ok)
+      expect(tud_account.notes).to eq('Test note string goes here.')
     end
   end
 end

--- a/modules/test_user_dashboard/spec/support/spec_users.csv
+++ b/modules/test_user_dashboard/spec/support/spec_users.csv
@@ -1,2 +1,2 @@
-first_name,middle_name,last_name,gender,birth_date,ssn,phone,email,password,idme_uuid,services
-MARK,,WEBB,M,1950-10-04,796104437,800-827-1000,vets.gov.user+228@gmail.com,testpass,2693564c-8e76-4733-a382-2f2c6ffe0ba8,"facilities,hca,edu_benefits,form-save-in-progress,form-prefill,user-profile,appeals-status,identity-proofed,vet360,claim_increase"
+first_name,middle_name,last_name,gender,birth_date,ssn,phone,email,password,idme_uuid,services,notes
+MARK,,WEBB,M,1950-10-04,796104437,800-827-1000,vets.gov.user+228@gmail.com,testpass,2693564c-8e76-4733-a382-2f2c6ffe0ba8,"facilities,hca,edu_benefits,form-save-in-progress,form-prefill,user-profile,appeals-status,identity-proofed,vet360,claim_increase",This is a test string in the notes column.


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This change adds routing, business logic, and specs for updating a test account's `notes` field to the TUD module. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#26884

## Things to know about this PR
TUD unit tests have been updated to include the new PUT route; manual testing of reading and updating a tud account's notes via an API client was also done.