### PR TITLE
Add EVSS middleware error handling to the mobile claims proxy

### DIFF
--- a/modules/mobile/app/services/mobile/v0/claims/proxy.rb
+++ b/modules/mobile/app/services/mobile/v0/claims/proxy.rb
@@ -8,7 +8,7 @@ module Mobile
       class Proxy
         STATSD_UPLOAD_LATENCY = 'mobile.api.claims.upload.latency'
 
-        def initialize(user)
+        def initialize(user)individual_claim_request_spec.rb:53
           @user = user
         end
 

--- a/modules/mobile/app/services/mobile/v0/claims/proxy.rb
+++ b/modules/mobile/app/services/mobile/v0/claims/proxy.rb
@@ -32,8 +32,8 @@ module Mobile
           raw_claim = claims_service.find_claim_with_docs_by_id(claim.evss_id).body.fetch('claim', {})
           claim.update(data: raw_claim)
           EVSSClaimDetailSerializer.new(claim)
-        rescue EVSS::ErrorMiddleware::EVSSError => error
-          handle_middleware_error(error)
+        rescue EVSS::ErrorMiddleware::EVSSError => e
+          handle_middleware_error(e)
         end
 
         def get_appeal(id)
@@ -45,8 +45,8 @@ module Mobile
           serializable_resource[:id] = appeal['id']
           serializable_resource[:type] = appeal['type']
           serializable_resource
-        rescue EVSS::ErrorMiddleware::EVSSError => error
-          handle_middleware_error(error)
+        rescue EVSS::ErrorMiddleware::EVSSError => e
+          handle_middleware_error(e)
         end
 
         def request_decision(id)
@@ -185,12 +185,13 @@ module Mobile
           temp_file.write(File.read(pdf_path))
           ActionDispatch::Http::UploadedFile.new(filename: pdf_filename, type: 'application/pdf', tempfile: temp_file)
         end
-        
+
         def handle_middleware_error(error)
           response_values = {
             details: error.details
           }
-          raise Common::Exceptions::BackendServiceException.new('MOBL_502_upstream_error', response_values, 500, error.body)
+          raise Common::Exceptions::BackendServiceException.new('MOBL_502_upstream_error', response_values, 500,
+                                                                error.body)
         end
       end
     end

--- a/modules/mobile/app/services/mobile/v0/claims/proxy.rb
+++ b/modules/mobile/app/services/mobile/v0/claims/proxy.rb
@@ -8,7 +8,7 @@ module Mobile
       class Proxy
         STATSD_UPLOAD_LATENCY = 'mobile.api.claims.upload.latency'
 
-        def initialize(user)individual_claim_request_spec.rb:53
+        def initialize(user)
           @user = user
         end
 

--- a/modules/mobile/app/services/mobile/v0/claims/proxy.rb
+++ b/modules/mobile/app/services/mobile/v0/claims/proxy.rb
@@ -32,6 +32,8 @@ module Mobile
           raw_claim = claims_service.find_claim_with_docs_by_id(claim.evss_id).body.fetch('claim', {})
           claim.update(data: raw_claim)
           EVSSClaimDetailSerializer.new(claim)
+        rescue EVSS::ErrorMiddleware::EVSSError => error
+          handle_middleware_error(error)
         end
 
         def get_appeal(id)
@@ -43,6 +45,8 @@ module Mobile
           serializable_resource[:id] = appeal['id']
           serializable_resource[:type] = appeal['type']
           serializable_resource
+        rescue EVSS::ErrorMiddleware::EVSSError => error
+          handle_middleware_error(error)
         end
 
         def request_decision(id)
@@ -180,6 +184,13 @@ module Mobile
           temp_file = Tempfile.new(pdf_filename, encoding: 'ASCII-8BIT')
           temp_file.write(File.read(pdf_path))
           ActionDispatch::Http::UploadedFile.new(filename: pdf_filename, type: 'application/pdf', tempfile: temp_file)
+        end
+        
+        def handle_middleware_error(error)
+          response_values = {
+            details: error.details
+          }
+          raise Common::Exceptions::BackendServiceException.new('MOBL_502_upstream_error', response_values, 500, error.body)
         end
       end
     end

--- a/modules/mobile/spec/request/individual_claim_request_spec.rb
+++ b/modules/mobile/spec/request/individual_claim_request_spec.rb
@@ -14,28 +14,46 @@ RSpec.describe 'individual claim', type: :request do
       FactoryBot.create(:evss_claim, id: 2, evss_id: 111_222_333, user_uuid: '1234567890')
     end
 
-    it 'and a result that matches our schema is successfully returned with the 200 status ',
-       run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
-      VCR.use_cassette('evss/claims/claim_with_docs') do
-        get '/mobile/v0/claim/600117255', headers: iam_headers
-        expect(response).to have_http_status(:ok)
+    context 'when the claim is found' do
+      it 'matches our schema is successfully returned with the 200 status ',
+        run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+        VCR.use_cassette('evss/claims/claim_with_docs') do
+          get '/mobile/v0/claim/600117255', headers: iam_headers
+          expect(response).to have_http_status(:ok)
+        end
       end
     end
 
-    it 'and attempting to access a nonexistant claim returns a 404 with an error ',
-       run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
-      VCR.use_cassette('evss/claims/claim_with_docs') do
-        get '/mobile/v0/claim/2222222', headers: iam_headers
-        expect(response).to have_http_status(:not_found)
-        expect(response.body).to match_json_schema('evss_errors')
+    context 'with a non-existent claim' do
+      it 'returns a 404 with an error ',
+        run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+        VCR.use_cassette('evss/claims/claim_with_docs') do
+          get '/mobile/v0/claim/2222222', headers: iam_headers
+          expect(response).to have_http_status(:not_found)
+          expect(response.body).to match_json_schema('evss_errors')
+        end
       end
     end
-    it 'and attempting to access another users claim returns a 404 with an error ',
-       run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
-      VCR.use_cassette('evss/claims/claim_with_docs') do
-        get '/mobile/v0/claim/111222333', headers: iam_headers
-        expect(response).to have_http_status(:not_found)
-        expect(response.body).to match_json_schema('evss_errors')
+
+    context 'when attempting to access another users claim' do
+      it 'returns a 404 with an error ',
+        run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+        VCR.use_cassette('evss/claims/claim_with_docs') do
+          get '/mobile/v0/claim/111222333', headers: iam_headers
+          expect(response).to have_http_status(:not_found)
+          expect(response.body).to match_json_schema('evss_errors')
+        end
+      end
+    end
+    
+    context 'when evss returns a failure message' do
+      it 'returns a 502 response', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+        VCR.use_cassette('evss/claims/claim_doc_with_errors') do
+          get '/mobile/v0/claim/600117255', headers: iam_headers
+          binding.pry
+          expect(response).to have_http_status(:bad_gateway)
+          expect(response.body).to match_json_schema('errors')
+        end
       end
     end
   end

--- a/modules/mobile/spec/request/individual_claim_request_spec.rb
+++ b/modules/mobile/spec/request/individual_claim_request_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe 'individual claim', type: :request do
       it 'returns a 502 response', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         VCR.use_cassette('evss/claims/claim_doc_with_errors') do
           get '/mobile/v0/claim/600117255', headers: iam_headers
-          binding.pry
           expect(response).to have_http_status(:bad_gateway)
           expect(response.body).to match_json_schema('errors')
         end

--- a/modules/mobile/spec/request/individual_claim_request_spec.rb
+++ b/modules/mobile/spec/request/individual_claim_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'individual claim', type: :request do
 
     context 'when the claim is found' do
       it 'matches our schema is successfully returned with the 200 status ',
-        run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+         run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         VCR.use_cassette('evss/claims/claim_with_docs') do
           get '/mobile/v0/claim/600117255', headers: iam_headers
           expect(response).to have_http_status(:ok)
@@ -26,7 +26,7 @@ RSpec.describe 'individual claim', type: :request do
 
     context 'with a non-existent claim' do
       it 'returns a 404 with an error ',
-        run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+         run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         VCR.use_cassette('evss/claims/claim_with_docs') do
           get '/mobile/v0/claim/2222222', headers: iam_headers
           expect(response).to have_http_status(:not_found)
@@ -37,7 +37,7 @@ RSpec.describe 'individual claim', type: :request do
 
     context 'when attempting to access another users claim' do
       it 'returns a 404 with an error ',
-        run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
+         run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         VCR.use_cassette('evss/claims/claim_with_docs') do
           get '/mobile/v0/claim/111222333', headers: iam_headers
           expect(response).to have_http_status(:not_found)
@@ -45,7 +45,7 @@ RSpec.describe 'individual claim', type: :request do
         end
       end
     end
-    
+
     context 'when evss returns a failure message' do
       it 'returns a 502 response', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
         VCR.use_cassette('evss/claims/claim_doc_with_errors') do

--- a/spec/support/vcr_cassettes/evss/claims/claim_doc_with_errors.yml
+++ b/spec/support/vcr_cassettes/evss/claims/claim_doc_with_errors.yml
@@ -1,0 +1,172 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<EVSS_BASE_URL>/wss-claims-services-web-3.6/rest/vbaClaimStatusService/getClaimDetailWithDocsById"
+    body:
+      encoding: UTF-8
+      string: '{"id":1}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 13 Dec 2017 23:45:40 GMT
+      Va-Eauth-Csid:
+      - DSLogon
+      Va-Eauth-Authenticationmethod:
+      - DSLogon
+      Va-Eauth-Pnidtype:
+      - SSN
+      Va-Eauth-Assurancelevel:
+      - '3'
+      Va-Eauth-Firstname:
+      - WESLEY
+      Va-Eauth-Lastname:
+      - FORD
+      Va-Eauth-Issueinstant:
+      - '2017-12-07T00:55:09Z'
+      Va-Eauth-Dodedipnid:
+      - '1007697216'
+      Va-Eauth-Birlsfilenumber:
+      - '796043735'
+      Va-Eauth-Pid:
+      - '600061742'
+      Va-Eauth-Pnid:
+      - '796043735'
+      Va-Eauth-Birthdate:
+      - '1986-05-06T00:00:00+00:00'
+      Va-Eauth-Authorization:
+      - '{"authorizationResponse":{"status":"VETERAN","idType":"SSN","id":"796043735","edi":"1007697216","firstName":"WESLEY","lastName":"FORD","birthDate":"1986-05-06T00:00:00+00:00"}}'
+      Va-Eauth-Authenticationauthority:
+      - 'eauth'
+      Va-Eauth-Service-Transaction-Id:
+      - <%= transaction_id %>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 13 Dec 2017 23:45:40 GMT
+      Server:
+      - Apache
+      Content-Type:
+      - application/json
+      X-Wily-Servlet:
+      - Encrypt1 hR/KG2GOR16aRfvv3/q1AW0eXDaeERIVopFkOCXDj8aBMFJ3Yx6n3JU460kEeiDI+f7tx96uM7rd6Q66kG1F301pdCrOJfMsJBfCUXtpBBUC10v84zvjZZhZrTuMJwibXwrFyA6VYWhxQ0aj5bSLXKVvNWBYquJXTZ8L8ia/vdk=
+      X-Wily-Info:
+      - Clear guid=5244FC5D0AE153E03B6B6CF4D733A9E1
+      Via:
+      - 1.1 pint.ebenefits.va.gov:444
+      Vary:
+      - Accept-Encoding,User-Agent
+      Content-Encoding:
+      - gzip
+      X-Ua-Compatible:
+      - IE=Edge
+      Content-Length:
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+        	"claim": {
+        		"appeal_possible": "No",
+        		"attention_needed": "No",
+        		"base_end_product_code": "400",
+        		"benefit_claim_type_code": "400SUPP",
+        		"claim_consolidatable": true,
+        		"claim_phase_dates": {
+        			"current_phase_back": false,
+        			"ever_phase_back": false,
+        			"latest_phase_type": "Under Review",
+        			"phase1_complete_date": "10/05/2020",
+        			"phase_change_date": "10/05/2020",
+        			"phase_type_change_ind": "12"
+        		},
+        		"claim_tracked_items": {
+        			"never_received_from_others_list": [
+
+        			],
+        			"never_received_from_you_list": [
+
+        			],
+        			"received_from_others_list": [
+
+        			],
+        			"received_from_you_list": [
+
+        			],
+        			"still_need_from_others_list": [
+
+        			],
+        			"still_need_from_you_list": [
+
+        			]
+        		},
+        		"consolidated_tracked_items_list": [
+
+        		],
+        		"contention_list": [
+        			"PTSD (Increase)",
+        			" headaches migraine (Increase)"
+        		],
+        		"date": "10/05/2020",
+        		"dbq_list": [
+
+        		],
+        		"decision_notification_sent": "No",
+        		"development_letter_sent": "No",
+        		"end_product_code": "406",
+        		"id": "600207591",
+        		"jurisdiction": "National Work Queue",
+        		"mailing_address": {
+        			"address_line1": "FILTERED-CLIENTSIDE",
+        			"address_line2": "FILTERED-CLIENTSIDE",
+        			"address_line3": "FILTERED-CLIENTSIDE",
+        			"city": "[Filtered]",
+        			"state": "[Filtered]",
+        			"zip": "20420"
+        		},
+        		"new_evidence_received": false,
+        		"past_est_claim_date": false,
+        		"past_evidence_due_date": false,
+        		"past_phase_est_date": false,
+        		"poa": "AMERICAN LEGION",
+        		"program_type": "CPL",
+        		"status": "PEND",
+        		"status_changed": false,
+        		"status_type": "Compensation",
+        		"submitter_application_code": "VBMS",
+        		"submitter_role_code": "VBA",
+        		"temp_jurisdiction": "St. Petersburg",
+        		"vba_document_list": [
+
+        		],
+        		"waiver5103_submitted": false,
+        		"wwd": [
+
+        		],
+        		"wwr": [
+
+        		],
+        		"wwsnfy": [
+
+        		]
+        	},
+        	"messages": [
+        		{
+        			"key": "EVSS_10021",
+        			"severity": "ERROR"
+        		}
+        	]
+        }
+    http_version:
+  recorded_at: Wed, 13 Dec 2017 23:46:11 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Description of change
If there's an error listed in the EVSS claims response the lib middleware will raise a `EVSS::ErrorMiddleware::EVSSError` which is returned as a 500. PR updates our proxy to catch that error and map it to a 502 so that the app knows the error is from EVSS rather than the mobile API.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27039

