### PR TITLE
GCIO email change for flipper

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -777,7 +777,7 @@ flipper:
     - tze@adhocteam.us
     - zurbergram@gmail.com
     - zmorel@governmentcio.com
-    - zachary.morel@gcio.com
+    - zach.morel@gcio.com
 
 bgs:
   application: ~


### PR DESCRIPTION
## Description of change
Changing email for Flipper now that GCIO email is live.

## Original issue(s)
N/A

