### PR TITLE
Api 6021/add event subscription migration

### DIFF
--- a/modules/appeals_api/db/migrate/20210712152651_add_event_subscriptions_to_migrations.rb
+++ b/modules/appeals_api/db/migrate/20210712152651_add_event_subscriptions_to_migrations.rb
@@ -2,6 +2,6 @@ class AddEventSubscriptionsToMigrations < ActiveRecord::Migration[6.1]
   def change
     AppealsApi::Events::Handler.subscribe(:hlr_status_updated, 'AppealsApi::Events::StatusUpdated')
     AppealsApi::Events::Handler.subscribe(:nod_status_updated, 'AppealsApi::Events::StatusUpdated')
-    AppealsApi::Events::Handler.subscribe(:hlr_received, 'AppealsApi::Events::AppealReceived')
+    AppealsApi::Events::Handler.subscribe(:higher_level_review, 'AppealsApi::Events::AppealReceived')
   end
 end

--- a/modules/appeals_api/db/migrate/20210712152651_add_event_subscriptions_to_migrations.rb
+++ b/modules/appeals_api/db/migrate/20210712152651_add_event_subscriptions_to_migrations.rb
@@ -2,6 +2,6 @@ class AddEventSubscriptionsToMigrations < ActiveRecord::Migration[6.1]
   def change
     AppealsApi::Events::Handler.subscribe(:hlr_status_updated, 'AppealsApi::Events::StatusUpdated')
     AppealsApi::Events::Handler.subscribe(:nod_status_updated, 'AppealsApi::Events::StatusUpdated')
-    AppealsApi::Events::Handler.subscribe(:higher_level_review, 'AppealsApi::Events::AppealReceived')
+    AppealsApi::Events::Handler.subscribe(:hlr_received, 'AppealsApi::Events::AppealReceived')
   end
 end

--- a/modules/appeals_api/db/migrate/20210712152651_add_event_subscriptions_to_migrations.rb
+++ b/modules/appeals_api/db/migrate/20210712152651_add_event_subscriptions_to_migrations.rb
@@ -1,0 +1,7 @@
+class AddEventSubscriptionsToMigrations < ActiveRecord::Migration[6.1]
+  def change
+    AppealsApi::Events::Handler.subscribe(:hlr_status_updated, 'AppealsApi::Events::StatusUpdated')
+    AppealsApi::Events::Handler.subscribe(:nod_status_updated, 'AppealsApi::Events::StatusUpdated')
+    AppealsApi::Events::Handler.subscribe(:hlr_received, 'AppealsApi::Events::AppealReceived')
+  end
+end


### PR DESCRIPTION
[API-6021](https://vajira.max.gov/browse/API-6021)

This PR moves event subscriptions from initializer to migrations. The `subscribe` method is a `find_or_create!`.

