### PR TITLE
API-8523:     no implicit conversion of Symbol into Integer - ClaimsApi::V1::Forms::PowerOfAttorneyController#submit_form_2122

### DIFF
--- a/modules/claims_api/spec/models/veteran/service/user_spec.rb
+++ b/modules/claims_api/spec/models/veteran/service/user_spec.rb
@@ -51,5 +51,15 @@ describe Veteran::User do
         expect(veteran.previous_power_of_attorney.code).to eq('133')
       end
     end
+
+    it 'does not bomb out if poa history contains a single record' do
+      VCR.use_cassette('bgs/claimant_web_service/find_poa_by_participant_id') do
+        allow_any_instance_of(BGS::OrgWebService).to receive(:find_poa_history_by_ptcpnt_id)
+          .and_return({ person_poa_history: { person_poa: { begin_dt: Time.zone.now, legacy_poa_cd: '033' } } })
+        veteran = Veteran::User.new(user)
+        expect(veteran.power_of_attorney.code).to eq('044')
+        expect(veteran.previous_power_of_attorney.code).to eq('033')
+      end
+    end
   end
 end

--- a/modules/veteran/app/models/veteran/user.rb
+++ b/modules/veteran/app/models/veteran/user.rb
@@ -34,7 +34,9 @@ module Veteran
       return nil if poa_history[:person_poa_history].blank?
 
       # Sorts previous power of attorneys by begin date
-      poa_history = poa_history[:person_poa_history][:person_poa].sort_by { |poa| poa[:begin_dt] }.reverse
+      poa_history = poa_history[:person_poa_history][:person_poa]
+      poa_history = [poa_history] unless poa_history.is_a?(Array)
+      poa_history = poa_history.sort_by { |poa| poa[:begin_dt] }.reverse
       poa_codes = poa_history.pluck(:legacy_poa_cd)
 
       @previous_poa_code = poa_codes.delete_if { |poa_code| poa_code == current_poa_code }.first


### PR DESCRIPTION
## Description of change
Fixes an issue when a Veteran's POA history contains only a single record.
The structure of this response is an array when there is more than one historical POA record.
However, if the response has only a single record, its unfortunately a hash instead of an array.

## Original issue(s)
https://vajira.max.gov/browse/API-8523