### PR TITLE
Adding Adam's email to approved admin logins

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -697,6 +697,7 @@ search_click_tracking:
 
 flipper:
   admin_user_emails:
+    - adam.whitlock@adhocteam.us # Adam Whitlock # Ad Hoc
     - adewitt@thoughtworks.com
     - agarcia@clarityinnovates.com
     - alastair@adhocteam.us


### PR DESCRIPTION
# Background

Adam recently joined Ad Hoc as a software engineer and thus needs to be able to make changes to feature toggles. This PR ads his email to the list of approved admin emails.