### PR TITLE
26822 remove ssn and va file number from ch31

### DIFF
--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -93,7 +93,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
         'edipi' => user.edipi,
         'vet360ID' => user.vet360_id,
         'dob' => user.birth_date,
-        'ssn' => user.ssn,
+        'ssn' => user.ssn
       }
     ).except!('vaFileNumber')
   end

--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -88,11 +88,12 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
   def add_veteran_info(updated_form, user)
     updated_form['veteranInformation'].merge!(
       {
-        'VAFileNumber' => updated_form['veteranInformation']['vaFileNumber'] || veteran_va_file_number(user),
+        'VAFileNumber' => veteran_va_file_number(user),
         'pid' => user.participant_id,
         'edipi' => user.edipi,
         'vet360ID' => user.vet360_id,
-        'dob' => user.birth_date
+        'dob' => user.birth_date,
+        'ssn' => user.ssn,
       }
     ).except!('vaFileNumber')
   end

--- a/spec/factories/veteran_readiness_employment_claim.rb
+++ b/spec/factories/veteran_readiness_employment_claim.rb
@@ -41,9 +41,7 @@ FactoryBot.define do
             'middle' => 'John',
             'last' => 'Simpson'
           },
-          'ssn' => '987456457',
           'dob' => '1998-01-02',
-          'VAFileNumber' => '88776655',
           'pid' => '600036503',
           'edipi' => '1005354478',
           'vet360ID' => nil,

--- a/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
+++ b/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     it 'adds veteran information' do
       VCR.use_cassette 'veteran_readiness_employment/add_claimant_info' do
         claim.add_claimant_info(user_object)
-        claimant_keys = %w[fullName ssn dob VAFileNumber pid edipi vet360ID regionalOffice]
+        claimant_keys = %w[fullName dob pid edipi vet360ID regionalOffice VAFileNumber ssn]
         expect(claim.parsed_form['veteranInformation']).to include(
           {
             'fullName' => {


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This PR is the backend side of removing two fields from Ch31 frontend form: SSN, and VA File Number. Instead of using the form data, the user object is the desired source going forward.

The related FE PR's are:
- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/616
- https://github.com/department-of-veterans-affairs/vets-website/pull/17783

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/26822

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
I updated the spec so that the ssn and va_file_number are still included in the keys returned from the parsed_form but they are at the end since their values are merged into the form data in `SavedClaim::VeteranReadinessEmploymentClaim#add_veteran_info`