### PR TITLE
Add job arguments to sidekiq retry notifier output

### DIFF
--- a/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
+++ b/modules/appeals_api/app/workers/appeals_api/higher_level_review_pdf_submit_job.rb
@@ -14,6 +14,9 @@ module AppealsApi
     include Sidekiq::MonitoredWorker
     include CentralMail::Utilities
 
+    # Retry for ~7 days
+    sidekiq_options retry: 20
+
     def perform(higher_level_review_id, version = 'V1')
       higher_level_review = AppealsApi::HigherLevelReview.find(higher_level_review_id)
 
@@ -32,7 +35,8 @@ module AppealsApi
     end
 
     def retry_limits_for_notification
-      [2, 5]
+      # Alert @ 1m, 10m, 30m, 4h, 1d, 3d, and 7d
+      [2, 5, 6, 10, 14, 17, 20]
     end
 
     def notify(retry_params)
@@ -90,10 +94,10 @@ module AppealsApi
       higher_level_review.update(status: 'error', code: e.code, detail: e.detail)
 
       if e.code == 'DOC201' || e.code == 'DOC202'
-        AppealsApi::SidekiqRetryNotifier.notify!(
+        notify(
           {
             'class' => self.class.name,
-            'retry_count' => '-',
+            'args' => [higher_level_review.id],
             'error_class' => e.code,
             'error_message' => e.detail,
             'failed_at' => Time.zone.now

--- a/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
+++ b/modules/appeals_api/lib/appeals_api/sidekiq_retry_notifier.rb
@@ -7,17 +7,19 @@ module AppealsApi
     API_PATH = 'https://slack.com/api/chat.postMessage'
 
     class << self
+      # Params are expected to be in the Sidekiq Job Format (https://github.com/mperham/sidekiq/wiki/Job-Format),
       def notify!(params)
         Faraday.post(API_PATH, request_body(params), request_headers)
       end
 
       def message_text(params)
-        "
-        ENVIRONMENT: #{Settings.vsp_environment} \n
-        The sidekiq job #{params['class']} has hit #{params['retry_count'] + 1} retries.
-        \nError Type: #{params['error_class']} \n Error Message: \n #{params['error_message']} \n\n
-This job failed at: #{Time.zone.at(params['failed_at'])}, and #{retried_at(params['retried_at'])}
-        "
+        msg = "ENVIRONMENT: #{Settings.vsp_environment}".dup
+        msg << "\nThe sidekiq job #{params['class']} #{retries(params['retry_count'])}"
+        msg << "\nJob Args: #{params['args']}" if params['args'].present?
+        msg << "\nError Type: #{params['error_class']}"
+        msg << "\nError Message:\n #{params['error_message']}"
+        msg << "\n\nThis job failed at: #{Time.zone.at(params['failed_at'])}, and #{retried_at(params['retried_at'])}"
+        msg
       end
 
       private
@@ -40,6 +42,13 @@ This job failed at: #{Time.zone.at(params['failed_at'])}, and #{retried_at(param
         return 'was not retried.' unless retried_time
 
         "was retried at: #{Time.zone.at(retried_time)}."
+      end
+
+      def retries(retry_count)
+        retry_count = retry_count.presence&.to_i
+        return 'threw an error.' unless retry_count
+
+        "has hit #{retry_count + 1} retries."
       end
 
       def slack_channel_id

--- a/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
+++ b/modules/appeals_api/spec/lib/sidekiq_retry_notifier_spec.rb
@@ -9,12 +9,52 @@ module AppealsApi
       let(:params) do
         {
           'class' => 'HigherLevelReviewPdfSubmitJob',
+          'args' => %w[1234 5678],
           'retry_count' => 2,
           'error_class' => 'RuntimeError',
-          'error_message' => '',
+          'error_message' => 'Here there be dragons',
           'failed_at' => 1_613_670_737.966083,
           'retried_at' => 1_613_680_062.5507782
         }
+      end
+
+      describe '#message_text' do
+        it 'returns the VSP environment' do
+          with_settings(Settings, vsp_environment: 'humid') do
+            expect(described_class.message_text(params)).to include('ENVIRONMENT: humid')
+          end
+        end
+
+        it 'returns the class that errored' do
+          expect(described_class.message_text(params)).to include('HigherLevelReviewPdfSubmitJob')
+        end
+
+        it 'returns the adjusted retry count, if present' do
+          expect(described_class.message_text(params)).to include('has hit 3 retries')
+          params.delete 'retry_count'
+          expect(described_class.message_text(params)).to include('threw an error')
+        end
+
+        it 'returns args passed to job, if present' do
+          expect(described_class.message_text(params)).to include('Job Args: ["1234", "5678"]')
+          params.delete 'args'
+          expect(described_class.message_text(params)).not_to include('Job Args:')
+        end
+
+        it 'returns the error class and error message' do
+          expect(described_class.message_text(params)).to include('RuntimeError')
+          expect(described_class.message_text(params)).to include('Here there be dragons')
+        end
+
+        it 'returns the time the job failed' do
+          expect(described_class.message_text(params)).to include('failed at: 2021-02-18 17:52:17 UTC')
+        end
+
+        it 'returns the retry time, if present' do
+          expect(described_class.message_text(params)).to include('retried at: 2021-02-18 20:27:42 UTC')
+          params.delete 'retried_at'
+          expect(described_class.message_text(params)).to include('was not retried')
+        end
       end
 
       it 'sends a network request' do


### PR DESCRIPTION
## Description of change
* Added job arguments to notifier output
* Adjusted a few params for HLRPDFSubmitJob to take advantage of the changes
** Also updated the retry notify limits of the job to alert us for longer, should the job error for a while.

## Original issue(s)
https://vajira.max.gov/browse/API-8570