### PR TITLE
API-8394 - Add "veteran_icn" column to ClaimsApi::AutoEstablishedClaim table

### DIFF
--- a/db/migrate/20210713192552_add_veteran_icn_to_claims_api_auto_established_claims.rb
+++ b/db/migrate/20210713192552_add_veteran_icn_to_claims_api_auto_established_claims.rb
@@ -1,0 +1,5 @@
+class AddVeteranIcnToClaimsApiAutoEstablishedClaims < ActiveRecord::Migration[6.1]
+  def change
+    add_column :claims_api_auto_established_claims, :veteran_icn, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_01_173435) do
+ActiveRecord::Schema.define(version: 2021_07_13_192552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -229,6 +229,7 @@ ActiveRecord::Schema.define(version: 2021_07_01_173435) do
     t.jsonb "special_issues", default: []
     t.string "encrypted_bgs_special_issue_responses"
     t.string "encrypted_bgs_special_issue_responses_iv"
+    t.string "veteran_icn"
     t.index ["evss_id"], name: "index_claims_api_auto_established_claims_on_evss_id"
     t.index ["md5"], name: "index_claims_api_auto_established_claims_on_md5"
     t.index ["source"], name: "index_claims_api_auto_established_claims_on_source"
@@ -741,10 +742,10 @@ ActiveRecord::Schema.define(version: 2021_07_01_173435) do
     t.datetime "checkout_time"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "services"
     t.string "id_type"
     t.string "loa"
     t.string "account_type"
-    t.text "services"
     t.uuid "idme_uuid"
     t.text "notes"
   end
@@ -822,6 +823,7 @@ ActiveRecord::Schema.define(version: 2021_07_01_173435) do
     t.string "whodunnit"
     t.text "object"
     t.datetime "created_at"
+    t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Adds a `veteran_icn` column to the `ClaimsApi::AutoEstablishedClaim` table.
## Original issue(s)
[API-8394](https://vajira.max.gov/browse/API-8394)