### PR TITLE
Modify flipper to enforce enable_in_development setting

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -48,7 +48,9 @@ Rails.application.reloader.to_prepare do
         Flipper.add(feature)
 
         # default features to enabled for test and those explicitly set for development
-        if Rails.env.test? || (Rails.env.development? && feature_config['enable_in_development']) || (Settings.vsp_environment == 'development' && feature_config['enable_in_development'])
+        if Rails.env.test? ||
+           (Rails.env.development? && feature_config['enable_in_development']) ||
+           (Settings.vsp_environment == 'development' && feature_config['enable_in_development'])
           Flipper.enable(feature)
         end
       end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -48,7 +48,7 @@ Rails.application.reloader.to_prepare do
         Flipper.add(feature)
 
         # default features to enabled for test and those explicitly set for development
-        if Rails.env.test? || (Rails.env.development? && feature_config['enable_in_development'])
+        if Rails.env.test? || (Rails.env.development? && feature_config['enable_in_development']) || (Settings.vsp_environment == 'development' && feature_config['enable_in_development'])
           Flipper.enable(feature)
         end
       end


### PR DESCRIPTION
## Description of change
Since all environments (dev, sandbox, staging, prod) have RAILS_ENV set to "production", the enable_in_development flag currently does not work as intended. This change attempts to remedy that by having flipper check vsp_environment in settings.yml. 

## Original issue(s)
https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/24868


