### PR TITLE
Send VA file number to VBMS instead of ssn

### DIFF
--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -98,7 +98,7 @@ class SavedClaim::DependencyClaim < SavedClaim
   def upload_to_vbms(path:, doc_type: '148')
     uploader = ClaimsApi::VBMSUploader.new(
       filepath: path,
-      file_number: parsed_form['veteran_information']['ssn'],
+      file_number: parsed_form['veteran_information']['va_file_number'] || parsed_form['veteran_information']['ssn'],
       doc_type: doc_type
     )
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Alters `SavedClaim::DependencyClaim#upload_to_vbms` so it sends the `va_file_number` primarily, and the `ssn` secondarily, if needed.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/21680

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Since the VA file number and the SSN were identical in the test data, then there's no need to test implementation details. The form still uploads with using the `va_file_number`.