### PR TITLE
Dependents Application Claim Label Adjustment

### DIFF
--- a/spec/lib/bgs/form674_spec.rb
+++ b/spec/lib/bgs/form674_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'bgs/form674'
+require 'bid/awards/service'
 
 RSpec.describe BGS::Form674 do
   let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
@@ -10,31 +11,36 @@ RSpec.describe BGS::Form674 do
   # @TODO: may want to return something else
   it 'returns a hash with proc information' do
     VCR.use_cassette('bgs/form674/submit') do
-      modify_dependents = BGS::Form674.new(user_object).submit(all_flows_payload)
+      VCR.use_cassette('bid/awards/get_awards_pension') do
+        modify_dependents = BGS::Form674.new(user_object).submit(all_flows_payload)
 
-      expect(modify_dependents).to include(
-        :jrn_dt,
-        :jrn_lctn_id,
-        :jrn_obj_id,
-        :jrn_status_type_cd,
-        :jrn_user_id,
-        :vnp_proc_id
-      )
+        expect(modify_dependents).to include(
+          :jrn_dt,
+          :jrn_lctn_id,
+          :jrn_obj_id,
+          :jrn_status_type_cd,
+          :jrn_user_id,
+          :vnp_proc_id
+        )
+      end
     end
   end
 
   it 'calls all methods in flow' do
     VCR.use_cassette('bgs/form674/submit') do
-      expect_any_instance_of(BGS::Service).to receive(:create_proc).and_call_original
-      expect_any_instance_of(BGS::Service).to receive(:create_proc_form).and_call_original
-      expect_any_instance_of(BGS::VnpVeteran).to receive(:create).and_call_original
-      expect_any_instance_of(BGS::BenefitClaim).to receive(:create).and_call_original
-      expect_any_instance_of(BGS::StudentSchool).to receive(:create).and_call_original
-      expect_any_instance_of(BGS::VnpBenefitClaim).to receive(:create).and_call_original
-      expect_any_instance_of(BGS::VnpBenefitClaim).to receive(:update).and_call_original
-      expect_any_instance_of(BGS::VnpRelationships).to receive(:create_all).and_call_original
+      VCR.use_cassette('bid/awards/get_awards_pension') do
+        expect_any_instance_of(BGS::Service).to receive(:create_proc).and_call_original
+        expect_any_instance_of(BGS::Service).to receive(:create_proc_form).and_call_original
+        expect_any_instance_of(BGS::VnpVeteran).to receive(:create).and_call_original
+        expect_any_instance_of(BGS::BenefitClaim).to receive(:create).and_call_original
+        expect_any_instance_of(BGS::StudentSchool).to receive(:create).and_call_original
+        expect_any_instance_of(BGS::VnpBenefitClaim).to receive(:create).and_call_original
+        expect_any_instance_of(BGS::VnpBenefitClaim).to receive(:update).and_call_original
+        expect_any_instance_of(BGS::VnpRelationships).to receive(:create_all).and_call_original
+        expect_any_instance_of(BID::Awards::Service).to receive(:get_awards_pension).and_call_original
 
-      BGS::Form674.new(user_object).submit(all_flows_payload)
+        BGS::Form674.new(user_object).submit(all_flows_payload)
+      end
     end
   end
 end

--- a/spec/lib/bgs/form686c_spec.rb
+++ b/spec/lib/bgs/form686c_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'bgs/form686c'
+require 'bid/awards/service'
 
 RSpec.describe BGS::Form686c do
   let(:user_object) { FactoryBot.create(:evss_user, :loa3) }
@@ -10,32 +11,37 @@ RSpec.describe BGS::Form686c do
   # @TODO: may want to return something else
   it 'returns a hash with proc information' do
     VCR.use_cassette('bgs/form686c/submit') do
-      modify_dependents = BGS::Form686c.new(user_object).submit(all_flows_payload)
+      VCR.use_cassette('bid/awards/get_awards_pension') do
+        modify_dependents = BGS::Form686c.new(user_object).submit(all_flows_payload)
 
-      expect(modify_dependents).to include(
-        :jrn_dt,
-        :jrn_lctn_id,
-        :jrn_obj_id,
-        :jrn_status_type_cd,
-        :jrn_user_id,
-        :vnp_proc_id
-      )
+        expect(modify_dependents).to include(
+          :jrn_dt,
+          :jrn_lctn_id,
+          :jrn_obj_id,
+          :jrn_status_type_cd,
+          :jrn_user_id,
+          :vnp_proc_id
+        )
+      end
     end
   end
 
   it 'calls all methods in flow' do
     VCR.use_cassette('bgs/form686c/submit') do
-      expect_any_instance_of(BGS::Service).to receive(:create_proc).and_call_original
-      expect_any_instance_of(BGS::Service).to receive(:create_proc_form).and_call_original
-      expect_any_instance_of(BGS::VnpVeteran).to receive(:create).and_call_original
-      expect_any_instance_of(BGS::Dependents).to receive(:create_all).and_call_original
-      expect_any_instance_of(BGS::VnpRelationships).to receive(:create_all).and_call_original
-      expect_any_instance_of(BGS::VnpBenefitClaim).to receive(:create).and_call_original
-      expect_any_instance_of(BGS::BenefitClaim).to receive(:create).and_call_original
-      expect_any_instance_of(BGS::VnpBenefitClaim).to receive(:update).and_call_original
-      expect_any_instance_of(BGS::Service).to receive(:update_proc).with('3831475', { proc_state: 'MANUAL_VAGOV' })
+      VCR.use_cassette('bid/awards/get_awards_pension') do
+        expect_any_instance_of(BGS::Service).to receive(:create_proc).and_call_original
+        expect_any_instance_of(BGS::Service).to receive(:create_proc_form).and_call_original
+        expect_any_instance_of(BGS::VnpVeteran).to receive(:create).and_call_original
+        expect_any_instance_of(BGS::Dependents).to receive(:create_all).and_call_original
+        expect_any_instance_of(BGS::VnpRelationships).to receive(:create_all).and_call_original
+        expect_any_instance_of(BGS::VnpBenefitClaim).to receive(:create).and_call_original
+        expect_any_instance_of(BGS::BenefitClaim).to receive(:create).and_call_original
+        expect_any_instance_of(BGS::VnpBenefitClaim).to receive(:update).and_call_original
+        expect_any_instance_of(BGS::Service).to receive(:update_proc).with('3831475', { proc_state: 'MANUAL_VAGOV' })
+        expect_any_instance_of(BID::Awards::Service).to receive(:get_awards_pension).and_call_original
 
-      BGS::Form686c.new(user_object).submit(all_flows_payload)
+        BGS::Form686c.new(user_object).submit(all_flows_payload)
+      end
     end
   end
 

--- a/spec/lib/bid/awards/service_spec.rb
+++ b/spec/lib/bid/awards/service_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe BID::Awards::Service do
     context 'with a successful submission' do
       it 'successfully receives an Award Pension object' do
         VCR.use_cassette('bid/awards/get_awards_pension') do
-          allow(user).to receive(:participant_id).and_return('32436649')
           response = service.get_awards_pension
 
           expect(response.status).to eq(200)

--- a/spec/support/vcr_cassettes/bid/awards/get_awards_pension.yml
+++ b/spec/support/vcr_cassettes/bid/awards/get_awards_pension.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://fake_url.com/api/v1/awards/pension/32436649
+    uri: https://fake_url.com/api/v1/awards/pension/600061742
     body:
       encoding: US-ASCII
       string: ''
@@ -55,7 +55,7 @@ http_interactions:
       string: |-
         {
           "awardsPension" : {
-            "veteranId" : 32436649,
+            "veteranId" : 600061742,
             "isEligibleForPension" : true,
             "isInReceiptOfPension" : true,
             "netWorthLimit" : 129094


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
When submitting a Dependents Application (VA Form 21-686c or VA Form 21-674), there are certain use cases that are not able to be processed automatically so we set those statuses to `MANUAL_VAGOV` for manual processing. We have been asked by our partners to add a check to determine whether or not the Veteran is currently receiving pension benefits, and change the claim type label depending on the response.

This PR does the following: if the status is `MANUAL_VAGOV`, call the awards API, then set the claim type based on whether or not the Veteran is currently receiving pension benefits.  Otherwise, use the default claim type label for claims that are not being set to manual.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27272

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is an update to existing functionality, no new logging or settings have been added.
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] Local testing
- [x] Specs updated
- [x] Staging testing planned