### PR TITLE
add additional VA profile error codes

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -1895,6 +1895,18 @@ en:
         detail: International numbers must have a valid country code that is not 1, and
           no area code.
         status: 400
+      VET360_PHON211:
+        <<: *external_defaults
+        title: Area Code Pattern
+        code: VET360_PHON211
+        detail: Area Codes do not end with the same two digits
+        status: 400
+      VET360_PHON213:
+        <<: *external_defaults
+        title: Area Code Pattern
+        code: VET360_PHON213
+        detail: Area Codes do not include 9 as the middle digit
+        status: 400
       VET360_PHON300:
         <<: *external_defaults
         title: Phone Inactive


### PR DESCRIPTION
## Description of change
When @Mottie was testing the NOD profile modal in staging he was using bogus numbers and got error messages that were unmapped. 
the phone number `1005551212`  got 
<img width="751" alt="Screen Shot 2021-07-20 at 1 01 27 PM" src="https://user-images.githubusercontent.com/19188/126365446-fae762e3-426d-4ba2-80c2-1befd58474e6.png">
http://sentry.vfs.va.gov/organizations/vsp/issues/6192/events/0825f4b392d945e59e72aa9527f95547/?environment=staging&project=3&query=is%3Aunresolved


the phone number `1987651212` got 
<img width="751" alt="Screen Shot 2021-07-20 at 1 04 23 PM" src="https://user-images.githubusercontent.com/19188/126366543-538b9ff1-bcb3-421b-991f-59454df4d981.png">
http://sentry.vfs.va.gov/organizations/vsp/issues/6192/events/4783b9b86254441cb2d932839685b65c/?environment=staging&project=3&query=is%3Aunresolved


Apparently the authoritative source for error messages is/was https://github.com/department-of-veterans-affairs/mdm-cuf-person/blob/development/mdm-cuf-person-server/src/inttest/resources/mdm/cuf/person/testData/error_codes.csv but I don't have access or the link changed.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#27563

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
