### PR TITLE
Updating VA File Number Class Type When Submitting VA Form 21-686c

### DIFF
--- a/app/models/vet_info.rb
+++ b/app/models/vet_info.rb
@@ -15,7 +15,7 @@ class VetInfo
           'last' => @user.last_name
         },
         'ssn' => @user.ssn,
-        'va_file_number' => @bgs_person[:file_nbr],
+        'va_file_number' => @bgs_person[:file_nbr].to_s,
         'birth_date' => @user.birth_date
       }
     }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
When submitting a Dependents Application (VA Form 21-686c) we are generating a PDF and uploading it to VBMS.  We recently made a change to use VA File Number as the identifier for uploading instead of SSN.  This works on our local testing environments, however, in staging we are seeing an error that says "Invalid format for Veteran Identifier".  We determined that the error is being caused by the way the response comes back from BGS when we get the file number - instead of a `String`, it is a `Nori::StringWithAttributes`, which is causing the upload to VBMS to fail.  This PR is a small fix that sets the VA File Number to a String.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27651

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
This is just a quick fix PR so no new logging or settings have been added.
<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] Local testing
- [x] Staging testing planned