### PR TITLE
Revert "Send VA file number to VBMS instead of ssn"

### DIFF
--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -98,7 +98,7 @@ class SavedClaim::DependencyClaim < SavedClaim
   def upload_to_vbms(path:, doc_type: '148')
     uploader = ClaimsApi::VBMSUploader.new(
       filepath: path,
-      file_number: parsed_form['veteran_information']['va_file_number'] || parsed_form['veteran_information']['ssn'],
+      file_number: parsed_form['veteran_information']['ssn'],
       doc_type: doc_type
     )
 


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#7430

@thilton-oddball we are having a weird bug in staging (not dev or test) so we are reverting this for now so testing can continue.

original issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/21680