### PR TITLE
[26888] updates afterlogin and afterlogout job TUD flags to use Settings

### DIFF
--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -59,7 +59,9 @@ module AuthenticationAndSSOConcerns
 
   # Destroys the users session in 1) Redis, 2) the MHV SSO Cookie, 3) and the Session Cookie
   def reset_session
-    AfterLogoutJob.perform_async(account_uuid: @current_user&.account_uuid) unless Rails.env.production?
+    if Settings.test_user_dashboard.env == 'staging'
+      AfterLogoutJob.perform_async(account_uuid: @current_user&.account_uuid)
+    end
     Rails.logger.info('SSO: ApplicationController#reset_session', sso_logging_info)
 
     clear_session

--- a/app/workers/after_login_job.rb
+++ b/app/workers/after_login_job.rb
@@ -22,6 +22,8 @@ class AfterLoginJob
 
     evss_create_account
     create_user_account
-    TestUserDashboard::CheckoutUser.new(@current_user.account_uuid).call unless Rails.env.production?
+    if Settings.test_user_dashboard.env == 'staging'
+      TestUserDashboard::CheckoutUser.new(@current_user.account_uuid).call
+    end
   end
 end

--- a/spec/jobs/after_login_job_spec.rb
+++ b/spec/jobs/after_login_job_spec.rb
@@ -22,21 +22,31 @@ RSpec.describe AfterLoginJob do
       end
     end
 
-    context 'in a production environment' do
+    context 'in a non-staging environment' do
       let(:user) { create(:user) }
 
+      around do |example|
+        with_settings(Settings.test_user_dashboard, env: 'production') do
+          example.run
+        end
+      end
+
       it 'does not call TUD account checkout' do
-        expect(Rails.env).to receive('production?').once.and_return(true)
         expect_any_instance_of(TestUserDashboard::CheckoutUser).not_to receive(:call)
         described_class.new.perform('user_uuid' => user.uuid)
       end
     end
 
-    context 'in a non-production environment' do
+    context 'in a staging environment' do
       let(:user) { create(:user) }
 
+      around do |example|
+        with_settings(Settings.test_user_dashboard, env: 'staging') do
+          example.run
+        end
+      end
+
       it 'calls TUD account checkout' do
-        expect(Rails.env).to receive('production?').once.and_return(false)
         expect_any_instance_of(TestUserDashboard::CheckoutUser).to receive(:call)
         described_class.new.perform('user_uuid' => user.uuid)
       end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This change updates the gating of TUD-related features in the afterlogin and afterlogout Sidekiq jobs to use the same Settings as the [TUD module's route configuration](https://github.com/department-of-veterans-affairs/vets-api/pull/7404)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#26888

## Things to know about this PR
Unit tests updated, manual test of TUD checked-in/checked-out feature
