### PR TITLE
Dependents Application PDF Upload to VBMS

### DIFF
--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -98,7 +98,7 @@ class SavedClaim::DependencyClaim < SavedClaim
   def upload_to_vbms(path:, doc_type: '148')
     uploader = ClaimsApi::VBMSUploader.new(
       filepath: path,
-      file_number: parsed_form['veteran_information']['ssn'],
+      file_number: parsed_form['veteran_information']['va_file_number'] || parsed_form['veteran_information']['ssn'],
       doc_type: doc_type
     )
 

--- a/app/services/bgs/dependent_service.rb
+++ b/app/services/bgs/dependent_service.rb
@@ -17,6 +17,12 @@ module BGS
 
       BGS::SubmitForm686cJob.perform_async(@user.uuid, claim.id, vet_info.to_686c_form_hash) if claim.submittable_686?
       BGS::SubmitForm674Job.perform_async(@user.uuid, claim.id, vet_info.to_686c_form_hash) if claim.submittable_674?
+      VBMS::SubmitDependentsPdfJob.perform_async(
+        claim.id,
+        vet_info.to_686c_form_hash,
+        claim.submittable_686?,
+        claim.submittable_674?
+      )
     rescue => e
       report_error(e)
     end

--- a/app/workers/bgs/submit_form674_job.rb
+++ b/app/workers/bgs/submit_form674_job.rb
@@ -23,13 +23,6 @@ module BGS
     rescue
       salvage_save_in_progress_form(FORM_ID, user_uuid, in_progress_copy)
       DependentsApplicationFailureMailer.build(user).deliver_later if user.present?
-    else
-      VBMS::SubmitDependentsPdfJob.perform_async(
-        saved_claim_id,
-        vet_info,
-        @submittable_686,
-        @submittable_674
-      )
     end
 
     private
@@ -41,8 +34,6 @@ module BGS
 
       raise Invalid674Claim unless claim.valid?(:run_686_form_jobs)
 
-      @submittable_686 = claim.submittable_686?
-      @submittable_674 = claim.submittable_674?
       claim.formatted_674_data(vet_info)
     end
   end

--- a/app/workers/bgs/submit_form686c_job.rb
+++ b/app/workers/bgs/submit_form686c_job.rb
@@ -23,13 +23,6 @@ module BGS
     rescue
       salvage_save_in_progress_form(FORM_ID, user_uuid, in_progress_copy)
       DependentsApplicationFailureMailer.build(user).deliver_now if user.present?
-    else
-      VBMS::SubmitDependentsPdfJob.perform_async(
-        saved_claim_id,
-        vet_info,
-        @submittable_686,
-        @submittable_674
-      )
     end
 
     private
@@ -41,8 +34,6 @@ module BGS
 
       raise Invalid686cClaim unless claim.valid?(:run_686_form_jobs)
 
-      @submittable_686 = claim.submittable_686?
-      @submittable_674 = claim.submittable_674?
       claim.formatted_686_data(vet_info)
     end
   end

--- a/spec/jobs/bgs/submit_form674_job_spec.rb
+++ b/spec/jobs/bgs/submit_form674_job_spec.rb
@@ -23,8 +23,6 @@ RSpec.describe BGS::SubmitForm674Job, type: :job do
     client_stub = instance_double('BGS::Form674')
     allow(BGS::Form674).to receive(:new).with(an_instance_of(User)) { client_stub }
     expect(client_stub).to receive(:submit).once
-    expect_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_686?).and_return(false)
-    expect_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
 
     described_class.new.perform(user.uuid, dependency_claim.id, vet_info)
   end
@@ -40,8 +38,6 @@ RSpec.describe BGS::SubmitForm674Job, type: :job do
       mailer_double = double('Mail::Message')
       allow(BGS::Form674).to receive(:new).with(an_instance_of(User)) { client_stub }
       expect(client_stub).to receive(:submit).and_raise(StandardError)
-      expect_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_686?).and_return(false)
-      expect_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
       allow(mailer_double).to receive(:deliver_later)
       expect(DependentsApplicationFailureMailer).to receive(:build).with(an_instance_of(User)) { mailer_double }
       expect(job).to receive(:salvage_save_in_progress_form).with('686C-674', user.uuid, anything)

--- a/spec/jobs/bgs/submit_form686c_job_spec.rb
+++ b/spec/jobs/bgs/submit_form686c_job_spec.rb
@@ -23,8 +23,6 @@ RSpec.describe BGS::SubmitForm686cJob, type: :job do
     client_stub = instance_double('BGS::Form686c')
     allow(BGS::Form686c).to receive(:new).with(an_instance_of(User)) { client_stub }
     expect(client_stub).to receive(:submit).once
-    expect_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_686?).and_return(true)
-    expect_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(false)
 
     described_class.new.perform(user.uuid, dependency_claim.id, vet_info)
   end
@@ -35,8 +33,6 @@ RSpec.describe BGS::SubmitForm686cJob, type: :job do
       mailer_double = double('Mail::Message')
       allow(BGS::Form686c).to receive(:new).with(an_instance_of(User)) { client_stub }
       expect(client_stub).to receive(:submit).and_raise(StandardError)
-      expect_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_686?).and_return(true)
-      expect_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(false)
 
       allow(mailer_double).to receive(:deliver_now)
       expect(DependentsApplicationFailureMailer).to receive(:build).with(an_instance_of(User)) { mailer_double }

--- a/spec/services/bgs/dependent_service_spec.rb
+++ b/spec/services/bgs/dependent_service_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe BGS::DependentService do
         allow(claim).to receive(:submittable_686?).and_return(true)
         allow(claim).to receive(:submittable_674?).and_return(false)
 
+        expect(VBMS::SubmitDependentsPdfJob).to receive(:perform_async).with(claim.id, vet_info, true, false)
+
         service.submit_686c_form(claim)
       end
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
When submitting a Dependents Application (VA Form 21-686c), the form submission is processed by a Sidekiq job.  At the end of the job, it generates a PDF and then uploads it to VBMS.  This job was failing when uploading the PDF to VBMS, so this PR moves the PDF job to a different part of the 686c submission workflow.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27651

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] Local testing
- [x] Specs updated
- [x] Tested on review instance