### PR TITLE
27740 Throttling check_in endpoints

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -33,6 +33,10 @@ class Rack::Attack
     req.ip if req.path.starts_with?('/covid_vaccine/v0') && (req.post? || req.put?)
   end
 
+  throttle('check_in/ip', limit: 10, period: 1.minute) do |req|
+    req.ip if req.path.starts_with?('/check_in/v0') && (req.post? || req.get?)
+  end
+
   # Source: https://github.com/kickstarter/rack-attack#x-ratelimit-headers-for-well-behaved-clients
   Rack::Attack.throttled_response = lambda do |env|
     rate_limit = env['rack.attack.match_data']

--- a/spec/middleware/rack/attack_spec.rb
+++ b/spec/middleware/rack/attack_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Rack::Attack do
   include Rack::Test::Methods
 
+  let(:headers) { { 'REMOTE_ADDR' => '1.2.3.4' } }
+
   def app
     Rails.application
   end
@@ -19,10 +21,10 @@ RSpec.describe Rack::Attack do
 
   describe '#throttled_response' do
     it 'adds X-RateLimit-* headers to the response' do
-      post '/v0/limited', headers: { 'REMOTE_ADDR' => '1.2.3.4' }
+      post '/v0/limited', headers: headers
       expect(last_response.status).not_to eq(429)
 
-      post '/v0/limited', headers: { 'REMOTE_ADDR' => '1.2.3.4' }
+      post '/v0/limited', headers: headers
       expect(last_response.status).to eq(429)
       expect(last_response.headers).to include(
         'X-RateLimit-Limit',
@@ -33,8 +35,6 @@ RSpec.describe Rack::Attack do
   end
 
   describe 'covid_vaccine' do
-    let(:headers) { { 'REMOTE_ADDR' => '1.2.3.4' } }
-
     it 'limits requests for any post and put endpoints to 4 in 5 minutes' do
       post '/covid_vaccine/v0/registration', headers: headers
       expect(last_response.status).not_to eq(429)
@@ -50,9 +50,51 @@ RSpec.describe Rack::Attack do
     end
   end
 
-  describe 'vic rate-limits', run_at: 'Thu, 26 Dec 2015 15:54:20 GMT' do
-    let(:headers) { { 'REMOTE_ADDR' => '1.2.3.4' } }
+  describe 'check_in/ip' do
+    let(:data) { { data: 'foo', status: 200 } }
 
+    context 'when more than 10 requests' do
+      context 'when GET endpoint' do
+        before do
+          allow_any_instance_of(ChipApi::Service).to receive(:get_check_in).and_return(data)
+
+          10.times do
+            get '/check_in/v0/patient_check_ins/123456', headers: headers
+
+            expect(last_response.status).to eq(200)
+          end
+        end
+
+        it 'throttles with status 429' do
+          get '/check_in/v0/patient_check_ins/123456', headers: headers
+
+          expect(last_response.status).to eq(429)
+        end
+      end
+
+      context 'when POST endpoint' do
+        let(:post_params) { { patient_check_ins: { id: '123aBc' } } }
+
+        before do
+          allow_any_instance_of(ChipApi::Service).to receive(:create_check_in).with(anything).and_return(data)
+
+          10.times do
+            post '/check_in/v0/patient_check_ins', post_params, headers # rubocop:disable Rails/HttpPositionalArguments
+
+            expect(last_response.status).to eq(200)
+          end
+        end
+
+        it 'throttles with status 429' do
+          post '/check_in/v0/patient_check_ins', post_params, headers # rubocop:disable Rails/HttpPositionalArguments
+
+          expect(last_response.status).to eq(429)
+        end
+      end
+    end
+  end
+
+  describe 'vic rate-limits', run_at: 'Thu, 26 Dec 2015 15:54:20 GMT' do
     before do
       limit.times do
         post endpoint, headers: headers


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
- We wish to throttle the publicly exposed Check-in endpoints.
- GET and POST calls to the `/check_in/v0/patient_check_ins` will be throttled by `rack_attack`
- No more than 10 requests per IP will be allowed to hit the endpoints in under a minute. This limit can be changed based on security and business requirements.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#27740

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] Specs passing