### PR TITLE
Update default Cypress viewport values in Sidekiq job

### DIFF
--- a/app/workers/cypress_viewport_updater/cypress_json_file.rb
+++ b/app/workers/cypress_viewport_updater/cypress_json_file.rb
@@ -8,6 +8,8 @@ module CypressViewportUpdater
 
     def update(viewports:)
       hash = JSON.parse(raw_content)
+      hash['viewportWidth'] = viewports.desktop[0].width
+      hash['viewportHeight'] = viewports.desktop[0].height
       hash['env']['vaTopMobileViewports'] = viewports.mobile
       hash['env']['vaTopTabletViewports'] = viewports.tablet
       hash['env']['vaTopDesktopViewports'] = viewports.desktop


### PR DESCRIPTION
## Description of change
In reference to some work in [this ticket](https://github.com/department-of-veterans-affairs/va.gov-team/pull/27779):

This is a quick update to a Sidekiq job that updates a couple of Cypress files in `vets-website` once a month.

This update sets the default width and height in the `config/cypress.json` file. The updated width and height is derived from the top desktop viewport width and height as reported by Google Analytics for the VA.gov property.

I ran this job locally and it successfully submitted a PR with the updated viewport values - https://github.com/department-of-veterans-affairs/vets-website/pull/17985

## Original issue(s)
Previously, the default Cypress viewport was set manually. This PR will allow it to be set automatically based on GA data, once a month.

## Please note!
I didn't commit `Gemfile.lock` because of this:

```
√ vets-api % git diff Gemfile.lock
diff --git a/Gemfile.lock b/Gemfile.lock
index 5afa87287..e73a79cf7 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,6 @@ PATH
 
 GEM
   remote: https://rubygems.org/
-  remote: https://enterprise.contribsys.com/
   specs:
     Ascii85 (1.1.0)
     aasm (5.2.0)
@@ -344,7 +343,6 @@ GEM
     e2mmap (0.1.0)
     ecma-re-validator (0.3.0)
       regexp_parser (~> 2.0)
-    einhorn (0.8.2)
     encryptor (3.0.0)
     erubi (1.10.0)
     et-orbi (1.2.4)
@@ -846,13 +844,6 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sidekiq-ent (2.2.2)
-      einhorn (>= 0.7.4)
-      sidekiq (>= 6.1.1)
-      sidekiq-pro (>= 5.1.1)
-    sidekiq-pro (5.2.2)
-      connection_pool (>= 2.2.3)
-      sidekiq (>= 6.2.0)
```