### PR TITLE
[7518] Plumbing up ability to call person_types on User model and get…

### DIFF
--- a/app/models/mpi_data.rb
+++ b/app/models/mpi_data.rb
@@ -104,6 +104,11 @@ class MPIData < Common::RedisStore
   # @return [Boolean] presence or absence of identity theft flag
   delegate :id_theft_flag, to: :profile
 
+  # The person types that the user's profile represents
+  #
+  # @return [Array[String]] the list of person types
+  delegate :person_types, to: :profile, allow_nil: true
+
   # The profile returned from the MVI service. Either returned from cached response in Redis or the MVI service.
   #
   # @return [MPI::Models::MviProfile] patient 'golden record' data from MVI

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -212,6 +212,10 @@ class User < Common::RedisStore
     mpi_profile&.normalized_suffix
   end
 
+  def person_types
+    identity_person_types.presence || mpi_person_types
+  end
+
   def ssn_mpi
     mpi_profile&.ssn
   end
@@ -256,7 +260,7 @@ class User < Common::RedisStore
   delegate :mhv_icn, to: :identity, allow_nil: true
   delegate :idme_uuid, to: :identity, allow_nil: true
   delegate :common_name, to: :identity, allow_nil: true
-  delegate :person_types, to: :identity, allow_nil: true
+  delegate :person_types, to: :identity, allow_nil: true, prefix: true
 
   # mpi attributes
   delegate :birls_id, to: :mpi, prefix: true
@@ -266,6 +270,7 @@ class User < Common::RedisStore
   delegate :icn_with_aaid, to: :mpi
   delegate :vet360_id, to: :mpi
   delegate :search_token, to: :mpi
+  delegate :person_types, to: :mpi, prefix: true
   delegate :id_theft_flag, to: :mpi
   delegate :status, to: :mpi, prefix: true
   delegate :error, to: :mpi, prefix: true

--- a/app/models/user_identity.rb
+++ b/app/models/user_identity.rb
@@ -37,6 +37,7 @@ class UserIdentity < Common::RedisStore
   attribute :sign_in, Hash # original sign_in (see sso_service#mergable_identity_attributes)
   attribute :icn_with_aaid
   attribute :search_token
+  attribute :person_types
 
   validates :uuid, presence: true
   validates :loa, presence: true

--- a/app/models/user_relationship.rb
+++ b/app/models/user_relationship.rb
@@ -4,6 +4,8 @@ class UserRelationship
   attr_accessor :first_name, :last_name, :birth_date, :ssn,
                 :gender, :veteran_status, :participant_id, :icn
 
+  PERSON_TYPE_VETERAN = 'VET'
+
   # Initializer with a single 'person' from a BGS get_dependents call
   def self.from_bgs_dependent(bgs_dependent)
     user_relationship = new
@@ -28,7 +30,7 @@ class UserRelationship
     user_relationship.birth_date = Formatters::DateFormatter.format_date(mpi_relationship.birth_date)
     user_relationship.ssn = mpi_relationship.ssn
     user_relationship.gender = mpi_relationship.gender
-    user_relationship.veteran_status = mpi_relationship.person_type_code == 'Veteran'
+    user_relationship.veteran_status = mpi_relationship.person_types.include? PERSON_TYPE_VETERAN
     # ID attributes
     user_relationship.icn = mpi_relationship.icn
     user_relationship.participant_id = mpi_relationship.participant_id

--- a/lib/mpi/models/mvi_profile_identity.rb
+++ b/lib/mpi/models/mvi_profile_identity.rb
@@ -16,7 +16,7 @@ module MPI
       attribute :ssn, String
       attribute :address, MviProfileAddress
       attribute :home_phone, String
-      attribute :person_type_code, String
+      attribute :person_types, Array[String]
 
       def normalized_suffix
         case @suffix

--- a/lib/mpi/responses/profile_parser.rb
+++ b/lib/mpi/responses/profile_parser.rb
@@ -33,7 +33,8 @@ module MPI
       ADDRESS_XPATH = 'addr'
       PHONE = 'telecom'
       PERSON_TYPE = 'PERSON_TYPE'
-      DISPLAY_NAME_XPATH = 'value/@displayName'
+      PERSON_TYPE_SEPERATOR = '~'
+      PERSON_TYPE_VALUE_XPATH = 'value/@code'
       PERSON_TYPE_CODE_XPATH = 'code/@code'
       ADMIN_OBSERVATION_XPATH = '*/administrativeObservation'
 
@@ -115,7 +116,7 @@ module MPI
 
       def create_mvi_profile_identity(person, person_prefix)
         person_component = locate_element(person, person_prefix)
-        person_type = parse_person_type(person)
+        person_types = parse_person_type(person)
         name = parse_name(locate_element(person_component, NAME_XPATH))
         {
           given_names: name[:given],
@@ -126,7 +127,7 @@ module MPI
           ssn: parse_ssn(locate_element(person_component, SSN_XPATH)),
           address: parse_address(person_component),
           home_phone: parse_phone(person, person_prefix),
-          person_type_code: person_type
+          person_types: person_types
         }
       end
 
@@ -228,7 +229,10 @@ module MPI
 
       def parse_person_type(person)
         person.locate(ADMIN_OBSERVATION_XPATH).each do |element|
-          return element.locate(DISPLAY_NAME_XPATH).first if element.locate(PERSON_TYPE_CODE_XPATH).first == PERSON_TYPE
+          if element.locate(PERSON_TYPE_CODE_XPATH).first == PERSON_TYPE
+            person_type_string = element.locate(PERSON_TYPE_VALUE_XPATH).first
+            return person_type_string&.split(PERSON_TYPE_SEPERATOR) || []
+          end
         end
       end
     end

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -81,9 +81,9 @@ module SAML
         safe_attr('va_eauth_emailaddress')
       end
 
-      # Returns an array beause a person can have multipe types.
+      # Returns an array because a person can have multipe types.
       def person_types
-        safe_attr('va_eauth_persontype')&.split('|')
+        safe_attr('va_eauth_persontype')&.split('|') || []
       end
 
       ### Identifiers

--- a/spec/factories/mvi_profile_relationships.rb
+++ b/spec/factories/mvi_profile_relationships.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :mpi_profile_relationship, class: 'MPI::Models::MviProfileRelationship' do
-    person_type_code { 'VET' }
+    person_types { ['VET'] }
     given_names { %w[Joe William] }
     family_name { 'Smith' }
     suffix { 'Sr' }

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -45,7 +45,7 @@ FactoryBot.define do
     ssn { Faker::IDNumber.valid.delete('-') }
     address { build(:mvi_profile_address) }
     home_phone { Faker::PhoneNumber.phone_number }
-    person_type_code { 'Patient' }
+    person_types { ['PAT'] }
     full_mvi_ids {
       [
         '1000123456V123456^NI^200M^USVHA^P',

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
       search_token { nil }
       icn_with_aaid { nil }
       common_name { nil }
-      person_types { [] }
+      person_types { ['VET'] }
 
       sign_in do
         {
@@ -60,6 +60,7 @@ FactoryBot.define do
                              icn: t.icn,
                              mhv_icn: t.mhv_icn,
                              loa: t.loa,
+                             person_types: t.person_types,
                              multifactor: t.multifactor,
                              mhv_correlation_id: t.mhv_correlation_id,
                              mhv_account_type: t.mhv_account_type,

--- a/spec/lib/mpi/responses/profile_parser_spec.rb
+++ b/spec/lib/mpi/responses/profile_parser_spec.rb
@@ -164,7 +164,7 @@ describe MPI::Responses::ProfileParser do
           birls_id: nil,
           birls_ids: [],
           search_token: 'WSDOC2005221733165441605720989',
-          person_type_code: 'Dependent',
+          person_types: %w[DEP VET],
           relationships: [mpi_profile_relationship_component],
           id_theft_flag: false
         )
@@ -173,7 +173,7 @@ describe MPI::Responses::ProfileParser do
       let(:mpi_profile_relationship_component) do
         build(
           :mpi_profile_relationship,
-          person_type_code: [],
+          person_types: [],
           given_names: %w[Mark],
           family_name: 'Webb',
           suffix: 'Jr',
@@ -291,7 +291,7 @@ describe MPI::Responses::ProfileParser do
           '123412345^PI^200BRLS^USVBA^A'
         ],
         search_token: 'WSDOC1611060614456041732180196',
-        person_type_code: 'Patient',
+        person_types: ['PAT'],
         id_theft_flag: false
       )
     end

--- a/spec/lib/mpi/service_spec.rb
+++ b/spec/lib/mpi/service_spec.rb
@@ -31,7 +31,7 @@ describe MPI::Service do
       birls_ids: ['796122306'],
       historical_icns: nil,
       icn_with_aaid: icn_with_aaid,
-      person_type_code: [],
+      person_types: [],
       full_mvi_ids: [
         '1008714701V416111^NI^200M^USVHA^P',
         '796122306^PI^200BRLS^USVBA^A',

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe SAML::User do
           birls_id: nil,
           icn: nil,
           common_name: nil,
-          person_types: nil
+          person_types: []
         )
       end
 
@@ -159,7 +159,7 @@ RSpec.describe SAML::User do
           birls_id: nil,
           icn: nil,
           common_name: nil,
-          person_types: nil
+          person_types: []
         )
       end
 
@@ -197,7 +197,7 @@ RSpec.describe SAML::User do
           birls_id: nil,
           icn: '1008830476V316605',
           common_name: 'vets.gov.user+262@example.com',
-          person_types: nil
+          person_types: []
         )
       end
 
@@ -237,7 +237,7 @@ RSpec.describe SAML::User do
           icn: nil,
           multifactor: multifactor,
           common_name: nil,
-          person_types: nil
+          person_types: []
         )
       end
 
@@ -279,7 +279,7 @@ RSpec.describe SAML::User do
           icn: '1013183292V131165',
           multifactor: multifactor,
           common_name: 'alexmac_0@example.com',
-          person_types: nil
+          person_types: []
         )
       end
     end
@@ -319,7 +319,7 @@ RSpec.describe SAML::User do
           participant_id: nil,
           multifactor: true,
           common_name: nil,
-          person_types: nil
+          person_types: []
         )
       end
 
@@ -362,7 +362,7 @@ RSpec.describe SAML::User do
           icn: '1012853550V207686',
           multifactor: multifactor,
           common_name: 'k+tristan@example.com',
-          person_types: nil
+          person_types: []
         )
       end
     end
@@ -406,7 +406,7 @@ RSpec.describe SAML::User do
           icn: nil,
           multifactor: multifactor,
           common_name: 'k+tristan@example.com',
-          person_types: nil
+          person_types: []
         )
       end
     end
@@ -686,7 +686,7 @@ RSpec.describe SAML::User do
           birls_id: nil,
           icn: nil,
           multifactor: multifactor,
-          person_types: nil
+          person_types: []
         )
       end
     end
@@ -725,7 +725,7 @@ RSpec.describe SAML::User do
           icn: '1013173963V366678',
           multifactor: false,
           common_name: 'iam.tester@example.com',
-          person_types: nil
+          person_types: []
         )
       end
 
@@ -872,7 +872,7 @@ RSpec.describe SAML::User do
           icn: '1012779219V964737',
           multifactor: multifactor,
           common_name: 'SOFIA MCKIBBENS',
-          person_types: nil
+          person_types: []
         )
       end
 
@@ -925,7 +925,7 @@ RSpec.describe SAML::User do
           icn: '1013062086V794840',
           multifactor: multifactor,
           common_name: 'mhvzack@mhv.va.gov',
-          person_types: nil
+          person_types: []
         )
       end
     end
@@ -967,7 +967,7 @@ RSpec.describe SAML::User do
           icn: '1012827134V054550',
           multifactor: multifactor,
           common_name: 'vets.gov.user+262@gmail.com',
-          person_types: nil
+          person_types: []
         )
       end
     end

--- a/spec/models/mpi_data_spec.rb
+++ b/spec/models/mpi_data_spec.rb
@@ -84,6 +84,7 @@ describe MPIData, skip_mvi: true do
       let(:search_token) { 'some-search_token' }
       let(:gender) { 'M' }
       let(:ssn) { '987654321' }
+      let(:person_types) { ['VET'] }
       let(:mvi_profile) do
         build(:mvi_profile,
               given_names: given_names,
@@ -93,6 +94,7 @@ describe MPIData, skip_mvi: true do
               edipi: edipi,
               search_token: search_token,
               ssn: ssn,
+              person_types: person_types,
               gender: gender)
       end
       let(:expected_user_identity) do
@@ -107,6 +109,7 @@ describe MPIData, skip_mvi: true do
               search_token: search_token,
               gender: gender,
               ssn: ssn,
+              person_types: person_types,
               idme_uuid: user.idme_uuid)
       end
 

--- a/spec/models/user_relationship_spec.rb
+++ b/spec/models/user_relationship_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe UserRelationship, type: :model do
       expect(user_relationship.birth_date).to eq Formatters::DateFormatter.format_date(mpi_relationship.birth_date)
       expect(user_relationship.ssn).to eq mpi_relationship.ssn
       expect(user_relationship.gender).to eq mpi_relationship.gender
-      expect(user_relationship.veteran_status).to eq false
+      expect(user_relationship.veteran_status).to eq mpi_relationship.person_types.include? 'VET'
       expect(user_relationship.icn).to eq mpi_relationship.icn
       expect(user_relationship.participant_id).to eq mpi_relationship.participant_id
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -125,6 +125,45 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#person_types' do
+    let(:user) { build(:user, person_types: identity_person_types) }
+    let(:mpi_profile) { build(:mvi_profile, person_types: mpi_person_types) }
+    let(:identity_person_types) { ['some_identity_person_types'] }
+    let(:mpi_person_types) { 'some_mpi_person_types' }
+
+    before do
+      allow(user).to receive(:mpi).and_return(mpi_profile)
+    end
+
+    context 'when person_types on User Identity exists' do
+      let(:identity_person_types) { ['some_identity_person_types'] }
+
+      it 'returns person_types off the User Identity' do
+        expect(user.person_types).to eq(identity_person_types)
+      end
+    end
+
+    context 'when person_types on identity does not exist' do
+      let(:identity_person_types) { nil }
+
+      context 'and person_types on MPI Data exists' do
+        let(:mpi_person_types) { 'some_mpi_person_types' }
+
+        it 'returns person_types from the MPI Data' do
+          expect(user.person_types).to eq([mpi_person_types])
+        end
+      end
+
+      context 'and person_types on MPI Data does not exist' do
+        let(:mpi_person_types) { nil }
+
+        it 'returns an empty array' do
+          expect(user.person_types).to eq([])
+        end
+      end
+    end
+  end
+
   describe '#all_emails' do
     let(:user) { build(:user, :loa3) }
     let(:vet360_email) { user.vet360_contact_info.email.email_address }
@@ -376,6 +415,10 @@ RSpec.describe User, type: :model do
           expect(user.gender).to be(user.identity.gender)
         end
 
+        it 'fetches person_types from IDENTITY' do
+          expect(user.identity_person_types).to be(user.identity.person_types)
+        end
+
         it 'fetches properly parsed birth_date from IDENTITY' do
           expect(user.birth_date).to eq(Date.parse(user.identity.birth_date).iso8601)
         end
@@ -420,6 +463,10 @@ RSpec.describe User, type: :model do
 
         it 'fetches last_name from MPI' do
           expect(user.last_name_mpi).to be(mvi_profile.family_name)
+        end
+
+        it 'fetches person_types from MPI' do
+          expect(user.mpi_person_types).to be(mvi_profile.person_types)
         end
 
         it 'fetches gender from MPI' do

--- a/spec/support/mpi/find_candidate_with_relationship_response.xml
+++ b/spec/support/mpi/find_candidate_with_relationship_response.xml
@@ -113,7 +113,7 @@
                 <subjectOf2 typeCode="SBJ">
                   <administrativeObservation classCode="VERIF">
                     <code codeSystem="2.16.840.1.113883.4.349" code="PERSON_TYPE" displayName="Person Type"/>
-                    <value xsi:type="CD" code="DEP" displayName="Dependent"/>
+                    <value xsi:type="CD" code="DEP~VET" displayName="Dependent, Veteran"/>
                   </administrativeObservation>
                 </subjectOf2>
               </patient>


### PR DESCRIPTION
…ting an array of the user identity person types

## Description of change
This PR adds a function on the User model, `person_types`, which returns an array of strings representing the person types the logged in user may be a part of. This function defers to the User Identity model first, and if it does not exist there, then queries MPI

## Original issue(s)
department-of-veterans-affairs/vets-api/issues/7518

## Things to know about this PR
- Currently user types are a string of three characters, represented in this table:
`VET  = Veteran
CON  = CONTRACTOR
PAT  = PATIENT
EMP  = EMPLOYEE
CGP = Caregiver Primary
CGS = Caregiver Secondary
CGG = Caregiver General
Coming in the future:
ACR = ACCREDITED REPRESENTATIVE
AFF  = AFFILIATE
ASI  = ASSOCIATED INDIVIDUAL
DEP  = DEPENDENT
GUA  = GUARDIAN
HPT  = HEALTH PROFESSIONAL TRAINEE`
It may be good to include this table in code in a future PR

- Result is an array, so user could be multiple types, for example: `['VET', 'PAT', 'EMP']`

- To test this, I logged in and set a `binding.pry` after the user was logged in, then tested with `@current_user.person_types` and confirmed the result was `['VET']` 
