### PR TITLE
[26795] adds error handling for multiple BIRLS and CORP ids

### DIFF
--- a/lib/saml/errors.rb
+++ b/lib/saml/errors.rb
@@ -10,6 +10,8 @@ module SAML
     MULTIPLE_EDIPIS_CODE = '102'
     MHV_ICN_MISMATCH_CODE = '103'
     IDME_UUID_MISSING_CODE = '104'
+    MULTIPLE_BIRLS_IDS_CODE = '105'
+    MULTPLE_CORP_IDS_CODE = '106'
 
     ERRORS = {
       multiple_mhv_ids: { code: MULTIPLE_MHV_IDS_CODE,
@@ -23,7 +25,13 @@ module SAML
                           message: 'MHV credential ICN does not match MPI record' }.freeze,
       idme_uuid_missing: { code: IDME_UUID_MISSING_CODE,
                            tag: :idme_uuid_missing,
-                           message: 'User attributes is missing an ID.me UUID' }.freeze
+                           message: 'User attributes is missing an ID.me UUID' }.freeze,
+      multiple_birls_ids: { code: MULTIPLE_BIRLS_IDS_CODE,
+                            tag: :multiple_birls_ids,
+                            message: 'User attributes contain multiple distinct BIRLS ID values' }.freeze,
+      multiple_corp_ids: { code: MULTPLE_CORP_IDS_CODE,
+                           tag: :multiple_corp_ids,
+                           message: 'User attributes contain multiple distinct CORP ID values' }.freeze
     }.freeze
 
     attr_reader :identifier

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -208,6 +208,8 @@ module SAML
         raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_mhv_ids] if mhv_id_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_edipis] if edipi_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:mhv_icn_mismatch] if mhv_icn_mismatch?
+        raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_birls_ids] if birls_id_mismatch?
+        raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_corp_ids] if corp_id_mismatch?
       end
 
       private
@@ -253,6 +255,16 @@ module SAML
         mhvicn_val = safe_attr('va_eauth_mhvicn')
         icn_val = safe_attr('va_eauth_icn')
         icn_val.present? && mhvicn_val.present? && icn_val != mhvicn_val
+      end
+
+      def birls_id_mismatch?
+        birls_ids = safe_attr('va_eauth_birlsfilenumber')&.split(',') || []
+        birls_ids.reject(&:nil?).uniq.size > 1
+      end
+
+      def corp_id_mismatch?
+        corp_ids = safe_attr('vba_corp_id')&.split(',') || []
+        corp_ids.reject(&:nil?).uniq.size > 1
       end
 
       def csid

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -607,6 +607,44 @@ RSpec.describe SAML::User do
       end
     end
 
+    context 'with multi-value birls_id' do
+      let(:saml_attributes) do
+        build(:ssoe_idme_mhv_loa3,
+              va_eauth_birlsfilenumber: [birls_id])
+      end
+
+      context 'with different values' do
+        let(:birls_id) { '0123456789,0000000054' }
+
+        it 'does not validate' do
+          expect { subject.validate! }
+            .to raise_error { |error|
+                  expect(error).to be_a(SAML::UserAttributeError)
+                  expect(error.message).to eq('User attributes contain multiple distinct BIRLS ID values')
+                }
+        end
+      end
+    end
+
+    context 'with multi-value corp_id' do
+      let(:saml_attributes) do
+        build(:ssoe_idme_mhv_loa3,
+              vba_corp_id: [corp_id])
+      end
+
+      context 'with different values' do
+        let(:corp_id) { '0123456789,0000000054' }
+
+        it 'does not validate' do
+          expect { subject.validate! }
+            .to raise_error { |error|
+                  expect(error).to be_a(SAML::UserAttributeError)
+                  expect(error.message).to eq('User attributes contain multiple distinct CORP ID values')
+                }
+        end
+      end
+    end
+
     context 'with multi-value edipi' do
       let(:saml_attributes) do
         build(:ssoe_idme_mhv_loa3,


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
As part of a broader effort to systematically manage how we handle users that have multiple conflicting IDs, this change extends existing checks for conflicting mhv_ids and edipis to also cover birls_ids and corp_ids. The second part of this change will be to implement an automatic monthly report of any users that triggered one of these mismatch errors so that their case can be resolved.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#26795

## Things to know about this PR
Unit tests updated, manual login/logout tests performed.
