### PR TITLE
form 526 - update rated disabilities when name, diagnostic_code or ra…

### DIFF
--- a/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
@@ -22,7 +22,9 @@ module V0
 
       # If EVSS's list of rated disabilties does not match our prefilled rated disabilites
       if rated_disabilities_evss.present? &&
-         names_arr(parsed_form_data.dig('ratedDisabilities')) != names_arr(rated_disabilities_evss.rated_disabilities)
+         arr_to_compare(parsed_form_data.dig('ratedDisabilities')) !=
+         arr_to_compare(rated_disabilities_evss.rated_disabilities)
+
         if parsed_form_data['ratedDisabilities'].present? &&
            parsed_form_data.dig('view:claimType', 'view:claimingIncrease')
           metadata['returnUrl'] = '/disabilities/rated-disabilities'
@@ -42,8 +44,12 @@ module V0
                                                         .initialize_rated_disabilities_information
     end
 
-    def names_arr(rated_disabilities)
-      rated_disabilities&.collect { |rd| rd['name'] }&.sort
+    def arr_to_compare(rated_disabilities)
+      rated_disabilities&.collect do |rd|
+        diagnostic_code = rd['diagnostic_code'] || rd['diagnosticCode']
+        rated_disability_id = rd['rated_disability_id'] || rd['ratedDisabilityId']
+        "#{diagnostic_code}#{rated_disability_id}#{rd['name']}"
+      end&.sort
     end
   end
 end

--- a/spec/request/v0/disability_compensation_in_progress_forms_controller_request_spec.rb
+++ b/spec/request/v0/disability_compensation_in_progress_forms_controller_request_spec.rb
@@ -16,8 +16,24 @@ RSpec.describe V0::DisabilityCompensationInProgressFormsController, type: :reque
 
     describe '#show' do
       let(:user) { loa3_user }
+      let(:rated_disabilites_from_evss) do
+        [{ 'name' => 'Diabetes mellitus0',
+           'ratedDisabilityId' => '0',
+           'ratingDecisionId' => '63655',
+           'diagnosticCode' => 5238,
+           'decisionCode' => 'SVCCONNCTED',
+           'decisionText' => 'Service Connected',
+           'ratingPercentage' => 100 },
+         { 'name' => 'Diabetes mellitus1',
+           'ratedDisabilityId' => '1',
+           'ratingDecisionId' => '63655',
+           'diagnosticCode' => 5238,
+           'decisionCode' => 'SVCCONNCTED',
+           'decisionText' => 'Service Connected',
+           'ratingPercentage' => 100 }]
+      end
       let!(:in_progress_form) do
-        form_json = JSON.parse(File.read('spec/support/disability_compensation_form/526_in_progress_form_maixmal.json'))
+        form_json = JSON.parse(File.read('spec/support/disability_compensation_form/526_in_progress_form_minimal.json'))
         FactoryBot.create(:in_progress_form,
                           user_uuid: user.uuid,
                           form_id: '21-526EZ',
@@ -34,34 +50,39 @@ RSpec.describe V0::DisabilityCompensationInProgressFormsController, type: :reque
         end
       end
 
-      context 'when a form is found' do
-        let(:rated_disabilites_from_evss) do
-          [{ 'name' => 'Diabetes mellitus0',
-             'ratedDisabilityId' => '0',
-             'ratingDecisionId' => '63655',
-             'diagnosticCode' => 5238,
-             'decisionCode' => 'SVCCONNCTED',
-             'decisionText' => 'Service Connected',
-             'ratingPercentage' => 100 },
-           { 'name' => 'Diabetes mellitus1',
-             'ratedDisabilityId' => '1',
-             'ratingDecisionId' => '63655',
-             'diagnosticCode' => 5238,
-             'decisionCode' => 'SVCCONNCTED',
-             'decisionText' => 'Service Connected',
-             'ratingPercentage' => 100 }]
-        end
-
+      context 'when a form is found and rated_disabilites have updates' do
         it 'returns the form as JSON' do
-          rated_disabilities_before = JSON.parse(in_progress_form.form_data).dig('ratedDisabilities')
+          # change form data
+          fd = JSON.parse(in_progress_form.form_data)
+          fd['ratedDisabilities'].first['diagnosticCode'] = '111'
+          in_progress_form.update(form_data: fd)
+
           VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
             get v0_disability_compensation_in_progress_form_url(in_progress_form.form_id), params: nil
           end
           expect(response).to have_http_status(:ok)
           json_response = JSON.parse(response.body)
-          expect(json_response['formData']['ratedDisabilities']).to eq(rated_disabilities_before)
+          expect(json_response['formData']['ratedDisabilities']).to eq(
+            JSON.parse(in_progress_form.form_data).dig('ratedDisabilities')
+          )
           expect(json_response['formData']['updatedRatedDisabilities']).to eq(rated_disabilites_from_evss)
           expect(json_response['metadata']['returnUrl']).to eq('/disabilities/rated-disabilities')
+        end
+      end
+
+      context 'when a form is found and rated_disabilites are unchanged' do
+        it 'returns the form as JSON' do
+          VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
+            get v0_disability_compensation_in_progress_form_url(in_progress_form.form_id), params: nil
+          end
+
+          expect(response).to have_http_status(:ok)
+          json_response = JSON.parse(response.body)
+          expect(json_response['formData']['ratedDisabilities']).to eq(
+            JSON.parse(in_progress_form.form_data).dig('ratedDisabilities')
+          )
+          expect(json_response['formData']['updatedRatedDisabilities']).to be_nil
+          expect(json_response['metadata']['returnUrl']).to eq('/va-employee')
         end
       end
     end

--- a/spec/support/disability_compensation_form/526_in_progress_form_minimal.json
+++ b/spec/support/disability_compensation_form/526_in_progress_form_minimal.json
@@ -1,0 +1,160 @@
+{
+  "formData": {
+    "view:claimType": {
+      "view:claimingIncrease": true
+    },
+    "isVaEmployee": false,
+    "homelessOrAtRisk": "no",
+    "phoneAndEmail": {
+      "primaryPhone": "4445551212",
+      "emailAddress": "test2@test1.net"
+    },
+    "mailingAddress": {
+      "country": "USA",
+      "addressLine1": "123 Main",
+      "city": "Bigcity",
+      "state": "AK",
+      "zipCode": "12345"
+    },
+    "view:contactInfoDescription": {},
+    "view:hasEvidence": false,
+    "view:powStatus": false,
+    "ratedDisabilities": [
+      {
+        "name": "Diabetes mellitus0",
+        "ratedDisabilityId": "0",
+        "ratingDecisionId": "63655",
+        "diagnosticCode": 5238,
+        "decisionCode": "SVCCONNCTED",
+        "decisionText": "Service Connected",
+        "ratingPercentage": 100,
+        "disabilityActionType": "NONE",
+        "view:selected": true
+      },
+      {
+        "name": "Diabetes mellitus1",
+        "ratedDisabilityId": "1",
+        "ratingDecisionId": "63655",
+        "diagnosticCode": 5238,
+        "decisionCode": "SVCCONNCTED",
+        "decisionText": "Service Connected",
+        "ratingPercentage": 100,
+        "disabilityActionType": "NONE"
+      }
+    ],
+    "view:disabilitiesClarification": {},
+    "serviceInformation": {
+      "reservesNationalGuardService": {
+        "view:isTitle10Activated": false,
+        "obligationTermOfServiceDateRange": {
+          "from": "2007-05-22",
+          "to": "2008-06-05"
+        },
+        "unitName": "Unit name here"
+      },
+      "servicePeriods": [
+        {
+          "serviceBranch": "Air Force Reserve",
+          "dateRange": {
+            "from": "2001-03-21",
+            "to": "2014-07-21"
+          }
+        }
+      ],
+      "view:militaryHistoryNote": {}
+    },
+    "view:selectablePtsdTypes": {},
+    "view:ptsdTypeHelp": {},
+    "view:upload781ChoiceHelp": {},
+    "incident0": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "incident1": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "incident2": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "view:upload781aChoiceHelp": {},
+    "secondaryIncident0": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "view:otherSourcesHelp": {},
+    "secondaryIncident1": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "secondaryIncident2": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "physicalChanges": {},
+    "mentalChanges": {},
+    "workBehaviorChanges": {},
+    "socialBehaviorChanges": {},
+    "view:ancillaryFormsWizardIntro": {},
+    "view:unemployabilityHelp": {},
+    "unemployability": {
+      "view:recordsInfo": {},
+      "view:unemployabilityDatesDesc": {},
+      "view:grossIncomeAdditionalInfo": {},
+      "view:supplementalBenefitsHelp": {},
+      "view:substantiallyGainfulEmploymentInfo": {},
+      "view:statementsAreTrue": {},
+      "view:informOfReturnToWork": {}
+    },
+    "view:privateMedicalFacility": {},
+    "view:upload4192Choice": {},
+    "view:downloadInfo": {},
+    "view:vaMedicalRecordsIntro": {},
+    "view:uploadPrivateRecordsQualifier": {
+      "view:aboutPrivateMedicalRecords": {},
+      "view:privateRecordsChoiceHelp": {}
+    },
+    "view:privateRecordsChoiceHelp": {},
+    "view:faqAccordion": {},
+    "view:bankAccount": {
+      "view:hasPrefilledBank": true
+    },
+    "view:waiveRetirementPayDescription": {},
+    "standardClaim": false,
+    "view:fdcWarning": {},
+    "view:originalBankAccount": {
+      "view:bankAccountType": "Checking",
+      "view:bankAccountNumber": "*********1234",
+      "view:bankRoutingNumber": "*****2115",
+      "view:bankName": "Comerica"
+    }
+  },
+  "metadata": {
+    "returnUrl": "/va-employee",
+    "savedAt": 1610376890141,
+    "submission": {
+        "errorMessage": false,
+        "hasAttemptedSubmit": false,
+        "id": false,
+        "status": false,
+        "timestamp": false
+    },
+    "version": 6
+  }
+}


### PR DESCRIPTION
…ted_disability_id change

## Description of change
we already had code in place to handle when the name of a rated disability was updated by an upstream system, but we now see that rated disabilities need to be updated when diagnostic_code or rated_disability_id change;

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22484

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
