### PR TITLE
Adding New Flipper Feature for 686 Pension Check

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -93,7 +93,7 @@ features:
     actor_type: user
     description: Feature gates the dependency verification modal for updating the diaries service.
     enable_in_development: true
-  dependents_bid_awards_pension_check:
+  dependents_pension_check:
     actor_type: user
     description: Manage whether or not Pension check is enabled for the 686/674
     enable_in_development: true

--- a/config/features.yml
+++ b/config/features.yml
@@ -93,6 +93,10 @@ features:
     actor_type: user
     description: Feature gates the dependency verification modal for updating the diaries service.
     enable_in_development: true
+  dependents_bid_awards_pension_check:
+    actor_type: user
+    description: Manage whether or not Pension check is enabled for the 686/674
+    enable_in_development: true
   dependents_management:
     actor_type: user
     description: Manage dependent removal from view dependent page

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -741,6 +741,7 @@ flipper:
     - kabrown@thoughtworks.com
     - kadams@governmentcio.com
     - kam@adhocteam.us
+    - kathleen.crawford@gcio.com
     - kenneth.gary@va.gov
     - kenneth.santiago2010@gmail.com
     - kevin.musiorski@gcio.com # Kevin Musiorski (GCIO), Engineer

--- a/lib/bgs/form674.rb
+++ b/lib/bgs/form674.rb
@@ -85,8 +85,12 @@ module BGS
     # else use 130SCHEBNREJ (eBenefits School Attendance Reject)
     def set_claim_type(proc_state)
       if proc_state == 'MANUAL_VAGOV'
-        pension_response = bid_service.get_awards_pension
-        receiving_pension = pension_response.body['awards_pension']['is_in_receipt_of_pension']
+        receiving_pension = false
+
+        if Flipper.enabled?(:dependents_pension_check)
+          pension_response = bid_service.get_awards_pension
+          receiving_pension = pension_response.body['awards_pension']['is_in_receipt_of_pension']
+        end
 
         if receiving_pension
           @end_product_name = 'PMC eBenefits School Attendance Reject'

--- a/lib/bgs/form686c.rb
+++ b/lib/bgs/form686c.rb
@@ -107,8 +107,12 @@ module BGS
     # else use 130DPEBNAJRE (eBenefits Dependency Adjustment Reject)
     def set_claim_type(proc_state)
       if proc_state == 'MANUAL_VAGOV'
-        pension_response = bid_service.get_awards_pension
-        receiving_pension = pension_response.body['awards_pension']['is_in_receipt_of_pension']
+        receiving_pension = false
+
+        if Flipper.enabled?(:dependents_bid_awards_pension_check)
+          pension_response = bid_service.get_awards_pension
+          receiving_pension = pension_response.body['awards_pension']['is_in_receipt_of_pension']
+        end
 
         if receiving_pension
           @end_product_name = 'PMC eBenefits Dependency Adjustment Reject'

--- a/lib/bgs/form686c.rb
+++ b/lib/bgs/form686c.rb
@@ -109,7 +109,7 @@ module BGS
       if proc_state == 'MANUAL_VAGOV'
         receiving_pension = false
 
-        if Flipper.enabled?(:dependents_bid_awards_pension_check)
+        if Flipper.enabled?(:dependents_pension_check)
           pension_response = bid_service.get_awards_pension
           receiving_pension = pension_response.body['awards_pension']['is_in_receipt_of_pension']
         end

--- a/spec/lib/bgs/form674_spec.rb
+++ b/spec/lib/bgs/form674_spec.rb
@@ -45,23 +45,19 @@ RSpec.describe BGS::Form674 do
 
   it 'submits a manual claim with pension disabled' do
     VCR.use_cassette('bgs/form674/submit') do
-      claim = BGS::Form674.new(user_object)
-
       expect(Flipper).to receive(:enabled?).with(:dependents_pension_check).and_return(false)
 
-      claim.submit(all_flows_payload)
+      BGS::Form674.new(user_object).submit(all_flows_payload)
     end
   end
 
   it 'submits a manual claim with pension enabled' do
     VCR.use_cassette('bgs/form674/submit') do
       VCR.use_cassette('bid/awards/get_awards_pension') do
-        claim = BGS::Form674.new(user_object)
-
         expect(Flipper).to receive(:enabled?).with(:dependents_pension_check).and_return(true)
         expect_any_instance_of(BID::Awards::Service).to receive(:get_awards_pension).and_call_original
 
-        claim.submit(all_flows_payload)
+        BGS::Form674.new(user_object).submit(all_flows_payload)
       end
     end
   end

--- a/spec/lib/bgs/form674_spec.rb
+++ b/spec/lib/bgs/form674_spec.rb
@@ -42,4 +42,27 @@ RSpec.describe BGS::Form674 do
       end
     end
   end
+
+  it 'submits a manual claim with pension disabled' do
+    VCR.use_cassette('bgs/form674/submit') do
+      claim = BGS::Form674.new(user_object)
+
+      expect(Flipper).to receive(:enabled?).with(:dependents_pension_check).and_return(false)
+
+      claim.submit(all_flows_payload)
+    end
+  end
+
+  it 'submits a manual claim with pension enabled' do
+    VCR.use_cassette('bgs/form674/submit') do
+      VCR.use_cassette('bid/awards/get_awards_pension') do
+        claim = BGS::Form674.new(user_object)
+
+        expect(Flipper).to receive(:enabled?).with(:dependents_pension_check).and_return(true)
+        expect_any_instance_of(BID::Awards::Service).to receive(:get_awards_pension).and_call_original
+
+        claim.submit(all_flows_payload)
+      end
+    end
+  end
 end

--- a/spec/lib/bgs/form686c_spec.rb
+++ b/spec/lib/bgs/form686c_spec.rb
@@ -54,4 +54,27 @@ RSpec.describe BGS::Form686c do
       claim.submit(all_flows_payload)
     end
   end
+
+  it 'submits a manual claim with pension disabled' do
+    VCR.use_cassette('bgs/form686c/submit') do
+      claim = BGS::Form686c.new(user_object)
+
+      expect(Flipper).to receive(:enabled?).with(:dependents_pension_check).and_return(false)
+
+      claim.submit(all_flows_payload)
+    end
+  end
+
+  it 'submits a manual claim with pension enabled' do
+    VCR.use_cassette('bgs/form686c/submit') do
+      VCR.use_cassette('bid/awards/get_awards_pension') do
+        claim = BGS::Form686c.new(user_object)
+
+        expect(Flipper).to receive(:enabled?).with(:dependents_pension_check).and_return(true)
+        expect_any_instance_of(BID::Awards::Service).to receive(:get_awards_pension).and_call_original
+
+        claim.submit(all_flows_payload)
+      end
+    end
+  end
 end

--- a/spec/lib/bgs/form686c_spec.rb
+++ b/spec/lib/bgs/form686c_spec.rb
@@ -57,23 +57,19 @@ RSpec.describe BGS::Form686c do
 
   it 'submits a manual claim with pension disabled' do
     VCR.use_cassette('bgs/form686c/submit') do
-      claim = BGS::Form686c.new(user_object)
-
       expect(Flipper).to receive(:enabled?).with(:dependents_pension_check).and_return(false)
 
-      claim.submit(all_flows_payload)
+      BGS::Form686c.new(user_object).submit(all_flows_payload)
     end
   end
 
   it 'submits a manual claim with pension enabled' do
     VCR.use_cassette('bgs/form686c/submit') do
       VCR.use_cassette('bid/awards/get_awards_pension') do
-        claim = BGS::Form686c.new(user_object)
-
         expect(Flipper).to receive(:enabled?).with(:dependents_pension_check).and_return(true)
         expect_any_instance_of(BID::Awards::Service).to receive(:get_awards_pension).and_call_original
 
-        claim.submit(all_flows_payload)
+        BGS::Form686c.new(user_object).submit(all_flows_payload)
       end
     end
   end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Adding a new flipper feature to determine whether or not the 686/674 (Dependents Application) should check if it is a pension claim when we are setting the claim to be manually reviewed.  Currently this feature should only be enabled in staging and not in production.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28052

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] Local testing
- [x] Specs updated