### PR TITLE
change use cache default

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/folders_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/folders_controller.rb
@@ -7,7 +7,7 @@ module Mobile
   module V0
     class FoldersController < MessagingController
       def index
-        resource = client.get_folders(@current_user.uuid, use_cache? || true)
+        resource = client.get_folders(@current_user.uuid, use_cache?)
         resource = resource.paginate(pagination_params)
 
         render json: resource.data,


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Change the folder's useCache to not always be true, allowing the count on folders to update in real-time

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27453

## Things to know about this PR
This pairs with a front-end PR to actually solve the issue listed in the ticket. This PR only solves the issue of the backend folders requests ignoring the useCache parameter, which was discovered during the process of solving the issue in the ticket.

<!-- Please describe testing done to verify the changes or any testing planned. -->
For testing, pushed this up to a review instance and mapped it to Postman.
Checked the count in a GET folders
Saved a draft
Checked the count in GET folders again to make sure it incremented when useCache=false