### PR TITLE
Set date on FSR singature

### DIFF
--- a/lib/debt_management_center/financial_status_report_service.rb
+++ b/lib/debt_management_center/financial_status_report_service.rb
@@ -19,6 +19,7 @@ module DebtManagementCenter
     configuration DebtManagementCenter::FinancialStatusReportConfiguration
 
     STATSD_KEY_PREFIX = 'api.dmc'
+    DATE_TIMEZONE = 'Central Time (US & Canada)'
 
     ##
     # Submit a financial status report to the Debt Management Center
@@ -31,6 +32,7 @@ module DebtManagementCenter
         form = camelize(form)
         raise_client_error unless form.key?('personalIdentification')
         form['personalIdentification']['fileNumber'] = @file_number
+        set_certification_date(form)
         response = DebtManagementCenter::FinancialStatusReportResponse.new(
           perform(:post, 'financial-status-report/formtopdf', form).body
         )
@@ -75,6 +77,13 @@ module DebtManagementCenter
 
     def camelize(hash)
       hash.deep_transform_keys! { |key| key.to_s.camelize(:lower) }
+    end
+
+    def set_certification_date(form)
+      date            = Time.now.in_time_zone(self.class::DATE_TIMEZONE).to_date
+      date_formatted  = date.strftime('%m/%d/%Y')
+
+      form['applicationCertifications']['veteranDateSigned'] = date_formatted if form['applicationCertifications']
     end
   end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
When a user submits an FSR, the "signature" and "date signed" should be sent to the DMC along with the rest of the submission data.

This is a follow-up to [PR #7476](https://github.com/department-of-veterans-affairs/vets-api/pull/7476) where the signature was enabled as a parameter.

## Original issue(s)
Fixes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/27442

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
