### PR TITLE
changes multiple birls ids error to a warning [26795]

### DIFF
--- a/lib/saml/errors.rb
+++ b/lib/saml/errors.rb
@@ -10,7 +10,6 @@ module SAML
     MULTIPLE_EDIPIS_CODE = '102'
     MHV_ICN_MISMATCH_CODE = '103'
     IDME_UUID_MISSING_CODE = '104'
-    MULTIPLE_BIRLS_IDS_CODE = '105'
     MULTPLE_CORP_IDS_CODE = '106'
 
     ERRORS = {
@@ -26,9 +25,6 @@ module SAML
       idme_uuid_missing: { code: IDME_UUID_MISSING_CODE,
                            tag: :idme_uuid_missing,
                            message: 'User attributes is missing an ID.me UUID' }.freeze,
-      multiple_birls_ids: { code: MULTIPLE_BIRLS_IDS_CODE,
-                            tag: :multiple_birls_ids,
-                            message: 'User attributes contain multiple distinct BIRLS ID values' }.freeze,
       multiple_corp_ids: { code: MULTPLE_CORP_IDS_CODE,
                            tag: :multiple_corp_ids,
                            message: 'User attributes contain multiple distinct CORP ID values' }.freeze

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -208,8 +208,13 @@ module SAML
         raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_mhv_ids] if mhv_id_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_edipis] if edipi_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:mhv_icn_mismatch] if mhv_icn_mismatch?
-        raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_birls_ids] if birls_id_mismatch?
         raise SAML::UserAttributeError, SAML::UserAttributeError::ERRORS[:multiple_corp_ids] if corp_id_mismatch?
+
+        # Multiple BIRLS IDs are more common, only raise a warning
+        if birls_id_mismatch?
+          log_message_to_sentry('User attributes contain multiple distinct BIRLS ID values.', 'warn',
+                                birls_ids: @attributes['va_eauth_birlsfilenumber'])
+        end
       end
 
       private

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -616,12 +616,13 @@ RSpec.describe SAML::User do
       context 'with different values' do
         let(:birls_id) { '0123456789,0000000054' }
 
-        it 'does not validate' do
-          expect { subject.validate! }
-            .to raise_error { |error|
-                  expect(error).to be_a(SAML::UserAttributeError)
-                  expect(error.message).to eq('User attributes contain multiple distinct BIRLS ID values')
-                }
+        it 'logs warning to sentry' do
+          expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
+            'User attributes contain multiple distinct BIRLS ID values.',
+            'warn',
+            { birls_ids: birls_id }
+          )
+          subject.validate!
         end
       end
     end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
After a [previous PR](https://github.com/department-of-veterans-affairs/vets-api/pull/7531) added error catching for user logins with multiple BIRLS and CORP ids we have determined users possessing multiple BIRLS ids is a semi-frequent occurrence, as such this PR downgrades the BIRLS SAML error to a warning that is logged to Sentry. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#26795

## Things to know about this PR
Specs updated, manual logins performed.