### PR TITLE
Timecop freeze instead of Timecop travel to have expected timestamps

### DIFF
--- a/modules/vba_documents/spec/models/upload_submission_spec.rb
+++ b/modules/vba_documents/spec/models/upload_submission_spec.rb
@@ -203,7 +203,7 @@ describe VBADocuments::UploadSubmission, type: :model do
           Timecop.freeze(time)
           upload = VBADocuments::UploadSubmission.new
           upload.consumer_name = "consumer_#{index}"
-          Timecop.travel(time + 1.minute)
+          Timecop.freeze(time + 1.minute)
           upload.status = 'uploaded'
           upload.save
         end
@@ -231,7 +231,7 @@ describe VBADocuments::UploadSubmission, type: :model do
       time = Time.zone.now
       Timecop.freeze(time)
       upload = VBADocuments::UploadSubmission.new
-      Timecop.travel(time + 1.minute)
+      Timecop.freeze(time + 1.minute)
       upload.status = 'uploaded'
       upload.save!
       elapsed = upload.metadata['status']['pending']['end'] - upload.metadata['status']['pending']['start']
@@ -291,7 +291,7 @@ describe VBADocuments::UploadSubmission, type: :model do
         expect(ancient_in_flights.count).to eq 0
       end
 
-      Timecop.travel(time + 14.days + 1.minute)
+      Timecop.freeze(time + 14.days + 1.minute)
       # find four things, one in each state
       states.each do |status|
         ancient_in_flights = VBADocuments::UploadSubmission.aged_processing(14, :days, status).to_a

--- a/modules/vba_documents/spec/models/upload_submission_spec.rb
+++ b/modules/vba_documents/spec/models/upload_submission_spec.rb
@@ -275,6 +275,7 @@ describe VBADocuments::UploadSubmission, type: :model do
     end
   end
 
+
   context 'aged_processing' do
     it 'can find submissions that have been in-flight for too long' do
       states = %w[pending uploaded received processing]

--- a/modules/vba_documents/spec/models/upload_submission_spec.rb
+++ b/modules/vba_documents/spec/models/upload_submission_spec.rb
@@ -275,7 +275,6 @@ describe VBADocuments::UploadSubmission, type: :model do
     end
   end
 
-
   context 'aged_processing' do
     it 'can find submissions that have been in-flight for too long' do
       states = %w[pending uploaded received processing]


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Very rarely a spec test would fail because of timing issues. This PR freezes timestamps so the timestamps will always be what we expect of them.

## Original issue(s)
https://vajira.max.gov/browse/API-8996

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
No to all
<!-- Please describe testing done to verify the changes or any testing planned. -->

The spec file in question was tested multiple times