### PR TITLE
Catch Backend Service Exceptions that are missing fields

### DIFF
--- a/lib/common/client/middleware/response/raise_error.rb
+++ b/lib/common/client/middleware/response/raise_error.rb
@@ -26,7 +26,7 @@ module Common
           private
 
           def raise_error!
-            if status&.between?(400, 599)
+            if backend_service_exception?
               raise Common::Exceptions::BackendServiceException.new(service_i18n_key, response_values, status, body)
             else
               raise BackendUnhandledException, "Unhandled Exception - status: #{status}, body: #{body}"
@@ -48,6 +48,10 @@ module Common
               code: service_i18n_key,
               source: body['source']
             }
+          end
+
+          def backend_service_exception?
+            status&.between?(400, 599) && %w[detail source].all? { |key| body&.has_key(key) }
           end
         end
       end


### PR DESCRIPTION
PPMS is changing how some of their error messages

This is causing us to throw a 500 internal server error
this should catch the issues with a nil body in raise_error

[Sentry Error](http://sentry.vfs.va.gov/organizations/vsp/issues/39314/?environment=staging&project=3&query=is%3Aunresolved+ccp&statsPeriod=14d)

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

Checking if the body of the error has the needed keys to be a valid backend service exception
