### PR TITLE
10203 Claim Processing - EVSS POA Removal

### DIFF
--- a/app/workers/education_form/process10203_submissions.rb
+++ b/app/workers/education_form/process10203_submissions.rb
@@ -93,6 +93,9 @@ module EducationForm
 
     # Retrieve poa status fromEVSS VSOSearch for a user
     def get_user_poa_status(account, auth_headers)
+      # stem_automated_decision feature disables EVSS call  for POA which will be removed in a future PR
+      return nil if Flipper.enabled?(:stem_automated_decision)
+
       return nil if auth_headers.nil?
       return nil unless auth_headers.key?('va_eauth_dodedipnid')
 

--- a/spec/jobs/education_form/process10203_submissions_spec.rb
+++ b/spec/jobs/education_form/process10203_submissions_spec.rb
@@ -130,7 +130,18 @@ RSpec.describe EducationForm::Process10203Submissions, type: :model, form: :educ
                    .and change { EducationStemAutomatedDecision.processed.count }.from(0).to(1)
       end
 
+      it 'skips POA check with  without poa' do
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, any_args).and_return(true).at_least(:once)
+        application_10203 = create(:va10203)
+        application_10203.create_stem_automated_decision(evss_user)
+
+        subject.perform
+        application_10203.reload
+        expect(application_10203.education_benefits_claim.education_stem_automated_decision.poa).to eq(nil)
+      end
+
       it 'sets claim poa for evss user without poa' do
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, any_args).and_return(false).at_least(:once)
         application_10203 = create(:va10203)
         application_10203.create_stem_automated_decision(evss_user)
         evss_response_without_poa = OpenStruct.new({ 'userPoaInfoAvailable' => false })
@@ -146,6 +157,7 @@ RSpec.describe EducationForm::Process10203Submissions, type: :model, form: :educ
       end
 
       it 'sets claim poa for evss user with poa' do
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, any_args).and_return(false).at_least(:once)
         application_10203 = create(:va10203)
         application_10203.create_stem_automated_decision(evss_user)
         gi_bill_status = build(:gi_bill_status_response, remaining_entitlement: nil)

--- a/spec/jobs/education_form/process10203_submissions_spec.rb
+++ b/spec/jobs/education_form/process10203_submissions_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe EducationForm::Process10203Submissions, type: :model, form: :educ
                    .and change { EducationStemAutomatedDecision.processed.count }.from(0).to(1)
       end
 
-      it 'skips POA check with  without poa' do
+      it 'skips POA check when :stem_automated_decision flag is on' do
         expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, any_args).and_return(true).at_least(:once)
         application_10203 = create(:va10203)
         application_10203.create_stem_automated_decision(evss_user)

--- a/spec/models/saved_claim/education_benefits/va10203_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va10203_spec.rb
@@ -30,16 +30,8 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
     end
 
     context 'stem_automated_decision feature disabled' do
-      it 'does not create education_stem_automated_decision' do
-        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(false).at_least(:once)
-        instance.after_submit(user)
-        expect(instance.education_benefits_claim.education_stem_automated_decision).to be_nil
-      end
-    end
-
-    context 'stem_automated_decision feature enabled' do
       it 'creates education_stem_automated_decision for user' do
-        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(true).at_least(:once)
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(false).at_least(:once)
         instance.after_submit(user)
         expect(instance.education_benefits_claim.education_stem_automated_decision).not_to be_nil
         expect(instance.education_benefits_claim.education_stem_automated_decision.user_uuid)
@@ -48,28 +40,28 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
       end
 
       it 'saves user auth_headers' do
-        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(true).at_least(:once)
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(false).at_least(:once)
         instance.after_submit(user)
         expect(instance.education_benefits_claim.education_stem_automated_decision.auth_headers).not_to be_nil
       end
 
       it 'populates claim with user POA' do
         expect(user).to receive(:power_of_attorney).and_return({ poa_code: 'aaa' })
-        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(true).at_least(:once)
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(false).at_least(:once)
         instance.after_submit(user)
         expect(instance.education_benefits_claim.education_stem_automated_decision.poa).to eq(true)
       end
 
       it 'treats user POA nil as nil' do
         expect(user).to receive(:power_of_attorney).and_return(nil)
-        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(true).at_least(:once)
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(false).at_least(:once)
         instance.after_submit(user)
         expect(instance.education_benefits_claim.education_stem_automated_decision.poa).to be_nil
       end
 
       it 'handles POA exception' do
         expect(user).to receive(:power_of_attorney).and_raise(StandardError)
-        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(true).at_least(:once)
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(false).at_least(:once)
         instance.after_submit(user)
         expect(instance.education_benefits_claim.education_stem_automated_decision.poa).to be_nil
       end
@@ -77,6 +69,14 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
       it 'does not create education_stem_automated_decision without user' do
         instance.after_submit(nil)
         expect(instance.education_benefits_claim.education_stem_automated_decision).to be_nil
+      end
+    end
+
+    context 'stem_automated_decision feature enabled' do
+      it 'does not load user POA' do
+        expect(Flipper).to receive(:enabled?).with(:stem_automated_decision, user).and_return(true).at_least(:once)
+        instance.after_submit(user)
+        expect(instance.education_benefits_claim.education_stem_automated_decision.poa).to be_nil
       end
     end
 


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Removed EVSS calls for user POA from 10203 processing.  This was always failing and we think it was contributing to the long runtimes of the processing job.  The removal is behind the `stem_automated_decision` feature flag

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27920

## Things to know about this PR
- Tested locally and QA reviewed
