### PR TITLE
Form 526 - always upcase militaryPostOfficeTypeCode

### DIFF
--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -353,7 +353,7 @@ module EVSS
 
       def set_military_address(address, zip_code)
         {
-          'militaryPostOfficeTypeCode' => address['city']&.upcase,
+          'militaryPostOfficeTypeCode' => address['city']&.strip&.upcase,
           'militaryStateCode' => address['state'],
           'zipFirstFive' => zip_code.first,
           'zipLastFour' => zip_code.last

--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -353,7 +353,7 @@ module EVSS
 
       def set_military_address(address, zip_code)
         {
-          'militaryPostOfficeTypeCode' => address['city'],
+          'militaryPostOfficeTypeCode' => address['city']&.upcase,
           'militaryStateCode' => address['state'],
           'zipFirstFive' => zip_code.first,
           'zipLastFour' => zip_code.last

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -669,7 +669,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
           'form526' => {
             'mailingAddress' => {
               'country' => 'Germany',
-              'city' => 'Hamburg',
+              'city' => 'apo',
               'state' => 'AA',
               'addressLine1' => '1234 Couch Strasse',
               'zipCode' => '12345-6789'
@@ -682,7 +682,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
         expect(subject.send(:translate_veteran)).to eq 'veteran' => {
           'currentMailingAddress' => {
             'addressLine1' => '1234 Couch Strasse',
-            'militaryPostOfficeTypeCode' => 'Hamburg',
+            'militaryPostOfficeTypeCode' => 'APO',
             'country' => 'Germany',
             'militaryStateCode' => 'AA',
             'type' => 'MILITARY',

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -669,7 +669,7 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
           'form526' => {
             'mailingAddress' => {
               'country' => 'Germany',
-              'city' => 'apo',
+              'city' => ' apo ',
               'state' => 'AA',
               'addressLine1' => '1234 Couch Strasse',
               'zipCode' => '12345-6789'


### PR DESCRIPTION
## Description of change
EVSS accepts 
> militaryPostOfficeTypeCode:
>   type: “string”
>   enum:
>   - “APO”
>   - “DPO”
>   - “FPO”

and we've seen errors:

>   Invalid value: apo
>   Invalid value: Apo
>   Invalid value: fpo
so, upcase.
## Original issue(s)
department-of-veterans-affairs/va.gov-team#28204
