### PR TITLE
validate claim date

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -139,12 +139,12 @@ module ClaimsApi
 
         private
 
-        # 
+        #
         # Any custom 526 submission validations above and beyond json schema validation
-        # 
+        #
         def validate_form_526_submission_values
           return if form_attributes['claimDate'].blank?
-          return if Date.parse(form_attributes['claimDate']) <= Date.today
+          return if Date.parse(form_attributes['claimDate']) <= Time.zone.today
 
           raise ::Common::Exceptions::InvalidFieldValue.new('claimDate', form_attributes['claimDate'])
         end

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -28,7 +28,7 @@ module ClaimsApi
         # @return [JSON] Record in pending state
         def submit_form_526 # rubocop:disable Metrics/MethodLength
           validate_json_schema
-          validate_form_526_submission_values
+          validate_form_526_submission_values!
           validate_initial_claim
 
           auto_claim = ClaimsApi::AutoEstablishedClaim.create(
@@ -142,7 +142,11 @@ module ClaimsApi
         #
         # Any custom 526 submission validations above and beyond json schema validation
         #
-        def validate_form_526_submission_values
+        def validate_form_526_submission_values!
+          validate_form_526_submission_claim_date!
+        end
+
+        def validate_form_526_submission_claim_date!
           return if form_attributes['claimDate'].blank?
           return if Date.parse(form_attributes['claimDate']) <= Time.zone.today
 

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -28,6 +28,7 @@ module ClaimsApi
         # @return [JSON] Record in pending state
         def submit_form_526 # rubocop:disable Metrics/MethodLength
           validate_json_schema
+          validate_form_526_submission_values
           validate_initial_claim
 
           auto_claim = ClaimsApi::AutoEstablishedClaim.create(
@@ -137,6 +138,16 @@ module ClaimsApi
         # rubocop:enable Metrics/MethodLength
 
         private
+
+        # 
+        # Any custom 526 submission validations above and beyond json schema validation
+        # 
+        def validate_form_526_submission_values
+          return if form_attributes['claimDate'].blank?
+          return if Date.parse(form_attributes['claimDate']) <= Date.today
+
+          raise ::Common::Exceptions::InvalidFieldValue.new('claimDate', form_attributes['claimDate'])
+        end
 
         def flashes
           initial_flashes = form_attributes.dig('veteran', 'flashes') || []

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Disability Claims ', type: :request do
   end
 
   describe '#526' do
-    let(:claim_date) { (Date.today - 1.day).to_s }
+    let(:claim_date) { (Time.zone.today - 1.day).to_s }
     let(:auto_cest_pdf_generation_disabled) { false }
     let(:data) do
       temp = File.read(Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'form_526_json_api.json'))
@@ -477,12 +477,11 @@ RSpec.describe 'Disability Claims ', type: :request do
     end
 
     context 'when submitted claim_date is in the future' do
-      let(:claim_date) { (Date.today + 1.day).to_s }
+      let(:claim_date) { (Time.zone.today + 1.day).to_s }
 
       before do
         stub_mpi
       end
-
 
       it 'creates the sidekick job' do
         with_okta_user(scopes) do |auth_header|

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -483,7 +483,7 @@ RSpec.describe 'Disability Claims ', type: :request do
         stub_mpi
       end
 
-      it 'creates the sidekick job' do
+      it 'responds with bad request' do
         with_okta_user(scopes) do |auth_header|
           VCR.use_cassette('evss/claims/claims') do
             post path, params: data, headers: headers.merge(auth_header)


### PR DESCRIPTION
## Description of change
We discovered several validations that EVSS would kick our claims back for so we decided to validate them before submitting upstream.
One of those validations is making sure `claimDate` is not in the future.

## Original issue(s)
** Jira is down **