### PR TITLE
Revert "Add statsd logging to ch33 direct deposit api calls (#7537)"

### DIFF
--- a/spec/lib/bgs/service_spec.rb
+++ b/spec/lib/bgs/service_spec.rb
@@ -24,24 +24,6 @@ RSpec.describe BGS::Service do
           expect(response.body[:find_ch33_dd_eft_response][:return][:dposit_acnt_nbr]).to eq('444')
         end
       end
-
-      it 'increments statsd' do
-        VCR.use_cassette('bgs/service/find_ch33_dd_eft_no_icn', VCR::MATCH_EVERYTHING) do
-          expect do
-            bgs_service.find_ch33_dd_eft
-          end.to trigger_statsd_increment('api.bgs.find_ch33_dd_eft.total')
-        end
-      end
-    end
-
-    describe '#find_bank_name_by_routng_trnsit_nbr' do
-      it 'increments statsd' do
-        VCR.use_cassette('bgs/ddeft/find_bank_name_valid', VCR::MATCH_EVERYTHING) do
-          expect do
-            bgs_service.find_bank_name_by_routng_trnsit_nbr('122400724')
-          end.to trigger_statsd_increment('api.bgs.find_bank_name_by_routng_trnsit_nbr.total')
-        end
-      end
     end
 
     describe '#get_ch33_dd_eft_info' do
@@ -92,18 +74,6 @@ RSpec.describe BGS::Service do
       VCR.use_cassette('bgs/service/find_ch33_dd_eft', VCR::MATCH_EVERYTHING) do
         response = bgs_service.find_ch33_dd_eft
         expect(response.body[:find_ch33_dd_eft_response][:return][:dposit_acnt_nbr]).to eq('123')
-      end
-    end
-
-    it 'updates increment statsd' do
-      VCR.use_cassette('bgs/service/update_ch33_dd_eft', VCR::MATCH_EVERYTHING) do
-        expect do
-          bgs_service.update_ch33_dd_eft(
-            '122239982',
-            '444',
-            true
-          )
-        end.to trigger_statsd_increment('api.bgs.update_ch33_dd_eft.total')
       end
     end
 


### PR DESCRIPTION
This reverts commit c48d473a27c8af838e0ff0d028d80c448fd617c5.

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
