### PR TITLE
allow vets to resume a 526 form when EVSS is not responding

### DIFF
--- a/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
@@ -40,13 +40,11 @@ module V0
     end
 
     def rated_disabilities_evss
-      begin
-        @rated_disabilities_evss ||= FormProfiles::VA526ez.for(form_id: form_id, user: @current_user)
+      @rated_disabilities_evss ||= FormProfiles::VA526ez.for(form_id: form_id, user: @current_user)
                                                         .initialize_rated_disabilities_information
-      rescue
-        # if the call to EVSS fails we can skip updating. EVSS fails around an hour each night.
-        nil
-      end
+    rescue
+      # if the call to EVSS fails we can skip updating. EVSS fails around an hour each night.
+      nil
     end
 
     def arr_to_compare(rated_disabilities)

--- a/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
@@ -40,8 +40,13 @@ module V0
     end
 
     def rated_disabilities_evss
-      @rated_disabilities_evss ||= FormProfiles::VA526ez.for(form_id: form_id, user: @current_user)
+      begin
+        @rated_disabilities_evss ||= FormProfiles::VA526ez.for(form_id: form_id, user: @current_user)
                                                         .initialize_rated_disabilities_information
+      rescue
+        # if the call to EVSS fails we can skip updating. EVSS fails around an hour each night.
+        nil
+      end
     end
 
     def arr_to_compare(rated_disabilities)

--- a/spec/request/v0/disability_compensation_in_progress_forms_controller_request_spec.rb
+++ b/spec/request/v0/disability_compensation_in_progress_forms_controller_request_spec.rb
@@ -71,7 +71,9 @@ RSpec.describe V0::DisabilityCompensationInProgressFormsController, type: :reque
 
         it 'returns an unaltered form if EVSS does not respond' do
           rated_disabilities_before = JSON.parse(in_progress_form.form_data).dig('ratedDisabilities')
-          allow_any_instance_of(EVSS::DisabilityCompensationForm::Service).to receive(:get_rated_disabilities).and_raise(Common::Client::Errors::ClientError)
+          allow_any_instance_of(EVSS::DisabilityCompensationForm::Service).to(
+            receive(:get_rated_disabilities).and_raise(Common::Client::Errors::ClientError)
+          )
           get v0_disability_compensation_in_progress_form_url(in_progress_form.form_id), params: nil
 
           expect(response).to have_http_status(:ok)
@@ -80,8 +82,6 @@ RSpec.describe V0::DisabilityCompensationInProgressFormsController, type: :reque
           expect(json_response['formData']['updatedRatedDisabilities']).to be_nil
           expect(json_response['metadata']['returnUrl']).to eq('/va-employee')
         end
-
-
       end
 
       context 'when a form is found and rated_disabilites are unchanged' do

--- a/spec/request/v0/disability_compensation_in_progress_forms_controller_request_spec.rb
+++ b/spec/request/v0/disability_compensation_in_progress_forms_controller_request_spec.rb
@@ -68,6 +68,20 @@ RSpec.describe V0::DisabilityCompensationInProgressFormsController, type: :reque
           expect(json_response['formData']['updatedRatedDisabilities']).to eq(rated_disabilites_from_evss)
           expect(json_response['metadata']['returnUrl']).to eq('/disabilities/rated-disabilities')
         end
+
+        it 'returns an unaltered form if EVSS does not respond' do
+          rated_disabilities_before = JSON.parse(in_progress_form.form_data).dig('ratedDisabilities')
+          allow_any_instance_of(EVSS::DisabilityCompensationForm::Service).to receive(:get_rated_disabilities).and_raise(Common::Client::Errors::ClientError)
+          get v0_disability_compensation_in_progress_form_url(in_progress_form.form_id), params: nil
+
+          expect(response).to have_http_status(:ok)
+          json_response = JSON.parse(response.body)
+          expect(json_response['formData']['ratedDisabilities']).to eq(rated_disabilities_before)
+          expect(json_response['formData']['updatedRatedDisabilities']).to be_nil
+          expect(json_response['metadata']['returnUrl']).to eq('/va-employee')
+        end
+
+
       end
 
       context 'when a form is found and rated_disabilites are unchanged' do


### PR DESCRIPTION
## Description of change
http://grafana.vfs.va.gov/d/000000066/form-526-disability-compensation?orgId=1&from=now-7d&to=now
<img width="1361" alt="Screen Shot 2021-08-04 at 4 38 49 PM" src="https://user-images.githubusercontent.com/19188/128251924-c61318e3-4e48-4f1d-a6e6-8518e04faf9c.png">
resuming an in-progress was failing when EVSS is down (nightly). Updating rated disabilities is nice to have but not essential so they should be able to continue if evss errors

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28300

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
