### PR TITLE
Fix flipper to enforce enable_in_development setting

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -49,10 +49,14 @@ Rails.application.reloader.to_prepare do
 
         # default features to enabled for test and those explicitly set for development
         if Rails.env.test? ||
-           (Rails.env.development? && feature_config['enable_in_development']) ||
-           (Settings.vsp_environment == 'development' && feature_config['enable_in_development'])
+           (Rails.env.development? && feature_config['enable_in_development'])
           Flipper.enable(feature)
         end
+      end
+
+      # this will enable features on dev-api.va.gov if they are set to enable_in_development
+      if Settings.vsp_environment == 'development' && feature_config['enable_in_development']
+        Flipper.enable(feature)
       end
     end
     # remove features from UI that have been removed from code

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,7 @@
 hostname: 127.0.0.1:3000 # possible fallback for unsafe request.host
 
+vsp_environment: 
+
 virtual_hosts: ["127.0.0.1", "localhost"] # Safe host names
 
 # For CORS requests; separate multiple origins with a comma


### PR DESCRIPTION
This is a continuation of a previous PR that was merged with master but did not end up working as intended. 

## Description of change
Since all environments are set to prod, the enable_in_dev setting was not working since it was based on Rails.env being equal to 'development'. This change will instead check vsp_environment in settings.local.yml, which accurately reflects the different environments, so that those features that are set to enable_in_dev will be enabled on dev-api.va.gov.

## Original issue(s)
https://app.zenhub.com/workspaces/vsp---backend-tools-6019ab9387ae890011e05e73/issues/department-of-veterans-affairs/vets-api/7519