### PR TITLE
28064 address subtle bug

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1058,7 +1058,8 @@ pg_hero:
 
 check_in:
   chip_api:
-    url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com/dev
+    url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
+    base_path: dev
     host: vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
     tmp_api_user: TzY6DFrnjPE8dwxUMbFf9HjbFqRim2MgXpMpMciXJFVohyURUJAc7W99rpFzhfh2B3sVnn4
     tmp_api_id: 2dcdrrn5zc

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -160,7 +160,8 @@ sidekiq:
 
 check_in:
   chip_api:
-    url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com/dev
+    url: https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
+    base_path: dev
     host: vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com
     tmp_api_user: TzY6DFrnjPE8dwxUMbFf9HjbFqRim2MgXpMpMciXJFVohyURUJAc7W99rpFzhfh2B3sVnn4
     tmp_api_id: 2dcdrrn5zc

--- a/modules/check_in/app/services/chip_api/service.rb
+++ b/modules/check_in/app/services/chip_api/service.rb
@@ -53,7 +53,7 @@ module ChipApi
       return handle_response(client_error) unless valid?
 
       token = session.retrieve
-      resp = request.get(path: "/appointments/#{uuid}", access_token: token)
+      resp = request.get(path: "/#{base_path}/appointments/#{uuid}", access_token: token)
 
       handle_response(resp)
     end
@@ -67,9 +67,19 @@ module ChipApi
       return handle_response(client_error) unless valid?
 
       token = session.retrieve
-      resp = request.post(path: "/actions/check-in/#{uuid}", access_token: token)
+      resp = request.post(path: "/#{base_path}/actions/check-in/#{uuid}", access_token: token)
 
       handle_response(resp)
+    end
+
+    ##
+    # Helper method for returning the Chip URL base path
+    # from our environment configuration file
+    #
+    # @return [String]
+    #
+    def base_path
+      Settings.check_in.chip_api.base_path
     end
 
     ##

--- a/modules/check_in/app/services/chip_api/token.rb
+++ b/modules/check_in/app/services/chip_api/token.rb
@@ -35,7 +35,7 @@ module ChipApi
     # @return [ChipApi::Token]
     #
     def fetch
-      response = request.post(path: '/token', claims_token: claims_token.static)
+      response = request.post(path: "/#{base_path}/token", claims_token: claims_token.static)
 
       self.access_token = Oj.load(response.body)['token']
       self
@@ -57,6 +57,16 @@ module ChipApi
     #
     def created_at
       @created_at ||= Time.zone.now.utc.to_i
+    end
+
+    ##
+    # Helper method for returning the Chip URL base path
+    # from our environment configuration file
+    #
+    # @return [String]
+    #
+    def base_path # rubocop:disable Rails/Delegate
+      chip_api.base_path
     end
 
     ##

--- a/modules/check_in/spec/services/chip_api/request_spec.rb
+++ b/modules/check_in/spec/services/chip_api/request_spec.rb
@@ -14,7 +14,7 @@ describe ChipApi::Request do
   describe '#get' do
     let(:opts) do
       {
-        path: '/appointments/123abc',
+        path: '/dev/appointments/d602d9eb-9a31-484f-9637-13ab0b507e0d',
         access_token: 'abc123'
       }
     end
@@ -24,7 +24,7 @@ describe ChipApi::Request do
       allow_any_instance_of(Faraday::Connection).to receive(:get).with(anything).and_return(anything)
 
       expect_any_instance_of(Faraday::Connection).to receive(:get)
-        .with('/appointments/123abc').once
+        .with('/dev/appointments/d602d9eb-9a31-484f-9637-13ab0b507e0d').once
 
       subject.build.get(opts)
     end
@@ -33,7 +33,7 @@ describe ChipApi::Request do
   describe '#post' do
     let(:opts) do
       {
-        path: '/actions/check-in/789',
+        path: '/dev/actions/check-in/d602d9eb-9a31-484f-9637-13ab0b507e0d',
         access_token: 'abc123'
       }
     end
@@ -42,7 +42,7 @@ describe ChipApi::Request do
       allow_any_instance_of(Faraday::Connection).to receive(:post).with(anything).and_return(anything)
 
       expect_any_instance_of(Faraday::Connection).to receive(:post)
-        .with('/actions/check-in/789').once
+        .with('/dev/actions/check-in/d602d9eb-9a31-484f-9637-13ab0b507e0d').once
 
       subject.build.post(opts)
     end
@@ -53,7 +53,7 @@ describe ChipApi::Request do
     let(:conn) { Faraday.new { |b| b.adapter(:test, stubs) } }
     let(:opts) do
       {
-        path: 'appointments/123',
+        path: '/dev/appointments/d602d9eb-9a31-484f-9637-13ab0b507e0d',
         access_token: 'abc123'
       }
     end
@@ -63,7 +63,7 @@ describe ChipApi::Request do
     end
 
     it 'GET has headers' do
-      stubs.get('/appointments/123') do |_env|
+      stubs.get('/dev/appointments/d602d9eb-9a31-484f-9637-13ab0b507e0d') do |_env|
         [
           200,
           { 'Content-Type': 'application/json' },
@@ -82,13 +82,13 @@ describe ChipApi::Request do
     context 'with access_token' do
       let(:opts) do
         {
-          path: 'actions/check-in/789',
+          path: '/dev/actions/check-in/d602d9eb-9a31-484f-9637-13ab0b507e0d',
           access_token: 'abc123'
         }
       end
 
       it 'POST has bearer headers' do
-        stubs.post('/actions/check-in/789') do |_env|
+        stubs.post('/dev/actions/check-in/d602d9eb-9a31-484f-9637-13ab0b507e0d') do |_env|
           [
             200,
             { 'Content-Type': 'application/json' },
@@ -108,13 +108,13 @@ describe ChipApi::Request do
     context 'with claims_token' do
       let(:opts) do
         {
-          path: 'token',
+          path: '/dev/token',
           claims_token: 'efgh5678'
         }
       end
 
       it 'POST has basic headers' do
-        stubs.post('/token') do |_env|
+        stubs.post('/dev/token') do |_env|
           [
             200,
             { 'Content-Type': 'application/json' },
@@ -140,7 +140,7 @@ describe ChipApi::Request do
 
   describe '#url' do
     it 'has default headers' do
-      expect(subject.build.url).to eq('https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com/dev')
+      expect(subject.build.url).to eq('https://vpce-06399548ef94bdb41-lk4qp2nd.execute-api.us-gov-west-1.vpce.amazonaws.com')
     end
   end
 end

--- a/modules/check_in/spec/services/chip_api/service_spec.rb
+++ b/modules/check_in/spec/services/chip_api/service_spec.rb
@@ -20,7 +20,7 @@ describe ChipApi::Service do
 
     let(:opts) do
       {
-        path: '/appointments/d602d9eb-9a31-484f-9637-13ab0b507e0d',
+        path: '/dev/appointments/d602d9eb-9a31-484f-9637-13ab0b507e0d',
         access_token: 'abc123'
       }
     end
@@ -50,7 +50,7 @@ describe ChipApi::Service do
   describe '#create_check_in' do
     let(:opts) do
       {
-        path: '/actions/check-in/d602d9eb-9a31-484f-9637-13ab0b507e0d',
+        path: '/dev/actions/check-in/d602d9eb-9a31-484f-9637-13ab0b507e0d',
         access_token: 'abc123'
       }
     end
@@ -131,6 +131,12 @@ describe ChipApi::Service do
 
         expect(subject.build(valid_check_in).handle_response(resp)).to eq(hsh)
       end
+    end
+  end
+
+  describe '#base_path' do
+    it 'returns base_path' do
+      expect(subject.build(valid_check_in).base_path).to eq('dev')
     end
   end
 end

--- a/modules/check_in/spec/services/chip_api/token_spec.rb
+++ b/modules/check_in/spec/services/chip_api/token_spec.rb
@@ -61,4 +61,10 @@ describe ChipApi::Token do
       expect(subject.build.chip_api).to be_a(Config::Options)
     end
   end
+
+  describe '#base_path' do
+    it 'returns base_path' do
+      expect(subject.build.chip_api.base_path).to eq('dev')
+    end
+  end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->
- Faraday might be using the URI base instead of the additional path
- Adding the base path as config in settings
## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28064

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
- [x] RSpec passing