### PR TITLE
API-9114 - Remove conditional logic around HLR v2 stuff

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/metadata_controller.rb
@@ -92,23 +92,17 @@ module AppealsApi
     end
 
     def decision_reviews_versions
-      if v2_enabled?
-        [
-          decision_reviews_v1.merge({ status: VERSION_STATUS[:previous] }),
-          decision_reviews_v2
-        ]
-      else
-        [
-          decision_reviews_v1
-        ]
-      end
+      [
+        decision_reviews_v1,
+        decision_reviews_v2
+      ]
     end
 
     def decision_reviews_v1
       {
         version: '1.0.0',
         internal_only: true,
-        status: VERSION_STATUS[:current],
+        status: VERSION_STATUS[:previous],
         path: '/services/appeals/docs/v1/decision_reviews',
         healthcheck: '/services/appeals/v1/healthcheck'
       }
@@ -122,10 +116,6 @@ module AppealsApi
         path: '/services/appeals/docs/v2/decision_reviews',
         healthcheck: '/services/appeals/v2/healthcheck'
       }
-    end
-
-    def v2_enabled?
-      Settings.modules_appeals_api.documentation.path_enabled_flag
     end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews/contestable_issues_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews/contestable_issues_controller.rb
@@ -4,7 +4,7 @@ class AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesCont
   include AppealsApi::HeaderModification
 
   def index
-    deprecate(response: response, link: AppealsApi::HeaderModification::V2_DEV_DOCS) if hlr_v2_live?
+    deprecate(response: response, link: AppealsApi::HeaderModification::V2_DEV_DOCS)
 
     get_contestable_issues_from_caseflow
 
@@ -19,9 +19,5 @@ class AppealsApi::V1::DecisionReviews::HigherLevelReviews::ContestableIssuesCont
 
   def decision_review_type
     'higher_level_reviews'
-  end
-
-  def hlr_v2_live?
-    Settings.modules_appeals_api.documentation.path_enabled_flag
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/higher_level_reviews_controller.rb
@@ -146,9 +146,6 @@ class AppealsApi::V1::DecisionReviews::HigherLevelReviewsController < AppealsApi
   end
 
   def deprecate_headers
-    if Settings.modules_appeals_api.documentation.path_enabled_flag
-      # used in swagger to denote deprecation, should be replaced when we go live
-      deprecate(response: response, link: AppealsApi::HeaderModification::RELEASE_NOTES_LINK, sunset: sunset_date)
-    end
+    deprecate(response: response, link: AppealsApi::HeaderModification::RELEASE_NOTES_LINK, sunset: sunset_date)
   end
 end

--- a/modules/appeals_api/app/swagger/appeals_api/v1/higher_level_reviews_controller_swagger.rb
+++ b/modules/appeals_api/app/swagger/appeals_api/v1/higher_level_reviews_controller_swagger.rb
@@ -5,8 +5,6 @@ class AppealsApi::V1::HigherLevelReviewsControllerSwagger
 
   OBJ = :object
   HLR_TAG = ['Higher-Level Reviews'].freeze
-  DOC_VISIBILITY_SETTING = Settings.modules_appeals_api.documentation.path_enabled_flag
-  DEPRECATION_V2_NOTICE = DOC_VISIBILITY_SETTING ? 'See v2 for this endpoint - ' : ''
 
   read_file = ->(path) { File.read(AppealsApi::Engine.root.join(*path)) }
   read_json = ->(path) { JSON.parse(read_file.call(path)) }
@@ -70,9 +68,9 @@ class AppealsApi::V1::HigherLevelReviewsControllerSwagger
 
   swagger_path '/higher_level_reviews' do
     operation :post, tags: HLR_TAG do
-      key :deprecated, DOC_VISIBILITY_SETTING
+      key :deprecated, true
       key :operationId, 'postHigherLevelReviews'
-      key :summary, "#{DEPRECATION_V2_NOTICE}Creates a new Higher-Level Review."
+      key :summary, 'Creates a new Higher-Level Review.'
       desc = 'Submits a Decision Review request of type *Higher-Level Review*. This endpoint is the same as ' \
         'submitting [VA Form 20-0996](https://www.vba.va.gov/pubs/forms/VBA-20-0996-ARE.pdf) via mail or fax.'
       key :description, desc
@@ -87,9 +85,9 @@ class AppealsApi::V1::HigherLevelReviewsControllerSwagger
 
   swagger_path '/higher_level_reviews/{uuid}' do
     operation :get, tags: HLR_TAG do
-      key :deprecated, DOC_VISIBILITY_SETTING
+      key :deprecated, true
       key :operationId, 'getHigherLevelReview'
-      key :summary, "#{DEPRECATION_V2_NOTICE}Shows a specific Higher-Level Review. (a.k.a. the Show endpoint)"
+      key :summary, 'Shows a specific Higher-Level Review. (a.k.a. the Show endpoint)'
       key :description, 'Returns all of the data associated with a specific Higher-Level Review.'
       parameter name: 'uuid', in: 'path', required: true, description: 'Higher-Level Review UUID' do
         schema { key :$ref, :uuid }
@@ -103,9 +101,9 @@ class AppealsApi::V1::HigherLevelReviewsControllerSwagger
 
   swagger_path '/higher_level_reviews/contestable_issues/{benefit_type}' do
     operation :get, tags: HLR_TAG do
-      key :deprecated, DOC_VISIBILITY_SETTING
+      key :deprecated, true
       key :operationId, 'getContestableIssues'
-      key :summary, "#{DEPRECATION_V2_NOTICE}Returns all contestable issues for a specific veteran."
+      key :summary, 'Returns all contestable issues for a specific veteran.'
       desc = 'Returns all issues associated with a Veteran that have not previously been decided by a Higher-Level ' \
         'Review as of the `receiptDate` and bound by `benefitType`. Not all issues returned are guaranteed to be ' \
         'eligible for appeal. Associate these results when creating a new Higher-Level Review.'
@@ -146,9 +144,9 @@ class AppealsApi::V1::HigherLevelReviewsControllerSwagger
 
   swagger_path '/higher_level_reviews/schema' do
     operation :get, tags: HLR_TAG do
-      key :deprecated, DOC_VISIBILITY_SETTING
+      key :deprecated, true
       key :operationId, 'getHigherLevelReviewSchema'
-      key :summary, "#{DEPRECATION_V2_NOTICE}Gets the Higher-Level Review JSON Schema."
+      key :summary, 'Gets the Higher-Level Review JSON Schema.'
       desc = 'Returns the [JSON Schema](https://json-schema.org/) for the `POST /higher_level_reviews` endpoint.'
       key :description, desc
       response '200' do
@@ -164,9 +162,9 @@ class AppealsApi::V1::HigherLevelReviewsControllerSwagger
 
   swagger_path '/higher_level_reviews/validate' do
     operation :post, tags: HLR_TAG do
-      key :deprecated, DOC_VISIBILITY_SETTING
+      key :deprecated, true
       key :operationId, 'postValidateHigherLevelReview'
-      key :summary, "#{DEPRECATION_V2_NOTICE}Validates a POST request body against the JSON schema."
+      key :summary, 'Validates a POST request body against the JSON schema.'
       desc = 'Like the `POST /higher_level_reviews`, but *only* does the validations **—does not submit anything.**'
       key :description, desc
       key :parameters, hlr_create_parameters


### PR DESCRIPTION
## Description of change
This PR removes the conditional logic related to our V2 endpoints (now that they are fully rolled out).

## Original issue(s)
https://vajira.max.gov/browse/API-9114