### PR TITLE
API-9060: Only require birls for 526 and 0966 submission

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
@@ -22,10 +22,11 @@ module ClaimsApi
 
       protected
 
-      def validate_veteran_identifiers
-        return if target_veteran.participant_id.present? && target_veteran.birls_id.present?
+      def validate_veteran_identifiers(require_birls: false)
+        return if !require_birls && target_veteran.participant_id.present?
+        return if require_birls && target_veteran.participant_id.present? && target_veteran.birls_id.present?
 
-        if target_veteran.participant_id.present? && target_veteran.birls_id.blank?
+        if require_birls && target_veteran.participant_id.present? && target_veteran.birls_id.blank?
           raise ::Common::Exceptions::UnprocessableEntity.new(detail: 'No birls_id while participant_id present')
         end
 

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -22,6 +22,7 @@ module ClaimsApi
         end
         skip_before_action :validate_json_format, only: %i[upload_supporting_documents]
         before_action :verify_power_of_attorney!, if: :header_request?
+        skip_before_action :validate_veteran_identifiers, only: %i[submit_form_526 validate_form_526]
 
         # POST to submit disability claim.
         #
@@ -29,6 +30,7 @@ module ClaimsApi
         def submit_form_526 # rubocop:disable Metrics/MethodLength
           validate_json_schema
           validate_form_526_submission_values!
+          validate_veteran_identifiers(require_birls: true)
           validate_initial_claim
 
           auto_claim = ClaimsApi::AutoEstablishedClaim.create(
@@ -111,6 +113,7 @@ module ClaimsApi
         def validate_form_526
           add_deprecation_headers_to_response(response: response, link: ClaimsApi::EndpointDeprecation::V1_DEV_DOCS)
           validate_json_schema
+          validate_veteran_identifiers(require_birls: true)
           validate_initial_claim
 
           service = EVSS::DisabilityCompensationForm::Service.new(auth_headers)

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/intent_to_file_controller.rb
@@ -13,6 +13,7 @@ module ClaimsApi
           permit_scopes %w[claim.write]
         end
         before_action :verify_power_of_attorney!, if: :header_request?
+        skip_before_action :validate_veteran_identifiers, only: %i[submit_form_0966 validate]
 
         FORM_NUMBER = '0966'
         ITF_TYPES = %w[compensation pension burial].freeze
@@ -22,6 +23,7 @@ module ClaimsApi
         # @return [JSON] Response from BGS
         def submit_form_0966
           validate_json_schema
+          validate_veteran_identifiers(require_birls: true)
           check_for_invalid_burial_submission! if form_type == 'burial'
 
           bgs_response = bgs_service.intent_to_file.insert_intent_to_file(intent_to_file_options)
@@ -58,6 +60,7 @@ module ClaimsApi
         def validate
           add_deprecation_headers_to_response(response: response, link: ClaimsApi::EndpointDeprecation::V1_DEV_DOCS)
           validate_json_schema
+          validate_veteran_identifiers(require_birls: true)
           render json: validation_success
         end
 


### PR DESCRIPTION
## Description of change
Changes to only require Veteran to be in birls if they are submitting a 526 or a 0966. All other interactions only require the Veteran to have a participant_id

## Original issue(s)
https://vajira.max.gov/browse/API-9060