### PR TITLE
remove dashboard_show_dashboard_2 flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -79,10 +79,6 @@ features:
   covid_volunteer_delivery:
     actor_type: cookie_id
     description: Toggles whether COVID Research volunteer submissions will be delivered to genISIS
-  dashboard_show_dashboard_2:
-    actor_type: user
-    description: Enables The New My VA Dashboard 2.0
-    enable_in_development: true
   debt_letters_show_letters:
     actor_type: user
     description: Enables debt letters


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Removes the `dashboard_show_dashboard_2` flag as it's no longer needed or referenced in the FE; [all usage was removed in this PR](https://github.com/department-of-veterans-affairs/vets-website/issues/17940)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->