### PR TITLE
updates sanitzer to scrub va_eauth_gcIds

### DIFF
--- a/lib/sentry/processor/pii_sanitizer.rb
+++ b/lib/sentry/processor/pii_sanitizer.rb
@@ -31,6 +31,7 @@ module Sentry
           street
           va_eauth_authorization
           va_eauth_birlsfilenumber
+          va_eauth_gcIds
           vaEauthPnid
           zipCode
         ].freeze

--- a/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
+++ b/spec/lib/sentry/processor/pii_sanitizer_processor_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Sentry::Processor::PIISanitizer do
         gender: 'M',
         phone: '5035551234',
         va_eauth_birthdate: '1945-02-13T00:00:00+00:00',
+        va_eauth_gcIds: ['1234567890^NI^200M^USVHA^P|1234567890^NI^200DOD^USDOD^A|1234567890^PI^200BRLS^USVBA^'],
         va_eauth_pnid: '796375555'
       }
     end
@@ -108,6 +109,10 @@ RSpec.describe Sentry::Processor::PIISanitizer do
       expect(result[:va_eauth_birthdate]).to eq('FILTERED-CLIENTSIDE')
     end
 
+    it 'filters EVSS va_eauth_gcIds data' do
+      expect(result[:va_eauth_gcIds]).to eq(['FILTERED-CLIENTSIDE'])
+    end
+
     it 'filters EVSS va_eauth_pnid data' do
       expect(result[:va_eauth_pnid]).to eq('FILTERED-CLIENTSIDE')
     end
@@ -128,6 +133,7 @@ RSpec.describe Sentry::Processor::PIISanitizer do
         'gender' => 'F',
         'phone' => '5415551234',
         'va_eauth_birthdate' => '1945-02-13T00:00:00+00:00',
+        'va_eauth_gcIds' => ['1234567890^NI^200M^USVHA^P|1234567890^NI^200DOD^USDOD^A|1234567890^PI^200BRLS^USVBA^'],
         'va_eauth_pnid' => '796375555'
       }
     end
@@ -154,6 +160,10 @@ RSpec.describe Sentry::Processor::PIISanitizer do
 
     it 'filters EVSS va_eauth_birthdate data' do
       expect(result['va_eauth_birthdate']).to eq('FILTERED-CLIENTSIDE')
+    end
+
+    it 'filters EVSS va_eauth_gcIds data' do
+      expect(result['va_eauth_gcIds']).to eq(['FILTERED-CLIENTSIDE'])
     end
 
     it 'filters EVSS va_eauth_pnid data' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
After adding some [additional logging to identify users with duplicate IDs](http://sentry.vfs.va.gov/organizations/vsp/issues/44529/?environment=production&project=3&project=4&query=is%3Aunresolved+User+attributes+contain+multiple+distinct&statsPeriod=14d), @bosawt noticed that the `va_eauth_gcIds` field was not sanitized and contained information, such as BIRLS IDs, that were supposed to be sanitized. This PR updates the sanitizer to scrub the `va_eauth_gcIds` field.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#26795

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Unit tests updated to test for `va_eauth_gcIds` field.