### PR TITLE
Fix HLR VaNotify service call

### DIFF
--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -225,7 +225,6 @@ module AppealsApi
       email_handler = Events::Handler.new(event_type: :hlr_received, opts: {
                                             email: email_v2,
                                             veteran_first_name: first_name,
-                                            veteran_last_name: last_name,
                                             date_submitted: date_signed,
                                             guid: id
                                           })

--- a/modules/appeals_api/app/services/appeals_api/events/appeal_received.rb
+++ b/modules/appeals_api/app/services/appeals_api/events/appeal_received.rb
@@ -20,8 +20,7 @@ module AppealsApi
           email_address: email,
           template_id: template_id,
           personalisation: {
-            'veteran_first_name' => opts['veteran_first_name'],
-            'veteran_last_name' => opts['veteran_last_name'],
+            'first_name' => opts['veteran_first_name'],
             'date_submitted' => opts['date_submitted']
           }
         )
@@ -56,7 +55,7 @@ module AppealsApi
       end
 
       def required_keys
-        %w[guid email date_submitted veteran_first_name veteran_last_name]
+        %w[guid email date_submitted veteran_first_name]
       end
     end
 

--- a/modules/appeals_api/spec/services/appeals_api/events/appeal_received_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/events/appeal_received_spec.rb
@@ -20,7 +20,6 @@ module AppealsApi
           opts = {
             'email' => 'fake_email@email.com',
             'veteran_first_name' => 'first name',
-            'veteran_last_name' => 'last name',
             'date_submitted' => Time.zone.now.to_date,
             'guid' => '1234556'
           }


### PR DESCRIPTION
## Description of change
Fix to use the proper personalization keys keys for the email template VANotify uses to send our HLR received emails

## Original issue(s)
https://vajira.max.gov/browse/API-8966