### PR TITLE
allowing any digit in the 3 digit area code

### DIFF
--- a/modules/appeals_api/config/schemas/v2/200996.json
+++ b/modules/appeals_api/config/schemas/v2/200996.json
@@ -18,7 +18,7 @@
       "type": "object",
       "properties": {
         "countryCode":     { "type": "string", "pattern": "^[0-9]+$", "minLength": 1, "maxLength": 3 },
-        "areaCode":        { "type": "string", "pattern": "^[0-9]{3}$", "minLength": 1, "maxLength": 4 },
+        "areaCode":        { "type": "string", "pattern": "^[0-9]{4}$", "minLength": 1, "maxLength": 4 },
         "phoneNumber":     { "type": "string", "pattern": "^[0-9]{1,14}$", "minLength": 1, "maxLength": 14 },
         "phoneNumberExt":  { "type": "string", "pattern": "^[a-zA-Z0-9]{1,10}$", "minLength": 1, "maxLength": 10 }
       },

--- a/modules/appeals_api/config/schemas/v2/200996.json
+++ b/modules/appeals_api/config/schemas/v2/200996.json
@@ -18,7 +18,7 @@
       "type": "object",
       "properties": {
         "countryCode":     { "type": "string", "pattern": "^[0-9]+$", "minLength": 1, "maxLength": 3 },
-        "areaCode":        { "type": "string", "pattern": "^[0-9]{4}$", "minLength": 1, "maxLength": 4 },
+        "areaCode":        { "type": "string", "pattern": "^[0-9]{3,4}$", "minLength": 1, "maxLength": 4 },
         "phoneNumber":     { "type": "string", "pattern": "^[0-9]{1,14}$", "minLength": 1, "maxLength": 14 },
         "phoneNumberExt":  { "type": "string", "pattern": "^[a-zA-Z0-9]{1,10}$", "minLength": 1, "maxLength": 10 }
       },

--- a/modules/appeals_api/config/schemas/v2/200996.json
+++ b/modules/appeals_api/config/schemas/v2/200996.json
@@ -18,7 +18,7 @@
       "type": "object",
       "properties": {
         "countryCode":     { "type": "string", "pattern": "^[0-9]+$", "minLength": 1, "maxLength": 3 },
-        "areaCode":        { "type": "string", "pattern": "^[2-9][0-9]{2}$", "minLength": 1, "maxLength": 4 },
+        "areaCode":        { "type": "string", "pattern": "^[0-9]{3}$", "minLength": 1, "maxLength": 4 },
         "phoneNumber":     { "type": "string", "pattern": "^[0-9]{1,14}$", "minLength": 1, "maxLength": 14 },
         "phoneNumberExt":  { "type": "string", "pattern": "^[a-zA-Z0-9]{1,10}$", "minLength": 1, "maxLength": 10 }
       },


### PR DESCRIPTION
[API-9148](https://vajira.max.gov/browse/API-9148)

This PR adjusts the regex pattern for areaCodes for HLRv2. 

We still limit the area code to 3 characters, but allow for any digit to be present in the pattern.