### PR TITLE
Remove Rolling  unhashed access_token lookup

### DIFF
--- a/app/controllers/openid_application_controller.rb
+++ b/app/controllers/openid_application_controller.rb
@@ -37,7 +37,6 @@ class OpenidApplicationController < ApplicationController
 
     # Only want to fetch the Okta profile if the session isn't already established and not a CC token
     @session = Session.find(hash_token(token)) unless token.client_credentials_token?
-    @session = Session.find(token) unless token.client_credentials_token? || !@session.nil?
     profile = @session.profile unless @session.nil? || @session.profile.nil?
     profile = fetch_profile(token.identifiers.okta_uid) unless token.client_credentials_token? || !profile.nil?
     populate_ssoi_token_payload(profile) if !profile.nil? && profile.attrs['last_login_type'] == 'ssoi'
@@ -74,7 +73,6 @@ class OpenidApplicationController < ApplicationController
 
   def analyze_redis_launch_context
     @session = Session.find(hash_token(token))
-    @session = Session.find(token) if @session.nil?
     # Sessions are not originally created for client credentials tokens, one will be created here.
     if @session.nil?
       ttl = token.payload['exp'] - Time.current.utc.to_i

--- a/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
@@ -16,8 +16,6 @@ module VeteranVerification
       return false if token.blank? || token.client_credentials_token?
 
       @session = Session.find(Digest::SHA256.hexdigest(token.to_s))
-      # Remove
-      @session = Session.find(token) if @session.nil?
       if @session.nil?
         profile = fetch_profile(token.identifiers.okta_uid)
         establish_session(profile)

--- a/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/application_controller.rb
@@ -16,6 +16,7 @@ module VeteranVerification
       return false if token.blank? || token.client_credentials_token?
 
       @session = Session.find(Digest::SHA256.hexdigest(token.to_s))
+      # Remove
       @session = Session.find(token) if @session.nil?
       if @session.nil?
         profile = fetch_profile(token.identifiers.okta_uid)


### PR DESCRIPTION
# Description

OpenId modules use hashed access_tokens as redis keys for user information. Remove any unhashed access token redis lookups.

## Related PR

https://github.com/department-of-veterans-affairs/vets-api/pull/7561