### PR TITLE
[API-9012] - Adds EVSS validation checks for Form526 "servicePay" attributes

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -152,6 +152,7 @@ module ClaimsApi
           validate_form_526_claimant_certification!
           validate_form_526_location_codes!
           validate_form_526_veteran_homelessness!
+          validate_form_526_service_pay!
         end
 
         def validate_form_526_submission_claim_date!
@@ -194,6 +195,21 @@ module ClaimsApi
             raise ::Common::Exceptions::InvalidFieldValue.new(
               'homelessness',
               form_attributes['veteran']['homelessness']
+            )
+          end
+        end
+
+        def validate_form_526_service_pay!
+          receiving_attr    = form_attributes.dig('servicePay', 'militaryRetiredPay', 'receiving')
+          will_receive_attr = form_attributes.dig('servicePay', 'militaryRetiredPay', 'willReceiveInFuture')
+
+          return if receiving_attr.nil? || will_receive_attr.nil?
+
+          # EVSS does not allow both attributes to be the same value (unless that value is nil)
+          if receiving_attr == will_receive_attr
+            raise ::Common::Exceptions::InvalidFieldValue.new(
+              'servicePay.militaryRetiredPay',
+              form_attributes['servicePay']['militaryRetiredPay']
             )
           end
         end

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -204,14 +204,13 @@ module ClaimsApi
           will_receive_attr = form_attributes.dig('servicePay', 'militaryRetiredPay', 'willReceiveInFuture')
 
           return if receiving_attr.nil? || will_receive_attr.nil?
+          return unless receiving_attr == will_receive_attr
 
           # EVSS does not allow both attributes to be the same value (unless that value is nil)
-          if receiving_attr == will_receive_attr
-            raise ::Common::Exceptions::InvalidFieldValue.new(
-              'servicePay.militaryRetiredPay',
-              form_attributes['servicePay']['militaryRetiredPay']
-            )
-          end
+          raise ::Common::Exceptions::InvalidFieldValue.new(
+            'servicePay.militaryRetiredPay',
+            form_attributes['servicePay']['militaryRetiredPay']
+          )
         end
 
         def too_many_homelessness_attributes_provided?

--- a/modules/claims_api/app/swagger/claims_api/v1/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v1/swagger.json
@@ -496,7 +496,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "43343126-d1cf-4bd5-8e56-7636b1af422c",
+                    "id": "fbbd5a18-c8bb-4193-bc17-0d6f86f75bf1",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": 600118851,
@@ -545,11 +545,11 @@
                       "status": "Initial review",
                       "supporting_documents": [
                         {
-                          "id": "e4e73fb3-76fc-4d53-9b87-3bc866944332",
+                          "id": "6047f5fe-f76e-4100-83ee-a354935772d3",
                           "type": "claim_supporting_document",
                           "md5": "d927c7e283b3158a54822a493d06181d",
                           "filename": "extras.pdf",
-                          "uploaded_at": "2021-08-13T16:00:46.244Z"
+                          "uploaded_at": "2021-08-13T20:15:32.320Z"
                         }
                       ]
                     }
@@ -2072,9 +2072,15 @@
                               ],
                               "properties": {
                                 "receiving": {
-                                  "description": "Is Veteran getting Retiree pay.",
+                                  "description": "Is Veteran getting Retiree pay?",
                                   "type": "boolean",
                                   "example": true
+                                },
+                                "willReceiveInFuture": {
+                                  "description": "Will Veteran get Retiree pay in future?",
+                                  "type": "boolean",
+                                  "default": false,
+                                  "example": false
                                 },
                                 "payment": {
                                   "description": "Part of DoD paying Retirement Benefits.",
@@ -2269,7 +2275,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "d43d066c-b9d7-46d0-836e-57641cc5b1a4",
+                    "id": "e5600e0e-b94c-415a-b087-5fa7b30b20a6",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -2287,13 +2293,13 @@
                       "current_phase_back": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-08-13T16:00:46.667Z",
+                      "updated_at": "2021-08-13T20:15:32.808Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
 
                       ],
-                      "token": "d43d066c-b9d7-46d0-836e-57641cc5b1a4",
+                      "token": "e5600e0e-b94c-415a-b087-5fa7b30b20a6",
                       "status": "pending",
                       "flashes": [
                         "Hardship",
@@ -3766,9 +3772,15 @@
                                 ],
                                 "properties": {
                                   "receiving": {
-                                    "description": "Is Veteran getting Retiree pay.",
+                                    "description": "Is Veteran getting Retiree pay?",
                                     "type": "boolean",
                                     "example": true
+                                  },
+                                  "willReceiveInFuture": {
+                                    "description": "Will Veteran get Retiree pay in future?",
+                                    "type": "boolean",
+                                    "default": false,
+                                    "example": false
                                   },
                                   "payment": {
                                     "description": "Part of DoD paying Retirement Benefits.",
@@ -3976,7 +3988,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "c5b8c81d-6cd6-4c86-ade3-4742c51bace4",
+                    "id": "d8cabd57-aa42-4459-836c-4523af5c9d53",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -3994,13 +4006,13 @@
                       "current_phase_back": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-08-13T16:00:47.133Z",
+                      "updated_at": "2021-08-13T20:15:33.356Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
 
                       ],
-                      "token": "c5b8c81d-6cd6-4c86-ade3-4742c51bace4",
+                      "token": "d8cabd57-aa42-4459-836c-4523af5c9d53",
                       "status": "pending",
                       "flashes": [
                         "Hardship",
@@ -5874,9 +5886,15 @@
                                 ],
                                 "properties": {
                                   "receiving": {
-                                    "description": "Is Veteran getting Retiree pay.",
+                                    "description": "Is Veteran getting Retiree pay?",
                                     "type": "boolean",
                                     "example": true
+                                  },
+                                  "willReceiveInFuture": {
+                                    "description": "Will Veteran get Retiree pay in future?",
+                                    "type": "boolean",
+                                    "default": false,
+                                    "example": false
                                   },
                                   "payment": {
                                     "description": "Part of DoD paying Retirement Benefits.",
@@ -6084,7 +6102,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "82eabcd3-96f3-499a-aa2e-5630e6ebc78c",
+                    "id": "e2689d2a-eb60-4954-9d25-496f6d1a7eba",
                     "type": "claims_api_claim",
                     "attributes": {
                       "evss_id": null,
@@ -6098,7 +6116,7 @@
                       "decision_letter_sent": null,
                       "requested_decision": null,
                       "claim_type": null,
-                      "updated_at": "2021-08-13T16:00:47.933Z",
+                      "updated_at": "2021-08-13T20:15:34.405Z",
                       "contention_list": null,
                       "va_representative": null,
                       "events_timeline": [
@@ -6107,7 +6125,7 @@
                       "status": "pending",
                       "supporting_documents": [
                         {
-                          "id": "4d169c27-5515-4071-a510-103b8d5b689c",
+                          "id": "fe2cbff2-cb1b-45fc-9fbe-0ecc76967645",
                           "type": "claim_supporting_document",
                           "md5": null,
                           "filename": null,
@@ -8064,7 +8082,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "fb0fc7dd-d3ce-43f6-ab2e-a5c7564ac8de",
+                    "id": "b49790e1-a413-45ac-ab72-3c222ac30f83",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "pending",
@@ -8777,7 +8795,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "a6c7f441-e180-4089-850a-c9b4023fe9a8",
+                    "id": "4a1539b7-9452-4a22-aacd-2b3ecc299404",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "submitted",
@@ -9102,7 +9120,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "aa30cf0f-170a-4a13-b781-ae75cc315362",
+                    "id": "7ce54e2c-6bae-40ac-8714-2032ab83ef60",
                     "type": "claims_api_power_of_attorneys",
                     "attributes": {
                       "status": "submitted",

--- a/modules/claims_api/config/schemas/526.json
+++ b/modules/claims_api/config/schemas/526.json
@@ -1067,9 +1067,15 @@
           "required": ["receiving", "payment"],
           "properties": {
             "receiving": {
-              "description": "Is Veteran getting Retiree pay.",
+              "description": "Is Veteran getting Retiree pay?",
               "type": "boolean",
               "example": true
+            },
+            "willReceiveInFuture": {
+              "description": "Will Veteran get Retiree pay in future?",
+              "type": "boolean",
+              "default": false,
+              "example": false
             },
             "payment": {
               "description": "Part of DoD paying Retirement Benefits.",

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -680,6 +680,118 @@ RSpec.describe 'Disability Claims ', type: :request do
         end
       end
     end
+
+    describe "'servicePay.militaryRetiredPay' validations" do
+      let(:service_pay_attribute) do
+        {
+          'militaryRetiredPay': {
+            'receiving': receiving,
+            'willReceiveInFuture': will_receive,
+            'payment': {
+              'serviceBranch': 'Air Force'
+            }
+          },
+          'waiveVABenefitsToRetainTrainingPay': false,
+          'waiveVABenefitsToRetainRetiredPay': false
+        }
+      end
+
+      context "when 'receiving' and 'willReceiveInFuture' are equal but not 'nil'" do
+        context "when both are 'true'" do
+          let(:receiving) { true }
+          let(:will_receive) { true }
+
+          before do
+            stub_mpi
+          end
+
+          it 'responds with a bad request' do
+            with_okta_user(scopes) do |auth_header|
+              VCR.use_cassette('evss/claims/claims') do
+                VCR.use_cassette('evss/reference_data/get_intake_sites') do
+                  json_data = JSON.parse data
+                  params = json_data
+                  params['data']['attributes']['servicePay'] = service_pay_attribute
+                  post path, params: params.to_json, headers: headers.merge(auth_header)
+                  expect(response.status).to eq(400)
+                end
+              end
+            end
+          end
+        end
+
+        context "when both are 'false'" do
+          let(:receiving) { false }
+          let(:will_receive) { false }
+
+          before do
+            stub_mpi
+          end
+
+          it 'responds with a bad request' do
+            with_okta_user(scopes) do |auth_header|
+              VCR.use_cassette('evss/claims/claims') do
+                VCR.use_cassette('evss/reference_data/get_intake_sites') do
+                  json_data = JSON.parse data
+                  params = json_data
+                  params['data']['attributes']['servicePay'] = service_pay_attribute
+                  post path, params: params.to_json, headers: headers.merge(auth_header)
+                  expect(response.status).to eq(400)
+                end
+              end
+            end
+          end
+        end
+      end
+
+      context "when 'receiving' and 'willReceiveInFuture' are not equal" do
+        context "when 'receiving' is 'false' and 'willReceiveInFuture' is 'true'" do
+          let(:receiving) { false }
+          let(:will_receive) { true }
+
+          before do
+            stub_mpi
+          end
+
+          it 'responds with a 200' do
+            with_okta_user(scopes) do |auth_header|
+              VCR.use_cassette('evss/claims/claims') do
+                VCR.use_cassette('evss/reference_data/get_intake_sites') do
+                  json_data = JSON.parse data
+                  params = json_data
+                  params['data']['attributes']['servicePay'] = service_pay_attribute
+                  post path, params: params.to_json, headers: headers.merge(auth_header)
+                  expect(response.status).to eq(200)
+                end
+              end
+            end
+          end
+        end
+
+        context "when 'receiving' is 'true' and 'willReceiveInFuture' is 'false'" do
+          let(:receiving) { true }
+          let(:will_receive) { false }
+
+          before do
+            stub_mpi
+          end
+
+          it 'responds with a 200' do
+            with_okta_user(scopes) do |auth_header|
+              VCR.use_cassette('evss/claims/claims') do
+                VCR.use_cassette('evss/reference_data/get_intake_sites') do
+                  json_data = JSON.parse data
+                  params = json_data
+                  params['data']['attributes']['servicePay'] = service_pay_attribute
+                  post path, params: params.to_json, headers: headers.merge(auth_header)
+                  expect(response.status).to eq(200)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe '#upload_documents' do


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Adds logic to validate that the `servicePay` attribute provided in a Form526 submission meet EVSS expectations.

**EVSS expectations**
```
'receiving' and 'willReceiveInfuture' cannot have the same value if they are not null
For "Currently receiving military retired pay" and "Will receive military retired pay in the future" fields, the only valid combinations are "True/False" or "False/True"
```

## Original issue(s)
[API-9012](https://vajira.max.gov/browse/API-9012)