### PR TITLE
raise caseflow timeout

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -425,7 +425,10 @@ caseflow:
   mock: true
   app_token: PUBLICDEMO123
   host: https://dsva-appeals-certification-dev-1895622301.us-gov-west-1.elb.amazonaws.com
-  timeout: 60
+  timeout: 119
+  # The forwardproxy timeout is 2m so I want something slightly less than that so we don't get the forwardproxy's html
+  # response when we're expecting JSON.  Ideally, caseflow would respond quicker but they're still giving good responses
+  # in over a minute.
 
 vic:
   url: https://some.fakesite.com

--- a/spec/lib/caseflow/configuration_spec.rb
+++ b/spec/lib/caseflow/configuration_spec.rb
@@ -19,7 +19,7 @@ describe Caseflow::Configuration do
   describe '.read_timeout' do
     context 'when Settings.caseflow.timeout is set' do
       it 'uses the setting' do
-        expect(Caseflow::Configuration.instance.read_timeout).to eq(60)
+        expect(Caseflow::Configuration.instance.read_timeout).to eq(119)
       end
     end
   end

--- a/spec/lib/decision_review/configuration_spec.rb
+++ b/spec/lib/decision_review/configuration_spec.rb
@@ -7,7 +7,7 @@ describe DecisionReview::Configuration do
   describe '.read_timeout' do
     context 'when Settings.caseflow.timeout is set' do
       it 'uses the setting' do
-        expect(DecisionReview::Configuration.instance.read_timeout).to eq(60)
+        expect(DecisionReview::Configuration.instance.read_timeout).to eq(119)
       end
     end
   end


### PR DESCRIPTION
## Description of change
Ideally, caseflow would respond fast, but I think we should give vets the option to wait for the response.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28676

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
