### PR TITLE
Revert "Bump pundit from 2.1.0 to 2.1.1 (#7641)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -658,7 +658,7 @@ GEM
       nio4r (~> 2.0)
     puma-plugin-statsd (2.0.0)
       puma (>= 5.0, < 6)
-    pundit (2.1.1)
+    pundit (2.1.0)
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.5.2)


### PR DESCRIPTION
This reverts commit b55d38d48f990fc21412ecb2ed0d94cf3e5b3390.

The gem update may have introduced a breaking change related to the way that we use headless policies. The changelog says that there was a breaking change introduced related to the policy return value and it looks like it may apply to us. It also seems like there’s quite a few Sentry errors related to pundit/access over the weekend. We use the headless policies https://github.com/varvet/pundit#headless-policies https://github.com/department-of-veterans-affairs/vets-api/tree/master/app/policies.

Reverting until this change is understood 

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
