### PR TITLE
Revert "rate-limit PPMS lookup to curb abuse (#7664)"

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -9,13 +9,6 @@ class Rack::Attack
     req.ip if req.path == '/v0/limited'
   end
 
-  # Rate-limit PPMS lookup, in order to bore abusers.
-  # See https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Postmortems/2021-08-16-facility-locator-possible-DOS.md
-  # for details.
-  throttle('facility_locator/ip', limit: 3, period: 1.minute) do |req|
-    req.ip if req.path == '/facilities_api/v1/ccp/provider'
-  end
-
   throttle('vic_profile_photos_download/ip', limit: 8, period: 5.minutes) do |req|
     req.ip if req.path == '/v0/vic/profile_photo_attachments' && req.get?
   end

--- a/spec/middleware/rack/attack_spec.rb
+++ b/spec/middleware/rack/attack_spec.rb
@@ -94,26 +94,6 @@ RSpec.describe Rack::Attack do
     end
   end
 
-  describe 'facility_locator/ip' do
-    before do
-      limit.times do
-        post endpoint, headers: headers
-        expect(last_response.status).not_to eq(429)
-      end
-
-      post endpoint, headers: headers
-    end
-
-    context 'limit PPMS abuse' do
-      let(:limit) { 3 }
-      let(:endpoint) { '/facilities_api/v1/ccp/provider' }
-
-      it 'limits requests' do
-        expect(last_response.status).to eq(429)
-      end
-    end
-  end
-
   describe 'vic rate-limits', run_at: 'Thu, 26 Dec 2015 15:54:20 GMT' do
     before do
       limit.times do


### PR DESCRIPTION
This reverts commit d1de315fb63ad7f57b32af929552df268b1ce230.

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

This is causing 429's for the facility locator. Reverting and further debugging needed

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
