### PR TITLE
28780 sanitize data before sending it to ppms

### DIFF
--- a/modules/facilities_api/app/services/facilities_api/v1/ppms/client.rb
+++ b/modules/facilities_api/app/services/facilities_api/v1/ppms/client.rb
@@ -13,8 +13,11 @@ module FacilitiesApi
       # Dev swagger site for testing endpoints
       # https://dev.dws.ppms.va.gov/swagger
       class Client < Common::Client::Base
-        MIN_RESULTS = 1
-        MAX_RESULTS = 50
+        DEGREES_OF_ACCURACY = 6
+        RADIUS_MAX = 500
+        RADIUS_MIN = 1
+        RESULTS_MAX = 50
+        RESULTS_MIN = 2
 
         configuration FacilitiesApi::V1::PPMS::Configuration
 
@@ -106,12 +109,15 @@ module FacilitiesApi
           page = Integer(params[:page] || 1)
           per_page = Integer(params[:per_page] || BaseFacility.per_page)
 
-          cnr = params.slice(:latitude, :longitude, :radius)
+          latitude = params.fetch(:latitude).round(DEGREES_OF_ACCURACY)
+          longitude = params.fetch(:longitude).round(DEGREES_OF_ACCURACY)
+          radius = params.fetch(:radius).clamp(RADIUS_MIN, RADIUS_MAX)
+          max_results = (per_page * page + 1).clamp(RESULTS_MIN, RESULTS_MAX)
 
           {
-            address: [cnr[:latitude], cnr[:longitude]].join(','),
-            radius: cnr[:radius],
-            maxResults: (per_page * page + 1).clamp(MIN_RESULTS, MAX_RESULTS)
+            address: [latitude, longitude].join(','),
+            radius: radius,
+            maxResults: max_results
           }
         end
 

--- a/modules/facilities_api/spec/services/facilities_api/v1/ppms/client_spec.rb
+++ b/modules/facilities_api/spec/services/facilities_api/v1/ppms/client_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
       describe 'base params' do
         let(:client) { FacilitiesApi::V1::PPMS::Client.new }
         let(:fake_response) { double('fake_response') }
+
         before do
           allow(fake_response).to receive(:body)
         end
@@ -237,10 +238,10 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
             ).and_return(fake_response)
 
             client.provider_locator(params.merge(
-              specialties: %w[Code1],
-              latitude: 40.123456789012345,
-              longitude: -74.123456789012345)
-            )
+                                      specialties: %w[Code1],
+                                      latitude: 40.123456789012345,
+                                      longitude: -74.123456789012345
+                                    ))
           end
         end
       end

--- a/modules/facilities_api/spec/services/facilities_api/v1/ppms/client_spec.rb
+++ b/modules/facilities_api/spec/services/facilities_api/v1/ppms/client_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
         Flipper.enable(:facility_locator_ppms_use_secure_api, feature_flag)
       end
 
+      if feature_flag
+        let(:path) { '/dws/v1.0/ProviderLocator' }
+      else
+        let(:path) { 'v1.0/ProviderLocator' }
+      end
+
       context 'StatsD notifications' do
         context 'PPMS responds Successfully' do
           it "sends a 'facilities.ppms.request.faraday' notification to any subscribers listening" do
@@ -127,16 +133,122 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
         end
       end
 
+      describe 'base params' do
+        let(:client) { FacilitiesApi::V1::PPMS::Client.new }
+        let(:fake_response) { double('fake_response') }
+        before do
+          allow(fake_response).to receive(:body)
+        end
+
+        describe 'Clamping Results' do
+          it 'page and per_page is not required' do
+            expect(client).to receive(:perform).with(
+              :get,
+              path,
+              {
+                address: '40.415217,-74.057114',
+                maxResults: 11,
+                radius: 200,
+                specialtycode1: 'Code1'
+              }
+            ).and_return(fake_response)
+
+            client.provider_locator(params.merge(specialties: %w[Code1]))
+          end
+
+          it 'maxResults cannot be greater then 50' do
+            expect(client).to receive(:perform).with(
+              :get,
+              path,
+              {
+                address: '40.415217,-74.057114',
+                maxResults: 50,
+                radius: 200,
+                specialtycode1: 'Code1'
+              }
+            ).exactly(3).and_return(fake_response)
+
+            client.provider_locator(params.merge(specialties: %w[Code1], page: 1, per_page: 60))
+            client.provider_locator(params.merge(specialties: %w[Code1], page: 60, per_page: 1))
+            client.provider_locator(params.merge(specialties: %w[Code1], page: 60, per_page: 60))
+          end
+
+          it 'maxResults cannot be less than 2' do
+            expect(client).to receive(:perform).with(
+              :get,
+              path,
+              {
+                address: '40.415217,-74.057114',
+                maxResults: 2,
+                radius: 200,
+                specialtycode1: 'Code1'
+              }
+            ).exactly(4).and_return(fake_response)
+
+            client.provider_locator(params.merge(specialties: %w[Code1], page: 1, per_page: 1))
+            client.provider_locator(params.merge(specialties: %w[Code1], page: 1, per_page: 0))
+            client.provider_locator(params.merge(specialties: %w[Code1], page: 0, per_page: 0))
+            client.provider_locator(params.merge(specialties: %w[Code1], page: -10, per_page: 1))
+          end
+        end
+
+        describe 'Clamping Radius' do
+          it 'limits radius to 500' do
+            expect(client).to receive(:perform).with(
+              :get,
+              path,
+              {
+                address: '40.415217,-74.057114',
+                maxResults: 11,
+                radius: 500,
+                specialtycode1: 'Code1'
+              }
+            ).and_return(fake_response)
+
+            client.provider_locator(params.merge(specialties: %w[Code1], radius: 600))
+          end
+          it 'limits radius to 1' do
+            expect(client).to receive(:perform).with(
+              :get,
+              path,
+              {
+                address: '40.415217,-74.057114',
+                maxResults: 11,
+                radius: 1,
+                specialtycode1: 'Code1'
+              }
+            ).and_return(fake_response)
+
+            client.provider_locator(params.merge(specialties: %w[Code1], radius: 1))
+          end
+        end
+
+        describe 'Sanitizing Longitude and Latitude' do
+          it 'only sends 5 digits of accuracy to ppms' do
+            expect(client).to receive(:perform).with(
+              :get,
+              path,
+              {
+                address: '40.123457,-74.123457',
+                maxResults: 11,
+                radius: 200,
+                specialtycode1: 'Code1'
+              }
+            ).and_return(fake_response)
+
+            client.provider_locator(params.merge(
+              specialties: %w[Code1],
+              latitude: 40.123456789012345,
+              longitude: -74.123456789012345)
+            )
+          end
+        end
+      end
+
       describe '#provider_locator' do
         describe 'Require between 1 and 5 Specialties' do
           let(:client) { FacilitiesApi::V1::PPMS::Client.new }
           let(:fake_response) { double('fake_response') }
-
-          if feature_flag
-            let(:path) { '/dws/v1.0/ProviderLocator' }
-          else
-            let(:path) { 'v1.0/ProviderLocator' }
-          end
 
           it 'accepts upto 5 specialties' do
             allow(fake_response).to receive(:body)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
PPMS is throwing a stack trace if we send 13 digits of accuracy on lat/long, its something we get from mapbox.
this also limits the radius to 500 miles
this is only for the facilities engine

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28780

## Things to know about this PR
* rounds lat and long to 6 digits
* clamps radius from 1 to 500
* adds tests to verify these are working
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
