### PR TITLE
add placeholder url for mcp.vbs.url

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -76,7 +76,7 @@ dmc:
 
 mcp:
   vbs:
-    url: ~
+    url: http://fake.com
     host: ~
     service_name: VBS
     mock: true


### PR DESCRIPTION
otherwise I see
`ArgumentError: bad argument (expected URI object or URI string)
(erb):34:in <main>` when I try to start the rails server or console in development.

Caused by https://github.com/department-of-veterans-affairs/vets-api/pull/7695

cc: @dillo 