### PR TITLE
Create account_login_stats table and indexes

### DIFF
--- a/db/migrate/20210826205558_create_account_login_stats.rb
+++ b/db/migrate/20210826205558_create_account_login_stats.rb
@@ -1,0 +1,11 @@
+class CreateAccountLoginStats < ActiveRecord::Migration[6.1]
+  def change
+    create_table :account_login_stats do |t|
+      t.references :account, foreign_key: true, null: false, index: { unique: true }
+      t.datetime :idme_at, index: true
+      t.datetime :myhealthevet_at, index: true
+      t.datetime :dslogon_at, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_23_134730) do
+ActiveRecord::Schema.define(version: 2021_08_26_205558) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -20,6 +20,19 @@ ActiveRecord::Schema.define(version: 2021_07_23_134730) do
   enable_extension "plpgsql"
   enable_extension "postgis"
   enable_extension "uuid-ossp"
+
+  create_table "account_login_stats", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.datetime "idme_at"
+    t.datetime "myhealthevet_at"
+    t.datetime "dslogon_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_account_login_stats_on_account_id", unique: true
+    t.index ["dslogon_at"], name: "index_account_login_stats_on_dslogon_at"
+    t.index ["idme_at"], name: "index_account_login_stats_on_idme_at"
+    t.index ["myhealthevet_at"], name: "index_account_login_stats_on_myhealthevet_at"
+  end
 
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.uuid "uuid", null: false
@@ -891,6 +904,7 @@ ActiveRecord::Schema.define(version: 2021_07_23_134730) do
     t.index ["api_name", "consumer_id", "api_guid"], name: "index_webhooks_subscription", unique: true
   end
 
+  add_foreign_key "account_login_stats", "accounts"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
## Description of change
This pull request introduces a new table, `account_login_stats`. This new table will be used in future features to track how our accounts choose to log in to va.gov (id.me, dslogon, myhealthevet). These stats will eventually be rolled up into a report.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28911

## Things to know about this PR
Merge this before merging https://github.com/department-of-veterans-affairs/vets-api/pull/7764
