### PR TITLE
Revert "28637 updates to clinic data logging Loki/Grafana"

### DIFF
--- a/modules/vaos/app/controllers/vaos/v0/clinics_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v0/clinics_controller.rb
@@ -16,19 +16,11 @@ module VAOS
       private
 
       def log_clinic_names(clinic_data)
-        clinic_names = {}
+        clinic_names = []
         clinic_data.each do |clinic|
-          clinic_names.merge! check_friendly_clinic_name(clinic) => clinic_name_metrics(clinic)
+          clinic_names << check_friendly_clinic_name(clinic)
         end
-        Rails.logger.info('Clinic names returned', clinic_names.to_json)
-      end
-
-      def clinic_name_metrics(clinic)
-        {
-          clinicName: clinic.clinic_name,
-          clinicFriendlyLocationName: clinic.clinic_friendly_location_name,
-          institutionCode: clinic.institution_code
-        }
+        Rails.logger.info('Clinic names returned', clinic_names)
       end
 
       def check_friendly_clinic_name(clinic)

--- a/modules/vaos/app/controllers/vaos/v2/clinics_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/clinics_controller.rb
@@ -16,18 +16,11 @@ module VAOS
       private
 
       def log_clinic_names(clinic_data)
-        clinic_names = {}
+        clinic_names = []
         clinic_data.each do |clinic|
-          clinic_names.merge! clinic.service_name => clinic_name_metrics(clinic)
+          clinic_names << clinic.service_name
         end
-        Rails.logger.info('Clinic names returned', clinic_names.to_json)
-      end
-
-      def clinic_name_metrics(clinic)
-        {
-          stationId: clinic.station_id,
-          serviceName: clinic.service_name
-        }
+        Rails.logger.info('Clinic names returned', clinic_names)
       end
 
       def systems_service

--- a/modules/vaos/spec/request/facilities_request_spec.rb
+++ b/modules/vaos/spec/request/facilities_request_spec.rb
@@ -105,19 +105,8 @@ RSpec.describe 'facilities', type: :request do
             get '/vaos/v0/facilities/983/clinics', params: { type_of_care_id: '323', system_id: '983' }
 
             expect(Rails.logger).to have_received(:info).with('Clinic names returned',
-                                                              '{"Green Team Clinic1":'\
-                                                              '{"clinicName":"CHY PC KILPATRICK",'\
-                                                              '"clinicFriendlyLocationName":"Green Team Clinic1",'\
-                                                              '"institutionCode":"983"},'\
-                                                              '"CHY PC CASSIDY":{"clinicName":"CHY PC CASSIDY",'\
-                                                              '"clinicFriendlyLocationName":"",'\
-                                                              '"institutionCode":"983"},'\
-                                                              '"Green Team Clinic2":{"clinicName":"MCINTYRE PC",'\
-                                                              '"clinicFriendlyLocationName":"Green Team Clinic2",'\
-                                                              '"institutionCode":"983"},'\
-                                                              '"CHY PC VAR2":{"clinicName":"CHY PC VAR2",'\
-                                                              '"clinicFriendlyLocationName":"CHY PC VAR2",'\
-                                                              '"institutionCode":"983"}}').at_least(:once)
+                                                              ['Green Team Clinic1', 'CHY PC CASSIDY',
+                                                               'Green Team Clinic2', 'CHY PC VAR2']).at_least(:once)
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('vaos/facility_clinics')
           end

--- a/modules/vaos/spec/request/v2/clinics_request_spec.rb
+++ b/modules/vaos/spec/request/v2/clinics_request_spec.rb
@@ -23,21 +23,10 @@ RSpec.describe 'clinics', type: :request do
             allow(Rails.logger).to receive(:info).at_least(:once)
             get '/vaos/v2/locations/983/clinics?clinical_service=audiology', headers: inflection_header
             expect(Rails.logger).to have_received(:info).with('Clinic names returned',
-                                                              '{"CHY C&P AUDIO":{"stationId":"983",'\
-                                                              '"serviceName":"CHY C&P AUDIO"},'\
-                                                              '"FTC C&P AUDIO BEV":{"stationId":"983GC",'\
-                                                              '"serviceName":"FTC C&P AUDIO BEV"},'\
-                                                              '"CHY C&P AUDIO JAN":{"stationId":"983",'\
-                                                              '"serviceName":"CHY C&P AUDIO JAN"},'\
-                                                              '"CHY AUDIOLOGY":{"stationId":"983",'\
-                                                              '"serviceName":"CHY AUDIOLOGY"},'\
-                                                              '"WHT AUDIO VAR2":{"stationId":"983",'\
-                                                              '"serviceName":"WHT AUDIO VAR2"},'\
-                                                              '"TOR C&P LORI":{"stationId":"983",'\
-                                                              '"serviceName":"TOR C&P LORI"},'\
-                                                              '"WHT HEARING AID LORI":{"stationId":"983",'\
-                                                              '"serviceName":"WHT HEARING AID LORI"}}')
-                                                        .at_least(:once)
+                                                              ['CHY C&P AUDIO', 'FTC C&P AUDIO BEV',
+                                                               'CHY C&P AUDIO JAN', 'CHY AUDIOLOGY',
+                                                               'WHT AUDIO VAR2', 'TOR C&P LORI',
+                                                               'WHT HEARING AID LORI']).at_least(:once)
             expect(response).to have_http_status(:ok)
             expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
             x = JSON.parse(response.body)


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#7815

Reverting temporarily to investigate this deployment failure and not interrupt other builds and deployments.