### PR TITLE
Gha temp git cleanup

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -122,12 +122,13 @@ jobs:
           path: log/*.xml
           if-no-files-found: ignore
 
-      - name: Docker Cleanup
+      - name: Cleanup
         if: always()
         run: |
           docker network prune -f
           docker rmi -f vets-api:${{ env.DOCKER_IMAGE }} 2> /dev/null || true
           docker rm -f ${{ env.DOCKER_IMAGE }}_postgres_1 2> /dev/null || true
+          rm -rf .git
 
   publish_results:
     name: Publish Results

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -122,6 +122,8 @@ jobs:
           path: log/*.xml
           if-no-files-found: ignore
 
+      # rm -rf .git is a temporary fix for actions/checkout@v2 action
+      # see: https://github.com/actions/checkout/issues/582
       - name: Cleanup
         if: always()
         run: |


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
There is a potential issue with the `actions/checkout@v2` action where it is looking for submodules that exist. This PR adds a temp fix to clean up `.git` after the run. 

