### PR TITLE
fix linting error after ruby upgrade

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
@@ -103,8 +103,8 @@ class AppealsApi::V2::DecisionReviews::SupplementalClaimsController < AppealsApi
             e.source[:pointer] == '/data/attributes/noticeAcknowledgement'
           end)
         va_exception.errors[notice_index].detail = 'Please ensure the Veteran reviews the 38 U.S.CC 5103 information ' \
-        'regarding evidence necessary to substantiate the claim found here: ' \
-        'https://www.va.gov/disability/how-to-file-claim/evidence-needed'
+                                                   'regarding evidence necessary to substantiate the claim found here: ' \
+                                                   'https://www.va.gov/disability/how-to-file-claim/evidence-needed'
       end
       render json: { errors: va_exception.errors }, status: va_exception.status_code
     end


### PR DESCRIPTION
it seems that ruby 2.7 has different opinions on style so master has a linting error