### PR TITLE
Add lighthouse health api immunization setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1166,3 +1166,7 @@ lighthouse_health_immunization:
   key_path: ~
   access_token_url: 'https://sandbox-api.va.gov/oauth2/health/system/v1/token'
   api_url: 'https://sandbox-api.va.gov/services/fhir/v0/r4'
+  scopes:
+    - "launch launch/patient"
+    - "patient/Immunization.read"
+    - "patient/Location.read"


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
The VA Health and Benefits mobile app will soon be adding the ability to view immunization records. PR adds an entry to the vets-api settings YAML file with the private key, token url, base api url, and scopes fields for the LH Health API which is the source of that data.

## Original issue(s)
department-of-veterans-affairs/va-mobile-app#1765
