### PR TITLE
WIP Add/Update Primary key for veteran_representatives table

### DIFF
--- a/db/migrate/20211118154042_add_primary_id_to_veteran_representatives_table.rb
+++ b/db/migrate/20211118154042_add_primary_id_to_veteran_representatives_table.rb
@@ -1,0 +1,5 @@
+class AddPrimaryIdToVeteranRepresentativesTable < ActiveRecord::Migration[6.1]
+  def change
+    add_column :veteran_representatives, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_172528) do
+ActiveRecord::Schema.define(version: 2021_11_18_154042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -869,7 +869,7 @@ ActiveRecord::Schema.define(version: 2021_11_03_172528) do
     t.index ["poa"], name: "index_veteran_organizations_on_poa", unique: true
   end
 
-  create_table "veteran_representatives", id: false, force: :cascade do |t|
+  create_table "veteran_representatives", force: :cascade do |t|
     t.string "representative_id"
     t.string "first_name"
     t.string "last_name"

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -34,12 +34,13 @@ RSpec.describe 'Power of Attorney ', type: :request do
 
     context 'when poa code is valid' do
       before do
-        Veteran::Service::Representative.new(representative_id: "12345", poa_codes: ['074']).save!
+        Veteran::Service::Representative.new(representative_id: '12345', poa_codes: ['074']).save!
       end
 
       context 'when poa code is associated with current user' do
         before do
-          Veteran::Service::Representative.new(representative_id: "67890", poa_codes: ['074'], first_name: 'Abraham', last_name: 'Lincoln').save!
+          Veteran::Service::Representative.new(representative_id: '67890', poa_codes: ['074'], first_name: 'Abraham',
+                                               last_name: 'Lincoln').save!
         end
 
         context 'when Veteran has all necessary identifiers' do

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe 'Power of Attorney ', type: :request do
 
     context 'when poa code is valid' do
       before do
-        Veteran::Service::Representative.new(poa_codes: ['074']).save!
+        Veteran::Service::Representative.new(representative_id: "12345", poa_codes: ['074']).save!
       end
 
       context 'when poa code is associated with current user' do
         before do
-          Veteran::Service::Representative.new(poa_codes: ['074'], first_name: 'Abraham', last_name: 'Lincoln').save!
+          Veteran::Service::Representative.new(representative_id: "67890", poa_codes: ['074'], first_name: 'Abraham', last_name: 'Lincoln').save!
         end
 
         context 'when Veteran has all necessary identifiers' do

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe 'Power Of Attorney', type: :request do
   describe 'PowerOfAttorney' do
     describe 'AppointIndividual' do
       before do
-        Veteran::Service::Representative.new(poa_codes: [individual_poa_code], first_name: 'Abraham',
+        Veteran::Service::Representative.new(representative_id: "12345", poa_codes: [individual_poa_code], first_name: 'Abraham',
                                              last_name: 'Lincoln').save!
-        Veteran::Service::Representative.new(poa_codes: [organization_poa_code], first_name: 'George',
+        Veteran::Service::Representative.new(representative_id: "67890", poa_codes: [organization_poa_code], first_name: 'George',
                                              last_name: 'Washington', user_types: ['veteran_service_officer']).save!
         Veteran::Service::Organization.create(poa: organization_poa_code,
                                               name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS")

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
@@ -20,10 +20,11 @@ RSpec.describe 'Power Of Attorney', type: :request do
   describe 'PowerOfAttorney' do
     describe 'AppointIndividual' do
       before do
-        Veteran::Service::Representative.new(representative_id: "12345", poa_codes: [individual_poa_code], first_name: 'Abraham',
-                                             last_name: 'Lincoln').save!
-        Veteran::Service::Representative.new(representative_id: "67890", poa_codes: [organization_poa_code], first_name: 'George',
-                                             last_name: 'Washington', user_types: ['veteran_service_officer']).save!
+        Veteran::Service::Representative.new(representative_id: '12345', poa_codes: [individual_poa_code],
+                                             first_name: 'Abraham', last_name: 'Lincoln').save!
+        Veteran::Service::Representative.new(representative_id: '67890', poa_codes: [organization_poa_code],
+                                             first_name: 'George', last_name: 'Washington',
+                                             user_types: ['veteran_service_officer']).save!
         Veteran::Service::Organization.create(poa: organization_poa_code,
                                               name: "#{organization_poa_code} - DISABLED AMERICAN VETERANS")
       end

--- a/modules/veteran/app/models/veteran/service/representative.rb
+++ b/modules/veteran/app/models/veteran/service/representative.rb
@@ -8,7 +8,6 @@ module Veteran
     class Representative < ApplicationRecord
       BASE_URL = 'https://www.va.gov/ogc/apps/accreditation/'
 
-      self.primary_key = :representative_id
       has_kms_key
       encrypts :dob, :ssn, key: :kms_key
 
@@ -17,6 +16,7 @@ module Veteran
       scope :claim_agents, -> { where(user_types: ['claim_agents']) }
 
       validates :poa_codes, presence: true
+      validates_uniqueness_of :representative_id
 
       #
       # Find all representatives that matches the provided search criteria

--- a/modules/veteran/app/models/veteran/service/representative.rb
+++ b/modules/veteran/app/models/veteran/service/representative.rb
@@ -16,7 +16,7 @@ module Veteran
       scope :claim_agents, -> { where(user_types: ['claim_agents']) }
 
       validates :poa_codes, presence: true
-      validates_uniqueness_of :representative_id
+      validates_uniqueness_of :representative_id, allow_nil: false
 
       #
       # Find all representatives that matches the provided search criteria

--- a/modules/veteran/app/models/veteran/service/representative.rb
+++ b/modules/veteran/app/models/veteran/service/representative.rb
@@ -16,7 +16,7 @@ module Veteran
       scope :claim_agents, -> { where(user_types: ['claim_agents']) }
 
       validates :poa_codes, presence: true
-      validates_uniqueness_of :representative_id, allow_nil: false
+      validates :representative_id, uniqueness: { allow_nil: false }
 
       #
       # Find all representatives that matches the provided search criteria

--- a/modules/veteran/spec/workers/veteran/vso_reloader_spec.rb
+++ b/modules/veteran/spec/workers/veteran/vso_reloader_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Veteran::VSOReloader, type: :job do
     it 'loads a claim agent with the poa code' do
       VCR.use_cassette('veteran/ogc_claim_agent_data') do
         Veteran::VSOReloader.new.reload_claim_agents
-        expect(Veteran::Service::Representative.last.poa_codes).to include('FDN')
+        expect(Veteran::Service::Representative.last.poa_codes).to include('ELC')
       end
     end
 


### PR DESCRIPTION
DO NOT MERGE: Breaking out DB changes to a separate PR [found here](https://github.com/department-of-veterans-affairs/vets-api/pull/8485)

This change adds a primary key to the veteran_represenatives table. It appears that the current implementation allowed for a null primary key. It was noticed that the primary key (representative_id) was blank in a handful of records across all env databases. This caused issues during the key rotation wrt KMS because the primary key is used to find a record and update its respective encrypted_kms_key field. Errors were thrown on records that had a nil representative_id. 

This change still requires the representative_id to be unique but uses ‘id’ for it’s new primary key, which will never be null. Throughout the code, records are created using find_or_initalize_by (not plain find/create), so this change doesn’t break the current implementation. 

The spec had to be updated because the `Veteran::Service::Representative` model is now ordered by id rather than representative_id. Before `Veteran::Service::Representative.last` returned Kevin Allen (as seen in the VCR cassette because his representative_id was the highest. 40393 vs 42535). Since James Alston is created last ([see cassette](https://github.com/department-of-veterans-affairs/vets-api/blob/master/spec/support/vcr_cassettes/veteran/ogc_claim_agent_data.yml#L43-L56)), the test now reflects the correct ordering by id.