### PR TITLE
break out migration and schema to separate PR

### DIFF
--- a/db/migrate/20211118154042_add_primary_id_to_veteran_representatives_table.rb
+++ b/db/migrate/20211118154042_add_primary_id_to_veteran_representatives_table.rb
@@ -1,0 +1,5 @@
+class AddPrimaryIdToVeteranRepresentativesTable < ActiveRecord::Migration[6.1]
+  def change
+    add_column :veteran_representatives, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_172528) do
+ActiveRecord::Schema.define(version: 2021_11_18_154042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -869,7 +869,7 @@ ActiveRecord::Schema.define(version: 2021_11_03_172528) do
     t.index ["poa"], name: "index_veteran_organizations_on_poa", unique: true
   end
 
-  create_table "veteran_representatives", id: false, force: :cascade do |t|
+  create_table "veteran_representatives", force: :cascade do |t|
     t.string "representative_id"
     t.string "first_name"
     t.string "last_name"


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This change adds a primary key to the veteran_represenatives table. It appears that the current implementation allowed for a null primary key. It was noticed that the primary key (representative_id) was blank in a handful of records across all env databases. This caused issues during the key rotation wrt KMS because the primary key is used to find a record and update its respective encrypted_kms_key field. Errors were thrown on records that had a nil representative_id.


The subsequent PR can be found [here](https://github.com/department-of-veterans-affairs/vets-api/pull/8481) but the db changes were broken apart from the first PR to ensure app code be backwards compatible with the db.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000
