### PR TITLE
Temporary fix for negative argument error

### DIFF
--- a/app/services/medical_copays/vista_account_numbers.rb
+++ b/app/services/medical_copays/vista_account_numbers.rb
@@ -49,7 +49,7 @@ module MedicalCopays
     #
     def vista_account_id(key, id)
       offset = 16 - (key + id).length
-      padding = '0' * offset
+      padding = '0' * offset if offset >= 0
 
       "#{key}#{padding}#{id}".to_i
     end


### PR DESCRIPTION
## Description of change
- Assert padding for vista account id is at least 0

## Original issue(s)
[Sentry Error](http://sentry.vfs.va.gov/organizations/vsp/issues/56248/?environment=production&project=3&query=medical_copays&statsPeriod=14d)

## Things to know about this PR
- Temp fix until we can recognize the structure of prod data

