### PR TITLE
Bump bundler from 2.1.4 to 2.2.29

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Setup Docker
         run: |
-          docker volume create --name=test_bundle_v2_7
+          docker volume create --name=test_bundle_2_2_29
           cp /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem config/ca-trust/
 
       - name: Build Docker Image

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,8 +112,17 @@ PATH
     veteran_verification (0.0.1)
 
 GEM
-  remote: https://rubygems.org/
   remote: https://enterprise.contribsys.com/
+  specs:
+    sidekiq-ent (2.2.3)
+      einhorn (>= 0.7.4)
+      sidekiq (>= 6.2.0)
+      sidekiq-pro (>= 5.2.0)
+    sidekiq-pro (5.2.4)
+      sidekiq (>= 6.2.0)
+
+GEM
+  remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
     aasm (5.2.0)
@@ -857,12 +866,6 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sidekiq-ent (2.2.3)
-      einhorn (>= 0.7.4)
-      sidekiq (>= 6.2.0)
-      sidekiq-pro (>= 5.2.0)
-    sidekiq-pro (5.2.4)
-      sidekiq (>= 6.2.0)
     sidekiq-scheduler (3.1.0)
       e2mmap
       redis (>= 3, < 5)
@@ -1164,4 +1167,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.1.4
+   2.2.29

--- a/docker-compose.gha.yml
+++ b/docker-compose.gha.yml
@@ -6,4 +6,4 @@ services:
 volumes:
   test_bundle:
     external: true
-    name: test_bundle_v2_7
+    name: test_bundle_2_2_29


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
Bump bundler from 2.1.4 to 2.2.29. This will fix the Dependabot issues as well 
