### PR TITLE
Fixing Rubocop RSpec/StubbedMock offenses Part 1

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -180,8 +180,8 @@ RSpec/MultipleMemoizedHelpers:
   Max: 37
 
 # Offense count: 585
-RSpec/StubbedMock:
-  Enabled: false
+# RSpec/StubbedMock:
+#   Enabled: false
 
 # Offense count: 4
 # Configuration parameters: ForbiddenMethods, AllowedMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -180,8 +180,8 @@ RSpec/MultipleMemoizedHelpers:
   Max: 37
 
 # Offense count: 585
-# RSpec/StubbedMock:
-#   Enabled: false
+RSpec/StubbedMock:
+  Enabled: false
 
 # Offense count: 4
 # Configuration parameters: ForbiddenMethods, AllowedMethods.

--- a/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_pdf_submit_job_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
     allow(faraday_response).to receive(:body).and_return('')
     allow(faraday_response).to receive(:success?).and_return(true)
     capture_body = nil
-    expect(client_stub).to receive(:upload) { |arg|
+    allow(client_stub).to receive(:upload) { |arg|
       capture_body = arg
       faraday_response
     }
@@ -45,7 +45,7 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
     allow(faraday_response).to receive(:body).and_return('')
     allow(faraday_response).to receive(:success?).and_return(false)
     capture_body = nil
-    expect(client_stub).to receive(:upload) { |arg|
+    allow(client_stub).to receive(:upload) { |arg|
       capture_body = arg
       faraday_response
     }
@@ -70,7 +70,7 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
     end
 
     it 'puts the HLR into an error state' do
-      expect(client_stub).to receive(:upload) { |_arg| faraday_response }
+      allow(client_stub).to receive(:upload) { |_arg| faraday_response }
       messager_instance = instance_double(AppealsApi::Slack::Messager)
       allow(AppealsApi::Slack::Messager).to receive(:new).and_return(messager_instance)
       allow(messager_instance).to receive(:notify!).and_return(true)
@@ -80,7 +80,7 @@ RSpec.describe AppealsApi::HigherLevelReviewPdfSubmitJob, type: :job do
     end
 
     it 'sends a retry notification' do
-      expect(client_stub).to receive(:upload) { |_arg| faraday_response }
+      allow(client_stub).to receive(:upload) { |_arg| faraday_response }
       messager_instance = instance_double(AppealsApi::Slack::Messager)
       allow(AppealsApi::Slack::Messager).to receive(:new).and_return(messager_instance)
       allow(messager_instance).to receive(:notify!).and_return(true)

--- a/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
+++ b/modules/appeals_api/spec/workers/higher_level_review_upload_status_updater_spec.rb
@@ -18,9 +18,9 @@ describe AppealsApi::HigherLevelReviewUploadStatusUpdater, type: :job do
 
   describe '#perform' do
     it 'updates the status of a HigherLevelReview' do
-      expect(CentralMail::Service).to receive(:new) { client_stub }
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(CentralMail::Service).to receive(:new) { client_stub }
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       in_process_element[0]['uuid'] = upload.id
       expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
 

--- a/modules/appeals_api/spec/workers/notice_of_disagreement_upload_status_updater_spec.rb
+++ b/modules/appeals_api/spec/workers/notice_of_disagreement_upload_status_updater_spec.rb
@@ -18,9 +18,9 @@ describe AppealsApi::NoticeOfDisagreementUploadStatusUpdater, type: :job do
 
   describe '#perform' do
     it 'updates the status of a NoticeOfDisagreement' do
-      expect(CentralMail::Service).to receive(:new) { client_stub }
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(CentralMail::Service).to receive(:new) { client_stub }
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       in_process_element[0]['uuid'] = upload.id
       expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
 

--- a/modules/appeals_api/spec/workers/pdf_submit_job_spec.rb
+++ b/modules/appeals_api/spec/workers/pdf_submit_job_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe AppealsApi::PdfSubmitJob, type: :job do
         allow(faraday_response).to receive(:body).and_return('')
         allow(faraday_response).to receive(:success?).and_return(true)
         capture_body = nil
-        expect(client_stub).to receive(:upload) { |arg|
+        allow(client_stub).to receive(:upload) { |arg|
           capture_body = arg
           faraday_response
         }
@@ -79,7 +79,7 @@ RSpec.describe AppealsApi::PdfSubmitJob, type: :job do
         allow(faraday_response).to receive(:body).and_return('')
         allow(faraday_response).to receive(:success?).and_return(true)
         capture_body = nil
-        expect(client_stub).to receive(:upload) { |arg|
+        allow(client_stub).to receive(:upload) { |arg|
           capture_body = arg
           faraday_response
         }
@@ -124,7 +124,7 @@ RSpec.describe AppealsApi::PdfSubmitJob, type: :job do
         allow(faraday_response).to receive(:body).and_return('')
         allow(faraday_response).to receive(:success?).and_return(true)
         capture_body = nil
-        expect(client_stub).to receive(:upload) { |arg|
+        allow(client_stub).to receive(:upload) { |arg|
           capture_body = arg
           faraday_response
         }
@@ -163,7 +163,7 @@ RSpec.describe AppealsApi::PdfSubmitJob, type: :job do
     allow(faraday_response).to receive(:body).and_return('')
     allow(faraday_response).to receive(:success?).and_return(false)
     capture_body = nil
-    expect(client_stub).to receive(:upload) { |arg|
+    allow(client_stub).to receive(:upload) { |arg|
       capture_body = arg
       faraday_response
     }
@@ -190,7 +190,7 @@ RSpec.describe AppealsApi::PdfSubmitJob, type: :job do
     end
 
     it 'puts the NOD into an error state' do
-      expect(client_stub).to receive(:upload) { |_arg| faraday_response }
+      allow(client_stub).to receive(:upload) { |_arg| faraday_response }
       messager_instance = instance_double(AppealsApi::Slack::Messager)
       allow(AppealsApi::Slack::Messager).to receive(:new).and_return(messager_instance)
       allow(messager_instance).to receive(:notify!).and_return(true)
@@ -200,7 +200,7 @@ RSpec.describe AppealsApi::PdfSubmitJob, type: :job do
     end
 
     it 'sends a retry notification' do
-      expect(client_stub).to receive(:upload) { |_arg| faraday_response }
+      allow(client_stub).to receive(:upload) { |_arg| faraday_response }
       messager_instance = instance_double(AppealsApi::Slack::Messager)
       allow(AppealsApi::Slack::Messager).to receive(:new).and_return(messager_instance)
       allow(messager_instance).to receive(:notify!).and_return(true)

--- a/modules/appeals_api/spec/workers/supplemental_claim_upload_status_updater_spec.rb
+++ b/modules/appeals_api/spec/workers/supplemental_claim_upload_status_updater_spec.rb
@@ -18,9 +18,9 @@ describe AppealsApi::SupplementalClaimUploadStatusUpdater, type: :job do
 
   describe '#perform' do
     it 'updates the status of a SupplementalClaim' do
-      expect(CentralMail::Service).to receive(:new) { client_stub }
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(CentralMail::Service).to receive(:new) { client_stub }
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       in_process_element[0]['uuid'] = upload.id
       expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
 

--- a/modules/apps_api/spec/workers/fetch_connections_spec.rb
+++ b/modules/apps_api/spec/workers/fetch_connections_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AppsApi::FetchConnections, type: :worker do
     end
 
     it 'calls handle_event twice' do
-      expect_any_instance_of(AppsApi::NotificationService).to receive(:handle_event)
+      allow_any_instance_of(AppsApi::NotificationService).to receive(:handle_event)
         .with('app.oauth2.as.consent.grant', 'fake_template_id').and_return(1)
       fetch_connections.perform
     end

--- a/modules/check_in/spec/services/v2/chip/client_spec.rb
+++ b/modules/check_in/spec/services/v2/chip/client_spec.rb
@@ -42,7 +42,7 @@ describe V2::Chip::Client do
     end
 
     it 'yields to block' do
-      expect_any_instance_of(Faraday::Connection).to receive(:post).with('/dev/token').and_yield(Faraday::Request.new)
+      allow_any_instance_of(Faraday::Connection).to receive(:post).with('/dev/token').and_yield(Faraday::Request.new)
 
       subject.token
     end
@@ -62,7 +62,7 @@ describe V2::Chip::Client do
     end
 
     it 'yields to block' do
-      expect_any_instance_of(Faraday::Connection).to receive(:post)
+      allow_any_instance_of(Faraday::Connection).to receive(:post)
         .with("/dev/actions/check-in/#{uuid}").and_yield(Faraday::Request.new)
 
       subject.check_in_appointment(token: token, appointment_ien: appointment_ien)
@@ -83,7 +83,7 @@ describe V2::Chip::Client do
     end
 
     it 'yields to block' do
-      expect_any_instance_of(Faraday::Connection).to receive(:post)
+      allow_any_instance_of(Faraday::Connection).to receive(:post)
         .with("/dev/actions/refresh-appointments/#{uuid}").and_yield(Faraday::Request.new)
 
       subject.refresh_appointments(token: token, identifier_params: identifier_params)
@@ -115,7 +115,7 @@ describe V2::Chip::Client do
     end
 
     it 'yields to block' do
-      expect_any_instance_of(Faraday::Connection).to receive(:post)
+      allow_any_instance_of(Faraday::Connection).to receive(:post)
         .with("/dev/actions/pre-checkin/#{uuid}").and_yield(Faraday::Request.new)
 
       subject.pre_check_in(token: token, demographic_confirmations: demographic_confirmations)

--- a/modules/check_in/spec/services/v2/lorota/client_spec.rb
+++ b/modules/check_in/spec/services/v2/lorota/client_spec.rb
@@ -42,7 +42,7 @@ describe V2::Lorota::Client do
     end
 
     it 'yields to block' do
-      expect_any_instance_of(Faraday::Connection).to receive(:post).with(anything).and_yield(Faraday::Request.new)
+      allow_any_instance_of(Faraday::Connection).to receive(:post).with(anything).and_yield(Faraday::Request.new)
 
       subject.token
     end
@@ -63,7 +63,7 @@ describe V2::Lorota::Client do
     end
 
     it 'yields to block' do
-      expect_any_instance_of(Faraday::Connection).to receive(:get).with(anything).and_yield(Faraday::Request.new)
+      allow_any_instance_of(Faraday::Connection).to receive(:get).with(anything).and_yield(Faraday::Request.new)
 
       subject.data(token: token)
     end

--- a/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v0/disability_compensation_request_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe 'Disability Claims ', type: :request do
     end
 
     it 'responds with a 422 when unknown error' do
-      expect(ClaimsApi::ClaimUploader).to receive(:perform_async).and_raise(Common::Exceptions::UnprocessableEntity)
+      allow(ClaimsApi::ClaimUploader).to receive(:perform_async).and_raise(Common::Exceptions::UnprocessableEntity)
       put "/services/claims/v0/forms/526/#{auto_claim.id}", params: binary_params, headers: headers
       expect(response.status).to eq(422)
     end

--- a/modules/claims_api/spec/requests/v1/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/claims_request_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
                  auth_headers: { some: 'data' },
                  evss_id: 600_118_851,
                  id: 'd5536c5c-0465-4038-a368-1a9d9daf65c9')
-          expect_any_instance_of(ClaimsApi::UnsynchronizedEVSSClaimService).to receive(:update_from_remote)
+          allow_any_instance_of(ClaimsApi::UnsynchronizedEVSSClaimService).to receive(:update_from_remote)
             .and_raise(StandardError.new('no claim found'))
           VCR.use_cassette('evss/claims/claim') do
             get(
@@ -243,7 +243,7 @@ RSpec.describe 'EVSS Claims management', type: :request do
 
   context "when a 'Token Validation Error' is received" do
     it "raises a 'Common::Exceptions::Unauthorized' exception", run_at: 'Tue, 12 Dec 2017 03:09:06 GMT' do
-      expect_any_instance_of(Token).to receive(:initialize).and_raise(
+      allow_any_instance_of(Token).to receive(:initialize).and_raise(
         Common::Exceptions::TokenValidationError.new(detail: 'Some Error')
       )
 

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -1565,7 +1565,7 @@ RSpec.describe 'Disability Claims ', type: :request do
         let(:classification_type_codes) { [{ clsfcn_id: '1111' }] }
 
         before do
-          expect_any_instance_of(BGS::StandardDataService)
+          allow_any_instance_of(BGS::StandardDataService)
             .to receive(:get_contention_classification_type_code_list).and_return(classification_type_codes)
         end
 
@@ -1603,7 +1603,7 @@ RSpec.describe 'Disability Claims ', type: :request do
         let(:classification_type_codes) { [{ clsfcn_id: '1111' }] }
 
         before do
-          expect_any_instance_of(BGS::StandardDataService)
+          allow_any_instance_of(BGS::StandardDataService)
             .to receive(:get_contention_classification_type_code_list).and_return(classification_type_codes)
         end
 
@@ -1763,7 +1763,7 @@ RSpec.describe 'Disability Claims ', type: :request do
         before do
           stub_mpi
 
-          expect_any_instance_of(BGS::StandardDataService)
+          allow_any_instance_of(BGS::StandardDataService)
             .to receive(:get_contention_classification_type_code_list).and_return(classification_type_codes)
         end
 

--- a/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/power_of_attorney_request_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe 'Power of Attorney ', type: :request do
         it 'returns a 404' do
           with_okta_user(scopes) do |auth_header|
             allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(bgs_poa_verifier)
-            expect(bgs_poa_verifier).to receive(:current_poa).and_return(nil)
+            allow(bgs_poa_verifier).to receive(:current_poa).and_return(nil)
             get('/services/claims/v1/forms/2122/active',
                 params: nil, headers: headers.merge(auth_header))
             expect(response.status).to eq(404)
@@ -300,9 +300,9 @@ RSpec.describe 'Power of Attorney ', type: :request do
         it 'returns a 200' do
           with_okta_user(scopes) do |auth_header|
             allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(bgs_poa_verifier)
-            expect(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new('HelloWorld'))
-            expect(bgs_poa_verifier).to receive(:previous_poa_code).and_return(nil)
-            expect_any_instance_of(
+            allow(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new('HelloWorld'))
+            allow(bgs_poa_verifier).to receive(:previous_poa_code).and_return(nil)
+            allow_any_instance_of(
               ClaimsApi::V1::Forms::PowerOfAttorneyController
             ).to receive(:build_representative_info).and_return(representative_info)
             get('/services/claims/v1/forms/2122/active',
@@ -324,9 +324,9 @@ RSpec.describe 'Power of Attorney ', type: :request do
 
                 with_settings(Settings.claims_api.token_validation, api_key: 'some_value') do
                   allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(bgs_poa_verifier)
-                  expect(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new('HelloWorld'))
-                  expect(bgs_poa_verifier).to receive(:previous_poa_code).and_return(nil)
-                  expect_any_instance_of(
+                  allow(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new('HelloWorld'))
+                  allow(bgs_poa_verifier).to receive(:previous_poa_code).and_return(nil)
+                  allow_any_instance_of(
                     ClaimsApi::V1::Forms::PowerOfAttorneyController
                   ).to receive(:build_representative_info).and_return(representative_info)
                   get '/services/claims/v1/forms/2122/active', params: nil, headers: headers.merge(auth_header)
@@ -375,16 +375,16 @@ RSpec.describe 'Power of Attorney ', type: :request do
 
           it "returns the organization's name and phone" do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(
+              allow_any_instance_of(
                 ClaimsApi::V1::Forms::PowerOfAttorneyController
               ).to receive(:validate_user_is_accredited!).and_return(nil)
               allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(bgs_poa_verifier)
-              expect(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new('HelloWorld'))
-              expect(bgs_poa_verifier).to receive(:previous_poa_code).and_return(nil)
-              expect(::Veteran::Service::Representative).to receive(:where).and_return(
+              allow(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new('HelloWorld'))
+              allow(bgs_poa_verifier).to receive(:previous_poa_code).and_return(nil)
+              allow(::Veteran::Service::Representative).to receive(:where).and_return(
                 [OpenStruct.new(user_types: user_types)]
               )
-              expect(::Veteran::Service::Organization).to receive(:find_by).and_return(
+              allow(::Veteran::Service::Organization).to receive(:find_by).and_return(
                 OpenStruct.new(name: 'Some Great Organization', phone: '555-555-5555')
               )
 
@@ -410,12 +410,12 @@ RSpec.describe 'Power of Attorney ', type: :request do
 
           it "returns the representative's name and phone" do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(
+              allow_any_instance_of(
                 ClaimsApi::V1::Forms::PowerOfAttorneyController
               ).to receive(:validate_user_is_accredited!).and_return(nil)
               allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(bgs_poa_verifier)
-              expect(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new('HelloWorld'))
-              expect(bgs_poa_verifier).to receive(:previous_poa_code).and_return(nil)
+              allow(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new('HelloWorld'))
+              allow(bgs_poa_verifier).to receive(:previous_poa_code).and_return(nil)
               allow(::Veteran::Service::Representative).to receive(:where).and_return(
                 [
                   OpenStruct.new(

--- a/modules/claims_api/spec/requests/v1/rswag_intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_intent_to_file_request_spec.rb
@@ -146,7 +146,7 @@ describe 'Intent to file', swagger_doc: 'modules/claims_api/app/swagger/claims_a
             stub_mpi
 
             with_okta_user(scopes) do
-              expect_any_instance_of(
+              allow_any_instance_of(
                 ClaimsApi::V1::Forms::IntentToFileController
               ).to receive(:veteran_submitting_burial_itf?).and_return(true)
               VCR.use_cassette('bgs/intent_to_file_web_service/insert_intent_to_file') do

--- a/modules/claims_api/spec/requests/v1/rswag_power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_power_of_attorney_request_spec.rb
@@ -549,9 +549,9 @@ describe 'Power of Attorney', swagger_doc: 'modules/claims_api/app/swagger/claim
             with_okta_user(scopes) do
               allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(bgs_poa_verifier)
               allow(::Veteran::Service::Representative).to receive(:for_user).and_return(true)
-              expect(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new('HelloWorld'))
-              expect(bgs_poa_verifier).to receive(:previous_poa_code).and_return(nil)
-              expect_any_instance_of(
+              allow(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new('HelloWorld'))
+              allow(bgs_poa_verifier).to receive(:previous_poa_code).and_return(nil)
+              allow_any_instance_of(
                 ClaimsApi::V1::Forms::PowerOfAttorneyController
               ).to receive(:build_representative_info).and_return(representative_info)
               submit_request(example.metadata)
@@ -618,7 +618,7 @@ describe 'Power of Attorney', swagger_doc: 'modules/claims_api/app/swagger/claim
             with_okta_user(scopes) do
               allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(bgs_poa_verifier)
               allow(::Veteran::Service::Representative).to receive(:for_user).and_return(true)
-              expect(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new(nil))
+              allow(bgs_poa_verifier).to receive(:current_poa).and_return(Struct.new(:code).new(nil))
               submit_request(example.metadata)
             end
           end

--- a/modules/claims_api/spec/requests/v2/rswag_veteran_identifier_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/rswag_veteran_identifier_request_spec.rb
@@ -44,10 +44,10 @@ describe 'Veteran Identifier', swagger_doc: 'modules/claims_api/app/swagger/clai
           )
 
           before do |example|
-            expect(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
+            allow(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
             allow(veteran).to receive(:mpi).and_return(veteran_mpi_data)
             allow(veteran_mpi_data).to receive(:icn).and_return(test_user_icn)
-            expect(::Veteran::Service::Representative).to receive(:find_by).and_return(true)
+            allow(::Veteran::Service::Representative).to receive(:find_by).and_return(true)
             with_okta_user(scopes) do |auth_header|
               Authorization = auth_header # rubocop:disable Naming/ConstantName
               submit_request(example.metadata)
@@ -130,10 +130,10 @@ describe 'Veteran Identifier', swagger_doc: 'modules/claims_api/app/swagger/clai
 
       describe 'Getting a 403 response' do
         before do |example|
-          expect(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
+          allow(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
           allow(veteran).to receive(:mpi).and_return(veteran_mpi_data)
           allow(veteran_mpi_data).to receive(:icn).and_return(test_user_icn)
-          expect(::Veteran::Service::Representative).to receive(:find_by).and_return(nil)
+          allow(::Veteran::Service::Representative).to receive(:find_by).and_return(nil)
           with_okta_user(scopes) do |auth_header|
             Authorization = auth_header # rubocop:disable Naming/ConstantName
             submit_request(example.metadata)
@@ -163,7 +163,7 @@ describe 'Veteran Identifier', swagger_doc: 'modules/claims_api/app/swagger/clai
 
       describe 'Getting a 404 response' do
         before do |example|
-          expect(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
+          allow(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
           allow(veteran).to receive(:mpi).and_return(veteran_mpi_data)
           allow(veteran_mpi_data).to receive(:icn).and_return(nil)
           with_okta_user(scopes) do |auth_header|

--- a/modules/claims_api/spec/requests/v2/veteran_identifier_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veteran_identifier_request_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe 'Veteran Identifier Endpoint', type: :request do
       context 'when veteran icn is found' do
         context 'when user is a Veteran representative' do
           it 'returns an id' do
-            expect(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
+            allow(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
             allow(veteran).to receive(:mpi).and_return(veteran_mpi_data)
             allow(veteran_mpi_data).to receive(:icn).and_return(test_user_icn)
-            expect(::Veteran::Service::Representative).to receive(:find_by).and_return(true)
+            allow(::Veteran::Service::Representative).to receive(:find_by).and_return(true)
             with_okta_user(scopes) do |auth_header|
               post path, params: data, headers: auth_header
               icn = JSON.parse(response.body)['id']
@@ -53,7 +53,7 @@ RSpec.describe 'Veteran Identifier Endpoint', type: :request do
           end
 
           it 'returns an id' do
-            expect(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
+            allow(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
             allow(veteran).to receive(:mpi).and_return(veteran_mpi_data)
             allow(veteran_mpi_data).to receive(:icn).and_return(test_user_icn)
             with_okta_user(scopes) do |auth_header|
@@ -88,7 +88,7 @@ RSpec.describe 'Veteran Identifier Endpoint', type: :request do
 
     context 'when veteran icn cannot be found' do
       it 'returns a 404' do
-        expect(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
+        allow(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
         allow(veteran).to receive(:mpi).and_return(veteran_mpi_data)
         allow(veteran_mpi_data).to receive(:icn).and_return(nil)
         with_okta_user(scopes) do |auth_header|
@@ -177,10 +177,10 @@ RSpec.describe 'Veteran Identifier Endpoint', type: :request do
     context 'when request is forbidden' do
       context 'when user is not a Veteran representative, nor the matching Veteran' do
         it 'reutrns a 403 forbidden response' do
-          expect(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
+          allow(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
           allow(veteran).to receive(:mpi).and_return(veteran_mpi_data)
           allow(veteran_mpi_data).to receive(:icn).and_return(test_user_icn)
-          expect(::Veteran::Service::Representative).to receive(:find_by).and_return(nil)
+          allow(::Veteran::Service::Representative).to receive(:find_by).and_return(nil)
           with_okta_user(scopes) do |auth_header|
             post path, params: data, headers: auth_header
 

--- a/modules/claims_api/spec/requests/v2/veterans/claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/claims_request_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe 'Claims', type: :request do
         context 'when provided' do
           it 'returns a 200' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+              allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                 .to receive(:find_benefit_claims_status_by_ptcpnt_id).and_return(
                   benefit_claims_dto: {
                     benefit_claim: []
                   }
                 )
-              expect(ClaimsApi::AutoEstablishedClaim)
+              allow(ClaimsApi::AutoEstablishedClaim)
                 .to receive(:where).and_return([])
 
               get all_claims_path, headers: auth_header
@@ -45,9 +45,9 @@ RSpec.describe 'Claims', type: :request do
           context 'when current user is not a representative of the target veteran' do
             it 'returns a 403' do
               with_okta_user(scopes) do |auth_header|
-                expect_any_instance_of(ClaimsApi::V2::ApplicationController)
+                allow_any_instance_of(ClaimsApi::V2::ApplicationController)
                   .to receive(:user_is_target_veteran?).and_return(false)
-                expect_any_instance_of(ClaimsApi::V2::ApplicationController)
+                allow_any_instance_of(ClaimsApi::V2::ApplicationController)
                   .to receive(:user_represents_veteran?).and_return(false)
 
                 get all_claims_path, headers: auth_header
@@ -73,13 +73,13 @@ RSpec.describe 'Claims', type: :request do
         context 'when known veteran_id is provided' do
           it 'returns a 200' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+              allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                 .to receive(:find_benefit_claims_status_by_ptcpnt_id).and_return(
                   benefit_claims_dto: {
                     benefit_claim: []
                   }
                 )
-              expect(ClaimsApi::AutoEstablishedClaim)
+              allow(ClaimsApi::AutoEstablishedClaim)
                 .to receive(:where).and_return([])
 
               get all_claims_path, headers: auth_header
@@ -93,7 +93,7 @@ RSpec.describe 'Claims', type: :request do
 
           it 'returns a 403 error code' do
             with_okta_user(scopes) do |auth_header|
-              expect(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
+              allow(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
 
               get all_claims_path, headers: auth_header
               expect(response.status).to eq(403)
@@ -131,9 +131,9 @@ RSpec.describe 'Claims', type: :request do
 
             it 'returns a collection that contains the claim with the Lighthouse id, BGS type, & BGS status' do
               with_okta_user(scopes) do |auth_header|
-                expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+                allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                   .to receive(:find_benefit_claims_status_by_ptcpnt_id).and_return(bgs_claims)
-                expect(ClaimsApi::AutoEstablishedClaim)
+                allow(ClaimsApi::AutoEstablishedClaim)
                   .to receive(:where).and_return(lighthouse_claims)
 
                 get all_claims_path, headers: auth_header
@@ -177,9 +177,9 @@ RSpec.describe 'Claims', type: :request do
 
             it 'returns a collection that contains both Lighthouse claim and BGS claim' do
               with_okta_user(scopes) do |auth_header|
-                expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+                allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                   .to receive(:find_benefit_claims_status_by_ptcpnt_id).and_return(bgs_claims)
-                expect(ClaimsApi::AutoEstablishedClaim)
+                allow(ClaimsApi::AutoEstablishedClaim)
                   .to receive(:where).and_return(lighthouse_claims)
 
                 get all_claims_path, headers: auth_header
@@ -214,9 +214,9 @@ RSpec.describe 'Claims', type: :request do
 
           it 'returns a collection that contains the BGS claims' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+              allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                 .to receive(:find_benefit_claims_status_by_ptcpnt_id).and_return(bgs_claims)
-              expect(ClaimsApi::AutoEstablishedClaim)
+              allow(ClaimsApi::AutoEstablishedClaim)
                 .to receive(:where).and_return(lighthouse_claims)
 
               get all_claims_path, headers: auth_header
@@ -251,9 +251,9 @@ RSpec.describe 'Claims', type: :request do
 
           it 'returns a collection that contains the Lighthouse claims' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+              allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                 .to receive(:find_benefit_claims_status_by_ptcpnt_id).and_return(bgs_claims)
-              expect(ClaimsApi::AutoEstablishedClaim)
+              allow(ClaimsApi::AutoEstablishedClaim)
                 .to receive(:where).and_return(lighthouse_claims)
 
               get all_claims_path, headers: auth_header
@@ -280,9 +280,9 @@ RSpec.describe 'Claims', type: :request do
 
           it 'returns an empty collection' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+              allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                 .to receive(:find_benefit_claims_status_by_ptcpnt_id).and_return(bgs_claims)
-              expect(ClaimsApi::AutoEstablishedClaim)
+              allow(ClaimsApi::AutoEstablishedClaim)
                 .to receive(:where).and_return(lighthouse_claims)
 
               get all_claims_path, headers: auth_header
@@ -311,9 +311,9 @@ RSpec.describe 'Claims', type: :request do
         context 'when current user is not a representative of the target veteran' do
           it 'returns a 403' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(ClaimsApi::V2::ApplicationController)
+              allow_any_instance_of(ClaimsApi::V2::ApplicationController)
                 .to receive(:user_is_target_veteran?).and_return(false)
-              expect_any_instance_of(ClaimsApi::V2::ApplicationController)
+              allow_any_instance_of(ClaimsApi::V2::ApplicationController)
                 .to receive(:user_represents_veteran?).and_return(false)
 
               get claim_by_id_path, headers: auth_header
@@ -329,7 +329,7 @@ RSpec.describe 'Claims', type: :request do
         context 'when a Lighthouse claim does not exist' do
           it 'returns a 404' do
             with_okta_user(scopes) do |auth_header|
-              expect(ClaimsApi::AutoEstablishedClaim).to receive(:get_by_id_or_evss_id).and_return(nil)
+              allow(ClaimsApi::AutoEstablishedClaim).to receive(:get_by_id_or_evss_id).and_return(nil)
 
               get claim_by_id_path, headers: auth_header
 
@@ -353,9 +353,9 @@ RSpec.describe 'Claims', type: :request do
 
             it 'returns the Lighthouse claim' do
               with_okta_user(scopes) do |auth_header|
-                expect(ClaimsApi::AutoEstablishedClaim)
+                allow(ClaimsApi::AutoEstablishedClaim)
                   .to receive(:get_by_id_or_evss_id).and_return(lighthouse_claim)
-                expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+                allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                   .to receive(:find_benefit_claim_details_by_benefit_claim_id).and_return(bgs_claim)
 
                 get claim_by_id_path, headers: auth_header
@@ -384,9 +384,9 @@ RSpec.describe 'Claims', type: :request do
 
             it "returns a claim with the Lighthouse 'id', BGS 'type', & BGS 'status'" do
               with_okta_user(scopes) do |auth_header|
-                expect(ClaimsApi::AutoEstablishedClaim)
+                allow(ClaimsApi::AutoEstablishedClaim)
                   .to receive(:get_by_id_or_evss_id).and_return(lighthouse_claim)
-                expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+                allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                   .to receive(:find_benefit_claim_details_by_benefit_claim_id).and_return(bgs_claim)
 
                 get claim_by_id_path, headers: auth_header
@@ -409,7 +409,7 @@ RSpec.describe 'Claims', type: :request do
         context 'when a BGS claim does not exist' do
           it 'returns a 404' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+              allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                 .to receive(:find_benefit_claim_details_by_benefit_claim_id).and_return(nil)
 
               get claim_by_id_path, headers: auth_header
@@ -444,9 +444,9 @@ RSpec.describe 'Claims', type: :request do
 
             it "returns a claim with the Lighthouse 'id' and the BGS 'type'" do
               with_okta_user(scopes) do |auth_header|
-                expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+                allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                   .to receive(:find_benefit_claim_details_by_benefit_claim_id).and_return(bgs_claim)
-                expect(ClaimsApi::AutoEstablishedClaim)
+                allow(ClaimsApi::AutoEstablishedClaim)
                   .to receive(:get_by_id_or_evss_id).and_return(lighthouse_claim)
 
                 get claim_by_id_path, headers: auth_header
@@ -464,9 +464,9 @@ RSpec.describe 'Claims', type: :request do
           context 'and a Lighthouse claim does not exit' do
             it "returns a claim with the BGS 'id'" do
               with_okta_user(scopes) do |auth_header|
-                expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+                allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                   .to receive(:find_benefit_claim_details_by_benefit_claim_id).and_return(bgs_claim)
-                expect(ClaimsApi::AutoEstablishedClaim)
+                allow(ClaimsApi::AutoEstablishedClaim)
                   .to receive(:get_by_id_or_evss_id).and_return(nil)
 
                 get claim_by_id_path, headers: auth_header

--- a/modules/claims_api/spec/requests/v2/veterans/intent_to_files_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/intent_to_files_request_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'IntentToFiles', type: :request do
         context 'when provided' do
           it 'returns a 200' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::IntentToFileWebService)
+              allow_any_instance_of(BGS::IntentToFileWebService)
                 .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(
                   stub_response
                 )
@@ -74,7 +74,7 @@ RSpec.describe 'IntentToFiles', type: :request do
 
             it 'returns a 200' do
               with_okta_user(scopes) do |auth_header|
-                expect_any_instance_of(BGS::IntentToFileWebService)
+                allow_any_instance_of(BGS::IntentToFileWebService)
                   .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(
                     stub_response
                   )
@@ -90,7 +90,7 @@ RSpec.describe 'IntentToFiles', type: :request do
 
             it 'returns a 200' do
               with_okta_user(scopes) do |auth_header|
-                expect_any_instance_of(BGS::IntentToFileWebService)
+                allow_any_instance_of(BGS::IntentToFileWebService)
                   .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(
                     stub_response
                   )
@@ -106,7 +106,7 @@ RSpec.describe 'IntentToFiles', type: :request do
 
             it 'returns a 200' do
               with_okta_user(scopes) do |auth_header|
-                expect_any_instance_of(BGS::IntentToFileWebService)
+                allow_any_instance_of(BGS::IntentToFileWebService)
                   .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(
                     stub_response
                   )
@@ -122,7 +122,7 @@ RSpec.describe 'IntentToFiles', type: :request do
       context 'when no record is found in BGS' do
         it 'returns a 404' do
           with_okta_user(scopes) do |auth_header|
-            expect_any_instance_of(BGS::IntentToFileWebService)
+            allow_any_instance_of(BGS::IntentToFileWebService)
               .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(
                 nil
               )
@@ -156,7 +156,7 @@ RSpec.describe 'IntentToFiles', type: :request do
 
           it 'chooses the first non-expired ITF' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::IntentToFileWebService)
+              allow_any_instance_of(BGS::IntentToFileWebService)
                 .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(
                   stub_response
                 )
@@ -192,7 +192,7 @@ RSpec.describe 'IntentToFiles', type: :request do
 
           it 'returns 404' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::IntentToFileWebService)
+              allow_any_instance_of(BGS::IntentToFileWebService)
                 .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(
                   stub_response
                 )
@@ -226,7 +226,7 @@ RSpec.describe 'IntentToFiles', type: :request do
 
           it 'returns 404' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::IntentToFileWebService)
+              allow_any_instance_of(BGS::IntentToFileWebService)
                 .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(
                   stub_response
                 )
@@ -253,7 +253,7 @@ RSpec.describe 'IntentToFiles', type: :request do
 
           it 'returns a 404' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::IntentToFileWebService)
+              allow_any_instance_of(BGS::IntentToFileWebService)
                 .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(
                   stub_response
                 )
@@ -278,7 +278,7 @@ RSpec.describe 'IntentToFiles', type: :request do
 
           it 'returns a 404' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::IntentToFileWebService)
+              allow_any_instance_of(BGS::IntentToFileWebService)
                 .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(
                   stub_response
                 )

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney_request_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Power Of Attorney', type: :request do
         context 'when provided' do
           it 'returns a 200' do
             with_okta_user(scopes) do |auth_header|
-              expect_any_instance_of(BGS::ClaimantWebService).to receive(:find_poa_by_participant_id)
+              allow_any_instance_of(BGS::ClaimantWebService).to receive(:find_poa_by_participant_id)
                 .and_return(bgs_poa)
               allow_any_instance_of(BGS::OrgWebService).to receive(:find_poa_history_by_ptcpnt_id)
                 .and_return({ person_poa_history: nil })

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_claims_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_claims_request_spec.rb
@@ -45,9 +45,9 @@ describe 'Claims', swagger_doc: 'modules/claims_api/app/swagger/claims_api/v2/sw
 
           before do |example|
             with_okta_user(scopes) do
-              expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+              allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                 .to receive(:find_benefit_claims_status_by_ptcpnt_id).and_return(bgs_response)
-              expect(ClaimsApi::AutoEstablishedClaim)
+              allow(ClaimsApi::AutoEstablishedClaim)
                 .to receive(:where).and_return([])
 
               submit_request(example.metadata)
@@ -106,7 +106,7 @@ describe 'Claims', swagger_doc: 'modules/claims_api/app/swagger/claims_api/v2/sw
 
           before do |example|
             with_okta_user(scopes) do
-              expect(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
+              allow(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
 
               submit_request(example.metadata)
             end
@@ -171,8 +171,8 @@ describe 'Claims', swagger_doc: 'modules/claims_api/app/swagger/claims_api/v2/sw
 
           before do |example|
             with_okta_user(scopes) do
-              expect(ClaimsApi::AutoEstablishedClaim).to receive(:get_by_id_or_evss_id).and_return(nil)
-              expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+              allow(ClaimsApi::AutoEstablishedClaim).to receive(:get_by_id_or_evss_id).and_return(nil)
+              allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                 .to receive(:find_benefit_claim_details_by_benefit_claim_id).and_return(bgs_response)
 
               submit_request(example.metadata)
@@ -231,7 +231,7 @@ describe 'Claims', swagger_doc: 'modules/claims_api/app/swagger/claims_api/v2/sw
 
           before do |example|
             with_okta_user(scopes) do
-              expect(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
+              allow(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
 
               submit_request(example.metadata)
             end
@@ -263,8 +263,8 @@ describe 'Claims', swagger_doc: 'modules/claims_api/app/swagger/claims_api/v2/sw
 
           before do |example|
             with_okta_user(scopes) do
-              expect(ClaimsApi::AutoEstablishedClaim).to receive(:get_by_id_or_evss_id).and_return(nil)
-              expect_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
+              allow(ClaimsApi::AutoEstablishedClaim).to receive(:get_by_id_or_evss_id).and_return(nil)
+              allow_any_instance_of(BGS::EbenefitsBenefitClaimsStatus)
                 .to receive(:find_benefit_claim_details_by_benefit_claim_id).and_return(nil)
 
               submit_request(example.metadata)

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_intent_to_file_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_intent_to_file_request_spec.rb
@@ -55,7 +55,7 @@ describe 'IntentToFile', swagger_doc: 'modules/claims_api/app/swagger/claims_api
             Timecop.freeze(Time.zone.parse('2022-01-01T08:00:00Z'))
 
             with_okta_user(scopes) do
-              expect_any_instance_of(BGS::IntentToFileWebService)
+              allow_any_instance_of(BGS::IntentToFileWebService)
                 .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(bgs_response)
 
               submit_request(example.metadata)
@@ -115,7 +115,7 @@ describe 'IntentToFile', swagger_doc: 'modules/claims_api/app/swagger/claims_api
 
           before do |example|
             with_okta_user(scopes) do
-              expect(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
+              allow(ClaimsApi::Veteran).to receive(:new).and_return(veteran)
 
               submit_request(example.metadata)
             end
@@ -146,7 +146,7 @@ describe 'IntentToFile', swagger_doc: 'modules/claims_api/app/swagger/claims_api
 
           before do |example|
             with_okta_user(scopes) do
-              expect_any_instance_of(BGS::IntentToFileWebService)
+              allow_any_instance_of(BGS::IntentToFileWebService)
                 .to receive(:find_intent_to_file_by_ptcpnt_id_itf_type_cd).and_return(nil)
 
               submit_request(example.metadata)

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -40,7 +40,7 @@ describe 'PowerOfAttorney', swagger_doc: 'modules/claims_api/app/swagger/claims_
                                                       'get.json')))
 
           before do |example|
-            expect_any_instance_of(BGS::ClaimantWebService).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
+            allow_any_instance_of(BGS::ClaimantWebService).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
             allow_any_instance_of(BGS::OrgWebService).to receive(:find_poa_history_by_ptcpnt_id)
               .and_return({ person_poa_history: nil })
             Veteran::Service::Representative.new(representative_id: '12345',
@@ -73,7 +73,7 @@ describe 'PowerOfAttorney', swagger_doc: 'modules/claims_api/app/swagger/claims_
 
         response '204', 'Successful response with no current Power of Attorney' do
           before do |example|
-            expect_any_instance_of(BGS::ClaimantWebService).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
+            allow_any_instance_of(BGS::ClaimantWebService).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
             allow_any_instance_of(BGS::OrgWebService).to receive(:find_poa_history_by_ptcpnt_id)
               .and_return({ person_poa_history: nil })
             with_okta_user(scopes) do |auth_header|
@@ -197,7 +197,7 @@ describe 'PowerOfAttorney', swagger_doc: 'modules/claims_api/app/swagger/claims_
                                                       'get.json')))
 
           before do |example|
-            expect_any_instance_of(BGS::ClaimantWebService).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
+            allow_any_instance_of(BGS::ClaimantWebService).to receive(:find_poa_by_participant_id).and_return(bgs_poa)
             allow_any_instance_of(BGS::OrgWebService).to receive(:find_poa_history_by_ptcpnt_id)
               .and_return({ person_poa_history: nil })
             Veteran::Service::Representative.new(representative_id: '67890',

--- a/modules/claims_api/spec/workers/claim_establisher_spec.rb
+++ b/modules/claims_api/spec/workers/claim_establisher_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe ClaimsApi::ClaimEstablisher, type: :job do
     evss_service_stub = instance_double('EVSS::DisabilityCompensationForm::Service')
     allow(EVSS::DisabilityCompensationForm::Service).to receive(:new) { evss_service_stub }
     allow(evss_service_stub).to receive(:submit_form526) { OpenStruct.new(claim_id: 1337) }
-    expect_any_instance_of(ClaimsApi::AutoEstablishedClaim).to receive(:save!)
+    allow_any_instance_of(ClaimsApi::AutoEstablishedClaim).to receive(:save!)
       .and_raise(ActiveRecord::RecordInvalid.new(claim))
 
     expect do

--- a/modules/claims_api/spec/workers/flash_updater_spec.rb
+++ b/modules/claims_api/spec/workers/flash_updater_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ClaimsApi::FlashUpdater, type: :job do
       expect_any_instance_of(BGS::ClaimantWebService)
         .to receive(:add_flash).with(file_number: user['ssn'], flash_name: flash_name)
     end
-    expect_any_instance_of(BGS::ClaimantWebService)
+    allow_any_instance_of(BGS::ClaimantWebService)
       .to receive(:find_assigned_flashes).with(user['ssn']).and_return(assigned_flashes)
 
     subject.new.perform(user, flashes)
@@ -47,14 +47,14 @@ RSpec.describe ClaimsApi::FlashUpdater, type: :job do
   it 'continues submitting flashes on exception' do
     flashes.each_with_index do |flash_name, index|
       if index.zero?
-        expect_any_instance_of(BGS::ClaimantWebService).to receive(:add_flash)
+        allow_any_instance_of(BGS::ClaimantWebService).to receive(:add_flash)
           .with(file_number: user['ssn'], flash_name: flash_name).and_raise(BGS::ShareError.new('failed', 500))
       else
         expect_any_instance_of(BGS::ClaimantWebService)
           .to receive(:add_flash).with(file_number: user['ssn'], flash_name: flash_name)
       end
     end
-    expect_any_instance_of(BGS::ClaimantWebService)
+    allow_any_instance_of(BGS::ClaimantWebService)
       .to receive(:find_assigned_flashes).with(user['ssn']).and_return(assigned_flashes)
 
     subject.new.perform(user, flashes, claim.id)
@@ -62,10 +62,10 @@ RSpec.describe ClaimsApi::FlashUpdater, type: :job do
 
   it 'stores multiple bgs exceptions correctly' do
     flashes.each do |flash_name|
-      expect_any_instance_of(BGS::ClaimantWebService).to receive(:add_flash)
+      allow_any_instance_of(BGS::ClaimantWebService).to receive(:add_flash)
         .with(file_number: user['ssn'], flash_name: flash_name).and_raise(BGS::ShareError.new('failed', 500))
     end
-    expect_any_instance_of(BGS::ClaimantWebService)
+    allow_any_instance_of(BGS::ClaimantWebService)
       .to receive(:find_assigned_flashes).with(user['ssn']).and_return({ flashes: [] })
 
     subject.new.perform(user, flashes, claim.id)

--- a/modules/claims_api/spec/workers/poa_updater_spec.rb
+++ b/modules/claims_api/spec/workers/poa_updater_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ClaimsApi::PoaUpdater, type: :job do
     vet_record_stub = BGS::Services.new(external_uid: 'uid', external_key: 'key').vet_record
     allow(vet_record_stub).to receive(:update_birls_record).and_return(return_code: 'BMOD0001')
     service_double = instance_double('BGS::Services')
-    expect(service_double).to receive(:vet_record).and_return(vet_record_stub)
-    expect(BGS::Services).to receive(:new).and_return(service_double)
+    allow(service_double).to receive(:vet_record).and_return(vet_record_stub)
+    allow(BGS::Services).to receive(:new).and_return(service_double)
   end
 end

--- a/modules/claims_api/spec/workers/special_issue_updater_spec.rb
+++ b/modules/claims_api/spec/workers/special_issue_updater_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ClaimsApi::SpecialIssueUpdater, type: :job do
     let(:claims) { { benefit_claims: [] } }
 
     it 'job fails and retries later' do
-      expect_any_instance_of(BGS::ContentionService).to receive(:find_contentions_by_ptcpnt_id)
+      allow_any_instance_of(BGS::ContentionService).to receive(:find_contentions_by_ptcpnt_id)
         .and_return(claims)
 
       expect do
@@ -40,7 +40,7 @@ RSpec.describe ClaimsApi::SpecialIssueUpdater, type: :job do
 
   context 'when a matching claim is found' do
     before do
-      expect_any_instance_of(BGS::ContentionService).to receive(:find_contentions_by_ptcpnt_id)
+      allow_any_instance_of(BGS::ContentionService).to receive(:find_contentions_by_ptcpnt_id)
         .and_return(claims)
     end
 
@@ -115,7 +115,7 @@ RSpec.describe ClaimsApi::SpecialIssueUpdater, type: :job do
           end
 
           it 'stores bgs exceptions correctly' do
-            expect_any_instance_of(BGS::ContentionService).to receive(:manage_contentions)
+            allow_any_instance_of(BGS::ContentionService).to receive(:manage_contentions)
               .and_raise(BGS::ShareError.new('failed', 500))
 
             subject.new.perform(user, contention_id, special_issues, claim_record.id)

--- a/modules/claims_api/spec/workers/vbms_updater_spec.rb
+++ b/modules/claims_api/spec/workers/vbms_updater_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe ClaimsApi::VBMSUpdater, type: :job do
       allow_poa_c_add: allow_poa_c_add
     )
     service_double = instance_double('BGS::Services')
-    expect(service_double).to receive(:corporate_update).and_return(corporate_update_stub)
-    expect(BGS::Services).to receive(:new).and_return(service_double)
+    allow(service_double).to receive(:corporate_update).and_return(corporate_update_stub)
+    allow(BGS::Services).to receive(:new).and_return(service_double)
   end
 end

--- a/modules/covid_research/spec/workers/covid_research/volunteer/confirmation_mailer_job_spec.rb
+++ b/modules/covid_research/spec/workers/covid_research/volunteer/confirmation_mailer_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CovidResearch::Volunteer::ConfirmationMailerJob do
   describe '#perform' do
     it 'builds an email to the given email' do
       allow(dummy).to receive(:deliver)
-      expect(CovidResearch::Volunteer::SubmissionMailer).to receive(:build).with(recipient).and_return(dummy)
+      allow(CovidResearch::Volunteer::SubmissionMailer).to receive(:build).with(recipient).and_return(dummy)
 
       subject.perform(recipient)
     end

--- a/modules/covid_vaccine/spec/jobs/covid_vaccine/expanded_registration_email_job_spec.rb
+++ b/modules/covid_vaccine/spec/jobs/covid_vaccine/expanded_registration_email_job_spec.rb
@@ -60,14 +60,14 @@ RSpec.describe CovidVaccine::ExpandedRegistrationEmailJob, type: :worker do
 
     context 'with an error response from VANotify' do
       it 'raises an exception' do
-        expect_any_instance_of(VaNotify::Service).to receive(:send_email)
+        allow_any_instance_of(VaNotify::Service).to receive(:send_email)
           .and_raise(Common::Exceptions::BadGateway)
         expect(StatsD).to receive(:increment).with('worker.covid_vaccine_expanded_registration_email.error')
         expect { subject.perform(registration_submission.id) }.to raise_error(StandardError)
       end
 
       it 'increments the StatsD error counter' do
-        expect_any_instance_of(VaNotify::Service).to receive(:send_email)
+        allow_any_instance_of(VaNotify::Service).to receive(:send_email)
           .and_raise(StandardError.new('test error'))
         expect(StatsD).to receive(:increment).with('worker.covid_vaccine_expanded_registration_email.error')
         expect { subject.perform(registration_submission.id) }.to raise_error(StandardError)

--- a/modules/covid_vaccine/spec/jobs/covid_vaccine/registration_email_job_spec.rb
+++ b/modules/covid_vaccine/spec/jobs/covid_vaccine/registration_email_job_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CovidVaccine::RegistrationEmailJob, type: :worker do
       with_settings(
         Settings.vanotify.services.va_gov, { api_key: test_service_api_key }
       ) do
-        expect(VaNotify::Service).to receive(:new).with(test_service_api_key).and_return(instance)
+        allow(VaNotify::Service).to receive(:new).with(test_service_api_key).and_return(instance)
         described_class.new.perform(email, date, confirmation_id)
       end
     end

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/expanded_registration_request_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Covid Vaccine Expanded Registration', type: :request do
 
     context 'when encountering an Internal Server Error' do
       it 'raises a BackendServiceException' do
-        expect(CovidVaccine::V0::ExpandedRegistrationSubmission).to receive(:create!)
+        allow(CovidVaccine::V0::ExpandedRegistrationSubmission).to receive(:create!)
           .and_raise(ActiveRecord::RecordInvalid.new(nil))
         post '/covid_vaccine/v0/expanded_registration', params: { registration: registration_attributes }
 

--- a/modules/covid_vaccine/spec/request/covid_vaccine/v0/registration_request_spec.rb
+++ b/modules/covid_vaccine/spec/request/covid_vaccine/v0/registration_request_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Covid Vaccine Registration', type: :request do
       end
 
       it 'raises a BackendServiceException' do
-        expect(CovidVaccine::V0::RegistrationSubmission).to receive(:create!)
+        allow(CovidVaccine::V0::RegistrationSubmission).to receive(:create!)
           .and_raise(ActiveRecord::RecordInvalid.new(nil))
         post '/covid_vaccine/v0/registration', params: { registration: registration_attributes }
         expect(response).to have_http_status(:internal_server_error)

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/enrollment_upload_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/enrollment_upload_service_spec.rb
@@ -31,7 +31,7 @@ describe CovidVaccine::V0::EnrollmentUploadService do
     it 'responds to upload' do
       with_settings(Settings.covid_vaccine.enrollment_service.sftp, host: host, username: username,
                                                                     password: password, port: port) do
-        expect(Net::SFTP).to receive(:start).with(host, username, password: password,
+        allow(Net::SFTP).to receive(:start).with(host, username, password: password,
                                                                   port: port).and_yield(sftp_connection_double)
         expect(sftp_connection_double)
           .to receive(:upload!).with(subject.io, file_name, name: file_name, progress: instance_of(handler))

--- a/modules/covid_vaccine/spec/services/covid_vaccine/v0/registration_service_spec.rb
+++ b/modules/covid_vaccine/spec/services/covid_vaccine/v0/registration_service_spec.rb
@@ -45,7 +45,7 @@ describe CovidVaccine::V0::RegistrationService do
   describe '#register', vcr: vcr_options do
     context 'unauthenticated' do
       it 'coerces input to vetext format' do
-        expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+        allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
           .with(hash_including(:first_name,
                                :last_name,
                                :patient_ssn,
@@ -60,7 +60,7 @@ describe CovidVaccine::V0::RegistrationService do
                                :sta3n,
                                :authenticated))
           .and_return({ sid: SecureRandom.uuid })
-        expect_any_instance_of(MPI::Service).to receive(:find_profile)
+        allow_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_profile_response)
 
         expect { subject.register(submission, 'unauthenticated') }
@@ -68,10 +68,10 @@ describe CovidVaccine::V0::RegistrationService do
       end
 
       it 'passes authenticated attribute as false' do
-        expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+        allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
           .with(hash_including(authenticated: false))
           .and_return({ sid: SecureRandom.uuid })
-        expect_any_instance_of(MPI::Service).to receive(:find_profile)
+        allow_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_profile_response)
         expect { subject.register(submission, 'unauthenticated') }
           .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
@@ -79,9 +79,9 @@ describe CovidVaccine::V0::RegistrationService do
 
       it 'updates submission record' do
         sid = SecureRandom.uuid
-        expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+        allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
           .and_return({ sid: sid })
-        expect_any_instance_of(MPI::Service).to receive(:find_profile)
+        allow_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_profile_response)
 
         expect { subject.register(submission, 'unauthenticated') }
@@ -91,9 +91,9 @@ describe CovidVaccine::V0::RegistrationService do
 
       context 'with sufficient traits' do
         it 'injects user traits from MPI when found' do
-          expect_any_instance_of(MPI::Service).to receive(:find_profile)
+          allow_any_instance_of(MPI::Service).to receive(:find_profile)
             .and_return(mvi_profile_response)
-          expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+          allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
             .with(hash_including(first_name: mvi_profile.given_names&.first))
             .and_return({ sid: SecureRandom.uuid })
           expect { subject.register(submission, 'unauthenticated') }
@@ -101,9 +101,9 @@ describe CovidVaccine::V0::RegistrationService do
         end
 
         it 'proceeds without traits from MPI when not found' do
-          expect_any_instance_of(MPI::Service).to receive(:find_profile)
+          allow_any_instance_of(MPI::Service).to receive(:find_profile)
             .and_return(mvi_profile_not_found)
-          expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+          allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
             .with(hash_including(first_name: submission.raw_form_data['first_name']))
             .and_return({ sid: SecureRandom.uuid })
           expect { subject.register(submission, 'unauthenticated') }
@@ -113,7 +113,7 @@ describe CovidVaccine::V0::RegistrationService do
 
       context 'with insufficient traits' do
         it 'omits MPI query' do
-          expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+          allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
             .and_return({ sid: SecureRandom.uuid })
           expect_any_instance_of(MPI::Service).not_to receive(:find_profile)
           expect { subject.register(insufficient_submission, 'unauthenticated') }
@@ -129,7 +129,7 @@ describe CovidVaccine::V0::RegistrationService do
         end
 
         it 'omits MPI query' do
-          expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+          allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
             .and_return({ sid: SecureRandom.uuid })
           expect_any_instance_of(MPI::Service).not_to receive(:find_profile)
           expect { subject.register(bad_date_submission, 'unauthenticated') }
@@ -142,7 +142,7 @@ describe CovidVaccine::V0::RegistrationService do
       let(:user) { build(:user, :mhv) }
 
       it 'uses traits from proofed user' do
-        expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+        allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
           .with(hash_including(first_name: loa3_submission.raw_form_data['first_name']))
           .and_return({ sid: SecureRandom.uuid })
         expect { subject.register(loa3_submission, 'loa3') }
@@ -151,7 +151,7 @@ describe CovidVaccine::V0::RegistrationService do
 
       it 'omits MPI query' do
         expect_any_instance_of(MPI::Service).not_to receive(:find_profile)
-        expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+        allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
           .and_return({ sid: SecureRandom.uuid })
         expect { subject.register(loa3_submission, 'loa3') }
           .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)
@@ -159,7 +159,7 @@ describe CovidVaccine::V0::RegistrationService do
 
       it 'passes authenticated attribute as true' do
         expect_any_instance_of(MPI::Service).not_to receive(:find_profile)
-        expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+        allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
           .with(hash_including(authenticated: true))
           .and_return({ sid: SecureRandom.uuid })
         expect { subject.register(loa3_submission, 'loa3') }
@@ -172,9 +172,9 @@ describe CovidVaccine::V0::RegistrationService do
 
       context 'with sufficient traits' do
         it 'injects user traits from MPI when found' do
-          expect_any_instance_of(MPI::Service).to receive(:find_profile)
+          allow_any_instance_of(MPI::Service).to receive(:find_profile)
             .and_return(mvi_profile_response)
-          expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+          allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
             .with(hash_including(first_name: mvi_profile.given_names&.first))
             .and_return({ sid: SecureRandom.uuid })
           expect { subject.register(submission, 'loa1') }
@@ -183,10 +183,10 @@ describe CovidVaccine::V0::RegistrationService do
       end
 
       it 'passes authenticated attribute as false' do
-        expect_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
+        allow_any_instance_of(CovidVaccine::V0::VetextService).to receive(:put_vaccine_registry)
           .with(hash_including(authenticated: false))
           .and_return({ sid: SecureRandom.uuid })
-        expect_any_instance_of(MPI::Service).to receive(:find_profile)
+        allow_any_instance_of(MPI::Service).to receive(:find_profile)
           .and_return(mvi_profile_response)
         expect { subject.register(submission, 'loa1') }
           .to change(CovidVaccine::RegistrationEmailJob.jobs, :size).by(1)

--- a/modules/facilities_api/spec/services/facilities_api/v1/ppms/client_spec.rb
+++ b/modules/facilities_api/spec/services/facilities_api/v1/ppms/client_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
 
         describe 'Clamping Results' do
           it 'page and per_page is not required' do
-            expect(client).to receive(:perform).with(
+            allow(client).to receive(:perform).with(
               :get,
               path,
               {
@@ -257,7 +257,7 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
 
         describe 'Clamping Radius' do
           it 'limits radius to 500' do
-            expect(client).to receive(:perform).with(
+            allow(client).to receive(:perform).with(
               :get,
               path,
               {
@@ -274,7 +274,7 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
           end
 
           it 'limits radius to 1' do
-            expect(client).to receive(:perform).with(
+            allow(client).to receive(:perform).with(
               :get,
               path,
               {
@@ -293,7 +293,7 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
 
         describe 'Sanitizing Longitude and Latitude' do
           it 'only sends 5 digits of accuracy to ppms' do
-            expect(client).to receive(:perform).with(
+            allow(client).to receive(:perform).with(
               :get,
               path,
               {
@@ -328,7 +328,7 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
 
           it 'accepts upto 5 specialties' do
             allow(fake_response).to receive(:body)
-            expect(client).to receive(:perform).with(
+            allow(client).to receive(:perform).with(
               :get,
               path,
               {
@@ -352,7 +352,7 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
 
           it 'ignores more than 5 specialties' do
             allow(fake_response).to receive(:body)
-            expect(client).to receive(:perform).with(
+            allow(client).to receive(:perform).with(
               :get,
               path,
               {
@@ -523,7 +523,7 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
 
           it 'accepts upto 5 specialties' do
             allow(fake_response).to receive(:body)
-            expect(client).to receive(:perform).with(
+            allow(client).to receive(:perform).with(
               :get,
               path,
               {
@@ -545,7 +545,7 @@ RSpec.describe FacilitiesApi::V1::PPMS::Client, team: :facilities, vcr: vcr_opti
 
           it 'ignores more than 5 specialties' do
             allow(fake_response).to receive(:body)
-            expect(client).to receive(:perform).with(
+            allow(client).to receive(:perform).with(
               :get,
               path,
               {

--- a/modules/mobile/spec/request/payment_information_request_spec.rb
+++ b/modules/mobile/spec/request/payment_information_request_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe 'payment_information', type: :request do
 
           it 'logs a message to Sentry' do
             VCR.use_cassette('evss/ppiu/update_payment_information') do
-              expect_any_instance_of(User).to receive(:all_emails).and_return([])
+              allow_any_instance_of(User).to receive(:all_emails).and_return([])
               expect(Raven).to receive(:capture_message).once
 
               put '/mobile/v0/payment-information/benefits', params: payment_info_request,

--- a/modules/vba_documents/spec/jobs/upload_processor_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_processor_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       allow(faraday_response).to receive(:body).and_return('')
       allow(faraday_response).to receive(:success?).and_return(true)
       capture_body = nil
-      expect(client_stub).to receive(:upload) { |arg|
+      allow(client_stub).to receive(:upload) { |arg|
         capture_body = arg
         faraday_response
       }
@@ -173,7 +173,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       allow(faraday_response).to receive(:body).and_return('')
       allow(faraday_response).to receive(:success?).and_return(true)
       capture_body = nil
-      expect(client_stub).to receive(:upload) { |arg|
+      allow(client_stub).to receive(:upload) { |arg|
         capture_body = arg
         faraday_response
       }
@@ -194,7 +194,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       allow(faraday_response).to receive(:body).and_return('')
       allow(faraday_response).to receive(:success?).and_return(true)
       capture_body = nil
-      expect(client_stub).to receive(:upload) { |arg|
+      allow(client_stub).to receive(:upload) { |arg|
         capture_body = arg
         faraday_response
       }
@@ -265,7 +265,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
         allow(faraday_response).to receive(:status).and_return(200)
         allow(faraday_response).to receive(:body).and_return('')
         allow(faraday_response).to receive(:success?).and_return(true)
-        expect(client_stub).to receive(:upload) { faraday_response }
+        allow(client_stub).to receive(:upload) { faraday_response }
         described_class.new.perform(upload.guid, test_caller)
         updated = VBADocuments::UploadSubmission.find_by(guid: upload.guid)
         expect(updated.status).to eq('received')
@@ -493,7 +493,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
         allow(faraday_response).to receive(:body).and_return('')
         allow(faraday_response).to receive(:success?).and_return(true)
         capture_body = nil
-        expect(client_stub).to receive(:upload) { |arg|
+        allow(client_stub).to receive(:upload) { |arg|
           capture_body = arg
           faraday_response
         }
@@ -559,7 +559,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       )
       allow(faraday_response).to receive(:success?).and_return(false)
       capture_body = nil
-      expect(client_stub).to receive(:upload) { |arg|
+      allow(client_stub).to receive(:upload) { |arg|
         capture_body = arg
         faraday_response
       }
@@ -584,7 +584,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       allow(faraday_response).to receive(:body).and_return('')
       allow(faraday_response).to receive(:success?).and_return(false)
       capture_body = nil
-      expect(client_stub).to receive(:upload) { |arg|
+      allow(client_stub).to receive(:upload) { |arg|
         capture_body = arg
         faraday_response
       }
@@ -610,7 +610,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
 
       it 'does not set error status for upstream server error' do
         capture_body = nil
-        expect(client_stub).to receive(:upload) { |arg|
+        allow(client_stub).to receive(:upload) { |arg|
           capture_body = arg
           faraday_response
         }
@@ -628,7 +628,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       it 'sets error status for upstream server error after retries' do
         capture_body = nil
         after_retries = 4
-        expect(client_stub).to receive(:upload) { |arg|
+        allow(client_stub).to receive(:upload) { |arg|
           capture_body = arg
           faraday_response
         }
@@ -644,7 +644,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
       end
 
       it 'queues another job to retry the request' do
-        expect(client_stub).to receive(:upload) { |_arg| faraday_response }
+        allow(client_stub).to receive(:upload) { |_arg| faraday_response }
         Timecop.freeze(Time.zone.now)
         described_class.new.perform(upload.guid, test_caller)
         expect(described_class.jobs.last['at']).to eq(30.minutes.from_now.to_f)
@@ -655,7 +655,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
     it 'checks for updated status for Gateway timeout error' do
       allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
       allow(CentralMail::Service).to receive(:new) { client_stub }
-      expect(client_stub).to receive(:upload)
+      allow(client_stub).to receive(:upload)
         .and_raise(Common::Exceptions::GatewayTimeout.new)
       expect do
         described_class.new.perform(upload.guid, test_caller)
@@ -667,7 +667,7 @@ RSpec.describe VBADocuments::UploadProcessor, type: :job do
     it 'checks for updated status for Faraday timeout error' do
       allow(VBADocuments::MultipartParser).to receive(:parse) { valid_parts }
       allow(CentralMail::Service).to receive(:new) { client_stub }
-      expect(client_stub).to receive(:upload)
+      allow(client_stub).to receive(:upload)
         .and_raise(Faraday::TimeoutError.new)
       expect { described_class.new.perform(upload.guid, test_caller) }.not_to raise_error(Faraday::TimeoutError)
       upload.reload

--- a/modules/vba_documents/spec/jobs/upload_scanner_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_scanner_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe VBADocuments::UploadScanner, type: :job do
   describe '#perform' do
     it 'spawns processor jobs and updates state' do
       with_settings(Settings.vba_documents.s3, enabled: true) do
-        expect(@s3_bucket).to receive(:object).with(upload.guid).and_return(@s3_object)
-        expect(@s3_object).to receive(:exists?).and_return(true)
+        allow(@s3_bucket).to receive(:object).with(upload.guid).and_return(@s3_object)
+        allow(@s3_object).to receive(:exists?).and_return(true)
         processor = class_double(VBADocuments::UploadProcessor).as_stubbed_const
         expect(processor).to receive(:perform_async).with(upload.guid, caller: described_class.name)
         described_class.new.perform
@@ -28,8 +28,8 @@ RSpec.describe VBADocuments::UploadScanner, type: :job do
 
     it 'skips objects that have not been uploaded' do
       with_settings(Settings.vba_documents.s3, enabled: true) do
-        expect(@s3_bucket).to receive(:object).with(upload.guid).and_return(@s3_object)
-        expect(@s3_object).to receive(:exists?).and_return(false)
+        allow(@s3_bucket).to receive(:object).with(upload.guid).and_return(@s3_object)
+        allow(@s3_object).to receive(:exists?).and_return(false)
         processor = class_double(VBADocuments::UploadProcessor).as_stubbed_const
         expect(processor).not_to receive(:perform_async).with(upload.guid)
         described_class.new.perform
@@ -40,8 +40,8 @@ RSpec.describe VBADocuments::UploadScanner, type: :job do
 
     it 'expires objects for which no upload has occurred' do
       with_settings(Settings.vba_documents.s3, enabled: true) do
-        expect(@s3_bucket).to receive(:object).with(upload.guid).and_return(@s3_object)
-        expect(@s3_object).to receive(:exists?).and_return(false)
+        allow(@s3_bucket).to receive(:object).with(upload.guid).and_return(@s3_object)
+        allow(@s3_object).to receive(:exists?).and_return(false)
         processor = class_double(VBADocuments::UploadProcessor).as_stubbed_const
         expect(processor).not_to receive(:perform_async).with(upload.guid)
         Timecop.travel(Time.zone.now + 25.minutes) do
@@ -54,8 +54,8 @@ RSpec.describe VBADocuments::UploadScanner, type: :job do
 
     it 'does not expire objects for which upload has occurred' do
       with_settings(Settings.vba_documents.s3, enabled: true) do
-        expect(@s3_bucket).to receive(:object).with(upload.guid).and_return(@s3_object)
-        expect(@s3_object).to receive(:exists?).and_return(true)
+        allow(@s3_bucket).to receive(:object).with(upload.guid).and_return(@s3_object)
+        allow(@s3_object).to receive(:exists?).and_return(true)
         processor = class_double(VBADocuments::UploadProcessor).as_stubbed_const
         expect(processor).to receive(:perform_async).with(upload.guid, caller: described_class.name)
         Timecop.travel(Time.zone.now + 25.minutes) do

--- a/modules/vba_documents/spec/jobs/upload_status_batch_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_status_batch_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe VBADocuments::UploadStatusBatch, type: :job do
 
   describe '#perform' do
     it 'updates all the statuses' do
-      expect(CentralMail::Service).to receive(:new) { client_stub }
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(CentralMail::Service).to receive(:new) { client_stub }
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       in_process_element[0]['uuid'] = upload.guid
       expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
 

--- a/modules/vba_documents/spec/jobs/upload_status_updater_spec.rb
+++ b/modules/vba_documents/spec/jobs/upload_status_updater_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe VBADocuments::UploadStatusUpdater, type: :job do
 
   describe '#perform' do
     it 'updates the status of an inflight submission' do
-      expect(CentralMail::Service).to receive(:new) { client_stub }
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(CentralMail::Service).to receive(:new) { client_stub }
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       in_process_element[0]['uuid'] = upload.guid
       expect(faraday_response).to receive(:body).at_least(:once).and_return([in_process_element].to_json)
 

--- a/modules/vba_documents/spec/lib/object_store_spec.rb
+++ b/modules/vba_documents/spec/lib/object_store_spec.rb
@@ -15,15 +15,15 @@ RSpec.describe VBADocuments::ObjectStore do
 
   describe '#bucket' do
     it 'returns a bucket' do
-      expect(@resource).to receive(:bucket).and_return(@bucket)
+      allow(@resource).to receive(:bucket).and_return(@bucket)
       described_class.new.bucket
     end
   end
 
   describe '#object' do
     it 'returns an object' do
-      expect(@resource).to receive(:bucket).and_return(@bucket)
-      expect(@bucket).to receive(:object).and_return(@object)
+      allow(@resource).to receive(:bucket).and_return(@bucket)
+      allow(@bucket).to receive(:object).and_return(@object)
       described_class.new.object('foo')
     end
   end
@@ -32,8 +32,8 @@ RSpec.describe VBADocuments::ObjectStore do
     it 'deletes the object' do
       v1 = instance_double(Aws::S3::ObjectVersion)
       v2 = instance_double(Aws::S3::ObjectVersion)
-      expect(@resource).to receive(:bucket).and_return(@bucket)
-      expect(@bucket).to receive(:object_versions).and_return([v1, v2])
+      allow(@resource).to receive(:bucket).and_return(@bucket)
+      allow(@bucket).to receive(:object_versions).and_return([v1, v2])
       expect(v1).to receive(:delete)
       expect(v2).to receive(:delete)
       described_class.new.delete('foo')
@@ -46,10 +46,10 @@ RSpec.describe VBADocuments::ObjectStore do
       v2 = instance_double(Aws::S3::ObjectVersion)
       t1 = Time.zone.now - 1.minute
       t2 = Time.zone.now - 2.minutes
-      expect(v1).to receive(:last_modified).and_return(t1)
-      expect(v2).to receive(:last_modified).and_return(t2)
-      expect(@resource).to receive(:bucket).and_return(@bucket)
-      expect(@bucket).to receive(:object_versions).and_return([v1, v2])
+      allow(v1).to receive(:last_modified).and_return(t1)
+      allow(v2).to receive(:last_modified).and_return(t2)
+      allow(@resource).to receive(:bucket).and_return(@bucket)
+      allow(@bucket).to receive(:object_versions).and_return([v1, v2])
       result = described_class.new.first_version('foo')
       expect(result).to eq(v2)
     end
@@ -58,9 +58,9 @@ RSpec.describe VBADocuments::ObjectStore do
   describe '#download' do
     it 'downloads the specified version' do
       v1 = instance_double(Aws::S3::ObjectVersion)
-      expect(v1).to receive(:bucket_name).and_return('my-bucket')
-      expect(v1).to receive(:object_key).and_return('foo')
-      expect(v1).to receive(:version_id).and_return('123456')
+      allow(v1).to receive(:bucket_name).and_return('my-bucket')
+      allow(v1).to receive(:object_key).and_return('foo')
+      allow(v1).to receive(:version_id).and_return('123456')
       expect(@client).to receive(:get_object).with(hash_including(
                                                      bucket: 'my-bucket',
                                                      key: 'foo',

--- a/modules/vba_documents/spec/models/upload_submission_spec.rb
+++ b/modules/vba_documents/spec/models/upload_submission_spec.rb
@@ -98,8 +98,8 @@ describe VBADocuments::UploadSubmission, type: :model do
 
   describe 'refresh_status!' do
     it 'updates received status from upstream' do
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(received_body)
       upload_received.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
@@ -107,8 +107,8 @@ describe VBADocuments::UploadSubmission, type: :model do
     end
 
     it 'updates processing status from upstream' do
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(processing_body)
       upload_received.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
@@ -116,8 +116,8 @@ describe VBADocuments::UploadSubmission, type: :model do
     end
 
     it 'updates processing success status from upstream' do
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(processing_success_body)
       upload_received.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
@@ -127,8 +127,8 @@ describe VBADocuments::UploadSubmission, type: :model do
     it 'updates completed status from upstream to VBMS' do
       resp = status_complete_packets(VBADocuments::UploadSubmission::COMPLETED_DOWNLOAD_CONFIRMED,
                                      VBADocuments::UploadSubmission::COMPLETED_UPLOAD_SUCCEEDED)
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(resp)
       upload_success.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_success.guid)
@@ -138,8 +138,8 @@ describe VBADocuments::UploadSubmission, type: :model do
 
     it 'updates completed status from upstream to SUCCESS and marked as final' do
       resp = status_complete_packets(VBADocuments::UploadSubmission::COMPLETED_DOWNLOAD_CONFIRMED)
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(resp)
       upload_success.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_success.guid)
@@ -151,8 +151,8 @@ describe VBADocuments::UploadSubmission, type: :model do
       resp = status_complete_packets(VBADocuments::UploadSubmission::COMPLETED_DOWNLOAD_CONFIRMED,
                                      VBADocuments::UploadSubmission::COMPLETED_UNIDENTIFIABLE_MAIL,
                                      VBADocuments::UploadSubmission::COMPLETED_DOWNLOAD_CONFIRMED)
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(resp)
       upload_success.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_success.guid)
@@ -163,8 +163,8 @@ describe VBADocuments::UploadSubmission, type: :model do
 
     it 'Logs an error if no packets are sent' do
       resp = status_complete_packets
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(resp)
       upload_success.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_success.guid)
@@ -186,8 +186,8 @@ describe VBADocuments::UploadSubmission, type: :model do
         ]
       }]].to_json
 
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(resp)
       upload_success.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_success.guid)
@@ -195,8 +195,8 @@ describe VBADocuments::UploadSubmission, type: :model do
     end
 
     it 'updates success status from upstream' do
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(success_body)
       upload_processing.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_processing.guid)
@@ -204,8 +204,8 @@ describe VBADocuments::UploadSubmission, type: :model do
     end
 
     it 'updates error status from upstream' do
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(processing_error_body)
       upload_received.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
@@ -215,8 +215,8 @@ describe VBADocuments::UploadSubmission, type: :model do
     end
 
     it 'updates processing error status from upstream' do
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(error_body)
       upload_received.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
@@ -241,9 +241,9 @@ describe VBADocuments::UploadSubmission, type: :model do
     end
 
     it 'raises on error status from upstream without updating state' do
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(false)
-      expect(faraday_response).to receive(:status).and_return(401)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(false)
+      allow(faraday_response).to receive(:status).and_return(401)
       expect(faraday_response).to receive(:body).at_least(:once).and_return('Unauthorized')
       expect { upload_received.refresh_status! }.to raise_error(Common::Exceptions::BadGateway)
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
@@ -251,9 +251,9 @@ describe VBADocuments::UploadSubmission, type: :model do
     end
 
     it 'raises on duplicate error status from upstream and updates state' do
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(false)
-      expect(faraday_response).to receive(:status).and_return(401)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(false)
+      allow(faraday_response).to receive(:status).and_return(401)
       expect(faraday_response).to receive(:body).at_least(:once).and_return('Document already uploaded with uuid')
       expect { upload_received.refresh_status! }.to raise_error(Common::Exceptions::BadGateway)
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
@@ -261,8 +261,8 @@ describe VBADocuments::UploadSubmission, type: :model do
     end
 
     it 'raises on unexpected status from upstream without updating state' do
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(nonsense_body)
       expect { upload_received.refresh_status! }.to raise_error(Common::Exceptions::BadGateway)
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)
@@ -270,8 +270,8 @@ describe VBADocuments::UploadSubmission, type: :model do
     end
 
     it 'ignores empty status from upstream for known uuid' do
-      expect(client_stub).to receive(:status).and_return(faraday_response)
-      expect(faraday_response).to receive(:success?).and_return(true)
+      allow(client_stub).to receive(:status).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
       expect(faraday_response).to receive(:body).at_least(:once).and_return(empty_body)
       upload_received.refresh_status!
       updated = VBADocuments::UploadSubmission.find_by(guid: upload_received.guid)

--- a/modules/vba_documents/spec/request/v0/upload_complete_request_spec.rb
+++ b/modules/vba_documents/spec/request/v0/upload_complete_request_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'VBA Document SNS upload complete notification', type: :request d
             token: token,
             topic_arn: 'arn:aws:sns:us-west-2:123456789012:MyTopic'
           )
-          expect(Aws::SNS::Client).to receive(:new).with(region: 'us-gov-west-1').and_return(client)
+          allow(Aws::SNS::Client).to receive(:new).with(region: 'us-gov-west-1').and_return(client)
           verifier = double(Aws::SNS::MessageVerifier)
           allow(verifier).to receive(:authentic?).and_return(true)
           allow(Aws::SNS::MessageVerifier).to receive(:new).and_return(verifier)

--- a/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v1/uploads_request_spec.rb
@@ -98,10 +98,10 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request, retry: 3 do
         allow(faraday_response).to receive(:body).and_return([[], []].to_json)
         allow(faraday_response).to receive(:success?).and_return(true)
         allow(VBADocuments::PayloadManager).to receive(:download_raw_file) { [Tempfile.new, Time.zone.now] }
-        expect(client_stub).to receive(:upload) {
+        allow(client_stub).to receive(:upload) {
           faraday_response
         }
-        expect(client_stub).to receive(:status) {
+        allow(client_stub).to receive(:status) {
           faraday_response
         }
       end

--- a/modules/vba_documents/spec/request/v2/uploads_request_spec.rb
+++ b/modules/vba_documents/spec/request/v2/uploads_request_spec.rb
@@ -167,10 +167,10 @@ RSpec.describe 'VBA Document Uploads Endpoint', type: :request, retry: 3 do
         allow(faraday_response).to receive(:body).and_return([[], []].to_json)
         allow(faraday_response).to receive(:success?).and_return(true)
         allow(VBADocuments::PayloadManager).to receive(:download_raw_file) { [Tempfile.new, Time.zone.now] }
-        expect(client_stub).to receive(:upload) {
+        allow(client_stub).to receive(:upload) {
           faraday_response
         }
-        expect(client_stub).to receive(:status) {
+        allow(client_stub).to receive(:status) {
           faraday_response
         }
       end

--- a/modules/veteran_confirmation/spec/services/veteran_confirmation/status_service_spec.rb
+++ b/modules/veteran_confirmation/spec/services/veteran_confirmation/status_service_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe VeteranConfirmation::StatusService do
       end
 
       it 'confirms veteran status for persons with a title38 status of V1' do
-        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+        allow_any_instance_of(MPI::AttrService).to receive(:find_profile)
           .and_return(mvi_profile)
-        expect_any_instance_of(EMIS::VeteranStatusService).to receive(:get_veteran_status)
+        allow_any_instance_of(EMIS::VeteranStatusService).to receive(:get_veteran_status)
           .and_return(veteran_status_response)
 
         result = subject.get_by_attributes(valid_attributes)
@@ -85,9 +85,9 @@ RSpec.describe VeteranConfirmation::StatusService do
       end
 
       it 'does not confirm for title38 status codes other than V1' do
-        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+        allow_any_instance_of(MPI::AttrService).to receive(:find_profile)
           .and_return(mvi_profile)
-        expect_any_instance_of(EMIS::VeteranStatusService).to receive(:get_veteran_status)
+        allow_any_instance_of(EMIS::VeteranStatusService).to receive(:get_veteran_status)
           .and_return(non_veteran_status_response)
 
         result = subject.get_by_attributes(valid_attributes)
@@ -95,7 +95,7 @@ RSpec.describe VeteranConfirmation::StatusService do
       end
 
       it 'raises an exception if MVI returns a server error' do
-        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+        allow_any_instance_of(MPI::AttrService).to receive(:find_profile)
           .and_return(server_error_mvi_profile)
 
         expect do
@@ -104,7 +104,7 @@ RSpec.describe VeteranConfirmation::StatusService do
       end
 
       it 'does not confirm if a profile is not found in MVI' do
-        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+        allow_any_instance_of(MPI::AttrService).to receive(:find_profile)
           .and_return(not_found_mvi_profile)
 
         result = subject.get_by_attributes(valid_attributes)
@@ -113,10 +113,10 @@ RSpec.describe VeteranConfirmation::StatusService do
       end
 
       it 'does not confirm if EMIS returns an error response' do
-        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+        allow_any_instance_of(MPI::AttrService).to receive(:find_profile)
           .and_return(mvi_profile)
 
-        expect_any_instance_of(EMIS::VeteranStatusService).to receive(:get_veteran_status)
+        allow_any_instance_of(EMIS::VeteranStatusService).to receive(:get_veteran_status)
           .and_return(emis_error)
 
         result = subject.get_by_attributes(valid_attributes)
@@ -125,10 +125,10 @@ RSpec.describe VeteranConfirmation::StatusService do
       end
 
       it 'does not confirm if EMIS returns an empty response' do
-        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+        allow_any_instance_of(MPI::AttrService).to receive(:find_profile)
           .and_return(mvi_profile)
 
-        expect_any_instance_of(EMIS::VeteranStatusService).to receive(:get_veteran_status)
+        allow_any_instance_of(EMIS::VeteranStatusService).to receive(:get_veteran_status)
           .and_return(empty_veteran_status_response)
 
         result = subject.get_by_attributes(valid_attributes)
@@ -148,9 +148,9 @@ RSpec.describe VeteranConfirmation::StatusService do
       end
 
       it 'confirms veteran status for persons with a title38 status of V1' do
-        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+        allow_any_instance_of(MPI::AttrService).to receive(:find_profile)
           .and_return(mvi_profile)
-        expect_any_instance_of(EMIS::MockVeteranStatusService).to receive(:get_veteran_status)
+        allow_any_instance_of(EMIS::MockVeteranStatusService).to receive(:get_veteran_status)
           .and_return(veteran_status_response)
 
         result = subject.get_by_attributes(valid_attributes)
@@ -158,9 +158,9 @@ RSpec.describe VeteranConfirmation::StatusService do
       end
 
       it 'does not confirm for title38 status codes other than V1' do
-        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+        allow_any_instance_of(MPI::AttrService).to receive(:find_profile)
           .and_return(mvi_profile)
-        expect_any_instance_of(EMIS::MockVeteranStatusService).to receive(:get_veteran_status)
+        allow_any_instance_of(EMIS::MockVeteranStatusService).to receive(:get_veteran_status)
           .and_return(non_veteran_status_response)
 
         result = subject.get_by_attributes(valid_attributes)
@@ -168,7 +168,7 @@ RSpec.describe VeteranConfirmation::StatusService do
       end
 
       it 'raises an exception if MVI returns a server error' do
-        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+        allow_any_instance_of(MPI::AttrService).to receive(:find_profile)
           .and_return(server_error_mvi_profile)
 
         expect do
@@ -177,7 +177,7 @@ RSpec.describe VeteranConfirmation::StatusService do
       end
 
       it 'does not confirm if a profile is not found in MVI' do
-        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+        allow_any_instance_of(MPI::AttrService).to receive(:find_profile)
           .and_return(not_found_mvi_profile)
 
         result = subject.get_by_attributes(valid_attributes)
@@ -186,10 +186,10 @@ RSpec.describe VeteranConfirmation::StatusService do
       end
 
       it 'does not confirm if EMIS returns an error response' do
-        expect_any_instance_of(MPI::AttrService).to receive(:find_profile)
+        allow_any_instance_of(MPI::AttrService).to receive(:find_profile)
           .and_return(mvi_profile)
 
-        expect_any_instance_of(EMIS::MockVeteranStatusService).to receive(:get_veteran_status)
+        allow_any_instance_of(EMIS::MockVeteranStatusService).to receive(:get_veteran_status)
           .and_return(emis_error)
 
         result = subject.get_by_attributes(valid_attributes)


### PR DESCRIPTION
## Description of change
Fixing Rubocop RSpec/StubbedMock offenses. Offense count: 258 (In this PR)
This is broken into 2 parts to keep the PR under 500 lines

## Original issue(s)
department-of-veterans-affairs/va.gov-team#26887