### PR TITLE
Toggle virus scanner

### DIFF
--- a/app/uploaders/form1010cg/poa_uploader.rb
+++ b/app/uploaders/form1010cg/poa_uploader.rb
@@ -4,7 +4,7 @@ module Form1010cg
   class PoaUploader < CarrierWave::Uploader::Base
     include SetAWSConfig
     include LogMetrics
-    include UploaderVirusScan
+    include UploaderVirusScan if Flipper.enabled?('10_10cg_poa_upload_virus_scanner_enabled')
 
     storage :aws
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,10 @@ features:
   can_upload_10_10cg_poa:
     actor_type: cookie_id
     description: Allows users to upload POA documentation when completing the 10-10CG.
+  10_10cg_poa_upload_virus_scanner_enabled:
+    actor_type: cookie_id
+    description: Feature to turn off virus scanner in lower environments.
+    enable_in_development: true
   cerner_override_463:
     actor_type: user
     description: This will show the Cerner facility 463 as `isCerner`.


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->
- We want the ability to test Form 1010CG file upload in the staging environment with the virus scanner turned off
- Currently, the file upload shows as failed in the UI even though the data is persisted in the staging s3 bucket.
- The vets-api request to process and upload the file takes well over a minute while the revproxy time out is 60 seconds.
- When the revproxy times out, it returns a 504 back to the UI without any of the expected CORS headers.
- Please see the following slack conversation for more information.
- This feature will be turned on in production.
- https://dsva.slack.com/archives/CBU0KDSB1/p1643052924190500
## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
