### PR TITLE
36452/36402: Flippers for vets-website mobile auth logic

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -321,6 +321,14 @@ features:
     actor_type: cookie_id
     description: Enables/disables the Login.gov button for MyVAHealth (VSP Identity)
     enable_in_development: true
+  login_mobile_occ:
+    actor_type: cookie_id
+    description: Enables/disables the USiP being able to handle mobile authentication logic for VA OCC mobile app
+    enable_in_development: true
+  login_mobile_flagship:
+    actor_type: cookie_id
+    description: Enables/disables the USiP being able to handle mobile authentication logic for VA Flagshig mobile app
+    enable_in_development: true
   loop_pages:
     actor_type: user
     description: Enable new list loop pattern


### PR DESCRIPTION
## Description of change
Adds 2 feature flags to be used by the `vets-website` unified sign-in page which allows it to handle mobile application authentication.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#36452
department-of-veterans-affairs/va.gov-team#36402

## Things to know about this PR
1. `login_mobile_occ`: enables mobile authentication flow on `vets-website` for VA OCC application.
2. `login_mobile_flagship`: enables mobile authentication flow on `vets-website` for VA Flagship application.
