### PR TITLE
Remove timestamp from BP reading

### DIFF
--- a/app/services/rapid_ready_for_decision/hypertension_pdf_generator.rb
+++ b/app/services/rapid_ready_for_decision/hypertension_pdf_generator.rb
@@ -84,8 +84,7 @@ module RapidReadyForDecision
 
         @pdf.text "<b>Blood pressure: #{systolic}/#{diastolic}</b>",
                   inline_format: true, size: 11
-        @pdf.text "Taken on: #{bp[:effectiveDateTime].to_date.strftime('%m/%d/%Y')} " \
-                  "at #{Time.iso8601(bp[:effectiveDateTime]).strftime('%H:%M %Z')}",
+        @pdf.text "Taken on: #{bp[:effectiveDateTime].to_date.strftime('%m/%d/%Y')} ",
                   size: 11
         @pdf.text "Location: #{bp[:organization] || 'Unknown'}", size: 11
         @pdf.text "\n", size: 8


### PR DESCRIPTION
## Description of change
Small change removes the timestamp from the BP readings

## Original issue(s)
https://www.notion.so/PDF-Display-the-effective-date-for-the-BP-reading-instead-of-the-issued-date-b82a61b2e11544f18e8b7f361e9022d5

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
