### PR TITLE
RRD: revert some code to diagnose lack of special issue and PDF problem 

### DIFF
--- a/app/services/rapid_ready_for_decision/hypertension_special_issue_manager.rb
+++ b/app/services/rapid_ready_for_decision/hypertension_special_issue_manager.rb
@@ -9,8 +9,8 @@ module RapidReadyForDecision
     end
 
     def add_special_issue
-      submission_data = JSON.parse(submission.form_json)
-      disabilities = submission_data.dig('form526', 'form526', 'disabilities')
+      submission_data = JSON.parse(submission.form_json, symbolize_names: true)
+      disabilities = submission_data[:form526][:form526][:disabilities]
       disabilities.each do |disability|
         add_rrd_code(disability) if hypertension_increase?(disability)
       end
@@ -23,13 +23,16 @@ module RapidReadyForDecision
     RRD_CODE = 'RRD'
 
     def hypertension_increase?(disability)
-      RapidReadyForDecision::ProcessorSelector.disability_increase?(disability, HYPERTENSION_CODE)
+      # Does the same as RapidReadyForDecision::ProcessorSelector.disability_increase?(disability, HYPERTENSION_CODE)
+      # except using symbols as the keys instead of strings
+      disability[:diagnosticCode] == HYPERTENSION_CODE &&
+        disability[:disabilityActionType].downcase == 'increase'
     end
 
     # Must return an array containing special string codes for EVSS
     def add_rrd_code(disability)
-      disability['specialIssues'] ||= []
-      disability['specialIssues'].append(RRD_CODE) unless disability['specialIssues'].include?(RRD_CODE)
+      disability[:specialIssues] ||= []
+      disability[:specialIssues].append(RRD_CODE) unless disability[:specialIssues].include?(RRD_CODE)
       disability
     end
   end

--- a/app/services/rapid_ready_for_decision/processor_selector.rb
+++ b/app/services/rapid_ready_for_decision/processor_selector.rb
@@ -22,7 +22,7 @@ module RapidReadyForDecision
 
     def self.disability_increase?(disability, diagnostic_code)
       disability['diagnosticCode'] == diagnostic_code &&
-        disability['disabilityActionType'] == 'INCREASE'
+        disability['disabilityActionType'].upcase == 'INCREASE'
     end
 
     private


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

Some refactoring was done in #9181 that likely caused a problem with submission to EVSS. This PR reverts the most likely change (using symbols as the keys into a hash instead of strings).

## Original issue(s)
[Slack thread describing the problem](https://dsva.slack.com/archives/C01BVF2A3V0/p1645819743365719): claims do not have the 'RRD' special issue or PDF file that RRD generates.

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

We're gradually rolling back small changes at a time to help us identify the root cause, since EVSS is somewhat of a blackhole and we can't query its data to check our Form 526 submission.

<!-- Please describe testing done to verify the changes or any testing planned. -->
