### PR TITLE
37423 updates authn CSP_METHOD for new logins

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -171,15 +171,15 @@ module V1
       when 'mhv'
         url_service.login_url('mhv', 'myhealthevet', 'IDME_MHV')
       when 'mhv_verified'
-        url_service.login_url('mhv', 'myhealthevet_loa3', AuthnContext::ID_ME)
+        url_service.login_url('mhv', 'myhealthevet_loa3', 'IDME_MHV')
       when 'dslogon'
         url_service.login_url('dslogon', 'dslogon', 'IDME_DSL')
       when 'dslogon_verified'
-        url_service.login_url('dslogon', 'dslogon_loa3', AuthnContext::ID_ME)
+        url_service.login_url('dslogon', 'dslogon_loa3', 'IDME_DSL')
       when 'idme'
         url_service.login_url('idme', LOA::IDME_LOA1_VETS, 'IDME', AuthnContext::MINIMUM)
       when 'idme_verified'
-        url_service.login_url('idme', LOA::IDME_LOA3, AuthnContext::ID_ME, AuthnContext::MINIMUM)
+        url_service.login_url('idme', LOA::IDME_LOA3, 'IDME')
       when 'idme_signup'
         url_service.idme_signup_url(LOA::IDME_LOA1_VETS)
       when 'idme_signup_verified'
@@ -195,8 +195,7 @@ module V1
         url_service.login_url(
           'logingov',
           [IAL::LOGIN_GOV_IAL2, AAL::LOGIN_GOV_AAL2],
-          AuthnContext::LOGIN_GOV,
-          AuthnContext::MINIMUM
+          'LOGINGOV'
         )
       when 'logingov_signup'
         url_service.logingov_signup_url([IAL::LOGIN_GOV_IAL1, AAL::LOGIN_GOV_AAL2])

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -169,15 +169,15 @@ module V1
 
       case type
       when 'mhv'
-        url_service.login_url('mhv', 'myhealthevet')
+        url_service.login_url('mhv', 'myhealthevet', 'IDME_MHV')
       when 'mhv_verified'
-        url_service.login_url('mhv', 'myhealthevet_loa3')
+        url_service.login_url('mhv', 'myhealthevet_loa3', AuthnContext::ID_ME)
       when 'dslogon'
-        url_service.login_url('dslogon', 'dslogon')
+        url_service.login_url('dslogon', 'dslogon', 'IDME_DSL')
       when 'dslogon_verified'
-        url_service.login_url('dslogon', 'dslogon_loa3')
+        url_service.login_url('dslogon', 'dslogon_loa3', AuthnContext::ID_ME)
       when 'idme'
-        url_service.login_url('idme', LOA::IDME_LOA1_VETS, AuthnContext::ID_ME, AuthnContext::MINIMUM)
+        url_service.login_url('idme', LOA::IDME_LOA1_VETS, 'IDME', AuthnContext::MINIMUM)
       when 'idme_verified'
         url_service.login_url('idme', LOA::IDME_LOA3, AuthnContext::ID_ME, AuthnContext::MINIMUM)
       when 'idme_signup'
@@ -188,7 +188,7 @@ module V1
         url_service.login_url(
           'logingov',
           [IAL::LOGIN_GOV_IAL1, AAL::LOGIN_GOV_AAL2],
-          AuthnContext::LOGIN_GOV,
+          'LOGINGOV',
           AuthnContext::MINIMUM
         )
       when 'logingov_verified'

--- a/config/initializers/authn_context.rb
+++ b/config/initializers/authn_context.rb
@@ -4,8 +4,7 @@ module AuthnContext
   ID_ME = 'https://eauth.va.gov/csp?Select=idme3'
   LOGIN_GOV = 'https://eauth.va.gov/csp?Select=logingov3'
 
-  CSP_METHODS = %w[DSL CAC DFAS DSL_SURROGATE CAC_SURROGATE DFAS_SURROGATE DSL_LOGINGOV
-                   DSL_LOGINGOV_SURROGATE IDME IDME_DSL IDME_MHV IDME_VETS LOGINGOV MHV VACAC VAPIV VCSP]
+  CSP_METHODS = %w[IDME LOGINGOV IDME_MHV IDME_DSL].freeze
   CSP_URL = 'https://eauth.va.gov/csp/'
 
   EXACT = 'exact'

--- a/config/initializers/authn_context.rb
+++ b/config/initializers/authn_context.rb
@@ -3,6 +3,11 @@
 module AuthnContext
   ID_ME = 'https://eauth.va.gov/csp?Select=idme3'
   LOGIN_GOV = 'https://eauth.va.gov/csp?Select=logingov3'
+
+  CSP_METHODS = %w[DSL CAC DFAS DSL_SURROGATE CAC_SURROGATE DFAS_SURROGATE DSL_LOGINGOV
+                   DSL_LOGINGOV_SURROGATE IDME IDME_DSL IDME_MHV IDME_VETS LOGINGOV MHV VACAC VAPIV VCSP]
+  CSP_URL = 'https://eauth.va.gov/csp/'
+
   EXACT = 'exact'
   MINIMUM = 'minimum'
 end

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -182,10 +182,13 @@ module SAML
       saml_auth_request.create(new_url_settings, query_params)
     end
 
-    def build_authn_context(authn_context, csp_method)
-      require 'pry'; binding.pry
-      assurance_level_url = [assurance_level_url] unless assurance_level_url.is_a?(Array)
-      assurance_level_url.push(build_csp_url(csp_method))
+    def build_authn_context(authn_context, csp_method = AuthnContext::ID_ME)
+      authn_context = [authn_context] unless authn_context.is_a?(Array)
+      if csp_method == AuthnContext::ID_ME || csp_method == AuthnContext::LOGIN_GOV
+        authn_context.push(csp_method)
+      else
+        authn_context.push(build_csp_url(csp_method))
+      end
     end
 
     def build_csp_url(csp_method)

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -129,9 +129,9 @@ module SAML
         when 'logingov'
           build_authn_context([IAL::LOGIN_GOV_IAL2, AAL::LOGIN_GOV_AAL2], 'LOGINGOV')
         when 'mhv'
-          build_authn_context('myhealthevet_loa3')
+          build_authn_context('myhealthevet_loa3', 'IDME_MHV')
         when 'dslogon'
-          build_authn_context('dslogon_loa3')
+          build_authn_context('dslogon_loa3', 'IDME_DSL')
         end
 
       build_sso_url(link_authn_context)
@@ -184,7 +184,7 @@ module SAML
 
     def build_authn_context(authn_context, csp_method = AuthnContext::ID_ME)
       authn_context = [authn_context] unless authn_context.is_a?(Array)
-      if csp_method == AuthnContext::ID_ME || csp_method == AuthnContext::LOGIN_GOV
+      if csp_method == AuthnContext::ID_ME
         authn_context.push(csp_method)
       else
         authn_context.push(build_csp_url(csp_method))

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -89,21 +89,21 @@ RSpec.describe V1::SessionsController, type: :controller do
             let(:authn) do
               case type
               when 'mhv'
-                ['myhealthevet', AuthnContext::ID_ME]
+                ['myhealthevet', 'https://eauth.va.gov/csp/IDME_MHV']
               when 'mhv_verified'
                 ['myhealthevet_loa3', AuthnContext::ID_ME]
               when 'idme'
-                [LOA::IDME_LOA1_VETS, AuthnContext::ID_ME]
+                [LOA::IDME_LOA1_VETS, 'https://eauth.va.gov/csp/IDME']
               when 'idme_verified'
                 [LOA::IDME_LOA3, AuthnContext::ID_ME]
               when 'dslogon'
-                ['dslogon', AuthnContext::ID_ME]
+                ['dslogon', 'https://eauth.va.gov/csp/IDME_DSL']
               when 'dslogon_verified'
                 ['dslogon_loa3', AuthnContext::ID_ME]
               when 'logingov'
                 [IAL::LOGIN_GOV_IAL1,
                  AAL::LOGIN_GOV_AAL2,
-                 AuthnContext::LOGIN_GOV]
+                 'https://eauth.va.gov/csp/LOGINGOV']
               when 'logingov_verified'
                 [IAL::LOGIN_GOV_IAL2,
                  AAL::LOGIN_GOV_AAL2,


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This PR updates the CSP identifier information included in the `authn_context` sent to IAM when authenticating users. The new URL included is `eauth.va.gov/csp/CSP_METHOD`. In this change the authn_context is changed for the SAML generated for outbound login requests for all 4 CSPS. Other routes will be changed over in subsequent PRs after further coordination with IAM. ID.me/Login.gov signup routes were also changed, as they are functionally almost identical to the normal ID.me/Login.gov authentication SAML formatting.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37423

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
Affected unit specs have been updated. Manual logins attempts with all four CSPS: Login.gov & ID.me were successful, was directed to MHV login (where it is then blocked for localhost/dev), went through DSLogon authentication successfully but errored out after choosing the account's security image. For reproduction, the updated authn_context can seen by base64 decoding the SSORequest param passed in the authentication call to ISAM.