### PR TITLE
37204 session refresh endpoint

### DIFF
--- a/app/services/sign_in/errors.rb
+++ b/app/services/sign_in/errors.rb
@@ -15,5 +15,6 @@ module SignIn
     class AntiCSRFMismatchError < StandardError; end
     class SessionNotAuthorizedError < StandardError; end
     class TokenTheftDetectedError < StandardError; end
+    class MalformedParamsError < StandardError; end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   get '/sign_in/:type/callback',
       to: 'sign_in#callback',
       constraints: ->(request) { SignInController::REDIRECT_URLS.include?(request.path_parameters[:type]) }
+  post '/sign_in/refresh', to: 'sign_in#refresh'
 
   namespace :v0, defaults: { format: 'json' } do
     resources :onsite_notifications, only: %i[create index update]

--- a/spec/controllers/sign_in_controller_spec.rb
+++ b/spec/controllers/sign_in_controller_spec.rb
@@ -56,4 +56,215 @@ RSpec.describe SignInController, type: :controller do
       end
     end
   end
+
+  describe 'POST refresh' do
+    subject { post(:refresh, params: {}.merge(refresh_token_param).merge(anti_csrf_token_param)) }
+
+    let(:refresh_token_param) { { refresh_token: refresh_token } }
+    let(:anti_csrf_token_param) { { anti_csrf_token: anti_csrf_token } }
+    let(:refresh_token) { 'some-refresh-token' }
+    let(:anti_csrf_token) { 'some-anti-csrf-token' }
+
+    context 'when refresh_token and anti_csrf_token param is given' do
+      context 'and refresh_token is an arbitrary string' do
+        let(:refresh_token) { 'some-refresh-token' }
+        let(:expected_error) { 'Decryption failed' }
+        let(:expected_error_json) { { 'errors' => expected_error } }
+
+        it 'renders Decryption failed error' do
+          expect(JSON.parse(subject.body)).to eq(expected_error_json)
+        end
+
+        it 'returns unauthorized status' do
+          expect(subject).to have_http_status(:unauthorized)
+        end
+      end
+
+      context 'and refresh_token is the proper encrypted refresh token format' do
+        let(:user_account) { create(:user_account) }
+        let(:session_container) { SignIn::SessionCreator.new(user_account: user_account).perform }
+        let(:refresh_token) do
+          SignIn::RefreshTokenEncryptor.new(refresh_token: session_container.refresh_token).perform
+        end
+        let(:anti_csrf_token) { session_container.anti_csrf_token }
+
+        context 'and encrypted component has been modified' do
+          let(:expected_error) { 'Decryption failed' }
+          let(:expected_error_json) { { 'errors' => expected_error } }
+
+          let(:refresh_token) do
+            token = SignIn::RefreshTokenEncryptor.new(refresh_token: session_container.refresh_token).perform
+            split_token = token.split('.')
+            split_token[0] = 'some-modified-encrypted-component'
+            split_token.join
+          end
+
+          it 'renders Decryption failed error' do
+            expect(JSON.parse(subject.body)).to eq(expected_error_json)
+          end
+
+          it 'returns unauthorized status' do
+            expect(subject).to have_http_status(:unauthorized)
+          end
+        end
+
+        context 'and nonce component has been modified' do
+          let(:expected_error) { SignIn::Errors::RefreshNonceMismatchError.to_s }
+          let(:expected_error_json) { { 'errors' => expected_error } }
+
+          let(:refresh_token) do
+            token = SignIn::RefreshTokenEncryptor.new(refresh_token: session_container.refresh_token).perform
+            split_token = token.split('.')
+            split_token[1] = 'some-modified-nonce-component'
+            split_token.join('.')
+          end
+
+          it 'renders a nonce mismatch error' do
+            expect(JSON.parse(subject.body)).to eq(expected_error_json)
+          end
+
+          it 'returns unauthorized status' do
+            expect(subject).to have_http_status(:unauthorized)
+          end
+        end
+
+        context 'and version has been modified' do
+          let(:expected_error) { SignIn::Errors::RefreshVersionMismatchError.to_s }
+          let(:expected_error_json) { { 'errors' => expected_error } }
+
+          let(:refresh_token) do
+            token = SignIn::RefreshTokenEncryptor.new(refresh_token: session_container.refresh_token).perform
+            split_token = token.split('.')
+            split_token[2] = 'some-modified-version-component'
+            split_token.join('.')
+          end
+
+          it 'renders a version mismatch error' do
+            expect(JSON.parse(subject.body)).to eq(expected_error_json)
+          end
+
+          it 'returns unauthorized status' do
+            expect(subject).to have_http_status(:unauthorized)
+          end
+        end
+
+        context 'and anti_csrf_token has been modified' do
+          let(:expected_error) { SignIn::Errors::AntiCSRFMismatchError.to_s }
+          let(:expected_error_json) { { 'errors' => expected_error } }
+
+          let(:anti_csrf_token) { 'some-modified-anti-csrf-token' }
+
+          it 'renders an anti csrf mismatch error' do
+            expect(JSON.parse(subject.body)).to eq(expected_error_json)
+          end
+
+          it 'returns unauthorized status' do
+            expect(subject).to have_http_status(:unauthorized)
+          end
+        end
+
+        context 'and refresh token is expired' do
+          let(:expected_error) { SignIn::Errors::SessionNotAuthorizedError.to_s }
+          let(:expected_error_json) { { 'errors' => expected_error } }
+
+          before do
+            session = session_container.session
+            session.refresh_expiration = 1.day.ago
+            session.save!
+          end
+
+          it 'renders a session not authorized error' do
+            expect(JSON.parse(subject.body)).to eq(expected_error_json)
+          end
+
+          it 'returns unauthorized status' do
+            expect(subject).to have_http_status(:unauthorized)
+          end
+        end
+
+        context 'and refresh token does not map to an existing session' do
+          let(:expected_error) { SignIn::Errors::SessionNotAuthorizedError.to_s }
+          let(:expected_error_json) { { 'errors' => expected_error } }
+
+          before do
+            session = session_container.session
+            session.destroy!
+          end
+
+          it 'renders a session not authorized error' do
+            expect(JSON.parse(subject.body)).to eq(expected_error_json)
+          end
+
+          it 'returns unauthorized status' do
+            expect(subject).to have_http_status(:unauthorized)
+          end
+        end
+
+        context 'and refresh token is not a parent or child according to the session' do
+          let(:expected_error) { SignIn::Errors::TokenTheftDetectedError.to_s }
+          let(:expected_error_json) { { 'errors' => expected_error } }
+
+          before do
+            session = session_container.session
+            session.hashed_refresh_token = 'some-unrelated-refresh-token'
+            session.save!
+          end
+
+          it 'renders a session not authorized error' do
+            expect(JSON.parse(subject.body)).to eq(expected_error_json)
+          end
+
+          it 'returns unauthorized status' do
+            expect(subject).to have_http_status(:unauthorized)
+          end
+        end
+
+        context 'and both refresh token and anti csrf token are unmodified and valid' do
+          it 'returns ok status' do
+            expect(subject).to have_http_status(:ok)
+          end
+
+          it 'returns expected body with access token' do
+            expect(JSON.parse(subject.body)['data']).to have_key('access_token')
+          end
+
+          it 'returns expected body with refresh token' do
+            expect(JSON.parse(subject.body)['data']).to have_key('refresh_token')
+          end
+
+          it 'returns expected body with anti csrf token token' do
+            expect(JSON.parse(subject.body)['data']).to have_key('anti_csrf_token')
+          end
+        end
+      end
+    end
+
+    context 'when refresh_token param is not given' do
+      let(:expected_error) { SignIn::Errors::MalformedParamsError.to_s }
+      let(:expected_error_json) { { 'errors' => expected_error } }
+      let(:refresh_token_param) { {} }
+
+      it 'renders Malformed Params error' do
+        expect(JSON.parse(subject.body)).to eq(expected_error_json)
+      end
+
+      it 'returns unauthorized status' do
+        expect(subject).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when anti_csrf_token param is not given' do
+      let(:expected_error) { SignIn::Errors::MalformedParamsError.to_s }
+      let(:expected_error_json) { { 'errors' => expected_error } }
+      let(:anti_csrf_token_param) { {} }
+
+      it 'renders Malformed Params error' do
+        expect(JSON.parse(subject.body)).to eq(expected_error_json)
+      end
+
+      it 'returns unauthorized status' do
+        expect(subject).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
This PR adds an endpoint `sign_in/refresh` that takes a refresh_token and anti_csrf_token as parameters, and extends an existing OAuthSession

## Original issue(s)
department-of-veterans-affairs/va.gov-team#37204

## Things to know about this PR
- Not an easy way to actually create a session through rails server itself, so at the moment you'll have to manually get your refresh token/anti csrf token
- To do this, go on rails console, and do: `session_container = SignIn::SessionCreator.new(user_account: user_account).perform)`, this gets you a session container with relevant objects
- `session_container.anti_csrf_token` copy this value and save it
- `SignIn::RefreshTokenEncryptor.new(refresh_token: session_container.refresh_token).perform` copy this value and save it
- Send a POST request to `sign_in/refresh` with the saved fields above copied to the body of the request: `{ refresh_token: <saved_refresh_token>, anti_csrf_token: <saved_anti_csrf_token> }`
- Expectation is that the `OAuthSession` object on the backend will have `refresh_expiration` extended by 30 minutes, and the response to the POST will have a new `access_token`, `refresh_token`, and `anti_csrf_token`
