### PR TITLE
Fixing timezone bug in tests

### DIFF
--- a/modules/appeals_api/spec/models/higher_level_review_spec.rb
+++ b/modules/appeals_api/spec/models/higher_level_review_spec.rb
@@ -381,7 +381,7 @@ describe AppealsApi::HigherLevelReview, type: :model do
       end
 
       describe '#appellant_local_time' do
-        it { expect(higher_level_review_v2.appellant_local_time.strftime('%Z')).to eq 'EST' }
+        it { expect(higher_level_review_v2.appellant_local_time.strftime('%Z')).to match(/EST|EDT/) }
       end
     end
   end

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -273,7 +273,7 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
     end
 
     describe '#appellant_local_time' do
-      it { expect(notice_of_disagreement_v2.appellant_local_time.strftime('%Z')).to eq 'CST' }
+      it { expect(notice_of_disagreement_v2.appellant_local_time.strftime('%Z')).to match(/CST|CDT/) }
     end
 
     describe '#extension_request?' do


### PR DESCRIPTION
## Description of change
There are two tests that are breaking with the changeover to daylight savings time. This PR changes the tests to match for either EST|EDT or CST|CDT instead of expecting EST and CST.

## Original issue(s)
[https://github.com/department-of-veterans-affairs/vets-api/issues/9341](https://github.com/department-of-veterans-affairs/vets-api/issues/9341)

Tested locally
