### PR TITLE
DHP-92 Scaffold dhp connected devices module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,9 @@ modules/facilities_api @department-of-veterans-affairs/vsa-facilities-backend @d
 spec/support/*/facilities @department-of-veterans-affairs/vsa-facilities-backend @department-of-veterans-affairs/backend-review-group
 spec/support/*/lighthouse @department-of-veterans-affairs/vsa-facilities-backend @department-of-veterans-affairs/backend-review-group
 
+# DHP connected devices
+modules/dhp_connected_devices/ @department-of-veterans-affairs/digital-health-platform @department-of-veterans-affairs/backend-review-group
+
 # test user dashboard product
 modules/test_user_dashboard @department-of-veterans-affairs/vsp-identity @department-of-veterans-affairs/qa-standards
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,6 +83,7 @@ Metrics/MethodLength:
   Max: 20
   Exclude:
     - 'spec/support/form1010cg_helpers/build_claim_data_for.rb'
+    - 'spec/simplecov_helper.rb'
     - 'app/workers/education_form/create_daily_spool_files.rb'
 
 Metrics/ClassLength:

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ path 'modules' do
   gem 'claims_api'
   gem 'covid_research'
   gem 'covid_vaccine'
+  gem 'dhp_connected_devices'
   gem 'facilities_api'
   gem 'health_quest'
   gem 'identity'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ PATH
       sidekiq
     covid_vaccine (0.1.0)
       sidekiq
+    dhp_connected_devices (0.1.0)
     facilities_api (0.1.0)
     health_quest (0.1.0)
     identity (0.1.0)
@@ -1007,6 +1008,7 @@ DEPENDENCIES
   date_validator
   ddtrace
   debase
+  dhp_connected_devices!
   dry-struct
   dry-types
   ethon (>= 0.13.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -413,6 +413,7 @@ Rails.application.routes.draw do
   mount CheckIn::Engine, at: '/check_in'
   mount CovidResearch::Engine, at: '/covid-research'
   mount CovidVaccine::Engine, at: '/covid_vaccine'
+  mount DhpConnectedDevices::Engine, at: '/dhp_connected_devices'
   mount FacilitiesApi::Engine, at: '/facilities_api'
   mount HealthQuest::Engine, at: '/health_quest'
   mount MebApi::Engine, at: '/meb_api'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -573,28 +573,6 @@ claims_api:
   token_validation:
     api_key:
 
-#Settings for DHP Connected Devices
-dhp_connected_devices:
-  report_enabled: false
-  audit_enabled: false
-  s3:
-    enabled: false
-    aws_access_key_id: ~
-    aws_secret_access_key: ~
-    region: ~
-    bucket: ~
-  disability_claims_mock_override: false
-  schema_dir: config/schemas
-  slack:
-    webhook_url: https://example.com
-  claims_pending_reporting:
-    threshold: ~
-    environment_name: ~
-  v2_docs:
-    enabled: false
-  token_validation:
-    api_key:
-
 redis:
   host: localhost
   port: 6379

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -573,6 +573,28 @@ claims_api:
   token_validation:
     api_key:
 
+#Settings for DHP Connected Devices
+dhp_connected_devices:
+  report_enabled: false
+  audit_enabled: false
+  s3:
+    enabled: false
+    aws_access_key_id: ~
+    aws_secret_access_key: ~
+    region: ~
+    bucket: ~
+  disability_claims_mock_override: false
+  schema_dir: config/schemas
+  slack:
+    webhook_url: https://example.com
+  claims_pending_reporting:
+    threshold: ~
+    environment_name: ~
+  v2_docs:
+    enabled: false
+  token_validation:
+    api_key:
+
 redis:
   host: localhost
   port: 6379

--- a/modules/dhp_connected_devices/.rubocop.yml
+++ b/modules/dhp_connected_devices/.rubocop.yml
@@ -1,0 +1,24 @@
+inherit_from:
+  - ../../.rubocop.yml
+
+AllCops:
+  Exclude:
+    - 'bin/*'
+    - bin/rails
+    - db/migrate/*.rb
+    - 'spec/dummy/**/*'
+    - spec/dummy/db/schema.rb
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*.rb
+    - config/**/*.rb
+    - app/swagger/**/*.rb
+
+Metrics/ClassLength:
+  Exclude:
+    - app/swagger/**/*.rb
+
+Layout/LineLength:
+  Exclude:
+    - app/swagger/**/*.rb

--- a/modules/dhp_connected_devices/Gemfile
+++ b/modules/dhp_connected_devices/Gemfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Declare your gem's dependencies in dhpconnecteddevices.gemspec.
+# Bundler will treat runtime dependencies like base dependencies, and
+# development dependencies will be added by default to the :development group.
+gemspec
+
+# Declare any dependencies that are still in development here instead of in
+# your gemspec. These might include edge Rails or gems from your path or
+# Git. Remember to move these dependencies to your gemspec before releasing
+# your gem to rubygems.org.
+
+# To use a debugger
+# gem 'byebug', group: [:development, :test]

--- a/modules/dhp_connected_devices/README.rdoc
+++ b/modules/dhp_connected_devices/README.rdoc
@@ -1,0 +1,10 @@
+= DhpConnectedDevices
+TODO: Short description and motivation.
+
+== Installation
+Ensure the following line is in the root project's Gemfile:
+
+  gem 'dhpconnecteddevices', path: 'modules/dhpconnecteddevices'
+
+== License
+This module is open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/modules/dhp_connected_devices/Rakefile
+++ b/modules/dhp_connected_devices/Rakefile
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+require 'rdoc/task'
+
+RDoc::Task.new(:rdoc) do |rdoc|
+  rdoc.rdoc_dir = 'rdoc'
+  rdoc.title    = 'DhpConnectedDevices'
+  rdoc.options << '--line-numbers'
+  rdoc.rdoc_files.include('README.md')
+  rdoc.rdoc_files.include('lib/**/*.rb')
+end
+
+load 'rails/tasks/statistics.rake'
+
+require 'bundler/gem_tasks'
+
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = false
+end
+
+task default: :test

--- a/modules/dhp_connected_devices/bin/rails
+++ b/modules/dhp_connected_devices/bin/rails
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+ENGINE_ROOT = File.expand_path('../..', __dir__)
+ENGINE_PATH = File.expand_path('../../lib/dhpconnecteddevices/engine', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails/all'
+require 'rails/engine/commands'

--- a/modules/dhp_connected_devices/config/routes.rb
+++ b/modules/dhp_connected_devices/config/routes.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+DhpConnectedDevices::Engine.routes.draw do
+end

--- a/modules/dhp_connected_devices/dhp_connected_devices.gemspec
+++ b/modules/dhp_connected_devices/dhp_connected_devices.gemspec
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
+
+# Maintain your gem's version:
+require 'dhp_connected_devices/version'
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |spec|
+  spec.name        = 'dhp_connected_devices'
+  spec.version     = DhpConnectedDevices::VERSION
+  spec.authors     = ['Rebecca Green']
+  spec.email       = ['rebecca.green@thoughtworks.com']
+  spec.homepage    = 'https://api.va.gov'
+  spec.summary     = 'An api.va.gov module'
+  spec.description = 'This module was auto-generated please update this description'
+  spec.license     = 'CC0-1.0'
+
+  spec.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
+end

--- a/modules/dhp_connected_devices/lib/dhp_connected_devices.rb
+++ b/modules/dhp_connected_devices/lib/dhp_connected_devices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'dhpconnecteddevices/engine'
+
+module DhpConnectedDevices
+  # Your code goes here...
+end

--- a/modules/dhp_connected_devices/lib/dhp_connected_devices.rb
+++ b/modules/dhp_connected_devices/lib/dhp_connected_devices.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'dhpconnecteddevices/engine'
+require 'dhp_connected_devices/engine'
 
 module DhpConnectedDevices
   # Your code goes here...

--- a/modules/dhp_connected_devices/lib/dhp_connected_devices/engine.rb
+++ b/modules/dhp_connected_devices/lib/dhp_connected_devices/engine.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DhpConnectedDevices
+  class Engine < ::Rails::Engine
+    isolate_namespace DhpConnectedDevices
+    config.generators.api_only = true
+
+    initializer 'model_core.factories', after: 'factory_bot.set_factory_paths' do
+      FactoryBot.definition_file_paths << File.expand_path('../../spec/factories', __dir__) if defined?(FactoryBot)
+    end
+  end
+end

--- a/modules/dhp_connected_devices/lib/dhp_connected_devices/version.rb
+++ b/modules/dhp_connected_devices/lib/dhp_connected_devices/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module DhpConnectedDevices
+  VERSION = '0.1.0'
+end

--- a/modules/dhp_connected_devices/spec/spec_helper.rb
+++ b/modules/dhp_connected_devices/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Configure Rails Envinronment
+ENV['RAILS_ENV'] = 'test'
+# require File.expand_path('dummy/config/environment.rb', __dir__)
+
+require 'rspec/rails'
+
+ENGINE_RAILS_ROOT = File.join(File.dirname(__FILE__), '../')
+
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir[File.join(ENGINE_RAILS_ROOT, 'spec/support/**/*.rb')].sort.each { |f| require f }
+
+RSpec.configure { |config| config.use_transactional_fixtures = true }

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -64,6 +64,7 @@ class SimpleCovHelper
     add_group 'CheckIn', 'modules/check_in/'
     add_group 'ClaimsApi', 'modules/claims_api/'
     add_group 'CovidVaccine', 'modules/covid_vaccine/'
+    add_group 'DhpConnectedDevices', 'modules/dhp_connected_devices/'
     add_group 'FacilitiesApi', 'modules/facilities_api/'
     add_group 'HealthQuest', 'modules/health_quest'
     add_group 'Identity', 'modules/identity/'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,7 @@ unless ENV['NOCOVERAGE']
     add_group 'ClaimsApi', 'modules/claims_api/'
     add_group 'CovidResearch', 'modules/covid_research/'
     add_group 'CovidVaccine', 'modules/covid_vaccine/'
+    add_group 'DhpConnectedDevices', 'modules/dhp_connected_devices/'
     add_group 'FacilitiesApi', 'modules/facilities_api/'
     add_group 'HealthQuest', 'modules/health_quest/'
     add_group 'Identity', 'modules/identity/'


### PR DESCRIPTION
## Description of change
This PR scaffolds the DHP Connected Devices module. We needed to make a tweak to `spec/simplecov_helper.rb` because `rails generate module` updates that file and causes the linting CI step to fail. We also set the CODEOWNERS to the digital health platform team. 

## Original issue(s)
Collaboration Cycle Kickoff: https://github.com/department-of-veterans-affairs/va.gov-team/issues/34264
IA Request from Digital Health Platform team: https://github.com/department-of-veterans-affairs/va.gov-team/issues/35290

## Things to know about this PR
N/A
