### PR TITLE
Mhv identity model 35659

### DIFF
--- a/app/models/inherited_proofing/mhv_identity_data.rb
+++ b/app/models/inherited_proofing/mhv_identity_data.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module InheritedProofing
+  class MHVIdentityData < Common::RedisStore
+    redis_store REDIS_CONFIG[:mhv_identity_data][:namespace]
+    redis_ttl REDIS_CONFIG[:mhv_identity_data][:each_ttl]
+    redis_key :code
+
+    attribute :code, String
+    attribute :data, Hash
+
+    validates(:code, :data, presence: true)
+  end
+end

--- a/app/models/inherited_proofing/mhv_identity_data.rb
+++ b/app/models/inherited_proofing/mhv_identity_data.rb
@@ -6,9 +6,10 @@ module InheritedProofing
     redis_ttl REDIS_CONFIG[:mhv_identity_data][:each_ttl]
     redis_key :code
 
+    attribute :user_uuid, String
     attribute :code, String
     attribute :data, Hash
 
-    validates(:code, :data, presence: true)
+    validates(:user_uuid, :code, :data, presence: true)
   end
 end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -153,6 +153,9 @@ development: &defaults
   sign_in_code_container:
     namespace: sign_in_code_container
     each_ttl: 1800
+  mhv_identity_data:
+    namespace: mhv_identity_data
+    each_ttl: 1800
   transaction_notification:
     namespace: transaction_notification
     each_ttl: 2592000

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -155,7 +155,7 @@ development: &defaults
     each_ttl: 1800
   mhv_identity_data:
     namespace: mhv_identity_data
-    each_ttl: 1800
+    each_ttl: 5400
   transaction_notification:
     namespace: transaction_notification
     each_ttl: 2592000

--- a/spec/factories/inherited_proofing/mhv_identity_data.rb
+++ b/spec/factories/inherited_proofing/mhv_identity_data.rb
@@ -6,12 +6,12 @@ FactoryBot.define do
     code { SecureRandom.hex }
     data do
       {
-        'mhvId': 19031205, # rubocop:disable Style/NumericLiterals
+        'mhvId': 19031505, # rubocop:disable Style/NumericLiterals
         'identityProofedMethod': 'IPA',
         'identityProofingDate': '2020-12-14',
         'identityDocumentExist': true,
         'identityDocumentInfo': {
-          'primaryIdentityDocumentNumber': '73929233',
+          'primaryIdentityDocumentNumber': '73029213',
           'primaryIdentityDocumentType': 'StateIssuedId',
           'primaryIdentityDocumentCountry': 'United States',
           'primaryIdentityDocumentExpirationDate': '2026-03-30'

--- a/spec/factories/inherited_proofing/mhv_identity_data.rb
+++ b/spec/factories/inherited_proofing/mhv_identity_data.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :mhv_identity_data, class: 'InheritedProofing::MHVIdentityData' do
+    user_uuid { SecureRandom.uuid }
+    code { SecureRandom.hex }
+    data do
+      {
+        'mhvId': 19031205, # rubocop:disable Style/NumericLiterals
+        'identityProofedMethod': 'IPA',
+        'identityProofingDate': '2020-12-14',
+        'identityDocumentExist': true,
+        'identityDocumentInfo': {
+          'primaryIdentityDocumentNumber': '73929233',
+          'primaryIdentityDocumentType': 'StateIssuedId',
+          'primaryIdentityDocumentCountry': 'United States',
+          'primaryIdentityDocumentExpirationDate': '2026-03-30'
+        }
+      }
+    end
+  end
+end

--- a/spec/models/inherited_proofing/mhv_identity_data_spec.rb
+++ b/spec/models/inherited_proofing/mhv_identity_data_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InheritedProofing::MHVIdentityData, type: :model do
+end

--- a/spec/models/inherited_proofing/mhv_identity_data_spec.rb
+++ b/spec/models/inherited_proofing/mhv_identity_data_spec.rb
@@ -3,4 +3,49 @@
 require 'rails_helper'
 
 RSpec.describe InheritedProofing::MHVIdentityData, type: :model do
+  let(:mhv_identity_data) { InheritedProofing::MHVIdentityData.new(user_uuid: user_uuid, code: code, data: data) }
+  let(:user_uuid) { SecureRandom.uuid }
+  let(:code) { SecureRandom.hex }
+  let(:data) do
+    {
+      'mhvId': 19031505, # rubocop:disable Style/NumericLiterals
+      'identityProofedMethod': 'IPA',
+      'identityProofingDate': '2020-12-14',
+      'identityDocumentExist': true,
+      'identityDocumentInfo': {
+        'primaryIdentityDocumentNumber': '73029213',
+        'primaryIdentityDocumentType': 'StateIssuedId',
+        'primaryIdentityDocumentCountry': 'United States',
+        'primaryIdentityDocumentExpirationDate': '2026-03-30'
+      }
+    }
+  end
+  let(:error) { Common::Exceptions::ValidationErrors }
+  let(:error_message) { 'Validation error' }
+
+  describe 'validations' do
+    context 'user_uuid' do
+      let(:user_uuid) { nil }
+
+      it 'will return validation error if nil' do
+        expect { mhv_identity_data.save! }.to raise_error(error, error_message)
+      end
+    end
+
+    context 'code' do
+      let(:code) { nil }
+
+      it 'will return validation error if nil' do
+        expect { mhv_identity_data.save! }.to raise_error(error, error_message)
+      end
+    end
+
+    context 'data' do
+      let(:data) { nil }
+
+      it 'will return error message if nil' do
+        expect { mhv_identity_data.save! }.to raise_error(error, error_message)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
This PR creates a redis-backed model to temporarily store MHV inherited proofing data. This will be used as part of the larger inherited proofing initiative which involves storing data retrieved via API from MHV and forwarding that data to Login.gov

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35657

## Things to know about this PR

