### PR TITLE
RRD: remove old hypertension Flipper flags

### DIFF
--- a/app/services/rapid_ready_for_decision/processor_selector.rb
+++ b/app/services/rapid_ready_for_decision/processor_selector.rb
@@ -55,9 +55,7 @@ module RapidReadyForDecision
 
     # @return [Boolean] Is the specified disability RRD-enabled according to Flipper settings
     def rrd_enabled_disability?(disability)
-      # Todo later: Remove old RRD-related Flipper keys "disability_#{disability.downcase}_compensation_fast_track"
-      Flipper.enabled?("rrd_#{disability.downcase}_compensation".to_sym) ||
-        Flipper.enabled?("disability_#{disability.downcase}_compensation_fast_track".to_sym)
+      Flipper.enabled?("rrd_#{disability.downcase}_compensation".to_sym)
     end
 
     def form_disabilities

--- a/app/workers/rapid_ready_for_decision/disability_compensation_job.rb
+++ b/app/workers/rapid_ready_for_decision/disability_compensation_job.rb
@@ -98,8 +98,7 @@ module RapidReadyForDecision
 
     def upload_pdf_and_attach_special_issue(form526_submission, pdf)
       RapidReadyForDecision::HypertensionUploadManager.new(form526_submission).handle_attachment(pdf.render)
-      if Flipper.enabled?(:disability_hypertension_compensation_fast_track_add_rrd) ||
-         Flipper.enabled?(:rrd_add_special_issue)
+      if Flipper.enabled?(:rrd_add_special_issue)
         RapidReadyForDecision::HypertensionSpecialIssueManager.new(form526_submission).add_special_issue
       end
     end

--- a/app/workers/rapid_ready_for_decision/form526_base_job.rb
+++ b/app/workers/rapid_ready_for_decision/form526_base_job.rb
@@ -53,10 +53,7 @@ module RapidReadyForDecision
           pdf = generate_pdf(form526_submission, assessed_data)
           upload_pdf(form526_submission, pdf)
 
-          if Flipper.enabled?(:disability_hypertension_compensation_fast_track_add_rrd) ||
-             Flipper.enabled?(:rrd_add_special_issue)
-            set_special_issue(form526_submission)
-          end
+          set_special_issue(form526_submission) if Flipper.enabled?(:rrd_add_special_issue)
         end
       rescue => e
         # only retry if the error was raised within the "with_tracking" block

--- a/config/features.yml
+++ b/config/features.yml
@@ -203,14 +203,6 @@ features:
   direct_deposit_vanotify:
     actor_type: user
     description: Send direct deposit emails using VaNotify service
-  disability_hypertension_compensation_fast_track:
-    actor_type: user
-    description: Fast tracks 526 disability compensation hypertension claims by submitting additional health data
-    enable_in_development: true
-  disability_hypertension_compensation_fast_track_add_rrd:
-    actor_type: user
-    description: Fast tracks 526 disability compensation claims by submitting additional health data and adding the RRD special issue to the claim.
-    enable_in_development: true
   disability_compensation_flashes:
     actor_type: user
     description: enables sending flashes to BGS for disability_compensation submissions.

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe Form526Submission do
 
       context 'Flipper is enabled' do
         before do
-          Flipper.enable :disability_hypertension_compensation_fast_track
           Flipper.enable :rrd_hypertension_compensation
           Flipper.enable :rrd_asthma_compensation
           Sidekiq::Worker.clear_all
@@ -112,7 +111,6 @@ RSpec.describe Form526Submission do
 
       context 'Flipper is disabled' do
         before do
-          Flipper.disable :disability_hypertension_compensation_fast_track
           Flipper.disable :rrd_hypertension_compensation
           Flipper.disable :rrd_asthma_compensation
           Sidekiq::Worker.clear_all


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Remove old hypertension-specific Flipper flags `disability_hypertension_compensation_fast_track` and `disability_hypertension_compensation_fast_track_add_rrd`.

## Original issue(s)
PR to follow-up from PR #9360 to rename Flipper flags to be associated with RRD.

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
No change in behavior since removed Flipper flags have been replaced with new ones prefixed with `rrd_`.
<!-- Please describe testing done to verify the changes or any testing planned. -->
