### PR TITLE
fix sidekiq tests

### DIFF
--- a/modules/appeals_api/spec/services/appeals_api/events/handler_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/events/handler_spec.rb
@@ -6,6 +6,10 @@ require 'sidekiq/testing'
 module AppealsApi
   module Events
     describe Handler do
+      after do
+        Sidekiq.strict_args!(false)
+      end
+
       describe '.subscribe' do
         it 'creates a record of the callback needed for the event' do
           Handler.subscribe(:hlr_status_updated, 'AppealsApi::Events::StatusUpdated')


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
this test is breaking other tests that run sidekiq jobs. run this command to reproduce:
`bundle exec rspec modules/appeals_api/spec/services/appeals_api/events/handler_spec.rb spec/controllers/v0/profile/ch33_bank_accounts_controller_spec.rb --seed 64887`

this change makes it so that the spec will no longer break other tests
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
