### PR TITLE
Remove validation of international postal code

### DIFF
--- a/lib/va_profile/models/base_address.rb
+++ b/lib/va_profile/models/base_address.rb
@@ -114,7 +114,7 @@ module VAProfile
       end
 
       with_options if: proc { |a| a.address_type == INTERNATIONAL } do
-        validates :international_postal_code, presence: true
+        validates :international_postal_code, presence: true, if: :international_postal_code_required?
         validates :state_code, absence: true
         validates :zip_code, absence: true
         validates :zip_code_suffix, absence: true
@@ -126,6 +126,10 @@ module VAProfile
         return if zip_code.blank?
 
         [zip_code, zip_code_suffix].compact.join('-')
+      end
+
+      def international_postal_code_required?
+        !Flipper.enabled?(:profile_do_not_require_international_zip_code)
       end
     end
   end

--- a/spec/lib/va_profile/models/address_spec.rb
+++ b/spec/lib/va_profile/models/address_spec.rb
@@ -136,7 +136,7 @@ describe VAProfile::Models::Address do
         address.county_code = 'bar'
         expect(address.valid?).to eq(false)
       end
-      
+
       context 'with bypass international postal code validation feature toggle on' do
         it 'international_postal_code is not required' do
           Flipper.enable(:profile_do_not_require_international_zip_code)
@@ -153,7 +153,7 @@ describe VAProfile::Models::Address do
           address.international_postal_code = ''
           expect(address.valid?).to eq(false)
         end
-      end      
+      end
 
       it 'ensures international_postal_code is < 35 characters' do
         expect(address.valid?).to eq(true)

--- a/spec/lib/va_profile/models/address_spec.rb
+++ b/spec/lib/va_profile/models/address_spec.rb
@@ -136,12 +136,24 @@ describe VAProfile::Models::Address do
         address.county_code = 'bar'
         expect(address.valid?).to eq(false)
       end
-
-      it 'international_postal_code is required' do
-        expect(address.valid?).to eq(true)
-        address.international_postal_code = ''
-        expect(address.valid?).to eq(false)
+      
+      context 'with bypass international postal code validation feature toggle on' do
+        it 'international_postal_code is not required' do
+          Flipper.enable(:profile_do_not_require_international_zip_code)
+          expect(address.valid?).to eq(true)
+          address.international_postal_code = ''
+          expect(address.valid?).to eq(true)
+        end
       end
+
+      context 'when bypass international postal code validation feature toggle off' do
+        it 'international_postal_code is required' do
+          Flipper.disable(:profile_do_not_require_international_zip_code)
+          expect(address.valid?).to eq(true)
+          address.international_postal_code = ''
+          expect(address.valid?).to eq(false)
+        end
+      end      
 
       it 'ensures international_postal_code is < 35 characters' do
         expect(address.valid?).to eq(true)


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

## Original issue(s)
Remove international post code as a required field when adding or updating an address.

See ticket [#40324](https://github.com/department-of-veterans-affairs/va.gov-team/issues/40324) for more information.

## Things to know about this PR
* The validation is dependent on the `profile_do_not_require_international_zip_code` feature flag.  If the flag is on, international postal code is not required.  If the flag is off, international postal code is required.
