### PR TITLE
[39362] Add toggle to use new V2 MCP endpoint

### DIFF
--- a/app/services/medical_copays/request.rb
+++ b/app/services/medical_copays/request.rb
@@ -32,7 +32,7 @@ module MedicalCopays
     end
 
     def initialize
-      @settings = Settings.mcp.vbs
+      @settings = Flipper.enabled?(:medical_copays_api_key_change) ? Settings.mcp.vbs_v2 : Settings.mcp.vbs
     end
 
     ##

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -91,6 +91,14 @@ mcp:
     mock: false
     mock_vista: false
     api_key: abcd1234abcd1234abcd1234abcd1234abcd1234
+  vbs_v2:
+    url: https://fake_url.com:9000
+    host: fake_url.com:9000
+    base_path: /base/path
+    service_name: VBS
+    mock: false
+    mock_vista: false
+    api_key: abcd1234abcd1234abcd1234abcd1234abcd1234
 
 fsr:
   prefill: true


### PR DESCRIPTION
## Description of change
VBS team has added new endpoint that exists on VA network, once DevOps config is in place we will be able to toggle between the two until verified.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/39362

## Things to know about this PR
- New setting config `mcp -> vbs_v2`
