### PR TITLE
update rails-html-sanitizer for cve

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -732,7 +732,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rails-session_cookie (0.3.0)
       rails (>= 4.0)

--- a/app/models/appeal_submission.rb
+++ b/app/models/appeal_submission.rb
@@ -6,7 +6,7 @@ class AppealSubmission < ApplicationRecord
   validates :type_of_appeal, inclusion: APPEAL_TYPES
 
   has_kms_key
-  encrypts :upload_metadata, key: :kms_key, **lockbox_options
+  has_encrypted :upload_metadata, key: :kms_key, **lockbox_options
 
   has_many :appeal_submission_uploads, dependent: :destroy
 

--- a/app/models/async_transaction/base.rb
+++ b/app/models/async_transaction/base.rb
@@ -17,7 +17,7 @@ module AsyncTransaction
     serialize :metadata, JsonMarshal::Marshaller
 
     has_kms_key
-    encrypts :metadata, key: :kms_key, **lockbox_options
+    has_encrypted :metadata, key: :kms_key, **lockbox_options
 
     before_save :serialize_metadata
 

--- a/app/models/education_stem_automated_decision.rb
+++ b/app/models/education_stem_automated_decision.rb
@@ -8,7 +8,7 @@ class EducationStemAutomatedDecision < ApplicationRecord
   DECISION_STATES = [INIT, PROCESSED, DENIED].freeze
 
   has_kms_key
-  encrypts :auth_headers_json, key: :kms_key, **lockbox_options
+  has_encrypted :auth_headers_json, key: :kms_key, **lockbox_options
 
   validates(:automated_decision_state, inclusion: DECISION_STATES)
 

--- a/app/models/form1095_b.rb
+++ b/app/models/form1095_b.rb
@@ -2,7 +2,7 @@
 
 class Form1095B < ApplicationRecord
   has_kms_key
-  encrypts :form_data, key: :kms_key, **lockbox_options
+  has_encrypted :form_data, key: :kms_key, **lockbox_options
 
   # validations
   validates :veteran_icn, :tax_year,  presence: true

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -28,7 +28,7 @@ class Form526Submission < ApplicationRecord
   #   @return [Timestamp] updated at date.
   #
   has_kms_key
-  encrypts :auth_headers_json, :birls_ids_tried, :form_json, key: :kms_key, **lockbox_options
+  has_encrypted :auth_headers_json, :birls_ids_tried, :form_json, key: :kms_key, **lockbox_options
 
   belongs_to :saved_claim,
              class_name: 'SavedClaim::DisabilityCompensation',

--- a/app/models/form_attachment.rb
+++ b/app/models/form_attachment.rb
@@ -5,7 +5,7 @@ class FormAttachment < ApplicationRecord
   include SentryLogging
 
   has_kms_key
-  encrypts :file_data, key: :kms_key, **lockbox_options
+  has_encrypted :file_data, key: :kms_key, **lockbox_options
 
   validates(:file_data, :guid, presence: true)
 

--- a/app/models/gibs_not_found_user.rb
+++ b/app/models/gibs_not_found_user.rb
@@ -3,7 +3,7 @@
 class GibsNotFoundUser < ApplicationRecord
   # :nocov:
   has_kms_key
-  encrypts :ssn, key: :kms_key, **lockbox_options
+  has_encrypted :ssn, key: :kms_key, **lockbox_options
 
   validates :edipi, presence: true, uniqueness: true
   validates :first_name, :last_name, :ssn_ciphertext, :dob, presence: true

--- a/app/models/in_progress_form.rb
+++ b/app/models/in_progress_form.rb
@@ -30,7 +30,7 @@ class InProgressForm < ApplicationRecord
   attribute :user_uuid, CleanUUID.new
   serialize :form_data, JsonMarshal::Marshaller
   has_kms_key
-  encrypts :form_data, key: :kms_key, **lockbox_options
+  has_encrypted :form_data, key: :kms_key, **lockbox_options
   validates(:form_data, presence: true)
   validates(:user_uuid, presence: true)
   validate(:id_me_user_uuid)

--- a/app/models/persistent_attachment.rb
+++ b/app/models/persistent_attachment.rb
@@ -9,7 +9,7 @@ class PersistentAttachment < ApplicationRecord
   include SetGuid
 
   has_kms_key
-  encrypts :file_data, key: :kms_key, **lockbox_options
+  has_encrypted :file_data, key: :kms_key, **lockbox_options
   belongs_to :saved_claim, inverse_of: :persistent_attachments, optional: true
   delegate :original_filename, :size, to: :file
 

--- a/app/models/saved_claim.rb
+++ b/app/models/saved_claim.rb
@@ -23,7 +23,7 @@ class SavedClaim < ApplicationRecord
   validate(:form_must_be_string)
 
   has_kms_key
-  encrypts :form, key: :kms_key, **lockbox_options
+  has_encrypted :form, key: :kms_key, **lockbox_options
 
   has_many :persistent_attachments, inverse_of: :saved_claim, dependent: :destroy
 

--- a/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
+++ b/modules/appeals_api/app/models/appeals_api/higher_level_review.rb
@@ -40,7 +40,7 @@ module AppealsApi
     serialize :auth_headers, JsonMarshal::Marshaller
     serialize :form_data, JsonMarshal::Marshaller
     has_kms_key
-    encrypts :auth_headers, :form_data, key: :kms_key, **lockbox_options
+    has_encrypted :auth_headers, :form_data, key: :kms_key, **lockbox_options
 
     NO_ADDRESS_PROVIDED_SENTENCE = 'USE ADDRESS ON FILE'
     NO_EMAIL_PROVIDED_SENTENCE = 'USE EMAIL ON FILE'

--- a/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
+++ b/modules/appeals_api/app/models/appeals_api/notice_of_disagreement.rb
@@ -39,7 +39,7 @@ module AppealsApi
     serialize :auth_headers, JsonMarshal::Marshaller
     serialize :form_data, JsonMarshal::Marshaller
     has_kms_key
-    encrypts :auth_headers, :form_data, key: :kms_key, **lockbox_options
+    has_encrypted :auth_headers, :form_data, key: :kms_key, **lockbox_options
 
     # the controller applies the JSON Schemas in modules/appeals_api/config/schemas/
     # further validations:

--- a/modules/appeals_api/app/models/appeals_api/supplemental_claim.rb
+++ b/modules/appeals_api/app/models/appeals_api/supplemental_claim.rb
@@ -30,7 +30,7 @@ module AppealsApi
     serialize :auth_headers, JsonMarshal::Marshaller
     serialize :form_data, JsonMarshal::Marshaller
     has_kms_key
-    encrypts :auth_headers, :form_data, key: :kms_key, **lockbox_options
+    has_encrypted :auth_headers, :form_data, key: :kms_key, **lockbox_options
 
     has_many :evidence_submissions, as: :supportable, dependent: :destroy
     has_many :status_updates, as: :statusable, dependent: :destroy

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -16,7 +16,7 @@ module ClaimsApi
     serialize :form_data, JsonMarshal::Marshaller
     serialize :evss_response, JsonMarshal::Marshaller
     has_kms_key
-    encrypts :auth_headers, :bgs_flash_responses, :bgs_special_issue_responses, :evss_response, :form_data,
+    has_encrypted :auth_headers, :bgs_flash_responses, :bgs_special_issue_responses, :evss_response, :form_data,
              key: :kms_key, **lockbox_options
 
     validate :validate_service_dates

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -17,7 +17,7 @@ module ClaimsApi
     serialize :evss_response, JsonMarshal::Marshaller
     has_kms_key
     has_encrypted :auth_headers, :bgs_flash_responses, :bgs_special_issue_responses, :evss_response, :form_data,
-             key: :kms_key, **lockbox_options
+                  key: :kms_key, **lockbox_options
 
     validate :validate_service_dates
     before_validation :set_md5

--- a/modules/claims_api/app/models/claims_api/power_of_attorney.rb
+++ b/modules/claims_api/app/models/claims_api/power_of_attorney.rb
@@ -10,7 +10,7 @@ module ClaimsApi
     serialize :form_data, JsonMarshal::Marshaller
     serialize :source_data, JsonMarshal::Marshaller
     has_kms_key
-    encrypts :auth_headers, :form_data, :source_data, key: :kms_key, **lockbox_options
+    has_encrypted :auth_headers, :form_data, :source_data, key: :kms_key, **lockbox_options
 
     PENDING = 'pending'
     SUBMITTED = 'submitted'

--- a/modules/claims_api/app/models/concerns/claims_api/file_data.rb
+++ b/modules/claims_api/app/models/concerns/claims_api/file_data.rb
@@ -9,7 +9,7 @@ module ClaimsApi
     included do
       serialize :file_data, JsonMarshal::Marshaller
       has_kms_key
-      encrypts :file_data, key: :kms_key, **lockbox_options
+      has_encrypted :file_data, key: :kms_key, **lockbox_options
 
       def file_name
         file_data['filename']

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/expanded_registration_submission.rb
@@ -52,7 +52,7 @@ module CovidVaccine
       serialize :form_data, JsonMarshal::Marshaller
       serialize :raw_form_data, JsonMarshal::Marshaller
       has_kms_key
-      encrypts :eligibility_info, :form_data, :raw_form_data, key: :kms_key, **lockbox_options
+      has_encrypted :eligibility_info, :form_data, :raw_form_data, key: :kms_key, **lockbox_options
     end
   end
 end

--- a/modules/covid_vaccine/app/models/covid_vaccine/v0/registration_submission.rb
+++ b/modules/covid_vaccine/app/models/covid_vaccine/v0/registration_submission.rb
@@ -14,7 +14,7 @@ module CovidVaccine
       serialize :form_data, JsonMarshal::Marshaller
       serialize :raw_form_data, JsonMarshal::Marshaller
       has_kms_key
-      encrypts :form_data, :raw_form_data, key: :kms_key, **lockbox_options
+      has_encrypted :form_data, :raw_form_data, key: :kms_key, **lockbox_options
     end
   end
 end

--- a/modules/health_quest/app/models/health_quest/questionnaire_response.rb
+++ b/modules/health_quest/app/models/health_quest/questionnaire_response.rb
@@ -22,7 +22,7 @@ module HealthQuest
     serialize :questionnaire_response_data, JsonMarshaller
     serialize :user_demographics_data, JsonMarshaller
     has_kms_key
-    encrypts :questionnaire_response_data, :user_demographics_data, key: :kms_key, **lockbox_options
+    has_encrypted :questionnaire_response_data, :user_demographics_data, key: :kms_key, **lockbox_options
 
     validates :questionnaire_response_data, presence: true
 

--- a/modules/veteran/app/models/veteran/service/representative.rb
+++ b/modules/veteran/app/models/veteran/service/representative.rb
@@ -10,7 +10,7 @@ module Veteran
 
       self.primary_key = :representative_id
       has_kms_key
-      encrypts :dob, :ssn, key: :kms_key, **lockbox_options
+      has_encrypted :dob, :ssn, key: :kms_key, **lockbox_options
 
       scope :attorneys, -> { where(user_types: ['attorney']) }
       scope :veteran_service_officers, -> { where(user_types: ['veteran_service_officer']) }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This PR updates Possible XSS vulnerability with certain configurations of Rails::Html::Sanitizer

This also addresses a deprecation warning for the lockbox gem that was causing tests to fail.

`DEPRECATION WARNING: `encrypts` is deprecated in favor of `has_encrypted``

```
Name: rails-html-sanitizer
Version: 1.4.2
CVE: CVE-2022-32209
Criticality: Unknown
URL: https://groups.google.com/g/rubyonrails-security/c/ce9PhUANQ6s
Title: Possible XSS vulnerability with certain configurations of Rails::Html::Sanitizer
Solution: upgrade to '>= 1.4.3'
```

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
