### PR TITLE
Add grafana & sentry links to vets-api catalog file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,6 +6,8 @@ metadata:
   description: This project provides common APIs for applications that live on VA.gov (formerly vets.gov APIs).
   annotations:
     github.com/project-slug: department-of-veterans-affairs/vets-api
+    # project slug for the VSP sentry project
+    sentry.io/project-slug: platform-api
     backstage.io/techdocs-ref: dir:.
   tags:
     - ruby
@@ -19,6 +21,12 @@ metadata:
       icon: dashboard
     - url: https://app.ddog-gov.com/sb/f327ad72-c02a-11ec-a50a-da7ad0900007-a1dfad12b43924de9033ad82897aadab
       title: Datadog - VSP - External Service Performance Indicators
+      icon: dashboard
+    - url: https://grafana.vfs.va.gov/
+      title: Grafana
+      icon: dashboard
+    - url: http://sentry.vfs.va.gov/organizations/vsp/
+      title: Sentry - VSP
       icon: dashboard
     - url: https://api.va.gov/sidekiq
       title: Sidekiq UI


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->


## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Add links so a user viewing `vets-api` entity can quickly navigate to Granfana and Sentry.  I've also added a new annotation to link the entity to  the `platform-api` sentry board which should allow for a more advanced integration mechanism to be present.  


## Original issue(s)
Relates to: 
* [department-of-veterans-affairs/platform-console-ui/643](https://github.com/department-of-veterans-affairs/platform-console-ui/issues/643)
* [department-of-veterans-affairs/platform-console-ui/647](https://github.com/department-of-veterans-affairs/platform-console-ui/issues/647)

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
The advanced integration mechanism is still experimental so there is a possibility _that_ will not work as fully expected, but other link-based integrations will still work.