### PR TITLE
10-10EZ HCA application - added feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -32,6 +32,10 @@ features:
     actor_type: user
     description: Enables Short Form for users with or self discloser of high disability.
     enable_in_development: true
+  hca_enrollment_status_override_enabled:
+    actor_type: user
+    description: Enables override of enrollment status for a user, to allow multiple submissions with same user.
+    enable_in_development: false
   can_autofill_10_10cg_address:
     actor_type: user
     description: Allows users to autofill a caregiver's address with the veteran's address when completing the 10-10CG.


### PR DESCRIPTION
## Description of change
Added feature flag to override hca enrollment status, so users can have multiple submissions; will be used in staging.
https://github.com/department-of-veterans-affairs/vets-website/pull/21819

## Original issue(s)
department-of-veterans-affairs/va.gov-team#44665


