### PR TITLE
MAS integration: Make pending_eps? method idempotent

### DIFF
--- a/app/models/concerns/form526_rapid_ready_for_decision_concern.rb
+++ b/app/models/concerns/form526_rapid_ready_for_decision_concern.rb
@@ -62,8 +62,10 @@ module Form526RapidReadyForDecisionConcern
     'unknown'
   end
 
-  def past_pending_eps?
-    return true if form.dig('rrd_metadata', 'offramp_reason')&.upcase == 'PENDING_EP'
+  # If a pending_ep was detected in the past, returns true
+  # Depends on offramp_reason in form JSON, which is inserted by pending_eps? method
+  def had_pending_eps?
+    return true if form.dig('rrd_metadata', 'offramp_reason') == 'pending_ep'
 
     pending_eps?
   end
@@ -117,7 +119,7 @@ module Form526RapidReadyForDecisionConcern
     diagnostic_codes.size == 1 &&
       RapidReadyForDecision::Constants::MAS_DISABILITIES.include?(diagnostic_codes.first) &&
       disabilities.first['disabilityActionType']&.upcase == 'INCREASE' &&
-      !past_pending_eps?
+      !had_pending_eps?
   end
 
   def rrd_new_pact_related_disability?


### PR DESCRIPTION
## Description of change
Potential fix for hypothesized race conditions when using `pending_ep?` method twice:

> currently, form526 submission uses the same method `forward_to_mas?` to check whether to insert classification codes before submitting to EVSS. After form submission, if successful, it will use forward_to_mas? again to determine whether or not to send a notification. forward_to_mas? includes a pending EP check…

This change will limit the possibility of a race condition by avoiding another (HTTP) query to EVSS.

**Further, it changes the meaning of `pending_ep?` to: "has a pending EP ever been detected?"**

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
