### PR TITLE
LGY: disable mock_coe for

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1392,7 +1392,7 @@ lgy:
   base_url: http://www.example.com
   app_id: ~
   api_key: ~
-  mock_coe: true
+  mock_coe: false
 
 form1095_b:
   s3:


### PR DESCRIPTION
## Description of change

This simply disables the `mock_coe` value in `config/settings`.