### PR TITLE
Add check for user identity when logging stats

### DIFF
--- a/app/controllers/concerns/sentry_controller_logging.rb
+++ b/app/controllers/concerns/sentry_controller_logging.rb
@@ -31,7 +31,7 @@ module SentryControllerLogging
 
   def tags_context
     { controller_name: controller_name }.tap do |tags|
-      if current_user.present?
+      if current_user.present? && current_user.identity
         tags[:sign_in_method] = current_user.identity.sign_in[:service_name]
         # account_type is filtered by sentry, becasue in other contexts it refers to a bank account type
         tags[:sign_in_acct_type] = current_user.identity.sign_in[:account_type]


### PR DESCRIPTION
## Description of change
Added a check for [this type of error in Sentry](http://sentry.vfs.va.gov/organizations/vsp/discover/platform-api:ee066c55375849bca185b191529f9fbe/?display=daily&environment=production&field=url&field=error.value&field=timestamp&field=user.id&name=Errors+by+URL&query=event.type%3Aerror+url%3Ahttps%3A%2F%2Fapi.va.gov%2Fv0%2Fuser&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&yAxis=count%28%29) in case `current_user.identity` is nil.

`tags[:sign_in_method] = current_user.identity.sign_in[:service_name]`