### PR TITLE
API-18932: Update MPI::Service to allow .find_profile calls with address attributes (part 1)

### DIFF
--- a/lib/mpi/messages/find_profile_message.rb
+++ b/lib/mpi/messages/find_profile_message.rb
@@ -55,6 +55,16 @@ module MPI
 
       private
 
+      def build_parameter_list
+        el = element('parameterList')
+        el << build_gender if @gender.present?
+        el << build_living_subject_birth_time
+        el << build_living_subject_id
+        el << build_living_subject_name
+        el << build_vba_orchestration if Settings.mvi.vba_orchestration
+        el
+      end
+
       def build_control_act_process
         el = element('controlActProcess', classCode: 'CACT', moodCode: 'EVN')
         el << element('code', code: 'PRPA_TE201305UV02', codeSystem: '2.16.840.1.113883.1.6')
@@ -76,49 +86,6 @@ module MPI
         assigned_person << assigned_person_instance
         assigned_person << build_orchestrated_search if @orch_search
         el << assigned_person
-        el
-      end
-
-      def build_parameter_list
-        el = element('parameterList')
-        el << build_gender if @gender.present?
-        el << build_living_subject_birth_time
-        el << build_living_subject_id
-        el << build_living_subject_name
-        el << build_vba_orchestration if Settings.mvi.vba_orchestration
-        el
-      end
-
-      def build_living_subject_name
-        el = element('livingSubjectName')
-        value = element('value', use: 'L')
-        @given_names.each do |given_name|
-          value << element('given', text!: given_name)
-        end
-        value << element('family', text!: @family_name)
-        el << value
-        el << element('semanticsText', text!: 'Legal Name')
-        el
-      end
-
-      def build_living_subject_birth_time
-        el = element('livingSubjectBirthTime')
-        el << element('value', value: Date.parse(@birth_date)&.strftime('%Y%m%d'))
-        el << element('semanticsText', text!: 'Date of Birth')
-        el
-      end
-
-      def build_living_subject_id
-        el = element('livingSubjectId')
-        el << element('value', root: '2.16.840.1.113883.4.1', extension: @ssn)
-        el << element('semanticsText', text!: 'SSN')
-        el
-      end
-
-      def build_gender
-        el = element('livingSubjectAdministrativeGender')
-        el << element('value', code: @gender)
-        el << element('semanticsText', text!: 'Gender')
         el
       end
 

--- a/lib/mpi/messages/find_profile_message_helpers.rb
+++ b/lib/mpi/messages/find_profile_message_helpers.rb
@@ -37,6 +37,54 @@ module MPI
         el << element('initialQuantity', value: 1)
       end
 
+      def build_gender
+        el = element('livingSubjectAdministrativeGender')
+        el << element('value', code: @gender)
+        el << element('semanticsText', text!: 'Gender')
+        el
+      end
+
+      def build_living_subject_birth_time
+        el = element('livingSubjectBirthTime')
+        el << element('value', value: Date.parse(@birth_date)&.strftime('%Y%m%d'))
+        el << element('semanticsText', text!: 'Date of Birth')
+        el
+      end
+
+      def build_living_subject_id
+        el = element('livingSubjectId')
+        el << element('value', root: '2.16.840.1.113883.4.1', extension: @ssn)
+        el << element('semanticsText', text!: 'SSN')
+        el
+      end
+
+      def build_living_subject_name
+        el = element('livingSubjectName')
+        value = element('value', use: 'L')
+        @given_names.each do |given_name|
+          value << element('given', text!: given_name)
+        end
+        value << element('family', text!: @family_name)
+        el << value
+        el << element('semanticsText', text!: 'Legal Name')
+        el
+      end
+
+      def build_patient_address
+        el = element('PatientAddress')
+        value = element('value', use: 'PHYS')
+        @street_address_lines.each do |street_address_line|
+          value << element('streetAddressLine', text!: street_address_line)
+        end
+        value << element('city', text!: @city)
+        value << element('state', text!: @state)
+        value << element('postalCode', text!: @postal_code)
+        value << element('country', text!: @country)
+        el << value
+        el << element('semanticsText', text!: 'Physical Address')
+        el
+      end
+
       def build_vba_orchestration
         el = element('otherIDsScopingOrganization')
         el << element('value', extension: 'VBA', root: '2.16.840.1.113883.4.349')

--- a/lib/mpi/messages/find_profile_message_with_address.rb
+++ b/lib/mpi/messages/find_profile_message_with_address.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative 'find_profile_message_fields'
+require_relative 'find_profile_message_with_address_fields'
+require_relative 'find_profile_message_helpers'
+require 'mpi/constants'
+
+module MPI
+  module Messages
+    class FindProfileMessageWithAddress
+      include FindProfileMessageHelpers
+      attr_reader :address, :given_names, :family_name, :birth_date, :gender, :search_type
+
+      def initialize(profile)
+        required_fields_present?(profile)
+        @given_names = profile[:given_names]
+        @family_name = profile[:last_name]
+        @birth_date = profile[:birth_date]
+        # gender is optional and will default to nil if it DNE
+        @gender = profile[:gender]
+
+        @address = profile[:address]
+        @street_address_lines = [address['addressLine1'], address['addressLine2'], address['addressLine3']].compact
+        @city = address['city']
+        @state = address['stateCode'] || ''
+        # TODO: add logic for international postal codes
+        @postal_code = address['zipCode5']
+        @country = address['countryCodeISO2']
+
+        # Hardcode search_type for now, with the option to parameterize it later if needed
+        @search_type = MPI::Constants::CORRELATION_WITH_RELATIONSHIP_DATA
+      end
+
+      def required_fields_present?(profile)
+        fields = FindProfileMessageFields.new(profile)
+        fields.validate
+        address_fields = FindProfileMessageWithAddressFields.new(profile[:address] || {})
+        address_fields.validate
+
+        # Ignore missing values for SSN while still validating for the rest
+        fields.missing_keys.delete(:ssn)
+        fields.missing_values.delete(:ssn)
+
+        all_missing_keys = fields.missing_keys + address_fields.missing_keys
+        all_missing_values = fields.missing_values + address_fields.missing_values
+
+        raise ArgumentError, "required keys are missing: #{all_missing_keys}" if all_missing_keys.present?
+
+        if all_missing_values.present?
+          raise ArgumentError,
+                "required values are missing for keys: #{all_missing_values}"
+        end
+      end
+
+      private
+
+      # This is the same as build_parameter_list in MPI::Messages::FindProfileMessages,
+      # except it swaps out build_living_subject_id, which uses SSN, for build_patient_address.
+      def build_parameter_list
+        el = element('parameterList')
+        el << build_gender if @gender.present?
+        el << build_living_subject_birth_time
+        el << build_living_subject_name
+        el << build_patient_address
+        el << build_vba_orchestration if Settings.mvi.vba_orchestration
+        el
+      end
+
+      def build_control_act_process
+        el = element('controlActProcess', classCode: 'CACT', moodCode: 'EVN')
+        el << element('code', code: 'PRPA_TE201305UV02', codeSystem: '2.16.840.1.113883.1.6')
+      end
+    end
+  end
+end

--- a/lib/mpi/messages/find_profile_message_with_address_fields.rb
+++ b/lib/mpi/messages/find_profile_message_with_address_fields.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module MPI
+  module Messages
+    # validates the fields used to find a profile with an address instead of SSN
+    class FindProfileMessageWithAddressFields
+      attr_reader :missing_keys, :missing_values
+
+      REQUIRED_ADDRESS_FIELDS = %i[
+        addressLine1
+        city
+        zipCode5
+        countryCodeISO2
+      ].freeze
+
+      def initialize(address = {})
+        @address = address.symbolize_keys
+      end
+
+      def valid?
+        @missing_keys.blank? && @missing_values.blank?
+      end
+
+      def validate
+        @missing_keys = REQUIRED_ADDRESS_FIELDS - @address.keys
+        @missing_values = REQUIRED_ADDRESS_FIELDS.select { |key| @address[key].nil? || @address[key].blank? }
+      end
+    end
+  end
+end

--- a/lib/mpi/service.rb
+++ b/lib/mpi/service.rb
@@ -10,6 +10,7 @@ require 'mpi/errors/errors'
 require 'mpi/messages/add_person_proxy_add_message'
 require 'mpi/messages/add_person_implicit_search_message'
 require 'mpi/messages/find_profile_message'
+require 'mpi/messages/find_profile_message_with_address'
 require 'mpi/messages/find_profile_message_identifier'
 require 'mpi/messages/find_profile_message_edipi'
 require 'mpi/messages/update_profile_message'
@@ -268,6 +269,7 @@ module MPI
         return message_identifier(user_identity.logingov_uuid, 'logingov', search_type)
       end
       return message_identifier(user_identity.idme_uuid, 'idme', search_type) if user_identity.idme_uuid.present?
+      return message_user_attributes_address(user_identity) if user_identity.ssn.nil? && user_identity.address.present?
 
       message_user_attributes(user_identity, search_type)
     end
@@ -309,12 +311,29 @@ module MPI
         ssn: user_identity.ssn,
         gender: user_identity.gender
       }
+
       MPI::Messages::FindProfileMessage.new(
         profile,
         search_type: search_type,
         orch_search: orch_search,
         edipi: orch_search == true ? user_identity.edipi : nil
       ).to_xml
+    end
+
+    def message_user_attributes_address(user_identity)
+      Raven.tags_context(mvi_find_profile: 'user_attributes_address')
+
+      given_names = [user_identity.first_name]
+      given_names.push user_identity.middle_name unless user_identity.middle_name.nil?
+      profile = {
+        given_names: given_names,
+        last_name: user_identity.last_name,
+        birth_date: user_identity.birth_date,
+        gender: user_identity.gender,
+        address: user_identity.address
+      }
+
+      MPI::Messages::FindProfileMessageWithAddress.new(profile).to_xml
     end
   end
 end

--- a/spec/lib/mpi/messages/find_profile_message_with_address_fields_spec.rb
+++ b/spec/lib/mpi/messages/find_profile_message_with_address_fields_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'mpi/messages/find_profile_message_with_address_fields'
+
+describe MPI::Messages::FindProfileMessageWithAddressFields do
+  describe '.valid?' do
+    subject { described_class.new(profile) }
+
+    let(:missing_keys) { %i[addressLine1 city zipCode5 countryCodeISO2] }
+
+    before do
+      subject.validate
+    end
+
+    context 'with missing keys and values' do
+      let(:profile) { {} }
+
+      its(:valid?) { is_expected.to be(false) }
+      its(:missing_keys) { is_expected.to match_array(missing_keys) }
+      its(:missing_values) { is_expected.to match_array(missing_keys) }
+    end
+
+    context 'with missing values' do
+      let(:profile) { { addressLine1: nil, city: '', zipCode5: '', countryCodeISO2: nil } }
+
+      its(:valid?) { is_expected.to be(false) }
+      its(:missing_keys) { is_expected.to be_blank }
+      its(:missing_values) { is_expected.to match_array(missing_keys) }
+    end
+
+    context 'with required attributes' do
+      let(:profile) { { addressLine1: '123 Main Street', city: 'New York', zipCode5: '12345', countryCodeISO2: 'US' } }
+
+      its(:valid?) { is_expected.to be(true) }
+      its(:missing_keys) { is_expected.to be_blank }
+      its(:missing_values) { is_expected.to be_blank }
+    end
+  end
+end

--- a/spec/lib/mpi/messages/find_profile_message_with_address_spec.rb
+++ b/spec/lib/mpi/messages/find_profile_message_with_address_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mpi/messages/find_profile_message_with_address'
+
+describe MPI::Messages::FindProfileMessageWithAddress do
+  describe '.to_xml' do
+    context 'with first, last, birth_date, and ssn from auth provider' do
+      let(:xml) do
+        described_class.new(
+          address: {
+            'addressLine1' => '123 Main Street',
+            'city' => 'New York',
+            'stateCode' => 'NY',
+            'zipCode5' => '30012',
+            'countryCodeISO2' => 'US'
+          },
+          given_names: %w[John William],
+          last_name: 'Smith',
+          birth_date: '1980-1-1',
+          gender: 'M'
+        ).to_xml
+      end
+      let(:idm_path) { 'env:Body/idm:PRPA_IN201305UV02' }
+      let(:parameter_list_path) { "#{idm_path}/controlActProcess/queryByParameter/parameterList" }
+
+      it 'has a USDSVA extension with a uuid' do
+        expect(xml).to match_at_path("#{idm_path}/id/@extension", /200VGOV-\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/)
+      end
+
+      it 'has a sender extension' do
+        expect(xml).to eq_at_path("#{idm_path}/sender/device/id/@extension", '200VGOV')
+      end
+
+      it 'has a receiver extension' do
+        expect(xml).to eq_at_path("#{idm_path}/receiver/device/id/@extension", '200M')
+      end
+
+      it 'has the correct query parameter order' do
+        parsed_xml = Ox.parse(xml)
+        nodes = parsed_xml.locate(parameter_list_path).first.nodes
+        expect(nodes[0].value).to eq('livingSubjectAdministrativeGender')
+        expect(nodes[1].value).to eq('livingSubjectBirthTime')
+        expect(nodes[2].value).to eq('livingSubjectName')
+        expect(nodes[3].value).to eq('PatientAddress')
+      end
+
+      it 'has a name node' do
+        expect(xml).to eq_text_at_path("#{parameter_list_path}/livingSubjectName/value/given[0]", 'John')
+        expect(xml).to eq_text_at_path("#{parameter_list_path}/livingSubjectName/value/given[1]", 'William')
+        expect(xml).to eq_text_at_path("#{parameter_list_path}/livingSubjectName/value/family", 'Smith')
+        expect(xml).to eq_text_at_path("#{parameter_list_path}/livingSubjectName/semanticsText", 'Legal Name')
+      end
+
+      it 'has a birth time node' do
+        expect(xml).to eq_at_path("#{parameter_list_path}/livingSubjectBirthTime/value/@value", '19800101')
+        expect(xml).to eq_text_at_path("#{parameter_list_path}/livingSubjectBirthTime/semanticsText", 'Date of Birth')
+      end
+
+      it 'has a gender node' do
+        expect(xml).to eq_at_path("#{parameter_list_path}/livingSubjectAdministrativeGender/value/@code", 'M')
+        expect(xml).to eq_text_at_path(
+          "#{parameter_list_path}/livingSubjectAdministrativeGender/semanticsText",
+          'Gender'
+        )
+      end
+    end
+
+    context 'with nil gender' do
+      let(:xml) do
+        MPI::Messages::FindProfileMessageWithAddress.new(
+          address: {
+            'addressLine1' => '123 Main Street',
+            'city' => 'New York',
+            'stateCode' => 'NY',
+            'zipCode5' => '30012',
+            'countryCodeISO2' => 'US'
+          },
+          given_names: %w[John William],
+          last_name: 'Smith',
+          birth_date: '1980-1-1',
+          gender: nil
+        ).to_xml
+      end
+      let(:idm_path) { 'env:Body/idm:PRPA_IN201305UV02' }
+      let(:parameter_list_path) { "#{idm_path}/controlActProcess/queryByParameter/parameterList" }
+
+      it 'does not have a gender node' do
+        expect(xml).to eq_at_path("#{parameter_list_path}/livingSubjectAdministrativeGender/value/@code", nil)
+      end
+
+      it 'has the correct query parameter order' do
+        parsed_xml = Ox.parse(xml)
+        nodes = parsed_xml.locate(parameter_list_path).first.nodes
+        expect(nodes[0].value).to eq('livingSubjectBirthTime')
+        expect(nodes[1].value).to eq('livingSubjectName')
+        expect(nodes[2].value).to eq('PatientAddress')
+      end
+    end
+
+    context 'missing arguments' do
+      let(:address_missing_key) { { addressLine1: '123 Main Street', zipCode5: '12345', countryCodeISO2: 'US' } }
+      let(:address_empty_value) do
+        { addressLine1: '123 Main Street', city: '', zipCode5: '12345', countryCodeISO2: 'US' }
+      end
+      let(:address_nil_values) { { addressLine1: '123 Main Street', city: nil, zipCode5: nil, countryCodeISO2: 'US' } }
+
+      it 'throws an argument error for missing key' do
+        expect do
+          MPI::Messages::FindProfileMessageWithAddress.new(
+            given_names: %w[John William],
+            last_name: 'Smith',
+            birth_date: Time.new(1980, 1, 1).utc,
+            address: address_missing_key
+          )
+        end.to raise_error(ArgumentError, 'required keys are missing: [:city]')
+      end
+
+      it 'throws an argument error for empty value' do
+        expect do
+          MPI::Messages::FindProfileMessageWithAddress.new(
+            given_names: %w[John William],
+            last_name: 'Smith',
+            birth_date: Time.new(1980, 1, 1).utc,
+            address: address_empty_value
+          )
+        end.to raise_error(ArgumentError, 'required values are missing for keys: [:city]')
+      end
+
+      it 'throws an argument error for nil value' do
+        expect do
+          MPI::Messages::FindProfileMessageWithAddress.new(
+            given_names: %w[John William],
+            last_name: nil,
+            birth_date: Time.new(1980, 1, 1).utc,
+            address: address_nil_values
+          )
+        end.to raise_error(ArgumentError, 'required values are missing for keys: [:last_name, :city, :zipCode5]')
+      end
+    end
+  end
+
+  describe '#required_fields_present?' do
+    subject { described_class.new(profile) }
+
+    let(:missing_keys) { ':given_names, :last_name, :birth_date, :address' }
+
+    context 'missing keys' do
+      let(:profile) { {} }
+
+      it 'raises with list of missing keys' do
+        expect { subject }.to raise_error(/#{missing_keys}/)
+      end
+    end
+
+    context 'missing values' do
+      let(:empty_address) { { addressLine1: '', city: '', zipCode5: '', countryCodeISO2: '' } }
+      let(:profile) { { given_names: nil, last_name: '', birth_date: nil, address: empty_address } }
+
+      it 'raises with list of keys for missing values' do
+        expect { subject }.to raise_error(/#{missing_keys}/)
+      end
+    end
+  end
+end

--- a/spec/lib/mpi/service_spec.rb
+++ b/spec/lib/mpi/service_spec.rb
@@ -837,30 +837,6 @@ describe MPI::Service do
       end
     end
 
-    describe '.find_profile with address attributes and without ICN' do
-      let(:nod_appeal) { create(:notice_of_disagreement_v2) }
-
-      it 'calls the find_profile endpoint with a find candidate with address message' do
-        VCR.use_cassette('mpi/find_candidate/valid') do
-          # This path for calling find_profile utilizes a Veteran model with a small subset of
-          # User attributes, but enough to be able to query MPI still.
-          user = AppealsApi::VeteranWithMPIAttributes.new(
-            type: :veteran,
-            auth_headers: nod_appeal.auth_headers,
-            form_data: nod_appeal.form_data&.dig('data', 'attributes', 'veteran')
-          )
-          expect(MPI::Messages::FindProfileMessageWithAddress).to receive(:new).once.and_call_original
-          profile = mvi_profile
-          profile['search_token'] = 'WSDOC1908281447208280163390431'
-          expect(Raven).to receive(:tags_context).once.with(mvi_find_profile: 'user_attributes_address')
-
-          response = subject.find_profile(user)
-          expect(response.status).to eq('OK')
-          expect(response.profile).to have_deep_attributes(profile)
-        end
-      end
-    end
-
     context 'when a MVI invalid request response is returned' do
       let(:id_extension) { '200VGOV-2c3c0c78-5e44-4ad2-b542-11388c3e45cd' }
       let(:error_texts) { ['MVI[S]:INVALID REQUEST'] }

--- a/spec/lib/mpi/service_spec.rb
+++ b/spec/lib/mpi/service_spec.rb
@@ -837,6 +837,30 @@ describe MPI::Service do
       end
     end
 
+    describe '.find_profile with address attributes and without ICN' do
+      let(:nod_appeal) { create(:notice_of_disagreement_v2) }
+
+      it 'calls the find_profile endpoint with a find candidate with address message' do
+        VCR.use_cassette('mpi/find_candidate/valid') do
+          # This path for calling find_profile utilizes a Veteran model with a small subset of
+          # User attributes, but enough to be able to query MPI still.
+          user = AppealsApi::VeteranWithMPIAttributes.new(
+            type: :veteran,
+            auth_headers: nod_appeal.auth_headers,
+            form_data: nod_appeal.form_data&.dig('data', 'attributes', 'veteran')
+          )
+          expect(MPI::Messages::FindProfileMessageWithAddress).to receive(:new).once.and_call_original
+          profile = mvi_profile
+          profile['search_token'] = 'WSDOC1908281447208280163390431'
+          expect(Raven).to receive(:tags_context).once.with(mvi_find_profile: 'user_attributes_address')
+
+          response = subject.find_profile(user)
+          expect(response.status).to eq('OK')
+          expect(response.profile).to have_deep_attributes(profile)
+        end
+      end
+    end
+
     context 'when a MVI invalid request response is returned' do
       let(:id_extension) { '200VGOV-2c3c0c78-5e44-4ad2-b542-11388c3e45cd' }
       let(:error_texts) { ['MVI[S]:INVALID REQUEST'] }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

This is the first of 2 PRs splitting up https://github.com/department-of-veterans-affairs/vets-api/pull/10574/ . This concerns itself entirely with adapting `MPI::Service` to expanding `.find_profile` to query MPI with address attributes as a substitute for SSN. The other PR will be the aspects of calling those modifications to `.find_profile` within the Lighthouse appeals modules.

## Original issue(s)
https://vajira.max.gov/browse/API-18932
## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
