### PR TITLE
API-18932: Update NOD to call AddIcnUpdater job with address data (part 2)

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
@@ -39,6 +39,7 @@ class AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController < Appeals
       'AppealsApi::NoticeOfDisagreement',
       'v2'
     )
+    AppealsApi::AddIcnUpdater.perform_async(@notice_of_disagreement.id, 'AppealsApi::NoticeOfDisagreement')
     render_notice_of_disagreement
   end
 

--- a/modules/appeals_api/app/models/appeals_api/veteran_with_mpi_attributes.rb
+++ b/modules/appeals_api/app/models/appeals_api/veteran_with_mpi_attributes.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Subclass of AppealsApi::Appellant, specifically intended for
+# calling MPI:Service's find_profile method with address attributes
+# in lieu of an ssn.
+module AppealsApi
+  class VeteranWithMPIAttributes < Appellant
+    # address is a private method on AppealsApi::Appellant.
+    # We need it public for querying MPI
+    def address
+      form_data['address'] || {}
+    end
+
+    # Override the inherited method to match expected formats for MPI
+    def birth_date
+      auth_headers['X-VA-Birth-Date']
+    end
+
+    # We don't take the following attributes in for NOD,
+    # but they are required for MPI.
+    def gender
+      nil
+    end
+
+    def authn_context
+      nil
+    end
+
+    def uuid
+      nil
+    end
+
+    # The follow methods get checked for in create_profile_message,
+    # but aren't need for our purposes.
+    # (See lib/mpi/service.rb)
+    def mhv_icn
+      nil
+    end
+
+    def edipi
+      nil
+    end
+
+    def logingov_uuid
+      nil
+    end
+
+    def idme_uuid
+      nil
+    end
+
+    def middle_name
+      nil
+    end
+  end
+end

--- a/modules/appeals_api/spec/requests/v2/notice_of_disagreements_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v2/notice_of_disagreements_controller_spec.rb
@@ -165,7 +165,9 @@ describe AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController, type:
         allow(client).to receive(:send_email)
 
         Sidekiq::Testing.inline! do
-          post(path, params: @max_data, headers: @max_headers)
+          VCR.use_cassette('mpi/find_candidate/valid_no_gender') do
+            post(path, params: @max_data, headers: @max_headers)
+          end
         end
 
         nod = AppealsApi::NoticeOfDisagreement.find_by(id: parsed['data']['id'])

--- a/modules/appeals_api/spec/workers/add_icn_updater_spec.rb
+++ b/modules/appeals_api/spec/workers/add_icn_updater_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module AppealsApi
+  RSpec.describe AddIcnUpdater, type: :job do
+    let(:notice_of_disagreement) { create(:notice_of_disagreement_v2) }
+
+    describe 'Notice Of Disagreement Submission' do
+      context 'when all required address data is provided' do
+        it 'succeeds' do
+          VCR.use_cassette('mpi/find_candidate/valid_no_gender') do
+            notice_of_disagreement.auth_headers.delete('X-Consumer-ID')
+            notice_of_disagreement.save!
+
+            expect(notice_of_disagreement.veteran_icn).to be(nil)
+            described_class.new.perform(notice_of_disagreement.id, 'AppealsApi::NoticeOfDisagreement')
+            expect(notice_of_disagreement.reload.veteran_icn).not_to be(nil)
+          end
+        end
+      end
+
+      context 'when required address keys are missing' do
+        it 'raises an ArgumentError' do
+          VCR.use_cassette('mpi/find_candidate/valid_no_gender') do
+            notice_of_disagreement.form_data['data']['attributes']['veteran']['address'].delete('addressLine1')
+            notice_of_disagreement.save!
+
+            expect do
+              described_class.new.perform(notice_of_disagreement.id, 'AppealsApi::NoticeOfDisagreement')
+            end.to raise_error(ArgumentError, 'required keys are missing: [:addressLine1]')
+          end
+        end
+      end
+
+      context 'when required address keys are blank' do
+        it 'raises an ArgumentError' do
+          VCR.use_cassette('mpi/find_candidate/valid_no_gender') do
+            notice_of_disagreement.form_data['data']['attributes']['veteran']['address']['addressLine1'] = ''
+            notice_of_disagreement.save!
+
+            expect do
+              described_class.new.perform(notice_of_disagreement.id, 'AppealsApi::NoticeOfDisagreement')
+            end.to raise_error(ArgumentError, 'required values are missing for keys: [:addressLine1]')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/mpi/service_spec.rb
+++ b/spec/lib/mpi/service_spec.rb
@@ -837,6 +837,30 @@ describe MPI::Service do
       end
     end
 
+    describe '.find_profile with address attributes and without ICN' do
+      let(:nod_appeal) { create(:notice_of_disagreement_v2) }
+
+      it 'calls the find_profile endpoint with a find candidate with address message' do
+        VCR.use_cassette('mpi/find_candidate/valid') do
+          # This path for calling find_profile utilizes a Veteran model with a small subset of
+          # User attributes, but enough to be able to query MPI still.
+          user = AppealsApi::VeteranWithMPIAttributes.new(
+            type: :veteran,
+            auth_headers: nod_appeal.auth_headers,
+            form_data: nod_appeal.form_data&.dig('data', 'attributes', 'veteran')
+          )
+          expect(MPI::Messages::FindProfileMessageWithAddress).to receive(:new).once.and_call_original
+          profile = mvi_profile
+          profile['search_token'] = 'WSDOC1908281447208280163390431'
+          expect(Raven).to receive(:tags_context).once.with(mvi_find_profile: 'user_attributes_address')
+
+          response = subject.find_profile(user)
+          expect(response.status).to eq('OK')
+          expect(response.profile).to have_deep_attributes(profile)
+        end
+      end
+    end
+
     context 'when a MVI invalid request response is returned' do
       let(:id_extension) { '200VGOV-2c3c0c78-5e44-4ad2-b542-11388c3e45cd' }
       let(:error_texts) { ['MVI[S]:INVALID REQUEST'] }


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

This is the first of 2 PRs splitting up https://github.com/department-of-veterans-affairs/vets-api/pull/10574 . [Part 1](https://github.com/department-of-veterans-affairs/vets-api/pull/10662) expanded MPI::Service to allow .find_profile to query MPI with address attributes as a substitute for SSN. This PR utilizes those options by calling `.find_profile` with that data from within the `AddIcnUpdater` job, called via `AppealsApi::NoticeOfDisagreements::V2::NoticeOfDisagreementsController`.

## Original issue(s)
https://vajira.max.gov/browse/API-18932

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->
Since this builds off of https://github.com/department-of-veterans-affairs/vets-api/pull/10662, I've presently got that branch as this PR's base, to make the diff more obvious. Once part 1 gets merged, this should have its base updated to master

<!-- Please describe testing done to verify the changes or any testing planned. -->
