### PR TITLE
Update VAOS Rspecs VCR Cassette match to ignore domain

### DIFF
--- a/modules/vaos/spec/request/appointment_requests_request_spec.rb
+++ b/modules/vaos/spec/request/appointment_requests_request_spec.rb
@@ -81,7 +81,8 @@ RSpec.describe 'vaos appointment requests', type: :request do
       end
 
       it 'has access and returns va appointments' do
-        VCR.use_cassette('vaos/appointment_requests/get_requests_with_params', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointment_requests/get_requests_with_params',
+                         match_requests_on: %i[method path query]) do
           get '/vaos/v0/appointment_requests', params: params
           expect(response).to have_http_status(:success)
           expect(response.body).to be_a(String)
@@ -90,7 +91,8 @@ RSpec.describe 'vaos appointment requests', type: :request do
       end
 
       it 'has access and returns va appointments when camel-inflected' do
-        VCR.use_cassette('vaos/appointment_requests/get_requests_with_params', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointment_requests/get_requests_with_params',
+                         match_requests_on: %i[method path query]) do
           get '/vaos/v0/appointment_requests', params: params, headers: inflection_header
           expect(response).to have_http_status(:success)
           expect(response.body).to be_a(String)
@@ -105,7 +107,7 @@ RSpec.describe 'vaos appointment requests', type: :request do
     let(:params) { build(:appointment_request_form, :creation, user: current_user).params }
 
     it 'creates a new appointment request' do
-      VCR.use_cassette('vaos/appointment_requests/post_request', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/appointment_requests/post_request', match_requests_on: %i[method path query]) do
         post '/vaos/v0/appointment_requests', params: params
         expect(response).to have_http_status(:created)
         expect(response.body).to be_a(String)
@@ -117,7 +119,7 @@ RSpec.describe 'vaos appointment requests', type: :request do
       let(:params) { build(:cc_appointment_request_form, :creation, user: current_user).params.merge(type: 'cc') }
 
       it 'creates a new appointment request' do
-        VCR.use_cassette('vaos/appointment_requests/post_request_CC', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointment_requests/post_request_CC', match_requests_on: %i[method path query]) do
           allow(Rails.logger).to receive(:info)
           post '/vaos/v0/appointment_requests', params: params
 
@@ -159,7 +161,7 @@ RSpec.describe 'vaos appointment requests', type: :request do
     let(:post_params) { params.merge(appointment_request_detail_code: ['DETCODE8']) }
 
     it 'cancels an appointment request' do
-      VCR.use_cassette('vaos/appointment_requests/put_request', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/appointment_requests/put_request', match_requests_on: %i[method path query]) do
         allow(Rails.logger).to receive(:info)
         put "/vaos/v0/appointment_requests/#{id}", params: params
 
@@ -181,7 +183,7 @@ RSpec.describe 'vaos appointment requests', type: :request do
     let(:id) { '8a4829dc7281184e017285000ab700cf' }
 
     it 'gets an appointment request by id' do
-      VCR.use_cassette('vaos/appointment_requests/get_request_with_id', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/appointment_requests/get_request_with_id', match_requests_on: %i[method path query]) do
         allow(Rails.logger).to receive(:info)
         get "/vaos/v0/appointment_requests/#{id}"
 
@@ -192,7 +194,7 @@ RSpec.describe 'vaos appointment requests', type: :request do
     end
 
     it 'gets an appointment request by id when camel-inflected' do
-      VCR.use_cassette('vaos/appointment_requests/get_request_with_id', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/appointment_requests/get_request_with_id', match_requests_on: %i[method path query]) do
         allow(Rails.logger).to receive(:info)
         get "/vaos/v0/appointment_requests/#{id}", params: {}, headers: inflection_header
 

--- a/modules/vaos/spec/request/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/appointments_request_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       context 'returns list of appointments' do
         it 'has access and returns va appointments' do
-          VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments', params: params
 
             expect(response).to have_http_status(:ok)
@@ -148,7 +148,8 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'has access and returns va appointments having partial errors' do
-          VCR.use_cassette('vaos/appointments/get_appointments_200_partial_error', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/get_appointments_200_partial_error',
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments', params: params
 
             expect(response).to have_http_status(:multi_status)
@@ -159,7 +160,8 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'increments statsD on a partial' do
-          VCR.use_cassette('vaos/appointments/get_appointments_200_partial_error', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/get_appointments_200_partial_error',
+                           match_requests_on: %i[method path query]) do
             expect { get('/vaos/v0/appointments', params: params) }
               .to trigger_statsd_increment(
                 'api.vaos.va_mobile.response.partial',
@@ -169,7 +171,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'has access and returns va appointments when camel-inflected' do
-          VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments', params: params, headers: inflection_header
 
             expect(response).to have_http_status(:ok)
@@ -181,7 +183,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       context 'shows single appointment' do
         it 'returns single appointment based on appointment id' do
-          VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments/va/202006031600983000030800000000000000.aaaaaa', params: params
             expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
@@ -191,7 +193,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'returns single appointment based on appointment id when camel-inflected' do
-          VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments/va/202006031600983000030800000000000000.aaaaaa',
                 params: params,
                 headers: inflection_header
@@ -205,7 +207,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       context 'when the upstream service returns an http status of 204, no content' do
         it 'returns an http status of 404 to the vets website' do
-          VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments/va/123456789101112'
             expect(response).to have_http_status(:not_found)
           end
@@ -214,7 +216,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       context 'when the upstream service returns an http status of 204, no content and X-Key-Inflection set' do
         it 'returns an http status of 404 to the vets website' do
-          VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments/va/123456789101112', params: params, headers: inflection_header
             expect(response).to have_http_status(:not_found)
           end
@@ -223,7 +225,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       context 'shows single appointment with dash in app id' do
         it 'returns single appointment based on appointment id' do
-          VCR.use_cassette('vaos/appointments/show_appointment_with_dash', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/show_appointment_with_dash', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments/va/202006031600983000030800000000000000-aaaaaa', params: params
             expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
@@ -233,7 +235,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'returns single appointment based on appointment id when camel-inflected' do
-          VCR.use_cassette('vaos/appointments/show_appointment_with_dash', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/show_appointment_with_dash', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments/va/202006031600983000030800000000000000-aaaaaa',
                 params: params,
                 headers: inflection_header
@@ -247,7 +249,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       context 'cc appointments' do
         it 'has access and returns cc appointments' do
-          VCR.use_cassette('vaos/appointments/get_cc_appointments', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/get_cc_appointments', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments', params: params.merge(type: 'cc')
             expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
@@ -256,7 +258,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'has access and returns cc appointments when camel-inflected' do
-          VCR.use_cassette('vaos/appointments/get_cc_appointments', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/get_cc_appointments', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments', params: params.merge(type: 'cc'), headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
@@ -267,7 +269,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       context 'with no appointments' do
         it 'returns an empty list' do
-          VCR.use_cassette('vaos/appointments/get_appointments_empty', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/get_appointments_empty', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments', params: params
             expect(response).to have_http_status(:ok)
             expect(JSON.parse(response.body)).to eq(
@@ -287,7 +289,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'returns an empty list when camel-inflected' do
-          VCR.use_cassette('vaos/appointments/get_appointments_empty', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/get_appointments_empty', match_requests_on: %i[method path query]) do
             get '/vaos/v0/appointments', params: params, headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(JSON.parse(response.body)).to eq(
@@ -310,7 +312,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
       context 'with a response that includes blank providers' do
         it 'parses the data and does not throw an undefined method error' do
           VCR.use_cassette('vaos/appointments/get_appointments_map_error',
-                           match_requests_on: %i[method uri], tag: :force_utf8) do
+                           match_requests_on: %i[method path query], tag: :force_utf8) do
             get '/vaos/v0/appointments', params: params
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('vaos/va_appointments', { strict: false })
@@ -319,7 +321,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
         it 'parses the data and does not throw an undefined method error when camel-inflected' do
           VCR.use_cassette('vaos/appointments/get_appointments_map_error',
-                           match_requests_on: %i[method uri], tag: :force_utf8) do
+                           match_requests_on: %i[method path query], tag: :force_utf8) do
             get '/vaos/v0/appointments', params: params, headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(response).to match_camelized_response_schema('vaos/va_appointments', { strict: false })
@@ -352,7 +354,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'returns bad request with detail in errors' do
-          VCR.use_cassette('vaos/appointments/post_appointment_409', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/post_appointment_409', match_requests_on: %i[method path query]) do
             allow(Rails.logger).to receive(:warn).at_least(:once)
             post '/vaos/v0/appointments', params: request_body
 
@@ -371,7 +373,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'returns bad request with detail in errors' do
-          VCR.use_cassette('vaos/appointments/post_appointment_400', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/post_appointment_400', match_requests_on: %i[method path query]) do
             expect(Rails.logger).to receive(:warn).with('Direct schedule submission error', any_args)
             expect(Rails.logger).to receive(:warn).with('VAOS service call failed!', any_args)
             expect(Rails.logger).to receive(:warn).with(
@@ -395,7 +397,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'creates the appointment' do
-          VCR.use_cassette('vaos/appointments/post_appointment', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/post_appointment', match_requests_on: %i[method path query]) do
             post '/vaos/v0/appointments', params: request_body
 
             expect(response).to have_http_status(:no_content)
@@ -440,7 +442,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'returns bad request with detail in errors' do
-          VCR.use_cassette('vaos/appointments/put_cancel_appointment_409', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/put_cancel_appointment_409', match_requests_on: %i[method path query]) do
             expect(Rails.logger).to receive(:warn).with('VAOS service call failed!', any_args).once
             expect(Rails.logger).to receive(:warn).with(
               'Clinic does not support VAOS appointment cancel',
@@ -474,7 +476,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'cancels the appointment' do
-          VCR.use_cassette('vaos/appointments/put_cancel_appointment', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/appointments/put_cancel_appointment', match_requests_on: %i[method path query]) do
             put '/vaos/v0/appointments/cancel', params: request_body
 
             expect(response).to have_http_status(:no_content)

--- a/modules/vaos/spec/request/cc_eligibility_request_spec.rb
+++ b/modules/vaos/spec/request/cc_eligibility_request_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'vaos community care eligibility', type: :request do
       end
 
       it 'has access and returns eligibility true', :skip_mvi do
-        VCR.use_cassette('vaos/cc_eligibility/get_eligibility_true', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/cc_eligibility/get_eligibility_true', match_requests_on: %i[method path query]) do
           get "/vaos/v0/community_care/eligibility/#{service_type}"
 
           expect(response).to have_http_status(:success)
@@ -51,7 +51,7 @@ RSpec.describe 'vaos community care eligibility', type: :request do
         let(:service_type) { 'NotAType' }
 
         it 'returns a validation error', :skip_mvi do
-          VCR.use_cassette('vaos/cc_eligibility/get_eligibility_400', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/cc_eligibility/get_eligibility_400', match_requests_on: %i[method path query]) do
             get "/vaos/v0/community_care/eligibility/#{service_type}"
 
             expect(response).to have_http_status(:bad_request)

--- a/modules/vaos/spec/request/cc_supported_sites_request_spec.rb
+++ b/modules/vaos/spec/request/cc_supported_sites_request_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'supported_sites', type: :request do
 
     context 'with a valid GET supported_sites request' do
       it 'returns a 200 with the correct schema' do
-        VCR.use_cassette('vaos/cc_supported_sites/get_one_site', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/cc_supported_sites/get_one_site', match_requests_on: %i[method path query]) do
           get '/vaos/v0/community_care/supported_sites', params: { site_codes: [983, 984] }
           expect(response).to have_http_status(:ok)
           expect(response.body).to be_a(String)
@@ -36,7 +36,7 @@ RSpec.describe 'supported_sites', type: :request do
       end
 
       it 'returns a 200 with the correct schema when camel-inflected' do
-        VCR.use_cassette('vaos/cc_supported_sites/get_one_site', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/cc_supported_sites/get_one_site', match_requests_on: %i[method path query]) do
           get '/vaos/v0/community_care/supported_sites',
               params: { site_codes: [983, 984] },
               headers: { 'X-Key-Inflection' => 'camel' }

--- a/modules/vaos/spec/request/direct_booking_eligiblity_criteria_request_spec.rb
+++ b/modules/vaos/spec/request/direct_booking_eligiblity_criteria_request_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'direct booking eligibility criteria', type: :request do
     let(:cassette) { 'vaos/systems/get_direct_booking_eligibility_criteria_by_id' }
 
     around do |example|
-      VCR.use_cassette(cassette, match_requests_on: %i[method uri], tag: :force_utf8) do
+      VCR.use_cassette(cassette, match_requests_on: %i[method path query], tag: :force_utf8) do
         example.run
       end
     end

--- a/modules/vaos/spec/request/facilities_request_spec.rb
+++ b/modules/vaos/spec/request/facilities_request_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'facilities', type: :request do
 
       context 'with a single valid facility code' do
         it 'returns a 200 with the correct schema' do
-          VCR.use_cassette('vaos/systems/get_facilities', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facilities', match_requests_on: %i[method path query]) do
             get '/vaos/v0/facilities', params: { facility_codes: 688 }
 
             expect(response).to have_http_status(:ok)
@@ -39,7 +39,7 @@ RSpec.describe 'facilities', type: :request do
         end
 
         it 'returns a 200 with the correct camel-inflected schema' do
-          VCR.use_cassette('vaos/systems/get_facilities', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facilities', match_requests_on: %i[method path query]) do
             get '/vaos/v0/facilities', params: { facility_codes: 688 }, headers: inflection_header
 
             expect(response).to have_http_status(:ok)
@@ -72,7 +72,7 @@ RSpec.describe 'facilities', type: :request do
         let(:json) { JSON.parse(response.body) }
 
         it 'returns a 400 with missing param info' do
-          VCR.use_cassette('vaos/systems/get_facilities', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facilities', match_requests_on: %i[method path query]) do
             get '/vaos/v0/facilities'
 
             expect(response).to have_http_status(:bad_request)
@@ -100,7 +100,7 @@ RSpec.describe 'facilities', type: :request do
 
       context 'with a valid GET response' do
         it 'returns a 200 with the correct schema' do
-          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method path query]) do
             allow(Rails.logger).to receive(:info).at_least(:once)
             get '/vaos/v0/facilities/983/clinics', params: { type_of_care_id: '323', system_id: '983' }
 
@@ -114,7 +114,7 @@ RSpec.describe 'facilities', type: :request do
         end
 
         it 'returns a 200 with the correct camel-inflected schema' do
-          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method path query]) do
             get '/vaos/v0/facilities/983/clinics',
                 params: { type_of_care_id: '323', system_id: '983' },
                 headers: inflection_header
@@ -129,7 +129,7 @@ RSpec.describe 'facilities', type: :request do
         let(:json) { JSON.parse(response.body) }
 
         it 'returns a 400 with missing param type_of_care_id' do
-          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method path query]) do
             get '/vaos/v0/facilities/984/clinics', params: { system_id: '984GA' }
 
             expect(response).to have_http_status(:bad_request)
@@ -138,7 +138,7 @@ RSpec.describe 'facilities', type: :request do
         end
 
         it 'returns a 400 with missing param system_id' do
-          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method path query]) do
             get '/vaos/v0/facilities/984/clinics', params: { type_of_care_id: '323' }
 
             expect(response).to have_http_status(:bad_request)
@@ -166,7 +166,7 @@ RSpec.describe 'facilities', type: :request do
 
       context 'with a valid GET response' do
         it 'returns a 200 with the correct schema' do
-          VCR.use_cassette('vaos/systems/get_cancel_reasons', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_cancel_reasons', match_requests_on: %i[method path query]) do
             get '/vaos/v0/facilities/984/cancel_reasons'
 
             expect(response).to have_http_status(:ok)
@@ -175,7 +175,7 @@ RSpec.describe 'facilities', type: :request do
         end
 
         it 'returns a 200 with the correct camel-inflected schema' do
-          VCR.use_cassette('vaos/systems/get_cancel_reasons', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_cancel_reasons', match_requests_on: %i[method path query]) do
             get '/vaos/v0/facilities/984/cancel_reasons', headers: inflection_header
 
             expect(response).to have_http_status(:ok)
@@ -215,7 +215,8 @@ RSpec.describe 'facilities', type: :request do
 
       context 'with a valid GET response' do
         it 'returns a 200 with the correct schema' do
-          VCR.use_cassette('vaos/systems/get_facility_available_appointments', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facility_available_appointments',
+                           match_requests_on: %i[method path query]) do
             get "/vaos/v0/facilities/#{facility_id}/available_appointments", params: {
               start_date: start_date,
               end_date: end_date,
@@ -228,7 +229,8 @@ RSpec.describe 'facilities', type: :request do
         end
 
         it 'returns a 200 with the correct camel-inflected schema' do
-          VCR.use_cassette('vaos/systems/get_facility_available_appointments', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facility_available_appointments',
+                           match_requests_on: %i[method path query]) do
             get "/vaos/v0/facilities/#{facility_id}/available_appointments",
                 params: {
                   start_date: start_date,
@@ -245,7 +247,7 @@ RSpec.describe 'facilities', type: :request do
 
       context 'when start_date is missing' do
         it 'returns a 400 with missing param start_date' do
-          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method path query]) do
             get "/vaos/v0/facilities/#{facility_id}/available_appointments", params: {
               end_date: end_date,
               clinic_ids: clinic_ids
@@ -259,7 +261,7 @@ RSpec.describe 'facilities', type: :request do
 
       context 'when end_date is missing' do
         it 'returns a 400 with missing param end_date' do
-          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method path query]) do
             get "/vaos/v0/facilities/#{facility_id}/available_appointments", params: {
               start_date: start_date,
               clinic_ids: clinic_ids
@@ -273,7 +275,7 @@ RSpec.describe 'facilities', type: :request do
 
       context 'when clinic_ids is missing' do
         it 'returns a 400 with missing param clinic_ids' do
-          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method path query]) do
             get "/vaos/v0/facilities/#{facility_id}/available_appointments", params: {
               start_date: start_date,
               end_date: end_date
@@ -289,7 +291,7 @@ RSpec.describe 'facilities', type: :request do
         let(:start_date) { '2019-22-11T00:00:00+00:00' }
 
         it 'returns a 400 with invalid date format' do
-          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method path query]) do
             get "/vaos/v0/facilities/#{facility_id}/available_appointments", params: {
               start_date: start_date,
               end_date: end_date,
@@ -308,7 +310,7 @@ RSpec.describe 'facilities', type: :request do
         let(:end_date) { '2019-35-11T00:00:00+00:00' }
 
         it 'returns a 400 with invalid date format' do
-          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method path query]) do
             get "/vaos/v0/facilities/#{facility_id}/available_appointments", params: {
               start_date: start_date,
               end_date: end_date,
@@ -330,7 +332,7 @@ RSpec.describe 'facilities', type: :request do
 
     context 'with a valid GET facility limits response' do
       it 'returns a 200 with the correct schema' do
-        VCR.use_cassette('vaos/systems/get_facility_limits', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_limits', match_requests_on: %i[method path query]) do
           get '/vaos/v0/facilities/688/limits', params: { type_of_care_id: '323' }
 
           expect(response).to have_http_status(:ok)
@@ -340,7 +342,7 @@ RSpec.describe 'facilities', type: :request do
       end
 
       it 'returns a 200 with the correct camel-inflected schema' do
-        VCR.use_cassette('vaos/systems/get_facility_limits', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_limits', match_requests_on: %i[method path query]) do
           get '/vaos/v0/facilities/688/limits', params: { type_of_care_id: '323' }, headers: inflection_header
 
           expect(response).to have_http_status(:ok)
@@ -352,7 +354,7 @@ RSpec.describe 'facilities', type: :request do
 
     context 'when type_of_care_id is missing' do
       it 'returns an error message with the missing param' do
-        VCR.use_cassette('vaos/systems/get_facility_limits', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_limits', match_requests_on: %i[method path query]) do
           get '/vaos/v0/facilities/688/limits'
 
           expect(response).to have_http_status(:bad_request)
@@ -425,7 +427,7 @@ RSpec.describe 'facilities', type: :request do
 
     context 'with a valid GET facility visits response' do
       it 'returns a 200 with the correct schema' do
-        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method path query]) do
           get '/vaos/v0/facilities/688/visits/direct', params: { system_id: '688', type_of_care_id: '323' }
 
           expect(response).to have_http_status(:ok)
@@ -435,7 +437,7 @@ RSpec.describe 'facilities', type: :request do
       end
 
       it 'returns a 200 with the correct camel-inflected schema' do
-        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method path query]) do
           get '/vaos/v0/facilities/688/visits/direct',
               params: { system_id: '688', type_of_care_id: '323' },
               headers: inflection_header
@@ -449,7 +451,7 @@ RSpec.describe 'facilities', type: :request do
 
     context 'when schedule_type is invalid' do
       it 'returns an error message with the invalid param' do
-        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method path query]) do
           get '/vaos/v0/facilities/688/visits/foo', params: { system_id: '688', type_of_care_id: '323' }
 
           expect(response).to have_http_status(:bad_request)
@@ -461,7 +463,7 @@ RSpec.describe 'facilities', type: :request do
 
     context 'when system_id is missing' do
       it 'returns an error message with the missing param' do
-        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method path query]) do
           get '/vaos/v0/facilities/688/visits/foo', params: { type_of_care_id: '323' }
 
           expect(response).to have_http_status(:bad_request)
@@ -473,7 +475,7 @@ RSpec.describe 'facilities', type: :request do
 
     context 'when type_of_care_id is missing' do
       it 'returns an error message with the missing param' do
-        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method path query]) do
           get '/vaos/v0/facilities/688/visits/foo', params: { system_id: '688' }
 
           expect(response).to have_http_status(:bad_request)

--- a/modules/vaos/spec/request/messages_request_spec.rb
+++ b/modules/vaos/spec/request/messages_request_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'vaos appointment request messages', type: :request do
       end
 
       it 'has access and returns messages', :skip_mvi do
-        VCR.use_cassette('vaos/messages/get_messages', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/messages/get_messages', match_requests_on: %i[method path query]) do
           get "/vaos/v0/appointment_requests/#{request_id}/messages"
 
           expect(response).to have_http_status(:success)
@@ -48,7 +48,7 @@ RSpec.describe 'vaos appointment request messages', type: :request do
       end
 
       it 'has access and returns messages when camel-inflected', :skip_mvi do
-        VCR.use_cassette('vaos/messages/get_messages', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/messages/get_messages', match_requests_on: %i[method path query]) do
           get "/vaos/v0/appointment_requests/#{request_id}/messages", headers: { 'X-Key-Inflection' => 'camel' }
 
           expect(response).to have_http_status(:success)
@@ -91,7 +91,7 @@ RSpec.describe 'vaos appointment request messages', type: :request do
 
       context 'with access and valid message' do
         it 'posts a message', :skip_mvi do
-          VCR.use_cassette('vaos/messages/post_message', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/messages/post_message', match_requests_on: %i[method path query]) do
             post "/vaos/v0/appointment_requests/#{request_id}/messages", params: request_body
 
             expect(response).to have_http_status(:success)
@@ -118,7 +118,7 @@ RSpec.describe 'vaos appointment request messages', type: :request do
         let(:request_id) { '8a4886886e4c8e22016eebd3b8820347' }
 
         it 'returns bad request', :skip_mvi do
-          VCR.use_cassette('vaos/messages/post_message_error', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/messages/post_message_error', match_requests_on: %i[method path query]) do
             post "/vaos/v0/appointment_requests/#{request_id}/messages", params: request_body
 
             expect(response).to have_http_status(:bad_request)
@@ -131,7 +131,7 @@ RSpec.describe 'vaos appointment request messages', type: :request do
 
       context 'with access and too many messages for appointment request' do
         it 'returns bad request', :skip_mvi do
-          VCR.use_cassette('vaos/messages/post_message_error_400', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/messages/post_message_error_400', match_requests_on: %i[method path query]) do
             post "/vaos/v0/appointment_requests/#{request_id}/messages", params: request_body
 
             expect(response).to have_http_status(:bad_request)

--- a/modules/vaos/spec/request/preferences_request_spec.rb
+++ b/modules/vaos/spec/request/preferences_request_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'preferences', type: :request do
 
     context 'with a valid GET preferences request' do
       it 'returns a 200 with the correct schema' do
-        VCR.use_cassette('vaos/preferences/get_preferences', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/preferences/get_preferences', match_requests_on: %i[method path query]) do
           get '/vaos/v0/preferences'
 
           expect(response).to have_http_status(:ok)
@@ -39,7 +39,7 @@ RSpec.describe 'preferences', type: :request do
       end
 
       it 'returns a 200 with the correct schema when camel-inflected' do
-        VCR.use_cassette('vaos/preferences/get_preferences', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/preferences/get_preferences', match_requests_on: %i[method path query]) do
           get '/vaos/v0/preferences', headers: inflection_header
 
           expect(response).to have_http_status(:ok)
@@ -62,7 +62,7 @@ RSpec.describe 'preferences', type: :request do
       end
 
       it 'returns a 200 with correct schema' do
-        VCR.use_cassette('vaos/preferences/put_preferences', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/preferences/put_preferences', match_requests_on: %i[method path query]) do
           put '/vaos/v0/preferences', params: request_body
 
           expect(response).to have_http_status(:ok)
@@ -72,7 +72,7 @@ RSpec.describe 'preferences', type: :request do
       end
 
       it 'returns a 200 with correct camel-inflected schema' do
-        VCR.use_cassette('vaos/preferences/put_preferences', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/preferences/put_preferences', match_requests_on: %i[method path query]) do
           put '/vaos/v0/preferences', params: request_body, headers: inflection_header
 
           expect(response).to have_http_status(:ok)

--- a/modules/vaos/spec/request/request_eligibility_criteria_request_spec.rb
+++ b/modules/vaos/spec/request/request_eligibility_criteria_request_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe 'request eligibility criteria', type: :request do
 
     context 'with one id' do
       it 'returns a 200 with the correct schema' do
-        VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_id', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_id',
+                         match_requests_on: %i[method path query]) do
           get '/vaos/v0/request_eligibility_criteria', params: { site_codes: '688' }
           expect(response).to have_http_status(:ok)
           expect(size).to eq(1)
@@ -39,7 +40,8 @@ RSpec.describe 'request eligibility criteria', type: :request do
       end
 
       it 'returns a 200 with the correct camel-inflected schema' do
-        VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_id', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_id',
+                         match_requests_on: %i[method path query]) do
           get '/vaos/v0/request_eligibility_criteria', params: { site_codes: '688' }, headers: inflection_header
           expect(response).to have_http_status(:ok)
           expect(size).to eq(1)
@@ -51,7 +53,7 @@ RSpec.describe 'request eligibility criteria', type: :request do
     context 'with multiple site_codes' do
       it 'returns a 200 with the correct schema' do
         VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_site_codes',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           get '/vaos/v0/request_eligibility_criteria', params: { site_codes: %w[442 534] }
           expect(response).to have_http_status(:ok)
           expect(size).to eq(2)
@@ -61,7 +63,7 @@ RSpec.describe 'request eligibility criteria', type: :request do
 
       it 'returns a 200 with the correct camel-inflected schema' do
         VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_site_codes',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           get '/vaos/v0/request_eligibility_criteria', params: { site_codes: %w[442 534] }, headers: inflection_header
           expect(response).to have_http_status(:ok)
           expect(size).to eq(2)
@@ -73,7 +75,7 @@ RSpec.describe 'request eligibility criteria', type: :request do
     context 'with multiple parent_sites' do
       it 'returns a 200 with the correct schema' do
         VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_parent_sites',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           get '/vaos/v0/request_eligibility_criteria', params: { parent_sites: %w[983 984] }
           expect(response).to have_http_status(:ok)
           expect(size).to eq(5)
@@ -83,7 +85,7 @@ RSpec.describe 'request eligibility criteria', type: :request do
 
       it 'returns a 200 with the correct camel-inflected schema' do
         VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_parent_sites',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           get '/vaos/v0/request_eligibility_criteria',\
               params: { parent_sites: %w[983 984] },
               headers: inflection_header

--- a/modules/vaos/spec/request/systems_request_spec.rb
+++ b/modules/vaos/spec/request/systems_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'systems', type: :request do
     describe 'GET /vaos/v0/systems' do
       context 'with a valid GET systems response' do
         it 'returns a 200 with the correct schema' do
-          VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method path query]) do
             expect { get '/vaos/v0/systems' }
               .to trigger_statsd_increment('api.external_http_request.VAOS.success', times: 1, value: 1)
 
@@ -42,7 +42,7 @@ RSpec.describe 'systems', type: :request do
         end
 
         it 'returns a 200 with the correct camel-inflected schema' do
-          VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method path query]) do
             expect { get '/vaos/v0/systems', headers: inflection_header }
               .to trigger_statsd_increment('api.external_http_request.VAOS.success', times: 1, value: 1)
 
@@ -55,7 +55,7 @@ RSpec.describe 'systems', type: :request do
 
       context 'with a 403 response' do
         it 'returns a VAOS 403 error response' do
-          VCR.use_cassette('vaos/systems/get_systems_403', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_systems_403', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems'
 
             expect(response).to have_http_status(:forbidden)
@@ -65,7 +65,7 @@ RSpec.describe 'systems', type: :request do
         end
 
         it 'returns a VAOS 403 error response when camel-inflected' do
-          VCR.use_cassette('vaos/systems/get_systems_403', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_systems_403', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems', headers: inflection_header
 
             expect(response).to have_http_status(:forbidden)
@@ -81,7 +81,7 @@ RSpec.describe 'systems', type: :request do
         end
 
         it 'returns the default 504 error response' do
-          VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems'
             expect(response).to have_http_status(:gateway_timeout)
             expect(error_code).to eq('504')
@@ -91,7 +91,7 @@ RSpec.describe 'systems', type: :request do
 
       context 'with a 500 response' do
         it 'returns a VAOS 500 error response' do
-          VCR.use_cassette('vaos/systems/get_systems_500', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_systems_500', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems'
 
             expect(response).to have_http_status(:bad_gateway)
@@ -101,7 +101,7 @@ RSpec.describe 'systems', type: :request do
         end
 
         it 'returns a VAOS 500 error response when camel-inflected' do
-          VCR.use_cassette('vaos/systems/get_systems_500', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_systems_500', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems', headers: inflection_header
 
             expect(response).to have_http_status(:bad_gateway)
@@ -113,7 +113,7 @@ RSpec.describe 'systems', type: :request do
 
       context 'with an unmapped error' do
         it 'returns the default VA900 response' do
-          VCR.use_cassette('vaos/systems/get_systems_420', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_systems_420', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems'
 
             expect(response).to have_http_status(:bad_request)
@@ -123,7 +123,7 @@ RSpec.describe 'systems', type: :request do
         end
 
         it 'returns the default VA900 response when camel-inflected' do
-          VCR.use_cassette('vaos/systems/get_systems_420', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_systems_420', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems', headers: inflection_header
 
             expect(response).to have_http_status(:bad_request)
@@ -137,7 +137,7 @@ RSpec.describe 'systems', type: :request do
     describe 'GET /vaos/v0/systems/:system_id/facilities' do
       context 'with a valid GET system facilities response' do
         it 'returns a 200 with the correct schema' do
-          VCR.use_cassette('vaos/systems/get_system_facilities', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_system_facilities', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/688/direct_scheduling_facilities', params: {
               parent_code: '688', type_of_care_id: '323'
             }
@@ -149,7 +149,7 @@ RSpec.describe 'systems', type: :request do
         end
 
         it 'returns a 200 with the correct camel-inflected schema' do
-          VCR.use_cassette('vaos/systems/get_system_facilities', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_system_facilities', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/688/direct_scheduling_facilities', params: {
               parent_code: '688', type_of_care_id: '323'
             }, headers: inflection_header
@@ -163,7 +163,8 @@ RSpec.describe 'systems', type: :request do
 
       context 'with a valid GET system facilities response that includes express care' do
         it 'returns a 200 with the correct schema' do
-          VCR.use_cassette('vaos/systems/get_system_facilities_express_care', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_system_facilities_express_care',
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/983/direct_scheduling_facilities', params: {
               parent_code: '983', type_of_care_id: 'CR1'
             }
@@ -184,7 +185,8 @@ RSpec.describe 'systems', type: :request do
         end
 
         it 'returns a 200 with the correct camel-inflected schema' do
-          VCR.use_cassette('vaos/systems/get_system_facilities_express_care', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_system_facilities_express_care',
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/983/direct_scheduling_facilities', params: {
               parent_code: '983', type_of_care_id: 'CR1'
             }, headers: inflection_header
@@ -207,7 +209,7 @@ RSpec.describe 'systems', type: :request do
 
       context 'when parent_code is missing' do
         it 'returns a 200 with the correct schema' do
-          VCR.use_cassette('vaos/systems/get_system_facilities_noparent', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_system_facilities_noparent', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/688/direct_scheduling_facilities', params: { type_of_care_id: '323' }
 
             expect(response).to have_http_status(:bad_request)
@@ -219,7 +221,7 @@ RSpec.describe 'systems', type: :request do
 
       context 'when type_of_care_id is missing' do
         it 'returns an error message with the missing param' do
-          VCR.use_cassette('vaos/systems/get_system_facilities', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_system_facilities', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/688/direct_scheduling_facilities', params: { parent_code: '688' }
 
             expect(response).to have_http_status(:bad_request)
@@ -231,7 +233,7 @@ RSpec.describe 'systems', type: :request do
 
       context 'with a set of clinic ids' do
         it 'returns a 200 with the correct schema' do
-          VCR.use_cassette('vaos/systems/get_institutions', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_institutions', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/442/clinic_institutions', params: { clinic_ids: [16, 90, 110, 192, 193] }
 
             expect(response).to have_http_status(:ok)
@@ -241,7 +243,7 @@ RSpec.describe 'systems', type: :request do
         end
 
         it 'returns a 200 with the correct camel-inflected schema' do
-          VCR.use_cassette('vaos/systems/get_institutions', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_institutions', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/442/clinic_institutions',
                 params: { clinic_ids: [16, 90, 110, 192, 193] },
                 headers: inflection_header
@@ -255,7 +257,7 @@ RSpec.describe 'systems', type: :request do
 
       context 'with one clinic id' do
         it 'returns a 200 with the correct schema' do
-          VCR.use_cassette('vaos/systems/get_institutions_single', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_institutions_single', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/442/clinic_institutions', params: { clinic_ids: 16 }
 
             expect(response).to have_http_status(:ok)
@@ -265,7 +267,7 @@ RSpec.describe 'systems', type: :request do
         end
 
         it 'returns a 200 with the correct camel-inflected schema' do
-          VCR.use_cassette('vaos/systems/get_institutions_single', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_institutions_single', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/442/clinic_institutions', params: { clinic_ids: 16 }, headers: inflection_header
 
             expect(response).to have_http_status(:ok)
@@ -279,7 +281,7 @@ RSpec.describe 'systems', type: :request do
     describe 'GET /vaos/v0/systems/:system_id/pact' do
       context 'with a valid GET system pact response' do
         it 'returns a 200 with the correct schema' do
-          VCR.use_cassette('vaos/systems/get_system_pact', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_system_pact', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/688/pact'
 
             expect(response).to have_http_status(:ok)
@@ -289,7 +291,7 @@ RSpec.describe 'systems', type: :request do
         end
 
         it 'returns a 200 with the correct camel-inflected schema' do
-          VCR.use_cassette('vaos/systems/get_system_pact', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/systems/get_system_pact', match_requests_on: %i[method path query]) do
             get '/vaos/v0/systems/688/pact', headers: inflection_header
 
             expect(response).to have_http_status(:ok)

--- a/modules/vaos/spec/request/v1/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/v1/appointments_request_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Appointment', type: :request do
         end
 
         it 'returns HTTP status 200 and passes the body through' do
-          VCR.use_cassette('vaos/fhir/appointment/search_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/appointment/search_200', match_requests_on: %i[method path query]) do
             get "/vaos/v1/Appointment?#{query_string}"
 
             expect(response).to have_http_status(:ok)
@@ -65,7 +65,7 @@ RSpec.describe 'Appointment', type: :request do
         end
 
         it 'returns HTTP status 200 and passes the body through' do
-          VCR.use_cassette('vaos/fhir/appointment/search_no_records', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/appointment/search_no_records', match_requests_on: %i[method path query]) do
             get "/vaos/v1/Appointment?#{query_string}"
 
             expect(response).to have_http_status(:ok)
@@ -100,7 +100,7 @@ RSpec.describe 'Appointment', type: :request do
 
         it 'returns HTTP status 201, Created, and the new resource content in body' do
           VCR.use_cassette('vaos/fhir/appointment/post_appointment_create_request_201',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             headers = { 'Content-Type' => 'application/json+fhir', 'Accept' => 'application/json+fhir' }
             post '/vaos/v1/Appointment', params: request_body, headers: headers
             expect(response).to have_http_status(:created)
@@ -114,7 +114,7 @@ RSpec.describe 'Appointment', type: :request do
 
         it 'returns HTTP status 400, bad request' do
           VCR.use_cassette('vaos/fhir/appointment/post_appointment_invalid_request_400',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             headers = { 'Content-Type' => 'application/json+fhir', 'Accept' => 'application/json+fhir' }
             post '/vaos/v1/Appointment', params: invalid_request_body, headers: headers
             expect(response).to have_http_status(:bad_request)
@@ -148,7 +148,8 @@ RSpec.describe 'Appointment', type: :request do
         end
 
         it 'returns HTTP status 200 along with the updated resource' do
-          VCR.use_cassette('vaos/fhir/appointment/put_appointment_request_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/appointment/put_appointment_request_200',
+                           match_requests_on: %i[method path query]) do
             headers = { 'Content-Type' => 'application/json+fhir', 'Accept' => 'application/json+fhir' }
             put '/vaos/v1/Appointment/1631', params: request_body, headers: headers
             expect(response).to have_http_status(:ok)
@@ -160,7 +161,7 @@ RSpec.describe 'Appointment', type: :request do
       context 'with invalid appointment update' do
         it 'returns HTTP status 400' do
           VCR.use_cassette('vaos/fhir/appointment/put_appointment_invalid_request_400',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             headers = { 'Content-Type' => 'application/json+fhir', 'Accept' => 'application/json+fhir' }
             put '/vaos/v1/Appointment/1631X', params: request_body, headers: headers
             expect(response).to have_http_status(:bad_request)
@@ -174,7 +175,7 @@ RSpec.describe 'Appointment', type: :request do
 
         it 'returns HTTP status 200 along with the cancelled resource' do
           VCR.use_cassette('vaos/fhir/appointment/put_appointment_cancel_request_200',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             headers = { 'Content-Type' => 'application/json+fhir', 'Accept' => 'application/json+fhir' }
             put '/vaos/v1/Appointment/1631', params: request_body, headers: headers
             expect(response).to have_http_status(:ok)

--- a/modules/vaos/spec/request/v1/healthcare_service_request_spec.rb
+++ b/modules/vaos/spec/request/v1/healthcare_service_request_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'VAOS::V1::HeathcareService', type: :request do
           let(:query_string) { '?organization.identifier=983&_include=HealthcareService:location' }
 
           it 'returns a 200' do
-            VCR.use_cassette('vaos/fhir/healthcare_service/search_200', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('vaos/fhir/healthcare_service/search_200', match_requests_on: %i[method path query]) do
               expect { get "/vaos/v1/HealthcareService#{query_string}" }
                 .to trigger_statsd_increment('api.vaos.fhir.search.healthcare_service.total', times: 1, value: 1)
 
@@ -63,7 +63,8 @@ RSpec.describe 'VAOS::V1::HeathcareService', type: :request do
           let(:query_string) { '?organization.identifier=123' }
 
           it 'returns a 200' do
-            VCR.use_cassette('vaos/fhir/healthcare_service/search_200_empty', match_requests_on: %i[method uri]) do
+            VCR.use_cassette('vaos/fhir/healthcare_service/search_200_empty',
+                             match_requests_on: %i[method path query]) do
               get "/vaos/v1/HealthcareService#{query_string}"
 
               expect(response).to have_http_status(:success)

--- a/modules/vaos/spec/request/v1/locations_request_spec.rb
+++ b/modules/vaos/spec/request/v1/locations_request_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'VAOS::V1::Location', type: :request do
         end
 
         it 'returns a 200 returning Location resource corresponding to id' do
-          VCR.use_cassette('vaos/fhir/location/read_by_id_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/location/read_by_id_200', match_requests_on: %i[method path query]) do
             expect { get '/vaos/v1/Location/393833' }
               .to trigger_statsd_increment('api.vaos.fhir.read.location.total', times: 1, value: 1)
 
@@ -51,7 +51,7 @@ RSpec.describe 'VAOS::V1::Location', type: :request do
 
       context 'with a 404 response' do
         it 'returns a 404 operation outcome' do
-          VCR.use_cassette('vaos/fhir/location/read_by_id_404', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/location/read_by_id_404', match_requests_on: %i[method path query]) do
             get '/vaos/v1/Location/353000'
 
             expect(response).to have_http_status(:not_found)

--- a/modules/vaos/spec/request/v1/organization_request_spec.rb
+++ b/modules/vaos/spec/request/v1/organization_request_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Organization', type: :request do
         end
 
         it 'returns a 200 and passes through the body' do
-          VCR.use_cassette('vaos/fhir/read_organization_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/read_organization_200', match_requests_on: %i[method path query]) do
             expect { get '/vaos/v1/Organization/353830' }
               .to trigger_statsd_increment('api.vaos.fhir.read.organization.total', times: 1, value: 1)
 
@@ -48,7 +48,7 @@ RSpec.describe 'Organization', type: :request do
 
       context 'with a 404 response' do
         it 'returns a 404 operation outcome' do
-          VCR.use_cassette('vaos/fhir/read_organization_404', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/read_organization_404', match_requests_on: %i[method path query]) do
             get '/vaos/v1/Organization/353000'
 
             expect(response).to have_http_status(:not_found)
@@ -59,7 +59,7 @@ RSpec.describe 'Organization', type: :request do
 
       context 'with a 500 response' do
         it 'returns a 502 operation outcome' do
-          VCR.use_cassette('vaos/fhir/read_organization_500', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/read_organization_500', match_requests_on: %i[method path query]) do
             get '/vaos/v1/Organization/1234567'
 
             expect(response).to have_http_status(:bad_gateway)
@@ -80,7 +80,7 @@ RSpec.describe 'Organization', type: :request do
         end
 
         it 'returns a 200' do
-          VCR.use_cassette('vaos/fhir/search_organization_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/search_organization_200', match_requests_on: %i[method path query]) do
             get '/vaos/v1/Organization?identifier=983,984'
 
             expect(response).to have_http_status(:ok)
@@ -99,7 +99,8 @@ RSpec.describe 'Organization', type: :request do
         end
 
         it 'returns a 200' do
-          VCR.use_cassette('vaos/fhir/search_organization_200_no_query_string', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/search_organization_200_no_query_string',
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v1/Organization'
 
             expect(response).to have_http_status(:ok)
@@ -110,7 +111,7 @@ RSpec.describe 'Organization', type: :request do
 
       context 'when records are not found' do
         it 'returns a 404' do
-          VCR.use_cassette('vaos/fhir/search_organization_404', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/search_organization_404', match_requests_on: %i[method path query]) do
             get '/vaos/v1/Organization?identifier=101'
 
             expect(response).to have_http_status(:not_found)
@@ -121,7 +122,7 @@ RSpec.describe 'Organization', type: :request do
 
       context 'when a backend service exception occurs' do
         it 'returns a 502' do
-          VCR.use_cassette('vaos/fhir/search_organization_500', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/search_organization_500', match_requests_on: %i[method path query]) do
             get '/vaos/v1/Organization?identifier=983,101'
 
             expect(response).to have_http_status(:bad_gateway)

--- a/modules/vaos/spec/request/v1/patient_request_spec.rb
+++ b/modules/vaos/spec/request/v1/patient_request_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'VAOS::V1::Patient', type: :request do
         end
 
         it 'returns a 200' do
-          VCR.use_cassette('vaos/fhir/patient/search_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/patient/search_200', match_requests_on: %i[method path query]) do
             get '/vaos/v1/Patient?identifier=200000008'
 
             expect(response).to have_http_status(:ok)
@@ -47,7 +47,7 @@ RSpec.describe 'VAOS::V1::Patient', type: :request do
 
       context 'when records are not found' do
         it 'returns a 404 operation outcome' do
-          VCR.use_cassette('vaos/fhir/patient/search_404', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/patient/search_404', match_requests_on: %i[method path query]) do
             get '/vaos/v1/Patient?identifier=identifier-value'
 
             expect(response).to have_http_status(:not_found)
@@ -58,7 +58,7 @@ RSpec.describe 'VAOS::V1::Patient', type: :request do
 
       context 'when there is an internal FHIR server error' do
         it 'turns a 502 operation outcome' do
-          VCR.use_cassette('vaos/fhir/patient/search_500', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/fhir/patient/search_500', match_requests_on: %i[method path query]) do
             get '/vaos/v1/Patient?identifier=identifier-value'
 
             expect(response).to have_http_status(:bad_gateway)

--- a/modules/vaos/spec/request/v1/slot_request_spec.rb
+++ b/modules/vaos/spec/request/v1/slot_request_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'VAOS::V1::Slot', type: :request do
       let(:user) { FactoryBot.create(:user, :vaos) }
 
       it 'returns no slots' do
-        VCR.use_cassette('vaos/fhir/slot/search_200_no_slots_found', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/fhir/slot/search_200_no_slots_found', match_requests_on: %i[method path query]) do
           get '/vaos/v1/Slot?schedule=no-such-resource'
           expect(response).to have_http_status(:ok)
           expect(JSON.parse(response.body)['total']).to eq(0)
@@ -35,7 +35,7 @@ RSpec.describe 'VAOS::V1::Slot', type: :request do
       end
 
       it 'returns slots' do
-        VCR.use_cassette('vaos/fhir/slot/search_200_slots_found', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/fhir/slot/search_200_slots_found', match_requests_on: %i[method path query]) do
           get '/vaos/v1/Slot?schedule=Schedule/sch.nep.AVT987.20191208'
           expect(response).to have_http_status(:ok)
           expect(JSON.parse(response.body)['total']).to eq(2)
@@ -45,7 +45,7 @@ RSpec.describe 'VAOS::V1::Slot', type: :request do
       end
 
       it 'returns a 500 error' do
-        VCR.use_cassette('vaos/fhir/slot/search_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/fhir/slot/search_500', match_requests_on: %i[method path query]) do
           get '/vaos/v1/Slot?start=2020-12-08'
           expect(response).to have_http_status(:bad_gateway)
           expect(JSON.parse(response.body)['issue'].first['code']).to eq('VAOS_502')

--- a/modules/vaos/spec/request/v2/appointments_request_spec.rb
+++ b/modules/vaos/spec/request/v2/appointments_request_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
       end
 
       it 'creates the cc appointment' do
-        VCR.use_cassette('vaos/v2/appointments/post_appointments_cc_200_2222022', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/post_appointments_cc_200_2222022',
+                         match_requests_on: %i[method path query]) do
           post '/vaos/v2/appointments', params: community_cares_request_body, headers: inflection_header
           expect(response).to have_http_status(:created)
           expect(json_body_for(response)).to match_camelized_schema('vaos/v2/appointment', { strict: false })
@@ -44,7 +45,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
       end
 
       it 'returns a 400 error' do
-        VCR.use_cassette('vaos/v2/appointments/post_appointments_400', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/post_appointments_400', match_requests_on: %i[method path query]) do
           post '/vaos/v2/appointments', params: community_cares_request_body
           expect(response).to have_http_status(:bad_request)
           expect(JSON.parse(response.body)['errors'][0]['status']).to eq('400')
@@ -66,7 +67,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       it 'creates the va appointment - proposed' do
         VCR.use_cassette('vaos/v2/appointments/post_appointments_va_proposed_clinic_200',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           post '/vaos/v2/appointments', params: va_proposed_request_body, headers: inflection_header
           expect(response).to have_http_status(:created)
           expect(json_body_for(response)).to match_camelized_schema('vaos/v2/appointment', { strict: false })
@@ -75,7 +76,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       it 'creates the va appointment - booked' do
         VCR.use_cassette('vaos/v2/appointments/post_appointments_va_booked_200_JACQUELINE_M',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           post '/vaos/v2/appointments', params: va_proposed_request_body, headers: inflection_header
           expect(response).to have_http_status(:created)
           expect(json_body_for(response)).to match_camelized_schema('vaos/v2/appointment', { strict: false })
@@ -90,7 +91,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       context 'requests a list of appointments' do
         it 'has access and returns va appointments and honors includes' do
-          VCR.use_cassette('vaos/v2/appointments/get_appointments_200', match_requests_on: %i[method uri],
+          VCR.use_cassette('vaos/v2/appointments/get_appointments_200', match_requests_on: %i[method path query],
                                                                         allow_playback_repeats: true) do
             get '/vaos/v2/appointments?_include=facilities,clinics', params: params, headers: inflection_header
             data = JSON.parse(response.body)['data']
@@ -107,7 +108,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         it 'has access and returns va appointments and honors includes with no physical_location field' do
           allow_any_instance_of(VAOS::V2::AppointmentsController).to receive(:get_clinic)
             .and_return(mock_clinic_without_physical_location)
-          VCR.use_cassette('vaos/v2/appointments/get_appointments_200', match_requests_on: %i[method uri],
+          VCR.use_cassette('vaos/v2/appointments/get_appointments_200', match_requests_on: %i[method path query],
                                                                         allow_playback_repeats: true) do
             get '/vaos/v2/appointments?_include=facilities,clinics', params: params, headers: inflection_header
             data = JSON.parse(response.body)['data']
@@ -121,7 +122,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'has access and returns va appointments' do
-          VCR.use_cassette('vaos/v2/appointments/get_appointments_200', match_requests_on: %i[method uri],
+          VCR.use_cassette('vaos/v2/appointments/get_appointments_200', match_requests_on: %i[method path query],
                                                                         allow_playback_repeats: true) do
             get '/vaos/v2/appointments', params: params, headers: inflection_header
             data = JSON.parse(response.body)['data']
@@ -137,7 +138,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         it 'has access and returns va appointments when systems service fails' do
           allow_any_instance_of(VAOS::V2::AppointmentsController).to receive(:get_clinic).and_call_original
           VCR.use_cassette('vaos/v2/appointments/get_appointments_200_with_system_service_500',
-                           match_requests_on: %i[method uri], allow_playback_repeats: true) do
+                           match_requests_on: %i[method path query], allow_playback_repeats: true) do
             get '/vaos/v2/appointments', params: params, headers: inflection_header
             data = JSON.parse(response.body)['data']
             expect(response).to have_http_status(:ok)
@@ -151,7 +152,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         it 'has access and returns va appointments when mobile facility service fails' do
           allow_any_instance_of(VAOS::V2::AppointmentsController).to receive(:get_facility).and_call_original
           VCR.use_cassette('vaos/v2/appointments/get_appointments_200_with_mobile_facility_service_500',
-                           match_requests_on: %i[method uri], allow_playback_repeats: true) do
+                           match_requests_on: %i[method path query], allow_playback_repeats: true) do
             get '/vaos/v2/appointments?_include=facilities', params: params, headers: inflection_header
             data = JSON.parse(response.body)['data']
             expect(response).to have_http_status(:ok)
@@ -165,7 +166,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
         it 'has access and returns va appointments given a date range and single status' do
           VCR.use_cassette('vaos/v2/appointments/get_appointments_single_status_200',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/appointments?start=2022-01-01T19:25:00Z&end=2022-12-01T19:45:00Z&statuses=proposed',
                 headers: inflection_header
             expect(response).to match_camelized_response_schema('vaos/v2/appointments', { strict: false })
@@ -179,7 +180,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
         it 'has access and returns va appointments given date a range and single status (as array)' do
           VCR.use_cassette('vaos/v2/appointments/get_appointments_single_status_200',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/appointments?start=2022-01-01T19:25:00Z&end=2022-12-01T19:45:00Z&statuses[]=proposed',
                 headers: inflection_header
             expect(response).to match_camelized_response_schema('vaos/v2/appointments', { strict: false })
@@ -193,7 +194,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
         it 'has access and returns va appointments given a date range and multiple statuses' do
           VCR.use_cassette('vaos/v2/appointments/get_appointments_multi_status_200',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/appointments?start=2022-01-01T19:25:00Z&end=2022-12-01T19:45:00Z&statuses=proposed,booked',
                 headers: inflection_header
             expect(response).to have_http_status(:ok)
@@ -208,7 +209,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
         it 'has access and returns va appointments given a date range and multiple statuses (as Array)' do
           VCR.use_cassette('vaos/v2/appointments/get_appointments_multi_status_200',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/appointments?start=2022-01-01T19:25:00Z&end=2022-12-01T19:45:00Z&statuses[]=proposed' \
                 '&statuses[]=booked',
                 headers: inflection_header
@@ -224,7 +225,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
         it 'has access and returns va appointments having partial errors' do
           VCR.use_cassette('vaos/v2/appointments/get_appointments_v2_partial_error',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/appointments?start=2022-01-01T19:25:00Z&end=2022-12-01T19:45:00Z&statuses[]=proposed',
                 params: params, headers: inflection_header
 
@@ -234,7 +235,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         end
 
         it 'returns a 400 error' do
-          VCR.use_cassette('vaos/v2/appointments/get_appointments_400', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/appointments/get_appointments_400', match_requests_on: %i[method path query]) do
             get '/vaos/v2/appointments', params: { start: start_date }
 
             expect(response).to have_http_status(:bad_request)
@@ -247,7 +248,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
     describe 'GET appointment' do
       context 'when the VAOS service returns a single appointment ' do
         it 'has access and returns appointment - va proposed' do
-          VCR.use_cassette('vaos/v2/appointments/get_appointment_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/appointments/get_appointment_200', match_requests_on: %i[method path query]) do
             get '/vaos/v2/appointments/70060', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(json_body_for(response)).to match_camelized_schema('vaos/v2/appointment', { strict: false })
@@ -261,7 +262,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
         it 'has access and returns appointment - cc proposed' do
           VCR.use_cassette('vaos/v2/appointments/get_appointment_200_JACQUELINE_M_PROPOSED',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/appointments/72105', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(json_body_for(response)).to match_camelized_schema('vaos/v2/appointment', { strict: false })
@@ -275,7 +276,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
         it 'has access and returns appointment - cc booked' do
           VCR.use_cassette('vaos/v2/appointments/get_appointment_200_JACQUELINE_M_BOOKED',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/appointments/72106', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(json_body_for(response)).to match_camelized_schema('vaos/v2/appointment', { strict: false })
@@ -290,7 +291,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       context 'when the VAOS service errors on retrieving an appointment' do
         it 'returns a 502 status code' do
-          VCR.use_cassette('vaos/v2/appointments/get_appointment_500', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/appointments/get_appointment_500', match_requests_on: %i[method path query]) do
             get '/vaos/v2/appointments/00000'
             expect(response).to have_http_status(:bad_gateway)
             expect(JSON.parse(response.body)['errors'][0]['code']).to eq('VAOS_502')
@@ -302,7 +303,8 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
     describe 'PUT appointments' do
       context 'when the appointment is successfully cancelled' do
         # it 'returns a status code of 200 and the cancelled appointment with the updated status' do
-        #   VCR.use_cassette('vaos/v2/appointments/cancel_appointments_200', match_requests_on: %i[method uri]) do
+        #   VCR.use_cassette('vaos/v2/appointments/cancel_appointments_200',
+        #                    match_requests_on: %i[method path query]) do
         #     put '/vaos/v2/appointments/42081', params: { status: 'cancelled' }, headers: inflection_header
         #     expect(response.status).to eq(200)
         #     expect(json_body_for(response)).to match_camelized_schema('vaos/v2/appointment', { strict: false })
@@ -313,7 +315,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
         #   end
         # end
         it 'returns a 400 status code' do
-          VCR.use_cassette('vaos/v2/appointments/cancel_appointment_400', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/appointments/cancel_appointment_400', match_requests_on: %i[method path query]) do
             put '/vaos/v2/appointments/42081', params: { status: 'cancelled' }
             expect(response.status).to eq(400)
             expect(JSON.parse(response.body)['errors'][0]['code']).to eq('VAOS_400')
@@ -323,7 +325,7 @@ RSpec.describe 'vaos appointments', type: :request, skip_mvi: true do
 
       context 'when the backend service cannot handle the request' do
         it 'returns a 502 status code' do
-          VCR.use_cassette('vaos/v2/appointments/cancel_appointment_500', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/appointments/cancel_appointment_500', match_requests_on: %i[method path query]) do
             put '/vaos/v2/appointments/35952', params: { status: 'cancelled' }
             expect(response.status).to eq(502)
             expect(JSON.parse(response.body)['errors'][0]['code']).to eq('VAOS_502')

--- a/modules/vaos/spec/request/v2/available_slots_request_spec.rb
+++ b/modules/vaos/spec/request/v2/available_slots_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Available Slots Request', type: :request do
     describe 'GET available appointment slots' do
       context 'on a successful request' do
         it 'returns list of available slots' do
-          VCR.use_cassette('vaos/v2/systems/get_available_slots_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/systems/get_available_slots_200', match_requests_on: %i[method path query]) do
             get '/vaos/v2/locations/983/clinics/1081/slots?end=2021-12-30T23:59:59Z&start=2021-10-26T00:00:00Z',
                 headers: inflection_header
             expect(response).to have_http_status(:ok)
@@ -38,7 +38,7 @@ RSpec.describe 'Available Slots Request', type: :request do
 
       context 'on a backend service error' do
         it 'returns a 502 status code' do
-          VCR.use_cassette('vaos/v2/systems/get_available_slots_500', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/systems/get_available_slots_500', match_requests_on: %i[method path query]) do
             get '/vaos/v2/locations/983/clinics/1081/slots?end=2021-12-31T23:59:59Z&start=2021-10-01T00:00:00Z'
 
             expect(response).to have_http_status(:bad_gateway)

--- a/modules/vaos/spec/request/v2/clinics_request_spec.rb
+++ b/modules/vaos/spec/request/v2/clinics_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'clinics', type: :request do
     describe 'GET facility clinics' do
       context 'on successful query for clinics given service type' do
         it 'returns a list of clinics' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
             allow(Rails.logger).to receive(:info).at_least(:once)
             get '/vaos/v2/locations/983/clinics?clinical_service=audiology', headers: inflection_header
             expect(Rails.logger).to have_received(:info).with('Clinic names returned',
@@ -38,7 +38,7 @@ RSpec.describe 'clinics', type: :request do
 
       context 'on successful query for clinics given csv clinic ids' do
         it 'returns a list of clinics' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
             get '/vaos/v2/locations/983/clinics?clinic_ids=570,945', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
@@ -53,7 +53,7 @@ RSpec.describe 'clinics', type: :request do
 
       context 'on successful query for clinics given array clinic ids' do
         it 'returns a list of clinics' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
             get '/vaos/v2/locations/983/clinics?clinic_ids[]=570&clinic_ids[]=945', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
@@ -64,7 +64,7 @@ RSpec.describe 'clinics', type: :request do
 
       context 'on successful query for clinics given an array with a single clinic id' do
         it 'returns a single clinic' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
             get '/vaos/v2/locations/983/clinics?clinic_ids[]=570', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(response.body).to match_camelized_schema('vaos/v2/clinics', { strict: false })
@@ -75,7 +75,7 @@ RSpec.describe 'clinics', type: :request do
 
       context 'on successful query for clinics given an array with a single clinic id when camel-inflected' do
         it 'returns a single clinic' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
             get '/vaos/v2/locations/983/clinics?clinic_ids[]=570', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(JSON.parse(response.body)['data'].size).to eq(1)
@@ -86,7 +86,7 @@ RSpec.describe 'clinics', type: :request do
 
       context 'on sending a bad request to the VAOS Service' do
         it 'returns a 400 http status' do
-          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400', match_requests_on: %i[method path query]) do
             get '/vaos/v2/locations/983/clinics?clinic_ids[]=570&clinical_service=audiology'
             expect(response).to have_http_status(:bad_request)
             expect(JSON.parse(response.body)['errors'][0]['code']).to eq('VAOS_400')

--- a/modules/vaos/spec/request/v2/facilities_request_spec.rb
+++ b/modules/vaos/spec/request/v2/facilities_request_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'facilities', type: :request do
       context 'on successful query for a facility' do
         it 'returns facility details' do
           VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_single_id_200',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/facilities?ids=688', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
@@ -31,7 +31,8 @@ RSpec.describe 'facilities', type: :request do
 
       context 'on successful query for a facility given multiple facilities in array form' do
         it 'returns facility details' do
-          VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_200',
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/facilities?ids[]=983&ids[]=984', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(JSON.parse(response.body)['data'].size).to eq(2)
@@ -43,7 +44,7 @@ RSpec.describe 'facilities', type: :request do
       context 'on successful query for a facility and children' do
         it 'returns facility details' do
           VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_with_children_200',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/facilities?ids=688&children=true', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
@@ -55,7 +56,8 @@ RSpec.describe 'facilities', type: :request do
 
       context 'on sending a bad request to the VAOS Service' do
         it 'returns a 400 http status' do
-          VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_400', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_400',
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/facilities?ids=688'
             expect(response).to have_http_status(:bad_request)
             expect(JSON.parse(response.body)['errors'][0]['code']).to eq('VAOS_400')
@@ -67,7 +69,8 @@ RSpec.describe 'facilities', type: :request do
     describe 'SHOW facilities' do
       context 'on successful query for a facility' do
         it 'returns facility details' do
-          VCR.use_cassette('vaos/v2/mobile_facility_service/get_facility_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/mobile_facility_service/get_facility_200',
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/facilities/983', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
@@ -78,7 +81,8 @@ RSpec.describe 'facilities', type: :request do
 
       context 'on sending a bad request to the VAOS Service' do
         it 'returns a 400 http status' do
-          VCR.use_cassette('vaos/v2/mobile_facility_service/get_facility_400', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/mobile_facility_service/get_facility_400',
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/facilities/983'
             expect(response).to have_http_status(:bad_request)
             expect(JSON.parse(response.body)['errors'][0]['code']).to eq('VAOS_400')

--- a/modules/vaos/spec/request/v2/mobile_ppms_request_spec.rb
+++ b/modules/vaos/spec/request/v2/mobile_ppms_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe VAOS::V2::ProvidersController, type: :request do
   describe 'when a valid NPI is provided' do
     it "responds with the provider's information" do
       VCR.use_cassette('vaos/v2/mobile_ppms_service/get_provider_200',
-                       match_requests_on: %i[method uri], tag: :force_utf8) do
+                       match_requests_on: %i[method path query], tag: :force_utf8) do
         get '/vaos/v2/providers/1407938061'
         expect(response).to have_http_status(:ok)
         expect(json_body_for(response)['attributes']['name']).to eq('DEHGHAN, AMIR ')
@@ -27,7 +27,7 @@ RSpec.describe VAOS::V2::ProvidersController, type: :request do
   describe 'when an invalid request is made' do
     it 'responds with a 400 error' do
       VCR.use_cassette('vaos/v2/mobile_ppms_service/get_provider_400',
-                       match_requests_on: %i[method uri], tag: :force_utf8) do
+                       match_requests_on: %i[method path query], tag: :force_utf8) do
         get '/vaos/v2/providers/489'
         expect(response).to have_http_status(:bad_request)
       end
@@ -37,7 +37,7 @@ RSpec.describe VAOS::V2::ProvidersController, type: :request do
   describe 'when a request is made and there is a server error' do
     it 'responds with a 500 error' do
       VCR.use_cassette('vaos/v2/mobile_ppms_service/get_provider_500',
-                       match_requests_on: %i[method uri], tag: :force_utf8) do
+                       match_requests_on: %i[method path query], tag: :force_utf8) do
         get '/vaos/v2/providers/489'
         expect(response).to have_http_status(:bad_gateway)
       end

--- a/modules/vaos/spec/request/v2/patients_request_spec.rb
+++ b/modules/vaos/spec/request/v2/patients_request_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'vaos patients', type: :request, skip_mvi: true do
 
       context 'patient appointment meta data' do
         it 'successfully returns patient appointment metadata' do
-          VCR.use_cassette('vaos/v2/patients/get_patient_appointment_metadata', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/patients/get_patient_appointment_metadata',
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/eligibility', params: params, headers: inflection_header
             expect(response).to have_http_status(:ok)
             attributes = JSON.parse(response.body)['data']['attributes']

--- a/modules/vaos/spec/request/v2/scheduling_configurations_request_spec.rb
+++ b/modules/vaos/spec/request/v2/scheduling_configurations_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'vaos scheduling/configurations', type: :request, skip_mvi: true 
       context 'has access and is given single facility id' do
         it 'returns a single scheduling configuration' do
           VCR.use_cassette('vaos/v2/mobile_facility_service/get_scheduling_configurations_200',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/scheduling/configurations?facility_ids=489', headers: inflection_header
             expect(response).to have_http_status(:ok)
             expect(response.body).to be_a(String)
@@ -32,7 +32,7 @@ RSpec.describe 'vaos scheduling/configurations', type: :request, skip_mvi: true 
       context 'has access and is given multiple facility ids as CSV' do
         it 'returns scheduling configurations' do
           VCR.use_cassette('vaos/v2/mobile_facility_service/get_scheduling_configurations_200',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/scheduling/configurations?facility_ids=489,984', headers: inflection_header
             expect(response).to have_http_status(:ok)
             data = JSON.parse(response.body)['data']
@@ -45,7 +45,7 @@ RSpec.describe 'vaos scheduling/configurations', type: :request, skip_mvi: true 
       context 'has access and is given multiple facility ids as []=' do
         it 'returns scheduling configurations' do
           VCR.use_cassette('vaos/v2/mobile_facility_service/get_scheduling_configurations_200',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/scheduling/configurations?facility_ids[]=489&facility_ids[]=984', headers: inflection_header
             expect(response).to have_http_status(:ok)
             data = JSON.parse(response.body)['data']
@@ -58,7 +58,7 @@ RSpec.describe 'vaos scheduling/configurations', type: :request, skip_mvi: true 
       context 'has access and is given multiple facility ids and cc enable parameters' do
         it 'returns scheduling configurations' do
           VCR.use_cassette('vaos/v2/mobile_facility_service/get_scheduling_configurations_200',
-                           match_requests_on: %i[method uri]) do
+                           match_requests_on: %i[method path query]) do
             get '/vaos/v2/scheduling/configurations?cc_enabled=true&facility_ids[]=489&facility_ids[]=984',
                 headers: inflection_header
             expect(response).to have_http_status(:ok)

--- a/modules/vaos/spec/services/appointment_requests_service_spec.rb
+++ b/modules/vaos/spec/services/appointment_requests_service_spec.rb
@@ -14,7 +14,7 @@ describe VAOS::AppointmentRequestsService do
       let(:appointment_request_params) { build(:appointment_request_form, :creation, user: user).params }
 
       it 'creates a new appointment request' do
-        VCR.use_cassette('vaos/appointment_requests/post_request', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointment_requests/post_request', match_requests_on: %i[method path query]) do
           response = subject.post_request(appointment_request_params)
           expect(response[:data].unique_id).to eq('8a4886886e4c8e22016e92be77cb00f9')
           expect(response[:data].appointment_request_detail_code).to be_empty
@@ -26,7 +26,7 @@ describe VAOS::AppointmentRequestsService do
       let(:params) { build(:cc_appointment_request_form, :creation, user: user).params.merge(type: 'cc') }
 
       it 'creates a new CC appointment request' do
-        VCR.use_cassette('vaos/appointment_requests/post_request_CC', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointment_requests/post_request_CC', match_requests_on: %i[method path query]) do
           response = subject.post_request(params)
           expect(response[:data].created_date).not_to be_nil
         end
@@ -56,7 +56,7 @@ describe VAOS::AppointmentRequestsService do
       end
 
       it 'cancels a pending appointment request' do
-        VCR.use_cassette('vaos/appointment_requests/put_request', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointment_requests/put_request', match_requests_on: %i[method path query]) do
           response = subject.put_request(id, appointment_request_params)
           expect(response[:data].unique_id).to eq('8a4886886e4c8e22016e92be77cb00f9')
           expect(response[:data].appointment_request_detail_code.first[:created_date])
@@ -73,7 +73,7 @@ describe VAOS::AppointmentRequestsService do
 
     context 'without data params but with cc appointment data' do
       it 'includes the cc appointment data' do
-        VCR.use_cassette('vaos/appointment_requests/get_requests', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointment_requests/get_requests', match_requests_on: %i[method path query]) do
           response = subject.get_requests
           request_with_cc = response[:data][40]
           expect(request_with_cc.cc_appointment_request).to eq(
@@ -104,7 +104,8 @@ describe VAOS::AppointmentRequestsService do
 
     context 'with data params' do
       it 'returns an array of size 1' do
-        VCR.use_cassette('vaos/appointment_requests/get_requests_with_params', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointment_requests/get_requests_with_params',
+                         match_requests_on: %i[method path query]) do
           response = subject.get_requests(start_date, end_date)
           expect(response[:data].size).to eq(1)
         end
@@ -117,7 +118,7 @@ describe VAOS::AppointmentRequestsService do
 
     context 'with valid appointment id' do
       it 'returns a single appointment request' do
-        VCR.use_cassette('vaos/appointment_requests/get_request_with_id', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointment_requests/get_request_with_id', match_requests_on: %i[method path query]) do
           response = subject.get_request('8a4829dc7281184e017285000ab700cf')
           expect(response[:data].unique_id).to eq('8a4829dc7281184e017285000ab700cf')
         end

--- a/modules/vaos/spec/services/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/appointment_service_spec.rb
@@ -19,7 +19,7 @@ describe VAOS::AppointmentService do
       end
 
       it 'returns a 400 Bad Request' do
-        VCR.use_cassette('vaos/appointments/post_appointment_400', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/post_appointment_400', match_requests_on: %i[method path query]) do
           allow(Rails.logger).to receive(:warn).at_least(:once)
           expect { subject.post_appointment(request_body) }
             .to raise_error(Common::Exceptions::BackendServiceException) do |error|
@@ -37,7 +37,7 @@ describe VAOS::AppointmentService do
       end
 
       it 'returns a 400 Bad Request for 409 conlicts as well' do
-        VCR.use_cassette('vaos/appointments/post_appointment_409', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/post_appointment_409', match_requests_on: %i[method path query]) do
           allow(Rails.logger).to receive(:warn).at_least(:once)
           expect { subject.post_appointment(request_body) }
             .to raise_error(Common::Exceptions::BackendServiceException) do |error|
@@ -55,7 +55,7 @@ describe VAOS::AppointmentService do
       end
 
       it 'returns the created appointment' do
-        VCR.use_cassette('vaos/appointments/post_appointment', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/post_appointment', match_requests_on: %i[method path query]) do
           response = subject.post_appointment(request_body)
           expect(response).to be_a(Hash)
         end
@@ -78,7 +78,7 @@ describe VAOS::AppointmentService do
       end
 
       it 'returns the bad request with detail in errors' do
-        VCR.use_cassette('vaos/appointments/put_cancel_appointment_409', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/put_cancel_appointment_409', match_requests_on: %i[method path query]) do
           expect { subject.put_cancel_appointment(request_body) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -100,7 +100,7 @@ describe VAOS::AppointmentService do
       end
 
       it 'cancels the appointment' do
-        VCR.use_cassette('vaos/appointments/put_cancel_appointment', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/put_cancel_appointment', match_requests_on: %i[method path query]) do
           response = subject.put_cancel_appointment(request_body)
           expect(response).to be_an_instance_of(String).and be_empty
         end
@@ -119,7 +119,8 @@ describe VAOS::AppointmentService do
       end
 
       it 'logs those partial responses to sentry' do
-        VCR.use_cassette('vaos/appointments/get_appointments_200_partial_error', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/get_appointments_200_partial_error',
+                         match_requests_on: %i[method path query]) do
           expect(Raven).to receive(:capture_message).with(
             'VAOS::AppointmentService#get_appointments has response errors.',
             level: 'info'
@@ -134,7 +135,8 @@ describe VAOS::AppointmentService do
 
     context 'with 12 va appointments' do
       it 'returns an array of size 12' do
-        VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method uri], tag: :force_utf8) do
+        VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method path query],
+                                                               tag: :force_utf8) do
           response = subject.get_appointments(type, start_date, end_date)
           expect(response[:data].size).to eq(28)
         end
@@ -143,7 +145,7 @@ describe VAOS::AppointmentService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/appointments/get_appointments_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/get_appointments_500', match_requests_on: %i[method path query]) do
           expect { subject.get_appointments(type, start_date, end_date) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -157,7 +159,7 @@ describe VAOS::AppointmentService do
 
     context 'with 17 cc appointments' do
       it 'returns an array of size 17' do
-        VCR.use_cassette('vaos/appointments/get_cc_appointments', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/get_cc_appointments', match_requests_on: %i[method path query]) do
           response = subject.get_appointments(type, start_date, end_date)
           expect(response[:data].size).to eq(101)
         end
@@ -166,7 +168,7 @@ describe VAOS::AppointmentService do
 
     context 'with 0 cc appointments' do
       it 'returns an array of size 0' do
-        VCR.use_cassette('vaos/appointments/get_cc_appointments_empty', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/get_cc_appointments_empty', match_requests_on: %i[method path query]) do
           response = subject.get_appointments(type, start_date, end_date)
           expect(response[:data].size).to eq(0)
         end
@@ -175,7 +177,7 @@ describe VAOS::AppointmentService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/appointments/get_cc_appointments_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/get_cc_appointments_500', match_requests_on: %i[method path query]) do
           expect { subject.get_appointments(type, start_date, end_date) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -189,7 +191,7 @@ describe VAOS::AppointmentService do
       let(:id) { '202006031600983000030800000000000000.aaaaaa' }
 
       it 'with a 200 success' do
-        VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method path query]) do
           response = subject.get_appointment(id)
           expect(response[:id]).to eq(id)
         end
@@ -198,7 +200,7 @@ describe VAOS::AppointmentService do
 
     context 'when upstream service returns an empty string in body' do
       it 'returns nil in body' do
-        VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/show_appointment', match_requests_on: %i[method path query]) do
           response = subject.get_appointment('123456789101112')
           expect(response.body).to be_nil
         end
@@ -209,7 +211,7 @@ describe VAOS::AppointmentService do
       let(:id) { '202006031600983000030800000000000000-aaaaaa' }
 
       it 'with a 200 success' do
-        VCR.use_cassette('vaos/appointments/show_appointment_with_dash', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/show_appointment_with_dash', match_requests_on: %i[method path query]) do
           response = subject.get_appointment(id)
           expect(response[:id]).to eq(id)
         end
@@ -218,7 +220,7 @@ describe VAOS::AppointmentService do
 
     context 'returns error status' do
       it 'with a 404 not found' do
-        VCR.use_cassette('vaos/appointments/show_appointment_404', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/show_appointment_404', match_requests_on: %i[method path query]) do
           expect { subject.get_appointment('1234567') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -226,7 +228,7 @@ describe VAOS::AppointmentService do
       end
 
       it 'with a 500 internal server error' do
-        VCR.use_cassette('vaos/appointments/show_appointment_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/show_appointment_500', match_requests_on: %i[method path query]) do
           expect { subject.get_appointment('1234567') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )

--- a/modules/vaos/spec/services/cc_eligibility_service_spec.rb
+++ b/modules/vaos/spec/services/cc_eligibility_service_spec.rb
@@ -12,14 +12,14 @@ describe VAOS::CCEligibilityService do
 
   describe '#get_eligibility', :skip_mvi do
     it 'gets an eligibility of true' do
-      VCR.use_cassette('vaos/cc_eligibility/get_eligibility_true', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/cc_eligibility/get_eligibility_true', match_requests_on: %i[method path query]) do
         response = subject.get_eligibility(service_type)
         expect(response[:data].eligible).to eq(true)
       end
     end
 
     it 'gets an eligibility of false' do
-      VCR.use_cassette('vaos/cc_eligibility/get_eligibility_false', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/cc_eligibility/get_eligibility_false', match_requests_on: %i[method path query]) do
         response = subject.get_eligibility(service_type)
         expect(response[:data].eligible).to eq(false)
       end
@@ -29,7 +29,7 @@ describe VAOS::CCEligibilityService do
       let(:service_type) { 'NotAType' }
 
       it 'handles 400 error appropriately' do
-        VCR.use_cassette('vaos/cc_eligibility/get_eligibility_400', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/cc_eligibility/get_eligibility_400', match_requests_on: %i[method path query]) do
           expect { subject.get_eligibility(service_type) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )

--- a/modules/vaos/spec/services/cc_supported_sites_service_spec.rb
+++ b/modules/vaos/spec/services/cc_supported_sites_service_spec.rb
@@ -12,7 +12,7 @@ describe VAOS::CCSupportedSitesService do
 
   describe '#get_supported_sites', :skip_mvi do
     it 'gets a single supported site' do
-      VCR.use_cassette('vaos/cc_supported_sites/get_one_site', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/cc_supported_sites/get_one_site', match_requests_on: %i[method path query]) do
         response = subject.get_supported_sites(site_codes)
         expect(response[:data].size).to eq(1)
         expect(response[:data].first.id).to eq('983')
@@ -20,7 +20,7 @@ describe VAOS::CCSupportedSitesService do
     end
 
     it 'gets no supported sites' do
-      VCR.use_cassette('vaos/cc_supported_sites/get_no_sites', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/cc_supported_sites/get_no_sites', match_requests_on: %i[method path query]) do
         response = subject.get_supported_sites(%w[1 2])
         expect(response[:data].size).to eq(0)
       end

--- a/modules/vaos/spec/services/messages_service_spec.rb
+++ b/modules/vaos/spec/services/messages_service_spec.rb
@@ -12,14 +12,14 @@ describe VAOS::MessagesService do
 
   describe '#get_messages', :skip_mvi do
     it 'returns an array of size 1' do
-      VCR.use_cassette('vaos/messages/get_messages', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/messages/get_messages', match_requests_on: %i[method path query]) do
         response = subject.get_messages(request_id)
         expect(response[:data].size).to eq(1)
       end
     end
 
     it 'handles unparsable JSON appropriately' do
-      VCR.use_cassette('vaos/messages/get_messages_unparsable', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/messages/get_messages_unparsable', match_requests_on: %i[method path query]) do
         Settings.sentry.dsn = 'test' # wont actually report to sentry since we're mocking
         expect(Raven).to receive(:capture_message).with("undefined method `map' for nil:NilClass", level: 'warning')
         expect(Raven).to receive(:extra_context).with(invalid_json: {})
@@ -30,7 +30,7 @@ describe VAOS::MessagesService do
     end
 
     it 'handles 500 errors appropriately' do
-      VCR.use_cassette('vaos/messages/get_messages_500', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/messages/get_messages_500', match_requests_on: %i[method path query]) do
         expect { subject.get_messages(request_id) }.to raise_error(
           Common::Exceptions::BackendServiceException
         )
@@ -44,7 +44,7 @@ describe VAOS::MessagesService do
 
     context 'when message is valid' do
       it 'creates a new message' do
-        VCR.use_cassette('vaos/messages/post_message', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/messages/post_message', match_requests_on: %i[method path query]) do
           response = subject.post_message(appointment_request_id, request_body)
           expect(response[:data].to_h.keys)
             .to contain_exactly(:data_identifier, :patient_identifier, :surrogate_identifier, :message_text,
@@ -58,7 +58,7 @@ describe VAOS::MessagesService do
       let(:appointment_request_id) { '8a4886886e4c8e22016eebd3b8820347' }
 
       it 'interprets a 204 response as an error' do
-        VCR.use_cassette('vaos/messages/post_message_error', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/messages/post_message_error', match_requests_on: %i[method path query]) do
           expect { subject.post_message(appointment_request_id, request_body) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -70,7 +70,7 @@ describe VAOS::MessagesService do
       let(:request_body) { { message_text: 'this is my third message' } }
 
       it 'interprets a 400 error' do
-        VCR.use_cassette('vaos/messages/post_message_error_400', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/messages/post_message_error_400', match_requests_on: %i[method path query]) do
           expect { subject.post_message(appointment_request_id, request_body) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )

--- a/modules/vaos/spec/services/middleware/vaos_logging_integration_spec.rb
+++ b/modules/vaos/spec/services/middleware/vaos_logging_integration_spec.rb
@@ -21,7 +21,7 @@ describe VAOS::Middleware::VAOSLogging do
     context 'with a succesful response' do
       # Line 38 fails Jenkins but would fail locally if removed.
       xit 'increments statsd' do
-        VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/get_appointments', match_requests_on: %i[method path query]) do
           expect(Rails.logger).to receive(:info).with(
             'VAOS service call succeeded!',
             duration: 0.0,
@@ -52,7 +52,7 @@ describe VAOS::Middleware::VAOSLogging do
 
     context 'with a failed response' do
       it 'increments statsd' do
-        VCR.use_cassette('vaos/appointments/get_appointments_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/appointments/get_appointments_500', match_requests_on: %i[method path query]) do
           expect(Rails.logger).to receive(:warn).with(
             'VAOS service call failed!',
             duration: 0.0,

--- a/modules/vaos/spec/services/preferences_service_spec.rb
+++ b/modules/vaos/spec/services/preferences_service_spec.rb
@@ -12,7 +12,7 @@ describe VAOS::PreferencesService do
   describe '#get_preferences' do
     context 'with a 200 response' do
       it 'includes' do
-        VCR.use_cassette('vaos/preferences/get_preferences', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/preferences/get_preferences', match_requests_on: %i[method path query]) do
           response = subject.get_preferences
           expect(response.notification_frequency).to eq('Never')
           expect(response.email_allowed).to be_truthy
@@ -37,7 +37,7 @@ describe VAOS::PreferencesService do
 
     context 'with valid params' do
       it 'updates preferences', :skip_mvi do
-        VCR.use_cassette('vaos/preferences/put_preferences', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/preferences/put_preferences', match_requests_on: %i[method path query]) do
           response = subject.put_preferences(request_body)
 
           expect(response.notification_frequency).to eq('Each new message')

--- a/modules/vaos/spec/services/session_service_spec.rb
+++ b/modules/vaos/spec/services/session_service_spec.rb
@@ -30,7 +30,7 @@ describe VAOS::SessionService do
 
   describe 'headers' do
     it 'includes Referer, X-VAMF-JWT and X-Request-ID headers in each request' do
-      VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method uri]) do
+      VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method path query]) do
         response = klass.new(user).get_systems
         expect(response.request_headers).to eq(expected_request_headers)
       end

--- a/modules/vaos/spec/services/systems_service_spec.rb
+++ b/modules/vaos/spec/services/systems_service_spec.rb
@@ -12,14 +12,14 @@ describe VAOS::SystemsService do
   describe '#get_systems' do
     context 'with 10 identifiers and 4 systems' do
       it 'returns an array of size 4' do
-        VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method path query]) do
           response = subject.get_systems
           expect(response.size).to eq(4)
         end
       end
 
       it 'increments metrics total' do
-        VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_systems', match_requests_on: %i[method path query]) do
           expect { subject.get_systems }.to trigger_statsd_increment(
             'api.vaos.get_systems.total', times: 1, value: 1
           )
@@ -29,7 +29,7 @@ describe VAOS::SystemsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/systems/get_systems_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_systems_500', match_requests_on: %i[method path query]) do
           expect { subject.get_systems }.to trigger_statsd_increment(
             'api.vaos.get_systems.total', times: 1, value: 1
           ).and trigger_statsd_increment(
@@ -41,7 +41,7 @@ describe VAOS::SystemsService do
 
     context 'when the upstream server returns a 403' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/systems/get_systems_403', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_systems_403', match_requests_on: %i[method path query]) do
           expect { subject.get_systems }.to trigger_statsd_increment(
             'api.vaos.get_systems.fail', times: 1, value: 1
           ).and raise_error(Common::Exceptions::BackendServiceException)
@@ -53,7 +53,7 @@ describe VAOS::SystemsService do
   describe '#get_facilities' do
     context 'with 141 facilities' do
       it 'returns an array of size 141' do
-        VCR.use_cassette('vaos/systems/get_facilities', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facilities', match_requests_on: %i[method path query]) do
           response = subject.get_facilities('688')
           expect(response.size).to eq(141)
         end
@@ -62,7 +62,7 @@ describe VAOS::SystemsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/systems/get_facilities_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facilities_500', match_requests_on: %i[method path query]) do
           expect { subject.get_facilities('688') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -74,7 +74,7 @@ describe VAOS::SystemsService do
   describe '#get_facility_clinics' do
     context 'with 1 clinic' do
       it 'returns an array of size 1' do
-        VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_clinics', match_requests_on: %i[method path query]) do
           response = subject.get_facility_clinics('983', '323', '983')
           expect(response.size).to eq(4)
         end
@@ -83,7 +83,7 @@ describe VAOS::SystemsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/systems/get_facility_clinics_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_clinics_500', match_requests_on: %i[method path query]) do
           expect { subject.get_facility_clinics('984GA', '323', '984') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -95,7 +95,7 @@ describe VAOS::SystemsService do
   describe '#get_cancel_reasons' do
     context 'with a 200 response' do
       it 'returns an array of size 6' do
-        VCR.use_cassette('vaos/systems/get_cancel_reasons', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_cancel_reasons', match_requests_on: %i[method path query]) do
           response = subject.get_cancel_reasons('984')
           expect(response.size).to eq(6)
         end
@@ -104,7 +104,7 @@ describe VAOS::SystemsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/systems/get_cancel_reasons_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_cancel_reasons_500', match_requests_on: %i[method path query]) do
           expect { subject.get_cancel_reasons('984') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -121,7 +121,8 @@ describe VAOS::SystemsService do
 
     context 'with a 200 response' do
       it 'lists available times by facility with coerced dates' do
-        VCR.use_cassette('vaos/systems/get_facility_available_appointments', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_available_appointments',
+                         match_requests_on: %i[method path query]) do
           response = subject.get_facility_available_appointments(facility_id, start_date, end_date, clinic_ids)
           clinic = response.first
           first_available_time = clinic.appointment_time_slot.first
@@ -133,7 +134,7 @@ describe VAOS::SystemsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/systems/get_facility_appointments', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_appointments', match_requests_on: %i[method path query]) do
           expect { subject.get_cancel_reasons('984') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -145,14 +146,14 @@ describe VAOS::SystemsService do
   describe '#get_system_facilities' do
     context 'with a 200 response' do
       it 'returns the six facilities for the system with id of 688' do
-        VCR.use_cassette('vaos/systems/get_system_facilities', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_system_facilities', match_requests_on: %i[method path query]) do
           response = subject.get_system_facilities('688', '688', '323')
           expect(response.size).to eq(6)
         end
       end
 
       it 'flattens the facility data' do
-        VCR.use_cassette('vaos/systems/get_system_facilities', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_system_facilities', match_requests_on: %i[method path query]) do
           response = subject.get_system_facilities('688', '688', '323')
           facility = response.first.to_h
           expect(facility).to eq(
@@ -174,7 +175,7 @@ describe VAOS::SystemsService do
 
     context 'with express care' do
       it 'includes express care data' do
-        VCR.use_cassette('vaos/systems/get_system_facilities_express_care', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_system_facilities_express_care', match_requests_on: %i[method path query]) do
           response = subject.get_system_facilities('983', '983', 'CR1')
           expect(response.pluck(:express_times)).to eq(
             [
@@ -210,7 +211,7 @@ describe VAOS::SystemsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/systems/get_system_facilities_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_system_facilities_500', match_requests_on: %i[method path query]) do
           expect { subject.get_system_facilities('688', '688', '323') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -222,7 +223,7 @@ describe VAOS::SystemsService do
   describe '#get_facility_limits' do
     context 'with a 200 response' do
       it 'returns the number of requests and limits for a facility' do
-        VCR.use_cassette('vaos/systems/get_facility_limits', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_limits', match_requests_on: %i[method path query]) do
           response = subject.get_facility_limits('688', '323')
           expect(response.number_of_requests).to eq(0)
           expect(response.request_limit).to eq(1)
@@ -232,7 +233,7 @@ describe VAOS::SystemsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/systems/get_facility_limits_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_limits_500', match_requests_on: %i[method path query]) do
           expect { subject.get_facility_limits('688', '323') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -246,7 +247,7 @@ describe VAOS::SystemsService do
 
     context 'with a 200 response' do
       it 'returns a number of requests and limits for multiple facilities' do
-        VCR.use_cassette('vaos/systems/get_facilities_limits_for_multiple', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facilities_limits_for_multiple', match_requests_on: %i[method path query]) do
           response = subject.get_facilities_limits(%w[688 442], '323')
           expect(response.size).to eq(2)
         end
@@ -255,7 +256,8 @@ describe VAOS::SystemsService do
 
     context 'with a 500 response' do
       it 'returns a number of requests and limits for multiple facilities' do
-        VCR.use_cassette('vaos/systems/get_facilities_limits_for_multiple_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facilities_limits_for_multiple_500',
+                         match_requests_on: %i[method path query]) do
           expect { subject.get_facility_limits(%w[688 442], '323') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -267,7 +269,7 @@ describe VAOS::SystemsService do
   describe '#get_system_pact' do
     context 'with a 200 response' do
       it 'returns pact info' do
-        VCR.use_cassette('vaos/systems/get_system_pact', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_system_pact', match_requests_on: %i[method path query]) do
           response = subject.get_system_pact('688')
           expect(response.size).to eq(6)
           expect(response.first.to_h).to eq(
@@ -287,7 +289,7 @@ describe VAOS::SystemsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/systems/get_system_pact_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_system_pact_500', match_requests_on: %i[method path query]) do
           expect { subject.get_system_pact('688') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -299,7 +301,7 @@ describe VAOS::SystemsService do
   describe '#get_facility_visits' do
     context 'with a 200 response for direct visits that is false' do
       it 'returns facility information showing no visits' do
-        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_visits', match_requests_on: %i[method path query]) do
           response = subject.get_facility_visits('688', '688', '323', 'direct')
           expect(response.has_visited_in_past_months).to be_falsey
           expect(response.duration_in_months).to eq(0)
@@ -309,7 +311,7 @@ describe VAOS::SystemsService do
 
     context 'with a 200 response for request visits that is true' do
       it 'returns facility information showing a past visit' do
-        VCR.use_cassette('vaos/systems/get_facility_visits_request', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_visits_request', match_requests_on: %i[method path query]) do
           response = subject.get_facility_visits('688', '688', '323', 'request')
           expect(response.has_visited_in_past_months).to be_truthy
           expect(response.duration_in_months).to eq(2)
@@ -319,7 +321,7 @@ describe VAOS::SystemsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/systems/get_facility_visits_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_facility_visits_500', match_requests_on: %i[method path query]) do
           expect { subject.get_facility_visits('688', '688', '323', 'direct') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -334,7 +336,7 @@ describe VAOS::SystemsService do
       let(:clinic_ids) { [16, 90, 110, 192, 193] }
 
       it 'returns only those clinics parsed correctly', :aggregate_failures do
-        VCR.use_cassette('vaos/systems/get_institutions', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_institutions', match_requests_on: %i[method path query]) do
           response = subject.get_clinic_institutions(system_id, clinic_ids)
           expect(response.map { |c| c[:location_ien].to_i }).to eq(clinic_ids)
           expect(response.last.to_h).to eq(
@@ -353,7 +355,7 @@ describe VAOS::SystemsService do
       let(:clinic_ids) { 16 }
 
       it 'returns the correctly parsed clinic', :aggregate_failures do
-        VCR.use_cassette('vaos/systems/get_institutions_single', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/systems/get_institutions_single', match_requests_on: %i[method path query]) do
           response = subject.get_clinic_institutions(system_id, clinic_ids)
           expect(response.map { |c| c[:location_ien].to_i }).to eq([*clinic_ids])
           expect(response.first.to_h).to eq(
@@ -372,7 +374,7 @@ describe VAOS::SystemsService do
     context 'with a site_codes param array' do
       it 'returns an array', :aggregate_failures do
         VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_site_codes',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           response = subject.get_request_eligibility_criteria(site_codes: %w[442 534])
           expect(response.size).to eq(2)
           first_result = response.first
@@ -394,7 +396,7 @@ describe VAOS::SystemsService do
     context 'with a parent_sites param array' do
       it 'returns an array', :aggregate_failures do
         VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_parent_sites',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           response = subject.get_request_eligibility_criteria(parent_sites: %w[983 984])
           expect(response.size).to eq(5)
           first_result = response.first
@@ -417,7 +419,7 @@ describe VAOS::SystemsService do
     context 'with a single id' do
       it 'returns the criteria for a single facility', :aggregate_failures do
         VCR.use_cassette('vaos/systems/get_request_eligibility_criteria_by_id',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           response = subject.get_request_eligibility_criteria(site_codes: '688')
           expect(response.first.to_h).to eq(
             { links: [{ title: 'request-eligibility-criteria',
@@ -523,7 +525,7 @@ describe VAOS::SystemsService do
     context 'with a site_codes param array' do
       it 'returns an array', :aggregate_failures do
         VCR.use_cassette('vaos/systems/get_direct_booking_eligibility_criteria_by_site_codes',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           response = subject.get_direct_booking_elig_crit(site_codes: %w[442 534])
           expect(response.size).to eq(2)
           first_result = response.first

--- a/modules/vaos/spec/services/v1/fhir_service_spec.rb
+++ b/modules/vaos/spec/services/v1/fhir_service_spec.rb
@@ -26,7 +26,7 @@ describe VAOS::V1::FHIRService do
   describe '#read' do
     context 'when VAMF returns a 404' do
       it 'raises a backend exception with key VAOS_404' do
-        VCR.use_cassette('vaos/fhir/read_organization_404', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/fhir/read_organization_404', match_requests_on: %i[method path query]) do
           expect { subject.read(353_000) }.to raise_error(
             Common::Exceptions::BackendServiceException
           ) { |e| expect(e.key).to eq('VAOS_404') }
@@ -44,7 +44,7 @@ describe VAOS::V1::FHIRService do
       end
 
       it 'returns the JSON response body from the VAMF response' do
-        VCR.use_cassette('vaos/fhir/read_organization_200', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/fhir/read_organization_200', match_requests_on: %i[method path query]) do
           response = subject.read(353_830)
           expect(response.body).to eq(expected_body)
         end
@@ -55,7 +55,7 @@ describe VAOS::V1::FHIRService do
       it 'logs the request in curl format' do
         allow(ENV).to receive(:[]).and_call_original
         allow(ENV).to receive(:[]).with('VAOS_DEBUG').and_return('true')
-        VCR.use_cassette('vaos/fhir/read_organization_200', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/fhir/read_organization_200', match_requests_on: %i[method path query]) do
           silence do
             expect_any_instance_of(::Logger).to receive(:warn).once
             subject.read(353_830)
@@ -68,7 +68,7 @@ describe VAOS::V1::FHIRService do
   describe '#search' do
     context 'when VAMF returns a 500' do
       xit 'raises a backend exception with key VAOS_502' do
-        VCR.use_cassette('vaos/fhir/search_organization_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/fhir/search_organization_500', match_requests_on: %i[method path query]) do
           expect { subject.search({ 'identifier' => '353000' }) }.to raise_error(
             Common::Exceptions::BackendServiceException
           ) { |e| expect(e.key).to eq('VAOS_502') }
@@ -86,7 +86,7 @@ describe VAOS::V1::FHIRService do
       end
 
       xit 'returns the JSON response body from the VAMF response' do
-        VCR.use_cassette('vaos/fhir/search_organization_200', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/fhir/search_organization_200', match_requests_on: %i[method path query]) do
           response = subject.search({ 'identifier' => '983,984' })
           expect(response.body).to eq(expected_body)
         end

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -37,7 +37,7 @@ describe VAOS::V2::AppointmentsService do
 
       it 'returns the created appointment - va - booked' do
         VCR.use_cassette('vaos/v2/appointments/post_appointments_va_booked_200_JACQUELINE_M',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           response = subject.post_appointment(va_booked_request_body)
           expect(response[:id]).to be_a(String)
         end
@@ -45,7 +45,7 @@ describe VAOS::V2::AppointmentsService do
 
       it 'returns the created appointment-va-proposed-clinic' do
         VCR.use_cassette('vaos/v2/appointments/post_appointments_va_proposed_clinic_200',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           response = subject.post_appointment(va_proposed_clinic_request_body)
           expect(response[:id]).to eq('70065')
         end
@@ -63,7 +63,8 @@ describe VAOS::V2::AppointmentsService do
     # TODO: Verify CC request details
     context 'when cc appointment create request is valid' do
       it 'returns the created appointment - cc - proposed' do
-        VCR.use_cassette('vaos/v2/appointments/post_appointments_cc_200_2222022', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/post_appointments_cc_200_2222022',
+                         match_requests_on: %i[method path query]) do
           response = subject.post_appointment(community_cares_request_body)
           expect(response[:id]).to be_a(String)
         end
@@ -72,7 +73,7 @@ describe VAOS::V2::AppointmentsService do
 
     context 'when the patientIcn is missing' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/v2/appointments/post_appointments_400', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/post_appointments_400', match_requests_on: %i[method path query]) do
           expect { subject.post_appointment(community_cares_request_body) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -82,7 +83,7 @@ describe VAOS::V2::AppointmentsService do
 
     context 'when the patientIcn is missing on a direct scheduling submission' do
       it 'raises a backend exception and logs error details' do
-        VCR.use_cassette('vaos/v2/appointments/post_appointments_400', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/post_appointments_400', match_requests_on: %i[method path query]) do
           allow(Rails.logger).to receive(:warn).at_least(:once)
           expect { subject.post_appointment(va_booked_request_body) }.to raise_error(
             Common::Exceptions::BackendServiceException
@@ -95,7 +96,7 @@ describe VAOS::V2::AppointmentsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/v2/appointments/post_appointments_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/post_appointments_500', match_requests_on: %i[method path query]) do
           expect { subject.post_appointment(community_cares_request_body) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -107,7 +108,7 @@ describe VAOS::V2::AppointmentsService do
   describe '#get_appointments' do
     context 'when requesting a list of appointments given a date range' do
       it 'returns a 200 status with list of appointments' do
-        VCR.use_cassette('vaos/v2/appointments/get_appointments_200', match_requests_on: %i[method uri],
+        VCR.use_cassette('vaos/v2/appointments/get_appointments_200', match_requests_on: %i[method path query],
                                                                       tag: :force_utf8) do
           response = subject.get_appointments(start_date2, end_date2)
           expect(response[:data].size).to eq(23)
@@ -117,8 +118,8 @@ describe VAOS::V2::AppointmentsService do
 
     context 'when requesting a list of appointments given a date range and single status' do
       it 'returns a 200 status with list of appointments' do
-        VCR.use_cassette('vaos/v2/appointments/get_appointments_single_status_200', match_requests_on: %i[method uri],
-                                                                                    tag: :force_utf8) do
+        VCR.use_cassette('vaos/v2/appointments/get_appointments_single_status_200',
+                         match_requests_on: %i[method path query], tag: :force_utf8) do
           response = subject.get_appointments(start_date2, end_date2, 'proposed')
           expect(response[:data].size).to eq(4)
           expect(response[:data][0][:status]).to eq('proposed')
@@ -128,8 +129,8 @@ describe VAOS::V2::AppointmentsService do
 
     context 'when requesting a list of appointments given a date range and multiple statuses' do
       it 'returns a 200 status with list of appointments' do
-        VCR.use_cassette('vaos/v2/appointments/get_appointments_multi_status_200', match_requests_on: %i[method uri],
-                                                                                   tag: :force_utf8) do
+        VCR.use_cassette('vaos/v2/appointments/get_appointments_multi_status_200',
+                         match_requests_on: %i[method path query], tag: :force_utf8) do
           response = subject.get_appointments(start_date2, end_date2, 'proposed,booked')
           expect(response[:data].size).to eq(4)
           expect(response[:data][0][:status]).to eq('proposed')
@@ -140,7 +141,7 @@ describe VAOS::V2::AppointmentsService do
 
     context '400' do
       it 'raises a 400 error' do
-        VCR.use_cassette('vaos/v2/appointments/get_appointments_400', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/get_appointments_400', match_requests_on: %i[method path query]) do
           expect { subject.get_appointments(start_date, end_date) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -150,7 +151,7 @@ describe VAOS::V2::AppointmentsService do
 
     context '401' do
       it 'raises a 401 error' do
-        VCR.use_cassette('vaos/v2/appointments/get_appointments_401', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/get_appointments_401', match_requests_on: %i[method path query]) do
           expect { subject.get_appointments(start_date, end_date) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -160,7 +161,7 @@ describe VAOS::V2::AppointmentsService do
 
     context '403' do
       it 'raises a 403' do
-        VCR.use_cassette('vaos/v2/appointments/get_appointments_403', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/get_appointments_403', match_requests_on: %i[method path query]) do
           expect { subject.get_appointments(start_date, end_date) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -170,7 +171,7 @@ describe VAOS::V2::AppointmentsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/v2/appointments/get_appointments_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/get_appointments_500', match_requests_on: %i[method path query]) do
           expect { subject.get_appointments(start_date, end_date) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -195,7 +196,7 @@ describe VAOS::V2::AppointmentsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/v2/appointments/get_appointment_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/get_appointment_500', match_requests_on: %i[method path query]) do
           expect { subject.get_appointment('00000') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -208,7 +209,7 @@ describe VAOS::V2::AppointmentsService do
     context 'when the upstream server attemps to cancel an appointment' do
       context 'with Jaqueline Morgan' do
         it 'returns a cancelled status and the cancelled appointment information' do
-          VCR.use_cassette('vaos/v2/appointments/cancel_appointments_200', match_requests_on: %i[method uri]) do
+          VCR.use_cassette('vaos/v2/appointments/cancel_appointments_200', match_requests_on: %i[method path query]) do
             response = subject.update_appointment('70060', 'cancelled')
             expect(response.status).to eq('cancelled')
           end
@@ -216,7 +217,7 @@ describe VAOS::V2::AppointmentsService do
       end
 
       it 'returns a 400 when the appointment is not cancellable' do
-        VCR.use_cassette('vaos/v2/appointments/cancel_appointment_400', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/cancel_appointment_400', match_requests_on: %i[method path query]) do
           expect { subject.update_appointment('42081', 'cancelled') }
             .to raise_error do |error|
             expect(error).to be_a(Common::Exceptions::BackendServiceException)
@@ -228,7 +229,7 @@ describe VAOS::V2::AppointmentsService do
 
     context 'when there is a server error in updating an appointment' do
       it 'throws a BackendServiceException' do
-        VCR.use_cassette('vaos/v2/appointments/cancel_appointment_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/appointments/cancel_appointment_500', match_requests_on: %i[method path query]) do
           expect { subject.update_appointment('35952', 'cancelled') }
             .to raise_error do |error|
             expect(error).to be_a(Common::Exceptions::BackendServiceException)

--- a/modules/vaos/spec/services/v2/mobile_facility_service_spec.rb
+++ b/modules/vaos/spec/services/v2/mobile_facility_service_spec.rb
@@ -13,7 +13,7 @@ describe VAOS::V2::MobileFacilityService do
     context 'with a single facility id arg' do
       it 'returns a scheduling configuration' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_scheduling_configurations_200',
-                         match_requests_on: %i[method uri], tag: :force_utf8) do
+                         match_requests_on: %i[method path query], tag: :force_utf8) do
           response = subject.get_scheduling_configurations('489')
           expect(response[:data].size).to eq(1)
         end
@@ -23,7 +23,7 @@ describe VAOS::V2::MobileFacilityService do
     context 'with multiple facility ids arg' do
       it 'returns scheduling configurations' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_scheduling_configurations_200',
-                         match_requests_on: %i[method uri], tag: :force_utf8) do
+                         match_requests_on: %i[method path query], tag: :force_utf8) do
           response = subject.get_scheduling_configurations('489,984')
           expect(response[:data].size).to eq(2)
         end
@@ -39,7 +39,7 @@ describe VAOS::V2::MobileFacilityService do
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_scheduling_configurations_500',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           expect { subject.get_scheduling_configurations(489, false) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -52,7 +52,7 @@ describe VAOS::V2::MobileFacilityService do
     context 'with a facility id' do
       it 'returns a configuration' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_single_id_200',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           response = subject.get_facilities(ids: '688')
           expect(response[:data].size).to eq(1)
         end
@@ -62,7 +62,7 @@ describe VAOS::V2::MobileFacilityService do
     context 'with multiple facility ids' do
       it 'returns a configuration' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_200',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           response = subject.get_facilities(ids: '983,984')
           expect(response[:data].size).to eq(2)
         end
@@ -72,7 +72,7 @@ describe VAOS::V2::MobileFacilityService do
     context 'with a facility id and children true' do
       it 'returns a configuration' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_with_children_200',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           response = subject.get_facilities(children: true, ids: '688')
           expect(response[:data].size).to eq(8)
         end
@@ -82,7 +82,7 @@ describe VAOS::V2::MobileFacilityService do
     context 'when the upstream server returns a 400' do
       it 'raises a backend exception' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_400',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           expect { subject.get_facilities(ids: 688) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -93,7 +93,7 @@ describe VAOS::V2::MobileFacilityService do
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_facilities_500',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           expect { subject.get_facilities(ids: '688') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -141,7 +141,7 @@ describe VAOS::V2::MobileFacilityService do
     context 'with a valid request' do
       it 'returns a facility' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_facility_200',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           response = subject.get_facility('983')
           expect(response[:id]).to eq('983')
           expect(response[:type]).to eq('va_facilities')
@@ -153,7 +153,7 @@ describe VAOS::V2::MobileFacilityService do
     context 'when the upstream server returns a 400' do
       it 'raises a backend exception' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_facility_400',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           expect { subject.get_facility('983') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -164,7 +164,7 @@ describe VAOS::V2::MobileFacilityService do
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
         VCR.use_cassette('vaos/v2/mobile_facility_service/get_facility_500',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           expect { subject.get_facility('983') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )

--- a/modules/vaos/spec/services/v2/mobile_ppms_service_spec.rb
+++ b/modules/vaos/spec/services/v2/mobile_ppms_service_spec.rb
@@ -13,7 +13,7 @@ describe VAOS::V2::MobilePPMSService do
     context 'with a single provider id' do
       it 'returns a provider name' do
         VCR.use_cassette('vaos/v2/mobile_ppms_service/get_provider_200',
-                         match_requests_on: %i[method uri], tag: :force_utf8) do
+                         match_requests_on: %i[method path query], tag: :force_utf8) do
           response = subject.get_provider('1407938061')
           expect(response.name).to eq 'DEHGHAN, AMIR '
         end
@@ -23,7 +23,7 @@ describe VAOS::V2::MobilePPMSService do
     context 'when the upstream server returns a 400' do
       it 'raises a bad request' do
         VCR.use_cassette('vaos/v2/mobile_ppms_service/get_provider_400',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           expect { subject.get_provider(489) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )
@@ -34,7 +34,7 @@ describe VAOS::V2::MobilePPMSService do
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
         VCR.use_cassette('vaos/v2/mobile_ppms_service/get_provider_500',
-                         match_requests_on: %i[method uri]) do
+                         match_requests_on: %i[method path query]) do
           expect { subject.get_provider(489) }.to raise_error(
             Common::Exceptions::BackendServiceException
           )

--- a/modules/vaos/spec/services/v2/patients_service_spec.rb
+++ b/modules/vaos/spec/services/v2/patients_service_spec.rb
@@ -12,7 +12,8 @@ describe VAOS::V2::PatientsService do
   describe '#index' do
     context 'with an patient' do
       it 'returns a patient' do
-        VCR.use_cassette('vaos/v2/patients/get_patient_appointment_metadata', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/patients/get_patient_appointment_metadata',
+                         match_requests_on: %i[method path query]) do
           response = subject.get_patient_appointment_metadata('primaryCare', '100', 'direct')
           expect(response[:eligible]).to eq(false)
 
@@ -23,7 +24,8 @@ describe VAOS::V2::PatientsService do
 
     context 'when the upstream server returns a 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/v2/patients/get_patient_appointment_metadata_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/patients/get_patient_appointment_metadata_500',
+                         match_requests_on: %i[method path query]) do
           expect { subject.get_patient_appointment_metadata('primaryCare', '100', 'direct') }.to raise_error(
             Common::Exceptions::BackendServiceException
           )

--- a/modules/vaos/spec/services/v2/systems_service_spec.rb
+++ b/modules/vaos/spec/services/v2/systems_service_spec.rb
@@ -12,7 +12,7 @@ describe VAOS::V2::SystemsService do
   describe '#get_facility_clinics' do
     context 'with 7 clinics' do
       it 'returns an array of size 7' do
-        VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/systems/get_facility_clinics_200', match_requests_on: %i[method path query]) do
           response = subject.get_facility_clinics(location_id: '983', clinical_service: 'audiology')
           expect(response.size).to eq(7)
           expect(response[0][:id]).to eq('570')
@@ -22,7 +22,7 @@ describe VAOS::V2::SystemsService do
 
     context 'when the upstream server returns a 400' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/systems/get_facility_clinics_400', match_requests_on: %i[method path query]) do
           expect do
             subject.get_facility_clinics(location_id: '983', clinic_ids: '570', clinical_service: 'audiology')
           end.to raise_error(Common::Exceptions::BackendServiceException, /VAOS_400/)
@@ -34,7 +34,7 @@ describe VAOS::V2::SystemsService do
   describe '#get_available_slots' do
     context 'when the upstream server returns status code 500' do
       it 'raises a backend exception' do
-        VCR.use_cassette('vaos/v2/systems/get_available_slots_500', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/systems/get_available_slots_500', match_requests_on: %i[method path query]) do
           expect do
             subject.get_available_slots(location_id: '983', clinic_id: '1081',
                                         start_dt: '2021-10-01T00:00:00Z',
@@ -46,7 +46,7 @@ describe VAOS::V2::SystemsService do
 
     context 'when the upstream server returns status code 200' do
       it 'returns a list of available slots' do
-        VCR.use_cassette('vaos/v2/systems/get_available_slots_200', match_requests_on: %i[method uri]) do
+        VCR.use_cassette('vaos/v2/systems/get_available_slots_200', match_requests_on: %i[method path query]) do
           available_slots = subject.get_available_slots(location_id: '983', clinic_id: '1081',
                                                         start_dt: '2021-10-26T00:00:00Z',
                                                         end_dt: '2021-12-30T23:59:59Z')


### PR DESCRIPTION
… match

<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
Changed VAOS VCR Cassette match from method, uri to method, path, query.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#46292

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
