### PR TITLE
API-18285 Prototype OAuth for appeals API endpoints

### DIFF
--- a/modules/appeals_api/app/controllers/appeals_api/application_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/application_controller.rb
@@ -46,5 +46,15 @@ module AppealsApi
       end
       { errors: errors }
     end
+
+    # HEADERS should be a list of header names of interest, defined in the parent
+    # controller based on the form schema.
+    #
+    # @return [Hash<String,String>] request headers of interest as a hash
+    def request_headers
+      return {} unless defined? self.class::HEADERS
+
+      self.class::HEADERS.index_with { |key| request.headers[key] }.compact
+    end
   end
 end

--- a/modules/appeals_api/app/controllers/appeals_api/higher_level_reviews/v2/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/higher_level_reviews/v2/higher_level_reviews_controller.rb
@@ -2,11 +2,18 @@
 
 require 'appeals_api/form_schemas'
 
-class AppealsApi::HigherLevelReviews::V2::HigherLevelReviewsController < AppealsApi::ApplicationController
-  skip_before_action :authenticate
+class AppealsApi::HigherLevelReviews::V2::HigherLevelReviewsController < AppealsApi::OAuthApplicationController
+  skip_before_action :authenticate, only: %i[schema]
+  skip_before_action :verify_oauth_token!, only: %i[schema]
+  skip_before_action :verify_oauth_scopes!, only: %i[schema]
 
+  HEADERS = AppealsApi::V2::DecisionReviews::HigherLevelReviewsController::HEADERS
   FORM_NUMBER = '200996_WITH_SHARED_REFS'
   SCHEMA_ERROR_TYPE = Common::Exceptions::DetailedSchemaErrors
+
+  def index
+    render json: AppealsApi::V2::DecisionReviews::HigherLevelReviewsController.veteran_hlrs(target_veteran_icn)
+  end
 
   def schema
     render json: AppealsApi::JsonSchemaToSwaggerConverter.remove_comments(

--- a/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v2/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/notice_of_disagreements/v2/notice_of_disagreements_controller.rb
@@ -2,11 +2,18 @@
 
 require 'appeals_api/form_schemas'
 
-class AppealsApi::NoticeOfDisagreements::V2::NoticeOfDisagreementsController < AppealsApi::ApplicationController
-  skip_before_action :authenticate
+class AppealsApi::NoticeOfDisagreements::V2::NoticeOfDisagreementsController < AppealsApi::OAuthApplicationController
+  skip_before_action :authenticate, only: %i[schema]
+  skip_before_action :verify_oauth_token!, only: %i[schema]
+  skip_before_action :verify_oauth_scopes!, only: %i[schema]
 
+  HEADERS = AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController::HEADERS
   FORM_NUMBER = '10182_WITH_SHARED_REFS'
   SCHEMA_ERROR_TYPE = Common::Exceptions::DetailedSchemaErrors
+
+  def index
+    render json: AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController.veteran_nods(target_veteran_icn)
+  end
 
   def schema
     # TODO: Return full schema after we've validated all Non-Veteran Claimant functionality

--- a/modules/appeals_api/app/controllers/appeals_api/oauth_application_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/oauth_application_controller.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+module AppealsApi
+  class OAuthApplicationController < ::OpenidApplicationController
+    include AppealsApi::MPIVeteran
+    before_action :verify_oauth_token!
+    before_action :verify_oauth_scopes!
+
+    # HEADERS should be a list of header names of interest, defined in the parent
+    # controller based on the form schema.
+    #
+    # @return [Hash<String,String>] request headers of interest as a hash
+    def request_headers
+      return {} unless defined? self.class::HEADERS
+
+      self.class::HEADERS.index_with { |key| request.headers[key] }.compact
+    end
+
+    #
+    # Override this in individual controllers if needed to return a list of required OAuth
+    # scopes based on the context.
+    # FIXME: replace these with actual scopes
+    #
+    # @return [Array<String>] OAuth scopes required for a successful current request
+    def oauth_scopes
+      case action_name
+      when 'index'
+        %w[claim.read]
+      when 'show'
+        %w[claim.read]
+      when 'create'
+        %w[claim.write]
+      else
+        []
+      end
+    end
+
+    #
+    # Overrides the default value defined in OpenidApplicationController and is
+    # required for the Client Credential Grant (CCG) flow.
+    #
+    # @return [String] The OAuth audience for the appeals API
+    def fetch_aud
+      # FIXME: replace with actual value
+      Settings.oidc.isolated_audience.claims
+    end
+
+    #
+    # Verify that the CCG token is valid or that the OAuth user matches the target veteran
+    #
+    # @return [boolean] True if the current authenticated user is the target veteran
+    def verify_oauth_token!
+      if token.client_credentials_token?
+        validate_ccg_token!
+        return
+      end
+
+      return if user_is_target_veteran? || user_represents_veteran?
+
+      raise ::Common::Exceptions::Forbidden
+    end
+
+    #
+    # Verify that the token's OAuth scope(s) match the required scopes, if any
+    #
+    def verify_oauth_scopes!
+      token_scopes = token.payload['scp'] || []
+      oauth_scopes.each do |scope|
+        raise ::Common::Exceptions::Forbidden unless token_scopes.include? scope
+      end
+    end
+
+    private
+
+    def error_klass(error_detail_string)
+      # Errors from the jwt gem (and other dependencies) are re-raised with
+      # this class so we can exclude them from Sentry without needing to know
+      # all the classes used by our dependencies.
+      Common::Exceptions::TokenValidationError.new(detail: error_detail_string)
+    end
+
+    def handle_opaque_token(token_string, aud)
+      opaque_token = OpaqueToken.new(token_string, aud)
+      @session = Session.find(hash_token(opaque_token))
+      if @session.nil?
+        opaque_token.set_payload(fetch_issued(token_string))
+        opaque_token.set_is_ssoi(!opaque_token.static?)
+        return opaque_token if TokenUtil.validate_token(opaque_token)
+      elsif @session.profile.attrs['iss'] == 'VA_SSOi_IDP'
+        opaque_token.set_is_ssoi(true)
+        return opaque_token
+      end
+      raise error_klass('Invalid token.')
+    end
+
+    def jwt?(token_string)
+      JWT.decode(token_string, nil, false, algorithm: 'RS256')
+      true
+    rescue JWT::DecodeError
+      false
+    end
+
+    def token_from_request
+      authorization = request.authorization.to_s
+      token_is_valid = ::OpenidApplicationController::TOKEN_REGEX.match?(authorization)
+      raise error_klass('Invalid token.') unless token_is_valid
+
+      token_string = authorization.sub(::OpenidApplicationController::TOKEN_REGEX, '').gsub(/^"|"$/, '')
+      if jwt?(token_string)
+        Token.new(token_string, fetch_aud)
+      else
+        # Handle opaque token
+        # FIXME: this will be the wrong Settings value
+        return handle_opaque_token(token_string, fetch_aud) if Settings.oidc.issued_url
+
+        raise error_klass('Invalid token.')
+      end
+    end
+
+    def token
+      @token ||= token_from_request
+    end
+
+    #
+    # Determine if the current authenticated user is the Veteran being acted on
+    #
+    # @return [boolean] True if the current user is the Veteran being acted on, false otherwise
+    def user_is_target_veteran?
+      return false if @current_user.icn.blank?
+
+      @current_user.icn == target_veteran_icn
+    end
+
+    #
+    # Determine if the current authenticated user is the target veteran's representative
+    #
+    # @return [boolean] True if the current authenticated user is the target veteran's representative
+    def user_represents_veteran?
+      return false unless @current_user
+
+      reps = ::Veteran::Service::Representative.all_for_user(
+        first_name: @current_user.first_name,
+        last_name: @current_user.last_name
+      )
+
+      return false if reps.blank?
+      return false if reps.count > 1
+
+      rep = reps.first
+      veteran_poa_code = ::Veteran::User.new(target_veteran)&.power_of_attorney&.code
+
+      return false if veteran_poa_code.blank?
+
+      rep&.poa_codes&.include?(veteran_poa_code) || false
+    end
+
+    def token_validation_client
+      # FIXME: replace with actual key
+      @client ||= TokenValidation::V2::Client.new(api_key: Settings.claims_api.token_validation.api_key)
+    end
+
+    def validate_ccg_token!
+      root_url = request.base_url == 'https://api.va.gov' ? 'https://api.va.gov' : 'https://sandbox-api.va.gov'
+      oauth_scopes.each do |scope|
+        @is_valid_ccg_flow = token_validation_client.token_valid?(
+          # FIXME: replace with actual URL
+          audience: "#{root_url}/services/claims",
+          scope: scope,
+          token: token
+        )
+        raise ::Common::Exceptions::Forbidden unless @is_valid_ccg_flow
+      end
+    end
+  end
+end

--- a/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v2/supplemental_claims_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/supplemental_claims/v2/supplemental_claims_controller.rb
@@ -2,11 +2,18 @@
 
 require 'appeals_api/form_schemas'
 
-class AppealsApi::SupplementalClaims::V2::SupplementalClaimsController < AppealsApi::ApplicationController
-  skip_before_action :authenticate
+class AppealsApi::SupplementalClaims::V2::SupplementalClaimsController < AppealsApi::OAuthApplicationController
+  skip_before_action :authenticate, only: %i[schema]
+  skip_before_action :verify_oauth_token!, only: %i[schema]
+  skip_before_action :verify_oauth_scopes!, only: %i[schema]
 
+  HEADERS = AppealsApi::V2::DecisionReviews::SupplementalClaimsController::HEADERS
   FORM_NUMBER = '200995_WITH_SHARED_REFS'
   SCHEMA_ERROR_TYPE = Common::Exceptions::DetailedSchemaErrors
+
+  def index
+    render json: AppealsApi::V2::DecisionReviews::SupplementalClaimsController.veteran_scs(target_veteran_icn)
+  end
 
   def schema
     # TODO: Return full schema after we've validated all Non-Veteran Claimant functionality

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/contestable_issues_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/contestable_issues_controller.rb
@@ -17,7 +17,7 @@ module AppealsApi::V2
       before_action :validate_json_schema, only: %i[index]
       before_action :validate_params, only: %i[index]
 
-      EXPECTED_HEADERS = %w[X-VA-SSN X-VA-Receipt-Date X-VA-File-Number].freeze
+      HEADERS = %w[X-VA-SSN X-VA-Receipt-Date X-VA-File-Number].freeze
 
       VALID_DECISION_REVIEW_TYPES = %w[higher_level_reviews notice_of_disagreements supplemental_claims].freeze
 
@@ -153,10 +153,6 @@ module AppealsApi::V2
             }
           ]
         }, status: '422'
-      end
-
-      def request_headers
-        EXPECTED_HEADERS.index_with { |key| request.headers[key] }.compact
       end
 
       def validate_json_schema

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -25,11 +25,15 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
   SCHEMA_ERROR_TYPE = Common::Exceptions::DetailedSchemaErrors
   ALLOWED_COLUMNS = %i[id status code detail created_at updated_at].freeze
 
+  def self.veteran_hlrs(veteran_icn)
+    hlrs = AppealsApi::HigherLevelReview.select(ALLOWED_COLUMNS)
+                                        .where(veteran_icn: veteran_icn)
+                                        .order(created_at: :desc)
+    AppealsApi::HigherLevelReviewSerializer.new(hlrs).serializable_hash
+  end
+
   def index
-    veteran_hlrs = AppealsApi::HigherLevelReview.select(ALLOWED_COLUMNS)
-                                                .where(veteran_icn: target_veteran.mpi_icn)
-                                                .order(created_at: :desc)
-    render json: AppealsApi::HigherLevelReviewSerializer.new(veteran_hlrs).serializable_hash
+    render json: self.class.veteran_hlrs(target_veteran_icn)
   end
 
   def create
@@ -104,10 +108,6 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
         }
       }
     }
-  end
-
-  def request_headers
-    HEADERS.index_with { |key| request.headers[key] }.compact
   end
 
   def new_higher_level_review

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/legacy_appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/legacy_appeals_controller.rb
@@ -40,10 +40,6 @@ class AppealsApi::V2::DecisionReviews::LegacyAppealsController < AppealsApi::App
 
   attr_reader :caseflow_response, :caseflow_exception_response
 
-  def request_headers
-    HEADERS.index_with { |key| request.headers[key] }.compact
-  end
-
   def validate_json_schema
     validate_json_schema_for_headers
   end

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -72,10 +72,6 @@ module AppealsApi::V2
           }
         end
 
-        def request_headers
-          HEADERS.index_with { |key| request.headers[key] }.compact
-        end
-
         def log_error(error_detail)
           log_exception_to_sentry(EvidenceSubmissionRequestValidatorError.new(error_detail), {}, {}, :warn)
           error_detail

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
@@ -26,11 +26,15 @@ class AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController < Appeals
   SCHEMA_ERROR_TYPE = Common::Exceptions::DetailedSchemaErrors
   ALLOWED_COLUMNS = %i[id status code detail created_at updated_at].freeze
 
+  def self.veteran_nods(veteran_icn)
+    nods = AppealsApi::NoticeOfDisagreement.select(ALLOWED_COLUMNS)
+                                           .where(veteran_icn: veteran_icn)
+                                           .order(created_at: :desc)
+    AppealsApi::NoticeOfDisagreementSerializer.new(nods).serializable_hash
+  end
+
   def index
-    veteran_nods = AppealsApi::NoticeOfDisagreement.select(ALLOWED_COLUMNS)
-                                                   .where(veteran_icn: request_headers['X-VA-ICN'].presence&.strip)
-                                                   .order(created_at: :desc)
-    render json: AppealsApi::NoticeOfDisagreementSerializer.new(veteran_nods).serializable_hash
+    render json: self.class.veteran_nods(request_headers['X-VA-ICN'].presence&.strip)
   end
 
   def create
@@ -102,10 +106,6 @@ class AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController < Appeals
         }
       }
     }
-  end
-
-  def request_headers
-    HEADERS.index_with { |key| request.headers[key] }.compact
   end
 
   def new_notice_of_disagreement

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims/evidence_submissions_controller.rb
@@ -73,10 +73,6 @@ module AppealsApi::V2
           }
         end
 
-        def request_headers
-          HEADERS.index_with { |key| request.headers[key] }.compact
-        end
-
         def log_error(error_detail)
           log_exception_to_sentry(EvidenceSubmissionRequestValidatorError.new(error_detail), {}, {}, :warn)
           error_detail

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
@@ -22,11 +22,15 @@ class AppealsApi::V2::DecisionReviews::SupplementalClaimsController < AppealsApi
   SCHEMA_ERROR_TYPE = Common::Exceptions::DetailedSchemaErrors
   ALLOWED_COLUMNS = %i[id status code detail created_at updated_at].freeze
 
+  def self.veteran_scs(veteran_icn)
+    scs = AppealsApi::SupplementalClaim.select(ALLOWED_COLUMNS)
+                                       .where(veteran_icn: veteran_icn)
+                                       .order(created_at: :desc)
+    AppealsApi::SupplementalClaimSerializer.new(scs).serializable_hash
+  end
+
   def index
-    veteran_scs = AppealsApi::SupplementalClaim.select(ALLOWED_COLUMNS)
-                                               .where(veteran_icn: target_veteran.mpi_icn)
-                                               .order(created_at: :desc)
-    render json: AppealsApi::SupplementalClaimSerializer.new(veteran_scs).serializable_hash
+    render json: self.class.veteran_scs(target_veteran_icn)
   end
 
   def create
@@ -105,10 +109,6 @@ class AppealsApi::V2::DecisionReviews::SupplementalClaimsController < AppealsApi
         }
       }
     }
-  end
-
-  def request_headers
-    HEADERS.index_with { |key| request.headers[key] }.compact
   end
 
   def render_model_errors(model)

--- a/modules/appeals_api/app/controllers/concerns/appeals_api/mpi_veteran.rb
+++ b/modules/appeals_api/app/controllers/concerns/appeals_api/mpi_veteran.rb
@@ -9,7 +9,7 @@ module AppealsApi
       # Calls to target_veteran expect typical request_headers and
       # a request body with identifying veteran attributes.
       #
-      # Returns the veteran with MPI attributes, including (of concern to us) their ICN.
+      # Returns the veteran with MPI attributes, including (of concern to us) their ICN, or nil.
       def target_veteran
         veteran ||= Appellant.new(
           type: :veteran,
@@ -25,6 +25,15 @@ module AppealsApi
         )
 
         mpi_veteran
+      rescue
+        nil
+      end
+
+      def target_veteran_icn
+        veteran_icn = request.headers['X-VA-ICN'].presence&.strip
+        return veteran_icn if veteran_icn.present?
+
+        target_veteran&.mpi_icn
       end
     end
   end

--- a/modules/appeals_api/config/routes.rb
+++ b/modules/appeals_api/config/routes.rb
@@ -111,6 +111,8 @@ AppealsApi::Engine.routes.draw do
       end
 
       resources :schemas, only: :show, param: :schema_type, controller: '/appeals_api/schemas/shared_schemas'
+
+      resources :notice_of_disagreements, only: %i[index], controller: nod_schema_cpath
     end
   end
 
@@ -135,6 +137,8 @@ AppealsApi::Engine.routes.draw do
       end
 
       resources :schemas, only: :show, param: :schema_type, controller: '/appeals_api/schemas/shared_schemas'
+
+      resources :higher_level_reviews, only: %i[index], controller: hlr_schema_cpath
     end
   end
 
@@ -161,6 +165,8 @@ AppealsApi::Engine.routes.draw do
       end
 
       resources :schemas, only: :show, param: :schema_type, controller: '/appeals_api/schemas/shared_schemas'
+
+      resources :supplemental_claims, only: %i[index], controller: sc_schema_cpath
     end
   end
 

--- a/modules/appeals_api/spec/requests/v2/higher_level_reviews_controller_spec.rb
+++ b/modules/appeals_api/spec/requests/v2/higher_level_reviews_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'token_validation/v2/client'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 describe AppealsApi::V2::DecisionReviews::HigherLevelReviewsController, type: :request do
@@ -24,6 +25,7 @@ describe AppealsApi::V2::DecisionReviews::HigherLevelReviewsController, type: :r
     @invalid_headers = fixture_as_json 'invalid_200996_headers.json', version: 'v2'
   end
 
+  let(:veteran_icn) { '1013062086V794840' }
   let(:parsed) { JSON.parse(response.body) }
 
   describe '#index' do
@@ -31,8 +33,8 @@ describe AppealsApi::V2::DecisionReviews::HigherLevelReviewsController, type: :r
 
     context 'with minimum required headers' do
       it 'returns all HLRs for the given Veteran' do
-        uuid_1 = create(:higher_level_review_v2, veteran_icn: '1013062086V794840', form_data: nil).id
-        uuid_2 = create(:higher_level_review_v2, veteran_icn: '1013062086V794840').id
+        uuid_1 = create(:higher_level_review_v2, veteran_icn: veteran_icn, form_data: nil).id
+        uuid_2 = create(:higher_level_review_v2, veteran_icn: veteran_icn).id
         create(:higher_level_review_v2, veteran_icn: 'something_else')
 
         get(path, headers: @minimum_required_headers)
@@ -390,6 +392,92 @@ describe AppealsApi::V2::DecisionReviews::HigherLevelReviewsController, type: :r
       expect(response.status).to eq(404)
       expect(parsed['errors']).to be_an Array
       expect(parsed['errors']).not_to be_empty
+    end
+  end
+
+  context 'using the dedicated HLR API path' do
+    describe '#index' do
+      let(:path) { new_base_path 'higher_level_reviews' }
+      let(:scopes) { %w[claim.read] }
+
+      context 'when not authenticated' do
+        it 'returns 401: Unauthorized' do
+          get(path, headers: @minimum_required_headers)
+
+          expect(response.status).to eq(401)
+          expect(parsed['errors']).to be_an(Array)
+        end
+      end
+
+      context 'when using Okta auth' do
+        context 'when valid' do
+          it 'returns all HLRs for an authenticated Veteran' do
+            create(:higher_level_review_v2, veteran_icn: veteran_icn, form_data: nil).id
+            create(:higher_level_review_v2, veteran_icn: veteran_icn).id
+            create(:higher_level_review_v2, veteran_icn: 'something_else')
+
+            with_okta_user(scopes) do |auth_header|
+              get(path, headers: @minimum_required_headers.merge(auth_header))
+
+              expect(response.status).to eq(200)
+              expect(parsed['data'].length).to eq(2)
+            end
+          end
+        end
+
+        context 'when invalid' do
+          context 'because of the wrong scope' do
+            let(:scopes) { %w[claim.something_else] }
+
+            it 'returns a 403' do
+              with_okta_user(scopes) do |auth_header|
+                get(path, headers: @minimum_required_headers.merge(auth_header))
+
+                expect(response.status).to eq(403)
+                expect(parsed['errors']).to be_an(Array)
+              end
+            end
+          end
+        end
+      end
+
+      context 'when using CCG auth' do
+        let(:ccg_token) { OpenStruct.new(client_credentials_token?: true, payload: { 'scp' => scopes }) }
+        let(:auth_header) { { 'Authorization' => 'Bearer TEST_TOKEN' } }
+
+        context 'when valid' do
+          it 'returns all HLRs for the Veteran' do
+            create(:higher_level_review_v2, veteran_icn: veteran_icn, form_data: nil).id
+            create(:higher_level_review_v2, veteran_icn: veteran_icn).id
+            create(:higher_level_review_v2, veteran_icn: 'something_else')
+            allow(JWT).to receive(:decode).and_return nil
+            allow(Token).to receive(:new).and_return ccg_token
+            allow_any_instance_of(TokenValidation::V2::Client).to receive(:token_valid?).and_return(true)
+
+            get(path, headers: @minimum_required_headers.merge(auth_header))
+
+            expect(response.status).to eq(200)
+            expect(parsed['data'].length).to eq(2)
+          end
+        end
+
+        context 'when invalid' do
+          context 'because of the wrong scope' do
+            let(:scopes) { %w[claim.something_else] }
+
+            it 'returns a 403' do
+              allow(JWT).to receive(:decode).and_return nil
+              allow(Token).to receive(:new).and_return ccg_token
+              allow_any_instance_of(TokenValidation::V2::Client).to receive(:token_valid?).and_return(true)
+
+              get(path, headers: @minimum_required_headers.merge(auth_header))
+
+              expect(response.status).to eq(403)
+              expect(parsed['errors']).to be_an(Array)
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Please read our guidelines before submitting your first PR https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md -->

## Description of change
This is a prototype of adding OAuth to the new segemented appeals endpoints via Okta/CCG. I don't expect this to be merged but I'm hoping for some feedback. Things to know:
* This is heavily based on the Claims API's auth implementation. Because we don't yet know auth details for the appeals API, I reused the Claims API's settings and scopes for now. These would be updated later.
* I mostly copied the format of the tests from the Claims API as well - we can minimize the amount of test code by using shared examples, but I haven't taken the time to set them up yet.
* Most of the authentication work is done by a new `OAuthApplicationController`, which extends the `OpenidApplicationController`, simlilar to the way the Claims API's `ClaimsApi::V2:ApplicationController` does. The segmented appeals controllers now use this new base controller instead of the appeals API's original application controller.
* In this PR, I've only added authentication for the `index` actions of HLR, SC, and NOD as a proof of concept - I wanted to check in about this approach before I continued with it.
