### PR TITLE
Monitoring for Mobile vs Web Latency

### DIFF
--- a/app/controllers/v0/appointments_controller.rb
+++ b/app/controllers/v0/appointments_controller.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 require 'ihub/appointments/service'
+require 'ddtrace'
 
 module V0
   class AppointmentsController < ApplicationController
     def index
-      response = service.appointments
+      Datadog::Tracing.trace('Appointments#Index Web') do
+        response = service.appointments
 
-      render json: response, serializer: AppointmentSerializer
+        render json: response, serializer: AppointmentSerializer
+      end
     end
 
     private

--- a/app/controllers/v0/letters_controller.rb
+++ b/app/controllers/v0/letters_controller.rb
@@ -13,7 +13,7 @@ module V0
       Datadog::Tracing.trace('Letters#Index Web') do
         response = service.get_letters
         render json: response,
-                     serializer: LettersSerializer
+               serializer: LettersSerializer
       end
     end
 

--- a/app/controllers/v0/letters_controller.rb
+++ b/app/controllers/v0/letters_controller.rb
@@ -3,28 +3,33 @@
 require 'common/exceptions/record_not_found'
 require 'evss/letters/download_service'
 require 'evss/letters/service'
+require 'ddtrace'
 
 module V0
   class LettersController < ApplicationController
     before_action { authorize :evss, :access_letters? }
 
     def index
-      response = service.get_letters
-      render json: response,
-             serializer: LettersSerializer
+      Datadog::Tracing.trace('Letters#Index Web') do
+        response = service.get_letters
+        render json: response,
+                     serializer: LettersSerializer
+      end
     end
 
     def download
-      unless EVSS::Letters::Letter::LETTER_TYPES.include? params[:id]
-        Raven.tags_context(team: 'benefits-memorial-1') # tag sentry logs with team name
-        raise Common::Exceptions::ParameterMissing, 'letter_type', "#{params[:id]} is not a valid letter type"
-      end
+      Datadog::Tracing.trace('Letters#Download Web') do
+        unless EVSS::Letters::Letter::LETTER_TYPES.include? params[:id]
+          Raven.tags_context(team: 'benefits-memorial-1') # tag sentry logs with team name
+          raise Common::Exceptions::ParameterMissing, 'letter_type', "#{params[:id]} is not a valid letter type"
+        end
 
-      response = download_service.download_letter(params[:id], request.body.string)
-      send_data response,
-                filename: "#{params[:id]}.pdf",
-                type: 'application/pdf',
-                disposition: 'attachment'
+        response = download_service.download_letter(params[:id], request.body.string)
+        send_data response,
+                  filename: "#{params[:id]}.pdf",
+                  type: 'application/pdf',
+                  disposition: 'attachment'
+      end
     end
 
     def beneficiary

--- a/app/controllers/v0/profile/payment_history_controller.rb
+++ b/app/controllers/v0/profile/payment_history_controller.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
+require 'ddtrace'
+
 module V0
   module Profile
     class PaymentHistoryController < ApplicationController
       before_action { authorize :bgs, :access? }
 
       def index
-        render(
-          json: PaymentHistory.new(payments: adapter.payments, return_payments: adapter.return_payments),
-          serializer: PaymentHistorySerializer
-        )
+        Datadog::Tracing.trace('Payment History#Index Web') do
+          render(
+            json: PaymentHistory.new(payments: adapter.payments, return_payments: adapter.return_payments),
+            serializer: PaymentHistorySerializer
+          )
+        end
       end
 
       private

--- a/app/controllers/v0/users_controller.rb
+++ b/app/controllers/v0/users_controller.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
 
+require 'ddtrace'
+
 module V0
   class UsersController < ApplicationController
     def show
-      pre_serialized_profile = Users::Profile.new(current_user, @session_object).pre_serialize
+      Datadog::Tracing.trace('Users#Show Web') do
+        pre_serialized_profile = Users::Profile.new(current_user, @session_object).pre_serialize
 
-      render(
-        json: pre_serialized_profile,
-        status: pre_serialized_profile.status,
-        serializer: UserSerializer,
-        meta: { errors: pre_serialized_profile.errors }
-      )
+        render(
+          json: pre_serialized_profile,
+          status: pre_serialized_profile.status,
+          serializer: UserSerializer,
+          meta: { errors: pre_serialized_profile.errors }
+        )
+      end
     end
   end
 end

--- a/modules/mobile/app/controllers/mobile/v0/disability_rating_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/disability_rating_controller.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 require_dependency 'mobile/application_controller'
+require 'ddtrace'
 
 module Mobile
   module V0
     class DisabilityRatingController < ApplicationController
       before_action { authorize :evss, :access? }
       def index
-        response = rating_proxy.get_disability_ratings
-        render json: Mobile::V0::DisabilityRatingSerializer.new(response)
+        Datadog::Tracing.trace('DisabilityRating#Index Mobile') do
+          response = rating_proxy.get_disability_ratings
+          render json: Mobile::V0::DisabilityRatingSerializer.new(response)
+        end
       end
 
       private

--- a/modules/mobile/app/controllers/mobile/v0/letters_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/letters_controller.rb
@@ -3,6 +3,7 @@
 require 'common/exceptions/record_not_found'
 require 'evss/letters/download_service'
 require 'evss/letters/service'
+require 'ddtrace'
 
 module Mobile
   module V0
@@ -11,7 +12,9 @@ module Mobile
 
       # returns list of letters available for a given user. List includes letter display name and letter type
       def index
-        render json: Mobile::V0::LettersSerializer.new(@current_user.uuid, service.get_letters.letters)
+        Datadog::Tracing.trace('Letters#Index Mobile') do
+          render json: Mobile::V0::LettersSerializer.new(@current_user.uuid, service.get_letters.letters)
+        end
       end
 
       # returns options and info needed to create user form required for benefit letter download
@@ -21,19 +24,21 @@ module Mobile
 
       # returns a pdf of the requested letter type given the user has that letter type available
       def download
-        unless EVSS::Letters::Letter::LETTER_TYPES.include? params[:type]
-          Raven.tags_context(team: 'va-mobile-app') # tag sentry logs with team name
-          raise Common::Exceptions::ParameterMissing, 'letter_type', "#{params[:type]} is not a valid letter type"
+        Datadog::Tracing.trace('Letters#Download Mobile') do
+          unless EVSS::Letters::Letter::LETTER_TYPES.include? params[:type]
+            Raven.tags_context(team: 'va-mobile-app') # tag sentry logs with team name
+            raise Common::Exceptions::ParameterMissing, 'letter_type', "#{params[:type]} is not a valid letter type"
+          end
+
+          response = download_service.download_letter(params[:type], request.body.string)
+
+          StatsD.increment('mobile.letters.download.type', tags: ["type:#{params[:type]}"], sample_rate: 1.0)
+
+          send_data response,
+                    filename: "#{params[:type]}.pdf",
+                    type: 'application/pdf',
+                    disposition: 'attachment'
         end
-
-        response = download_service.download_letter(params[:type], request.body.string)
-
-        StatsD.increment('mobile.letters.download.type', tags: ["type:#{params[:type]}"], sample_rate: 1.0)
-
-        send_data response,
-                  filename: "#{params[:type]}.pdf",
-                  type: 'application/pdf',
-                  disposition: 'attachment'
       end
 
       def service

--- a/modules/mobile/app/controllers/mobile/v0/payment_history_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/payment_history_controller.rb
@@ -2,20 +2,23 @@
 
 require_dependency 'mobile/application_controller'
 require 'adapters/payment_history_adapter'
+require 'ddtrace'
 
 module Mobile
   module V0
     class PaymentHistoryController < ApplicationController
       def index
-        validated_params = validate_params(params)
+        Datadog::Tracing.trace('DisabilityRating#Index Mobile') do
+          validated_params = validate_params(params)
 
-        payments = adapter.payments
-        available_years = available_years(payments)
-        payments = filter(payments, available_years, validated_params) unless payments.empty?
-        list, meta = paginate(payments, validated_params)
-        meta[:meta][:available_years] = available_years
+          payments = adapter.payments
+          available_years = available_years(payments)
+          payments = filter(payments, available_years, validated_params) unless payments.empty?
+          list, meta = paginate(payments, validated_params)
+          meta[:meta][:available_years] = available_years
 
-        render json: Mobile::V0::PaymentHistorySerializer.new(list, meta)
+          render json: Mobile::V0::PaymentHistorySerializer.new(list, meta)
+        end
       end
 
       private

--- a/modules/mobile/app/controllers/mobile/v1/users_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v1/users_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency 'mobile/application_controller'
+require 'ddtrace'
 
 module Mobile
   module V1
@@ -8,7 +9,9 @@ module Mobile
       after_action :pre_cache_resources, only: :show
 
       def show
-        render json: Mobile::V1::UserSerializer.new(@current_user, options)
+        Datadog::Tracing.trace('Users#Show Mobile') do
+          render json: Mobile::V1::UserSerializer.new(@current_user, options)
+        end
       end
 
       private

--- a/modules/veteran_verification/app/controllers/veteran_verification/v1/disability_rating_controller.rb
+++ b/modules/veteran_verification/app/controllers/veteran_verification/v1/disability_rating_controller.rb
@@ -15,7 +15,7 @@ module VeteranVerification
       before_action { permit_scopes %w[disability_rating.read] }
 
       def index
-        Datadog::Tracing.trace('DisabilityRating#Index Mobile') do
+        Datadog::Tracing.trace('DisabilityRating#Index Web') do
           response = DisabilityRating.for_user(@current_user)
           serialized = ActiveModelSerializers::SerializableResource.new(
             response,


### PR DESCRIPTION
## Description of change
Mobile routing is suspected to be slower than their web counterparts. After discussing the latency issue with the `va-mobile` team, the `appointments` and `letters` controllers were suggested as valid starting places to investigate any controller action time differences. 

`Appointments` are expected to be quicker on mobile than the web counterpart due to pre-caching.  `Letters` are suggested as an investigation to see if the mobile serializer is causing additional time for the controller methods. 

This change adds in DataDog tracing to the index method of the appointments controller, as well as the index and download method of the letters controller, for web & mobile.

Sorting through the top times from the APM of rack requests, `DisabilityRating`, `PaymentHistory`, and `Users` controllers were added to the trace monitoring.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#45364](https://app.zenhub.com/workspaces/platform-tech-team-3-6335ab9b1901b99243ce7601/issues/department-of-veterans-affairs/va.gov-team/45364)

