### PR TITLE
fix: Allow both PEM and DER encoded VA Certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,8 @@ COPY config/clamd.conf /etc/clamav/clamd.conf
 COPY config/ca-trust/*.crt /usr/local/share/ca-certificates/
 
 # Download VA Certs
-RUN wget -q -r -np -nH -nd -a .cer -AVA-Internal-S2-*.cer -P /usr/local/share/ca-certificates http://aia.pki.va.gov/PKI/AIA/VA/ \
-  && for f in /usr/local/share/ca-certificates/*.cer; do openssl x509 -inform der -in $f -out $f.crt; done \
-  && update-ca-certificates \
-  && rm .cer
+COPY ./import-va-certs.sh .
+RUN ./import-va-certs.sh
 
 ENV LANG=C.UTF-8 \
    BUNDLE_JOBS=4 \

--- a/import-va-certs.sh
+++ b/import-va-certs.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+(
+    cd /usr/local/share/ca-certificates/
+    
+    wget \
+        --level=1 \
+        --quiet \
+        --recursive \
+        --no-parent \
+        --no-host-directories \
+        --no-directories \
+        --accept="VA*.cer" \
+        http://aia.pki.va.gov/PKI/AIA/VA/
+
+    for cert in VA-*.cer
+    do
+        if file "${cert}" | grep 'PEM'
+        then
+            cp "${cert}" "${cert}.pem"
+        else
+            openssl x509 -in "${cert}" -inform der -outform pem -out "${cert}.pem"
+        fi
+        rm "${cert}"
+        cat "${cert}.pem" >> ca-bundle.pem
+    done
+
+    update-ca-certificates
+)


### PR DESCRIPTION
- the VA Internal certs have historically been DER
- A new VA Internal cert has been added that is PEM
- This update allows for both formats