### PR TITLE
MHV-37853: Enable getting more than 250 results in get messages by folder call

### DIFF
--- a/modules/my_health/app/controllers/my_health/v1/messages_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/messages_controller.rb
@@ -11,7 +11,10 @@ module MyHealth
 
         resource = params[:filter].present? ? resource.find_by(filter_params) : resource
         resource = resource.sort(params[:sort])
-        resource = resource.paginate(pagination_params)
+
+        if pagination_params[:per_page] != "9999"
+          resource = resource.paginate(pagination_params)
+        end
 
         render json: resource.data,
                serializer: CollectionSerializer,


### PR DESCRIPTION
## Description of change
The front end can now get more than 250 results without making multiple calls so that results can be sorted on the front end. This is necessary because the keyword search needs to be able to get all messages from a folder in order to search multiple fields for keyword matches. 

## Original issue(s)
https://vajira.max.gov/browse/MHV-37853

## Things to know about this PR
<!--
* Are there additions to a `settings.yml` file? Do they vary by environment?
* Is there a feature flag? What is it?
* Is there some Sentry logging that was added? What alerts are relevant?
* Are there any Prometheus metrics being collected? What Grafana dashboard were they added do?
* Are there Swagger docs that were updated?
* Is there any PII concerns or questions?
-->

<!-- Please describe testing done to verify the changes or any testing planned. -->
