### PR TITLE
Remove PII attributes from being logged in sentry

### DIFF
--- a/lib/debt_management_center/payments_service.rb
+++ b/lib/debt_management_center/payments_service.rb
@@ -16,7 +16,7 @@ module DebtManagementCenter
         begin
           BGS::People::Request.new.find_person_by_participant_id(user: current_user)
         rescue => e
-          report_error(e, current_user)
+          report_error(e)
           {}
         end
 
@@ -24,7 +24,7 @@ module DebtManagementCenter
         begin
           BGS::PaymentService.new(current_user).payment_history(@person)[:payments][:payment].presence || []
         rescue => e
-          report_error(e, current_user)
+          report_error(e)
           []
         end
     end
@@ -76,12 +76,10 @@ module DebtManagementCenter
       end
     end
 
-    def report_error(error, user)
+    def report_error(error)
       log_exception_to_sentry(
         error,
-        {
-          icn: user.icn
-        },
+        {},
         { team: 'vfs-debt' }
       )
     end

--- a/lib/debt_management_center/workers/va_notify_email_job.rb
+++ b/lib/debt_management_center/workers/va_notify_email_job.rb
@@ -16,18 +16,14 @@ module DebtManagementCenter
           personalisation: personalisation
         }.compact
       )
-    rescue Common::Exceptions::BackendServiceException => e
-      if e.status_code == 400
-        log_exception_to_sentry(
-          e,
-          {
-            args: { email: email, template_id: template_id, personalisation: personalisation }
-          },
-          { error: :dmc_va_notify_email_job }
-        )
-      else
-        raise e
-      end
+    rescue => e
+      log_exception_to_sentry(
+        e,
+        {
+          args: { template_id: template_id }
+        },
+        { error: :dmc_va_notify_email_job }
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary
PII being logged in Sentry statements that is unnecessary for the specific errors.

## Related issue(s)
[- department-of-veterans-affairs/va.gov-team-sensitive#666](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/666)


## Testing done
- Assure RSpec passes
- Errors will not break with removed attributes

## Screenshots
N/A


## What areas of the site does it impact?
Logging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

