### PR TITLE
Add tags to make it easier to deprecate EVSS code

### DIFF
--- a/app/controllers/v0/evss_claims_async_controller.rb
+++ b/app/controllers/v0/evss_claims_async_controller.rb
@@ -1,3 +1,4 @@
+# BEGIN lighthouse_migration
 # frozen_string_literal: true
 
 module V0
@@ -34,3 +35,5 @@ module V0
     end
   end
 end
+
+# END lighthouse_migration

--- a/app/controllers/v0/evss_claims_controller.rb
+++ b/app/controllers/v0/evss_claims_controller.rb
@@ -26,6 +26,7 @@ module V0
              meta: { successful_sync: synchronized }
     end
 
+    # BEGIN lighthouse_migration
     def request_decision
       claim = EVSSClaim.for_user(current_user).find_by(evss_id: params[:id])
       unless claim
@@ -37,6 +38,7 @@ module V0
       claim.update(requested_decision: true)
       render_job_id(jid)
     end
+    # END lighthouse_migration
 
     private
 

--- a/app/serializers/evss_claim_list_serializer.rb
+++ b/app/serializers/evss_claim_list_serializer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# BEGIN lighthouse_migration
 class EVSSClaimListSerializer < EVSSClaimBaseSerializer
   def phase
     phase_from_keys 'status'
@@ -11,3 +12,4 @@ class EVSSClaimListSerializer < EVSSClaimBaseSerializer
     object.list_data
   end
 end
+# END lighthouse_migration

--- a/app/services/evss_claim_service.rb
+++ b/app/services/evss_claim_service.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# BEGIN lighthouse_migration
 require 'evss/claims_service'
 require 'evss/documents_service'
 require 'evss/auth_headers'
@@ -82,3 +83,4 @@ class EVSSClaimService
     claim
   end
 end
+# END lighthouse_migration


### PR DESCRIPTION
Once we migrate the Claims Status Tool to use Lighthouse over EVSS, we should remove the code that references EVSS to make sure we don't increase technical debt.


## Summary

Comments (ONLY comments) have been added to candidates for removal once the Claims status tool migrates to using Lighthouse instead of EVSS. Team: Benefits Squad 1

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#48118


## Testing done
N/A - these are just temporary comments

## What areas of the site does it impact?
None

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

Is there anything you can see that I missed? Or is there code tagged by these comments that you think should continue to live in the codebase after migration?
