### PR TITLE
[11329] Refactoring MPI Service add_person_implicit_search

### DIFF
--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -71,18 +71,11 @@ class UserSessionForm
     return unless saml_user_attributes[:loa][:current] == LOA::THREE
 
     Rails.logger.info("[UserSessionForm] Adding CSP ID to MPI, idme: #{idme_uuid}")
-    add_csp_id_user_identity = UserIdentity.new({ idme_uuid: idme_uuid,
-                                                  loa: saml_user_attributes[:loa],
-                                                  sign_in: saml_user_attributes[:sign_in],
-                                                  first_name: saml_user_attributes[:first_name],
-                                                  last_name: saml_user_attributes[:last_name],
-                                                  birth_date: saml_user_attributes[:birth_date],
-                                                  ssn: saml_user_attributes[:ssn],
-                                                  edipi: saml_user_attributes[:edipi],
-                                                  icn: saml_user_attributes[:mhv_icn],
-                                                  mhv_icn: saml_user_attributes[:mhv_icn],
-                                                  uuid: idme_uuid })
-    mpi_response = MPI::Service.new.add_person_implicit_search(add_csp_id_user_identity)
+    mpi_response = MPI::Service.new.add_person_implicit_search(first_name: saml_user_attributes[:first_name],
+                                                               last_name: saml_user_attributes[:last_name],
+                                                               ssn: saml_user_attributes[:ssn],
+                                                               birth_date: saml_user_attributes[:birth_date],
+                                                               idme_uuid: idme_uuid)
     log_message_to_sentry("Failed Add CSP ID to MPI FAILED, idme: #{idme_uuid}", :warn) unless mpi_response.ok?
   end
 

--- a/app/services/sign_in/attribute_validator.rb
+++ b/app/services/sign_in/attribute_validator.rb
@@ -65,9 +65,16 @@ module SignIn
     end
 
     def add_mpi_user
-      add_person_response = mpi_service.add_person_implicit_search(user_identity_from_attributes)
+      add_person_response = mpi_service.add_person_implicit_search(first_name: first_name,
+                                                                   last_name: last_name,
+                                                                   ssn: ssn,
+                                                                   birth_date: birth_date,
+                                                                   email: credential_email,
+                                                                   address: address,
+                                                                   idme_uuid: idme_uuid,
+                                                                   logingov_uuid: logingov_uuid)
       if add_person_response.ok?
-        user_identity_from_attributes.icn = add_person_response.mvi_codes[:icn]
+        user_identity_from_attributes.icn = add_person_response.parsed_codes[:icn]
       else
         handle_error('User MPI record cannot be created',
                      Constants::ErrorCode::GENERIC_EXTERNAL_ISSUE,

--- a/lib/mpi/constants.rb
+++ b/lib/mpi/constants.rb
@@ -30,5 +30,9 @@ module MPI
     VA_ROOT_OID = '2.16.840.1.113883.4.349'
 
     FIND_PROFILE_CONTROL_ACT_PROCESS = 'PRPA_TE201305UV02'
+
+    ADD_PERSON_PROXY_TYPE = 'add_person_proxy'
+    ADD_PERSON_IMPLICIT_TYPE = 'add_person_implicit'
+    UPDATE_PROFILE_TYPE = 'update_profile'
   end
 end

--- a/lib/mpi/errors/errors.rb
+++ b/lib/mpi/errors/errors.rb
@@ -2,11 +2,7 @@
 
 module MPI
   module Errors
-    class Base < StandardError; end
-    class RecordNotFound < MPI::Errors::Base; end
-    class ArgumentError < MPI::Errors::Base; end
-
-    class ServiceError < MPI::Errors::Base
+    class ServiceError < StandardError
       attr_reader :body
 
       def initialize(body = nil)
@@ -15,8 +11,13 @@ module MPI
       end
     end
 
-    class FailedRequestError < MPI::Errors::ServiceError; end
-    class InvalidRequestError < MPI::Errors::ServiceError; end
-    class DuplicateRecords < MPI::Errors::RecordNotFound; end
+    class Response < ServiceError; end
+    class InvalidResponseParamsError < StandardError; end
+    class RecordNotFound < MPI::Errors::Response; end
+    class ArgumentError < MPI::Errors::Response; end
+    class DuplicateRecords < MPI::Errors::Response; end
+    class Request < ServiceError; end
+    class FailedRequestError < MPI::Errors::Request; end
+    class InvalidRequestError < MPI::Errors::Request; end
   end
 end

--- a/lib/mpi/responses/add_person_response.rb
+++ b/lib/mpi/responses/add_person_response.rb
@@ -1,75 +1,22 @@
 # frozen_string_literal: true
 
-require_relative 'add_parser'
-require 'common/client/concerns/service_status'
-
 module MPI
   module Responses
-    # Cacheable response from MVI's add person endpoint (prpa_in201301_uv02).
     class AddPersonResponse
-      include Virtus.model(nullify_blank: true)
-      include Common::Client::Concerns::ServiceStatus
+      attr_reader :status, :parsed_codes, :error
 
-      # @return [String] The status of the response
-      attribute :status, String
-
-      # @return [Array] The parsed response mvi codes
-      attribute :mvi_codes, Array[Hash], coerce: false
-
-      # @return [Common::Exceptions::BackendServiceException] The rescued exception
-      attribute :error, Common::Exceptions::BackendServiceException
-
-      # Builds a response with a server error status and a nil mvi_codes
-      #
-      # @return [MPI::Responses::AddPersonResponse] the response
-      def self.with_server_error(exception = nil)
-        AddPersonResponse.new(
-          status: AddPersonResponse::RESPONSE_STATUS[:server_error],
-          mvi_codes: nil,
-          error: exception
-        )
-      end
-
-      # Builds a response with a variable status and a nil mvi_codes. The status
-      # should represent the status returned from the orchestrated search.
-      #
-      # @return [MPI::Responses::AddPersonResponse] the response
-      def self.with_failed_orch_search(status, exception = nil)
-        AddPersonResponse.new(
-          status: status,
-          mvi_codes: nil,
-          error: exception
-        )
-      end
-
-      # Builds a response with a ok status and a codes response
-      #
-      # @param response [Ox::Element] ox element returned from the soap service middleware
-      # @return [MPI::Responses::AddPersonResponse] response with a possible parsed codes
-      def self.with_parsed_response(type, response)
-        add_parser = AddParser.new(response)
-        mvi_codes = add_parser.parse
-
-        raise MPI::Errors::InvalidRequestError, add_parser.error_details(mvi_codes) if add_parser.invalid_request?
-        raise MPI::Errors::FailedRequestError, add_parser.error_details(mvi_codes) if add_parser.failed_request?
-
-        Rails.logger.info("[MPI][Responses][AddPersonResponse] #{type}, " \
-                          "icn=#{mvi_codes[:icn]}, " \
-                          "idme_uuid=#{mvi_codes[:idme_uuid]}, " \
-                          "logingov_uuid=#{mvi_codes[:logingov_uuid]}, " \
-                          "transaction_id=#{mvi_codes[:transaction_id]}")
-        AddPersonResponse.new(
-          status: RESPONSE_STATUS[:ok],
-          mvi_codes: mvi_codes
-        )
+      def initialize(status:, parsed_codes: nil, error: nil)
+        @status = status
+        @parsed_codes = parsed_codes
+        @error = error
       end
 
       def ok?
-        @status == RESPONSE_STATUS[:ok]
+        status == :ok
       end
 
       def server_error?
-        @status == RESPONSE_STATUS[:server_error]
+        status == :server_error
       end
     end
   end

--- a/lib/mpi/services/add_person_response_creator.rb
+++ b/lib/mpi/services/add_person_response_creator.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'mpi/responses/add_parser'
+require 'sentry_logging'
+
+module MPI
+  module Services
+    class AddPersonResponseCreator
+      include SentryLogging
+
+      attr_reader :type, :response, :error
+
+      def initialize(type:, response: nil, error: nil)
+        @type = type
+        @response = response
+        @error = error
+      end
+
+      def perform
+        validations
+        if failed_response?
+          create_error_response
+        else
+          create_successful_response
+        end
+      end
+
+      private
+
+      def validations
+        raise Errors::InvalidResponseParamsError unless response.present? ^ error.present?
+      end
+
+      def create_successful_response
+        Rails.logger.info("[MPI][Services][AddPersonResponseCreator] #{type}, " \
+                          "icn=#{parsed_codes[:icn]}, " \
+                          "idme_uuid=#{parsed_codes[:idme_uuid]}, " \
+                          "logingov_uuid=#{parsed_codes[:logingov_uuid]}, " \
+                          "transaction_id=#{parsed_codes[:transaction_id]}")
+        Responses::AddPersonResponse.new(status: :ok, parsed_codes: parsed_codes)
+      end
+
+      def create_error_response
+        log_message_to_sentry("MPI #{type} response error", :warn, { error_message: detailed_error&.message })
+        Responses::AddPersonResponse.new(status: :server_error, error: detailed_error)
+      end
+
+      def detailed_error
+        @detailed_error ||=
+          if error
+            error
+          elsif add_parser.invalid_request?
+            MPI::Errors::InvalidRequestError.new(error_details)
+          elsif add_parser.failed_request?
+            MPI::Errors::FailedRequestError.new(error_details)
+          end
+      end
+
+      def failed_response?
+        error.present? || add_parser.failed_or_invalid?
+      end
+
+      def error_details
+        @error_details ||= add_parser.error_details(parsed_codes)
+      end
+
+      def parsed_codes
+        @parsed_codes ||= add_parser.parse
+      end
+
+      def add_parser
+        @add_parser ||= Responses::AddParser.new(response)
+      end
+    end
+  end
+end

--- a/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v1/disability_compensation_request_spec.rb
@@ -1065,7 +1065,7 @@ RSpec.describe 'Disability Claims ', type: :request do
       end
 
       context 'when consumer is Veteran' do
-        let(:mvi_codes) do
+        let(:parsed_codes) do
           {
             birls_id: '111985523',
             participant_id: '32397028'
@@ -1074,14 +1074,14 @@ RSpec.describe 'Disability Claims ', type: :request do
         let(:mvi_profile) { build(:mvi_profile) }
         let(:mvi_profile_response) do
           MPI::Responses::FindProfileResponse.new(
-            status: MPI::Responses::FindProfileResponse::RESPONSE_STATUS[:ok],
+            status: 'OK',
             profile: mvi_profile
           )
         end
         let(:add_response) do
           MPI::Responses::AddPersonResponse.new(
-            status: MPI::Responses::AddPersonResponse::RESPONSE_STATUS[:ok],
-            mvi_codes: mvi_codes
+            status: :ok,
+            parsed_codes: parsed_codes
           )
         end
 

--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -433,9 +433,9 @@ RSpec.describe V0::SignInController, type: :controller do
     let(:type) {}
     let(:acr) { nil }
     let(:client_id) { nil }
-    let(:mpi_update_profile_response) { MPI::Responses::AddPersonResponse.new(status: 'OK') }
+    let(:mpi_update_profile_response) { MPI::Responses::AddPersonResponse.new(status: :ok) }
     let(:mpi_add_person_response) do
-      MPI::Responses::AddPersonResponse.new(status: 'OK', mvi_codes: { icn: add_person_icn })
+      MPI::Responses::AddPersonResponse.new(status: :ok, parsed_codes: { icn: add_person_icn })
     end
     let(:add_person_icn) { nil }
     let(:find_profile) do

--- a/spec/lib/mpi/responses/add_person_response_spec.rb
+++ b/spec/lib/mpi/responses/add_person_response_spec.rb
@@ -4,159 +4,47 @@ require 'rails_helper'
 require 'mpi/responses/add_person_response'
 
 describe MPI::Responses::AddPersonResponse do
-  let(:faraday_response) { instance_double('Faraday::Env') }
-  let(:headers) { { 'x-global-transaction-id' => transaction_id } }
-  let(:transaction_id) { 'some-transaction-id' }
-  let(:body) { Ox.parse(File.read('spec/support/mpi/add_person_response.xml')) }
-  let(:type) { 'some-type' }
+  let(:add_person_response) { described_class.new(status: status, parsed_codes: parsed_codes, error: error) }
+  let(:status) { 'some-status' }
+  let(:parsed_codes) { 'some-parsed-codes' }
+  let(:error) { 'some-error' }
 
-  before do
-    allow(faraday_response).to receive(:body) { body }
-    allow(faraday_response).to receive(:response_headers) { headers }
-  end
+  describe '.ok?' do
+    subject { add_person_response.ok? }
 
-  describe '.with_server_error' do
-    subject { described_class.with_server_error }
+    context 'when status is :ok' do
+      let(:status) { :ok }
 
-    it 'builds a response with a nil mvi_codes and a status of SERVER_ERROR' do
-      expect(subject.status).to eq('SERVER_ERROR')
-      expect(subject.mvi_codes).to be_nil
-    end
-
-    it 'optionally sets #error to the passed exception', :aggregate_failures do
-      response = described_class.with_server_error(server_error_exception)
-      exception = response.error.errors.first
-
-      expect(response.error).to be_present
-      expect(exception.code).to eq server_error_exception.errors.first.code
-    end
-  end
-
-  describe '.with_failed_orch_search' do
-    subject { described_class.with_failed_orch_search(status) }
-
-    context 'with an SERVER_ERROR orchestrated search result' do
-      let(:status) { 'SERVER_ERROR' }
-
-      it 'builds a response with a nil mvi_codes and a status of SERVER_ERROR' do
-        expect(subject.status).to eq('SERVER_ERROR')
-        expect(subject.mvi_codes).to be_nil
+      it 'returns true' do
+        expect(subject).to eq(true)
       end
     end
 
-    context 'with an NOT_FOUND orchestrated search result' do
-      let(:status) { 'NOT_FOUND' }
+    context 'when status is not :ok' do
+      let(:status) { 'some-status' }
 
-      it 'builds a response with a nil mvi_codes and a status of NOT_FOUND' do
-        expect(subject.status).to eq('NOT_FOUND')
-        expect(subject.mvi_codes).to be_nil
-      end
-    end
-
-    it 'optionally sets #error to the passed exception', :aggregate_failures do
-      response = described_class.with_failed_orch_search('NOT_FOUND', not_found_exception)
-      exception = response.error.errors.first
-
-      expect(response.error).to be_present
-      expect(exception.code).to eq not_found_exception.errors.first.code
-    end
-  end
-
-  describe '.with_parsed_response' do
-    subject { described_class.with_parsed_response(type, faraday_response) }
-
-    let(:error_details) do
-      { other: [{ codeSystem: '2.16.840.1.113883.5.1100',
-                  code: 'INTERR',
-                  displayName: 'Internal System Error' }],
-        transaction_id: transaction_id,
-        error_details: { ack_detail_code: ack_detail_code,
-                         id_extension: '200VGOV-1373004c-e23e-4d94-90c5-5b101f6be54a',
-                         error_texts: ['Internal System Error'] } }
-    end
-
-    context 'with a successful response' do
-      let(:expected_log) do
-        "[MPI][Responses][AddPersonResponse] #{type}, " \
-          'icn=, ' \
-          'idme_uuid=, ' \
-          'logingov_uuid=, ' \
-          "transaction_id=#{transaction_id}"
-      end
-
-      it 'logs a message to rails logger' do
-        expect(Rails.logger).to receive(:info).with(expected_log)
-        subject
-      end
-
-      it 'builds a response with a nil errors a status of OK' do
-        expect(subject.status).to eq('OK')
-        expect(subject.error).to be_nil
-        expect(subject.mvi_codes).to eq(
-          {
-            birls_id: '111985523',
-            participant_id: '32397028',
-            transaction_id: transaction_id
-          }
-        )
-      end
-    end
-
-    context 'with an invalid request response' do
-      let(:body) { Ox.parse(File.read('spec/support/mpi/add_person_invalid_response.xml')) }
-      let(:ack_detail_code) { 'AE' }
-
-      it 'raises an invalid request error with parsed details from MPI' do
-        expect { described_class.with_parsed_response(type, faraday_response) }.to raise_error(
-          MPI::Errors::InvalidRequestError, error_details.to_s
-        )
-      end
-    end
-
-    context 'with a failed request response' do
-      let(:body) { Ox.parse(File.read('spec/support/mpi/add_person_internal_error_response.xml')) }
-      let(:ack_detail_code) { 'AR' }
-
-      it 'raises a failed request error with parsed details from MPI' do
-        expect { described_class.with_parsed_response(type, faraday_response) }.to raise_error(
-          MPI::Errors::FailedRequestError, error_details.to_s
-        )
+      it 'returns false' do
+        expect(subject).to eq(false)
       end
     end
   end
 
-  describe '#ok?' do
-    context 'with a successful response' do
-      subject { described_class.with_parsed_response(type, faraday_response).ok? }
+  describe '.server_error?' do
+    subject { add_person_response.server_error? }
 
-      it 'is true' do
-        expect(subject).to be true
+    context 'when status is :server_error' do
+      let(:status) { :server_error }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
       end
     end
 
-    context 'with an error response' do
-      subject { described_class.with_server_error.ok? }
+    context 'when status is not :server_error' do
+      let(:status) { 'some-status' }
 
-      it 'is false' do
-        expect(subject).to be false
-      end
-    end
-  end
-
-  describe '#server_error?' do
-    context 'with a successful response' do
-      subject { described_class.with_parsed_response(type, faraday_response).server_error? }
-
-      it 'is false' do
-        expect(subject).to be false
-      end
-    end
-
-    context 'with an error response' do
-      subject { described_class.with_server_error.server_error? }
-
-      it 'is true' do
-        expect(subject).to be true
+      it 'returns false' do
+        expect(subject).to eq(false)
       end
     end
   end

--- a/spec/lib/mpi/services/add_person_response_creator_spec.rb
+++ b/spec/lib/mpi/services/add_person_response_creator_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mpi/services/add_person_response_creator'
+
+describe MPI::Services::AddPersonResponseCreator do
+  describe '#perform' do
+    subject { described_class.new(type: type, response: response, error: error).perform }
+
+    let(:type) { 'some-type' }
+    let(:response) { 'some-response' }
+    let(:error) { 'some-error' }
+
+    shared_examples 'error response' do
+      let(:expected_error_message) { "MPI #{type} response error" }
+      let(:sentry_context) { { error_message: expected_error.message } }
+      let(:sentry_log_level) { :warn }
+      let(:expected_status) { :server_error }
+
+      it 'logs error to sentry' do
+        expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(expected_error_message,
+                                                                                      sentry_log_level,
+                                                                                      sentry_context)
+        subject
+      end
+
+      it 'returns an add person response with expected status' do
+        expect(subject.status).to eq(expected_status)
+      end
+
+      it 'returns an add person response with expected error' do
+        expect(subject.error).to eq(expected_error)
+      end
+    end
+
+    context 'when error is given in params' do
+      let(:error) { StandardError.new(error_message) }
+      let(:error_message) { 'some-error-message' }
+
+      context 'and response is given in params' do
+        let(:response) { 'some-response' }
+        let(:expected_error) { MPI::Errors::InvalidResponseParamsError }
+
+        it 'raises an invalid response params error' do
+          expect { subject }.to raise_error(expected_error)
+        end
+      end
+
+      context 'and response is not given in params' do
+        let(:response) { nil }
+        let(:expected_error) { error }
+
+        it_behaves_like 'error response'
+      end
+    end
+
+    context 'when error is not given in params' do
+      let(:error) { nil }
+
+      context 'and response is given in params with invalid request status' do
+        let(:response) do
+          OpenStruct.new({ body: Ox.parse(File.read('spec/support/mpi/add_person_invalid_response.xml')),
+                           response_headers: {} })
+        end
+        let(:mpi_codes) do
+          { other: [{ codeSystem: '2.16.840.1.113883.5.1100', code: 'INTERR', displayName: 'Internal System Error' }] }
+        end
+        let(:error_details) do
+          { other: mpi_codes[:other],
+            transaction_id: nil,
+            error_details: { ack_detail_code: ack_detail_code,
+                             id_extension: '200VGOV-1373004c-e23e-4d94-90c5-5b101f6be54a',
+                             error_texts: ['Internal System Error'] } }
+        end
+        let(:ack_detail_code) { 'AE' }
+        let(:expected_error) { MPI::Errors::InvalidRequestError.new(error_details) }
+
+        it_behaves_like 'error response'
+      end
+
+      context 'when response is given in params with failed request status' do
+        let(:response) do
+          OpenStruct.new({ body: Ox.parse(File.read('spec/support/mpi/add_person_internal_error_response.xml')),
+                           response_headers: {} })
+        end
+        let(:mpi_codes) do
+          { other: [{ codeSystem: '2.16.840.1.113883.5.1100', code: 'INTERR', displayName: 'Internal System Error' }] }
+        end
+        let(:error_details) do
+          { other: mpi_codes[:other],
+            transaction_id: nil,
+            error_details: { ack_detail_code: ack_detail_code,
+                             id_extension: '200VGOV-1373004c-e23e-4d94-90c5-5b101f6be54a',
+                             error_texts: ['Internal System Error'] } }
+        end
+        let(:ack_detail_code) { 'AR' }
+        let(:expected_error) { MPI::Errors::FailedRequestError.new(error_details) }
+
+        it_behaves_like 'error response'
+      end
+
+      context 'when response is given in params with success request status' do
+        let(:response) do
+          OpenStruct.new({ body: Ox.parse(File.read('spec/support/mpi/add_person_response.xml')),
+                           response_headers: { 'x-global-transaction-id' => transaction_id } })
+        end
+        let(:transaction_id) { 'some-transaction-id' }
+        let(:expected_log) do
+          "[MPI][Services][AddPersonResponseCreator] #{type}, " \
+            'icn=, ' \
+            'idme_uuid=, ' \
+            'logingov_uuid=, ' \
+            "transaction_id=#{transaction_id}"
+        end
+        let(:birls_id) { '111985523' }
+        let(:participant_id) { '32397028' }
+
+        it 'logs a message to rails logger' do
+          expect(Rails.logger).to receive(:info).with(expected_log)
+          subject
+        end
+
+        it 'creates an add person response with an ok status' do
+          expect(subject.status).to eq(:ok)
+        end
+
+        it 'creates an add person response with expected parsed codes' do
+          expect(subject.parsed_codes).to eq(
+            {
+              birls_id: birls_id,
+              participant_id: participant_id,
+              transaction_id: transaction_id
+            }
+          )
+        end
+      end
+
+      context 'and response is not given in params' do
+        let(:response) { nil }
+        let(:expected_error) { MPI::Errors::InvalidResponseParamsError }
+
+        it 'raises an invalid response params error' do
+          expect { subject }.to raise_error(expected_error)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/user_session_form_spec.rb
+++ b/spec/models/user_session_form_spec.rb
@@ -67,10 +67,10 @@ RSpec.describe UserSessionForm, type: :model do
          '12345748^PI^200MHS^USVHA^A']
       end
       let(:add_person_response) do
-        MPI::Responses::AddPersonResponse.new(status: status, mvi_codes: mvi_codes, error: nil)
+        MPI::Responses::AddPersonResponse.new(status: status, parsed_codes: parsed_codes)
       end
       let(:status) { 'OK' }
-      let(:mvi_codes) { { icn: saml_attributes[:va_eauth_icn] } }
+      let(:parsed_codes) { { icn: saml_attributes[:va_eauth_icn] } }
 
       before do
         allow_any_instance_of(MPI::Service).to receive(:add_person_implicit_search).and_return(add_person_response)
@@ -107,10 +107,10 @@ RSpec.describe UserSessionForm, type: :model do
         let!(:user_verification) { create(:idme_user_verification, user_account: user_account) }
         let(:idme_uuid) { user_verification.idme_uuid }
         let(:add_person_response) do
-          MPI::Responses::AddPersonResponse.new(status: status, mvi_codes: mvi_codes, error: nil)
+          MPI::Responses::AddPersonResponse.new(status: status, parsed_codes: parsed_codes)
         end
         let(:status) { 'OK' }
-        let(:mvi_codes) { { icn: saml_attributes[:va_eauth_icn] } }
+        let(:parsed_codes) { { icn: saml_attributes[:va_eauth_icn] } }
 
         before do
           allow_any_instance_of(MPI::Service).to receive(:add_person_implicit_search).and_return(add_person_response)

--- a/spec/services/sign_in/attribute_validator_spec.rb
+++ b/spec/services/sign_in/attribute_validator_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe SignIn::AttributeValidator do
         allow_any_instance_of(MPI::Service).to receive(:add_person_implicit_search).and_return(add_person_response)
         allow_any_instance_of(MPI::Service).to receive(:find_profile).and_return(find_profile_response)
         allow_any_instance_of(MPI::Service).to receive(:update_profile).and_return(update_profile_response)
+        allow(Rails.logger).to receive(:info)
       end
 
       shared_examples 'error response' do
@@ -287,10 +288,9 @@ RSpec.describe SignIn::AttributeValidator do
             let(:auto_uplevel) { false }
             let(:update_profile_response) do
               MPI::Responses::AddPersonResponse.new(status: update_status,
-                                                    mvi_codes: { logingov_uuid: logingov_uuid },
-                                                    error: nil)
+                                                    parsed_codes: { logingov_uuid: logingov_uuid })
             end
-            let(:update_status) { 'OK' }
+            let(:update_status) { :ok }
 
             it_behaves_like 'mpi versus credential mismatch'
 
@@ -303,11 +303,11 @@ RSpec.describe SignIn::AttributeValidator do
 
         context 'and mpi record does not exist for user' do
           let(:add_person_response) do
-            MPI::Responses::AddPersonResponse.new(status: status, mvi_codes: mvi_codes, error: nil)
+            MPI::Responses::AddPersonResponse.new(status: status, parsed_codes: parsed_codes, error: nil)
           end
-          let(:status) { 'OK' }
+          let(:status) { :ok }
           let(:icn) { 'some-icn' }
-          let(:mvi_codes) { { icn: icn } }
+          let(:parsed_codes) { { icn: icn } }
 
           before { allow_any_instance_of(SignIn::AttributeValidator).to receive(:mpi_record_exists?).and_return(false) }
 
@@ -319,7 +319,7 @@ RSpec.describe SignIn::AttributeValidator do
           end
 
           context 'and mpi add person call is not successful' do
-            let(:status) { 'NOT-OK' }
+            let(:status) { :server_error }
             let(:expected_error) { SignIn::Errors::MPIUserCreationFailedError }
             let(:expected_error_message) { 'User MPI record cannot be created' }
             let(:expected_error_code) { SignIn::Constants::ErrorCode::GENERIC_EXTERNAL_ISSUE }
@@ -328,7 +328,7 @@ RSpec.describe SignIn::AttributeValidator do
           end
 
           context 'and mpi add person call is successful' do
-            let(:status) { 'OK' }
+            let(:status) { :ok }
 
             it_behaves_like 'mpi attribute validations'
           end
@@ -383,11 +383,11 @@ RSpec.describe SignIn::AttributeValidator do
 
           context 'and mpi record exists for user' do
             let(:add_person_response) do
-              MPI::Responses::AddPersonResponse.new(status: status, mvi_codes: mvi_codes, error: nil)
+              MPI::Responses::AddPersonResponse.new(status: status, parsed_codes: parsed_codes, error: nil)
             end
-            let(:status) { 'OK' }
+            let(:status) { :ok }
             let(:icn) { mhv_icn }
-            let(:mvi_codes) { { icn: icn } }
+            let(:parsed_codes) { { icn: icn } }
             let(:find_profile_response) do
               MPI::Responses::FindProfileResponse.new(
                 status: MPI::Responses::FindProfileResponse::RESPONSE_STATUS[:ok],
@@ -425,7 +425,7 @@ RSpec.describe SignIn::AttributeValidator do
             end
 
             context 'and mpi add person call is not successful' do
-              let(:status) { 'NOT-OK' }
+              let(:status) { :server_error }
               let(:expected_error) { SignIn::Errors::MPIUserCreationFailedError }
               let(:expected_error_message) { 'User MPI record cannot be created' }
               let(:expected_error_code) { SignIn::Constants::ErrorCode::GENERIC_EXTERNAL_ISSUE }
@@ -434,7 +434,7 @@ RSpec.describe SignIn::AttributeValidator do
             end
 
             context 'and mpi add person call is successful' do
-              let(:status) { 'OK' }
+              let(:status) { :ok }
 
               it_behaves_like 'mpi attribute validations'
             end

--- a/spec/support/vcr_cassettes/mpi/add_person/add_person_internal_error_request.yml
+++ b/spec/support/vcr_cassettes/mpi/add_person/add_person_internal_error_request.yml
@@ -2,23 +2,17 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MPI_URL>"
+    uri: http://www.example.com/
     body:
       encoding: UTF-8
-      string: |
+      string: |+
         <?xml version="1.0" encoding="utf-8"?>
-        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-          xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
-          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
           <soap:Body>
-            <idm:PRPA_IN201302UV02 xmlns:idm="http://vaww.oed.oit.va.gov"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema‐instance" xsi:schemaLocation="urn:hl7‐org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/PRPA_IN201302UV02.xsd"
-              xmlns="urn:hl7‐org:v3" ITSVersion="XML_1.0">
-              <id extension="200VGOV-a632f12b-5330-4b02-9cef-6d2633f7b501" root="22a0f9e0-4454-11dc-a6be-3603d6866807"/>
-              <creationTime value="20220805211942"/>
+            <idm:PRPA_IN201301UV02 xmlns:idm="http://**********" xmlns:xsi="http://www.w3.org/2001/XMLSchema‐instance" xsi:schemaLocation="urn:hl7‐org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/PRPA_IN201305UV02.xsd" xmlns="urn:hl7‐org:v3" ITSVersion="XML_1.0">      <id extension="200VGOV-1373004c-e23e-4d94-90c5-5b101f6be54a" root="22a0f9e0-4454-11dc-a6be-3603d6866807"/>
+              <creationTime value="20200207005744"/>
               <versionCode code="4.1"/>
-              <interactionId extension="PRPA_IN201302UV02" root="2.16.840.1.113883.1.6"/>
+              <interactionId extension="PRPA_IN201301UV02" root="2.16.840.1.113883.1.6"/>
               <processingCode code="T"/>
               <processingModeCode code="T"/>
               <acceptAckCode code="AL"/>
@@ -32,32 +26,53 @@ http_interactions:
                   <id extension="200VGOV" root="2.16.840.1.113883.4.349"/>
                 </device>
               </sender>
+              <attentionLine>
+                <keyWordText>Search.Token</keyWordText>
+                <value xsi:type="ST">WSDOC2002061956255081680185785</value>
+              </attentionLine>
               <controlActProcess classCode="CACT" moodCode="EVN">
+                <dataEnterer contextControlCode="AP" typeCode="ENT">
+                  <assignedPerson classCode="ASSIGNED">
+                    <id extension="1008841684V642518^NI^200M^USVHA" root="2.16.840.1.113883.4.349"/>
+                    <assignedPerson determinerCode="INSTANCE" classCode="PSN">
+                      <name>
+                        <given>JON</given>
+                        <family>JERICHO</family>
+                      </name>
+                    </assignedPerson>
+                    <representedOrganization determinerCode="INSTANCE" classCode="ORG">
+                      <id extension="vagov" root="2.16.840.1.113883.4.349"/>
+                      <code code="2020-02-07 00:57:44"/>
+                      <desc>vagov</desc>
+                      <telecom value="1.2.3.4"/>
+                    </representedOrganization>
+                  </assignedPerson>
+                </dataEnterer>
                 <subject typeCode="SUBJ">
                   <registrationEvent classCode="REG" moodCode="EVN">
                     <id nullFlavor="NA"/>
                     <statusCode code="active"/>
                     <subject1 typeCode="SBJ">
                       <patient classCode="PAT">
-                        <id extension="1013677101V363970^NI^200M^USVHA^P" root="2.16.840.1.113883.4.349"/>
+                        <id extension="1008841684V642518^NI^200M^USVHA" root="2.16.840.1.113883.4.349"/>
                         <statusCode code="active"/>
                         <patientPerson>
                           <name use="L">
-                            <given>abraham</given>
-                            <family>lincoln</family>
+                            <given>JON</given>
+                            <family>JERICHO</family>
                           </name>
-                          <birthTime value="18090212"/>
-                          <id extension="384759483^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12"/>
+                          <birthTime value="19600507"/>
                           <asOtherIDs classCode="SSN">
-                            <id extension="796111863" root="2.16.840.1.113883.4.1"/>
+                            <id extension="333874412" root="2.16.840.1.113883.4.1"/>
                             <scopingOrganization determinerCode="INSTANCE" classCode="ORG">
                               <id root="2.16.840.1.113883.4.1"/>
                             </scopingOrganization>
                           </asOtherIDs>
                           <asOtherIDs classCode="PAT">
-                            <id extension="384759483^NI^200DOD^USDOD^A" root="2.16.840.1.113883.3.42.10001.100001.12"/>
-                            <scopingOrganization classCode="ORG" determinerCode="INSTANCE">
-                              <id root="2.16.840.1.113883.4.349" />
+                            <id extension="PROXY_ADD^PI^200VBA^USVBA" root="2.16.840.1.113883.4.349"/>
+                            <scopingOrganization determinerCode="INSTANCE" classCode="ORG">
+                              <id extension="VBA" root="2.16.840.1.113883.4.349"/>
+                              <name>MVI.ORCHESTRATION</name>
                             </scopingOrganization>
                           </asOtherIDs>
                         </patientPerson>
@@ -81,9 +96,10 @@ http_interactions:
                   </registrationEvent>
                 </subject>
               </controlActProcess>
-            </idm:PRPA_IN201302UV02>
+            </idm:PRPA_IN201301UV02>
           </soap:Body>
         </soap:Envelope>
+
     headers:
       Accept:
       - text/xml;charset=UTF-8
@@ -91,84 +107,70 @@ http_interactions:
       - text/xml;charset=UTF-8
       User-Agent:
       - Vets.gov Agent
-      Soapaction:
+      soapaction:
       - PRPA_IN201301UV02
       Date:
-      - Thu, 12 May 2022 18:17:30 GMT
+      - Fri, 07 Feb 2020 00:57:44 GMT
       Content-Length:
-      - '3732'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      - '4635'
   response:
     status:
       code: 200
       message: OK
     headers:
-      Accept-Ranges:
-      - bytes
-      Cache-Control:
-      - max-age=604800
-      Content-Type:
-      - text/html; charset=UTF-8
-      Date:
-      - Thu, 12 May 2022 18:17:30 GMT
-      Etag:
-      - '"3147526947+gzip"'
-      Expires:
-      - Thu, 19 May 2022 18:17:30 GMT
-      Last-Modified:
-      - Thu, 17 Oct 2019 07:18:26 GMT
-      Server:
-      - EOS (vny/044F)
-      Vary:
-      - Accept-Encoding
-      Transfer-Encoding:
+      x-backside-transport:
+      - OK OK,OK OK
+      transfer-encoding:
       - chunked
+      date:
+      - Fri, 07 Feb 2020 00:57:44 GMT
+      content-type:
+      - text/xml
+      x-global-transaction-id:
+      - 4bae058f5e3cb6080028a411
+      connection:
+      - close
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-          xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"
-          xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <env:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
           <env:Header/>
           <env:Body>
-            <idm:MCCI_IN000002UV01 ITSVersion="XML_1.0" xsi:schemaLocation="urn:hl7-org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/MCCI_IN000002UV01.xsd"
-              xmlns="urn:hl7-org:v3"
-              xmlns:idm="http://vaww.oed.oit.va.gov">
-              <id extension="WSDOC2208031915266070419759472" root="2.16.840.1.113883.4.349"/>
-              <creationTime value="20220803191526"/>
+            <idm:MCCI_IN000002UV01 ITSVersion="XML_1.0" xsi:schemaLocation="urn:hl7-org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/MCCI_IN000002UV01.xsd" xmlns="urn:hl7-org:v3" xmlns:idm="http://********">
+              <id extension="WSDOC2002061957449380569866168" root="2.16.840.1.113883.4.349"/>
+              <creationTime value="20200206195744"/>
               <versionCode code="4.1"/>
               <interactionId extension="MCCI_IN000002UV01" root="2.16.840.1.113883.1.6"/>
               <processingCode code="T"/>
               <processingModeCode code="T"/>
               <acceptAckCode code="NE"/>
               <receiver typeCode="RCV">
-                <device classCode="DEV" determinerCode="INSTANCE">
+                <device determinerCode="INSTANCE" classCode="DEV">
                   <id extension="200VGOV" root="2.16.840.1.113883.4.349"/>
                 </device>
               </receiver>
               <sender typeCode="SND">
-                <device classCode="DEV" determinerCode="INSTANCE">
+                <device determinerCode="INSTANCE" classCode="DEV">
                   <id extension="200M" root="2.16.840.1.113883.4.349"/>
                 </device>
               </sender>
               <acknowledgement>
-                <typeCode code="AE"/>
+                <typeCode code="AR"/>
                 <targetMessage>
-                  <id extension="200VGOV-0a8c7539-3490-4c5c-b36f-9df9c16af3a2" root="22a0f9e0-4454-11dc-a6be-3603d6866807"/>
+                  <id extension="200VGOV-1373004c-e23e-4d94-90c5-5b101f6be54a" root="22a0f9e0-4454-11dc-a6be-3603d6866807"/>
                 </targetMessage>
                 <acknowledgementDetail>
-                  <code codeSystem="2.16.840.1.113883.3.2017.11.6.1" code="PNUPDATE000005"  displayName="ICN-EDI PI Correlation does not exist"/>
-                  <text>Enterprise ID 1012592956V095840 passed is not linked to ID e4fd21a4-a677-4118-8c57-1f630cbc2a06</text>
+                  <code codeSystem="2.16.840.1.113883.5.1100" code="INTERR" displayName="Internal System Error"/>
+                  <text>Internal System Error</text>
                 </acknowledgementDetail>
                 <acknowledgementDetail>
-                  <text>Correlation NOT FOUND</text>
+                  <text>Internal System Error</text>
                 </acknowledgementDetail>
               </acknowledgement>
             </idm:MCCI_IN000002UV01>
           </env:Body>
         </env:Envelope>
-  recorded_at: Thu, 12 May 2022 18:17:30 GMT
-recorded_with: VCR 6.1.0
+    http_version:
+  recorded_at: Fri, 07 Feb 2020 00:57:45 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/vcr_cassettes/mpi/add_person/addadd_person_already_exists_person_success.yml
+++ b/spec/support/vcr_cassettes/mpi/add_person/addadd_person_already_exists_person_success.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<MPI_URL>"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPGVudjpFbnZlbG9wZSB4bWxuczpzb2FwZW5jPSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VuY29kaW5nLyIgeG1sbnM6eHNkPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYSIgeG1sbnM6ZW52PSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VudmVsb3BlLyIgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSI+CiAgPGVudjpIZWFkZXIvPgogIDxlbnY6Qm9keT4KICAgIDxpZG06UFJQQV9JTjIwMTMwMVVWMDIgeG1sbnM6aWRtPSJodHRwOi8vdmF3dy5vZWQub2l0LnZhLmdvdiIgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYeKAkGluc3RhbmNlIiB4c2k6c2NoZW1hTG9jYXRpb249InVybjpobDfigJBvcmc6djMgLi4vLi4vc2NoZW1hL0hMN1YzL05FMjAwOC9tdWx0aWNhY2hlc2NoZW1hcy9QUlBBX0lOMjAxMzAxVVYwMi54c2QiIHhtbG5zPSJ1cm46aGw34oCQb3JnOnYzIiBJVFNWZXJzaW9uPSJYTUxfMS4wIj4KICAgICAgPGlkIHJvb3Q9IjEuMi44NDAuMTE0MzUwLjEuMTMuMC4xLjcuMS4xIiBleHRlbnNpb249IjIwMFZHT1YtZjdmMDI5YzEtZmVmMi00M2E4LThmNmQtZjQ2ZGZkYjcxZmQxIi8+CiAgICAgIDxjcmVhdGlvblRpbWUgdmFsdWU9IjIwMjIxMjE0MjI0NDA0Ii8+CiAgICAgIDx2ZXJzaW9uQ29kZSBjb2RlPSI0LjEiLz4KICAgICAgPGludGVyYWN0aW9uSWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuMS42IiBleHRlbnNpb249IlBSUEFfSU4yMDEzMDFVVjAyIi8+CiAgICAgIDxwcm9jZXNzaW5nQ29kZSBjb2RlPSJUIi8+CiAgICAgIDxwcm9jZXNzaW5nTW9kZUNvZGUgY29kZT0iVCIvPgogICAgICA8YWNjZXB0QWNrQ29kZSBjb2RlPSJBTCIvPgogICAgICA8cmVjZWl2ZXIgdHlwZUNvZGU9IlJDViI+CiAgICAgICAgPGRldmljZSBjbGFzc0NvZGU9IkRFViIgZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIj4KICAgICAgICAgIDxpZCByb290PSIxLjIuODQwLjExNDM1MC4xLjEzLjk5OS4yMzQiIGV4dGVuc2lvbj0iMjAwTSIvPgogICAgICAgIDwvZGV2aWNlPgogICAgICA8L3JlY2VpdmVyPgogICAgICA8c2VuZGVyIHR5cGVDb2RlPSJTTkQiPgogICAgICAgIDxkZXZpY2UgY2xhc3NDb2RlPSJERVYiIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuNC4zNDkiIGV4dGVuc2lvbj0iMjAwVkdPViIvPgogICAgICAgIDwvZGV2aWNlPgogICAgICA8L3NlbmRlcj4KICAgICAgPGF0dGVudGlvbkxpbmU+CiAgICAgICAgPGtleVdvcmRUZXh0PlNlYXJjaC5Ub2tlbjwva2V5V29yZFRleHQ+CiAgICAgICAgPHZhbHVlIHhzaTp0eXBlPSJTVCI+V1NET0MyMDAyMDcxNTM4NDMyNzQxMTEwMDI3OTU2PC92YWx1ZT4KICAgICAgPC9hdHRlbnRpb25MaW5lPgogICAgICA8Y29udHJvbEFjdFByb2Nlc3MgY2xhc3NDb2RlPSJDQUNUIiBtb29kQ29kZT0iRVZOIj4KICAgICAgICA8ZGF0YUVudGVyZXIgdHlwZUNvZGU9IkVOVCIgY29udGV4dENvbnRyb2xDb2RlPSJBUCI+CiAgICAgICAgICA8YXNzaWduZWRQZXJzb24gY2xhc3NDb2RlPSJBU1NJR05FRCI+CiAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My40LjM0OSIgZXh0ZW5zaW9uPSIxMjM0OTg3NjdWMjM0ODU5Xk5JXjIwME1eVVNWSEFeUCIvPgogICAgICAgICAgICA8YXNzaWduZWRQZXJzb24gY2xhc3NDb2RlPSJQU04iIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAgICAgICAgICAgICAgPG5hbWU+CiAgICAgICAgICAgICAgICA8Z2l2ZW4+YWJyYWhhbTwvZ2l2ZW4+CiAgICAgICAgICAgICAgICA8ZmFtaWx5PmxpbmNvbG48L2ZhbWlseT4KICAgICAgICAgICAgICA8L25hbWU+CiAgICAgICAgICAgIDwvYXNzaWduZWRQZXJzb24+CiAgICAgICAgICAgIDxyZXByZXNlbnRlZE9yZ2FuaXphdGlvbiBkZXRlcm1pbmVyQ29kZT0iSU5TVEFOQ0UiIGNsYXNzQ29kZT0iT1JHIj4KICAgICAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuNC4zNDkiIGV4dGVuc2lvbj0iZHNsb2dvbi4zODQ3NTk0ODMiLz4KICAgICAgICAgICAgICA8Y29kZSBjb2RlPSIyMDIyLTEyLTE0IDIyOjQ0OjA0Ii8+CiAgICAgICAgICAgICAgPGRlc2M+dmFnb3Y8L2Rlc2M+CiAgICAgICAgICAgICAgPHRlbGVjb20gdmFsdWU9IjE5Mi4xNjguNTAuMjA2Ii8+CiAgICAgICAgICAgIDwvcmVwcmVzZW50ZWRPcmdhbml6YXRpb24+CiAgICAgICAgICA8L2Fzc2lnbmVkUGVyc29uPgogICAgICAgIDwvZGF0YUVudGVyZXI+CiAgICAgICAgPHN1YmplY3QgdHlwZUNvZGU9IlNVQkoiPgogICAgICAgICAgPHJlZ2lzdHJhdGlvbkV2ZW50IGNsYXNzQ29kZT0iUkVHIiBtb29kQ29kZT0iRVZOIj4KICAgICAgICAgICAgPGlkIG51bGxGbGF2b3I9Ik5BIi8+CiAgICAgICAgICAgIDxzdGF0dXNDb2RlIGNvZGU9ImFjdGl2ZSIvPgogICAgICAgICAgICA8c3ViamVjdDEgdHlwZUNvZGU9IlNCSiI+CiAgICAgICAgICAgICAgPHBhdGllbnQgY2xhc3NDb2RlPSJQQVQiPgogICAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMzQ5IiBleHRlbnNpb249IjEyMzQ5ODc2N1YyMzQ4NTleTkleMjAwTV5VU1ZIQV5QIi8+CiAgICAgICAgICAgICAgICA8c3RhdHVzQ29kZSBjb2RlPSJhY3RpdmUiLz4KICAgICAgICAgICAgICAgIDxwYXRpZW50UGVyc29uPgogICAgICAgICAgICAgICAgICA8bmFtZSB1c2U9IkwiPgogICAgICAgICAgICAgICAgICAgIDxnaXZlbj5hYnJhaGFtPC9naXZlbj4KICAgICAgICAgICAgICAgICAgICA8ZmFtaWx5PmxpbmNvbG48L2ZhbWlseT4KICAgICAgICAgICAgICAgICAgPC9uYW1lPgogICAgICAgICAgICAgICAgICA8YmlydGhUaW1lIHZhbHVlPSIxODA5MDIxMiIvPgogICAgICAgICAgICAgICAgICA8YXNPdGhlcklEcyBjbGFzc0NvZGU9IlNTTiI+CiAgICAgICAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMSIgZXh0ZW5zaW9uPSI3OTYxMTE4NjMiLz4KICAgICAgICAgICAgICAgICAgICA8c2NvcGluZ09yZ2FuaXphdGlvbiBkZXRlcm1pbmVyQ29kZT0iSU5TVEFOQ0UiIGNsYXNzQ29kZT0iT1JHIj4KICAgICAgICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My40LjEiLz4KICAgICAgICAgICAgICAgICAgICA8L3Njb3BpbmdPcmdhbml6YXRpb24+CiAgICAgICAgICAgICAgICAgIDwvYXNPdGhlcklEcz4KICAgICAgICAgICAgICAgICAgPGFzT3RoZXJJRHMgY2xhc3NDb2RlPSJQQVQiPgogICAgICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My40LjM0OSIgZXh0ZW5zaW9uPSJQUk9YWV9BREReUEleMjAwVkJBXlVTVkJBIi8+CiAgICAgICAgICAgICAgICAgICAgPHNjb3BpbmdPcmdhbml6YXRpb24gZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIiBjbGFzc0NvZGU9Ik9SRyI+CiAgICAgICAgICAgICAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuNC4zNDkiLz4KICAgICAgICAgICAgICAgICAgICAgIDxuYW1lPk1WSS5PUkNIRVNUUkFUSU9OPC9uYW1lPgogICAgICAgICAgICAgICAgICAgIDwvc2NvcGluZ09yZ2FuaXphdGlvbj4KICAgICAgICAgICAgICAgICAgPC9hc090aGVySURzPgogICAgICAgICAgICAgICAgPC9wYXRpZW50UGVyc29uPgogICAgICAgICAgICAgICAgPHByb3ZpZGVyT3JnYW5pemF0aW9uIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSIgY2xhc3NDb2RlPSJPUkciPgogICAgICAgICAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuMy45MzMiLz4KICAgICAgICAgICAgICAgICAgPG5hbWU+R29vZCBIZWFsdGggQ2xpbmljPC9uYW1lPgogICAgICAgICAgICAgICAgICA8Y29udGFjdFBhcnR5IGNsYXNzQ29kZT0iQ09OIj4KICAgICAgICAgICAgICAgICAgICA8dGVsZWNvbSB2YWx1ZT0iMzQyNTU1ODM5NCIvPgogICAgICAgICAgICAgICAgICA8L2NvbnRhY3RQYXJ0eT4KICAgICAgICAgICAgICAgIDwvcHJvdmlkZXJPcmdhbml6YXRpb24+CiAgICAgICAgICAgICAgPC9wYXRpZW50PgogICAgICAgICAgICA8L3N1YmplY3QxPgogICAgICAgICAgICA8Y3VzdG9kaWFuIHR5cGVDb2RlPSJDU1QiPgogICAgICAgICAgICAgIDxhc3NpZ25lZEVudGl0eSBjbGFzc0NvZGU9IkFTU0lHTkVEIj4KICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My4zLjkzMyIvPgogICAgICAgICAgICAgICAgPGFzc2lnbmVkT3JnYW5pemF0aW9uIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSIgY2xhc3NDb2RlPSJPUkciPgogICAgICAgICAgICAgICAgICA8bmFtZT5Hb29kIEhlYWx0aCBDbGluaWM8L25hbWU+CiAgICAgICAgICAgICAgICA8L2Fzc2lnbmVkT3JnYW5pemF0aW9uPgogICAgICAgICAgICAgIDwvYXNzaWduZWRFbnRpdHk+CiAgICAgICAgICAgIDwvY3VzdG9kaWFuPgogICAgICAgICAgPC9yZWdpc3RyYXRpb25FdmVudD4KICAgICAgICA8L3N1YmplY3Q+CiAgICAgIDwvY29udHJvbEFjdFByb2Nlc3M+CiAgICA8L2lkbTpQUlBBX0lOMjAxMzAxVVYwMj4KICA8L2VudjpCb2R5Pgo8L2VudjpFbnZlbG9wZT4K
+    headers:
+      Accept:
+      - text/xml;charset=UTF-8
+      Content-Type:
+      - text/xml;charset=UTF-8
+      User-Agent:
+      - Vets.gov Agent
+      Soapaction:
+      - PRPA_IN201301UV02
+      Date:
+      - Wed, 14 Dec 2022 22:44:04 GMT
+      Content-Length:
+      - '4665'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Wed, 14 Dec 2022 22:44:04 GMT
+      Etag:
+      - '"3147526947"'
+      Expires:
+      - Wed, 21 Dec 2022 22:44:04 GMT
+      Last-Modified:
+      - Thu, 17 Oct 2019 07:18:26 GMT
+      Server:
+      - EOS (vny/044E)
+      Content-Length:
+      - '1256'
+    body:
+      encoding: UTF-8
+      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
+        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
+        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system,
+        system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\",
+        Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width:
+        600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color:
+        #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px
+        rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n
+        \       text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div
+        {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n
+        \   </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
+        \   <p>This domain is for use in illustrative examples in documents. You may
+        use this\n    domain in literature without prior coordination or asking for
+        permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More
+        information...</a></p>\n</div>\n</body>\n</html>\n"
+  recorded_at: Wed, 14 Dec 2022 22:44:04 GMT
+recorded_with: VCR 6.1.0

--- a/spec/support/vcr_cassettes/mpi/add_person/update_profile_server_error.yml
+++ b/spec/support/vcr_cassettes/mpi/add_person/update_profile_server_error.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<MPI_URL>"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPGVudjpFbnZlbG9wZSB4bWxuczpzb2FwZW5jPSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VuY29kaW5nLyIgeG1sbnM6eHNkPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYSIgeG1sbnM6ZW52PSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VudmVsb3BlLyIgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSI+CiAgPGVudjpIZWFkZXIvPgogIDxlbnY6Qm9keT4KICAgIDxpZG06UFJQQV9JTjIwMTMwMlVWMDIgeG1sbnM6aWRtPSJodHRwOi8vdmF3dy5vZWQub2l0LnZhLmdvdiIgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYeKAkGluc3RhbmNlIiB4c2k6c2NoZW1hTG9jYXRpb249InVybjpobDfigJBvcmc6djMgLi4vLi4vc2NoZW1hL0hMN1YzL05FMjAwOC9tdWx0aWNhY2hlc2NoZW1hcy9QUlBBX0lOMjAxMzAyVVYwMi54c2QiIHhtbG5zPSJ1cm46aGw34oCQb3JnOnYzIiBJVFNWZXJzaW9uPSJYTUxfMS4wIj4KICAgICAgPGlkIHJvb3Q9IjEuMi44NDAuMTE0MzUwLjEuMTMuMC4xLjcuMS4xIiBleHRlbnNpb249IjIwMFZHT1YtYjMyODY3OGEtYWVlOC00Yjk4LWI2ODAtMTRhNjIyNDY3ZDBiIi8+CiAgICAgIDxjcmVhdGlvblRpbWUgdmFsdWU9IjIwMjIxMjE0MjEzOTA5Ii8+CiAgICAgIDx2ZXJzaW9uQ29kZSBjb2RlPSI0LjEiLz4KICAgICAgPGludGVyYWN0aW9uSWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuMS42IiBleHRlbnNpb249IlBSUEFfSU4yMDEzMDJVVjAyIi8+CiAgICAgIDxwcm9jZXNzaW5nQ29kZSBjb2RlPSJUIi8+CiAgICAgIDxwcm9jZXNzaW5nTW9kZUNvZGUgY29kZT0iVCIvPgogICAgICA8YWNjZXB0QWNrQ29kZSBjb2RlPSJBTCIvPgogICAgICA8cmVjZWl2ZXIgdHlwZUNvZGU9IlJDViI+CiAgICAgICAgPGRldmljZSBjbGFzc0NvZGU9IkRFViIgZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIj4KICAgICAgICAgIDxpZCByb290PSIxLjIuODQwLjExNDM1MC4xLjEzLjk5OS4yMzQiIGV4dGVuc2lvbj0iMjAwTSIvPgogICAgICAgIDwvZGV2aWNlPgogICAgICA8L3JlY2VpdmVyPgogICAgICA8c2VuZGVyIHR5cGVDb2RlPSJTTkQiPgogICAgICAgIDxkZXZpY2UgY2xhc3NDb2RlPSJERVYiIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuNC4zNDkiIGV4dGVuc2lvbj0iMjAwVkdPViIvPgogICAgICAgIDwvZGV2aWNlPgogICAgICA8L3NlbmRlcj4KICAgICAgPGNvbnRyb2xBY3RQcm9jZXNzIGNsYXNzQ29kZT0iQ0FDVCIgbW9vZENvZGU9IkVWTiI+CiAgICAgICAgPHN1YmplY3QgdHlwZUNvZGU9IlNVQkoiPgogICAgICAgICAgPHJlZ2lzdHJhdGlvbkV2ZW50IGNsYXNzQ29kZT0iUkVHIiBtb29kQ29kZT0iRVZOIj4KICAgICAgICAgICAgPGlkIG51bGxGbGF2b3I9Ik5BIi8+CiAgICAgICAgICAgIDxzdGF0dXNDb2RlIGNvZGU9ImFjdGl2ZSIvPgogICAgICAgICAgICA8c3ViamVjdDEgdHlwZUNvZGU9IlNCSiI+CiAgICAgICAgICAgICAgPHBhdGllbnQgY2xhc3NDb2RlPSJQQVQiPgogICAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMzQ5IiBleHRlbnNpb249IjEyMzQ5ODc2N1YyMzQ4NTleTkleMjAwTV5VU1ZIQV5QIi8+CiAgICAgICAgICAgICAgICA8c3RhdHVzQ29kZSBjb2RlPSJhY3RpdmUiLz4KICAgICAgICAgICAgICAgIDxwYXRpZW50UGVyc29uPgogICAgICAgICAgICAgICAgICA8bmFtZSB1c2U9IkwiPgogICAgICAgICAgICAgICAgICAgIDxnaXZlbj5NaXRjaGVsbDwvZ2l2ZW4+CiAgICAgICAgICAgICAgICAgICAgPGZhbWlseT5KZW5raW5zPC9mYW1pbHk+CiAgICAgICAgICAgICAgICAgIDwvbmFtZT4KICAgICAgICAgICAgICAgICAgPGJpcnRoVGltZSB2YWx1ZT0iMTk0OTAzMDQiLz4KICAgICAgICAgICAgICAgICAgPGFkZHIgdXNlPSJIUCI+CiAgICAgICAgICAgICAgICAgICAgPHN0cmVldEFkZHJlc3NMaW5lPjE2MDAgUGVubnN5bHZhbmlhIEF2ZTwvc3RyZWV0QWRkcmVzc0xpbmU+CiAgICAgICAgICAgICAgICAgICAgPGNpdHk+V2FzaGluZ3RvbjwvY2l0eT4KICAgICAgICAgICAgICAgICAgICA8c3RhdGU+REM8L3N0YXRlPgogICAgICAgICAgICAgICAgICAgIDxwb3N0YWxDb2RlPjIwNTAwPC9wb3N0YWxDb2RlPgogICAgICAgICAgICAgICAgICAgIDxjb3VudHJ5PlVTQTwvY291bnRyeT4KICAgICAgICAgICAgICAgICAgPC9hZGRyPgogICAgICAgICAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuMy40Mi4xMDAwMS4xMDAwMDEuMTIiIGV4dGVuc2lvbj0iMzg0NzU5NDgzXk5JXjIwMERPRF5VU0RPRF5BIi8+CiAgICAgICAgICAgICAgICAgIDx0ZWxlY29tIHVzZT0iSCIgdmFsdWU9ImFicmFoYW0ubGluY29sbkB2ZXRzLmdvdiIvPgogICAgICAgICAgICAgICAgICA8YXNPdGhlcklEcyBjbGFzc0NvZGU9IlNTTiI+CiAgICAgICAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMSIgZXh0ZW5zaW9uPSI3OTYxMjIzMDYiLz4KICAgICAgICAgICAgICAgICAgICA8c2NvcGluZ09yZ2FuaXphdGlvbiBkZXRlcm1pbmVyQ29kZT0iSU5TVEFOQ0UiIGNsYXNzQ29kZT0iT1JHIj4KICAgICAgICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My40LjEiLz4KICAgICAgICAgICAgICAgICAgICA8L3Njb3BpbmdPcmdhbml6YXRpb24+CiAgICAgICAgICAgICAgICAgIDwvYXNPdGhlcklEcz4KICAgICAgICAgICAgICAgICAgPGFzT3RoZXJJRHMgY2xhc3NDb2RlPSJQQVQiPgogICAgICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My4zLjQyLjEwMDAxLjEwMDAwMS4xMiIgZXh0ZW5zaW9uPSIzODQ3NTk0ODNeTkleMjAwRE9EXlVTRE9EXkEiLz4KICAgICAgICAgICAgICAgICAgICA8c2NvcGluZ09yZ2FuaXphdGlvbiBkZXRlcm1pbmVyQ29kZT0iSU5TVEFOQ0UiIGNsYXNzQ29kZT0iT1JHIj4KICAgICAgICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My4zLjQyLjEwMDAxLjEwMDAwMS4xMiIvPgogICAgICAgICAgICAgICAgICAgIDwvc2NvcGluZ09yZ2FuaXphdGlvbj4KICAgICAgICAgICAgICAgICAgPC9hc090aGVySURzPgogICAgICAgICAgICAgICAgPC9wYXRpZW50UGVyc29uPgogICAgICAgICAgICAgICAgPHByb3ZpZGVyT3JnYW5pemF0aW9uIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSIgY2xhc3NDb2RlPSJPUkciPgogICAgICAgICAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuMy45MzMiLz4KICAgICAgICAgICAgICAgICAgPG5hbWU+R29vZCBIZWFsdGggQ2xpbmljPC9uYW1lPgogICAgICAgICAgICAgICAgICA8Y29udGFjdFBhcnR5IGNsYXNzQ29kZT0iQ09OIj4KICAgICAgICAgICAgICAgICAgICA8dGVsZWNvbSB2YWx1ZT0iMzQyNTU1ODM5NCIvPgogICAgICAgICAgICAgICAgICA8L2NvbnRhY3RQYXJ0eT4KICAgICAgICAgICAgICAgIDwvcHJvdmlkZXJPcmdhbml6YXRpb24+CiAgICAgICAgICAgICAgPC9wYXRpZW50PgogICAgICAgICAgICA8L3N1YmplY3QxPgogICAgICAgICAgICA8Y3VzdG9kaWFuIHR5cGVDb2RlPSJDU1QiPgogICAgICAgICAgICAgIDxhc3NpZ25lZEVudGl0eSBjbGFzc0NvZGU9IkFTU0lHTkVEIj4KICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My4zLjkzMyIvPgogICAgICAgICAgICAgICAgPGFzc2lnbmVkT3JnYW5pemF0aW9uIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSIgY2xhc3NDb2RlPSJPUkciPgogICAgICAgICAgICAgICAgICA8bmFtZT5Hb29kIEhlYWx0aCBDbGluaWM8L25hbWU+CiAgICAgICAgICAgICAgICA8L2Fzc2lnbmVkT3JnYW5pemF0aW9uPgogICAgICAgICAgICAgIDwvYXNzaWduZWRFbnRpdHk+CiAgICAgICAgICAgIDwvY3VzdG9kaWFuPgogICAgICAgICAgPC9yZWdpc3RyYXRpb25FdmVudD4KICAgICAgICA8L3N1YmplY3Q+CiAgICAgIDwvY29udHJvbEFjdFByb2Nlc3M+CiAgICA8L2lkbTpQUlBBX0lOMjAxMzAyVVYwMj4KICA8L2VudjpCb2R5Pgo8L2VudjpFbnZlbG9wZT4K
+    headers:
+      Accept:
+      - text/xml;charset=UTF-8
+      Content-Type:
+      - text/xml;charset=UTF-8
+      User-Agent:
+      - Vets.gov Agent
+      Soapaction:
+      - PRPA_IN201302UV02
+      Date:
+      - Wed, 14 Dec 2022 21:39:09 GMT
+      Content-Length:
+      - '4173'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Wed, 14 Dec 2022 21:39:09 GMT
+      Etag:
+      - '"3147526947"'
+      Expires:
+      - Wed, 21 Dec 2022 21:39:09 GMT
+      Last-Modified:
+      - Thu, 17 Oct 2019 07:18:26 GMT
+      Server:
+      - EOS (vny/0452)
+      Content-Length:
+      - '1256'
+    body:
+      encoding: UTF-8
+      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
+        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
+        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system,
+        system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\",
+        Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width:
+        600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color:
+        #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px
+        rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n
+        \       text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div
+        {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n
+        \   </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
+        \   <p>This domain is for use in illustrative examples in documents. You may
+        use this\n    domain in literature without prior coordination or asking for
+        permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More
+        information...</a></p>\n</div>\n</body>\n</html>\n"
+  recorded_at: Wed, 14 Dec 2022 21:39:10 GMT
+recorded_with: VCR 6.1.0

--- a/spec/support/vcr_cassettes/mpi/add_person_internal_error_response.yml
+++ b/spec/support/vcr_cassettes/mpi/add_person_internal_error_response.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<MPI_URL>"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPGVudjpFbnZlbG9wZSB4bWxuczpzb2FwZW5jPSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VuY29kaW5nLyIgeG1sbnM6eHNkPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYSIgeG1sbnM6ZW52PSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VudmVsb3BlLyIgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSI+CiAgPGVudjpIZWFkZXIvPgogIDxlbnY6Qm9keT4KICAgIDxpZG06UFJQQV9JTjIwMTMwMVVWMDIgeG1sbnM6aWRtPSJodHRwOi8vdmF3dy5vZWQub2l0LnZhLmdvdiIgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYeKAkGluc3RhbmNlIiB4c2k6c2NoZW1hTG9jYXRpb249InVybjpobDfigJBvcmc6djMgLi4vLi4vc2NoZW1hL0hMN1YzL05FMjAwOC9tdWx0aWNhY2hlc2NoZW1hcy9QUlBBX0lOMjAxMzAxVVYwMi54c2QiIHhtbG5zPSJ1cm46aGw34oCQb3JnOnYzIiBJVFNWZXJzaW9uPSJYTUxfMS4wIj4KICAgICAgPGlkIHJvb3Q9IjEuMi44NDAuMTE0MzUwLjEuMTMuMC4xLjcuMS4xIiBleHRlbnNpb249IjIwMFZHT1YtMDFkY2ZmNjYtZTQxZi00NDBlLWFkMTUtMzg3NWYyMjNiN2VlIi8+CiAgICAgIDxjcmVhdGlvblRpbWUgdmFsdWU9IjIwMjIxMjE0MjAwNjI0Ii8+CiAgICAgIDx2ZXJzaW9uQ29kZSBjb2RlPSI0LjEiLz4KICAgICAgPGludGVyYWN0aW9uSWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuMS42IiBleHRlbnNpb249IlBSUEFfSU4yMDEzMDFVVjAyIi8+CiAgICAgIDxwcm9jZXNzaW5nQ29kZSBjb2RlPSJUIi8+CiAgICAgIDxwcm9jZXNzaW5nTW9kZUNvZGUgY29kZT0iVCIvPgogICAgICA8YWNjZXB0QWNrQ29kZSBjb2RlPSJBTCIvPgogICAgICA8cmVjZWl2ZXIgdHlwZUNvZGU9IlJDViI+CiAgICAgICAgPGRldmljZSBjbGFzc0NvZGU9IkRFViIgZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIj4KICAgICAgICAgIDxpZCByb290PSIxLjIuODQwLjExNDM1MC4xLjEzLjk5OS4yMzQiIGV4dGVuc2lvbj0iMjAwTSIvPgogICAgICAgIDwvZGV2aWNlPgogICAgICA8L3JlY2VpdmVyPgogICAgICA8c2VuZGVyIHR5cGVDb2RlPSJTTkQiPgogICAgICAgIDxkZXZpY2UgY2xhc3NDb2RlPSJERVYiIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuNC4zNDkiIGV4dGVuc2lvbj0iMjAwVkdPViIvPgogICAgICAgIDwvZGV2aWNlPgogICAgICA8L3NlbmRlcj4KICAgICAgPGF0dGVudGlvbkxpbmU+CiAgICAgICAgPGtleVdvcmRUZXh0PlNlYXJjaC5Ub2tlbjwva2V5V29yZFRleHQ+CiAgICAgICAgPHZhbHVlIHhzaTp0eXBlPSJTVCI+V1NET0MyMDAyMDcxNTM4NDMyNzQxMTEwMDI3OTU2PC92YWx1ZT4KICAgICAgPC9hdHRlbnRpb25MaW5lPgogICAgICA8Y29udHJvbEFjdFByb2Nlc3MgY2xhc3NDb2RlPSJDQUNUIiBtb29kQ29kZT0iRVZOIj4KICAgICAgICA8ZGF0YUVudGVyZXIgdHlwZUNvZGU9IkVOVCIgY29udGV4dENvbnRyb2xDb2RlPSJBUCI+CiAgICAgICAgICA8YXNzaWduZWRQZXJzb24gY2xhc3NDb2RlPSJBU1NJR05FRCI+CiAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My40LjM0OSIgZXh0ZW5zaW9uPSIxMjM0OTg3NjdWMjM0ODU5Xk5JXjIwME1eVVNWSEFeUCIvPgogICAgICAgICAgICA8YXNzaWduZWRQZXJzb24gY2xhc3NDb2RlPSJQU04iIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAgICAgICAgICAgICAgPG5hbWU+CiAgICAgICAgICAgICAgICA8Z2l2ZW4+TWl0Y2hlbGw8L2dpdmVuPgogICAgICAgICAgICAgICAgPGZhbWlseT5KZW5raW5zPC9mYW1pbHk+CiAgICAgICAgICAgICAgPC9uYW1lPgogICAgICAgICAgICA8L2Fzc2lnbmVkUGVyc29uPgogICAgICAgICAgICA8cmVwcmVzZW50ZWRPcmdhbml6YXRpb24gZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIiBjbGFzc0NvZGU9Ik9SRyI+CiAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMzQ5IiBleHRlbnNpb249ImRzbG9nb24uMzg0NzU5NDgzIi8+CiAgICAgICAgICAgICAgPGNvZGUgY29kZT0iMjAyMi0xMi0xNCAyMDowNjoyNCIvPgogICAgICAgICAgICAgIDxkZXNjPnZhZ292PC9kZXNjPgogICAgICAgICAgICAgIDx0ZWxlY29tIHZhbHVlPSIxOTIuMTY4LjUwLjIwNiIvPgogICAgICAgICAgICA8L3JlcHJlc2VudGVkT3JnYW5pemF0aW9uPgogICAgICAgICAgPC9hc3NpZ25lZFBlcnNvbj4KICAgICAgICA8L2RhdGFFbnRlcmVyPgogICAgICAgIDxzdWJqZWN0IHR5cGVDb2RlPSJTVUJKIj4KICAgICAgICAgIDxyZWdpc3RyYXRpb25FdmVudCBjbGFzc0NvZGU9IlJFRyIgbW9vZENvZGU9IkVWTiI+CiAgICAgICAgICAgIDxpZCBudWxsRmxhdm9yPSJOQSIvPgogICAgICAgICAgICA8c3RhdHVzQ29kZSBjb2RlPSJhY3RpdmUiLz4KICAgICAgICAgICAgPHN1YmplY3QxIHR5cGVDb2RlPSJTQkoiPgogICAgICAgICAgICAgIDxwYXRpZW50IGNsYXNzQ29kZT0iUEFUIj4KICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My40LjM0OSIgZXh0ZW5zaW9uPSIxMjM0OTg3NjdWMjM0ODU5Xk5JXjIwME1eVVNWSEFeUCIvPgogICAgICAgICAgICAgICAgPHN0YXR1c0NvZGUgY29kZT0iYWN0aXZlIi8+CiAgICAgICAgICAgICAgICA8cGF0aWVudFBlcnNvbj4KICAgICAgICAgICAgICAgICAgPG5hbWUgdXNlPSJMIj4KICAgICAgICAgICAgICAgICAgICA8Z2l2ZW4+TWl0Y2hlbGw8L2dpdmVuPgogICAgICAgICAgICAgICAgICAgIDxmYW1pbHk+SmVua2luczwvZmFtaWx5PgogICAgICAgICAgICAgICAgICA8L25hbWU+CiAgICAgICAgICAgICAgICAgIDxiaXJ0aFRpbWUgdmFsdWU9IjE5NDkwMzA0Ii8+CiAgICAgICAgICAgICAgICAgIDxhc090aGVySURzIGNsYXNzQ29kZT0iU1NOIj4KICAgICAgICAgICAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuNC4xIiBleHRlbnNpb249Ijc5NjEyMjMwNiIvPgogICAgICAgICAgICAgICAgICAgIDxzY29waW5nT3JnYW5pemF0aW9uIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSIgY2xhc3NDb2RlPSJPUkciPgogICAgICAgICAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMSIvPgogICAgICAgICAgICAgICAgICAgIDwvc2NvcGluZ09yZ2FuaXphdGlvbj4KICAgICAgICAgICAgICAgICAgPC9hc090aGVySURzPgogICAgICAgICAgICAgICAgICA8YXNPdGhlcklEcyBjbGFzc0NvZGU9IlBBVCI+CiAgICAgICAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMzQ5IiBleHRlbnNpb249IlBST1hZX0FERF5QSV4yMDBWQkFeVVNWQkEiLz4KICAgICAgICAgICAgICAgICAgICA8c2NvcGluZ09yZ2FuaXphdGlvbiBkZXRlcm1pbmVyQ29kZT0iSU5TVEFOQ0UiIGNsYXNzQ29kZT0iT1JHIj4KICAgICAgICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My40LjM0OSIvPgogICAgICAgICAgICAgICAgICAgICAgPG5hbWU+TVZJLk9SQ0hFU1RSQVRJT048L25hbWU+CiAgICAgICAgICAgICAgICAgICAgPC9zY29waW5nT3JnYW5pemF0aW9uPgogICAgICAgICAgICAgICAgICA8L2FzT3RoZXJJRHM+CiAgICAgICAgICAgICAgICA8L3BhdGllbnRQZXJzb24+CiAgICAgICAgICAgICAgICA8cHJvdmlkZXJPcmdhbml6YXRpb24gZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIiBjbGFzc0NvZGU9Ik9SRyI+CiAgICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My4zLjkzMyIvPgogICAgICAgICAgICAgICAgICA8bmFtZT5Hb29kIEhlYWx0aCBDbGluaWM8L25hbWU+CiAgICAgICAgICAgICAgICAgIDxjb250YWN0UGFydHkgY2xhc3NDb2RlPSJDT04iPgogICAgICAgICAgICAgICAgICAgIDx0ZWxlY29tIHZhbHVlPSIzNDI1NTU4Mzk0Ii8+CiAgICAgICAgICAgICAgICAgIDwvY29udGFjdFBhcnR5PgogICAgICAgICAgICAgICAgPC9wcm92aWRlck9yZ2FuaXphdGlvbj4KICAgICAgICAgICAgICA8L3BhdGllbnQ+CiAgICAgICAgICAgIDwvc3ViamVjdDE+CiAgICAgICAgICAgIDxjdXN0b2RpYW4gdHlwZUNvZGU9IkNTVCI+CiAgICAgICAgICAgICAgPGFzc2lnbmVkRW50aXR5IGNsYXNzQ29kZT0iQVNTSUdORUQiPgogICAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjMuOTMzIi8+CiAgICAgICAgICAgICAgICA8YXNzaWduZWRPcmdhbml6YXRpb24gZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIiBjbGFzc0NvZGU9Ik9SRyI+CiAgICAgICAgICAgICAgICAgIDxuYW1lPkdvb2QgSGVhbHRoIENsaW5pYzwvbmFtZT4KICAgICAgICAgICAgICAgIDwvYXNzaWduZWRPcmdhbml6YXRpb24+CiAgICAgICAgICAgICAgPC9hc3NpZ25lZEVudGl0eT4KICAgICAgICAgICAgPC9jdXN0b2RpYW4+CiAgICAgICAgICA8L3JlZ2lzdHJhdGlvbkV2ZW50PgogICAgICAgIDwvc3ViamVjdD4KICAgICAgPC9jb250cm9sQWN0UHJvY2Vzcz4KICAgIDwvaWRtOlBSUEFfSU4yMDEzMDFVVjAyPgogIDwvZW52OkJvZHk+CjwvZW52OkVudmVsb3BlPgo=
+    headers:
+      Accept:
+      - text/xml;charset=UTF-8
+      Content-Type:
+      - text/xml;charset=UTF-8
+      User-Agent:
+      - Vets.gov Agent
+      Soapaction:
+      - PRPA_IN201301UV02
+      Date:
+      - Wed, 14 Dec 2022 20:06:24 GMT
+      Content-Length:
+      - '4667'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Wed, 14 Dec 2022 20:06:24 GMT
+      Etag:
+      - '"3147526947"'
+      Expires:
+      - Wed, 21 Dec 2022 20:06:24 GMT
+      Last-Modified:
+      - Thu, 17 Oct 2019 07:18:26 GMT
+      Server:
+      - EOS (vny/0451)
+      Content-Length:
+      - '1256'
+    body:
+      encoding: UTF-8
+      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
+        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
+        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system,
+        system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\",
+        Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width:
+        600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color:
+        #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px
+        rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n
+        \       text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div
+        {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n
+        \   </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
+        \   <p>This domain is for use in illustrative examples in documents. You may
+        use this\n    domain in literature without prior coordination or asking for
+        permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More
+        information...</a></p>\n</div>\n</body>\n</html>\n"
+  recorded_at: Wed, 14 Dec 2022 20:06:24 GMT
+recorded_with: VCR 6.1.0

--- a/spec/support/vcr_cassettes/spec/support/mpi/add_person_internal_error_response.yml
+++ b/spec/support/vcr_cassettes/spec/support/mpi/add_person_internal_error_response.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<MPI_URL>"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPGVudjpFbnZlbG9wZSB4bWxuczpzb2FwZW5jPSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VuY29kaW5nLyIgeG1sbnM6eHNkPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYSIgeG1sbnM6ZW52PSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VudmVsb3BlLyIgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSI+CiAgPGVudjpIZWFkZXIvPgogIDxlbnY6Qm9keT4KICAgIDxpZG06UFJQQV9JTjIwMTMwMVVWMDIgeG1sbnM6aWRtPSJodHRwOi8vdmF3dy5vZWQub2l0LnZhLmdvdiIgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYeKAkGluc3RhbmNlIiB4c2k6c2NoZW1hTG9jYXRpb249InVybjpobDfigJBvcmc6djMgLi4vLi4vc2NoZW1hL0hMN1YzL05FMjAwOC9tdWx0aWNhY2hlc2NoZW1hcy9QUlBBX0lOMjAxMzAxVVYwMi54c2QiIHhtbG5zPSJ1cm46aGw34oCQb3JnOnYzIiBJVFNWZXJzaW9uPSJYTUxfMS4wIj4KICAgICAgPGlkIHJvb3Q9IjEuMi44NDAuMTE0MzUwLjEuMTMuMC4xLjcuMS4xIiBleHRlbnNpb249IjIwMFZHT1YtZTE1NzkzY2ItZmNkNS00MmRkLWJkMjAtMGIwZTZmOTMyOGExIi8+CiAgICAgIDxjcmVhdGlvblRpbWUgdmFsdWU9IjIwMjIxMjE0MjAwNjAxIi8+CiAgICAgIDx2ZXJzaW9uQ29kZSBjb2RlPSI0LjEiLz4KICAgICAgPGludGVyYWN0aW9uSWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuMS42IiBleHRlbnNpb249IlBSUEFfSU4yMDEzMDFVVjAyIi8+CiAgICAgIDxwcm9jZXNzaW5nQ29kZSBjb2RlPSJUIi8+CiAgICAgIDxwcm9jZXNzaW5nTW9kZUNvZGUgY29kZT0iVCIvPgogICAgICA8YWNjZXB0QWNrQ29kZSBjb2RlPSJBTCIvPgogICAgICA8cmVjZWl2ZXIgdHlwZUNvZGU9IlJDViI+CiAgICAgICAgPGRldmljZSBjbGFzc0NvZGU9IkRFViIgZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIj4KICAgICAgICAgIDxpZCByb290PSIxLjIuODQwLjExNDM1MC4xLjEzLjk5OS4yMzQiIGV4dGVuc2lvbj0iMjAwTSIvPgogICAgICAgIDwvZGV2aWNlPgogICAgICA8L3JlY2VpdmVyPgogICAgICA8c2VuZGVyIHR5cGVDb2RlPSJTTkQiPgogICAgICAgIDxkZXZpY2UgY2xhc3NDb2RlPSJERVYiIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuNC4zNDkiIGV4dGVuc2lvbj0iMjAwVkdPViIvPgogICAgICAgIDwvZGV2aWNlPgogICAgICA8L3NlbmRlcj4KICAgICAgPGF0dGVudGlvbkxpbmU+CiAgICAgICAgPGtleVdvcmRUZXh0PlNlYXJjaC5Ub2tlbjwva2V5V29yZFRleHQ+CiAgICAgICAgPHZhbHVlIHhzaTp0eXBlPSJTVCI+V1NET0MyMDAyMDcxNTM4NDMyNzQxMTEwMDI3OTU2PC92YWx1ZT4KICAgICAgPC9hdHRlbnRpb25MaW5lPgogICAgICA8Y29udHJvbEFjdFByb2Nlc3MgY2xhc3NDb2RlPSJDQUNUIiBtb29kQ29kZT0iRVZOIj4KICAgICAgICA8ZGF0YUVudGVyZXIgdHlwZUNvZGU9IkVOVCIgY29udGV4dENvbnRyb2xDb2RlPSJBUCI+CiAgICAgICAgICA8YXNzaWduZWRQZXJzb24gY2xhc3NDb2RlPSJBU1NJR05FRCI+CiAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My40LjM0OSIgZXh0ZW5zaW9uPSIxMjM0OTg3NjdWMjM0ODU5Xk5JXjIwME1eVVNWSEFeUCIvPgogICAgICAgICAgICA8YXNzaWduZWRQZXJzb24gY2xhc3NDb2RlPSJQU04iIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAgICAgICAgICAgICAgPG5hbWU+CiAgICAgICAgICAgICAgICA8Z2l2ZW4+TWl0Y2hlbGw8L2dpdmVuPgogICAgICAgICAgICAgICAgPGZhbWlseT5KZW5raW5zPC9mYW1pbHk+CiAgICAgICAgICAgICAgPC9uYW1lPgogICAgICAgICAgICA8L2Fzc2lnbmVkUGVyc29uPgogICAgICAgICAgICA8cmVwcmVzZW50ZWRPcmdhbml6YXRpb24gZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIiBjbGFzc0NvZGU9Ik9SRyI+CiAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMzQ5IiBleHRlbnNpb249ImRzbG9nb24uMzg0NzU5NDgzIi8+CiAgICAgICAgICAgICAgPGNvZGUgY29kZT0iMjAyMi0xMi0xNCAyMDowNjowMSIvPgogICAgICAgICAgICAgIDxkZXNjPnZhZ292PC9kZXNjPgogICAgICAgICAgICAgIDx0ZWxlY29tIHZhbHVlPSIxOTIuMTY4LjUwLjIwNiIvPgogICAgICAgICAgICA8L3JlcHJlc2VudGVkT3JnYW5pemF0aW9uPgogICAgICAgICAgPC9hc3NpZ25lZFBlcnNvbj4KICAgICAgICA8L2RhdGFFbnRlcmVyPgogICAgICAgIDxzdWJqZWN0IHR5cGVDb2RlPSJTVUJKIj4KICAgICAgICAgIDxyZWdpc3RyYXRpb25FdmVudCBjbGFzc0NvZGU9IlJFRyIgbW9vZENvZGU9IkVWTiI+CiAgICAgICAgICAgIDxpZCBudWxsRmxhdm9yPSJOQSIvPgogICAgICAgICAgICA8c3RhdHVzQ29kZSBjb2RlPSJhY3RpdmUiLz4KICAgICAgICAgICAgPHN1YmplY3QxIHR5cGVDb2RlPSJTQkoiPgogICAgICAgICAgICAgIDxwYXRpZW50IGNsYXNzQ29kZT0iUEFUIj4KICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My40LjM0OSIgZXh0ZW5zaW9uPSIxMjM0OTg3NjdWMjM0ODU5Xk5JXjIwME1eVVNWSEFeUCIvPgogICAgICAgICAgICAgICAgPHN0YXR1c0NvZGUgY29kZT0iYWN0aXZlIi8+CiAgICAgICAgICAgICAgICA8cGF0aWVudFBlcnNvbj4KICAgICAgICAgICAgICAgICAgPG5hbWUgdXNlPSJMIj4KICAgICAgICAgICAgICAgICAgICA8Z2l2ZW4+TWl0Y2hlbGw8L2dpdmVuPgogICAgICAgICAgICAgICAgICAgIDxmYW1pbHk+SmVua2luczwvZmFtaWx5PgogICAgICAgICAgICAgICAgICA8L25hbWU+CiAgICAgICAgICAgICAgICAgIDxiaXJ0aFRpbWUgdmFsdWU9IjE5NDkwMzA0Ii8+CiAgICAgICAgICAgICAgICAgIDxhc090aGVySURzIGNsYXNzQ29kZT0iU1NOIj4KICAgICAgICAgICAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuNC4xIiBleHRlbnNpb249Ijc5NjEyMjMwNiIvPgogICAgICAgICAgICAgICAgICAgIDxzY29waW5nT3JnYW5pemF0aW9uIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSIgY2xhc3NDb2RlPSJPUkciPgogICAgICAgICAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMSIvPgogICAgICAgICAgICAgICAgICAgIDwvc2NvcGluZ09yZ2FuaXphdGlvbj4KICAgICAgICAgICAgICAgICAgPC9hc090aGVySURzPgogICAgICAgICAgICAgICAgICA8YXNPdGhlcklEcyBjbGFzc0NvZGU9IlBBVCI+CiAgICAgICAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMzQ5IiBleHRlbnNpb249IlBST1hZX0FERF5QSV4yMDBWQkFeVVNWQkEiLz4KICAgICAgICAgICAgICAgICAgICA8c2NvcGluZ09yZ2FuaXphdGlvbiBkZXRlcm1pbmVyQ29kZT0iSU5TVEFOQ0UiIGNsYXNzQ29kZT0iT1JHIj4KICAgICAgICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My40LjM0OSIvPgogICAgICAgICAgICAgICAgICAgICAgPG5hbWU+TVZJLk9SQ0hFU1RSQVRJT048L25hbWU+CiAgICAgICAgICAgICAgICAgICAgPC9zY29waW5nT3JnYW5pemF0aW9uPgogICAgICAgICAgICAgICAgICA8L2FzT3RoZXJJRHM+CiAgICAgICAgICAgICAgICA8L3BhdGllbnRQZXJzb24+CiAgICAgICAgICAgICAgICA8cHJvdmlkZXJPcmdhbml6YXRpb24gZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIiBjbGFzc0NvZGU9Ik9SRyI+CiAgICAgICAgICAgICAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My4zLjkzMyIvPgogICAgICAgICAgICAgICAgICA8bmFtZT5Hb29kIEhlYWx0aCBDbGluaWM8L25hbWU+CiAgICAgICAgICAgICAgICAgIDxjb250YWN0UGFydHkgY2xhc3NDb2RlPSJDT04iPgogICAgICAgICAgICAgICAgICAgIDx0ZWxlY29tIHZhbHVlPSIzNDI1NTU4Mzk0Ii8+CiAgICAgICAgICAgICAgICAgIDwvY29udGFjdFBhcnR5PgogICAgICAgICAgICAgICAgPC9wcm92aWRlck9yZ2FuaXphdGlvbj4KICAgICAgICAgICAgICA8L3BhdGllbnQ+CiAgICAgICAgICAgIDwvc3ViamVjdDE+CiAgICAgICAgICAgIDxjdXN0b2RpYW4gdHlwZUNvZGU9IkNTVCI+CiAgICAgICAgICAgICAgPGFzc2lnbmVkRW50aXR5IGNsYXNzQ29kZT0iQVNTSUdORUQiPgogICAgICAgICAgICAgICAgPGlkIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjMuOTMzIi8+CiAgICAgICAgICAgICAgICA8YXNzaWduZWRPcmdhbml6YXRpb24gZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIiBjbGFzc0NvZGU9Ik9SRyI+CiAgICAgICAgICAgICAgICAgIDxuYW1lPkdvb2QgSGVhbHRoIENsaW5pYzwvbmFtZT4KICAgICAgICAgICAgICAgIDwvYXNzaWduZWRPcmdhbml6YXRpb24+CiAgICAgICAgICAgICAgPC9hc3NpZ25lZEVudGl0eT4KICAgICAgICAgICAgPC9jdXN0b2RpYW4+CiAgICAgICAgICA8L3JlZ2lzdHJhdGlvbkV2ZW50PgogICAgICAgIDwvc3ViamVjdD4KICAgICAgPC9jb250cm9sQWN0UHJvY2Vzcz4KICAgIDwvaWRtOlBSUEFfSU4yMDEzMDFVVjAyPgogIDwvZW52OkJvZHk+CjwvZW52OkVudmVsb3BlPgo=
+    headers:
+      Accept:
+      - text/xml;charset=UTF-8
+      Content-Type:
+      - text/xml;charset=UTF-8
+      User-Agent:
+      - Vets.gov Agent
+      Soapaction:
+      - PRPA_IN201301UV02
+      Date:
+      - Wed, 14 Dec 2022 20:06:01 GMT
+      Content-Length:
+      - '4667'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Wed, 14 Dec 2022 20:06:02 GMT
+      Etag:
+      - '"3147526947"'
+      Expires:
+      - Wed, 21 Dec 2022 20:06:02 GMT
+      Last-Modified:
+      - Thu, 17 Oct 2019 07:18:26 GMT
+      Server:
+      - EOS (vny/044E)
+      Content-Length:
+      - '1256'
+    body:
+      encoding: UTF-8
+      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
+        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
+        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system,
+        system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\",
+        Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width:
+        600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color:
+        #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px
+        rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n
+        \       text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div
+        {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n
+        \   </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
+        \   <p>This domain is for use in illustrative examples in documents. You may
+        use this\n    domain in literature without prior coordination or asking for
+        permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More
+        information...</a></p>\n</div>\n</body>\n</html>\n"
+  recorded_at: Wed, 14 Dec 2022 20:06:02 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Summary

- This PR refactors the `MPI::Service.new.add_person_implicit_search` function, so that instead of taking a `UserIdentity` object, the function now takes a series of attributes
- As further refactors, the rest of the functions in `MPI::Service will be refactored shortly

## Related issue(s)
- department-of-veterans-affairs/vets-api#11329


## Testing done

- I removed a mocked user for user228, then authenticated with loa3 idme sign in service: `localhost:3000/v0/sign_in/authorize?type=idme&code_challenge_method=S256&acr=loa3&client_id=mobile&code_challenge=1BUpxy37SoIPmKw96wbd6MDcvayOYm3ptT-zbe6L_zM=`
- Confirmed successful add person log: `[MPI][Services][AddPersonResponseCreator] add_person_implicit, icn=1234567891V123456, idme_uuid=, logingov_uuid=, transaction_id=f8ba53155f0b607c07bbeb02`


## What areas of the site does it impact?
- Authentication

## Acceptance criteria

- [ ] Authenticate with Sign in Service with a user that is not mocked with MPI. The authentication might fail because MPI is mocked for localhost, but should at least be able to see a log `[MPI][Services][AddPersonResponseCreator]`, representing the MPI `AddPerson` with `implicit_search` call

