### PR TITLE
Pulling DB stuff into it's own PR

### DIFF
--- a/db/migrate/20221214161602_add_backup_submitted_claim_id_to_form526submissions.rb
+++ b/db/migrate/20221214161602_add_backup_submitted_claim_id_to_form526submissions.rb
@@ -1,0 +1,12 @@
+class AddBackupSubmittedClaimIdToForm526submissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column(
+      :form526_submissions,
+      :backup_submitted_claim_id,
+      :string,
+      comment: '*After* a SubmitForm526 Job has exhausted all attempts, a paper submission is generated and sent to Central Mail Portal.'\
+      'This column will be nil for all submissions where a backup submission is not generated.'\
+      'It will have the central mail id for submissions where a backup submission is submitted.'
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_06_191853) do
+ActiveRecord::Schema.define(version: 2022_12_14_161602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -559,6 +559,7 @@ ActiveRecord::Schema.define(version: 2022_12_06_191853) do
     t.text "encrypted_kms_key"
     t.date "verified_decryptable_at"
     t.uuid "user_account_id"
+    t.string "backup_submitted_claim_id", comment: "*After* a SubmitForm526 Job has exhausted all attempts, a paper submission is generated and sent to Central Mail Portal.This column will be nil for all submissions where a backup submission is not generated.It will have the central mail id for submissions where a backup submission is submitted."
     t.index ["saved_claim_id"], name: "index_form526_submissions_on_saved_claim_id", unique: true
     t.index ["submitted_claim_id"], name: "index_form526_submissions_on_submitted_claim_id", unique: true
     t.index ["user_account_id"], name: "index_form526_submissions_on_user_account_id"
@@ -1090,11 +1091,11 @@ ActiveRecord::Schema.define(version: 2022_12_06_191853) do
   add_foreign_key "async_transactions", "user_accounts"
   add_foreign_key "deprecated_user_accounts", "user_accounts"
   add_foreign_key "deprecated_user_accounts", "user_verifications"
-  add_foreign_key "health_quest_questionnaire_responses", "user_accounts"
-  add_foreign_key "form5655_submissions", "user_accounts"
-  add_foreign_key "form526_submissions", "user_accounts"
-  add_foreign_key "evss_claims", "user_accounts"
   add_foreign_key "education_stem_automated_decisions", "user_accounts"
+  add_foreign_key "evss_claims", "user_accounts"
+  add_foreign_key "form526_submissions", "user_accounts"
+  add_foreign_key "form5655_submissions", "user_accounts"
+  add_foreign_key "health_quest_questionnaire_responses", "user_accounts"
   add_foreign_key "in_progress_forms", "user_accounts"
   add_foreign_key "inherited_proof_verified_user_accounts", "user_accounts"
   add_foreign_key "mhv_accounts", "user_accounts"


### PR DESCRIPTION
## Summary

- This will add a column to the Form526Submission table (adding the `backup_submitted_claim_id` attribute to the Form526Submission model)
- This new field is to keep track of 526 submissions that end up going the backup/paper submission route. For all claims that get successfully established via the mail EVSS route, this field will be `nil`, for claims that get PDFs generated and send to Central Mail (through Lighthouse Benefits Intake API), this field will be the returned CMP ID returned from the LH BI API `upload` endpoint) https://developer.va.gov/explore/benefits/docs/benefits?version=current


## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/50111
https://github.com/department-of-veterans-affairs/vets-api/pull/11317

## Testing done

- Testing covered in other related PRs rpec tests



## What areas of the site does it impact?

* This will add a column to the Form526Submission table (adding the `backup_submitted_claim_id` attribute to the Form526Submission model)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (nothing built but know where to monitor/look in the log)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

