### PR TITLE
Removes toggle from feature and tests

### DIFF
--- a/app/controllers/v0/virtual_agent/virtual_agent_appeal_controller.rb
+++ b/app/controllers/v0/virtual_agent/virtual_agent_appeal_controller.rb
@@ -6,7 +6,7 @@ module V0
   module VirtualAgent
     class VirtualAgentAppealController < AppealsBaseController
       def index
-        call_virtual_agent_store_user_info if Flipper.enabled?(:virtual_agent_user_access_records)
+        call_virtual_agent_store_user_info
         if Settings.vsp_environment == 'staging'
           @user_ssan, @user_name = set_user_credentials
           appeals_response = get_appeal_from_lighthouse(@user_ssan, @user_name)

--- a/app/controllers/v0/virtual_agent/virtual_agent_claim_controller.rb
+++ b/app/controllers/v0/virtual_agent/virtual_agent_claim_controller.rb
@@ -21,12 +21,12 @@ module V0
         when 'FAILED'
           error = EVSS::ErrorMiddleware::EVSSError.new('Could not retrieve claims')
           report_or_error(cxdw_reporting_service, conversation_id)
-          call_virtual_agent_store_user_info if Flipper.enabled?(:virtual_agent_user_access_records)
+          call_virtual_agent_store_user_info
           service_exception_handler(error)
         else
           data_for_three_most_recent_open_comp_claims(claims)
           report_or_error(cxdw_reporting_service, conversation_id)
-          call_virtual_agent_store_user_info if Flipper.enabled?(:virtual_agent_user_access_records)
+          call_virtual_agent_store_user_info
           render json: {
             data: data_for_three_most_recent_open_comp_claims(claims),
             meta: { sync_status: synchronized }

--- a/config/features.yml
+++ b/config/features.yml
@@ -782,10 +782,6 @@ features:
   va_view_dependents_access:
     actor_type: user
     description: Allows us to gate the View/ Modify dependents content in a progressive rollout
-  virtual_agent_user_access_records:
-    actor_type: user
-    description: Enables collection of user data for VBA
-    enable_in_development: true
   yellow_ribbon_mvp_enhancement:
     actor_type: user
     description: Enhances Yellow Ribbon MVP.

--- a/spec/controllers/v0/virtual_agent/virtual_agent_appeal_spec.rb
+++ b/spec/controllers/v0/virtual_agent/virtual_agent_appeal_spec.rb
@@ -392,7 +392,6 @@ RSpec.describe 'VirtualAgentAppeals', type: :request do
     describe 'VirtualAgentStoreUserInfoJob' do
       context 'when virtual_agent_user_access_records toggle is on'
       it 'runs with user info and appeals as action type' do
-        allow(Flipper).to receive(:enabled?).with(:virtual_agent_user_access_records).and_return(true)
         sign_in_as(user)
         kms = instance_double(KmsEncrypted::Box)
         allow(kms).to receive(:encrypt).and_return('encrypted_ssn')
@@ -417,7 +416,6 @@ RSpec.describe 'VirtualAgentAppeals', type: :request do
 
     context 'when virtual_agent_user_access_records toggle is off' do
       it 'does not store user data' do
-        allow(Flipper).to receive(:enabled?).with(:virtual_agent_user_access_records).and_return(false)
         sign_in_as(user)
         allow(VirtualAgentStoreUserInfoJob).to receive(:perform_async)
 

--- a/spec/controllers/v0/virtual_agent/virtual_agent_claim_spec.rb
+++ b/spec/controllers/v0/virtual_agent/virtual_agent_claim_spec.rb
@@ -331,7 +331,6 @@ RSpec.describe 'VirtualAgentClaims', type: :request do
     end
 
     context 'when the virtual_agent_user_access_records toggle is on' do
-
       it 'runs with user info and claims as action type when claims retrieval is successful' do
         sign_in_as(user)
 
@@ -370,7 +369,6 @@ RSpec.describe 'VirtualAgentClaims', type: :request do
     end
 
     context 'when the virtual_agent_user_access_records toggle is off' do
-
       it 'runs with user info and claims as action type when claims retrieval is successful' do
         sign_in_as(user)
 

--- a/spec/controllers/v0/virtual_agent/virtual_agent_claim_spec.rb
+++ b/spec/controllers/v0/virtual_agent/virtual_agent_claim_spec.rb
@@ -331,9 +331,6 @@ RSpec.describe 'VirtualAgentClaims', type: :request do
     end
 
     context 'when the virtual_agent_user_access_records toggle is on' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:virtual_agent_user_access_records).and_return(true)
-      end
 
       it 'runs with user info and claims as action type when claims retrieval is successful' do
         sign_in_as(user)
@@ -373,9 +370,6 @@ RSpec.describe 'VirtualAgentClaims', type: :request do
     end
 
     context 'when the virtual_agent_user_access_records toggle is off' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:virtual_agent_user_access_records).and_return(false)
-      end
 
       it 'runs with user info and claims as action type when claims retrieval is successful' do
         sign_in_as(user)


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- we're removing a feature toggle that is no longer needed (always on)
- code for claims and appeals API calls from the virtual_agent controller has been updated
- the flipper is no longer used, so the end-date is pre 1/4/2023

## Related issue(s)
- department-of-veterans-affairs/va-virtual-agent#758


## Testing done

- before the change, our service fed data to the CxDW datastore
- we manually check the CxDW store to ensure data is feeding still
- in Dev and Staging, the data continues to populate the datastore

## Screenshots
N/A


## What areas of the site does it impact?
* this only affects the APIs that are used by the virtual-agent chatbot to retrieve claims and appeals statuses

## Acceptance criteria

- [X]  I updated unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link N/A)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog or Grafana (N/A, but our code does have Sentry integrations)
- [X]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Justin rolled off our team during the holiday code freeze, so I (@joehall-tw) have taken ownership this PR. The only item to note is that I've made [a comment on the originating ticket](https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/758#issuecomment-1371018962) to revise the ruby tests to consolidate or eliminate the possibly useless tests. I'll ensure that's done as a fast follow to this.
