### PR TITLE
11486 remove account login stats table

### DIFF
--- a/db/migrate/20230106005600_remove_account_login_stats.rb
+++ b/db/migrate/20230106005600_remove_account_login_stats.rb
@@ -1,0 +1,9 @@
+class RemoveAccountLoginStats < ActiveRecord::Migration[6.1]
+ def up
+     drop_table :account_login_stats
+   end
+
+   def down
+     raise ActiveRecord::IrreversibleMigration
+   end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_14_161602) do
+ActiveRecord::Schema.define(version: 2023_01_06_005600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -20,23 +20,6 @@ ActiveRecord::Schema.define(version: 2022_12_14_161602) do
   enable_extension "plpgsql"
   enable_extension "postgis"
   enable_extension "uuid-ossp"
-
-  create_table "account_login_stats", force: :cascade do |t|
-    t.bigint "account_id", null: false
-    t.datetime "idme_at"
-    t.datetime "myhealthevet_at"
-    t.datetime "dslogon_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "current_verification"
-    t.datetime "logingov_at"
-    t.index ["account_id"], name: "index_account_login_stats_on_account_id", unique: true
-    t.index ["current_verification"], name: "index_account_login_stats_on_current_verification"
-    t.index ["dslogon_at"], name: "index_account_login_stats_on_dslogon_at"
-    t.index ["idme_at"], name: "index_account_login_stats_on_idme_at"
-    t.index ["logingov_at"], name: "index_account_login_stats_on_logingov_at"
-    t.index ["myhealthevet_at"], name: "index_account_login_stats_on_myhealthevet_at"
-  end
 
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.uuid "uuid", null: false
@@ -1084,7 +1067,6 @@ ActiveRecord::Schema.define(version: 2022_12_14_161602) do
     t.index ["api_name", "consumer_id", "api_guid"], name: "index_webhooks_subscription", unique: true
   end
 
-  add_foreign_key "account_login_stats", "accounts"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "appeal_submissions", "user_accounts"


### PR DESCRIPTION
## Summary

- This PR is the migration to remove the account login stats table

## Related issue(s)
- department-of-veterans-affairs/vets-api#11486


## Testing done

- This is no longer in code so shouldn't break anything, just confirm code has been deployed before this runs



## What areas of the site does it impact?
- Metrics

## Acceptance criteria

- [ ]  Confirm code change deploy has occurred before this is merged. We had issues before when drop table and code change occurred close to each other (the migrations can technically run before the deploy)
