### PR TITLE
51830 user verification credential email

### DIFF
--- a/db/migrate/20230112230529_add_credential_email_to_user_verification.rb
+++ b/db/migrate/20230112230529_add_credential_email_to_user_verification.rb
@@ -1,0 +1,7 @@
+class AddCredentialEmailToUserVerification < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_reference :user_verifications, :user_credential_emails, foreign_key: true, null: true, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_12_221719) do
+ActiveRecord::Schema.define(version: 2023_01_12_230529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -911,12 +911,14 @@ ActiveRecord::Schema.define(version: 2023_01_12_221719) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "backing_idme_uuid"
+    t.bigint "user_credential_emails_id"
     t.index ["backing_idme_uuid"], name: "index_user_verifications_on_backing_idme_uuid"
     t.index ["dslogon_uuid"], name: "index_user_verifications_on_dslogon_uuid", unique: true
     t.index ["idme_uuid"], name: "index_user_verifications_on_idme_uuid", unique: true
     t.index ["logingov_uuid"], name: "index_user_verifications_on_logingov_uuid", unique: true
     t.index ["mhv_uuid"], name: "index_user_verifications_on_mhv_uuid", unique: true
     t.index ["user_account_id"], name: "index_user_verifications_on_user_account_id"
+    t.index ["user_credential_emails_id"], name: "index_user_verifications_on_user_credential_emails_id"
     t.index ["verified_at"], name: "index_user_verifications_on_verified_at"
   end
 
@@ -1110,5 +1112,6 @@ ActiveRecord::Schema.define(version: 2023_01_12_221719) do
   add_foreign_key "oauth_sessions", "user_verifications"
   add_foreign_key "terms_and_conditions_acceptances", "user_accounts"
   add_foreign_key "user_verifications", "user_accounts"
+  add_foreign_key "user_verifications", "user_credential_emails", column: "user_credential_emails_id"
   add_foreign_key "veteran_device_records", "devices"
 end


### PR DESCRIPTION
## Summary

-This PR adds the schema changes to add the `user_credential_email` association to `user_verifications` table

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#51830


## Testing done

- `bundle exec rails db:migrate`
- `bundle exec rails db:rollback

## What areas of the site does it impact?
Database
