### PR TITLE
Call clamav via TCP socket

### DIFF
--- a/lib/common/virus_scan.rb
+++ b/lib/common/virus_scan.rb
@@ -13,12 +13,11 @@ module Common
       # args = ['-c', Rails.root.join('config', 'clamd.conf').to_s, file_path]
       # ClamScan::Client.scan(custom_args: args)
 
-      clamav = TCPSocket.open("127.0.0.1", 3310)
-      stripped_filename = file_path.gsub(/^tmp\//, "")
-      request = "SCAN /vets-api/#{stripped_filename}" #call the shared volume on clamav container
+      clamav = TCPSocket.open('127.0.0.1', 3310)
+      stripped_filename = file_path.gsub(%r{^tmp/}, '')
+      request = "SCAN /vets-api/#{stripped_filename}" # call the shared volume on clamav container
       clamav.puts(request)
-      response = clamav.gets
-      response
+      return clamav.gets
       clamav.close
     end
   end

--- a/lib/common/virus_scan.rb
+++ b/lib/common/virus_scan.rb
@@ -10,8 +10,16 @@ module Common
 
       # NOTE: If using custom_args, no other arguments can be passed to
       # ClamScan::Client.scan. All other arguments will be ignored
-      args = ['-c', Rails.root.join('config', 'clamd.conf').to_s, file_path]
-      ClamScan::Client.scan(custom_args: args)
+      # args = ['-c', Rails.root.join('config', 'clamd.conf').to_s, file_path]
+      # ClamScan::Client.scan(custom_args: args)
+
+      clamav = TCPSocket.open("127.0.0.1", 3310)
+      stripped_filename = file_path.gsub(/^tmp\//, "")
+      request = "SCAN /vets-api/#{stripped_filename}" #call the shared volume on clamav container
+      clamav.puts(request)
+      response = clamav.gets
+      response
+      clamav.close
     end
   end
 end

--- a/lib/common/virus_scan.rb
+++ b/lib/common/virus_scan.rb
@@ -20,5 +20,9 @@ module Common
       return clamav.gets
       clamav.close
     end
+
+    def safe?
+      #Todo
+    end
   end
 end

--- a/lib/common/virus_scan.rb
+++ b/lib/common/virus_scan.rb
@@ -5,14 +5,7 @@ module Common
     module_function
 
     def scan(file_path)
-      # `clamd` runs within service group, needs group read
       File.chmod(0o640, file_path)
-
-      # NOTE: If using custom_args, no other arguments can be passed to
-      # ClamScan::Client.scan. All other arguments will be ignored
-      # args = ['-c', Rails.root.join('config', 'clamd.conf').to_s, file_path]
-      # ClamScan::Client.scan(custom_args: args)
-
       clamav = TCPSocket.open('127.0.0.1', 3310)
       stripped_filename = file_path.gsub(%r{^tmp/}, '')
       request = "SCAN /vets-api/#{stripped_filename}" # call the shared volume on clamav container


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

We have deployed [ClamAV into it's own container](https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/blob/main/apps/vets-api/dev/values.yaml#L363-L390) on the same pod as the [vets-api server deployment](https://github.com/department-of-veterans-affairs/vets-api/blob/parent-helm-charts/chart/templates/server-deployment.yaml#L89-L100). The [shared volume was created here](https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/1418/files) in order to allow the two containers to have shared volumes/files 


We can no longer use the clam_scan gem/wrapper because it expects clamav to be running in the same process as vets-api.

https://app.zenhub.com/workspaces/platform-tech-team-1-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/53002

## Testing done

Tested in rails console in Argo
![Uploading Screen Shot 2023-02-06 at 3.25.34 PM.png…]()


## Screenshots
_Note: Optional_


