### PR TITLE
Mockdata repository_dispatch event.

### DIFF
--- a/.github/workflows/repo_dispatch_deploy.yml
+++ b/.github/workflows/repo_dispatch_deploy.yml
@@ -1,0 +1,46 @@
+name: Release and Update Manifests after Mockdata
+
+on:
+  repository_dispatch:
+    types: [vets-api-mockdata-update]
+
+permissions:
+  contents: read
+jobs:
+  build_and_push:
+    name: Build and Push
+    env:
+      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 'k8s' #checkout the k8s branch
+
+      - name: Setup Environment
+        run: echo "VETS_API_USER_ID=$(id -u)" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            BUNDLE_ENTERPRISE__CONTRIBSYS__COM=${{ env.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
+            USER_ID=${{ env.VETS_API_USER_ID }}
+            RAILS_ENV=production
+          context: .
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}
+          cache-from: type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY
+          cache-to: type=inline

--- a/.github/workflows/repo_dispatch_deploy.yml
+++ b/.github/workflows/repo_dispatch_deploy.yml
@@ -1,5 +1,7 @@
 name: Release and Update Manifests after Mockdata
 
+#Note: repository_dispatch can only be run from the master branch.
+
 on:
   repository_dispatch:
     types: [vets-api-mockdata-update]


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

We want to re-deploy `vets-api` upon a change to the `vets-api-mockdata` repo (which is mounted to the vets-api container). I set up a [repository_dispatch on the mockdata repo here](https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/248/files) to trigger the repository_dispatch event. This new action will listen for the repository_dispatch event and build the ECR image for the k8s branch. 

**NOTE** The reason this has to be on the master branch is because repository_dispatch events cannot be triggered on a non-default (master) branch. 

The deploy needs to be updated, but I want to test the image build first.

## Testing done
Repository event can be triggered from my PR

https://app.zenhub.com/workspaces/platform-tech-team-1-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/52436


=
