### PR TITLE
Revert "API-23874 Add metadata to appeals tables"

### DIFF
--- a/db/migrate/20230214001703_add_metadata_to_appeals_tables.rb
+++ b/db/migrate/20230214001703_add_metadata_to_appeals_tables.rb
@@ -1,9 +1,0 @@
-class AddMetadataToAppealsTables < ActiveRecord::Migration[6.1]
-  def change
-    safety_assured do
-      add_column :appeals_api_higher_level_reviews, :metadata, :jsonb, default: {}
-      add_column :appeals_api_notice_of_disagreements, :metadata, :jsonb, default: {}
-      add_column :appeals_api_supplemental_claims, :metadata, :jsonb, default: {}
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_14_001703) do
+ActiveRecord::Schema.define(version: 2023_01_12_221719) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -134,7 +134,6 @@ ActiveRecord::Schema.define(version: 2023_02_14_001703) do
     t.text "encrypted_kms_key"
     t.date "verified_decryptable_at"
     t.string "veteran_icn"
-    t.jsonb "metadata", default: {}
     t.index ["veteran_icn"], name: "index_appeals_api_higher_level_reviews_on_veteran_icn"
   end
 
@@ -153,7 +152,6 @@ ActiveRecord::Schema.define(version: 2023_02_14_001703) do
     t.text "encrypted_kms_key"
     t.date "verified_decryptable_at"
     t.string "veteran_icn"
-    t.jsonb "metadata", default: {}
     t.index ["veteran_icn"], name: "index_appeals_api_notice_of_disagreements_on_veteran_icn"
   end
 
@@ -185,7 +183,6 @@ ActiveRecord::Schema.define(version: 2023_02_14_001703) do
     t.boolean "evidence_submission_indicated"
     t.date "verified_decryptable_at"
     t.string "veteran_icn"
-    t.jsonb "metadata", default: {}
     t.index ["veteran_icn"], name: "index_appeals_api_supplemental_claims_on_veteran_icn"
   end
 


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#11788

Reverting as the migration does not follow the [standards](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-database-migrations#vets-apidatabasemigrations-Addingacolumnwithadefaultvalue) - it was adding a column with a default value in a single migration file.

Revert is safe since production hasn't run the previous migration, and no code is using the new column on lower envs either.