### PR TITLE
API-23874 Add metadata to appeals tables (fixed)

### DIFF
--- a/db/migrate/20230214001703_add_metadata_to_appeals_tables.rb
+++ b/db/migrate/20230214001703_add_metadata_to_appeals_tables.rb
@@ -1,9 +1,9 @@
 class AddMetadataToAppealsTables < ActiveRecord::Migration[6.1]
   def change
     safety_assured do
-      add_column :appeals_api_higher_level_reviews, :metadata, :jsonb, default: {}
-      add_column :appeals_api_notice_of_disagreements, :metadata, :jsonb, default: {}
-      add_column :appeals_api_supplemental_claims, :metadata, :jsonb, default: {}
+      add_column :appeals_api_higher_level_reviews, :metadata, :jsonb
+      add_column :appeals_api_notice_of_disagreements, :metadata, :jsonb
+      add_column :appeals_api_supplemental_claims, :metadata, :jsonb
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -134,7 +134,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_001703) do
     t.text "encrypted_kms_key"
     t.date "verified_decryptable_at"
     t.string "veteran_icn"
-    t.jsonb "metadata", default: {}
+    t.jsonb "metadata"
     t.index ["veteran_icn"], name: "index_appeals_api_higher_level_reviews_on_veteran_icn"
   end
 
@@ -153,7 +153,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_001703) do
     t.text "encrypted_kms_key"
     t.date "verified_decryptable_at"
     t.string "veteran_icn"
-    t.jsonb "metadata", default: {}
+    t.jsonb "metadata"
     t.index ["veteran_icn"], name: "index_appeals_api_notice_of_disagreements_on_veteran_icn"
   end
 
@@ -185,7 +185,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_001703) do
     t.boolean "evidence_submission_indicated"
     t.date "verified_decryptable_at"
     t.string "veteran_icn"
-    t.jsonb "metadata", default: {}
+    t.jsonb "metadata"
     t.index ["veteran_icn"], name: "index_appeals_api_supplemental_claims_on_veteran_icn"
   end
 


### PR DESCRIPTION
## Summary
Adds `metadata` jsonb column to the appeal record types.

This version follows the [migration standards](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-database-migrations#vets-apidatabasemigrations-Addingacolumnwithadefaultvalue) by not including a default value in the migration. I did some additional testing and found a default value wasn't necessary anyway :)

Requires #11838 get merged first to hide my shame.

## Related issue(s)
https://vajira.max.gov/browse/API-23874
#11838

## Testing done

- Successfully ran  db:migrate

## What areas of the site does it impact?
N/A

## Acceptance criteria
- [x] Splits the db migration from code that uses its changes