### PR TITLE
Api 2442 consent addr change

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -1164,7 +1164,14 @@
                                     "type": "string",
                                     "nullable": true,
                                     "description": "Enum with the status of the tracked item",
-                                    "example": "NO_LONGER_REQUIRED"
+                                    "example": "NO_LONGER_REQUIRED",
+                                    "enum": [
+                                      "ACCEPTED",
+                                      "INITIAL_REVIEW_COMPLETE",
+                                      "NEEDED",
+                                      "NO_LONGER_REQUIRED",
+                                      "SUBMITTED_AWAITING_REVIEW"
+                                    ]
                                   },
                                   "uploaded": {
                                     "type": "boolean",
@@ -1851,8 +1858,8 @@
                   "id": "1",
                   "type": "intent_to_file",
                   "attributes": {
-                    "creationDate": "2023-02-24",
-                    "expirationDate": "2024-02-24",
+                    "creationDate": "2023-02-27",
+                    "expirationDate": "2024-02-27",
                     "type": "compensation",
                     "status": "active"
                   }

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -1164,7 +1164,14 @@
                                     "type": "string",
                                     "nullable": true,
                                     "description": "Enum with the status of the tracked item",
-                                    "example": "NO_LONGER_REQUIRED"
+                                    "example": "NO_LONGER_REQUIRED",
+                                    "enum": [
+                                      "ACCEPTED",
+                                      "INITIAL_REVIEW_COMPLETE",
+                                      "NEEDED",
+                                      "NO_LONGER_REQUIRED",
+                                      "SUBMITTED_AWAITING_REVIEW"
+                                    ]
                                   },
                                   "uploaded": {
                                     "type": "boolean",

--- a/modules/claims_api/app/workers/claims_api/poa_vbms_updater.rb
+++ b/modules/claims_api/app/workers/claims_api/poa_vbms_updater.rb
@@ -47,6 +47,9 @@ module ClaimsApi
     end
 
     def allow_address_change?(poa_form)
+      if poa_form.form_data['consentAddressChange'] == 'y'
+        ClaimsApi::Logger.log('poa', poa_id: power_of_attorney_id, detail: 'consentAddressChange set to true')
+      end
       poa_form.form_data['consentAddressChange']
     end
   end

--- a/spec/support/schemas/claims_api/v2/veterans/claims/claim.json
+++ b/spec/support/schemas/claims_api/v2/veterans/claims/claim.json
@@ -325,7 +325,14 @@
                     "type": "string",
                     "nullable": true,
                     "description": "Enum with the status of the tracked item",
-                    "example": "NO_LONGER_REQUIRED"
+                    "example": "NO_LONGER_REQUIRED",
+                    "enum": [
+                      "ACCEPTED",
+                      "INITIAL_REVIEW_COMPLETE",
+                      "NEEDED",
+                      "NO_LONGER_REQUIRED",
+                      "SUBMITTED_AWAITING_REVIEW"
+                    ]
                   },
                   "uploaded": {
                     "type": "boolean",


### PR DESCRIPTION
## Summary

- adds log to track whenever consumers are setting it to true

## Related issue(s)
- [API-24442](https://vajira.max.gov/browse/API-24442)


## Testing done

- Rspec

## What areas of the site does it impact?
vets-api

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
