### PR TITLE
Updated Identity statsd metric names

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -15,16 +15,16 @@ module V1
     REDIRECT_URLS = %w[signup mhv mhv_verified dslogon dslogon_verified idme idme_verified idme_signup
                        idme_signup_verified logingov logingov_verified logingov_signup
                        logingov_signup_verified custom mfa verify slo].freeze
-    STATSD_SSO_NEW_KEY = 'api.auth.new'
-    STATSD_SSO_SAMLREQUEST_KEY = 'api.auth.saml_request'
-    STATSD_SSO_SAMLRESPONSE_KEY = 'api.auth.saml_response'
-    STATSD_SSO_CALLBACK_KEY = 'api.auth.saml_callback'
-    STATSD_SSO_CALLBACK_TOTAL_KEY = 'api.auth.login_callback.total'
-    STATSD_SSO_CALLBACK_FAILED_KEY = 'api.auth.login_callback.failed'
-    STATSD_LOGIN_NEW_USER_KEY = 'api.auth.new_user'
-    STATSD_LOGIN_STATUS_SUCCESS = 'api.auth.login.success'
-    STATSD_LOGIN_STATUS_FAILURE = 'api.auth.login.failure'
-    STATSD_LOGIN_LATENCY = 'api.auth.latency'
+    STATSD_SSO_NEW_KEY = 'api_auth_new'
+    STATSD_SSO_SAMLREQUEST_KEY = 'api_auth_saml_request'
+    STATSD_SSO_SAMLRESPONSE_KEY = 'api_auth_saml_response'
+    STATSD_SSO_CALLBACK_KEY = 'api_auth_saml_callback'
+    STATSD_SSO_CALLBACK_TOTAL_KEY = 'api_auth_login_callback_total'
+    STATSD_SSO_CALLBACK_FAILED_KEY = 'api_auth_login_callback_failed'
+    STATSD_LOGIN_NEW_USER_KEY = 'api_auth_new_user'
+    STATSD_LOGIN_STATUS_SUCCESS = 'api_auth_login_success'
+    STATSD_LOGIN_STATUS_FAILURE = 'api_auth_login_failure'
+    STATSD_LOGIN_LATENCY = 'api_auth_latency'
     VERSION_TAG = 'version:v1'
     FIM_INVALID_MESSAGE_TIMESTAMP = 'invalid_message_timestamp'
 

--- a/app/services/sign_in/constants/statsd.rb
+++ b/app/services/sign_in/constants/statsd.rb
@@ -3,22 +3,22 @@
 module SignIn
   module Constants
     module Statsd
-      STATSD_SIS_AUTHORIZE_SUCCESS = 'api.sis.auth.success'
-      STATSD_SIS_AUTHORIZE_FAILURE = 'api.sis.auth.failure'
-      STATSD_SIS_CALLBACK_SUCCESS = 'api.sis.callback.success'
-      STATSD_SIS_CALLBACK_FAILURE = 'api.sis.callback.failure'
-      STATSD_SIS_TOKEN_SUCCESS = 'api.sis.token.success'
-      STATSD_SIS_TOKEN_FAILURE = 'api.sis.token.failure'
-      STATSD_SIS_REFRESH_SUCCESS = 'api.sis.refresh.success'
-      STATSD_SIS_REFRESH_FAILURE = 'api.sis.refresh.failure'
-      STATSD_SIS_REVOKE_SUCCESS = 'api.sis.revoke.success'
-      STATSD_SIS_REVOKE_FAILURE = 'api.sis.revoke.failure'
-      STATSD_SIS_INTROSPECT_SUCCESS = 'api.sis.introspect.success'
-      STATSD_SIS_INTROSPECT_FAILURE = 'api.sis.introspect.failure'
-      STATSD_SIS_LOGOUT_SUCCESS = 'api.sis.logout.success'
-      STATSD_SIS_LOGOUT_FAILURE = 'api.sis.logout.failure'
-      STATSD_SIS_REVOKE_ALL_SESSIONS_SUCCESS = 'api.sis.revoke_all_sessions.success'
-      STATSD_SIS_REVOKE_ALL_SESSIONS_FAILURE = 'api.sis.revoke_all_sessions.failure'
+      STATSD_SIS_AUTHORIZE_SUCCESS = 'api_sis_auth_success'
+      STATSD_SIS_AUTHORIZE_FAILURE = 'api_sis_auth_failure'
+      STATSD_SIS_CALLBACK_SUCCESS = 'api_sis_callback_success'
+      STATSD_SIS_CALLBACK_FAILURE = 'api_sis_callback_failure'
+      STATSD_SIS_TOKEN_SUCCESS = 'api_sis_token_success'
+      STATSD_SIS_TOKEN_FAILURE = 'api_sis_token_failure'
+      STATSD_SIS_REFRESH_SUCCESS = 'api_sis_refresh_success'
+      STATSD_SIS_REFRESH_FAILURE = 'api_sis_refresh_failure'
+      STATSD_SIS_REVOKE_SUCCESS = 'api_sis_revoke_success'
+      STATSD_SIS_REVOKE_FAILURE = 'api_sis_revoke_failure'
+      STATSD_SIS_INTROSPECT_SUCCESS = 'api_sis_introspect_success'
+      STATSD_SIS_INTROSPECT_FAILURE = 'api_sis_introspect_failure'
+      STATSD_SIS_LOGOUT_SUCCESS = 'api_sis_logout_success'
+      STATSD_SIS_LOGOUT_FAILURE = 'api_sis_logout_failure'
+      STATSD_SIS_REVOKE_ALL_SESSIONS_SUCCESS = 'api_sis_revoke_all_sessions_success'
+      STATSD_SIS_REVOKE_ALL_SESSIONS_FAILURE = 'api_sis_revoke_all_sessions_failure'
     end
   end
 end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

When the identity routes were migrated over to the EKS servers, the Identity statsd metric names, defined in this repo, replaced the metric names coming from Prometheus. The [Identity dashboard](https://vagov.ddog-gov.com/dashboard/52g-hyg-wcj/vsp-identity-monitor-dashboard?from_ts=1681207068583&to_ts=1681221468583&live=true) is now missing all login metrics because of the name mismatch.


