### PR TITLE
824 create 22 1995 confirmation email trigger

### DIFF
--- a/app/models/saved_claim/education_benefits/va_1995.rb
+++ b/app/models/saved_claim/education_benefits/va_1995.rb
@@ -2,4 +2,47 @@
 
 class SavedClaim::EducationBenefits::VA1995 < SavedClaim::EducationBenefits
   add_form_and_validation('22-1995')
+
+  # pulled from https://github.com/department-of-veterans-affairs/vets-website/blob/f27b8a5ffe4e2f9357d6c501c9a6a73dacdad0e1/src/applications/edu-benefits/utils/helpers.jsx#L100
+  BENEFIT_TITLE_FOR_1995 = {
+    'chapter30' => 'Montgomery GI Bill (MGIB or Chapter 30) Education Assistance Program',
+    'chapter33' => 'Post-9/11 GI Bill (Chapter 33)',
+    'chapter1606' => 'Montgomery GI Bill Selected Reserve (MGIB-SR or Chapter 1606) Educational Assistance Program',
+    'chapter32' => 'Post-Vietnam Era Veterans’ Educational Assistance Program (VEAP or chapter 32)'
+  }.freeze
+
+  def after_submit(_user)
+    parsed_form_data ||= JSON.parse(form)
+    email = parsed_form_data['email']
+    return if email.blank?
+
+    return unless Flipper.enabled?(:form1995_confirmation_email)
+
+    send_confirmation_email(parsed_form_data, email)
+  end
+
+  private
+
+  def send_confirmation_email(parsed_form_data, email)
+
+    VANotify::EmailJob.perform_async(
+      email,
+      Settings.vanotify.services.va_gov.template_id.form1995_confirmation_email,
+      {
+        'first_name' => parsed_form.dig('veteranFullName', 'first')&.upcase.presence,
+        'benefits' => benefits_claimed(parsed_form_data),
+        'benefit_relinquished' => '',
+        'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+        'confirmation_number' => education_benefits_claim.confirmation_number,
+        'regional_office_address' => regional_office_address
+      }
+    )
+  end
+
+  def benefits_claimed(parsed_form_data)
+    %w[chapter30 chapter33 chapter1606 chapter32]
+      .map { |benefit| parsed_form_data[benefit] ? BENEFIT_TITLE_FOR_1995[benefit] : nil }
+      .compact
+      .join("\n\n^")
+  end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -362,6 +362,10 @@ features:
     actor_type: user
     description: Enables form 1990 email submission confirmation (VaNotify)
     enable_in_development: true
+  form1995_confirmation_email:
+    actor_type: user
+    description: Enables form 1995 email submission confirmation (VaNotify)
+    enable_in_development: true
   form1990e_confirmation_email:
     actor_type: user
     description: Enables form 1990e email submission confirmation (VaNotify)
@@ -795,7 +799,7 @@ features:
     description: Enables payment and debt section
   show_dashboard_notifications:
     actor_type: user
-    description: Enables on-site notifications 
+    description: Enables on-site notifications
   show_myva_dashboard_2_0:
     actor_type: user
     description: Enables My VA 2.0

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1241,6 +1241,7 @@ vanotify:
         contact_info_change: fake_template_id
         form1990_confirmation_email: form1990_confirmation_email_template_id
         form1990e_confirmation_email: form1990e_confirmation_email_template_id
+        form1995_confirmation_email: form1995_confirmation_email_template_id
         form526_confirmation_email: fake_template_id
         form526_submission_failed_email: fake_template_id
         form5490_confirmation_email: form5490_confirmation_email_template_id

--- a/spec/models/saved_claim/education_benefits/va1995_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va1995_spec.rb
@@ -9,4 +9,32 @@ RSpec.describe SavedClaim::EducationBenefits::VA1995 do
   it_behaves_like 'saved_claim'
 
   validate_inclusion(:form_id, '22-1995')
+
+  describe '#after_submit' do
+    let(:user) { create(:user) }
+
+    describe 'sends confirmation email for the 1995' do
+      it 'successfully submits' do
+        allow(VANotify::EmailJob).to receive(:perform_async)
+
+        subject = create(:va1995_full_form)
+        confirmation_number = subject.education_benefits_claim.confirmation_number
+
+        subject.after_submit(user)
+
+        expect(VANotify::EmailJob).to have_received(:perform_async).with(
+          'test@sample.com',
+          'form1995_confirmation_email_template_id',
+          {
+            'first_name' => 'FIRST',
+            'benefit_relinquished' => '',
+            'benefits' => '',
+            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+            'confirmation_number' => confirmation_number,
+            'regional_office_address' => "P.O. Box 4616\nBuffalo, NY 14240-4616"
+          }
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Summary**

- Includes changes to add trigger for 22-1995 form submission confirmation email.

## Related issue(s)
- [Create Trigger for 22-1995 Confirmation Email](https://app.zenhub.com/workspaces/forms-strike-team-620c2914e703390013c4b414/issues/gh/department-of-veterans-affairs/vanotify-team/824)


## Testing done

- [ ]  Modified specs to account for changes.
- [ ]  Manually tested changes.


## What areas of the site does it impact?
- Form 1995 submissions.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

