### PR TITLE
Refactor mhv-csid constants for clarity

### DIFF
--- a/app/controllers/concerns/accountable.rb
+++ b/app/controllers/concerns/accountable.rb
@@ -8,7 +8,7 @@ module Accountable
   def update_account_login_stats(login_type)
     return unless account_login_stats.present? && login_type.in?(SAML::User::LOGIN_TYPES)
 
-    login_type = login_type == SAML::User::MHV_CSID ? MHV_MAPPED_CSID : login_type
+    login_type = MHV_MAPPED_CSID if login_type == SAML::User::MHV_CSID
 
     account_login_stats.update!("#{login_type}_at" => Time.zone.now, current_verification: verification_level)
   rescue => e

--- a/app/controllers/concerns/accountable.rb
+++ b/app/controllers/concerns/accountable.rb
@@ -4,10 +4,11 @@ module Accountable
   extend ActiveSupport::Concern
   include SentryLogging
 
+  MHV_MAPPED_CSID = 'myhealthevet'
   def update_account_login_stats(login_type)
     return unless account_login_stats.present? && login_type.in?(SAML::User::LOGIN_TYPES)
 
-    login_type = login_type == SAML::User::MHV_ORIGINAL_CSID ? SAML::User::MHV_MAPPED_CSID : login_type
+    login_type = login_type == SAML::User::MHV_CSID ? MHV_MAPPED_CSID : login_type
 
     account_login_stats.update!("#{login_type}_at" => Time.zone.now, current_verification: verification_level)
   rescue => e

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -438,7 +438,7 @@ class User < Common::RedisStore
   # fall back to idme
   def get_user_verification
     case identity_sign_in&.dig(:service_name)
-    when SAML::User::MHV_ORIGINAL_CSID
+    when SAML::User::MHV_CSID
       return UserVerification.find_by(mhv_uuid: mhv_correlation_id) if mhv_correlation_id
     when SAML::User::DSLOGON_CSID
       return UserVerification.find_by(dslogon_uuid: identity.edipi) if identity.edipi

--- a/app/models/user_verification.rb
+++ b/app/models/user_verification.rb
@@ -20,7 +20,7 @@ class UserVerification < ApplicationRecord
   def credential_type
     return SAML::User::IDME_CSID if idme_uuid
     return SAML::User::LOGINGOV_CSID if logingov_uuid
-    return SAML::User::MHV_ORIGINAL_CSID if mhv_uuid
+    return SAML::User::MHV_CSID if mhv_uuid
     return SAML::User::DSLOGON_CSID if dslogon_uuid
   end
 

--- a/app/services/acceptable_verified_credential_adoption_service.rb
+++ b/app/services/acceptable_verified_credential_adoption_service.rb
@@ -43,7 +43,7 @@ class AcceptableVerifiedCredentialAdoptionService
   end
 
   def logged_in_with_mhv?
-    credential_type == SAML::User::MHV_ORIGINAL_CSID
+    credential_type == SAML::User::MHV_CSID
   end
 
   def verified_credential_at?

--- a/app/services/login/user_verifier.rb
+++ b/app/services/login/user_verifier.rb
@@ -155,7 +155,7 @@ module Login
 
     def type
       @type ||= case login_type
-                when SAML::User::MHV_ORIGINAL_CSID
+                when SAML::User::MHV_CSID
                   MHV_TYPE
                 when SAML::User::IDME_CSID
                   IDME_TYPE

--- a/app/workers/account_login_statistics_job.rb
+++ b/app/workers/account_login_statistics_job.rb
@@ -3,6 +3,7 @@
 class AccountLoginStatisticsJob
   include Sidekiq::Worker
 
+  MHV_MAPPED_CSID = 'myhealthevet'
   def perform
     total_stats.each do |metric, count|
       StatsD.gauge(metric, count)
@@ -37,7 +38,7 @@ class AccountLoginStatisticsJob
 
   def count_column_sql_statements
     SAML::User::LOGIN_TYPES.map do |type|
-      type = SAML::User::MHV_MAPPED_CSID if type == SAML::User::MHV_ORIGINAL_CSID
+      type = MHV_MAPPED_CSID if type == SAML::User::MHV_CSID
       %(
         COUNT(#{type}_at) FILTER (WHERE #{type}_at IS NOT NULL) AS "account_login_stats.total_#{type}_accounts",
         COUNT(#{type}_at) FILTER (WHERE #{type}_at > $1) AS "account_login_stats.#{type}_past_year",

--- a/lib/saml/user.rb
+++ b/lib/saml/user.rb
@@ -9,8 +9,7 @@ module SAML
     include SentryLogging
 
     UNKNOWN_AUTHN_CONTEXT = 'unknown'
-    MHV_ORIGINAL_CSID = 'mhv'
-    MHV_MAPPED_CSID = 'myhealthevet'
+    MHV_CSID = 'mhv'
     IDME_CSID = 'idme'
     DSLOGON_CSID = 'dslogon'
     LOGINGOV_CSID = 'logingov'
@@ -22,11 +21,11 @@ module SAML
       LOA::IDME_LOA3_VETS => { loa_current: LOA::THREE, sign_in: { service_name: IDME_CSID } },
       LOA::IDME_LOA3 => { loa_current: LOA::THREE, sign_in: { service_name: IDME_CSID } },
       'multifactor' => { loa_current: nil, sign_in: { service_name: IDME_CSID } },
-      'myhealthevet_multifactor' => { loa_current: nil, sign_in: { service_name: MHV_ORIGINAL_CSID } },
-      'myhealthevet_loa3' => { loa_current: LOA::THREE, sign_in: { service_name: MHV_ORIGINAL_CSID } },
+      'myhealthevet_multifactor' => { loa_current: nil, sign_in: { service_name: MHV_CSID } },
+      'myhealthevet_loa3' => { loa_current: LOA::THREE, sign_in: { service_name: MHV_CSID } },
       'dslogon_multifactor' => { loa_current: nil, sign_in: { service_name: DSLOGON_CSID } },
       'dslogon_loa3' => { loa_current: LOA::THREE, sign_in: { service_name: DSLOGON_CSID } },
-      'myhealthevet' => { loa_current: nil, sign_in: { service_name: MHV_ORIGINAL_CSID } },
+      'myhealthevet' => { loa_current: nil, sign_in: { service_name: MHV_CSID } },
       'dslogon' => { loa_current: nil, sign_in: { service_name: DSLOGON_CSID } },
       LOA::IDME_LOA3_2FA => { loa_current: LOA::THREE, sign_in: { service_name: IDME_CSID } },
       LOA::IDME_LOA3_MFA => { loa_current: LOA::THREE, sign_in: { service_name: IDME_CSID } },
@@ -38,7 +37,7 @@ module SAML
       IAL::LOGIN_GOV_IAL2_MFA => { loa_current: LOA::THREE, sign_in: { service_name: LOGINGOV_CSID } }
     }.freeze
 
-    LOGIN_TYPES = [MHV_ORIGINAL_CSID, IDME_CSID, DSLOGON_CSID, LOGINGOV_CSID].freeze
+    LOGIN_TYPES = [MHV_CSID, IDME_CSID, DSLOGON_CSID, LOGINGOV_CSID].freeze
 
     attr_reader :saml_response, :saml_attributes, :user_attributes, :tracker_uuid
 

--- a/spec/factories/user_identities.rb
+++ b/spec/factories/user_identities.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
 
     sign_in do
       {
-        service_name: SAML::User::MHV_ORIGINAL_CSID,
+        service_name: SAML::User::MHV_CSID,
         auth_broker: SAML::URLService::BROKER_CODE,
         client_id: create(:client_config).client_id
       }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -382,7 +382,7 @@ FactoryBot.define do
 
       sign_in do
         {
-          service_name: SAML::User::MHV_ORIGINAL_CSID,
+          service_name: SAML::User::MHV_CSID,
           auth_broker: SAML::URLService::BROKER_CODE,
           client_id: SAML::URLService::WEB_CLIENT_ID
         }

--- a/spec/models/user_verification_spec.rb
+++ b/spec/models/user_verification_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe UserVerification, type: :model do
     context 'when mhv_uuid is present' do
       let(:mhv_uuid) { 'some-mhv-uuid' }
       let(:backing_idme_uuid) { 'some-backing-idme-uuid' }
-      let(:expected_credential_type) { SAML::User::MHV_ORIGINAL_CSID }
+      let(:expected_credential_type) { SAML::User::MHV_CSID }
 
       it 'returns expected credential type' do
         expect(subject).to eq(expected_credential_type)

--- a/spec/services/acceptable_verified_credential_adoption_service_spec.rb
+++ b/spec/services/acceptable_verified_credential_adoption_service_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe AcceptableVerifiedCredentialAdoptionService do
         it 'hash returns true' do
           result = service.perform
           expect(result).to include(organic_modal: true)
-          expect(result).to include(credential_type: SAML::User::MHV_ORIGINAL_CSID)
+          expect(result).to include(credential_type: SAML::User::MHV_CSID)
         end
 
         it 'logs attempt' do

--- a/spec/services/login/after_login_actions_spec.rb
+++ b/spec/services/login/after_login_actions_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe Login::AfterLoginActions do
 
     context 'saving account_login_stats' do
       let(:user) { create(:user) }
-      let(:login_type) { SAML::User::MHV_ORIGINAL_CSID }
-      let(:login_type_stat) { SAML::User::MHV_MAPPED_CSID }
+      let(:login_type) { SAML::User::MHV_CSID }
+      let(:login_type_stat) { Accountable::MHV_MAPPED_CSID }
 
       before { allow_any_instance_of(UserIdentity).to receive(:sign_in).and_return(service_name: login_type) }
 

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Users::Profile do
         let(:user) { create(:user, :mhv) }
 
         it 'includes sign_in' do
-          expect(profile[:sign_in]).to eq(service_name: SAML::User::MHV_ORIGINAL_CSID,
+          expect(profile[:sign_in]).to eq(service_name: SAML::User::MHV_CSID,
                                           auth_broker: SAML::URLService::BROKER_CODE,
                                           client_id: SAML::URLService::WEB_CLIENT_ID)
         end
@@ -114,7 +114,7 @@ RSpec.describe Users::Profile do
           let(:user) { create(:user, :loa1, authn_context: 'myhealthevet_multifactor') }
 
           it 'includes sign_in.service_name' do
-            expect(profile[:sign_in][:service_name]).to eq(SAML::User::MHV_ORIGINAL_CSID)
+            expect(profile[:sign_in][:service_name]).to eq(SAML::User::MHV_CSID)
           end
         end
 
@@ -122,7 +122,7 @@ RSpec.describe Users::Profile do
           let(:user) { create(:user, :loa1, authn_context: 'myhealthevet_loa3') }
 
           it 'includes sign_in.service_name' do
-            expect(profile[:sign_in][:service_name]).to eq(SAML::User::MHV_ORIGINAL_CSID)
+            expect(profile[:sign_in][:service_name]).to eq(SAML::User::MHV_CSID)
           end
         end
       end


### PR DESCRIPTION
## Summary
Refactored code:
Removed MHV_MAPPED_CSID from  -> lib/saml/user.rb file and created a constant of MHV_MAPPED_CSID in account_login_statistics_job.rb plus accountable.rb. In user.rb, I changed MHV_ORIGINAL_CSID to MHV_CSID. This wherever it's defined and used. 

Team: identity-kong 
 Project: VET_API

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#55727
Ticket: 
https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/55727


## Testing done
RSPEC - Testing
Re-ran all rspec test that were affected by refactor changes. all was well. 

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
Vet_API