### PR TITLE
Increase feature toggle cache store expiration - 500 errors

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -17,7 +17,7 @@ Rails.application.reloader.to_prepare do
       cache = Rails.cache
 
       # Flipper settings will be stored in postgres and cached in memory for 1 minute in production/staging
-      cached_adapter = Flipper::Adapters::ActiveSupportCacheStore.new(activerecord_adapter, cache, expires_in: 1.minute)
+      cached_adapter = Flipper::Adapters::ActiveSupportCacheStore.new(activerecord_adapter, cache, expires_in: 2.minutes)
       instrumented = Flipper::Adapters::Instrumented.new(cached_adapter, instrumenter: ActiveSupport::Notifications)
 
       Flipper.new(instrumented, instrumenter: ActiveSupport::Notifications)


### PR DESCRIPTION
## Summary
We are seeing occasional (no specific cadence) 500 errors being returned from the `/v0/feature_toggles` endpoint. Testing our a theory. 

Setting the key expiration to 2 min. Testing out a theory that the cached settings become invalidated before the next cache refresh (the call to RDS)… (early eviction)? This could result in the 500 internal server error that we’re seeing.

Since it’s known that feature toggles can change frequently and  the changes to be reflected quickly, I’m going to be more conservative with increasing the cache expiry time. 2 min to start out my test.

Will be monitoring the logs to observe if setting cache time to a longer period to see if the error still persists. If it goes away, it may suggest that cache expiration is the issue

Datadog: [Example Feature Toggle 500 errors ](https://vagov.ddog-gov.com/logs?query=env%3Aeks-prod%20service%3Avets-api%20%40http.url_details.path%3A%22%2Fv0%2Ffeature_toggles%22%20%40http.status_code%3A500%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&spanID=1709902486602212458&stream_sort=service%2Cdesc&viz=stream&from_ts=1683559958648&to_ts=1683560784846&live=false)

[Corresponding Sentry Error](http://sentry.vfs.va.gov/organizations/vsp/issues/164442/?environment=production&project=3&query=is%3Aunresolved+FeatureToggle&statsPeriod=14d)

[RDS read/write latency in the given window](https://vagov.ddog-gov.com/dash/integration/210/aws-rds?tpl_var_dbinstance%5B0%5D=dsva-vets-api-prod-2&from_ts=1683559920000&to_ts=1683560760000&live=false)

## Related issue(s)
https://github.com/department-of-veterans-affairs/vets-api/pull/12613




