### PR TITLE
Revert debugging line

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,9 +45,7 @@ class ApplicationController < ActionController::API
   attr_reader :current_user
 
   def set_csrf_header
-    token = form_authenticity_token
-    response.set_header('X-CSRF-Token', token)
-    Rails.logger.info('CSRF response token', csrf_token: token)
+    response.set_header('X-CSRF-Token', form_authenticity_token)
   end
 
   def pagination_params


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

Reverting the debugging line that's no longer necessary. The CSRF issue has been identified as a frontend polling issue and session expiration. [Passed to the FE CoP here](https://dsva.slack.com/archives/C04868KS69L/p1683637224897219)

## Related issue(s)
https://app.zenhub.com/workspaces/platform-cop-backlog-6359535e384ff5a473132130/issues/gh/department-of-veterans-affairs/va.gov-team/58058


