### PR TITLE
dash as claims owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -132,3 +132,5 @@ modules/appeals_api @department-of-veterans-affairs/backend-review-group @depart
 
 # Disability Benefits Experience support
 lib/disability_compensation @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/bdex
+
+modules/claims_api @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/lighthouse-dash


### PR DESCRIPTION
## Summary

- Adds Dash as codeowner for claims_api


## Related issue(s)
- no ticket


## Testing done
-  No testing, just asking to be added.


## What areas of the site does it impact?
Changes modules/claims_api codeowners to be Team Dash.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Asking to add Dash as CODEOWNERS of the Claims API to _hopefully_ unblock our ability to merge our PRs. 

Also, says there are multiple errors in the codeowners file. Seems peculiar to me. 
