### PR TITLE
VA-13359: Add Trainings to PPMS facilities response

### DIFF
--- a/modules/facilities_api/app/models/facilities_api/v1/ppms/provider.rb
+++ b/modules/facilities_api/app/models/facilities_api/v1/ppms/provider.rb
@@ -25,6 +25,7 @@ module FacilitiesApi
     attribute :provider_identifier, String
     attribute :provider_name, String
     attribute :provider_type, String
+    attribute :trainings, Array
 
     def initialize(attr = {})
       super(attr)

--- a/modules/facilities_api/app/serializers/facilities_api/v1/ppms/provider_serializer.rb
+++ b/modules/facilities_api/app/serializers/facilities_api/v1/ppms/provider_serializer.rb
@@ -57,6 +57,8 @@ module FacilitiesApi
 
     attribute :pref_contact, &:contact_method
 
+    attribute :trainings
+
     attribute :unique_id, &:provider_identifier
   end
 end


### PR DESCRIPTION
This pull request aims to make the array of PPMS training information available through the `vets-api` endpoint on the front-end.

## Summary

- *(Summarize the changes that have been made to the platform)*
    - Making more PPMS data available on the front-end.
- *(Which team do you work for, does your team own the maintenance of this component?)*
    - I'm with the Facilities team.

## Related issue(s)
Closes department-of-veterans-affairs/va.gov-cms#13359

## Testing done

Still working on it

## Screenshots
_Note: Optional_


## What areas of the site does it impact?

Facility Locator

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
