### PR TITLE
Dedicated specs for NOD docs

### DIFF
--- a/modules/appeals_api/spec/docs/notice_of_disagreements/v0_spec.rb
+++ b/modules/appeals_api/spec/docs/notice_of_disagreements/v0_spec.rb
@@ -5,30 +5,29 @@ require Rails.root.join('spec', 'rswag_override.rb').to_s
 
 require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
+require AppealsApi::Engine.root.join('spec', 'support', 'doc_helpers.rb')
 
 def swagger_doc
-  "modules/appeals_api/app/swagger/decision_reviews/v2/swagger#{DocHelpers.doc_suffix}.json"
+  "modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger#{DocHelpers.doc_suffix}.json"
 end
 
-# rubocop:disable RSpec/VariableName, RSpec/ScatteredSetup, RSpec/RepeatedExample, Layout/LineLength
-describe 'Notice of Disagreements', swagger_doc:, type: :request do
+# rubocop:disable RSpec/VariableName, RSpec/RepeatedExample, Layout/LineLength
+RSpec.describe 'Notice of Disagreements', swagger_doc:, type: :request do
   include DocHelpers
-  let(:apikey) { 'apikey' }
+  let(:Authorization) { 'Bearer TEST_TOKEN' }
 
-  path '/notice_of_disagreements' do
+  path '/forms/10182' do
     post 'Creates a new Notice of Disagreement' do
+      scopes = AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreementsController::OAUTH_SCOPES[:POST]
       tags 'Notice of Disagreements'
       operationId 'createNod'
       description 'Submits an appeal of type Notice of Disagreement.' \
                   ' This endpoint is the same as submitting [VA Form 10182](https://www.va.gov/vaforms/va/pdf/VA10182.pdf)' \
                   ' via mail or fax directly to the Board of Veterans’ Appeals.'
-
-      security DocHelpers.decision_reviews_security_config
+      security DocHelpers.oauth_security_config(scopes)
       consumes 'application/json'
       produces 'application/json'
-
       parameter name: :nod_body, in: :body, schema: { '$ref' => '#/components/schemas/nodCreate' }
-
       parameter in: :body, examples: {
         'minimum fields used' => {
           value: JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'fixtures', 'v2', 'valid_10182_minimum.json')))
@@ -37,32 +36,23 @@ describe 'Notice of Disagreements', swagger_doc:, type: :request do
           value: JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'fixtures', 'v2', 'valid_10182_extra.json')))
         }
       }
-
       file_number_header_params = AppealsApi::SwaggerSharedComponents.header_params[:veteran_file_number_header]
       file_number_header_params[:required] = true
-
       parameter file_number_header_params
       let(:'X-VA-File-Number') { '987654321' }
-
-      parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_icn_header]
-
+      parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_icn_header].merge({ required: true })
+      let(:'X-VA-ICN') { '1234567890V123456' }
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_first_name_header]
       let(:'X-VA-First-Name') { 'first' }
-
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_middle_initial_header]
-
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_last_name_header]
       let(:'X-VA-Last-Name') { 'last' }
-
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_birth_date_header]
       let(:'X-VA-Birth-Date') { '1900-01-01' }
-
       parameter AppealsApi::SwaggerSharedComponents.header_params[:claimant_first_name_header]
       parameter AppealsApi::SwaggerSharedComponents.header_params[:claimant_middle_initial_header]
       parameter AppealsApi::SwaggerSharedComponents.header_params[:claimant_last_name_header]
       parameter AppealsApi::SwaggerSharedComponents.header_params[:claimant_birth_date_header]
-      parameter AppealsApi::SwaggerSharedComponents.header_params[:consumer_username_header]
-      parameter AppealsApi::SwaggerSharedComponents.header_params[:consumer_id_header]
 
       response '200', 'Info about a single Notice of Disagreement' do
         let(:nod_body) do
@@ -71,29 +61,15 @@ describe 'Notice of Disagreements', swagger_doc:, type: :request do
 
         schema '$ref' => '#/components/schemas/nodCreateResponse'
 
-        before do |example|
-          submit_request(example.metadata)
-        end
-
-        it 'minimum fields used' do |example|
-          assert_response_matches_metadata(example.metadata)
-        end
-
-        after do |example|
-          response_title = example.metadata[:description]
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              examples: {
-                "#{response_title}": {
-                  value: normalize_appeal_response(response)
-                }
-              }
-            }
-          }
-        end
+        it_behaves_like 'rswag example',
+                        desc: 'minimum fields used',
+                        response_wrapper: :normalize_appeal_response,
+                        extract_desc: true,
+                        scopes:
       end
 
       response '200', 'Info about a single Notice of Disagreement' do
+        schema '$ref' => '#/components/schemas/nodCreateResponse'
         let(:nod_body) do
           JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'fixtures', 'v2', 'valid_10182_extra.json')))
         end
@@ -102,38 +78,36 @@ describe 'Notice of Disagreements', swagger_doc:, type: :request do
         let(:'X-VA-NonVeteranClaimant-Last-Name') { 'last' }
         let(:'X-VA-NonVeteranClaimant-Birth-Date') { '1921-08-08' }
 
-        schema '$ref' => '#/components/schemas/nodCreateResponse'
-
-        it_behaves_like 'rswag example', desc: 'all fields used',
-                                         response_wrapper: :normalize_appeal_response,
-                                         extract_desc: true
+        it_behaves_like 'rswag example',
+                        desc: 'all fields used',
+                        response_wrapper: :normalize_appeal_response,
+                        extract_desc: true,
+                        scopes:
       end
 
       response '422', 'Violates JSON schema' do
         schema '$ref' => '#/components/schemas/errorModel'
-
         let(:nod_body) do
           request_body = JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'fixtures', 'v2', 'valid_10182.json')))
           request_body['data']['attributes'].delete('boardReviewOption')
           request_body
         end
 
-        it_behaves_like 'rswag example', desc: 'returns a 422 response'
+        it_behaves_like 'rswag example', desc: 'returns a 422 response', scopes:
       end
 
       it_behaves_like 'rswag 500 response'
     end
   end
 
-  path '/notice_of_disagreements/{uuid}' do
+  path '/forms/10182/{uuid}' do
     get 'Shows a specific Notice of Disagreement. (a.k.a. the Show endpoint)' do
+      scopes = AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreementsController::OAUTH_SCOPES[:GET]
       tags 'Notice of Disagreements'
       operationId 'showNod'
       description 'Returns all of the data associated with a specific Notice of Disagreement.'
-
-      security DocHelpers.decision_reviews_security_config
+      security DocHelpers.oauth_security_config(scopes)
       produces 'application/json'
-
       parameter name: :uuid,
                 in: :path,
                 type: :string,
@@ -142,52 +116,77 @@ describe 'Notice of Disagreements', swagger_doc:, type: :request do
 
       response '200', 'Info about a single Notice of Disagreement' do
         schema '$ref' => '#/components/schemas/nodShowResponse'
-
         let(:uuid) { FactoryBot.create(:notice_of_disagreement_v2).id }
 
-        it_behaves_like 'rswag example', desc: 'returns a 200 response',
-                                         response_wrapper: :normalize_appeal_response
+        it_behaves_like 'rswag example',
+                        desc: 'returns a 200 response',
+                        response_wrapper: :normalize_appeal_response,
+                        scopes:
       end
 
       response '404', 'Notice of Disagreement not found' do
         schema '$ref' => '#/components/schemas/errorModel'
-
         let(:uuid) { 'invalid' }
 
-        it_behaves_like 'rswag example', desc: 'returns a 404 response'
+        it_behaves_like 'rswag example', desc: 'returns a 404 response', scopes:
       end
 
       it_behaves_like 'rswag 500 response'
     end
   end
 
-  path '/notice_of_disagreements/schema' do
+  path '/schemas/{schema_type}' do
     get 'Gets the Notice of Disagreement JSON Schema.' do
+      scopes = AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreementsController::OAUTH_SCOPES[:GET]
       tags 'Notice of Disagreements'
       operationId 'nodSchema'
-      description 'Returns the [JSON Schema](https://json-schema.org/) for the `POST /notice_of_disagreements` endpoint.'
-      security DocHelpers.decision_reviews_security_config
+      description 'Returns the [JSON Schema](https://json-schema.org/) for the `POST /forms/10182` endpoint.'
+      security DocHelpers.oauth_security_config(scopes)
       produces 'application/json'
+      examples = {
+        '10182': { value: '10182' },
+        address: { value: 'address' },
+        non_blank_string: { value: 'non_blank_string' },
+        phone: { value: 'phone' },
+        timezone: { value: 'timezone' }
+      }
+      parameter(name: :schema_type,
+                in: :path,
+                type: :string,
+                description: "Schema type. Can be: `#{examples.keys.join('`, `')}`",
+                required: true,
+                examples:)
 
-      response '200', 'the JSON Schema for POST /notice_of_disagreements' do
-        it_behaves_like 'rswag example', desc: 'returns a 200 response', response_wrapper: :raw_body
+      examples.each do |_, v|
+        response '200', 'The JSON schema for the given `schema_type` parameter' do
+          let(:schema_type) { v[:value] }
+          it_behaves_like 'rswag example',
+                          desc: v[:value],
+                          extract_desc: true,
+                          scopes:
+        end
+      end
+
+      response '404', '`schema_type` not found' do
+        schema '$ref' => '#/components/schemas/errorModel'
+        let(:schema_type) { 'invalid_schema_type' }
+        it_behaves_like 'rswag example', desc: 'schema type not found', scopes:
       end
 
       it_behaves_like 'rswag 500 response'
     end
   end
 
-  path '/notice_of_disagreements/validate' do
+  path '/forms/10182/validate' do
     post 'Validates a POST request body against the JSON schema.' do
+      scopes = AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreementsController::OAUTH_SCOPES[:POST]
       tags 'Notice of Disagreements'
       operationId 'nodValidate'
-      description 'Like the POST /notice_of_disagreements, but only does the validations <b>—does not submit anything.</b>'
-      security DocHelpers.decision_reviews_security_config
+      description 'Like the POST /forms/10182, but only does the validations <b>—does not submit anything.</b>'
+      security DocHelpers.oauth_security_config(scopes)
       consumes 'application/json'
       produces 'application/json'
-
       parameter name: :nod_body, in: :body, schema: { '$ref' => '#/components/schemas/nodCreate' }
-
       parameter in: :body, examples: {
         'minimum fields used' => {
           value: JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'fixtures', 'v2', 'valid_10182_minimum.json')))
@@ -196,25 +195,17 @@ describe 'Notice of Disagreements', swagger_doc:, type: :request do
           value: JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'fixtures', 'v2', 'valid_10182_extra.json')))
         }
       }
-
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_file_number_header]
       let(:'X-VA-File-Number') { '987654321' }
-
-      parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_icn_header]
-
+      parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_icn_header].merge({ required: true })
+      let(:'X-VA-ICN') { '1234567890V123456' }
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_first_name_header]
       let(:'X-VA-First-Name') { 'first' }
-
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_middle_initial_header]
-
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_last_name_header]
       let(:'X-VA-Last-Name') { 'last' }
-
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_birth_date_header]
       let(:'X-VA-Birth-Date') { '1900-01-01' }
-
-      parameter AppealsApi::SwaggerSharedComponents.header_params[:consumer_username_header]
-      parameter AppealsApi::SwaggerSharedComponents.header_params[:consumer_id_header]
 
       response '200', 'Valid' do
         let(:nod_body) do
@@ -223,97 +214,105 @@ describe 'Notice of Disagreements', swagger_doc:, type: :request do
 
         schema JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'support', 'schemas', 'nod_validate.json')))
 
-        it_behaves_like 'rswag example', desc: 'minimum fields used', extract_desc: true
+        it_behaves_like 'rswag example',
+                        desc: 'minimum fields used',
+                        extract_desc: true,
+                        scopes:
       end
 
       response '200', 'Info about a single Notice of Disagreement' do
+        schema JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'support', 'schemas', 'nod_validate.json')))
         let(:nod_body) do
           JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'fixtures', 'v2', 'valid_10182.json')))
         end
 
-        schema JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'support', 'schemas', 'nod_validate.json')))
-
-        it_behaves_like 'rswag example', desc: 'all fields used', extract_desc: true
+        it_behaves_like 'rswag example',
+                        desc: 'all fields used',
+                        extract_desc: true,
+                        scopes:
       end
 
       response '422', 'Error' do
         schema '$ref' => '#/components/schemas/errorModel'
-
         let(:nod_body) do
           request_body = JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'fixtures', 'v2', 'valid_10182_minimum.json')))
           request_body['data']['attributes'].delete('boardReviewOption')
           request_body
         end
 
-        it_behaves_like 'rswag example', desc: 'Violates JSON schema', extract_desc: true
+        it_behaves_like 'rswag example',
+                        desc: 'Violates JSON schema',
+                        extract_desc: true,
+                        scopes:
       end
 
       response '422', 'Error' do
         schema '$ref' => '#/components/schemas/errorModel'
+        let(:nod_body) { nil }
 
-        let(:nod_body) do
-          nil
-        end
-
-        it_behaves_like 'rswag example', desc: 'Not JSON object', extract_desc: true
+        it_behaves_like 'rswag example',
+                        desc: 'Not JSON object',
+                        extract_desc: true,
+                        scopes:
       end
 
       it_behaves_like 'rswag 500 response'
     end
   end
 
-  path '/notice_of_disagreements/evidence_submissions' do
+  path '/evidence-submissions' do
     post 'Get a location for subsequent evidence submission document upload PUT request' do
+      scopes = AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreementsController::OAUTH_SCOPES[:POST]
       tags 'Notice of Disagreements'
       operationId 'postNoticeOfDisagreementEvidenceSubmission'
       description <<~DESC
         This is the first step to submitting supporting evidence for an NOD.  (See the Evidence Uploads section above for additional information.)
         The Notice of Disagreement GUID that is returned when the NOD is submitted, is supplied to this endpoint to ensure the NOD is in a valid state for sending supporting evidence documents.  Only NODs that selected the Evidence Submission lane are allowed to submit evidence documents up to 90 days after the NOD is received by VA.
       DESC
-
       parameter name: :nod_uuid,
                 in: :query,
                 type: :string,
                 required: true,
                 description: 'Associated Notice of Disagreement UUID',
                 example: '9dbc8f83-a778-417e-9f8b-a9a36d710f70'
-
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_file_number_header]
       let(:'X-VA-File-Number') { '987654321' }
-
-      security DocHelpers.decision_reviews_security_config
+      security DocHelpers.oauth_security_config(scopes)
       produces 'application/json'
 
       response '202', 'Accepted. Location generated' do
-        let(:nod_uuid) { FactoryBot.create(:notice_of_disagreement_v2, :board_review_evidence_submission).id }
-
         schema '$ref' => '#/components/schemas/nodEvidenceSubmissionResponse'
+        let(:nod_uuid) { FactoryBot.create(:notice_of_disagreement_v2, :board_review_evidence_submission).id }
 
         before do
           allow_any_instance_of(VBADocuments::UploadSubmission).to receive(:get_location).and_return(+'http://some.fakesite.com/path/uuid')
         end
 
-        it_behaves_like 'rswag example', desc: 'returns a 202 response',
-                                         response_wrapper: :normalize_evidence_submission_response
+        it_behaves_like 'rswag example',
+                        desc: 'returns a 202 response',
+                        response_wrapper: :normalize_evidence_submission_response,
+                        scopes:
       end
 
       response '400', 'Bad Request' do
-        let(:nod_uuid) { nil }
         schema '$ref' => '#/components/schemas/errorModel'
-        it_behaves_like 'rswag example', desc: 'returns a 400 response', skip_match: true
+        let(:nod_uuid) { nil }
+
+        it_behaves_like 'rswag example', desc: 'returns a 400 response', scopes:, skip_match: true
       end
 
       response '404', 'Associated Notice of Disagreement not found' do
-        let(:nod_uuid) { '101010101010101010101010' }
         schema '$ref' => '#/components/schemas/errorModel'
-        it_behaves_like 'rswag example', desc: 'returns a 404 response'
+        let(:nod_uuid) { '101010101010101010101010' }
+
+        it_behaves_like 'rswag example', desc: 'returns a 404 response', scopes:
       end
 
       response '422', 'Validation errors' do
         let(:nod_uuid) { FactoryBot.create(:notice_of_disagreement_v2, :board_review_direct_review).id }
         let(:'X-VA-File-Number') { '987654321' }
         schema '$ref' => '#/components/schemas/errorModel'
-        it_behaves_like 'rswag example', desc: 'returns a 422 response'
+        it_behaves_like 'rswag example', desc: 'returns a 422 response', scopes:
       end
 
       it_behaves_like 'rswag 500 response'
@@ -322,18 +321,20 @@ describe 'Notice of Disagreements', swagger_doc:, type: :request do
 
   path '/nod_upload_path' do
     put 'Accepts Notice of Disagreement Evidence Submission document upload.' do
+      scopes = AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreementsController::OAUTH_SCOPES[:PUT]
       tags 'Notice of Disagreements'
       operationId 'putNoticeOfDisagreementEvidenceSubmission'
-      description File.read(DocHelpers.output_directory_file_path('put_description.md'))
-      security DocHelpers.decision_reviews_security_config
-
+      description File.read('modules/appeals_api/app/swagger/notice_of_disagreements/v0/put_description.md')
+      security DocHelpers.oauth_security_config(scopes)
       parameter name: :'Content-MD5', in: :header, type: :string, description: 'Base64-encoded 128-bit MD5 digest of the message. Use for integrity control.'
       let(:'Content-MD5') { nil }
 
       response '200', 'Document upload staged' do
+        # rubocop:disable RSpec/NoExpectationExample
         it 'returns a 200 response' do |example|
           # noop
         end
+        # rubocop:enable RSpec/NoExpectationExample
       end
 
       response '400', 'Document upload failed' do
@@ -341,7 +342,7 @@ describe 'Notice of Disagreements', swagger_doc:, type: :request do
 
         schema type: :object,
                description: 'Document upload failed',
-               xml: { 'name': 'Error' },
+               xml: { name: 'Error' },
                properties: {
                  Code: {
                    type: :string, description: 'Error code', example: 'Bad Digest'
@@ -358,24 +359,25 @@ describe 'Notice of Disagreements', swagger_doc:, type: :request do
                  }
                }
 
+        # rubocop:disable RSpec/NoExpectationExample
         it 'returns a 400 response' do |example|
           # noop
         end
+        # rubocop:enable RSpec/NoExpectationExample
       end
 
       it_behaves_like 'rswag 500 response'
     end
   end
 
-  path '/notice_of_disagreements/evidence_submissions/{uuid}' do
+  path '/evidence-submissions/{uuid}' do
     get 'Returns all of the data associated with a specific Notice of Disagreement Evidence Submission.' do
+      scopes = AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreementsController::OAUTH_SCOPES[:GET]
       tags 'Notice of Disagreements'
       operationId 'getNoticeOfDisagreementEvidenceSubmission'
       description 'Returns all of the data associated with a specific Notice of Disagreement Evidence Submission.'
-
-      security DocHelpers.decision_reviews_security_config
+      security DocHelpers.oauth_security_config(scopes)
       produces 'application/json'
-
       parameter name: :uuid,
                 in: :path,
                 type: :string,
@@ -384,21 +386,22 @@ describe 'Notice of Disagreements', swagger_doc:, type: :request do
 
       response '200', 'Info about a single Notice of Disagreement Evidence Submission.' do
         schema '$ref' => '#/components/schemas/nodEvidenceSubmissionResponse'
-
         let(:uuid) { FactoryBot.create(:evidence_submission).guid }
 
-        it_behaves_like 'rswag example', desc: 'returns a 200 response',
-                                         response_wrapper: :normalize_evidence_submission_response
+        it_behaves_like 'rswag example',
+                        desc: 'returns a 200 response',
+                        response_wrapper: :normalize_evidence_submission_response,
+                        scopes:
       end
 
       response '404', 'Notice of Disagreement Evidence Submission not found' do
         schema '$ref' => '#/components/schemas/errorModel'
         let(:uuid) { 'invalid' }
-        it_behaves_like 'rswag example', desc: 'returns a 404 response'
+        it_behaves_like 'rswag example', desc: 'returns a 404 response', scopes:
       end
 
       it_behaves_like 'rswag 500 response'
     end
   end
 end
-# rubocop:enable RSpec/VariableName, RSpec/ScatteredSetup, RSpec/RepeatedExample, Layout/LineLength
+# rubocop:enable RSpec/VariableName, RSpec/RepeatedExample, Layout/LineLength

--- a/modules/appeals_api/spec/support/rswag_config.rb
+++ b/modules/appeals_api/spec/support/rswag_config.rb
@@ -77,6 +77,14 @@ class AppealsApi::RswagConfig
         base_path_template: '/services/appeals/legacy-appeals/{version}',
         name: 'legacy_appeals',
         tags: [{ name: 'Legacy Appeals', description: '' }]
+      ),
+      "modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger#{DocHelpers.doc_suffix}.json" => rswag_doc_config(
+        title: 'Notice of Disagreements',
+        version: 'v0',
+        description_file_path: AppealsApi::Engine.root.join("app/swagger/notice_of_disagreements/v0/api_description#{DocHelpers.doc_suffix}.md"),
+        base_path_template: '/services/appeals/notice-of-disagreements/{version}',
+        name: 'notice_of_disagreements',
+        tags: [{ name: 'Notice of Disagreements', description: '' }]
       )
     }
   end

--- a/modules/vba_documents/app/models/vba_documents/upload_submission.rb
+++ b/modules/vba_documents/app/models/vba_documents/upload_submission.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'vba_documents/sql_support'
+require 'vba_documents/upload_error'
 require 'central_mail/service'
 require 'common/exceptions'
 

--- a/rakelib/rswag.rake
+++ b/rakelib/rswag.rake
@@ -4,7 +4,7 @@ require 'fileutils'
 
 # Docs for APIs in this list have been split out from the decision reviews docs specs and into their own files
 # FIXME: remove this constant once all the segmented APIs have their own dedicated files
-INDEPENDENT_SEGMENTED_API_NAMES = %w[contestable_issues legacy_appeals].freeze
+INDEPENDENT_SEGMENTED_API_NAMES = %w[contestable_issues legacy_appeals notice_of_disagreements].freeze
 
 APPEALS_API_DOCS_DIR = 'modules/appeals_api/spec/docs'
 SEGMENTED_DECISION_REVIEWS_API_NAMES = Dir["#{APPEALS_API_DOCS_DIR}/decision_reviews/*.rb"]
@@ -30,6 +30,11 @@ APPEALS_API_DOCS = [
     name: 'legacy_appeals',
     version: 'v0',
     pattern: "#{APPEALS_API_DOCS_DIR}/legacy_appeals/v0_spec.rb"
+  },
+  {
+    name: 'notice_of_disagreements',
+    version: 'v0',
+    pattern: "#{APPEALS_API_DOCS_DIR}/notice_of_disagreements/v0_spec.rb"
   }
 ] + SEGMENTED_DECISION_REVIEWS_API_NAMES.map do |api_name|
   {


### PR DESCRIPTION
## Summary

- Splits rswag specs for the Notice of Disagreements API v0 out into their own dedicated file - generated outputs remain the same for both the NOD docs and the decision reviews docs

## Related issue(s)
- [API-24891](https://vajira.max.gov/browse/API-25891)
- #12576 is very similar - please see [this comment](https://github.com/department-of-veterans-affairs/vets-api/pull/12576#discussion_r1187916207) for a caveat that still applies here (and will until all docs are split out like this)

## Testing done

- Updated docs specs, ran rake tasks for decision reviews and NOD

## What areas of the site does it impact?
- Does not change actual docs, just their generation process

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
