### PR TITLE
Finish splitting decision reviews and appeals docs

### DIFF
--- a/modules/appeals_api/app/swagger/appealable_issues/v0/swagger.json
+++ b/modules/appeals_api/app/swagger/appealable_issues/v0/swagger.json
@@ -135,7 +135,7 @@
                 "example": {
                   "data": [
                     {
-                      "type": "contestableIssue",
+                      "type": "appealableIssue",
                       "attributes": {
                         "ratingIssueSubjectText": "right knee",
                         "ratingIssuePercentNumber": "10",
@@ -160,7 +160,7 @@
                       }
                     },
                     {
-                      "type": "contestableIssue",
+                      "type": "appealableIssue",
                       "attributes": {
                         "ratingIssueSubjectText": "ptsd",
                         "ratingIssueReferenceId": "826209441170",
@@ -184,7 +184,7 @@
                       }
                     },
                     {
-                      "type": "contestableIssue",
+                      "type": "appealableIssue",
                       "attributes": {
                         "ratingIssueSubjectText": "left knee",
                         "ratingIssueReferenceId": "826209597423",
@@ -210,7 +210,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/contestableIssues"
+                  "$ref": "#/components/schemas/appealableIssues"
                 }
               }
             }
@@ -394,14 +394,14 @@
       }
     },
     "schemas": {
-      "contestableIssue": {
+      "appealableIssue": {
         "type": "object",
-        "description": "A contestable issue (to contest this, you include it as a RequestIssue when creating a HigherLevelReview, SupplementalClaim, or Appeal)",
+        "description": "An appealable issue (to appeal this, you include it as a RequestIssue when creating a HigherLevelReview, SupplementalClaim, or Appeal)",
         "properties": {
           "type": {
             "type": "string",
             "enum": [
-              "contestableIssue"
+              "appealableIssue"
             ]
           },
           "id": {
@@ -433,7 +433,7 @@
               "ratingDecisionReferenceId": {
                 "type": "string",
                 "nullable": true,
-                "description": "The BGS ID for the contested rating decision. This may be populated while ratingIssueReferenceId is nil",
+                "description": "The BGS ID for the appealable rating decision. This may be populated while ratingIssueReferenceId is nil",
                 "example": null
               },
               "decisionIssueId": {
@@ -480,7 +480,7 @@
               },
               "latestIssuesInChain": {
                 "type": "array",
-                "description": "Shows the chain of decision and rating issues that preceded this issue. Only the most recent issue can be contested (the object itself that contains the latestIssuesInChain attribute).",
+                "description": "Shows the chain of decision and rating issues that preceded this issue. Only the most recent issue can be appealed (the object itself that contains the latestIssuesInChain attribute).",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -526,13 +526,13 @@
           }
         }
       },
-      "contestableIssues": {
+      "appealableIssues": {
         "type": "object",
         "properties": {
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/contestableIssue"
+              "$ref": "#/components/schemas/appealableIssue"
             }
           }
         }
@@ -628,7 +628,7 @@
         "pattern": "^[0-9]{10}V[0-9]{6}$"
       },
       "X-VA-Receipt-Date": {
-        "description": "(yyyy-mm-dd) Date to limit the contestable issues",
+        "description": "(yyyy-mm-dd) Date to limit the appealable issues",
         "type": "string",
         "format": "date"
       },

--- a/modules/appeals_api/app/swagger/appealable_issues/v0/swagger_dev.json
+++ b/modules/appeals_api/app/swagger/appealable_issues/v0/swagger_dev.json
@@ -135,7 +135,7 @@
                 "example": {
                   "data": [
                     {
-                      "type": "contestableIssue",
+                      "type": "appealableIssue",
                       "attributes": {
                         "ratingIssueSubjectText": "right knee",
                         "ratingIssuePercentNumber": "10",
@@ -160,7 +160,7 @@
                       }
                     },
                     {
-                      "type": "contestableIssue",
+                      "type": "appealableIssue",
                       "attributes": {
                         "ratingIssueSubjectText": "ptsd",
                         "ratingIssueReferenceId": "826209441170",
@@ -184,7 +184,7 @@
                       }
                     },
                     {
-                      "type": "contestableIssue",
+                      "type": "appealableIssue",
                       "attributes": {
                         "ratingIssueSubjectText": "left knee",
                         "ratingIssueReferenceId": "826209597423",
@@ -210,7 +210,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/contestableIssues"
+                  "$ref": "#/components/schemas/appealableIssues"
                 }
               }
             }
@@ -394,14 +394,14 @@
       }
     },
     "schemas": {
-      "contestableIssue": {
+      "appealableIssue": {
         "type": "object",
-        "description": "A contestable issue (to contest this, you include it as a RequestIssue when creating a HigherLevelReview, SupplementalClaim, or Appeal)",
+        "description": "An appealable issue (to appeal this, you include it as a RequestIssue when creating a HigherLevelReview, SupplementalClaim, or Appeal)",
         "properties": {
           "type": {
             "type": "string",
             "enum": [
-              "contestableIssue"
+              "appealableIssue"
             ]
           },
           "id": {
@@ -433,7 +433,7 @@
               "ratingDecisionReferenceId": {
                 "type": "string",
                 "nullable": true,
-                "description": "The BGS ID for the contested rating decision. This may be populated while ratingIssueReferenceId is nil",
+                "description": "The BGS ID for the appealable rating decision. This may be populated while ratingIssueReferenceId is nil",
                 "example": null
               },
               "decisionIssueId": {
@@ -480,7 +480,7 @@
               },
               "latestIssuesInChain": {
                 "type": "array",
-                "description": "Shows the chain of decision and rating issues that preceded this issue. Only the most recent issue can be contested (the object itself that contains the latestIssuesInChain attribute).",
+                "description": "Shows the chain of decision and rating issues that preceded this issue. Only the most recent issue can be appealed (the object itself that contains the latestIssuesInChain attribute).",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -526,13 +526,13 @@
           }
         }
       },
-      "contestableIssues": {
+      "appealableIssues": {
         "type": "object",
         "properties": {
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/contestableIssue"
+              "$ref": "#/components/schemas/appealableIssue"
             }
           }
         }
@@ -628,7 +628,7 @@
         "pattern": "^[0-9]{10}V[0-9]{6}$"
       },
       "X-VA-Receipt-Date": {
-        "description": "(yyyy-mm-dd) Date to limit the contestable issues",
+        "description": "(yyyy-mm-dd) Date to limit the appealable issues",
         "type": "string",
         "format": "date"
       },

--- a/modules/appeals_api/spec/docs/decision_reviews/higher_level_reviews_spec.rb
+++ b/modules/appeals_api/spec/docs/decision_reviews/higher_level_reviews_spec.rb
@@ -41,12 +41,7 @@ describe 'Higher-Level Reviews', swagger_doc:, type: :request do
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_ssn_header]
       let(:'X-VA-SSN') { '000000000' }
 
-      parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_icn_header].merge(
-        {
-          required: !DocHelpers.decision_reviews?
-        }
-      )
-      let(:'X-VA-ICN') { '1234567890V123456' } unless DocHelpers.decision_reviews?
+      parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_icn_header]
 
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_first_name_header]
       let(:'X-VA-First-Name') { 'first' }
@@ -265,12 +260,7 @@ describe 'Higher-Level Reviews', swagger_doc:, type: :request do
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_ssn_header]
       let(:'X-VA-SSN') { '000000000' }
 
-      parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_icn_header].merge(
-        {
-          required: !DocHelpers.decision_reviews?
-        }
-      )
-      let(:'X-VA-ICN') { '1234567890V123456' } unless DocHelpers.decision_reviews?
+      parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_icn_header]
 
       parameter AppealsApi::SwaggerSharedComponents.header_params[:veteran_first_name_header]
       let(:'X-VA-First-Name') { 'first' }

--- a/modules/appeals_api/spec/docs/decision_reviews/legacy_appeals_spec.rb
+++ b/modules/appeals_api/spec/docs/decision_reviews/legacy_appeals_spec.rb
@@ -6,8 +6,12 @@ require Rails.root.join('spec', 'rswag_override.rb').to_s
 require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
+def swagger_doc
+  "modules/appeals_api/app/swagger/decision_reviews/v2/swagger#{DocHelpers.doc_suffix}.json"
+end
+
 # rubocop:disable RSpec/VariableName
-describe 'Legacy Appeals', swagger_doc: DocHelpers.output_json_path, type: :request do
+describe 'Legacy Appeals', swagger_doc:, type: :request do
   include DocHelpers
   let(:apikey) { 'apikey' }
 

--- a/modules/appeals_api/spec/docs/decision_reviews/notice_of_disagreements_spec.rb
+++ b/modules/appeals_api/spec/docs/decision_reviews/notice_of_disagreements_spec.rb
@@ -324,7 +324,7 @@ describe 'Notice of Disagreements', swagger_doc:, type: :request do
     put 'Accepts Notice of Disagreement Evidence Submission document upload.' do
       tags 'Notice of Disagreements'
       operationId 'putNoticeOfDisagreementEvidenceSubmission'
-      description File.read(DocHelpers.output_directory_file_path('put_description.md'))
+      description File.read(AppealsApi::Engine.root.join('app', 'swagger', 'decision_reviews', 'v2', 'put_description.md'))
       security DocHelpers.decision_reviews_security_config
 
       parameter name: :'Content-MD5', in: :header, type: :string, description: 'Base64-encoded 128-bit MD5 digest of the message. Use for integrity control.'

--- a/modules/appeals_api/spec/docs/decision_reviews/supplemental_claims_spec.rb
+++ b/modules/appeals_api/spec/docs/decision_reviews/supplemental_claims_spec.rb
@@ -6,8 +6,12 @@ require Rails.root.join('spec', 'rswag_override.rb').to_s
 require 'rails_helper'
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
+def swagger_doc
+  "modules/appeals_api/app/swagger/decision_reviews/v2/swagger#{DocHelpers.doc_suffix}.json"
+end
+
 # rubocop:disable RSpec/VariableName, RSpec/RepeatedExample, Layout/LineLength
-describe 'Supplemental Claims', swagger_doc: DocHelpers.output_json_path, type: :request do
+describe 'Supplemental Claims', swagger_doc:, type: :request do
   include DocHelpers
   let(:apikey) { 'apikey' }
 
@@ -358,7 +362,7 @@ describe 'Supplemental Claims', swagger_doc: DocHelpers.output_json_path, type: 
       tags 'Supplemental Claims'
       operationId 'putSupplementalClaimEvidenceSubmission'
 
-      description File.read(DocHelpers.output_directory_file_path('put_description.md'))
+      description File.read(AppealsApi::Engine.root.join('app', 'swagger', 'decision_reviews', 'v2', 'put_description.md'))
       security DocHelpers.decision_reviews_security_config
 
       parameter name: :'Content-MD5', in: :header, type: :string, description: 'Base64-encoded 128-bit MD5 digest of the message. Use for integrity control.'

--- a/modules/appeals_api/spec/docs/notice_of_disagreements/v0_spec.rb
+++ b/modules/appeals_api/spec/docs/notice_of_disagreements/v0_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe 'Notice of Disagreements', swagger_doc:, type: :request do
       scopes = AppealsApi::NoticeOfDisagreements::V0::NoticeOfDisagreementsController::OAUTH_SCOPES[:PUT]
       tags 'Notice of Disagreements'
       operationId 'putNoticeOfDisagreementEvidenceSubmission'
-      description File.read('modules/appeals_api/app/swagger/notice_of_disagreements/v0/put_description.md')
+      description File.read(AppealsApi::Engine.root.join('app', 'swagger', 'notice_of_disagreements', 'v0', 'put_description.md'))
       security DocHelpers.oauth_security_config(scopes)
       parameter name: :'Content-MD5', in: :header, type: :string, description: 'Base64-encoded 128-bit MD5 digest of the message. Use for integrity control.'
       let(:'Content-MD5') { nil }

--- a/modules/appeals_api/spec/docs/supplemental_claims/v0_spec.rb
+++ b/modules/appeals_api/spec/docs/supplemental_claims/v0_spec.rb
@@ -393,8 +393,7 @@ RSpec.describe 'Supplemental Claims', swagger_doc:, type: :request do
       scopes = AppealsApi::SupplementalClaims::V0::SupplementalClaimsController::OAUTH_SCOPES[:POST]
       tags 'Supplemental Claims'
       operationId 'putSupplementalClaimEvidenceSubmission'
-
-      description File.read(DocHelpers.output_directory_file_path('put_description.md'))
+      description File.read(AppealsApi::Engine.root.join('app', 'swagger', 'supplemental_claims', 'v0', 'put_description.md'))
       security DocHelpers.oauth_security_config(scopes)
 
       parameter name: :'Content-MD5', in: :header, type: :string, description: 'Base64-encoded 128-bit MD5 digest of the message. Use for integrity control.'

--- a/modules/appeals_api/spec/support/doc_helpers.rb
+++ b/modules/appeals_api/spec/support/doc_helpers.rb
@@ -48,12 +48,8 @@ module DocHelpers
     [{ productionOauth: scopes }, { sandboxOauth: scopes }, { bearer_token: [] }]
   end
 
-  def self.decision_reviews_security_config(oauth_scopes = [])
-    if DocHelpers.api_name == 'decision_reviews'
-      [{ apikey: [] }]
-    else
-      DocHelpers.oauth_security_config(oauth_scopes)
-    end
+  def self.decision_reviews_security_config
+    [{ apikey: [] }]
   end
 
   # @param [Hash] opts
@@ -147,87 +143,8 @@ module DocHelpers
     DocHelpers.wip_doc_enabled?(sym)
   end
 
-  DECISION_REVIEWS_DOC_TITLES = {
-    higher_level_reviews: 'Higher-Level Reviews',
-    notice_of_disagreements: 'Notice of Disagreements',
-    supplemental_claims: 'Supplemental Claims',
-    contestable_issues: 'Contestable Issues',
-    legacy_appeals: 'Legacy Appeals'
-  }.freeze
-
-  ALL_DOC_TITLES = DECISION_REVIEWS_DOC_TITLES.merge(
-    {
-      appealable_issues: 'Appealable Issues',
-      appeals_status: 'Appeals Status',
-      decision_reviews: 'Decision Reviews'
-    }
-  ).freeze
-
-  def self.api_name
-    DocHelpers.running_rake_task? ? ENV['API_NAME'].presence : DEFAULT_CONFIG_VALUES[:api_name]
-  end
-
-  def self.decision_reviews?
-    DocHelpers.api_name == 'decision_reviews'
-  end
-
-  def self.use_shared_schemas?
-    !DocHelpers.decision_reviews?
-  end
-
-  def self.running_rake_task?
-    # SWAGGER_DRY_RUN is set in the appeals rake tasks: if it's not set, it means the spec is running as part of
-    # a normal rspec suite instead.
-    ENV['SWAGGER_DRY_RUN'].present?
-  end
-
-  def self.api_version
-    DocHelpers.running_rake_task? ? ENV['API_VERSION'].presence : DEFAULT_CONFIG_VALUES[:api_version]
-  end
-
-  def self.api_title
-    ALL_DOC_TITLES[DocHelpers.api_name&.to_sym]
-  end
-
-  def self.api_tags
-    if DocHelpers.decision_reviews?
-      DECISION_REVIEWS_DOC_TITLES.values.collect { |title| { name: title, description: '' } }
-    else
-      [{ name: ALL_DOC_TITLES[DocHelpers.api_name.to_sym], description: '' }]
-    end
-  end
-
-  def self.api_base_path_template
-    if DocHelpers.decision_reviews?
-      '/services/appeals/{version}/decision_reviews'
-    else
-      "/services/appeals/#{DocHelpers.api_name.tr('_', '-')}/{version}"
-    end
-  end
-
-  def self.api_base_path
-    DocHelpers.api_base_path_template.gsub('{version}', DocHelpers.api_version)
-  end
-
   def self.doc_suffix
     ENV['RSWAG_ENV'] == 'dev' ? '_dev' : ''
-  end
-
-  def self.output_directory_file_path(file_name)
-    AppealsApi::Engine.root.join(
-      "app/swagger/#{DocHelpers.api_name}/#{DocHelpers.api_version}/#{file_name}"
-    ).to_s
-  end
-
-  def self.api_description_file_path
-    DocHelpers.output_directory_file_path("api_description#{DocHelpers.doc_suffix}.md")
-  end
-
-  def self.output_json_path
-    # Note that rswag expects this path to be relative to the working directory when running the specs
-    # rubocop:disable Layout/LineLength
-    "modules/appeals_api/app/swagger/#{DocHelpers.api_name}/#{DocHelpers.api_version}/swagger#{DocHelpers.doc_suffix}.json"
-    # rubocop:enable Layout/LineLength
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/modules/appeals_api/spec/support/rswag_config.rb
+++ b/modules/appeals_api/spec/support/rswag_config.rb
@@ -2,24 +2,17 @@
 
 require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
 
-# rubocop:disable Metrics/MethodLength, Layout/LineLength, Metrics/ClassLength, Metrics/ParameterLists
+# rubocop:disable Metrics/MethodLength, Layout/LineLength, Metrics/ClassLength
 class AppealsApi::RswagConfig
   include DocHelpers
 
-  def rswag_doc_config(
-    base_path_template: DocHelpers.api_base_path_template,
-    description_file_path: DocHelpers.api_description_file_path,
-    name: DocHelpers.api_name,
-    tags: DocHelpers.api_tags,
-    title: DocHelpers.api_title,
-    version: DocHelpers.api_version
-  )
+  def rswag_doc_config(base_path_template:, description_file_path:, name:, tags:, version:)
     {
       # FIXME: The Lighthouse docs UI code does not yet support openapi versions above 3.0.z
       # This version should be updated to 3.1.0+ once that changes.
       openapi: '3.0.0',
       info: {
-        title:,
+        title: DOC_TITLES[name.to_sym],
         version:,
         contact: { name: 'developer.va.gov' },
         termsOfService: 'https://developer.va.gov/terms-of-service',
@@ -30,8 +23,8 @@ class AppealsApi::RswagConfig
       # basePath helps with rswag runs, but is not valid OAS v3. rswag.rake removes it from the output file.
       basePath: base_path_template.gsub('{version}', version),
       components: {
-        securitySchemes: security_schemes(name),
-        schemas: schemas(name)
+        securitySchemes: name == 'decision_reviews' ? decision_reviews_security_schemes : oauth_security_schemes(name),
+        schemas: schemas(api_name: name)
       },
       servers: [
         {
@@ -49,63 +42,73 @@ class AppealsApi::RswagConfig
   end
 
   def config
-    # Avoid trying to build this config when running a rake task for a non-appeals API (e.g. Claims)
-    return {} if DocHelpers.running_rake_task? && ENV['RAILS_MODULE'] != 'appeals_api'
-
     {
-      DocHelpers.output_json_path => rswag_doc_config,
       "modules/appeals_api/app/swagger/appealable_issues/v0/swagger#{DocHelpers.doc_suffix}.json" => rswag_doc_config(
-        title: 'Appealable Issues',
         version: 'v0',
         description_file_path: AppealsApi::Engine.root.join("app/swagger/appealable_issues/v0/api_description#{DocHelpers.doc_suffix}.md"),
         base_path_template: '/services/appeals/appealable-issues/{version}',
         name: 'appealable_issues',
-        tags: [{ name: 'Appealable Issues', description: '' }]
+        tags: api_tags(:appealable_issues)
       ),
       "modules/appeals_api/app/swagger/appeals_status/v1/swagger#{DocHelpers.doc_suffix}.json" => rswag_doc_config(
-        title: 'Appeals Status',
         version: 'v1',
         description_file_path: AppealsApi::Engine.root.join("app/swagger/appeals_status/v1/api_description#{DocHelpers.doc_suffix}.md"),
         base_path_template: '/services/appeals/appeals-status/{version}',
         name: 'appeals_status',
-        tags: [{ name: 'Appeals Status', description: '' }]
+        tags: api_tags(:appeals_status)
+      ),
+      "modules/appeals_api/app/swagger/decision_reviews/v2/swagger#{DocHelpers.doc_suffix}.json" => rswag_doc_config(
+        version: 'v2',
+        description_file_path: AppealsApi::Engine.root.join("app/swagger/decision_reviews/v2/api_description#{DocHelpers.doc_suffix}.md"),
+        base_path_template: '/services/appeals/{version}/decision_reviews',
+        name: 'decision_reviews',
+        tags: api_tags(*%i[
+                         higher_level_reviews notice_of_disagreements supplemental_claims contestable_issues legacy_appeals
+                       ])
       ),
       "modules/appeals_api/app/swagger/higher_level_reviews/v0/swagger#{DocHelpers.doc_suffix}.json" => rswag_doc_config(
-        title: 'Higher-Level Reviews',
         version: 'v0',
         description_file_path: AppealsApi::Engine.root.join("app/swagger/higher_level_reviews/v0/api_description#{DocHelpers.doc_suffix}.md"),
         base_path_template: '/services/appeals/higher-level-reviews/{version}',
         name: 'higher_level_reviews',
-        tags: [{ name: 'Higher-Level Reviews', description: '' }]
+        tags: api_tags(:higher_level_reviews)
       ),
       "modules/appeals_api/app/swagger/legacy_appeals/v0/swagger#{DocHelpers.doc_suffix}.json" => rswag_doc_config(
-        title: 'Legacy Appeals',
         version: 'v0',
         description_file_path: AppealsApi::Engine.root.join("app/swagger/legacy_appeals/v0/api_description#{DocHelpers.doc_suffix}.md"),
         base_path_template: '/services/appeals/legacy-appeals/{version}',
         name: 'legacy_appeals',
-        tags: [{ name: 'Legacy Appeals', description: '' }]
+        tags: api_tags(:legacy_appeals)
       ),
       "modules/appeals_api/app/swagger/notice_of_disagreements/v0/swagger#{DocHelpers.doc_suffix}.json" => rswag_doc_config(
-        title: 'Notice of Disagreements',
         version: 'v0',
         description_file_path: AppealsApi::Engine.root.join("app/swagger/notice_of_disagreements/v0/api_description#{DocHelpers.doc_suffix}.md"),
         base_path_template: '/services/appeals/notice-of-disagreements/{version}',
         name: 'notice_of_disagreements',
-        tags: [{ name: 'Notice of Disagreements', description: '' }]
+        tags: api_tags(:notice_of_disagreements)
       ),
       "modules/appeals_api/app/swagger/supplemental_claims/v0/swagger#{DocHelpers.doc_suffix}.json" => rswag_doc_config(
-        title: 'Supplemental Claims',
         version: 'v0',
         description_file_path: AppealsApi::Engine.root.join("app/swagger/supplemental_claims/v0/api_description#{DocHelpers.doc_suffix}.md"),
         base_path_template: '/services/appeals/supplemental-claims/{version}',
         name: 'supplemental_claims',
-        tags: [{ name: 'Supplemental Claims', description: '' }]
+        tags: api_tags(:supplemental_claims)
       )
     }
   end
 
   private
+
+  DOC_TITLES = {
+    appealable_issues: 'Appealable Issues',
+    appeals_status: 'Appeals Status',
+    contestable_issues: 'Contestable Issues',
+    decision_reviews: 'Decision Reviews',
+    higher_level_reviews: 'Higher-Level Reviews',
+    legacy_appeals: 'Legacy Appeals',
+    notice_of_disagreements: 'Notice of Disagreements',
+    supplemental_claims: 'Supplemental Claims'
+  }.freeze
 
   DEFAULT_READ_SCOPE_DESCRIPTIONS = {
     'veteran/appeals.read': 'Allows a veteran to see all their own decision review or appeal data',
@@ -164,127 +167,133 @@ class AppealsApi::RswagConfig
     }
   }.freeze
 
-  def security_schemes(api_name = DocHelpers.api_name)
-    if api_name == 'decision_reviews'
-      {
-        apikey: {
-          type: :apiKey,
-          name: :apikey,
-          in: :header
-        }
-      }
-    else
-      api_specific_scopes = OAUTH_SCOPE_DESCRIPTIONS[api_name.to_sym]
-      scope_descriptions = api_specific_scopes.merge(DEFAULT_READ_SCOPE_DESCRIPTIONS)
+  def api_tags(*api_names) = api_names.map { |api_name| { name: DOC_TITLES[api_name.to_sym], description: '' } }
 
-      if api_specific_scopes.keys.any? { |name| name.end_with?('.write') }
-        scope_descriptions.merge!(DEFAULT_WRITE_SCOPE_DESCRIPTIONS)
-      end
-
-      {
-        bearer_token: {
-          type: :http,
-          scheme: :bearer,
-          bearerFormat: :JWT
-        },
-        productionOauth: {
-          type: :oauth2,
-          description: 'This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)',
-          flows: {
-            authorizationCode: {
-              authorizationUrl: 'https://api.va.gov/oauth2/authorization',
-              tokenUrl: 'https://api.va.gov/oauth2/token',
-              scopes: scope_descriptions
-            }
-          }
-        },
-        sandboxOauth: {
-          type: :oauth2,
-          description: 'This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)',
-          flows: {
-            authorizationCode: {
-              authorizationUrl: 'https://sandbox-api.va.gov/oauth2/authorization',
-              tokenUrl: 'https://sandbox-api.va.gov/oauth2/token',
-              scopes: scope_descriptions
-            }
-          }
-        }
+  def decision_reviews_security_schemes
+    {
+      apikey: {
+        type: :apiKey,
+        name: :apikey,
+        in: :header
       }
-    end
+    }
   end
 
-  # rubocop:disable Metrics/AbcSize
-  def schemas(api_name = nil)
-    a = []
+  def oauth_security_schemes(api_name)
+    api_specific_scopes = OAUTH_SCOPE_DESCRIPTIONS[api_name.to_sym]
+    scope_descriptions = api_specific_scopes.merge(DEFAULT_READ_SCOPE_DESCRIPTIONS)
+
+    if api_specific_scopes.keys.any? { |name| name.end_with?('.write') }
+      scope_descriptions.merge!(DEFAULT_WRITE_SCOPE_DESCRIPTIONS)
+    end
+
+    {
+      bearer_token: {
+        type: :http,
+        scheme: :bearer,
+        bearerFormat: :JWT
+      },
+      productionOauth: {
+        type: :oauth2,
+        description: 'This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)',
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://api.va.gov/oauth2/authorization',
+            tokenUrl: 'https://api.va.gov/oauth2/token',
+            scopes: scope_descriptions
+          }
+        }
+      },
+      sandboxOauth: {
+        type: :oauth2,
+        description: 'This API uses OAuth 2 with the authorization code grant flow. [More info](https://developer.va.gov/explore/authorization?api=claims)',
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://sandbox-api.va.gov/oauth2/authorization',
+            tokenUrl: 'https://sandbox-api.va.gov/oauth2/token',
+            scopes: scope_descriptions
+          }
+        }
+      }
+    }
+  end
+
+  def merge_schemas(*schema_parts) = schema_parts.reduce(&:merge).sort_by { |k, _| k.to_s.downcase }.to_h
+
+  def schemas(api_name: nil)
+    nbs_key = api_name == 'decision_reviews' ? 'nonBlankString' : 'non_blank_string'
+
     case api_name
     when 'higher_level_reviews'
-      a << hlr_v2_create_schemas
-      a << hlr_v2_response_schemas('#/components/schemas')
-      a << generic_schemas('#/components/schemas').except(
-        *%i[
-          errorWithTitleAndDetail timeStamp X-Consumer-Username X-Consumer-ID
-        ]
+      merge_schemas(
+        hlr_create_schemas,
+        hlr_response_schemas,
+        generic_schemas.except(*%i[errorWithTitleAndDetail timeStamp X-Consumer-Username X-Consumer-ID documentUploadMetadata]),
+        shared_schemas
       )
-      a << shared_schemas
     when 'notice_of_disagreements'
-      a << nod_v2_create_schemas
-      a << nod_v2_response_schemas('#/components/schemas')
-      a << contestable_issues_schema('#/components/schemas').slice(*%i[contestableIssue])
-      a << generic_schemas('#/components/schemas').except(
-        *%i[
-          errorWithTitleAndDetail timeStamp X-Consumer-ID X-Consumer-Username X-VA-Insurance-Policy-Number
-          X-VA-NonVeteranClaimant-SSN X-VA-SSN
-        ]
+      merge_schemas(
+        nod_create_schemas,
+        nod_response_schemas,
+        contestable_issues_schema.slice(*%i[contestableIssue]),
+        generic_schemas.except(*%i[
+                                 errorWithTitleAndDetail timeStamp X-Consumer-ID X-Consumer-Username X-VA-Insurance-Policy-Number
+                                 X-VA-NonVeteranClaimant-SSN X-VA-SSN
+                               ]),
+        shared_schemas.slice(*%W[address phone timezone #{nbs_key}])
       )
-      a << shared_schemas.slice(*%W[address phone timezone #{nbs_key}])
     when 'supplemental_claims'
-      a << sc_create_schemas
-      a << sc_response_schemas('#/components/schemas')
-      a << sc_alternate_signer_schemas('#/components/schemas')
-      a << contestable_issues_schema('#/components/schemas').slice(*%i[contestableIssue])
-      a << generic_schemas('#/components/schemas').except(
-        *%i[
-          errorWithTitleAndDetail timeStamp uuid X-Consumer-ID X-Consumer-Username X-VA-NonVeteranClaimant-SSN
-          X-VA-NonVeteranClaimant-Birth-Date
-        ]
+      merge_schemas(
+        sc_create_schemas,
+        sc_response_schemas,
+        sc_alt_signer_schemas,
+        contestable_issues_schema.slice(*%i[contestableIssue]),
+        generic_schemas.except(*%i[
+                                 errorWithTitleAndDetail timeStamp uuid X-Consumer-ID X-Consumer-Username X-VA-NonVeteranClaimant-SSN
+                                 X-VA-NonVeteranClaimant-Birth-Date
+                               ]),
+        shared_schemas.slice(*%W[address phone timezone #{nbs_key}])
       )
-      a << shared_schemas.slice(*%W[address phone timezone #{nbs_key}])
     when 'appealable_issues'
-      a << appealable_issues_schema('#/components/schemas')
-      a << generic_schemas('#/components/schemas').slice(*%i[errorModel X-VA-SSN X-VA-File-Number X-VA-ICN])
-      a << shared_schemas.slice(*%W[#{nbs_key}])
+      merge_schemas(
+        appealable_issues_schema,
+        generic_schemas.slice(*%i[errorModel X-VA-SSN X-VA-File-Number X-VA-ICN]),
+        shared_schemas.slice(*%W[#{nbs_key}])
+      )
     when 'legacy_appeals'
-      a << legacy_appeals_schema('#/components/schemas')
-      a << generic_schemas('#/components/schemas').slice(*%i[errorModel X-VA-SSN X-VA-File-Number X-VA-ICN])
-      a << shared_schemas.slice(*%W[#{nbs_key}])
+      merge_schemas(
+        legacy_appeals_schema,
+        generic_schemas.slice(*%i[errorModel X-VA-SSN X-VA-File-Number X-VA-ICN]),
+        shared_schemas.slice(*%W[#{nbs_key}])
+      )
     when 'appeals_status'
-      a << appeals_status_response_schemas
-      a << generic_schemas('#/components/schemas').slice(*%i[errorModel X-VA-SSN])
+      merge_schemas(
+        appeals_status_response_schemas,
+        generic_schemas.slice(*%i[errorModel X-VA-SSN])
+      )
     when 'decision_reviews'
-      a << hlr_v2_create_schemas
-      a << hlr_v2_response_schemas('#/components/schemas')
-      a << nod_v2_create_schemas
-      a << nod_v2_response_schemas('#/components/schemas')
-      a << sc_create_schemas
-      a << sc_response_schemas('#/components/schemas')
-      a << sc_alternate_signer_schemas('#/components/schemas')
-      a << contestable_issues_schema('#/components/schemas')
-      a << legacy_appeals_schema('#/components/schemas')
-      a << generic_schemas('#/components/schemas')
-      tmp = shared_schemas.tap { |h| h['nonBlankString'] = h.delete('non_blank_string') }
-      a << tmp
+      merge_schemas(
+        decision_reviews_hlr_create_schemas,
+        decision_reviews_hlr_response_schemas,
+        decision_reviews_nod_create_schemas,
+        decision_reviews_nod_response_schemas,
+        decision_reviews_sc_create_schemas,
+        decision_reviews_sc_response_schemas,
+        decision_reviews_sc_alt_signer_schemas,
+        contestable_issues_schema,
+        legacy_appeals_schema,
+        generic_schemas(nbs_key:),
+        shared_schemas(nbs_key:)
+      )
     else
       raise "Don't know how to build schemas for '#{api_name}'"
     end
-
-    a.reduce(&:merge).sort_by { |k, _| k.to_s.downcase }.to_h
   end
-  # rubocop:enable Metrics/AbcSize
 
-  def generic_schemas(ref_root)
-    nbs_ref = "#{ref_root}/#{nbs_key}"
+  def generic_schemas(nbs_key: 'non_blank_string')
+    nbs_ref = "#/components/schemas/#{nbs_key}"
 
-    schemas = {
+    {
       'errorModel': JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'support', 'schemas', 'errors', 'default.json'))),
       'errorWithTitleAndDetail': {
         'type': 'array',
@@ -397,17 +406,12 @@ class AppealsApi::RswagConfig
       'timeStamp': {
         'type': 'string',
         'pattern': '\\d{4}(-\\d{2}){2}T\\d{2}(:\\d{2}){2}\\.\\d{3}Z'
-      }
+      },
+      'documentUploadMetadata': JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'support', 'schemas', 'document_upload_metadata.json')))
     }
-
-    return schemas if ENV['API_NAME'].in?(%w[higher_level_reviews])
-
-    # Add in extra schemas for non-HLR api docs
-    schemas['documentUploadMetadata'] = JSON.parse(File.read(AppealsApi::Engine.root.join('spec', 'support', 'schemas', 'document_upload_metadata.json')))
-    schemas
   end
 
-  def appealable_issues_schema(ref_root)
+  def appealable_issues_schema
     {
       'appealableIssues': {
         'type': 'object',
@@ -415,7 +419,7 @@ class AppealsApi::RswagConfig
           'data': {
             'type': 'array',
             'items': {
-              '$ref': "#{ref_root}/appealableIssue"
+              '$ref': '#/components/schemas/appealableIssue'
             }
           }
         }
@@ -429,7 +433,7 @@ class AppealsApi::RswagConfig
     }
   end
 
-  def contestable_issues_schema(ref_root)
+  def contestable_issues_schema
     {
       'contestableIssues': {
         'type': 'object',
@@ -437,7 +441,7 @@ class AppealsApi::RswagConfig
           'data': {
             'type': 'array',
             'items': {
-              '$ref': "#{ref_root}/contestableIssue"
+              '$ref': '#/components/schemas/contestableIssue'
             }
           }
         }
@@ -451,26 +455,26 @@ class AppealsApi::RswagConfig
     }
   end
 
-  def hlr_v2_create_schemas
-    if DocHelpers.decision_reviews?
-      parse_create_schema 'v2', '200996.json'
-    else
-      hlr_schema = parse_create_schema('v2', '200996_with_shared_refs.json', return_raw: true)
-      {
-        hlrCreate: { type: 'object' }.merge!(hlr_schema.slice(*%w[description properties required]))
-      }
-    end
+  def hlr_create_schemas
+    hlr_schema = parse_create_schema('v2', '200996_with_shared_refs.json', return_raw: true)
+    {
+      hlrCreate: { type: 'object' }.merge!(hlr_schema.slice(*%w[description properties required]))
+    }
   end
 
-  def hlr_v2_response_schemas(ref_root)
-    schemas = {
+  def decision_reviews_hlr_create_schemas
+    parse_create_schema 'v2', '200996.json'
+  end
+
+  def hlr_response_schemas
+    {
       'hlrShow': {
         'type': 'object',
         'properties': {
           'data': {
             'properties': {
               'id': {
-                '$ref': "#{ref_root}/uuid"
+                '$ref': '#/components/schemas/uuid'
               },
               'type': {
                 'type': 'string',
@@ -504,10 +508,12 @@ class AppealsApi::RswagConfig
         'required': ['data']
       }
     }
+  end
 
-    # ContestableIssuesShow is not part of the segmented HLR api, so skip it when we're generating segmented docs
-    return schemas unless DocHelpers.decision_reviews?
+  def decision_reviews_hlr_response_schemas
+    schemas = hlr_response_schemas
 
+    # ContestableIssuesShow is not part of the segmented HLR api, so we only add it for Decision Reviews
     schemas['hlrContestableIssuesShow'] = {
       'type': 'object',
       'properties': {
@@ -648,18 +654,18 @@ class AppealsApi::RswagConfig
     schemas
   end
 
-  def nod_v2_create_schemas
-    if DocHelpers.decision_reviews?
-      parse_create_schema 'v2', '10182.json'
-    else
-      nod_schema = parse_create_schema('v2', '10182_with_shared_refs.json', return_raw: true)
-      {
-        nodCreate: { type: 'object' }.merge!(nod_schema.slice(*%w[description properties required]))
-      }
-    end
+  def nod_create_schemas
+    nod_schema = parse_create_schema('v2', '10182_with_shared_refs.json', return_raw: true)
+    {
+      nodCreate: { type: 'object' }.merge!(nod_schema.slice(*%w[description properties required]))
+    }
   end
 
-  def nod_v2_response_schemas(ref_root)
+  def decision_reviews_nod_create_schemas
+    parse_create_schema 'v2', '10182.json'
+  end
+
+  def nod_response_schemas
     {
       'nodCreateResponse': {
         'description': 'Successful response of a 10182 form submission',
@@ -699,14 +705,14 @@ class AppealsApi::RswagConfig
                 }
               },
               'formData': {
-                '$ref': "#{ref_root}/nodCreate"
+                '$ref': '#/components/schemas/nodCreate'
               }
             }
           },
           'included': {
             'type': 'array',
             'items': {
-              '$ref': "#{ref_root}/contestableIssue"
+              '$ref': '#/components/schemas/contestableIssue'
             }
           }
         }
@@ -717,7 +723,7 @@ class AppealsApi::RswagConfig
           'data': {
             'properties': {
               'id': {
-                '$ref': "#{ref_root}/uuid"
+                '$ref': '#/components/schemas/uuid'
               },
               'type': {
                 'type': 'string',
@@ -823,37 +829,36 @@ class AppealsApi::RswagConfig
     }
   end
 
+  def decision_reviews_nod_response_schemas
+    nod_response_schemas
+  end
+
   def sc_create_schemas
-    # TODO: Return full schema after we've enabled potentialPactAct functionality
-    if DocHelpers.decision_reviews?
-      sc_schema = parse_create_schema 'v2', '200995.json'
-      return sc_schema if wip_doc_enabled?(:sc_v2_potential_pact_act)
+    sc_schema = parse_create_schema('v2', '200995_with_shared_refs.json', return_raw: true)
 
-      # Removes 'potentialPactAct' from schema for production docs
+    # Removes 'potentialPactAct' from schema for production docs
+    unless wip_doc_enabled?(:sc_v2_potential_pact_act)
       sc_schema.tap do |s|
-        s.dig(*%w[scCreate properties data properties attributes properties])&.delete('potentialPactAct')
+        s.dig(*%w[properties data properties attributes properties])&.delete('potentialPactAct')
       end
-    else
-      sc_schema = parse_create_schema('v2', '200995_with_shared_refs.json', return_raw: true)
+    end
 
-      # Removes 'potentialPactAct' from schema for production docs
-      unless wip_doc_enabled?(:sc_v2_potential_pact_act)
-        sc_schema.tap do |s|
-          s.dig(*%w[properties data properties attributes properties])&.delete('potentialPactAct')
-        end
-      end
+    {
+      scCreate: { type: 'object' }.merge!(sc_schema.slice(*%w[description properties required]))
+    }
+  end
 
-      {
-        scCreate: { type: 'object' }.merge!(sc_schema.slice(*%w[description properties required]))
-      }
+  def decision_reviews_sc_create_schemas
+    sc_schema = parse_create_schema 'v2', '200995.json'
+    return sc_schema if wip_doc_enabled?(:sc_v2_potential_pact_act)
+
+    # Removes 'potentialPactAct' from schema for production docs
+    sc_schema.tap do |s|
+      s.dig(*%w[scCreate properties data properties attributes properties])&.delete('potentialPactAct')
     end
   end
 
-  def nbs_key
-    DocHelpers.decision_reviews? ? 'nonBlankString' : 'non_blank_string'
-  end
-
-  def sc_response_schemas(ref_root)
+  def decision_reviews_sc_response_schemas
     {
       'scCreateResponse': {
         'description': 'Successful response of a 200995 form submission',
@@ -892,13 +897,13 @@ class AppealsApi::RswagConfig
                   }
                 }
               },
-              'formData': { '$ref': "#{ref_root}/scCreate" }
+              'formData': { '$ref': '#/components/schemas/scCreate' }
             }
           },
           'included': {
             'type': 'array',
             'items': {
-              '$ref': "#{ref_root}/contestableIssue"
+              '$ref': '#/components/schemas/contestableIssue'
             }
           }
         }
@@ -976,7 +981,15 @@ class AppealsApi::RswagConfig
     }
   end
 
-  def sc_alternate_signer_schemas(ref_root)
+  def sc_response_schemas
+    decision_reviews_sc_response_schemas
+  end
+
+  def decision_reviews_sc_alt_signer_schemas
+    sc_alt_signer_schemas(nbs_key: 'nonBlankString')
+  end
+
+  def sc_alt_signer_schemas(nbs_key: 'non_blank_string')
     # Taken from 200995_headers.json
     {
       'X-Alternate-Signer-First-Name': {
@@ -989,18 +1002,18 @@ class AppealsApi::RswagConfig
         'description': 'Alternate signer\'s middle initial',
         'minLength': 1,
         'maxLength': 1,
-        '$ref': "#{ref_root}/#{nbs_key}"
+        '$ref': "#/components/schemas/#{nbs_key}"
       },
       'X-Alternate-Signer-Last-Name': {
         'description': 'Alternate signer\'s last name',
         'minLength': 1,
         'maxLength': 40,
-        '$ref': "#{ref_root}/#{nbs_key}"
+        '$ref': "#/components/schemas/#{nbs_key}"
       }
     }
   end
 
-  def legacy_appeals_schema(ref_root)
+  def legacy_appeals_schema
     {
       'legacyAppeals': {
         'type': 'object',
@@ -1008,7 +1021,7 @@ class AppealsApi::RswagConfig
           'data': {
             'type': 'array',
             'items': {
-              '$ref': "#{ref_root}/legacyAppeal"
+              '$ref': '#/components/schemas/legacyAppeal'
             }
           }
         }
@@ -1137,11 +1150,11 @@ class AppealsApi::RswagConfig
     }
   end
 
-  def shared_schemas
+  def shared_schemas(nbs_key: 'non_blank_string')
     # Keys are strings to override older, non-shared-schema definitions
     {
       'address' => JSON.parse(File.read(AppealsApi::Engine.root.join('config', 'schemas', 'shared', 'v1', 'address.json')))['properties']['address'],
-      'non_blank_string' => JSON.parse(File.read(AppealsApi::Engine.root.join('config', 'schemas', 'shared', 'v1', 'non_blank_string.json')))['properties']['nonBlankString'],
+      nbs_key => JSON.parse(File.read(AppealsApi::Engine.root.join('config', 'schemas', 'shared', 'v1', 'non_blank_string.json')))['properties']['nonBlankString'],
       'phone' => JSON.parse(File.read(AppealsApi::Engine.root.join('config', 'schemas', 'shared', 'v1', 'phone.json')))['properties']['phone'],
       'timezone' => JSON.parse(File.read(AppealsApi::Engine.root.join('config', 'schemas', 'shared', 'v1', 'timezone.json')))['properties']['timezone']
     }
@@ -1163,4 +1176,4 @@ class AppealsApi::RswagConfig
     return_raw ? schema : schema['definitions']
   end
 end
-# rubocop:enable Metrics/MethodLength, Layout/LineLength, Metrics/ClassLength, Metrics/ParameterLists
+# rubocop:enable Metrics/MethodLength, Layout/LineLength, Metrics/ClassLength

--- a/rakelib/rswag.rake
+++ b/rakelib/rswag.rake
@@ -2,58 +2,26 @@
 
 require 'fileutils'
 
-# Docs for APIs in this list have been split out from the decision reviews docs specs and into their own files
-# FIXME: remove this constant once all the segmented APIs have their own dedicated files
-INDEPENDENT_SEGMENTED_API_NAMES = %w[contestable_issues legacy_appeals notice_of_disagreements].freeze
-
 APPEALS_API_DOCS_DIR = 'modules/appeals_api/spec/docs'
-SEGMENTED_DECISION_REVIEWS_API_NAMES = Dir["#{APPEALS_API_DOCS_DIR}/decision_reviews/*.rb"]
-                                       .map { |file_name| File.basename(file_name, '_spec.rb') }
-                                       .reject { |api_name| INDEPENDENT_SEGMENTED_API_NAMES.include? api_name }
+
 APPEALS_API_DOCS = [
-  {
-    name: 'appealable_issues',
-    version: 'v0',
-    pattern: "#{APPEALS_API_DOCS_DIR}/appealable_issues/v0_spec.rb"
-  },
-  {
-    name: 'appeals_status',
-    version: 'v1',
-    pattern: "#{APPEALS_API_DOCS_DIR}/appeals_status/v1_spec.rb"
-  },
-  {
-    name: 'decision_reviews',
-    version: 'v2',
-    pattern: "#{APPEALS_API_DOCS_DIR}/decision_reviews"
-  },
-  {
-    name: 'higher_level_reviews',
-    version: 'v0',
-    pattern: "#{APPEALS_API_DOCS_DIR}/higher_level_reviews/v0_spec.rb"
-  },
-  {
-    name: 'legacy_appeals',
-    version: 'v0',
-    pattern: "#{APPEALS_API_DOCS_DIR}/legacy_appeals/v0_spec.rb"
-  },
-  {
-    name: 'notice_of_disagreements',
-    version: 'v0',
-    pattern: "#{APPEALS_API_DOCS_DIR}/notice_of_disagreements/v0_spec.rb"
-  }, {
-    name: 'supplemental_claims',
-    version: 'v0',
-    pattern: "#{APPEALS_API_DOCS_DIR}/supplemental_claims/v0_spec.rb"
-  }
-] + SEGMENTED_DECISION_REVIEWS_API_NAMES.map do |api_name|
-  {
-    name: api_name,
-    version: 'v0',
-    pattern: "#{APPEALS_API_DOCS_DIR}/decision_reviews/#{api_name}_spec.rb"
-  }
-end.freeze
+  { name: 'appealable_issues', version: 'v0' },
+  { name: 'appeals_status', version: 'v1' },
+  { name: 'decision_reviews', version: 'v2' },
+  { name: 'higher_level_reviews', version: 'v0' },
+  { name: 'legacy_appeals', version: 'v0' },
+  { name: 'notice_of_disagreements', version: 'v0' },
+  { name: 'supplemental_claims', version: 'v0' }
+].freeze
 
 APPEALS_API_NAMES = APPEALS_API_DOCS.pluck(:name).freeze
+
+def appeals_api_output_files(dev: false)
+  suffix = dev ? '_dev' : ''
+  APPEALS_API_DOCS.map do |config|
+    "modules/appeals_api/app/swagger/#{config[:name]}/#{config[:version]}/swagger#{suffix}.json"
+  end
+end
 
 def run_tasks_in_parallel(task_names)
   Parallel.each(task_names) { |task_name| Rake::Task[task_name].invoke }
@@ -90,34 +58,43 @@ namespace :rswag do
   end
 
   namespace :appeals_api do
-    APPEALS_API_DOCS.each do |config|
-      namespace abbreviate_snake_case_name(config[:name]).to_sym do
-        desc "Generate all docs for the #{config[:name]} appeals API"
-        task all: :environment do
-          run_tasks_in_parallel(%w[dev prod].map do |env|
-            "rswag:appeals_api:#{abbreviate_snake_case_name(config[:name])}:#{env}"
-          end)
-        end
-
-        desc "Generate production docs for the #{config[:name]} appeals API"
-        task prod: :environment do
-          generate_appeals_doc(config[:pattern], config[:name], config[:version])
-        end
-
-        desc "Generate development docs for the #{config[:name]} appeals API"
-        task dev: :environment do
-          generate_appeals_doc(config[:pattern], config[:name], config[:version], dev: true)
-        end
-      end
+    desc 'Generate production docs for all appeals APIs'
+    task prod: :environment do
+      generate_appeals_docs
     end
 
-    desc 'Generate rswag docs for all appeals APIs'
+    desc 'Generate development docs for all appeals APIs'
+    task dev: :environment do
+      generate_appeals_docs(dev: true)
+    end
+
+    desc 'Generate all docs for all appeals APIs'
     task all: :environment do
-      run_tasks_in_parallel(APPEALS_API_NAMES.map do |api_name|
-        "rswag:appeals_api:#{abbreviate_snake_case_name(api_name)}:all"
-      end)
+      run_tasks_in_parallel(%w[rswag:appeals_api:prod rswag:appeals_api:dev])
     end
   end
+end
+
+def generate_appeals_docs(dev: false)
+  ENV['RAILS_MODULE'] = 'appeals_api'
+  ENV['SWAGGER_DRY_RUN'] = '0'
+  ENV['PATTERN'] = 'modules/appeals_api/spec/docs'
+
+  if dev
+    ENV['RSWAG_ENV'] = 'dev'
+    ENV['WIP_DOCS_ENABLED'] = Settings.modules_appeals_api.documentation.wip_docs&.join(',') || ''
+  end
+
+  begin
+    Rake::Task['rswag:specs:swaggerize'].invoke
+  rescue => e
+    warn "Rswag doc generation for #{api_name} #{api_version} #{dev ? '(dev) ' : ''}failed:"
+    puts e.full_message(highlight: true, order: :top)
+    exit 1
+  end
+
+  # Correct formatting on rswag output so that it matches the expected OAS format
+  appeals_api_output_files(dev:).each { |file_path| rswag_to_oas!(file_path) }
 end
 
 def strip_swagger_base_path(version, env = nil)
@@ -148,29 +125,4 @@ def rswag_to_oas!(filepath)
   end
 
   FileUtils.mv(temp_path, filepath)
-end
-
-def generate_appeals_doc(spec_files_pattern, api_name, api_version, dev: false)
-  ENV['RAILS_MODULE'] = 'appeals_api'
-  ENV['SWAGGER_DRY_RUN'] = '0'
-  ENV['PATTERN'] = spec_files_pattern
-  ENV['API_NAME'] = api_name
-  ENV['API_VERSION'] = api_version
-
-  if dev
-    ENV['RSWAG_ENV'] = 'dev'
-    ENV['WIP_DOCS_ENABLED'] = Settings.modules_appeals_api.documentation.wip_docs&.join(',') || ''
-  end
-
-  begin
-    Rake::Task['rswag:specs:swaggerize'].invoke
-  rescue => e
-    warn "Rswag doc generation for #{api_name} #{api_version} #{dev ? '(dev) ' : ''}failed:"
-    puts e.full_message(highlight: true, order: :top)
-    exit 1
-  end
-
-  suffix = dev ? '_dev' : ''
-  # Correct formatting on rswag output so that it matches the expected OAS format
-  rswag_to_oas!("modules/appeals_api/app/swagger/#{api_name}/#{api_version}/swagger#{suffix}.json")
 end


### PR DESCRIPTION
## Summary

Finishes the process of splitting out rswag docs specs for the various segmented appeals APIs into their own files. Also updates the rswag rake tasks for appeals to match.

## Related issue(s)
- [API-25891](https://vajira.max.gov/browse/API-25891)

## Testing done

- Ran the newly refactored rake tasks to regenerate everything

## What areas of the site does it impact?
- Docs generation process (docs themselves have not changed)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

