### PR TITLE
Additional testing for branch protection settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,5 +1,5 @@
 # These settings are synced to GitHub by https://probot.github.io/apps/settings/
-# test
+
 branches:
   - name: master
     # https://docs.github.com/en/rest/reference/repos#update-branch-protection


### PR DESCRIPTION
Simple removing of commented code to test if branch protection settings updates the UI. 
In the UI, `danger/danger` is not enabled. In `settings.yml` it is. Ideally, the `settings.yml` file should take precedent and override the UI settings by reenabling `danger/danger`.

Fulfills https://app.zenhub.com/workspaces/platform-cop-backlog-6359535e384ff5a473132130/issues/gh/department-of-veterans-affairs/va.gov-team/56437

Screenshot:
<img width="913" alt="image" src="https://github.com/department-of-veterans-affairs/vets-api/assets/72466113/384a4c0b-3229-4faf-b857-6104122d1063">
