### PR TITLE
API-26710-pdf-mapping-country-code

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -65,6 +65,10 @@ module ClaimsApi
         @pdf_data[:data][:attributes][:changeOfAddress] =
           @auto_claim&.dig('changeOfAddress')&.deep_symbolize_keys
 
+        country = @pdf_data[:data][:attributes][:changeOfAddress][:country]
+        abbr_country = country == 'USA' ? 'US' : country
+        @pdf_data[:data][:attributes][:changeOfAddress][:country] = abbr_country
+
         chg_addr_zip
 
         @pdf_data
@@ -90,6 +94,11 @@ module ClaimsApi
         @pdf_data[:data][:attributes].merge!(
           identificationInformation: @auto_claim&.dig('veteranIdentification')&.deep_symbolize_keys
         )
+
+        country = @pdf_data[:data][:attributes][:identificationInformation][:mailingAddress][:country]
+        abbr_country = country == 'USA' ? 'US' : country
+        @pdf_data[:data][:attributes][:identificationInformation][:mailingAddress][:country] = abbr_country
+
         zip
 
         @pdf_data

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
@@ -77,7 +77,7 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
         expect(number_and_street).to eq('1234 Couch Street')
         expect(apartment_or_unit_number).to eq('22')
         expect(city).to eq('Portland')
-        expect(country).to eq('USA')
+        expect(country).to eq('US')
         expect(zip).to eq('417261234')
         expect(state).to eq('OR')
       end
@@ -127,7 +127,7 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
         expect(number_and_street).to eq('10 Peach St')
         expect(apartment_or_unit_number).to eq('Apt 1')
         expect(city).to eq('Atlanta')
-        expect(country).to eq('USA')
+        expect(country).to eq('US')
         expect(zip).to eq('422209897')
         expect(state).to eq('GA')
       end


### PR DESCRIPTION
## Summary

Discovery: BRD returns "USA" in the countries list for the US. With that being said, the gem lists it as "United States of America" so it would never locate the United States and be able to provide an alpha2 value. We also see 36 of the 213 retrieved countries fail during lookup using the gem, so it seems that trying to utilize the gem for this scenario is unfortunately not an effective approach.
"Solution": Hardcode the translation for US to be from "USA" to "US" and provide that. If not, send the entire string provided in the request (as long as it aligns with a valid country from BRD).
Reasoning: If the PDF service detects a 2 char code, it will apply it to the Country Code, if it senses anything more, it will apply the entirety of the name to the overflow page.

## Related issue(s)
- [API-26710](https://vajira.max.gov/browse/API-26710)


## Testing done

- rspec
- Postman

## What areas of the site does it impact?
	modified:   modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
	modified:   modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature