### PR TITLE
Task 526ez logging

### DIFF
--- a/app/models/concerns/form526_rapid_ready_for_decision_concern.rb
+++ b/app/models/concerns/form526_rapid_ready_for_decision_concern.rb
@@ -129,7 +129,8 @@ module Form526RapidReadyForDecisionConcern
   def send_post_evss_notifications!
     conditionally_notify_mas
     Rails.logger.info(
-      'Completed 526 submission to eVSS', id: id, saved_claim_id: saved_claim_id, submitted_claim_id: submitted_claim_id
+      "Completed 526 submission to eVSS id: #{id}" \
+      "saved_claim_id: #{saved_claim_id}, submitted_claim_id: #{submitted_claim_id}"
     )
   end
 

--- a/app/models/concerns/form526_rapid_ready_for_decision_concern.rb
+++ b/app/models/concerns/form526_rapid_ready_for_decision_concern.rb
@@ -128,6 +128,12 @@ module Form526RapidReadyForDecisionConcern
 
   def send_post_evss_notifications!
     conditionally_notify_mas
+    Rails.logger.info(
+      'Completed 526 submission to eVSS', id: id, saved_claim_id: saved_claim_id, submitted_claim_id: submitted_claim_id
+    )
+    Rails.logger.debug(
+      'Completed 526 submission to eVSS', id: id, saved_claim_id: saved_claim_id, submitted_claim_id: submitted_claim_id
+    )
   end
 
   # return whether all disabilities on this form are rated as not service-connected

--- a/app/models/concerns/form526_rapid_ready_for_decision_concern.rb
+++ b/app/models/concerns/form526_rapid_ready_for_decision_concern.rb
@@ -131,9 +131,6 @@ module Form526RapidReadyForDecisionConcern
     Rails.logger.info(
       'Completed 526 submission to eVSS', id: id, saved_claim_id: saved_claim_id, submitted_claim_id: submitted_claim_id
     )
-    Rails.logger.debug(
-      'Completed 526 submission to eVSS', id: id, saved_claim_id: saved_claim_id, submitted_claim_id: submitted_claim_id
-    )
   end
 
   # return whether all disabilities on this form are rated as not service-connected


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- Adds logging of Form526Submissions's id and vbms id.
- This serves as a place for contention classification engineers to look back on to measure coverage.
-

## Related issue(s)
- https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/93
- https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/149


## Testing done

- I have swapped the `Rails.logger.info` statement w/ `puts` locally
- `bundle exec rspec /Users/verdanceluke/kyle_example/vets-api/spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb:73`

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
526ez submission backend sidekiq job

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - n/a, logging to measure product in the future
- [x]  No error nor warning in the console.
  - n/a, specifically adding logging 
- [ ]  Events are being sent to the appropriate logging solution
  - ???
- [ ]  Documentation has been updated (link to documentation)
  - ???
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
