### PR TITLE
Forms api: set tag with form_id on active traces

### DIFF
--- a/modules/forms_api/app/controllers/forms_api/v1/uploads_controller.rb
+++ b/modules/forms_api/app/controllers/forms_api/v1/uploads_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'ddtrace'
 require 'forms_api_submission/service'
 
 module FormsApi
@@ -16,6 +17,8 @@ module FormsApi
       }.freeze
 
       def submit
+        Datadog::Tracing.active_span&.set_tag('form_id', params[:form_number])
+
         form_id = FORM_NUMBER_MAP[params[:form_number]]
         filler = FormsApi::PdfFiller.new(form_number: form_id, data: JSON.parse(params.to_json))
 


### PR DESCRIPTION
Note: `form_id` is a parameter defined in the vets-website code. The user cannot change it and thus cannot contain PII, PHI, or anything compromising.


## Summary

- Add identifying tag to active trace

## Related issue(s)
- https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/263


## Testing done

- Need to test in deployed env

## What areas of the site does it impact?
Forms submitted via forms_api (currently none in prod)
