### PR TITLE
53021 inject user data in fsr jobs

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -64,6 +64,14 @@ class Account < ApplicationRecord
     Account.where(icn: user_account.icn).first
   end
 
+  def mpi_profile
+    resp = MPI::Service.new.find_profile_by_identifier(
+      identifier: icn,
+      identifier_type: MPI::Constants::ICN
+    )
+    resp&.profile
+  end
+
   private
 
   def initialize_uuid

--- a/app/models/form5655_submission.rb
+++ b/app/models/form5655_submission.rb
@@ -10,11 +10,11 @@ class Form5655Submission < ApplicationRecord
     @form_hash ||= JSON.parse(form_json)
   end
 
-  def submit_to_vba(user_params={})
+  def submit_to_vba(user_params = {})
     Form5655::VBASubmissionJob.perform_async(id, user_params)
   end
 
-  def submit_to_vha(user_params={})
+  def submit_to_vha(user_params = {})
     Form5655::VHASubmissionJob.perform_async(id, user_params)
   end
 end

--- a/app/models/form5655_submission.rb
+++ b/app/models/form5655_submission.rb
@@ -10,11 +10,11 @@ class Form5655Submission < ApplicationRecord
     @form_hash ||= JSON.parse(form_json)
   end
 
-  def submit_to_vba
-    Form5655::VBASubmissionJob.perform_async(id, user_uuid)
+  def submit_to_vba(user_params={})
+    Form5655::VBASubmissionJob.perform_async(id, user_params)
   end
 
-  def submit_to_vha
-    Form5655::VHASubmissionJob.perform_async(id, user_uuid)
+  def submit_to_vha(user_params={})
+    Form5655::VHASubmissionJob.perform_async(id, user_params)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -423,11 +423,11 @@ class User < Common::RedisStore
 
   def identity_serial
     {
-      "uuid" => uuid,
-      "first_name" => first_name,
-      "last_name" => last_name,
-      "email" => email,
-      "ssn" => ssn
+      'uuid' => uuid,
+      'first_name' => first_name,
+      'last_name' => last_name,
+      'email' => email,
+      'ssn' => ssn
     }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -421,6 +421,16 @@ class User < Common::RedisStore
     @relationships ||= get_relationships_array
   end
 
+  def identity_serial
+    {
+      "uuid" => uuid,
+      "first_name" => first_name,
+      "last_name" => last_name,
+      "email" => email,
+      "ssn" => ssn
+    }
+  end
+
   private
 
   def mpi_profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -427,7 +427,7 @@ class User < Common::RedisStore
       'first_name' => first_name,
       'last_name' => last_name,
       'email' => email,
-      'ssn' => ssn
+      'account_id' => account.id
     }
   end
 

--- a/app/workers/form5655/vba_submission_job.rb
+++ b/app/workers/form5655/vba_submission_job.rb
@@ -8,10 +8,9 @@ module Form5655
 
     sidekiq_options retry: false
 
-    def perform(submission_id, user_uuid)
+    def perform(submission_id, user_params)
       submission = Form5655Submission.find(submission_id)
-      user = User.find(user_uuid)
-      DebtManagementCenter::FinancialStatusReportService.new(user).submit_vba_fsr(submission.form)
+      DebtManagementCenter::FinancialStatusReportService.new(nil).submit_vba_fsr(submission.form, user_params)
     end
   end
 end

--- a/app/workers/form5655/vba_submission_job.rb
+++ b/app/workers/form5655/vba_submission_job.rb
@@ -10,7 +10,8 @@ module Form5655
 
     def perform(submission_id, user_params)
       submission = Form5655Submission.find(submission_id)
-      DebtManagementCenter::FinancialStatusReportService.new(nil).submit_vba_fsr(submission.form, user_params)
+      user = User.find(user_params['uuid'])
+      DebtManagementCenter::FinancialStatusReportService.new(user).submit_vba_fsr(submission.form, user_params)
     end
   end
 end

--- a/app/workers/form5655/vha_submission_job.rb
+++ b/app/workers/form5655/vha_submission_job.rb
@@ -8,10 +8,9 @@ module Form5655
 
     sidekiq_options retry: false
 
-    def perform(submission_id, user_uuid)
+    def perform(submission_id, user_params)
       submission = Form5655Submission.find(submission_id)
-      user = User.find(user_uuid)
-      DebtManagementCenter::FinancialStatusReportService.new(user).submit_vha_fsr(submission)
+      DebtManagementCenter::FinancialStatusReportService.new(nil).submit_vha_fsr(submission, user_params)
     end
   end
 end

--- a/app/workers/form5655/vha_submission_job.rb
+++ b/app/workers/form5655/vha_submission_job.rb
@@ -10,7 +10,8 @@ module Form5655
 
     def perform(submission_id, user_params)
       submission = Form5655Submission.find(submission_id)
-      DebtManagementCenter::FinancialStatusReportService.new(nil).submit_vha_fsr(submission, user_params)
+      user = User.find(user_params['uuid'])
+      DebtManagementCenter::FinancialStatusReportService.new(user).submit_vha_fsr(submission, user_params)
     end
   end
 end

--- a/lib/debt_management_center/financial_status_report_service.rb
+++ b/lib/debt_management_center/financial_status_report_service.rb
@@ -195,7 +195,7 @@ module DebtManagementCenter
     end
 
     def update_filenet_id(response, user_params = {})
-      user_uuid = user_params['uuid'] || @user&.uuid
+      user_uuid = @user&.uuid || user_params['uuid']
       fsr_params = { REDIS_CONFIG[:financial_status_report][:namespace] => user_uuid }
       fsr = DebtManagementCenter::FinancialStatusReport.new(fsr_params)
       fsr.update(filenet_id: response.filenet_id, uuid: user_uuid)
@@ -259,7 +259,7 @@ module DebtManagementCenter
     def send_confirmation_email(template_id, user_params = {})
       return unless Flipper.enabled?(:fsr_confirmation_email)
 
-      email = user_params['email'] || @user&.email&.downcase
+      email = @user&.email&.downcase || user_params['email']
       return if email.blank?
 
       DebtManagementCenter::VANotifyEmailJob.perform_async(email, template_id, email_personalization_info(user_params))
@@ -270,7 +270,7 @@ module DebtManagementCenter
     end
 
     def email_personalization_info(user_params = {})
-      name = user_params['first_name'] || @user&.first_name
+      name = @user&.first_name || user_params['first_name']
       { 'name' => name, 'time' => '48 hours', 'date' => Time.zone.now.strftime('%m/%d/%Y') }
     end
 

--- a/lib/debt_management_center/sharepoint/request.rb
+++ b/lib/debt_management_center/sharepoint/request.rb
@@ -120,7 +120,8 @@ module DebtManagementCenter
         user = User.find(form_submission.user_uuid)
         first_name = user_params['first_name'] || user&.first_name
         last_name = user_params['last_name'] || user&.last_name
-        ssn = user_params['ssn'] || user&.ssn
+        user_account = Account.find(user_params['account_id'])
+        ssn = user&.ssn || user_account&.mpi_profile&.ssn
         with_monitoring do
           sharepoint_connection.post(path) do |req|
             req.headers['Content-Type'] = 'application/json;odata=verbose'

--- a/lib/debt_management_center/sharepoint/request.rb
+++ b/lib/debt_management_center/sharepoint/request.rb
@@ -30,7 +30,7 @@ module DebtManagementCenter
       #
       # @return [Faraday::Response] - Response from SharePoint upload
       #
-      def upload(form_contents:, form_submission:, station_id:, user_params:{})
+      def upload(form_contents:, form_submission:, station_id:, user_params: {})
         upload_response = upload_pdf(form_contents:, form_submission:,
                                      station_id:)
 
@@ -115,21 +115,19 @@ module DebtManagementCenter
       #
       # @return [Faraday::Response]
       #
-      def update_list_item_fields(list_item_id:, form_submission:, station_id:, user_params:{})
+      def update_list_item_fields(list_item_id:, form_submission:, station_id:, user_params: {})
         path = "#{base_path}/_api/Web/Lists/GetByTitle('Submissions')/items(#{list_item_id})"
         user = User.find(form_submission.user_uuid)
-        first_name = user_params["first_name"] || user&.first_name
-        last_name = user_params["last_name"] || user&.last_name
-        ssn = user_params["ssn"] || user&.ssn
+        first_name = user_params['first_name'] || user&.first_name
+        last_name = user_params['last_name'] || user&.last_name
+        ssn = user_params['ssn'] || user&.ssn
         with_monitoring do
           sharepoint_connection.post(path) do |req|
             req.headers['Content-Type'] = 'application/json;odata=verbose'
             req.headers['X-HTTP-METHOD'] = 'MERGE'
             req.headers['If-Match'] = '*'
             req.body = {
-              '__metadata' => {
-                'type' => 'SP.Data.SubmissionsItem'
-              },
+              '__metadata' => { 'type' => 'SP.Data.SubmissionsItem' },
               'StationId' => station_id,
               'UID' => form_submission.id,
               'SSN' => ssn,

--- a/lib/debt_management_center/sharepoint/request.rb
+++ b/lib/debt_management_center/sharepoint/request.rb
@@ -120,7 +120,7 @@ module DebtManagementCenter
         user = User.find(form_submission.user_uuid)
         first_name = user_params['first_name'] || user&.first_name
         last_name = user_params['last_name'] || user&.last_name
-        user_account = Account.find(user_params['account_id'])
+        user_account = Account.find_by_id(user_params['account_id'])
         ssn = user&.ssn || user_account&.mpi_profile&.ssn
         with_monitoring do
           sharepoint_connection.post(path) do |req|

--- a/lib/debt_management_center/sharepoint/request.rb
+++ b/lib/debt_management_center/sharepoint/request.rb
@@ -30,13 +30,13 @@ module DebtManagementCenter
       #
       # @return [Faraday::Response] - Response from SharePoint upload
       #
-      def upload(form_contents:, form_submission:, station_id:)
+      def upload(form_contents:, form_submission:, station_id:, user_params:{})
         upload_response = upload_pdf(form_contents:, form_submission:,
                                      station_id:)
 
         list_item_id = get_pdf_list_item_id(upload_response)
 
-        update_list_item_fields(list_item_id:, form_submission:, station_id:)
+        update_list_item_fields(list_item_id:, form_submission:, station_id:, user_params:)
       end
 
       private
@@ -115,9 +115,12 @@ module DebtManagementCenter
       #
       # @return [Faraday::Response]
       #
-      def update_list_item_fields(list_item_id:, form_submission:, station_id:)
+      def update_list_item_fields(list_item_id:, form_submission:, station_id:, user_params:{})
         path = "#{base_path}/_api/Web/Lists/GetByTitle('Submissions')/items(#{list_item_id})"
         user = User.find(form_submission.user_uuid)
+        first_name = user_params["first_name"] || user&.first_name
+        last_name = user_params["last_name"] || user&.last_name
+        ssn = user_params["ssn"] || user&.ssn
         with_monitoring do
           sharepoint_connection.post(path) do |req|
             req.headers['Content-Type'] = 'application/json;odata=verbose'
@@ -129,8 +132,8 @@ module DebtManagementCenter
               },
               'StationId' => station_id,
               'UID' => form_submission.id,
-              'SSN' => user.ssn,
-              'Name1' => "#{user.last_name}, #{user.first_name}"
+              'SSN' => ssn,
+              'Name1' => "#{last_name}, #{first_name}"
             }.to_json
           end
         end

--- a/spec/lib/debt_management_center/sharepoint/request_spec.rb
+++ b/spec/lib/debt_management_center/sharepoint/request_spec.rb
@@ -102,7 +102,11 @@ RSpec.describe DebtManagementCenter::Sharepoint::Request do
         client_stub = mock_faraday
         expect(client_stub).to receive(:post).twice
         expect(client_stub).to receive(:get).once
-        user_params = { 'first_name' => 'x', 'last_name' => 'y', 'ssn' => 'z' }
+        user_params = { 'uuid' => 'b2fab2b5-6af0-45e1-a9e2-394347af91ef',
+                        'first_name' => 'abraham',
+                        'last_name' => 'lincoln',
+                        'email' => 'abraham.lincoln@vets.gov',
+                        'account_id' => 147 }
         subject.upload(form_contents: form_content, form_submission:, station_id:, user_params:)
       end
     end

--- a/spec/lib/debt_management_center/sharepoint/request_spec.rb
+++ b/spec/lib/debt_management_center/sharepoint/request_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'debt_management_center/sharepoint/request'
+require 'pdf_fill/filler'
 
 RSpec.describe DebtManagementCenter::Sharepoint::Request do
   subject { described_class.new }
@@ -94,6 +95,19 @@ RSpec.describe DebtManagementCenter::Sharepoint::Request do
       expect(client_stub).to receive(:get).once
 
       subject.upload(form_contents: form_content, form_submission:, station_id:)
+    end
+
+    context 'with explicit user data' do
+      it 'uploads a pdf file to SharePoint' do
+        client_stub = mock_faraday
+        # expect(client_stub).to receive(:post).with("/base/_api/Web/GetFolderByServerRelativeUrl('/base/Submissions')/Files/add(url='20230530T134853_1863_lincoln.pdf',overwrite=true)").once
+        # expect(client_stub).to receive(:post).with("/base/_api/Web/Lists/GetByTitle('Submissions')/items(1)").once
+        expect(client_stub).to receive(:post).twice
+        expect(client_stub).to receive(:get).once
+        user_params = {"first_name"=>"x", "last_name"=>"y", "ssn"=>"z"}
+        subject.upload(form_contents: form_content, form_submission:, station_id:, user_params:)
+
+      end
     end
   end
 end

--- a/spec/lib/debt_management_center/sharepoint/request_spec.rb
+++ b/spec/lib/debt_management_center/sharepoint/request_spec.rb
@@ -100,13 +100,10 @@ RSpec.describe DebtManagementCenter::Sharepoint::Request do
     context 'with explicit user data' do
       it 'uploads a pdf file to SharePoint' do
         client_stub = mock_faraday
-        # expect(client_stub).to receive(:post).with("/base/_api/Web/GetFolderByServerRelativeUrl('/base/Submissions')/Files/add(url='20230530T134853_1863_lincoln.pdf',overwrite=true)").once
-        # expect(client_stub).to receive(:post).with("/base/_api/Web/Lists/GetByTitle('Submissions')/items(1)").once
         expect(client_stub).to receive(:post).twice
         expect(client_stub).to receive(:get).once
-        user_params = {"first_name"=>"x", "last_name"=>"y", "ssn"=>"z"}
+        user_params = { 'first_name' => 'x', 'last_name' => 'y', 'ssn' => 'z' }
         subject.upload(form_contents: form_content, form_submission:, station_id:, user_params:)
-
       end
     end
   end


### PR DESCRIPTION
## Summary

The FSR service takes a user as an input. This can become an issue when long running jobs try to trigger the service because the user object may become stale before the job can run. This team does not control the ttl of the user model and so we've opted to pass the necessary user data into the job as parameters rather than hoping that the user uuid we pass in is still valid.

## Testing done

Existing specs are green and additional specs have been written to confirm that the added parameters are being utilized.

## What areas of the site does it impact?
- The financial status report

## Acceptance criteria

- [ ]  Effected unit test pass
- [ ]  No error nor warning in the console.
- [ ]  The FSR service can submit vbs and vhs FSRs with or without the additional user parameters
