### PR TITLE
Update Debian to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
+ARG RELEASE=bullseye
+FROM ruby:3.2.2-slim-${RELEASE} AS RUBYIMG
+
 # XXX: using stretch here for pdftk dep, which is not availible after
 #      stretch (or in alpine) and is switched automatically to pdftk-java in buster
 #      https://github.com/department-of-veterans-affairs/va.gov-team/issues/3032
 
-ARG DEBIAN_VERSION=bullseye
-
-FROM ruby:3.2.2-slim-$DEBIAN_VERSION AS modules
+FROM RUBYIMG AS modules
 
 WORKDIR /tmp
 
@@ -16,18 +17,20 @@ RUN find modules -type f ! \( -name Gemfile -o -name "*.gemspec" -o -path "*/lib
 ###
 # shared build/settings for all child images, reuse these layers yo
 ###
-FROM ruby:3.2.2-slim-$DEBIAN_VERSION AS base
+FROM RUBYIMG AS base
+ARG RELEASE
+ENV RELEASE="$RELEASE"
 
 ARG userid=993
 SHELL ["/bin/bash", "-c"]
 RUN groupadd -g $userid -r vets-api && \
     useradd -u $userid -r -m -d /srv/vets-api -g vets-api vets-api
-RUN echo 'APT::Default-Release "$DEBIAN_VERSION";' >> /etc/apt/apt.conf.d/99defaultrelease
-RUN mv /etc/apt/sources.list /etc/apt/sources.list.d/$DEBIAN_VERSION.list
+RUN echo 'APT::Default-Release \"${RELEASE}\";' >> /etc/apt/apt.conf.d/99defaultrelease
+RUN mv /etc/apt/sources.list /etc/apt/sources.list.d/stable.list
 RUN echo "deb http://ftp.debian.org/debian testing main contrib non-free" >> /etc/apt/sources.list.d/testing.list
 RUN echo "deb http://deb.debian.org/debian unstable main" >> /etc/apt/sources.list.d/unstable.list
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -t $DEBIAN_VERSION \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -t ${RELEASE} \
     dumb-init imagemagick pdftk poppler-utils curl libpq5 vim libboost-all-dev
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -t unstable \
     clamav clamdscan clamav-daemon


### PR DESCRIPTION
## Summary

All Jenkins builds and CI runs for vets-api are failing with the error:
```
The value ''stable'' is invalid for APT::Default-Release as such a release is not available in the sources
```
Since vets-api has moved to EKS, Jenkins isn't super important anymore, but it should still be fixed. 

See investigation here: https://dsva.slack.com/archives/C37M86Y8G/p1686576102937789

- Debian 12 "bookworm" has been released: https://bits.debian.org/2023/06/bookworm-released.html

## Testing done

- none


## What areas of the site does it impact?
CI runs for vets-api PRs and Jenkins builds of vets-api

