### PR TITLE
Require specific paths in appeals factories

### DIFF
--- a/modules/appeals_api/spec/factories/higher_level_reviews.rb
+++ b/modules/appeals_api/spec/factories/higher_level_reviews.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
+require AppealsApi::Engine.root.join('spec', 'support', 'fixture_helpers.rb')
 
 FactoryBot.define do
   # Decision Reviews API v1 HLRs

--- a/modules/appeals_api/spec/factories/notice_of_disagreements.rb
+++ b/modules/appeals_api/spec/factories/notice_of_disagreements.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
+require AppealsApi::Engine.root.join('spec', 'support', 'fixture_helpers.rb')
 
 FactoryBot.define do
   # Decision Reviews API v1 NODs

--- a/modules/appeals_api/spec/factories/supplemental_claims.rb
+++ b/modules/appeals_api/spec/factories/supplemental_claims.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require AppealsApi::Engine.root.join('spec', 'spec_helper.rb')
+require AppealsApi::Engine.root.join('spec', 'support', 'fixture_helpers.rb')
 
 FactoryBot.define do
   # Decision Reviews API v2 SCs


### PR DESCRIPTION


## Summary

I didn't realize that including spec_helper in these factories would put the app into test mode while it should be running in dev ([see thread](https://dsva.slack.com/archives/CBU0KDSB1/p1687882852192909), and [another PR](https://github.com/department-of-veterans-affairs/vets-api/pull/13103) attempting to fix this)

## Related issue(s)


## Testing done



## What areas of the site does it impact?
Appeals tests

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

