### PR TITLE
API--27167-526-submit-v2-cleanup-part-4

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -28,6 +28,7 @@ module ClaimsApi
         @pdf_data[:data][:attributes] = @auto_claim&.deep_symbolize_keys
         claim_date_and_signature
         veteran_info
+        @pdf_data[:data][:attributes].delete(:claimantCertification)
 
         @pdf_data
       end
@@ -93,8 +94,24 @@ module ClaimsApi
         abbr_country = country == 'USA' ? 'US' : country
         @pdf_data[:data][:attributes][:identificationInformation][:mailingAddress][:country] = abbr_country
 
+        current_va_employee
+        phone
         zip
 
+        @pdf_data
+      end
+
+      def current_va_employee
+        currently_va_employee = @pdf_data[:data][:attributes][:identificationInformation][:currentlyVaEmployee]
+        @pdf_data[:data][:attributes][:identificationInformation][:currentVaEmployee] = currently_va_employee
+        @pdf_data[:data][:attributes][:identificationInformation].delete(:currentlyVaEmployee)
+        @pdf_data
+      end
+
+      def phone
+        phone = @pdf_data[:data][:attributes][:identificationInformation][:veteranNumber]
+        @pdf_data[:data][:attributes][:identificationInformation][:phoneNumber] = phone
+        @pdf_data[:data][:attributes][:identificationInformation].delete(:veteranNumber)
         @pdf_data
       end
 
@@ -103,6 +120,7 @@ module ClaimsApi
               (@auto_claim&.dig('veteranIdentification', 'mailingAddress', 'zipLastFour') || '')
         mailing_addr = @pdf_data&.dig(:data, :attributes, :identificationInformation, :mailingAddress).present?
         @pdf_data[:data][:attributes][:identificationInformation][:mailingAddress].merge!(zip:) if mailing_addr
+        @pdf_data
       end
 
       def disability_attributes

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
@@ -98,16 +98,16 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
       it 'maps the other veteran info' do
         mapper.map_claim
 
-        currently_va_employee = pdf_data[:data][:attributes][:identificationInformation][:currentlyVaEmployee]
+        current_va_employee = pdf_data[:data][:attributes][:identificationInformation][:currentVaEmployee]
         va_file_number = pdf_data[:data][:attributes][:identificationInformation][:vaFileNumber]
         email = pdf_data[:data][:attributes][:identificationInformation][:emailAddress][:email]
         agree_to_email =
           pdf_data[:data][:attributes][:identificationInformation][:emailAddress][:agreeToEmailRelatedToClaim]
-        telephone = pdf_data[:data][:attributes][:identificationInformation][:veteranNumber][:telephone]
+        telephone = pdf_data[:data][:attributes][:identificationInformation][:phoneNumber][:telephone]
         international_telephone =
-          pdf_data[:data][:attributes][:identificationInformation][:veteranNumber][:internationalTelephone]
+          pdf_data[:data][:attributes][:identificationInformation][:phoneNumber][:internationalTelephone]
 
-        expect(currently_va_employee).to eq(false)
+        expect(current_va_employee).to eq(false)
         expect(va_file_number).to eq('AB123CDEF')
         expect(email).to eq('valid@somedomain.com')
         expect(agree_to_email).to eq(true)


### PR DESCRIPTION
 Makes changes on pdf mapper, up to section 4 on spreadsheet (start on exposure info next).


## Summary

- Cleans up validation  & mapping code for 526 requests

## Related issue(s)
- [API-27167](https://jira.devops.va.gov/browse/API-27167)


## Testing done

- rspec
- swagger docs
- Postman

## What areas of the site does it impact?


## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
