### PR TITLE
Update direct deposit error parsing to handle 400 - no changes error

### DIFF
--- a/lib/lighthouse/direct_deposit/error_parser.rb
+++ b/lib/lighthouse/direct_deposit/error_parser.rb
@@ -63,6 +63,7 @@ module Lighthouse
         return 'cnp.payment.night.phone.number.invalid' if detail.include? 'Night phone number is invalid'
         return 'cnp.payment.night.area.number.invalid' if detail.include? 'Night area number is invalid'
         return 'cnp.payment.mailing.address.invalid' if detail.include? 'field not entered for mailing address update'
+        return 'cnp.payment.no.changes.made' if detail.include? 'GUIE50041'
         return 'cnp.payment.unspecified.error' if detail.include? 'GUIE50022'
 
         'cnp.payment.generic.error'

--- a/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
@@ -298,6 +298,32 @@ RSpec.describe V0::Profile::DirectDeposits::DisabilityCompensationsController, t
       end
     end
 
+    context 'when saved with no changes' do
+      let(:params) do
+        {
+          account_type: 'CHECKING',
+          account_number: '1234567890',
+          routing_number: '031000503'
+        }
+      end
+
+      it 'returns a day no changes made error' do
+        VCR.use_cassette('lighthouse/direct_deposit/update/400_no_changes_made') do
+          put(:update, params:)
+        end
+
+        expect(response).to have_http_status(:bad_request)
+
+        json = JSON.parse(response.body)
+        e = json['errors'].first
+
+        expect(e).not_to be_nil
+        expect(e['title']).to eq('Bad Request')
+        expect(e['code']).to eq('cnp.payment.no.changes.made')
+        expect(e['source']).to eq('Lighthouse Direct Deposit')
+      end
+    end
+
     context 'when user profile info is invalid' do
       let(:params) do
         {

--- a/spec/support/vcr_cassettes/lighthouse/direct_deposit/update/400_no_changes_made.yml
+++ b/spec/support/vcr_cassettes/lighthouse/direct_deposit/update/400_no_changes_made.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://sandbox-api.va.gov/services/direct-deposit-management/v1/direct-deposit?icn=1012666073V986297
+    body:
+      encoding: UTF-8
+      string: '{"paymentAccount":{"accountNumber":"1234567890","accountType":"CHECKING","financialInstitutionRoutingNumber":"031000503"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - Bearer abcdefghijklmnop
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Date:
+      - Mon, 20 Feb 2023 18:45:14 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      X-Ratelimit-Remaining-Minute:
+      - '59'
+      X-Ratelimit-Limit-Minute:
+      - '60'
+      Ratelimit-Remaining:
+      - '59'
+      Ratelimit-Limit:
+      - '60'
+      Ratelimit-Reset:
+      - '47'
+      Content-Language:
+      - en-US
+      X-Kong-Upstream-Latency:
+      - '735'
+      X-Kong-Proxy-Latency:
+      - '0'
+      Via:
+      - kong/3.0.2
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{
+                "type": "https://api.va.gov/direct-deposit-management/errors/bad-request",
+                "title": "Bad Request",
+                "status": 400,
+                "detail": "No changes were made. GUIE50041&FABusnsTranRule(CFABUSNS_TRAN) Failed with Exception!!",
+                "instance": "61b45dc6-058d-4449-862c-567dbb9290d9",
+                "errorCodes": []
+              }'
+  recorded_at: Mon, 20 Feb 2023 18:45:14 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Summary
Currently, when a user saves direct deposit information without making any changes, the following errors is returned with a code of `cnp.payment.generic.error`.

The error parsing has been updated to map to the code `cnp.payment.no.changes.made`.

## Related Ticket
https://github.com/department-of-veterans-affairs/va.gov-team/issues/63717

## Testing done
Added spec to test error handling.