### PR TITLE
Add error handling/parsing for 502 bad gateway responses from Lighthouse

### DIFF
--- a/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
+++ b/spec/controllers/v0/profile/direct_deposits/disability_compensations_controller_spec.rb
@@ -125,6 +125,16 @@ RSpec.describe V0::Profile::DirectDeposits::DisabilityCompensationsController, t
       end
     end
 
+    context 'when there is a bad gateway' do
+      it 'returns a status of 502' do
+        VCR.use_cassette('lighthouse/direct_deposit/show/502_bad_gateway') do
+          get(:show)
+        end
+
+        expect(response).to have_http_status(:bad_gateway)
+      end
+    end
+
     context 'when lighthouse direct deposit feature flag is disabled' do
       before do
         allow(Flipper).to receive(:enabled?).with(:profile_lighthouse_direct_deposit, instance_of(User))

--- a/spec/support/vcr_cassettes/lighthouse/direct_deposit/show/502_bad_gateway.yml
+++ b/spec/support/vcr_cassettes/lighthouse/direct_deposit/show/502_bad_gateway.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/direct-deposit-management/v1/direct-deposit?icn=1012666073V986297
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - Bearer abcdefghijklmnop
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 502
+      message: ''
+    headers:
+      Date:
+      - Mon, 20 Feb 2023 18:45:14 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      X-Ratelimit-Remaining-Minute:
+      - '59'
+      X-Ratelimit-Limit-Minute:
+      - '60'
+      Ratelimit-Remaining:
+      - '59'
+      Ratelimit-Limit:
+      - '60'
+      Ratelimit-Reset:
+      - '47'
+      Content-Language:
+      - en-US
+      X-Kong-Upstream-Latency:
+      - '735'
+      X-Kong-Proxy-Latency:
+      - '0'
+      Via:
+      - kong/3.0.2
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        <html>
+        <head><title>502 Bad Gateway</title></head>
+        <body>
+        <center><h1>502 Bad Gateway</h1></center>
+        </body>
+        </html>
+  recorded_at: Mon, 20 Feb 2023 18:45:14 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Summary
Add parsing to handle 502 Bad Gateway responses from Lighthouse.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/63323

## Testing done
Added a spec to test 502 response.