### PR TITLE
WIP - Dbx 63417 migrate document service to lh

### DIFF
--- a/app/controllers/v0/documents_controller.rb
+++ b/app/controllers/v0/documents_controller.rb
@@ -10,7 +10,7 @@ module V0
       claim = EVSSClaim.for_user(current_user).find_by(evss_id: params[:evss_claim_id])
       raise Common::Exceptions::RecordNotFound, params[:evss_claim_id] unless claim
 
-      # [wipn8923] probably needs switching?
+      # [wipn8923] probably needs switching?  Is this related to 526?
       document_data = EVSSClaimDocument.new(
         evss_claim_id: claim.evss_id,
         file_obj: params[:file],
@@ -29,7 +29,7 @@ module V0
     private
 
     def service
-      # [wipn8923] probably needs switching?
+      # [wipn8923] probably needs switching?  Is this related to 526?
       EVSSClaimService.new(current_user)
     end
   end

--- a/app/controllers/v0/documents_controller.rb
+++ b/app/controllers/v0/documents_controller.rb
@@ -10,6 +10,7 @@ module V0
       claim = EVSSClaim.for_user(current_user).find_by(evss_id: params[:evss_claim_id])
       raise Common::Exceptions::RecordNotFound, params[:evss_claim_id] unless claim
 
+      # [wipn8923] probably needs switching?
       document_data = EVSSClaimDocument.new(
         evss_claim_id: claim.evss_id,
         file_obj: params[:file],
@@ -28,6 +29,7 @@ module V0
     private
 
     def service
+      # [wipn8923] probably needs switching?
       EVSSClaimService.new(current_user)
     end
   end

--- a/app/controllers/v0/upload_supporting_evidences_controller.rb
+++ b/app/controllers/v0/upload_supporting_evidences_controller.rb
@@ -7,6 +7,7 @@ module V0
     include FormAttachmentCreate
     extend Logging::ThirdPartyTransaction::MethodWrapper
 
+    # [wipn8923] update to use flipper
     FORM_ATTACHMENT_MODEL = SupportingEvidenceAttachment
 
     wrap_with_logging(

--- a/app/models/lighthouse_document.rb
+++ b/app/models/lighthouse_document.rb
@@ -3,11 +3,13 @@
 require 'common/models/base'
 require 'pdf_info'
 
+# [wipn8923] replaces evss_claim_document.rb ?
 class LighthouseDocument < Common::Base
   include ActiveModel::Validations
   include ActiveModel::Validations::Callbacks
   include SentryLogging
 
+  # [wipn8923] TODO: is file_number the equivalent value of evss_claim_id?
   attribute :file_number, String
   attribute :claim_id, Integer
   attribute :tracked_item_id, Integer

--- a/app/models/supporting_evidence_attachment.rb
+++ b/app/models/supporting_evidence_attachment.rb
@@ -3,6 +3,8 @@
 # Files uploaded as part of a form526 submission that will be sent to EVSS upon form submission.
 # inherits from ApplicationRecord
 class SupportingEvidenceAttachment < FormAttachment
+  # [wipn8923] this is problematic... SupportingEvidenceAttachmentUploader inherits from EVSS logic, so this will
+  # need to respect the flipper, however, we don't have access to the flipper at this level
   ATTACHMENT_UPLOADER_CLASS = SupportingEvidenceAttachmentUploader
 
   # this uploads the file to S3 through its parent class

--- a/app/services/evss_claim_service.rb
+++ b/app/services/evss_claim_service.rb
@@ -5,6 +5,7 @@ require 'evss/documents_service'
 require 'evss/auth_headers'
 
 # EVSS Claims Status Tool
+# [wipn8923] verify that this is replaced by LH object
 class EVSSClaimService
   include SentryLogging
   EVSS_CLAIM_KEYS = %w[open_claims historical_claims].freeze

--- a/app/uploaders/lighthouse_document_uploader.rb
+++ b/app/uploaders/lighthouse_document_uploader.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# [wipn8923] replaces app/uploaders/evss_claim_document_uploader.rb ?
 # Files that will be associated with a previously submitted claim, from the Claim Status tool
 class LighthouseDocumentUploader < LighthouseDocumentUploaderBase
   def initialize(icn, ids)

--- a/app/uploaders/lighthouse_document_uploader_base.rb
+++ b/app/uploaders/lighthouse_document_uploader_base.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# [wipn8923] replaces app/uploaders/evss_claim_document_uploader_base.r ?
 class LighthouseDocumentUploaderBase < CarrierWave::Uploader::Base
   include SetAWSConfig
   include ValidatePdf
@@ -34,6 +35,7 @@ class LighthouseDocumentUploaderBase < CarrierWave::Uploader::Base
     50.megabytes
   end
 
+  # [wipn8923] is this accurate?
   # Lighthouse will split PDF's larger than 50mb before sending to VBA who has a limit of 50mb. so,
   # PDF's can be larger than other files
   def validate_file_size(file)

--- a/app/uploaders/supporting_evidence_attachment_uploader.rb
+++ b/app/uploaders/supporting_evidence_attachment_uploader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Files uploaded as part of a form526 submission that will be sent to EVSS upon form submission.
+# [wipn8923] update?
 class SupportingEvidenceAttachmentUploader < EVSSClaimDocumentUploaderBase
   before :store, :log_transaction_start
   after :store, :log_transaction_complete

--- a/app/workers/evss/disability_compensation_form/evss_document.rb
+++ b/app/workers/evss/disability_compensation_form/evss_document.rb
@@ -3,6 +3,7 @@
 require 'central_mail/datestamp_pdf'
 require 'pdf_fill/filler'
 
+# [wipn8923] verify that this is replaced by LH object
 module EVSS
   module DisabilityCompensationForm
     # Base document class for the 526 ancillary forms

--- a/app/workers/evss/disability_compensation_form/submit_form0781.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form0781.rb
@@ -4,7 +4,7 @@ require 'central_mail/datestamp_pdf'
 require 'pdf_fill/filler'
 require 'logging/third_party_transaction'
 
-# [wipn8923] renamespace?
+# [wipn8923] renamespacing would be good, but feels out of scope for the first pass
 module EVSS
   module DisabilityCompensationForm
     class SubmitForm0781 < Job

--- a/app/workers/evss/disability_compensation_form/submit_form8940.rb
+++ b/app/workers/evss/disability_compensation_form/submit_form8940.rb
@@ -78,7 +78,7 @@ module EVSS
 
       def client
         @client ||= if Flipper.enabled?(:disability_compensation_lighthouse_document_service_provider)
-                      # TODO: create client from lighthouse document service
+                      BenefitsDocuments::Service.new(submission.auth_headers)
                     else
                       EVSS::DocumentsService.new(submission.auth_headers)
                     end

--- a/app/workers/evss/document_upload.rb
+++ b/app/workers/evss/document_upload.rb
@@ -4,6 +4,7 @@ require 'ddtrace'
 require 'timeout'
 require 'logging/third_party_transaction'
 
+# [wipn8923] verifigy that this is replaced by lighthouse object and wrap that object with logging
 class EVSS::DocumentUpload
   include Sidekiq::Worker
   extend Logging::ThirdPartyTransaction::MethodWrapper

--- a/app/workers/evss/document_upload.rb
+++ b/app/workers/evss/document_upload.rb
@@ -4,7 +4,6 @@ require 'ddtrace'
 require 'timeout'
 require 'logging/third_party_transaction'
 
-# [wipn8923] verifigy that this is replaced by lighthouse object and wrap that object with logging
 class EVSS::DocumentUpload
   include Sidekiq::Worker
   extend Logging::ThirdPartyTransaction::MethodWrapper

--- a/app/workers/lighthouse/document_upload.rb
+++ b/app/workers/lighthouse/document_upload.rb
@@ -4,6 +4,7 @@ require 'ddtrace'
 require 'timeout'
 require 'lighthouse/benefits_documents/worker_service'
 
+# [wipn8923] replaces app/workers/evss/document_upload.rb ?
 class Lighthouse::DocumentUpload
   include Sidekiq::Worker
 
@@ -23,6 +24,7 @@ class Lighthouse::DocumentUpload
 
       raise Common::Exceptions::ValidationErrors, document_data unless document.valid?
 
+      # [wipn8923] references the worker service (client facotry?) but doesn't seem to replace anything
       client = BenefitsDocuments::WorkerService.new(user_icn)
       uploader = LighthouseDocumentUploader.new(user_icn, document.uploader_ids)
       uploader.retrieve_from_store!(document.file_name)

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -862,7 +862,6 @@
         :uid_location: "url"
         :uid_locator: "\/services/claims/v2/veterans\/(?:.+)\/claims\/(.+)/5103"
 
-          # [wipn8923] get these endpoints
 # Lighthouse Benefits Documents API
 - :name: "Lighthouse Benefits Documents"
   :base_uri: <%= "#{URI(Settings.lighthouse.benefits_documents.host).host}:#{URI(Settings.lighthouse.benefits_documents.host).port}" %>

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -862,6 +862,7 @@
         :uid_location: "url"
         :uid_locator: "\/services/claims/v2/veterans\/(?:.+)\/claims\/(.+)/5103"
 
+          # [wipn8923] get these endpoints
 # Lighthouse Benefits Documents API
 - :name: "Lighthouse Benefits Documents"
   :base_uri: <%= "#{URI(Settings.lighthouse.benefits_documents.host).host}:#{URI(Settings.lighthouse.benefits_documents.host).port}" %>

--- a/config/settings/local.yml
+++ b/config/settings/local.yml
@@ -1,0 +1,28 @@
+mvi:
+  url: http://ps-dev.commserv.healthevet.va.gov:8110/psim_webservice/IdMWebService
+  mock: true
+  processing_code: T
+  client_cert_path: config/certs/vetsgov-localhost.crt
+  client_key_path: config/certs/vetsgov-localhost.key
+
+betamocks:
+  enabled: true
+  recording: false
+  # the cache dir depends on how you run the api
+  cache_dir: ../vets-api-mockdata # via rails; e.g. bundle exec rails s or bundle exec rails c
+  services_config: config/betamocks/services_config.yml
+
+saml_ssoe:
+  idme_authn_context: https://eauth.va.gov/csp?Select=idme3
+
+account:
+  enabled: true
+
+locators:
+  mock_gis: true
+
+web_origin_regex: \Ahttps?:\/\/.*\z
+
+modules_appeals_api:
+  documentation:
+    notice_of_disagreements_v1: true

--- a/lib/evss/disability_compensation_form/service.rb
+++ b/lib/evss/disability_compensation_form/service.rb
@@ -67,7 +67,7 @@ module EVSS
       # Returns PDF stream in response, instead of submitting to auto-establish.
       # This is used in the 526ez backup submission process when auto-establisment errors and is not possible.
       #
-      # @param form_content [JSON] JSON serialized version of a {Form526Submission}
+      # @param form_content [JSON] JSON serialized version of a {Form525Submission}
       # @return [Faraday::Response] - Response from EVSS /getPDF endpoint
       def get_form526(form_content)
         with_monitoring_and_error_handling do

--- a/lib/lighthouse/benefits_documents/service.rb
+++ b/lib/lighthouse/benefits_documents/service.rb
@@ -4,6 +4,7 @@ require 'common/client/base'
 require 'lighthouse/benefits_documents/configuration'
 require 'lighthouse/service_exception'
 
+# [wipn8923] this is the new document service that delegates to the Lighthouse stuff
 module BenefitsDocuments
   class Service < Common::Client::Base
     configuration BenefitsDocuments::Configuration

--- a/lib/sidekiq/form526_backup_submission_process/processor.rb
+++ b/lib/sidekiq/form526_backup_submission_process/processor.rb
@@ -360,6 +360,7 @@ module Sidekiq
         uploads = submission.form[FORM_526_UPLOADS]
         uploads.each do |upload|
           guid = upload['confirmationCode']
+          # [wipn8923] update to use flipper (probably need new SupportingEvidenceAttachment for LH specific inheritance
           sea = SupportingEvidenceAttachment.find_by(guid:)
           file = sea&.get_file
           raise ArgumentError, "supporting evidence attachment with guid #{guid} has no file data" if file.nil?

--- a/modules/mobile/app/services/mobile/v0/claims/proxy.rb
+++ b/modules/mobile/app/services/mobile/v0/claims/proxy.rb
@@ -2,6 +2,7 @@
 
 require 'lighthouse/facilities/client'
 
+# [wipn8923] is this a valid use case?  if so, do we need to update or replace it?
 module Mobile
   module V0
     module Claims

--- a/spec/jobs/evss/disability_compensation_form/submit_form0781_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form0781_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# [wipn8923] TODO: replicate spec
 RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
   subject { described_class }
 

--- a/spec/jobs/evss/disability_compensation_form/submit_form8940_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_form8940_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# [wipn8923] TODO: replicate spec
 RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm8940, type: :job do
   subject { described_class }
 

--- a/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# [wipn8923] TODO: replicate spec
 RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
   subject { described_class }
 

--- a/spec/jobs/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
+++ b/spec/jobs/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# [wipn8923] TODO: replicate spec
 RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :job do
   subject { described_class }
 

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe 'Documents management', type: :request do
       params = { file: tempfile, tracked_item_id:, document_type: }
       post('/v0/evss_claims/189625/documents', params:)
       expect(response.status).to eq(202)
+      # [wipn8923] probably need to update specs like this
       expect(JSON.parse(response.body)['job_id']).to eq(EVSS::DocumentUpload.jobs.first['jid'])
     end
   end


### PR DESCRIPTION
## Summary

- Add ability to leverage Lighthouse Document service via feature flipper

## Related issue(s)
- [Ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/63417)


## Testing done

- TBD.  This is the primary work of this ticket.

## What areas of the site does it impact?
526 document upload

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
