### PR TITLE
API-5103-failed-sub-nil-error

### DIFF
--- a/modules/claims_api/app/workers/claims_api/ews_updater.rb
+++ b/modules/claims_api/app/workers/claims_api/ews_updater.rb
@@ -15,6 +15,13 @@ module ClaimsApi
     def perform(ews_id)
       ews = ClaimsApi::EvidenceWaiverSubmission.find(ews_id)
       bgs_claim = benefit_claim_service(ews).find_bnft_claim(claim_id: ews.claim_id)
+      if bgs_claim[:bnft_claim_dto].empty?
+        ClaimsApi::Logger.log(ews_id: ews.id, keys: bgs_claim.keys,
+                              detail: "Failed to update for claim #{ews.claim_id}: #{e.message}")
+        ews.status = ClaimsApi::EvidenceWaiverSubmission::ERRORED
+        ews.save
+        return
+      end
 
       unless bgs_claim&.dig(:bnft_claim_dto, :filed5103_waiver_ind) == FILE_5103
         bgs_claim[:bnft_claim_dto][:filed5103_waiver_ind] = FILE_5103


### PR DESCRIPTION
## Summary

- manually resolves the impacted submissions
- Adds logs for errored submissions

## Related issue(s)
- [API-29139](https://jira.devops.va.gov/browse/API-29139)

## Testing done

- rspec
- Postman
- {{uri}}/services/claims/v2/veterans/{{veteran_id}}/claims/600016536/5103
change `perform_async` to `new.perform` [here](https://github.com/department-of-veterans-affairs/vets-api/blob/API-5103-failed-sub-nil-error/modules/claims_api/app/controllers/claims_api/v2/veterans/evidence_waiver_controller.rb#L23)


## What areas of the site does it impact?
[*(Describe what parts of the site are impacted and*if*code touched other areas)*](modified:   modules/claims_api/app/workers/claims_api/ews_updater.rb)

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature