### PR TITLE
Mitigate slow letters release for problematic letter type

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -21,7 +21,11 @@ features:
     enable_in_development: true
   bcas_letters_use_lighthouse:
     actor_type: user
-    description: Use lighthouse instead of EVSS to view/download benefit letters.
+    description: Use lighthouse instead of EVSS to view benefit letters.
+    enable_in_development: true
+  bcas_letters_use_lighthouse_download:
+    actor_type: user
+    description: Use lighthouse instead of EVSS to download benefit letters.
     enable_in_development: true
   caregiver_use_facilities_API:
     actor_type: user

--- a/lib/lighthouse/letters_generator/veteran_sponsor_resolver.rb
+++ b/lib/lighthouse/letters_generator/veteran_sponsor_resolver.rb
@@ -14,6 +14,12 @@ module Lighthouse
           sponsor = get_sponsor_for user
           raise ArgumentError, 'Unable to find sponsor for dependent user' unless sponsor
 
+          ::Rails.logger.info({
+            message: 'User is a dependent. Using sponsor information.',
+            id: user.uuid,
+            sponsor_id: sponsor.uuid
+          })
+
           icn = sponsor.icn
         end
 


### PR DESCRIPTION
The letters app release has been held back or rolled back to a lower percentage of users because of a single letter type. We're working with the Lighthouse team on discovering the root cause.

In the meantime, gating the problematic letter type behind a feature flag allows maintain fine-grained release control of the problem type while still enabling more users to use the bulk of the letters app.

Closes department-of-veterans-affairs/va.gov-team#64304