### PR TITLE
Feature update 526 classifier endpoint

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -120,12 +120,13 @@ module Form526ClaimFastTrackingConcern
       claim_type:
     }
 
-    classification = classify_by_diagnostic_code(params)
+    classification = get_classification(params)
     Rails.logger.info('CLassified 526Submission', id:, saved_claim_id:, classification:)
     update_form_with_classification_code(classification['classification_code']) if classification.present?
   end
 
-  def classify_by_diagnostic_code(params)
+  # @return [Hash] predicted classification response from VRO
+  def get_classification(params)
     vro_client = VirtualRegionalOffice::Client.new
     response = vro_client.classify_single_contention(params)
     response.body

--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -80,7 +80,9 @@ module Form526ClaimFastTrackingConcern
   end
 
   def increase_or_new?
-    disabilities.all? { |disability| disability['disabilityActionType']&.upcase == 'INCREASE' || disability['disabilityActionType']&.upcase == 'NEW' }
+    disabilities.all? do |disability|
+      disability['disabilityActionType']&.upcase == 'INCREASE' || disability['disabilityActionType']&.upcase == 'NEW'
+    end
   end
 
   def diagnostic_codes

--- a/lib/virtual_regional_office/client.rb
+++ b/lib/virtual_regional_office/client.rb
@@ -7,7 +7,7 @@ module VirtualRegionalOffice
     include Common::Client::Concerns::Monitoring
     configuration VirtualRegionalOffice::Configuration
 
-    def classify_contention_by_diagnostic_code(params)
+    def classify_single_contention(params)
       perform(:post, Settings.virtual_regional_office.ctn_classification_path, params.to_json.to_s, headers_hash)
     end
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- Route additional claims to contention classification service in VRO.
- Previously, we only send over single-contention claims for increase (CfI).
- The API now supports classification based on dropdown contentions from the freetext dropdown


## Related issue(s)
- depends on: https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/242
- ticket for this work: https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/215


## Testing done

- `bundle exec rspec spec/jobs/evss/disability_compensation_form/submit_form526_all_claim_spec.rb`
- TODO: manual testing
- *Describe the tests completed and the results*

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
