### PR TITLE
Add Filtering for SQL and File Number Data

### DIFF
--- a/lib/bgs/exceptions/bgs_errors.rb
+++ b/lib/bgs/exceptions/bgs_errors.rb
@@ -6,7 +6,7 @@ module BGS
     module BGSErrors
       include SentryLogging
       MAX_ATTEMPTS = 3
-      SQL_STATEMENT_MATCH = /(\{prepstmnt.*VALUES.*\[params=.*?})/
+      SQL_STATEMENT_MATCH = /(\{prepstmnt.*?VALUES.*?\[params=.*?\})/
       SQL_DATA_MATCH = /(\(\w+\)\s+)([^,\]]+)/s
 
       def with_multiple_attempts_enabled

--- a/lib/bgs/exceptions/bgs_errors.rb
+++ b/lib/bgs/exceptions/bgs_errors.rb
@@ -23,7 +23,7 @@ module BGS
       end
 
       def notify_of_service_exception(error, method, attempt = nil, status = :error)
-        error = error.exception(filter_senstive_information(error.message))
+        error = error.exception(filter_senstive_data(error.message))
 
         msg = "Unable to #{method}: #{error.message}: try #{attempt} of #{MAX_ATTEMPTS}"
         context = { icn: @user[:icn] }
@@ -66,7 +66,7 @@ module BGS
         end
       end
 
-      def filter_senstive_information(message)
+      def filter_senstive_data(message)
         message.gsub(SQL_STATEMENT_MATCH) { |match| match.gsub(SQL_DATA_MATCH, '\1<FILTERED>') }
       end
     end

--- a/lib/bgs/exceptions/bgs_errors.rb
+++ b/lib/bgs/exceptions/bgs_errors.rb
@@ -6,7 +6,7 @@ module BGS
     module BGSErrors
       include SentryLogging
       MAX_ATTEMPTS = 3
-      SQL_STATEMENT_MATCH = /(\{prepstmnt.*?VALUES.*?\[params=.*?\})/
+      SQL_STATEMENT_MATCH = /\{prepstmnt.*?VALUES.*?\[params=.*?\}/
       SQL_DATA_MATCH = /(\(\w+\)\s+)([^,\]]+)/s
 
       def with_multiple_attempts_enabled

--- a/lib/bgs/exceptions/bgs_errors.rb
+++ b/lib/bgs/exceptions/bgs_errors.rb
@@ -7,7 +7,7 @@ module BGS
       include SentryLogging
       MAX_ATTEMPTS = 3
       SQL_STATEMENT_MATCH = /(\{prepstmnt.*VALUES.*\[params=.*?})/
-      SQL_DATA_MATCH = /(\([\w+]+\)\s+)([^,\]]+)/s
+      SQL_DATA_MATCH = /(\(\w+\)\s+)([^,\]]+)/s
 
       def with_multiple_attempts_enabled
         attempt ||= 0

--- a/lib/bgs/service.rb
+++ b/lib/bgs/service.rb
@@ -42,7 +42,9 @@ module BGS
     def find_rating_data
       service.rating.find_rating_data(@user.ssn)
     rescue => e
-      raise(e.class, filter_sensitive_information(e.message))
+      error = e.exception(filter_sensitive_data(e.message))
+    ensure
+      raise error if error.present?
     end
 
     def create_proc_form(vnp_proc_id, form_type_code)
@@ -286,7 +288,7 @@ module BGS
       )
     end
 
-    def filter_sensitive_information(message)
+    def filter_sensitive_data(message)
       message.gsub(FILE_NUMBER_MATCH, '\1<FILTERED>')
     end
   end

--- a/lib/bgs/service.rb
+++ b/lib/bgs/service.rb
@@ -6,6 +6,7 @@ require 'common/client/concerns/monitoring'
 module BGS
   class Service
     STATSD_KEY_PREFIX = 'api.bgs'
+    FILE_NUMBER_MATCH = /(No record found for file number )(\d+)/
 
     include BGS::Exceptions::BGSErrors
     include SentryLogging
@@ -40,6 +41,8 @@ module BGS
 
     def find_rating_data
       service.rating.find_rating_data(@user.ssn)
+    rescue => e
+      raise(e.class, filter_sensitive_information(e.message))
     end
 
     def create_proc_form(vnp_proc_id, form_type_code)
@@ -281,6 +284,10 @@ module BGS
         external_uid: @user.icn || @user.uuid,
         external_key: @user.common_name || @user.email
       )
+    end
+
+    def filter_sensitive_information(message)
+      message.gsub(FILE_NUMBER_MATCH, '\1<FILTERED>')
     end
   end
 end


### PR DESCRIPTION
## Summary
- File number was appearing in a deep error with a SQL statement that got sent through a BGS error, this change is to filter all SQL data values
  - example of error with fake data included with attachment [sql-soap-error.log](https://github.com/department-of-veterans-affairs/vets-api/files/12528678/sql-soap-error.log)

- An additional error was found that logs file number when a VA can not be found with a file number, this should also still be considered PII and a filter was added for this log as well
  - This error comes in the form of the line `No record found for file number 123456789`
- File number is many times the SSN but it can also be different, this causes this value to be considered PII at all times

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/56528

## Testing done
Neither of the errors being filtered can be tested naturally due to the errors coming from an outside service (BGS), testing was done by directly invoking the involved method by doing as follows in rails console:
```
require_relative 'lib/bgs/service'
bgs_service = BGS::Service.new({icn: 123})
str = <<-LONGSTRING
**Copied error message**
LONGSTRING
error = StandardError.new str
bgs_service.notify_of_service_exception(error, 'method')
```

The second error filtered was tested by modifying the code to raise the error manually and then run the following in console:
```
require_relative 'lib/bgs/service'
bgs_service = BGS::Service.new({icn: 123})
bgs_service.find_rating_data
```

Check that the printed error in console is filtered as expected

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

## Requested Feedback
I'm not sure if using `rescue` and then `raise` another error actually filters the message, testing in rails console shows both error messages. Can someone verify only the filtered message will be sent to Datadog/Sentry for the code in **service.rb**?
