### PR TITLE
feat: Bump HPA to newer version

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -72,7 +72,8 @@ type: application
 # 0.12.06 - Remove clamav command
 # 0.12.07 - update traefik name for preview-environment - broken do not use
 # 0.12.08 - update traefik name for preview-environment
-version: 0.12.08
+# 0.12.09 - Bump HPA apiVersion as part of EKS upgrade preparation
+version: 0.12.09
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/hpa.yml
+++ b/chart/templates/hpa.yml
@@ -15,10 +15,13 @@ spec:
   minReplicas: {{ $service.autoscaling.minReplicas | default $root.Values.web.autoscaling.minReplicas }}
   maxReplicas: {{ $service.autoscaling.maxReplicas | default $root.Values.web.autoscaling.maxReplicas }}
   metrics:
-  - type: External
-    external:
-      metricName: "datadogmetric@{{ $root.Release.Namespace }}:puma-backlog-{{ $name }}"
-      targetValue: {{ $service.autoscaling.targetValue | default $root.Values.web.autoscaling.targetValue }}
+  - external:
+      metric:
+        name: "datadogmetric@{{ $root.Release.Namespace }}:puma-backlog-{{ $name }}"
+      target:
+        type: Value
+        value: {{ $service.autoscaling.targetValue | default $root.Values.web.autoscaling.targetValue }}
+    type: External
 {{- end }}
 {{- end }}
 
@@ -36,9 +39,13 @@ spec:
     name: {{ .Values.appName }}-sidekiq
   minReplicas: {{ .Values.worker.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.worker.autoscaling.maxReplicas }}
+
   metrics:
-  - type: External
-    external:
-      metricName: "datadogmetric@{{ $root.Release.Namespace }}:sidekiq-enqueued-jobs"
-      targetValue: {{ .Values.worker.autoscaling.targetValue }}
+  - external:
+      metric:
+        name: "datadogmetric@{{ $root.Release.Namespace }}:sidekiq-enqueued-jobs"
+      target:
+        type: Value
+        value: {{ .Values.worker.autoscaling.targetValue }}
+    type: External
 {{- end }}

--- a/chart/templates/hpa.yml
+++ b/chart/templates/hpa.yml
@@ -2,7 +2,7 @@
 {{- range $name, $service := $root.Values.web.webServices }}
 {{- if $service.autoscaling.enabled }}
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $name }}
@@ -25,7 +25,7 @@ spec:
 
 {{- if .Values.worker.autoscaling.enabled }}
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Values.appName }}-sidekiq


### PR DESCRIPTION
- Bump HPA to version supported by current and future EKS clusters
- Works in current EKS 1.23 as well as future EKS 1.27
- Tested on a separate test cluster; only failure is from lack of Datadog on test cluster


```
kubectl explain horizontalpodautoscalers
```