### PR TITLE
Api 28294 cleanup part 1

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_evss_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_evss_mapper.rb
@@ -45,6 +45,9 @@ module ClaimsApi
                                                                type: 'DOMESTIC'
                                                              })
         @evss_claim[:veteran][:currentMailingAddress].except!(:numberAndStreet, :apartmentOrUnitNumber)
+        if @evss_claim[:veteran][:currentMailingAddress][:zipLastFour].blank?
+          @evss_claim[:veteran][:currentMailingAddress].except!(:zipLastFour)
+        end
       end
 
       def disabilities

--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -495,11 +495,7 @@ module ClaimsApi
 
       def service_info_other_names
         other_names = @pdf_data[:data][:attributes][:serviceInformation][:alternateNames].present?
-        if other_names
-          names = @pdf_data[:data][:attributes][:serviceInformation][:alternateNames].join(', ')
-          @pdf_data[:data][:attributes][:serviceInformation][:servedUnderAnotherName] = 'YES'
-          @pdf_data[:data][:attributes][:serviceInformation][:alternateNames] = names
-        end
+        @pdf_data[:data][:attributes][:serviceInformation][:servedUnderAnotherName] = 'YES' if other_names
       end
 
       def fed_activation

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_pdf_mapper_spec.rb
@@ -340,7 +340,7 @@ describe ClaimsApi::V2::DisabilityCompensationPdfMapper do
         expect(unit_phone).to eq('5555555555')
         expect(act_duty_pay).to eq('YES')
         expect(other_name).to eq('YES')
-        expect(alt_names).to eq('john jacob, johnny smith')
+        expect(alt_names).to eq(['john jacob', 'johnny smith'])
         expect(fed_orders).to eq('YES')
         expect(fed_act).to eq({ month: 2, day: 11, year: 3619 })
         expect(fed_sep).to eq({ month: 10, day: 3, year: 6705 })


### PR DESCRIPTION
## Summary
- Allow retrying a submission if EVSS fails
- Add logging around the EVSS mapper
- Fix alternateNames (must now be an array)
- Allow a nil zipLastFour

## Related issue(s)
- [API-28294](https://jira.devops.va.gov/browse/API-28294)

## Testing done
- `rspec`
- POST local /services/claims/v2/veterans/:icn/526
It takes a bit, but should give you a 200. If you don't it the "too many EP code" issue, you should be able to look in the [dsva-vetsgov-sandbox-evss](https://us-gov-west-1.console.amazonaws-us-gov.com/s3/buckets/dsva-vetsgov-sandbox-evss) bucket for the LH claim UUID and find the generated PDF.

## What areas of the site does it impact?
V2 526 submissions

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
