### PR TITLE
Add SSO logging to CnP direct deposit updates

### DIFF
--- a/app/controllers/v0/profile/direct_deposits/disability_compensations_controller.rb
+++ b/app/controllers/v0/profile/direct_deposits/disability_compensations_controller.rb
@@ -29,6 +29,7 @@ module V0
 
         def update
           response = client.update_payment_info(payment_account)
+          Rails.logger.warn('DisabilityCompensationsController#update request completed', sso_logging_info)
           send_confirmation_email
 
           render status: response.status,


### PR DESCRIPTION
## Summary
Add SSO logging for C&P direct deposit updates.

Original ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/64875