### PR TITLE
[70023] Allow user_attributes claim for service account access tokens

### DIFF
--- a/app/models/sign_in/service_account_access_token.rb
+++ b/app/models/sign_in/service_account_access_token.rb
@@ -9,6 +9,7 @@ module SignIn
       :service_account_id,
       :audience,
       :scopes,
+      :user_attributes,
       :user_identifier,
       :version,
       :expiration_time,
@@ -33,12 +34,14 @@ module SignIn
                    audience:,
                    user_identifier:,
                    scopes: [],
+                   user_attributes: {},
                    uuid: nil,
                    version: nil,
                    expiration_time: nil,
                    created_time: nil)
       @uuid = uuid || create_uuid
       @service_account_id = service_account_id
+      @user_attributes = user_attributes
       @user_identifier = user_identifier
       @scopes = scopes
       @audience = audience
@@ -58,6 +61,7 @@ module SignIn
       {
         uuid:,
         service_account_id:,
+        user_attributes:,
         user_identifier:,
         scopes:,
         audience:,

--- a/app/services/sign_in/assertion_validator.rb
+++ b/app/services/sign_in/assertion_validator.rb
@@ -13,6 +13,7 @@ module SignIn
       validate_iss
       validate_audience
       validate_scopes
+      validate_user_attributes
       create_new_access_token
     end
 
@@ -39,6 +40,12 @@ module SignIn
     def validate_scopes
       unless decoded_assertion_scopes_are_defined_in_config?
         raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion scopes are not valid'
+      end
+    end
+
+    def validate_user_attributes
+      if (user_attributes.keys.map(&:to_s) - service_account_config.access_token_user_attributes).any?
+        raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion user attributes are not valid'
       end
     end
 

--- a/app/services/sign_in/assertion_validator.rb
+++ b/app/services/sign_in/assertion_validator.rb
@@ -46,6 +46,7 @@ module SignIn
       ServiceAccountAccessToken.new(service_account_id:,
                                     audience:,
                                     scopes:,
+                                    user_attributes:,
                                     user_identifier:)
     end
 
@@ -76,6 +77,10 @@ module SignIn
 
     def scopes
       @scopes ||= decoded_assertion.scopes
+    end
+
+    def user_attributes
+      @user_attributes = decoded_assertion.user_attributes || {}
     end
 
     def user_identifier

--- a/app/services/sign_in/service_account_access_token_jwt_decoder.rb
+++ b/app/services/sign_in/service_account_access_token_jwt_decoder.rb
@@ -13,6 +13,7 @@ module SignIn
       ServiceAccountAccessToken.new(service_account_id: decoded_token.service_account_id,
                                     audience: decoded_token.aud,
                                     scopes: decoded_token.scopes,
+                                    user_attributes: decoded_token.user_attributes,
                                     user_identifier: decoded_token.sub,
                                     uuid: decoded_token.jti,
                                     version: decoded_token.version,

--- a/app/services/sign_in/service_account_access_token_jwt_encoder.rb
+++ b/app/services/sign_in/service_account_access_token_jwt_encoder.rb
@@ -28,7 +28,8 @@ module SignIn
         iat: service_account_access_token.created_time.to_i,
         version: service_account_access_token.version,
         scopes: service_account_access_token.scopes,
-        service_account_id: service_account_access_token.service_account_id
+        service_account_id: service_account_access_token.service_account_id,
+        user_attributes: service_account_access_token.user_attributes
       }
     end
 

--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -1620,6 +1620,7 @@ RSpec.describe V0::SignInController, type: :controller do
           {
             uuid:,
             service_account_id:,
+            user_attributes: {},
             user_identifier:,
             scopes:,
             audience:,

--- a/spec/factories/sign_in/service_account_access_tokens.rb
+++ b/spec/factories/sign_in/service_account_access_tokens.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     audience { SecureRandom.hex }
     version { SignIn::Constants::ServiceAccountAccessToken::CURRENT_VERSION }
     scopes { [Faker::Internet.url] }
+    user_attributes { {} }
     user_identifier { Faker::Internet.email }
     expiration_time { Time.zone.now + SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
     created_time { Time.zone.now }
@@ -16,6 +17,7 @@ FactoryBot.define do
       new(service_account_id:,
           audience:,
           scopes:,
+          user_attributes:,
           user_identifier:,
           version:,
           expiration_time:,

--- a/spec/models/sign_in/service_account_access_token_spec.rb
+++ b/spec/models/sign_in/service_account_access_token_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SignIn::ServiceAccountAccessToken, type: :model do
     create(:service_account_access_token,
            service_account_id:,
            audience:,
+           user_attributes:,
            user_identifier:,
            scopes:,
            expiration_time:,
@@ -17,6 +18,7 @@ RSpec.describe SignIn::ServiceAccountAccessToken, type: :model do
   let(:service_account_id) { service_account_config.service_account_id }
   let!(:service_account_config) { create(:service_account_config) }
   let(:audience) { 'some-audience' }
+  let(:user_attributes) { { 'foo' => 'bar' } }
   let(:user_identifier) { 'some-user-identifier' }
   let(:scopes) { [scope] }
   let(:scope) { 'some-scope' }
@@ -133,6 +135,7 @@ RSpec.describe SignIn::ServiceAccountAccessToken, type: :model do
       {
         uuid: service_account_access_token.uuid,
         service_account_id: service_account_access_token.service_account_id,
+        user_attributes: service_account_access_token.user_attributes,
         user_identifier: service_account_access_token.user_identifier,
         scopes: service_account_access_token.scopes,
         audience: service_account_access_token.audience,

--- a/spec/services/sign_in/assertion_validator_spec.rb
+++ b/spec/services/sign_in/assertion_validator_spec.rb
@@ -138,6 +138,26 @@ RSpec.describe SignIn::AssertionValidator do
           end
         end
       end
+
+      context 'and user_attributes claim is provided' do
+        let(:user_attributes) { { 'foo' => 'bar' } }
+        let(:assertion_payload) do
+          {
+            iss: service_account_audience,
+            aud: token_route,
+            sub:,
+            jti:,
+            exp: 1.month.from_now.to_i,
+            service_account_id: service_account_config.service_account_id,
+            scopes: [service_account_config.scopes.first],
+            user_attributes:
+          }
+        end
+
+        it 'returns the service account access token with the user attributes' do
+          expect(subject.user_attributes).to eq(user_attributes)
+        end
+      end
     end
   end
 end

--- a/spec/services/sign_in/service_account_access_token_jwt_decoder_spec.rb
+++ b/spec/services/sign_in/service_account_access_token_jwt_decoder_spec.rb
@@ -111,5 +111,15 @@ RSpec.describe SignIn::ServiceAccountAccessTokenJwtDecoder do
         expect(decoded_access_token.created_time).to eq(Time.zone.at(service_account_access_token.created_time.to_i))
       end
     end
+
+    context 'when valid service account access token contains user_attributes claim' do
+      let(:service_account_access_token) { create(:service_account_access_token, user_attributes:) }
+      let(:user_attributes) { { 'foo' => 'bar' } }
+
+      it 'contains the user_attributes claim' do
+        decoded_access_token = subject
+        expect(decoded_access_token.user_attributes).to eq(user_attributes)
+      end
+    end
   end
 end

--- a/spec/services/sign_in/service_account_access_token_jwt_encoder_spec.rb
+++ b/spec/services/sign_in/service_account_access_token_jwt_encoder_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe SignIn::ServiceAccountAccessTokenJwtEncoder do
       let(:expected_version) { service_account_access_token.version }
       let(:expected_scopes) { service_account_access_token.scopes }
       let(:expected_service_account_id) { service_account_access_token.service_account_id }
+      let(:expected_user_attributes) { service_account_access_token.user_attributes }
 
       before do
         allow(SecureRandom).to receive(:hex).and_return(expected_jti)
@@ -34,6 +35,17 @@ RSpec.describe SignIn::ServiceAccountAccessTokenJwtEncoder do
         expect(decoded_jwt.version).to eq expected_version
         expect(decoded_jwt.scopes).to eq expected_scopes
         expect(decoded_jwt.service_account_id).to eq expected_service_account_id
+        expect(decoded_jwt.user_attributes).to eq expected_user_attributes
+      end
+
+      context 'with optional user_attributes claim' do
+        let(:service_account_access_token) { create(:service_account_access_token, user_attributes:) }
+        let(:user_attributes) { { 'foo' => 'bar' } }
+
+        it 'returns an encoded jwt with expected parameters' do
+          decoded_jwt = OpenStruct.new(JWT.decode(subject, false, nil).first)
+          expect(decoded_jwt.user_attributes).to eq expected_user_attributes
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR allows service accounts to pass a `user_attributes` claim in the assertion used to request a service account access token which will then be included in the generated access token. Some endpoints that use service account authentication (such as the in-progress MAP STS endpoint) require additional attributes about a user to perform a given action; this PR provides a mechanism for service accounts to provide that information and for the endpoints to retrieve it from the service account access token.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#70023


## Testing done

- Open the Rails console and generate an assertion.
```ruby
private_key = OpenSSL::PKey::RSA.new(
  File.read('spec/fixtures/sign_in/sample_service_account.pem')
)

payload = {
  'iss' => 'http://localhost:3001',
  'sub' => 'vets.gov.user+0@gmail.com',
  'aud' => 'http://127.0.0.1:3000/v0/sign_in/token',
  'iat' => Time.now.to_i,
  'exp' => 10.days.from_now.to_i,
  'scopes' => ['http://localhost:3000/v0/map_services/chatbot/token'],
  'service_account_id' => '88a6d94a3182fd63279ea5565f26bcb4',
  'jti' => SecureRandom.hex,
  'user_attributes' => { 'icn' => 'foobar' }
}

JWT.encode(payload, private_key, 'RS256')
```
- Using the Sign in Service postman collection, obtain a service account token.
  - Paste the generated assertion as the value for the `signed_service_account_assertion` collection variable.
  - Send the `token` request (located in the `Service Account Auth` collection.)
- Verify the endpoint responds with a valid service account token.
- Put a breakpoint in the `SignIn::ServiceAccountAccessTokenJwtDecoder` service, line 36 should work fine.
- Send the request to any service account authenticated endpoint with the token.
- Inspect the decoded access token and verify the user attributes claim is present and has the expected value.

## Screenshots
Not relevant.

## What areas of the site does it impact?
This impacts any area using service account authentication.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
