### PR TITLE
[70537] Add access_token_user_attributes to service_account_configs

### DIFF
--- a/db/migrate/20231124170404_add_access_token_attributes_to_service_account_configs.rb
+++ b/db/migrate/20231124170404_add_access_token_attributes_to_service_account_configs.rb
@@ -1,0 +1,5 @@
+class AddAccessTokenAttributesToServiceAccountConfigs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :service_account_configs, :access_token_user_attributes, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -853,6 +853,7 @@ ActiveRecord::Schema.define(version: 2023_12_01_160018) do
     t.string "certificates", array: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "access_token_user_attributes", default: [], array: true
     t.index ["service_account_id"], name: "index_service_account_configs_on_service_account_id", unique: true
   end
 


### PR DESCRIPTION
## Summary

This PR adds the `access_token_user_attributes` column to the `service_account_configs` table, allowing us to validate claims provided by a service account as part of the assertion used to obtain service account access tokens.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#70537


## Testing done

- Verify migration runs successfully.
- Verify new column is added with specified default.

## Screenshots
Not relevant.


## What areas of the site does it impact?
This impacts service account authentication.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

No additional feedback requested.
