### PR TITLE
[70539] Validate access_token_user_attributes for service_account_configs

### DIFF
--- a/app/models/sign_in/service_account_access_token.rb
+++ b/app/models/sign_in/service_account_access_token.rb
@@ -26,7 +26,7 @@ module SignIn
       presence: true
     )
 
-    validates :version, inclusion: Constants::AccessToken::VERSION_LIST
+    validates :version, inclusion: Constants::ServiceAccountAccessToken::VERSION_LIST
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(service_account_id:,
@@ -42,7 +42,7 @@ module SignIn
       @user_identifier = user_identifier
       @scopes = scopes
       @audience = audience
-      @version = version || Constants::AccessToken::CURRENT_VERSION
+      @version = version || Constants::ServiceAccountAccessToken::CURRENT_VERSION
       @expiration_time = expiration_time || set_expiration_time
       @created_time = created_time || set_created_time
 

--- a/app/models/sign_in/service_account_config.rb
+++ b/app/models/sign_in/service_account_config.rb
@@ -10,6 +10,7 @@ module SignIn
     validates :access_token_duration,
               presence: true,
               inclusion: { in: Constants::AccessToken::VALIDITY_LENGTHS, allow_nil: false }
+    validates :access_token_user_attributes, inclusion: { in: Constants::ServiceAccountAccessToken::USER_ATTRIBUTES }
 
     def assertion_public_keys
       @assertion_public_keys ||= certificates.compact.map do |certificate|

--- a/app/models/sign_in/service_account_config.rb
+++ b/app/models/sign_in/service_account_config.rb
@@ -9,7 +9,7 @@ module SignIn
     validates :access_token_audience, presence: true
     validates :access_token_duration,
               presence: true,
-              inclusion: { in: Constants::AccessToken::VALIDITY_LENGTHS, allow_nil: false }
+              inclusion: { in: Constants::ServiceAccountAccessToken::VALIDITY_LENGTHS, allow_nil: false }
     validates :access_token_user_attributes, inclusion: { in: Constants::ServiceAccountAccessToken::USER_ATTRIBUTES }
 
     def assertion_public_keys

--- a/app/services/sign_in/constants/service_account_access_token.rb
+++ b/app/services/sign_in/constants/service_account_access_token.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SignIn
+  module Constants
+    module ServiceAccountAccessToken
+      ISSUER = 'va.gov sign in'
+      JWT_ENCODE_ALGORITHM = 'RS256'
+      USER_ATTRIBUTES = %w[icn].freeze
+      VALIDITY_LENGTHS = [VALIDITY_LENGTH_SHORT_MINUTES = 5.minutes, VALIDITY_LENGTH_LONG_MINUTES = 30.minutes].freeze
+      VERSION_LIST = [
+        CURRENT_VERSION = 'V0'
+      ].freeze
+    end
+  end
+end

--- a/app/services/sign_in/service_account_access_token_jwt_decoder.rb
+++ b/app/services/sign_in/service_account_access_token_jwt_decoder.rb
@@ -29,7 +29,7 @@ module SignIn
         with_validation,
         {
           verify_expiration: with_validation,
-          algorithm: Constants::AccessToken::JWT_ENCODE_ALGORITHM
+          algorithm: Constants::ServiceAccountAccessToken::JWT_ENCODE_ALGORITHM
         }
       )&.first
       OpenStruct.new(decoded_jwt)

--- a/app/services/sign_in/service_account_access_token_jwt_encoder.rb
+++ b/app/services/sign_in/service_account_access_token_jwt_encoder.rb
@@ -15,12 +15,12 @@ module SignIn
     private
 
     def jwt_encode_service_account_access_token
-      JWT.encode(payload, private_key, Constants::AccessToken::JWT_ENCODE_ALGORITHM)
+      JWT.encode(payload, private_key, Constants::ServiceAccountAccessToken::JWT_ENCODE_ALGORITHM)
     end
 
     def payload
       {
-        iss: Constants::AccessToken::ISSUER,
+        iss: Constants::ServiceAccountAccessToken::ISSUER,
         aud: service_account_access_token.audience,
         jti: service_account_access_token.uuid,
         sub: service_account_access_token.user_identifier,

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -85,7 +85,7 @@ vaid_dash.update!(authentication: SignIn::Constants::Auth::COOKIE,
 # Create Service Account Config for VA Identity Dashboard Service Account auth
 vaid_certificate = File.read('spec/fixtures/sign_in/identity_dashboard_service_account.crt')
 vaid_service_account_id = '01b8ebaac5215f84640ade756b645f28'
-vaid_access_token_duration = SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES
+vaid_access_token_duration = SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES
 identity_dashboard_service_account_config =
   SignIn::ServiceAccountConfig.find_or_initialize_by(service_account_id: vaid_service_account_id)
 identity_dashboard_service_account_config.update!(service_account_id: vaid_service_account_id,
@@ -103,6 +103,6 @@ chatbot.update!(
   description: 'Chatbot',
   scopes: ['http://localhost:3000/v0/map_services/chatbot/token'],
   access_token_audience: 'http://localhost:3001',
-  access_token_duration: SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES,
+  access_token_duration: SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES,
   certificates: [File.read('spec/fixtures/sign_in/sample_service_account.crt')]
 )

--- a/spec/factories/sign_in/service_account_access_tokens.rb
+++ b/spec/factories/sign_in/service_account_access_tokens.rb
@@ -6,10 +6,10 @@ FactoryBot.define do
 
     service_account_id { create(:service_account_config).service_account_id }
     audience { SecureRandom.hex }
-    version { SignIn::Constants::AccessToken::CURRENT_VERSION }
+    version { SignIn::Constants::ServiceAccountAccessToken::CURRENT_VERSION }
     scopes { [Faker::Internet.url] }
     user_identifier { Faker::Internet.email }
-    expiration_time { Time.zone.now + SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
+    expiration_time { Time.zone.now + SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
     created_time { Time.zone.now }
 
     initialize_with do

--- a/spec/factories/sign_in/service_account_configs.rb
+++ b/spec/factories/sign_in/service_account_configs.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     description { SecureRandom.hex }
     scopes { [Faker::Internet.url] }
     access_token_audience { SecureRandom.hex }
-    access_token_duration { SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
+    access_token_duration { SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
     access_token_user_attributes { [] }
     certificates { [] }
   end

--- a/spec/factories/sign_in/service_account_configs.rb
+++ b/spec/factories/sign_in/service_account_configs.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     scopes { [Faker::Internet.url] }
     access_token_audience { SecureRandom.hex }
     access_token_duration { SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
+    access_token_user_attributes { [] }
     certificates { [] }
   end
 end

--- a/spec/models/sign_in/service_account_access_token_spec.rb
+++ b/spec/models/sign_in/service_account_access_token_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SignIn::ServiceAccountAccessToken, type: :model do
   let(:user_identifier) { 'some-user-identifier' }
   let(:scopes) { [scope] }
   let(:scope) { 'some-scope' }
-  let(:version) { SignIn::Constants::AccessToken::CURRENT_VERSION }
+  let(:version) { SignIn::Constants::ServiceAccountAccessToken::CURRENT_VERSION }
   let(:validity_length) { service_account_config.access_token_duration }
   let(:expiration_time) { Time.zone.now + validity_length }
   let(:created_time) { Time.zone.now }
@@ -83,7 +83,7 @@ RSpec.describe SignIn::ServiceAccountAccessToken, type: :model do
 
       context 'when version is nil' do
         let(:version) { nil }
-        let(:expected_version) { SignIn::Constants::AccessToken::CURRENT_VERSION }
+        let(:expected_version) { SignIn::Constants::ServiceAccountAccessToken::CURRENT_VERSION }
 
         it 'sets version to CURRENT_VERSION' do
           expect(subject).to be expected_version

--- a/spec/models/sign_in/service_account_config_spec.rb
+++ b/spec/models/sign_in/service_account_config_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe SignIn::ServiceAccountConfig, type: :model do
   let(:certificates) { [] }
   let(:service_account_id) { SecureRandom.hex }
-  let(:access_token_duration) { SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
+  let(:access_token_duration) { SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
   let(:description) { 'some-description' }
   let(:access_token_audience) { 'some-access-token-audience' }
   let(:access_token_user_attributes) { [] }

--- a/spec/models/sign_in/service_account_config_spec.rb
+++ b/spec/models/sign_in/service_account_config_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe SignIn::ServiceAccountConfig, type: :model do
   let(:access_token_duration) { SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
   let(:description) { 'some-description' }
   let(:access_token_audience) { 'some-access-token-audience' }
+  let(:access_token_user_attributes) { [] }
   let(:service_account_config) do
     create(:service_account_config,
            service_account_id:,
            access_token_duration:,
            description:,
            access_token_audience:,
+           access_token_user_attributes:,
            certificates:)
   end
 
@@ -91,6 +93,48 @@ RSpec.describe SignIn::ServiceAccountConfig, type: :model do
 
         it 'raises validation error' do
           expect { subject }.to raise_error(expected_error, expected_error_message)
+        end
+      end
+    end
+
+    describe '#access_token_user_attributes' do
+      subject { service_account_config.access_token_user_attributes }
+
+      let(:expected_error_message) do
+        'Validation failed: Access token user attributes is not included in the list'
+      end
+
+      context 'when access_token_user_attributes is empty' do
+        it 'does not raise validation error' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when access_token_user_attributes contains an unallowed item' do
+        let(:access_token_user_attributes) { ['foo'] }
+
+        it 'raises validation error' do
+          expect { subject }.to raise_error(expected_error, expected_error_message)
+        end
+      end
+
+      context 'when access_token_user_attributes contains an allowed item' do
+        let(:access_token_user_attributes) { items }
+
+        context 'and it contains only allowed items' do
+          let(:items) { ['icn'] }
+
+          it 'does not raise validation error' do
+            expect { subject }.not_to raise_error
+          end
+        end
+
+        context 'and it also contains an unallowed item' do
+          let(:items) { %w[icn foo] }
+
+          it 'raises validation error' do
+            expect { subject }.to raise_error(expected_error, expected_error_message)
+          end
         end
       end
     end

--- a/spec/services/sign_in/service_account_access_token_jwt_decoder_spec.rb
+++ b/spec/services/sign_in/service_account_access_token_jwt_decoder_spec.rb
@@ -47,13 +47,13 @@ RSpec.describe SignIn::ServiceAccountAccessTokenJwtDecoder do
         JWT.encode(
           jwt_payload,
           OpenSSL::PKey::RSA.new(2048),
-          SignIn::Constants::AccessToken::JWT_ENCODE_ALGORITHM
+          SignIn::Constants::ServiceAccountAccessToken::JWT_ENCODE_ALGORITHM
         )
       end
 
       let(:jwt_payload) do
         {
-          iss: SignIn::Constants::AccessToken::ISSUER,
+          iss: SignIn::Constants::ServiceAccountAccessToken::ISSUER,
           aud: service_account_access_token.audience,
           jti: service_account_access_token.uuid,
           sub: service_account_access_token.user_identifier,

--- a/spec/services/sign_in/service_account_access_token_jwt_encoder_spec.rb
+++ b/spec/services/sign_in/service_account_access_token_jwt_encoder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SignIn::ServiceAccountAccessTokenJwtEncoder do
     let(:service_account_access_token) { create(:service_account_access_token) }
 
     context 'when input object is a service account access token' do
-      let(:expected_iss) { SignIn::Constants::AccessToken::ISSUER }
+      let(:expected_iss) { SignIn::Constants::ServiceAccountAccessToken::ISSUER }
       let(:expected_aud) { service_account_access_token.audience }
       let(:expected_jti) { service_account_access_token.uuid }
       let(:expected_sub) { service_account_access_token.user_identifier }


### PR DESCRIPTION
## Summary

This PR validates the contents of the `access_token_user_attributes` field to ensure that only allowed values are set.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#70539


## Testing done

- Use the Rails console to load a service account config.
```ruby
config = SignIn::ServiceAccountConfig.last
```
- Attempt to store an invalid value (`['foobar'] }`)
```ruby
config.access_token_user_attributes = ['foobar']
```
- Verify the validation fails.
- Attempt to store a valid value (`['icn']`)
```ruby
config.access_token_user_attributes = ['icn']
```
- Verify the validation succeeds.

## Screenshots
Not relevant.


## What areas of the site does it impact?
This PR impacts service account authentication.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
