### PR TITLE
Remove yellow_ribbon_mvp_enhancement feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1105,10 +1105,6 @@ features:
   va_view_dependents_access:
     actor_type: user
     description: Allows us to gate the View/ Modify dependents content in a progressive rollout
-  yellow_ribbon_mvp_enhancement:
-    actor_type: user
-    description: Enhances Yellow Ribbon MVP.
-    enable_in_development: true
   show_edu_benefits_1990EZ_Wizard:
     actor_type: user
     description: Navigates user to 1990EZ or 1990 depending on form questions.


### PR DESCRIPTION
## Summary

- Remove the Yellow Ribbon MVP enhancement feature flag that does not appear to be used
- I work for the VA.gov Iterate, Innovate, and Run (IIR) Team

## Related issue(s)
- [VA-IIR 165](https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/165)


## Testing done

- Checked `http://localhost:3000/flipper/features` to make sure the yellow_ribbon_mvp_enhancement flag is no longer listed


## What areas of the site does it impact?
This should not impact any areas of the site since the feature flag is not being used.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
