### PR TITLE
[DBX-70888] bump 526 backup worker retries to 14

### DIFF
--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -20,7 +20,7 @@ module Sidekiq
       include SentryLogging
       include Sidekiq::Job
 
-      sidekiq_options retry: 10
+      sidekiq_options retry: 14
       STATSD_KEY = 'worker.evss.form526_backup_submission_process.exhausted'
 
       sidekiq_retries_exhausted do |msg, _ex|


### PR DESCRIPTION
## Summary

- Bump up the number of retries on form 526's backup submission worker from 10 to 14.  14 is the convention, this change brings the backup worker in line with the rest of the application

## Related issue(s)
- [Ticket](https://app.zenhub.com/workspaces/dbex-product-64777ee8daac5b0ea9c0f5cc/issues/gh/department-of-veterans-affairs/va.gov-team/70888)

## Testing done

- Class instantiation is sufficient to ensure continuity

## What areas of the site does it impact?
- Form 526 backup submissions

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
