### PR TITLE
API-31525 Update default sorting of results in VA Forms API

### DIFF
--- a/modules/va_forms/app/models/va_forms/form.rb
+++ b/modules/va_forms/app/models/va_forms/form.rb
@@ -29,7 +29,8 @@ module VAForms
     end
 
     def self.search_by_form_number(search_term)
-      Form.where('upper(form_name) LIKE ?', "%#{search_term.upcase}%").order(form_name: :asc, language: :asc)
+      Form.where('upper(form_name) LIKE ?', "%#{search_term.upcase}%")
+          .order(form_name: :asc, deleted_at: :desc, language: :asc, title: :asc)
     end
 
     def self.old_search(search_term: nil)


### PR DESCRIPTION
## Summary

Updates sorting of outputs when searching by form number so that deleted versions of forms come _after_ non-deleted versions.

Since there may also be multiple _current_ versions of forms with the same name (because the language or the suffix (a, b, etc.) may vary), this also sorts results by the `title` after the `name`. This tends to have the effect of putting spanish versions after english versions when the `language` attribute of the form is incorrectly set to `en` for spanish, because their titles tend to be along the lines of "form name (espanol)" vs the original "form name".

**Here are some examples that I tried out in the staging console:**

Form 10-493b (which initiated this change) - previously, the deleted result was first, followed by the Spanish version, followed by the current English version:
```
[
  {
    "form_name": "10-493b",
    "title": "CHAMPVA Benefits Election Affirmation",
    "deleted_at": null,
    "language": "en"
  },
  {
    "form_name": "10-493b",
    "title": "CHAMPVA Benefits Election Affirmation Espanol",
    "deleted_at": null,
    "language": "en"
  },
  {
    "form_name": "10-493b",
    "title": "CHAMPVA Benefits Election Affirmation",
    "deleted_at": "2021-03-11T00:00:00.000Z",
    "language": "en"
  }
]
```

**Here are few other examples of what results will look like with these changes:**

21P-8416 (which also has an incorrect language for the Spanish version):
```
[
  {
    "form_name": "21P-8416",
    "title": "Medical Expense Report",
    "deleted_at": null,
    "language": "en"
  },
  {
    "form_name": "21P-8416b",
    "title": "Report of Medical, Legal, and Other Expenses Incident to Recovery for Injury or Death",
    "deleted_at": null,
    "language": "en"
  },
  {
    "form_name": "21P-8416(Spanish)",
    "title": "Reporte De Gastos Medicos (Fillable)",
    "deleted_at": null,
    "language": "en"
  }
]
```

10-305, same issue:
```
[
  {
    "form_name": "10-305",
    "title": "VA Form 10-305 Your Rights to Seek Further Review of PCAFC Decisions",
    "deleted_at": null,
    "language": "en"
  },
  {
    "form_name": "10-305(s)",
    "title": "Your Rights To Seek Further Review of Program of Comprehensive Assistance     for Family Caregivers (PCAFC) Decisions – Spanish",
    "deleted_at": null,
    "language": "en"
  }
]
```

And 10-0137, which has a few English results and one (correctly attributed) Spanish one:
```
[
  {
    "form_name": "10-0137",
    "title": "VA Advance Directive: Durable Power of Attorney for Health Care and Living Will",
    "deleted_at": null,
    "language": "en"
  },
  {
    "form_name": "10-0137A",
    "title": "What You Should Know About Advance Directives",
    "deleted_at": null,
    "language": "en"
  },
  {
    "form_name": "10-0137B",
    "title": "WHAT YOU SHOULD KNOW ABOUT ADVANCE DIRECTIVES",
    "deleted_at": null,
    "language": null
  },
  {
    "form_name": "10-0137 (espanol)",
    "title": "Directrices Anticipadas De Va Poder Legal Para La Designacion De Agente Para El Cuidado De Salud Y Testamento En Vida",
    "deleted_at": null,
    "language": "es"
  }
]
```

## Related issue(s)
- [API-31525](https://jira.devops.va.gov/browse/API-31525)

## Testing done

- I just copied the code here to run these queries in the rails console in staging, since adding a unit test felt like testing the framework in this case



## What areas of the site does it impact?
- Sorting in VA Forms API results

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature