### PR TITLE
70751 check that cg pdf file exists before delete

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -42,7 +42,9 @@ module V0
       client_file_name = file_name_for_pdf(@claim.veteran_data)
       file_contents    = File.read(source_file_path)
 
-      File.delete(source_file_path)
+      # rubocop:disable Lint/NonAtomicFileOperation
+      File.delete(source_file_path) if File.exist?(source_file_path)
+      # rubocop:enable Lint/NonAtomicFileOperation
 
       auditor.record(:pdf_download)
 


### PR DESCRIPTION
## Summary

- Per [http://sentry.vfs.va.gov/organizations/vsp/issues/120920/?query=is%3Aunresolved+download_pdf&statsPeriod=14d](this issue) we have intermittent failures where the File to delete is either no longer there or the file permissions are triggering the wrong error.  This check will nullify the error coming through sentry and, as long as the file content is there , should not impact functionality.

## Related issue(s)
- [https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/70751](https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/70751)


## Testing done

- Manual testing 
