### PR TITLE
[DBX-70888] bump 526 backup retries to 14

### DIFF
--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -20,7 +20,7 @@ module Sidekiq
       include SentryLogging
       include Sidekiq::Job
 
-      sidekiq_options retry: 10
+      sidekiq_options retry: 14
       STATSD_KEY = 'worker.evss.form526_backup_submission_process.exhausted'
 
       sidekiq_retries_exhausted do |msg, _ex|


### PR DESCRIPTION
## Summary

- Previously approved, resubmitting after PII git history cleaning
- bumps retries for our form 526 backup submission worker to 14, bringing it inline with our established paradigm

## Related issue(s)
- [ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/70888)

## Testing done

- Class instantiation is sufficient to ensure continuity

## What areas of the site does it impact?
Form 526 submissions backup path

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
