### PR TITLE
API-32002 Update method name to follow Ruby conventions

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
@@ -460,9 +460,9 @@ module ClaimsApi
         treatments.each do |treatment|
           next if treatment['beginDate'].nil?
 
-          treatment_begin_date = if type_of_date_format?(treatment['beginDate']) == 'yyyy-mm'
+          treatment_begin_date = if type_of_date_format(treatment['beginDate']) == 'yyyy-mm'
                                    Date.strptime(treatment['beginDate'], '%Y-%m')
-                                 elsif type_of_date_format?(treatment['beginDate']) == 'yyyy'
+                                 elsif type_of_date_format(treatment['beginDate']) == 'yyyy'
                                    Date.strptime(treatment['beginDate'], '%Y')
 
                                  else
@@ -869,16 +869,16 @@ module ClaimsApi
       # Either date could be in MM-YYYY or MM-DD-YYYY format
       def begin_date_after_end_date_with_mixed_format_dates?(begin_date, end_date)
         # figure out if either has the day and remove it to compare
-        if type_of_date_format?(begin_date) == 'yyyy-mm-dd'
+        if type_of_date_format(begin_date) == 'yyyy-mm-dd'
           begin_date = remove_chars(begin_date.dup)
-        elsif type_of_date_format?(end_date) == 'yyyy-mm-dd'
+        elsif type_of_date_format(end_date) == 'yyyy-mm-dd'
           end_date = remove_chars(end_date.dup)
         end
         Date.strptime(begin_date, '%Y-%m') > Date.strptime(end_date, '%Y-%m') # only > is an issue
       end
 
       def date_is_valid_against_current_time_after_check_on_format?(date)
-        case type_of_date_format?(date)
+        case type_of_date_format(date)
         when 'yyyy-mm-dd'
           param_date = Date.strptime(date, '%Y-%m-%d')
           now_date = Date.strptime(Time.zone.today.strftime('%Y-%m-%d'), '%Y-%m-%d')
@@ -898,7 +898,7 @@ module ClaimsApi
       end
 
       # which of the three types are we dealing with
-      def type_of_date_format?(date)
+      def type_of_date_format(date)
         DATE_FORMATS[date.length]
       end
 


### PR DESCRIPTION
## Summary

- Updates validation method `type_of_date_format?` to remove the question mark, as Ruby conventions generally reserve such usage for methods returning a boolean.

## Related issue(s)
[API-32002](https://jira.devops.va.gov/browse/API-32002)

## Testing done

- Postman validation testing
- Ran rspec tests

## What areas of the site does it impact?
modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
