### PR TITLE
Bypass Carrierwave Lint in K8s Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           bundler-cache: true
 
       - name: Run bundle-audit (checks gems for CVE issues)
-        run:  bundle exec bundle-audit check --update --ignore CVE-2023-26141
+        run:  bundle exec bundle-audit check --update --ignore CVE-2023-26141 CVE-2023-49090
 
       - name: Run Rubocop
         run: bundle exec rubocop --parallel --format github


### PR DESCRIPTION
## Summary
Bypass a Carrierwave linting error in k8s branch causing CI failures until a fix for the specs can be found.


## Related issue(s)
[Slack Thread](https://dsva.slack.com/archives/CBU0KDSB1/p1701458800990639?thread_ts=1701380318.229599&cid=CBU0KDSB1)


