### PR TITLE
Use the MetadataValidator in the simple forms uploads controller

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -2,6 +2,7 @@
 
 require 'ddtrace'
 require 'simple_forms_api_submission/service'
+require 'simple_forms_api_submission/metadata_validator'
 
 module SimpleFormsApi
   module V1
@@ -75,7 +76,7 @@ module SimpleFormsApi
         filler = SimpleFormsApi::PdfFiller.new(form_number: form_id, data: parsed_form_data)
 
         file_path = filler.generate
-        metadata = filler.metadata
+        metadata = SimpleFormsApiSubmission::MetadataValidator.validate(filler.metadata)
 
         SimpleFormsApi::VBA400247.new(parsed_form_data).handle_attachments(file_path) if form_id == 'vba_40_0247'
 

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'simple_forms_api_submission/metadata_validator'
 
 RSpec.describe 'Dynamic forms uploader', type: :request do
   describe 'form request' do
@@ -18,13 +19,12 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
           VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
             fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', test_payload)
             data = JSON.parse(fixture_path.read)
+            allow(SimpleFormsApiSubmission::MetadataValidator).to receive(:validate)
 
             post '/simple_forms_api/v1/simple_forms', params: data
 
             expect(response).to have_http_status(:ok)
-          ensure
-            metadata_file = Dir['tmp/*.SimpleFormsApi.metadata.json'][0]
-            Common::FileHelpers.delete_file_if_exists(metadata_file) if defined?(metadata_file)
+            expect(SimpleFormsApiSubmission::MetadataValidator).to have_received(:validate)
           end
         end
       end

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
 
             expect(response).to have_http_status(:ok)
             expect(SimpleFormsApiSubmission::MetadataValidator).to have_received(:validate)
+          ensure
+            metadata_file = Dir['tmp/*.SimpleFormsApi.metadata.json'][0]
+            Common::FileHelpers.delete_file_if_exists(metadata_file) if defined?(metadata_file)
           end
         end
       end


### PR DESCRIPTION
## Summary
This PR makes use of the `MetadataValidator` previously introduced in [this commit](https://github.com/department-of-veterans-affairs/vets-api/commit/a1df17cb0f099ca0a40db74e18508846ff581c17). It calls the validator on the metadata that we construct in the Simple Forms API and will hopefully result in more errors being surfaced sooner.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/70638


## Testing done

Automated tests updated to confirm that we always call this when submitting forms.

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
Currently only the Simple Forms API but it is intended to be more widely applicable.

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
