### PR TITLE
Add exhaustion logging for 526 jobs (2 of 2)

### DIFF
--- a/app/sidekiq/bgs/flash_updater.rb
+++ b/app/sidekiq/bgs/flash_updater.rb
@@ -11,6 +11,12 @@ module BGS
 
     attr_accessor :submission_id
 
+    # Sidekiq has built in exponential back-off functionality for retries
+    # A max retry attempt of 10 will result in a run time of ~8 hours
+    # This job is invoked from 526 background job
+    sidekiq_options retry: 10
+    STATSD_KEY_PREFIX = 'worker.bgs.flash_updater.exhausted'
+
     wrap_with_logging(
       :add_flashes,
       additional_class_logs: {
@@ -20,6 +26,51 @@ module BGS
         submission_id: %i[submission_id]
       }
     )
+
+    sidekiq_retries_exhausted do |msg, _ex|
+      job_id = msg['jid']
+      error_class = msg['error_class']
+      error_message = msg['error_message']
+      timestamp = Time.now.utc
+      form526_submission_id = msg['args'].first
+
+      form_job_status = Form526JobStatus.find_by(job_id:)
+      bgjob_errors = form_job_status.bgjob_errors || {}
+      new_error = {
+        "#{timestamp.to_i}": {
+          caller_method: __method__.to_s,
+          error_class:,
+          error_message:,
+          timestamp:,
+          form526_submission_id:
+        }
+      }
+      form_job_status.update(
+        status: Form526JobStatus::STATUS[:exhausted],
+        bgjob_errors: bgjob_errors.merge(new_error)
+      )
+
+      StatsD.increment(STATSD_KEY_PREFIX)
+
+      ::Rails.logger.warn(
+        'Flash Updater Retries exhausted',
+        { job_id:, error_class:, error_message:, timestamp:, form526_submission_id: }
+      )
+    rescue => e
+      ::Rails.logger.error(
+        'Failure in FlashUpdater#sidekiq_retries_exhausted',
+        {
+          messaged_content: e.message,
+          job_id:,
+          submission_id: form526_submission_id,
+          pre_exhaustion_failure: {
+            error_class:,
+            error_message:
+          }
+        }
+      )
+      raise e
+    end
 
     def perform(submission_id)
       @submission_id = submission_id

--- a/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
@@ -3,17 +3,55 @@
 module EVSS
   module DisabilityCompensationForm
     class SubmitUploads < Job
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_upload'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_upload.exhausted'
 
       # retry for one day
       sidekiq_options retry: 14
 
-      # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
-      # :nocov:
       sidekiq_retries_exhausted do |msg, _ex|
-        job_exhausted(msg, STATSD_KEY_PREFIX)
+        job_id = msg['jid']
+        error_class = msg['error_class']
+        error_message = msg['error_message']
+        timestamp = Time.now.utc
+        form526_submission_id = msg['args'].first
+
+        form_job_status = Form526JobStatus.find_by(job_id:)
+        bgjob_errors = form_job_status.bgjob_errors || {}
+        new_error = {
+          "#{timestamp.to_i}": {
+            caller_method: __method__.to_s,
+            error_class:,
+            error_message:,
+            timestamp:,
+            form526_submission_id:
+          }
+        }
+        form_job_status.update(
+          status: Form526JobStatus::STATUS[:exhausted],
+          bgjob_errors: bgjob_errors.merge(new_error)
+        )
+
+        StatsD.increment(STATSD_KEY_PREFIX)
+
+        ::Rails.logger.warn(
+          'Submit Form 526 Upload Retries exhausted',
+          { job_id:, error_class:, error_message:, timestamp:, form526_submission_id: }
+        )
+      rescue => e
+        ::Rails.logger.error(
+          'Failure in SubmitUploads#sidekiq_retries_exhausted',
+          {
+            messaged_content: e.message,
+            job_id:,
+            submission_id: form526_submission_id,
+            pre_exhaustion_failure: {
+              error_class:,
+              error_message:
+            }
+          }
+        )
+        raise e
       end
-      # :nocov:
 
       # Recursively submits a file in a new instance of this job for each upload in the uploads list
       #

--- a/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
+++ b/app/sidekiq/evss/disability_compensation_form/upload_bdd_instructions.rb
@@ -7,17 +7,55 @@ module EVSS
     class UploadBddInstructions < Job
       extend Logging::ThirdPartyTransaction::MethodWrapper
 
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_bdd_instructions'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_bdd_instructions.exhausted'
 
       # retry for one day
       sidekiq_options retry: 14
 
-      # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
-      # :nocov:
       sidekiq_retries_exhausted do |msg, _ex|
-        job_exhausted(msg, STATSD_KEY_PREFIX)
+        job_id = msg['jid']
+        error_class = msg['error_class']
+        error_message = msg['error_message']
+        timestamp = Time.now.utc
+        form526_submission_id = msg['args'].first
+
+        form_job_status = Form526JobStatus.find_by(job_id:)
+        bgjob_errors = form_job_status.bgjob_errors || {}
+        new_error = {
+          "#{timestamp.to_i}": {
+            caller_method: __method__.to_s,
+            error_class:,
+            error_message:,
+            timestamp:,
+            form526_submission_id:
+          }
+        }
+        form_job_status.update(
+          status: Form526JobStatus::STATUS[:exhausted],
+          bgjob_errors: bgjob_errors.merge(new_error)
+        )
+
+        StatsD.increment(STATSD_KEY_PREFIX)
+
+        ::Rails.logger.warn(
+          'Submit Form 526 Upload BDD Instructions Retries exhausted',
+          { job_id:, error_class:, error_message:, timestamp:, form526_submission_id: }
+        )
+      rescue => e
+        ::Rails.logger.error(
+          'Failure in UploadBddInstructions#sidekiq_retries_exhausted',
+          {
+            messaged_content: e.message,
+            job_id:,
+            submission_id: form526_submission_id,
+            pre_exhaustion_failure: {
+              error_class:,
+              error_message:
+            }
+          }
+        )
+        raise e
       end
-      # :nocov:
 
       wrap_with_logging(
         :upload_bdd_instructions,

--- a/spec/lib/sidekiq/form526_job_status_tracker/job_tracker_spec.rb
+++ b/spec/lib/sidekiq/form526_job_status_tracker/job_tracker_spec.rb
@@ -43,12 +43,12 @@ describe Sidekiq::Form526JobStatusTracker::JobTracker do
       job_status = Form526JobStatus.last
       expect(job_status.status).to eq 'exhausted'
       expect(job_status.job_class).to eq 'SubmitForm526AllClaim'
-      expect(job_status.error_message).to eq msg['error_message']
       expect(job_status.form526_submission_id).to eq form526_submission.id
 
       expect(job_status.bgjob_errors).to be_a Hash
       key = job_status.bgjob_errors.keys.first
-      expect(job_status.bgjob_errors[key].keys).to match_array %w[timestamp caller_method error_class error_message]
+      expect(job_status.bgjob_errors[key].keys).to match_array %w[timestamp caller_method error_class
+                                                                  error_message form526_submission_id]
       expect(job_status.bgjob_errors[key]['caller_method']).to match 'job_exhausted'
     end
 
@@ -61,12 +61,12 @@ describe Sidekiq::Form526JobStatusTracker::JobTracker do
       job_status = Form526JobStatus.last
       expect(job_status.status).to eq 'exhausted'
       expect(job_status.job_class).to eq 'SubmitForm526AllClaim'
-      expect(job_status.error_message).to eq msg['error_message']
       expect(job_status.form526_submission_id).to eq form526_submission.id
 
       expect(job_status.bgjob_errors).to be_a Hash
       key = job_status.bgjob_errors.keys.first
-      expect(job_status.bgjob_errors[key].keys).to match_array %w[timestamp caller_method error_class error_message]
+      expect(job_status.bgjob_errors[key].keys).to match_array %w[timestamp caller_method error_class
+                                                                  error_message form526_submission_id]
       expect(job_status.bgjob_errors[key]['caller_method']).to match 'job_exhausted'
     end
 

--- a/spec/sidekiq/bgs/flash_updater_spec.rb
+++ b/spec/sidekiq/bgs/flash_updater_spec.rb
@@ -45,4 +45,20 @@ RSpec.describe BGS::FlashUpdater, type: :job do
 
     subject.new.perform(submission.id)
   end
+
+  context 'catastrophic failure state' do
+    describe 'when all retries are exhausted' do
+      let!(:form526_submission) { create(:form526_submission) }
+      let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
+
+      it 'updates a StatsD counter and updates the status on an exhaustion event' do
+        subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
+          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(Rails).to receive(:logger).and_call_original
+        end
+        form526_job_status.reload
+        expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
+      end
+    end
+  end
 end

--- a/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -101,4 +101,20 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
       end
     end
   end
+
+  context 'catastrophic failure state' do
+    describe 'when all retries are exhausted' do
+      let!(:form526_submission) { create(:form526_submission) }
+      let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
+
+      it 'updates a StatsD counter and updates the status on an exhaustion event' do
+        subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
+          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(Rails).to receive(:logger).and_call_original
+        end
+        form526_job_status.reload
+        expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
+      end
+    end
+  end
 end

--- a/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
@@ -61,4 +61,20 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
       end
     end
   end
+
+  context 'catastrophic failure state' do
+    describe 'when all retries are exhausted' do
+      let!(:form526_submission) { create(:form526_submission) }
+      let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
+
+      it 'updates a StatsD counter and updates the status on an exhaustion event' do
+        subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
+          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(Rails).to receive(:logger).and_call_original
+        end
+        form526_job_status.reload
+        expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- add / update / homogenize on-exhaustion hooks for 526 related sidekiq async jobs.  This allows for logs that can be aggregated on in Datadog, as well as the addition of stats D metrics.

### Note: PR is part 2 of 2
- [PR 1 of 2](https://github.com/department-of-veterans-affairs/vets-api/pull/14737)

## Related issue(s)
- [ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/67288)

## Testing done

- added RSpec tests
- manual click through and instantiation

## What areas of the site does it impact?
- 526 Async submission

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
