### PR TITLE
Remove Banana Peels from Codeowners entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,11 +7,11 @@ Dangerfile @department-of-veterans-affairs/backend-review-group
 Dockerfile @department-of-veterans-affairs/backend-review-group
 Gemfile @department-of-veterans-affairs/backend-review-group
 Gemfile.lock @department-of-veterans-affairs/backend-review-group
-app/controllers/appeals_base_controller.rb @department-of-veterans-affairs/lighthouse-banana-peels
-app/controllers/appeals_base_controller_v1.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/controllers/appeals_base_controller.rb
+app/controllers/appeals_base_controller_v1.rb
 app/controllers/application_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/bb_controller.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/controllers/claims_base_controller.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/controllers/claims_base_controller.rb
 app/controllers/concerns/accountable.rb @department-of-veterans-affairs/vsp-identity
 app/controllers/concerns/authentication_and_sso_concerns.rb @department-of-veterans-affairs/vsp-identity
 app/controllers/concerns/exception_handling.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -158,8 +158,8 @@ app/mailers/dependents_application_failure_mailer.rb @department-of-veterans-aff
 app/mailers/direct_deposit_mailer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/failed_claims_report_mailer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/hca_submission_failure_mailer.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/mailers/rrd_alert_mailer.rb @department-of-veterans-affairs/lighthouse-banana-peels
-app/mailers/rrd_mas_notification_mailer.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/mailers/rrd_alert_mailer.rb
+app/mailers/rrd_mas_notification_mailer.rb
 app/mailers/school_certifying_officials_mailer.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/spool10203_submissions_report_mailer.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/spool_submissions_report_mailer.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -173,8 +173,8 @@ app/mailers/views/dependents_application_failure.erb @department-of-veterans-aff
 app/mailers/views/direct_deposit.html.erb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/mailers/views/failed_claims_report.erb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/mailers/views/hca_submission_failure.html.erb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/mailers/views/rrd_alert_mailer.html.erb @department-of-veterans-affairs/lighthouse-banana-peels
-app/mailers/views/rrd_mas_notification_mailer.html.erb @department-of-veterans-affairs/lighthouse-banana-peels
+app/mailers/views/rrd_alert_mailer.html.erb
+app/mailers/views/rrd_mas_notification_mailer.html.erb
 app/mailers/views/school_certifying_officials.html.erb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/views/stem_applicant_confirmation.html.erb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/views/stem_applicant_denial.html.erb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -192,14 +192,14 @@ app/models/async_transaction/base.rb @department-of-veterans-affairs/vfs-authent
 app/models/async_transaction/va_profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/models/async_transaction/vet360 @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/models/attachment.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/models/backend_status.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/models/backend_status.rb
 app/models/bank_name.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/base_facility.rb @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/bgs_dependents @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 app/models/central_mail_claim.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/central_mail_submission.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/models/claims_api @department-of-veterans-affairs/lighthouse-banana-peels
-app/models/claims_api/claim_submission.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/models/claims_api
+app/models/claims_api/claim_submission.rb
 app/models/concerns/async_request.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/concerns/authorization.rb @department-of-veterans-affairs/backend-review-group
 app/models/concerns/form526_claim_fast_tracking_concern.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -266,7 +266,7 @@ app/models/identifier_index.rb @department-of-veterans-affairs/vsa-debt-resoluti
 app/models/inherited_proofing @department-of-veterans-affairs/vsp-identity
 app/models/inherited_proof_verified_user_account.rb @department-of-veterans-affairs/vsp-identity
 app/models/in_progress_form.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/models/lighthouse_document.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/models/lighthouse_document.rb
 app/models/maintenance_window.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/message_draft.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/message.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -276,11 +276,11 @@ app/models/message_thread.rb @department-of-veterans-affairs/vfs-mhv-secure-mess
 app/models/messaging_preference.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/mhv_opt_in_flag.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/mpi_data.rb @department-of-veterans-affairs/vsp-identity
-app/models/okta_redis @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/lighthouse-pivot
+app/models/okta_redis @department-of-veterans-affairs/lighthouse-pivot
 app/models/okta_redis/app.rb @department-of-veterans-affairs/lighthouse-pivot
-app/models/okta_redis/grants.rb @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/lighthouse-pivot
-app/models/okta_redis/model.rb @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/lighthouse-pivot
-app/models/okta_redis/profile.rb @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/lighthouse-pivot
+app/models/okta_redis/grants.rb @department-of-veterans-affairs/lighthouse-pivot
+app/models/okta_redis/model.rb @department-of-veterans-affairs/lighthouse-pivot
+app/models/okta_redis/profile.rb @department-of-veterans-affairs/lighthouse-pivot
 app/models/old_email.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/onsite_notification.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/opaque_token.rb @department-of-veterans-affairs/lighthouse-pivot
@@ -346,7 +346,7 @@ app/models/webhooks/notification_attempt.rb @department-of-veterans-affairs/back
 app/models/webhooks/notification.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/webhooks/subscription.rb @department-of-veterans-affairs/backend-review-group
 app/models/webhooks/utilities.rb @department-of-veterans-affairs/backend-review-group
-app/policies/appeals_policy.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/policies/appeals_policy.rb
 app/policies/bgs_policy.rb  @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 app/policies/ch33_dd_policy.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/policies/coe_policy.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -356,7 +356,7 @@ app/policies/debt_policy.rb @department-of-veterans-affairs/vsa-debt-resolution 
 app/policies/demographics_policy.rb@department-of-veterans-affairs/mobile-api-team
 app/policies/form1095_policy.rb @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/policies/hca_disability_rating_policy.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/policies/lighthouse_policy.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/policies/lighthouse_policy.rb
 app/policies/meb_policy.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/policies/medical_copays_policy.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 app/policies/mhv_health_records_policy.rb @department-of-veterans-affairs/vfs-health-modernization-initiative @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -372,7 +372,7 @@ app/serializers/attachment_serializer.rb @department-of-veterans-affairs/vfs-10-
 app/serializers/backend_statuses_serializer.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/backend_status_serializer.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/cemetery_serializer.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/serializers/central_mail_submission_serializer.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/serializers/central_mail_submission_serializer.rb
 app/serializers/ch33_bank_account_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/communication_groups_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/decision_review_evidence_attachment_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -402,7 +402,7 @@ app/serializers/hca_rating_info_serializer.rb @department-of-veterans-affairs/vf
 app/serializers/health_care_application_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/in_progress_form_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/letter_beneficiary_serializer.rb@department-of-veterans-affairs/mobile-api-team
-app/serializers/lighthouse @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/serializers/lighthouse @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/maintenance_window_serializer.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/message_serializer.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/messages_serializer.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -421,7 +421,7 @@ app/serializers/prescription_preference_serializer.rb @department-of-veterans-af
 app/serializers/prescription_serializer.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/profile_photo_attachment_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/rated_disabilities_serializer.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/serializers/rating_info_serializer.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/serializers/rating_info_serializer.rb
 app/serializers/receive_application_serializer.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/saved_claim_serializer.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/search_serializer.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -466,7 +466,7 @@ app/services/sign_in @department-of-veterans-affairs/vsp-identity
 app/services/terms_of_use/ @department-of-veterans-affairs/vsp-identity
 app/services/users @department-of-veterans-affairs/vsp-identity
 app/swagger/readme.md @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/swagger/swagger/requests/appeals @department-of-veterans-affairs/lighthouse-banana-peels
+app/swagger/swagger/requests/appeals
 app/swagger/swagger/requests/backend_statuses.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/bb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/bb/health_records.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -521,7 +521,7 @@ app/swagger/swagger/requests/user.rb @department-of-veterans-affairs/vsp-identit
 app/swagger/swagger/requests/veteran_readiness_employment_claims.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/virtual_agent_token.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/responses/ch33_bank_account_info.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/swagger/swagger/schemas/appeals @department-of-veterans-affairs/lighthouse-banana-peels
+app/swagger/swagger/schemas/appeals
 app/swagger/swagger/schemas/async_transaction @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/schemas/async_transaction/vet360.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/schemas/bb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -582,8 +582,8 @@ app/swagger/swagger/schemas/vet360/zipcodes.rb @department-of-veterans-affairs/v
 app/swagger/swagger/schemas/virtual_agent_webchat_token.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/v1/requests/facilities.rb  @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/v1/requests/income_limits.rb @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/swagger/swagger/v1/requests/appeals/appeals.rb @department-of-veterans-affairs/lighthouse-banana-peels
-app/swagger/swagger/v1/schemas/appeals @department-of-veterans-affairs/lighthouse-banana-peels
+app/swagger/swagger/v1/requests/appeals/appeals.rb
+app/swagger/swagger/v1/schemas/appeals
 app/swagger/swagger/v1/schemas/facilities.rb @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/v1/schemas/income_limits.rb @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/async_processing.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -595,21 +595,21 @@ app/uploaders/evss_claim_document_uploader.rb @department-of-veterans-affairs/Be
 app/uploaders/form1010cg @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/form1010cg/poa_uploader.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/hca_attachment_uploader.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/uploaders/lighthouse_document_uploader_base.rb @department-of-veterans-affairs/lighthouse-banana-peels
-app/uploaders/lighthouse_document_uploader.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/uploaders/lighthouse_document_uploader_base.rb
+app/uploaders/lighthouse_document_uploader.rb
 app/uploaders/preneed_attachment_uploader.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/set_aws_config.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/supporting_evidence_attachment_uploader.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/uploader_virus_scan.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/validate_pdf.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/vets_shrine.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/validators/token_util.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/validators/token_util.rb
 app/sidekiq/account_login_statistics_job.rb @department-of-veterans-affairs/vsp-identity
 app/sidekiq/bgs @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/central_mail/delete_old_claims.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/central_mail/submit_career_counseling_job.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/central_mail/submit_form4142_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/sidekiq/central_mail/submit_saved_claim_job.rb @department-of-veterans-affairs/lighthouse-banana-peels
+app/sidekiq/central_mail/submit_saved_claim_job.rb
 app/sidekiq/central_mail/submit_central_form686c_job.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-dependents-management
 app/sidekiq/copay_notifications @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 app/sidekiq/cypress_viewport_updater @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
@@ -643,7 +643,7 @@ app/sidekiq/identity @department-of-veterans-affairs/vsp-identity
 app/sidekiq/income_limits @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/in_progress_form_cleaner.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/kms_key_rotation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/sidekiq/lighthouse @department-of-veterans-affairs/lighthouse-banana-peels
+app/sidekiq/lighthouse
 app/sidekiq/mhv @department-of-veterans-affairs/vsp-identity
 app/sidekiq/pager_duty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/preneeds @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -823,7 +823,7 @@ lib/claim_letters @department-of-veterans-affairs/benefits-management-tools-be @
 lib/common/client/concerns/mhv_fhir_session_client.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/common/client/concerns/mhv_jwt_session_client.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/common/client/concerns/mhv_locked_session_client.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-lib/common/client/middleware/request/multipart_request.rb @department-of-veterans-affairs/lighthouse-banana-peels
+lib/common/client/middleware/request/multipart_request.rb
 lib/common/exceptions/open_id_service_error.rb @department-of-veterans-affairs/lighthouse-pivot
 lib/debt_management_center @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 lib/decision_review @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -867,7 +867,7 @@ lib/form526_backup_submission/service.rb @department-of-veterans-affairs/Benefit
 lib/form526_backup_submission/utilities @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/form526_backup_submission/utilities/convert_to_pdf.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/formatters @department-of-veterans-affairs/vsp-identity
-lib/forms @department-of-veterans-affairs/lighthouse-banana-peels
+lib/forms
 lib/generators @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/gi/client.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/gi/configuration.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -889,7 +889,7 @@ lib/lgy @department-of-veterans-affairs/benefits-non-disability @department-of-v
 lib/lgy/configuration.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lgy/service.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lgy/tag_sentry.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-lib/lighthouse @department-of-veterans-affairs/lighthouse-banana-peels
+lib/lighthouse
 lib/lighthouse/benefit_claims @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/mail_automation @department-of-veterans-affairs/vfs-benefits-delivery @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -900,7 +900,7 @@ lib/mhv_ac @department-of-veterans-affairs/vfs-health-modernization-initiative @
 lib/mhv_logging @department-of-veterans-affairs/vfs-health-modernization-initiative @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/mpi @department-of-veterans-affairs/vsp-identity
 lib/oidc @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-lib/okta @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/lighthouse-pivot
+lib/okta @department-of-veterans-affairs/lighthouse-pivot
 lib/olive_branch_patch.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/pagerduty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/pdf_fill @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/vfs-1095-b
@@ -970,9 +970,8 @@ modules/vba_documents @department-of-veterans-affairs/lighthouse-banana-peels
 modules/veteran @department-of-veterans-affairs/lighthouse-pivot @department-of-veterans-affairs/accredited-representation-management
 public @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 modules/veteran_confirmation @department-of-veterans-affairs/lighthouse-ninjapigs @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-rakelib/appeals_api_event_subscriber.rake @department-of-veterans-affairs/lighthouse-banana-peels
-rakelib/appeals_api_oauth.rake @department-of-veterans-affairs/lighthouse-banana-peels
-rakelib/breakers_outage.rake @department-of-veterans-affairs/lighthouse-banana-peels
+rakelib/appeals_api_oauth.rake
+rakelib/breakers_outage.rake
 rakelib/connectivity.rake @department-of-veterans-affairs/vsp-identity
 rakelib/covid_vaccine.rake @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
 rakelib/decision_review_repl.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1103,7 +1102,7 @@ spec/factories/iam_user_identities.rb @department-of-veterans-affairs/vsp-identi
 spec/factories/iam_users.rb @department-of-veterans-affairs/vsp-identity
 spec/factories/inherited_proofing @department-of-veterans-affairs/vsp-identity
 spec/factories/in_progress_forms @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/factories/lighthouse @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/factories/lighthouse @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/maintenance_windows.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/message_drafts.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/messages.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1180,7 +1179,7 @@ spec/fixtures/form1010_ezr @department-of-veterans-affairs/vfs-10-10 @department
 spec/fixtures/identity_dashboard @department-of-veterans-affairs/vsp-identity
 spec/fixtures/idme @department-of-veterans-affairs/vsp-identity
 spec/fixtures/json/detailed_schema_errors_schema.json @department-of-veterans-affairs/lighthouse-banana-peels
-spec/fixtures/json/evss_with_poa.json @department-of-veterans-affairs/lighthouse-banana-peels
+spec/fixtures/json/evss_with_poa.json
 spec/fixtures/json/get_active_rxs.json @department-of-veterans-affairs/vfs-mhv-medications
 spec/fixtures/json/get_determination_not_eligible.json @department-of-veterans-affairs/vfs-mhv-medications
 spec/fixtures/json/get_history_rxs.json @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1189,10 +1188,10 @@ spec/fixtures/logingov @department-of-veterans-affairs/vsp-identity
 spec/fixtures/logingov/logingov_oauth_pub.pem @department-of-veterans-affairs/vsp-identity
 spec/fixtures/map @department-of-veterans-affairs/vsp-identity
 spec/fixtures/medical_copays @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
-spec/fixtures/notice_of_disagreements @department-of-veterans-affairs/lighthouse-banana-peels
-spec/fixtures/notice_of_disagreements/NOD_contestable_issues_response_200.json @department-of-veterans-affairs/lighthouse-banana-peels
-spec/fixtures/notice_of_disagreements/NOD_show_response_200.json @department-of-veterans-affairs/lighthouse-banana-peels
-spec/fixtures/notice_of_disagreements/valid_NOD_create_request.json @department-of-veterans-affairs/lighthouse-banana-peels
+spec/fixtures/notice_of_disagreements
+spec/fixtures/notice_of_disagreements/NOD_contestable_issues_response_200.json
+spec/fixtures/notice_of_disagreements/NOD_show_response_200.json
+spec/fixtures/notice_of_disagreements/valid_NOD_create_request.json
 spec/fixtures/okta @department-of-veterans-affairs/lighthouse-pivot
 spec/fixtures/okta/okta_callback_request_idme_1567760195.json @department-of-veterans-affairs/lighthouse-pivot
 spec/fixtures/pdf_fill/10-10CG @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1220,8 +1219,8 @@ spec/fixtures/vbms @department-of-veterans-affairs/benefits-dependents-managemen
 spec/sidekiq/account_login_statistics_job_spec.rb @department-of-veterans-affairs/vsp-identity
 spec/sidekiq/bgs @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-dependents-management
 spec/sidekiq/central_mail/submit_career_counseling_job_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/sidekiq/central_mail/submit_form4142_job_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels
-spec/sidekiq/central_mail/submit_saved_claim_job_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/sidekiq/central_mail/submit_form4142_job_spec.rb
+spec/sidekiq/central_mail/submit_saved_claim_job_spec.rb
 spec/sidekiq/central_mail/submit_central_form686c_job_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-dependents-management
 spec/sidekiq/copay_notifications @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/decision_review @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1235,7 +1234,7 @@ spec/sidekiq/evss/disability_compensation_form/submit_form526_spec.rb @departmen
 spec/sidekiq/evss/disability_compensation_form/submit_form8940_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/sidekiq/evss/document_upload_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/sidekiq/evss/document_upload_spec.rb
 spec/sidekiq/evss/failed_claims_report_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/retrieve_claims_from_remote_job_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/update_claim_from_remote_job_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1307,7 +1306,7 @@ spec/lib/faraday_adapter_socks @department-of-veterans-affairs/va-api-engineers 
 spec/lib/flipper @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/form526_backup_submission @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/formatters/date_formatter_spec.rb @department-of-veterans-affairs/vsp-identity
-spec/lib/forms/client_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/lib/forms/client_spec.rb
 spec/lib/generators @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/gi/client_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/gi/configuration_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1323,18 +1322,18 @@ spec/lib/ihub @department-of-veterans-affairs/va-api-engineers @department-of-ve
 spec/lib/inherited_proofing @department-of-veterans-affairs/vsp-identity
 spec/lib/json_schema @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lgy @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/lighthouse @department-of-veterans-affairs/lighthouse-banana-peels
+spec/lib/lighthouse
 spec/lib/lighthouse/auth @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/benefits_claims @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/lighthouse/benefits_documents @department-of-veterans-affairs/lighthouse-banana-peels
-spec/lib/lighthouse/benefits_documents/service_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/lib/lighthouse/benefits_documents
+spec/lib/lighthouse/benefits_documents/service_spec.rb
 spec/lib/lighthouse/direct_deposit @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/dbex-trex @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/direct_deposit/payment_account_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/lighthouse/facilities @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/vfs-facilities
-spec/lib/lighthouse/facilities/client_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/vfs-facilities
+spec/lib/lighthouse/facilities @department-of-veterans-affairs/vfs-facilities
+spec/lib/lighthouse/facilities/client_spec.rb @department-of-veterans-affairs/vfs-facilities
 spec/lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/lighthouse/veterans_health @department-of-veterans-affairs/lighthouse-banana-peels
-spec/lib/lighthouse/veteran_verification @department-of-veterans-affairs/lighthouse-banana-peels
+spec/lib/lighthouse/veterans_health
+spec/lib/lighthouse/veteran_verification
 spec/lib/mail_automation @department-of-veterans-affairs/vfs-benefits-delivery  @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/map/ @department-of-veterans-affairs/vsp-identity
 spec/lib/mdot @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
@@ -1345,13 +1344,12 @@ spec/lib/mhv_logging @department-of-veterans-affairs/vfs-health-modernization-in
 spec/lib/mpi @department-of-veterans-affairs/vsp-identity
 spec/lib/oidc @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/oidc/key_service_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/okta @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/lighthouse-pivot
+spec/lib/okta @department-of-veterans-affairs/lighthouse-pivot
 spec/lib/okta/configuration_spec.rb @department-of-veterans-affairs/lighthouse-pivot
-spec/lib/okta/directory_service_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/lighthouse-pivot
+spec/lib/okta/directory_service_spec.rb @department-of-veterans-affairs/lighthouse-pivot
 spec/lib/olive_branch_patch_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/pagerduty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/pdf_fill @department-of-veterans-affairs/lighthouse-banana-peels
-spec/lib/pdf_info @department-of-veterans-affairs/lighthouse-banana-peels
+spec/lib/pdf_fill
 spec/lib/pdf_info/metadata_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels
 spec/lib/pdf_utilities @department-of-veterans-affairs/lighthouse-banana-peels
 spec/lib/pension_burial @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1403,13 +1401,13 @@ spec/mailers/previews/appeals_api_daily_error_report_mailer_preview.rb @departme
 spec/mailers/previews/appeals_api_decision_review_preview.rb @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 spec/mailers/previews/appeals_api_weekly_error_report_mailer_preview.rb @department-of-veterans-affairs/lighthouse-banana-peels
 spec/mailers/previews/ch31_submissions_report_mailer_preview.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/mailers/previews/claims_api_submission_report_mailer_preview.rb @department-of-veterans-affairs/lighthouse-banana-peels
-spec/mailers/previews/claims_api_unsuccessful_report_mailer_preview.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/mailers/previews/claims_api_submission_report_mailer_preview.rb @department-of-veterans-affairs/lighthouse-dash
+spec/mailers/previews/claims_api_unsuccessful_report_mailer_preview.rb @department-of-veterans-affairs/lighthouse-dash
 spec/mailers/previews/school_certifying_officials_mailer_preview.rb @department-of-veterans-affairs/my-education-benefits
 spec/mailers/previews/stem_applicant_confirmation_mailer_preview.rb @department-of-veterans-affairs/my-education-benefits
 spec/mailers/previews/stem_applicant_denial_mailer_preview.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/mailers/previews/stem_applicant_sco_mailer_preview.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/mailers/rrd_mas_notification_mailer_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/mailers/rrd_mas_notification_mailer_spec.rb
 spec/mailers/school_certifying_officials_mailer_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/mailers/spool10203_submissions_report_mailer_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/mailers/spool_submissions_report_mailer_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1454,7 +1452,7 @@ spec/models/in_progress_form_spec.rb @department-of-veterans-affairs/vfs-authent
 spec/models/message_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/mhv_opt_in_flag_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/mpi_data_spec.rb @department-of-veterans-affairs/vsp-identity
-spec/models/okta_redis @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/lighthouse-pivot
+spec/models/okta_redis @department-of-veterans-affairs/lighthouse-pivot
 spec/models/onsite_notification_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/openid_user_identity_spec.rb @department-of-veterans-affairs/vsp-identity
 spec/models/openid_user_spec.rb @department-of-veterans-affairs/vsp-identity
@@ -1480,14 +1478,14 @@ spec/models/user_spec.rb @department-of-veterans-affairs/vsp-identity
 spec/models/user_verification_spec.rb @department-of-veterans-affairs/vsp-identity
 spec/models/va_profile_redis @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/webhooks @department-of-veterans-affairs/lighthouse-banana-peels
-spec/policies/appeals_policy_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/policies/appeals_policy_spec.rb
 spec/policies/bgs_policy_spec.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 spec/policies/ch33_dd_policy_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/policies/coe_policy_spec.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/policies/debt_policy_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/policies/form1095_policy_spec.rb @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/policies/hca_disability_rating_policy_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/policies/lighthouse_policy_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/policies/lighthouse_policy_spec.rb
 spec/policies/meb_policy_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/policies/medical_copays_policy_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/policies/mpi_policy_spec.rb @department-of-veterans-affairs/vsp-identity
@@ -1504,7 +1502,7 @@ spec/rakelib/vet360_spec.rb @department-of-veterans-affairs/vfs-authenticated-ex
 spec/requests/address_request_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/admin_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/alternate_phone_request_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/requests/appeals_request_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/requests/appeals_request_spec.rb
 spec/requests/appointments_request_spec.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/attachments_request_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/authentication/standard_authentication_spec.rb @department-of-veterans-affairs/vsp-identity
@@ -1590,7 +1588,7 @@ spec/serializers/evss_claim_list_serializer_spec.rb @department-of-veterans-affa
 spec/serializers/folder_serializer_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/form1010cg @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/in_progress_form_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/serializers/lighthouse @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/vfs-facilities
+spec/serializers/lighthouse @department-of-veterans-affairs/vfs-facilities
 spec/serializers/message_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/personal_information_serializer_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/serializers/receive_application_serializer_spec.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1620,10 +1618,10 @@ spec/spec_helper.rb @department-of-veterans-affairs/va-api-engineers @department
 spec/support/authenticated_session_helper.rb @department-of-veterans-affairs/vsp-identity
 spec/support/aws_helpers.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/bb_client_helpers.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/certificates/lhdd-fake-private.pem @department-of-veterans-affairs/lighthouse-banana-peels
-spec/support/certificates/lhdd-fake-public.pem @department-of-veterans-affairs/lighthouse-banana-peels
-spec/support/certificates/notification-private.pem @department-of-veterans-affairs/lighthouse-banana-peels
-spec/support/certificates/notification-public.pem @department-of-veterans-affairs/lighthouse-banana-peels
+spec/support/certificates/lhdd-fake-private.pem
+spec/support/certificates/lhdd-fake-public.pem
+spec/support/certificates/notification-private.pem
+spec/support/certificates/notification-public.pem
 spec/support/certificates/ruby-saml.crt @department-of-veterans-affairs/vsp-identity
 spec/support/certificates/ruby-saml.key @department-of-veterans-affairs/vsp-identity
 spec/support/certificates/vic-signing-cert.pem @department-of-veterans-affairs/vsp-identity
@@ -1634,7 +1632,7 @@ spec/support/default_configuration_helper.rb @department-of-veterans-affairs/va-
 spec/support/disability_compensation_form @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/error_details.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/factory_bot.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/fake_api_key_for_lighthouse.txt @department-of-veterans-affairs/lighthouse-banana-peels
+spec/support/fake_api_key_for_lighthouse.txt
 spec/support/financial_status_report_helpers.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/support/fixture_helpers.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/form1010cg_helpers @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1647,27 +1645,27 @@ spec/support/mpi @department-of-veterans-affairs/vsp-identity
 spec/support/mr_client_helpers.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/okta_users_helpers.rb @department-of-veterans-affairs/lighthouse-pivot
 spec/support/pagerduty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/pdf_fill_helper.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/support/pdf_fill_helper.rb
 spec/support/poa_stub.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/ppiu @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/rakelib/users_serialized.json @department-of-veterans-affairs/vsp-identity
 spec/support/request_helper.rb @department-of-veterans-affairs/vsp-identity
-spec/support/rswag/text_helpers.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/support/rswag/text_helpers.rb @department-of-veterans-affairs/lighthouse-dash
 spec/support/rx_client_helpers.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/mobile-api-team
 spec/support/saml @department-of-veterans-affairs/vsp-identity
 spec/support/schemas/amendment.json @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/schemas/appeals_alert.json @department-of-veterans-affairs/lighthouse-banana-peels
-spec/support/schemas/appeals_event.json @department-of-veterans-affairs/lighthouse-banana-peels
-spec/support/schemas/appeals_evidence.json @department-of-veterans-affairs/lighthouse-banana-peels
-spec/support/schemas/appeals_issue.json @department-of-veterans-affairs/lighthouse-banana-peels
-spec/support/schemas/appeals.json @department-of-veterans-affairs/lighthouse-banana-peels
-spec/support/schemas/appeals_status.json @department-of-veterans-affairs/lighthouse-banana-peels
+spec/support/schemas/appeals_alert.json
+spec/support/schemas/appeals_event.json
+spec/support/schemas/appeals_evidence.json
+spec/support/schemas/appeals_issue.json
+spec/support/schemas/appeals.json
+spec/support/schemas/appeals_status.json
 spec/support/schemas/appointments_response.json @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/backend_statuses.json @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/schemas_camelized/appointments_response.json @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/schemas_camelized/backend_statuses.json @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/schemas_camelized/claims_api @department-of-veterans-affairs/lighthouse-banana-peels
-spec/support/schemas_camelized/control_information.json @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
+spec/support/schemas_camelized/claims_api
+spec/support/schemas_camelized/control_information.json @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 spec/support/schemas_camelized/delete_all_user_preferences.json @department-of-veterans-affairs/vsp-identity
 spec/support/schemas_camelized/dgi @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/schemas_camelized/disability_rating_response.json @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1720,7 +1718,7 @@ spec/support/schemas_camelized/va_profile @department-of-veterans-affairs/vfs-au
 spec/support/schemas_camelized/veteran_verification @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/claims_api @department-of-veterans-affairs/lighthouse-dash
 spec/support/schemas/contestable_issues.json @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/schemas/control_information.json @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
+spec/support/schemas/control_information.json @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/debts.json @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/dependents.json @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/dgi @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1812,7 +1810,7 @@ spec/support/uploader_helpers.rb @department-of-veterans-affairs/va-api-engineer
 spec/support/url_service_helpers.rb @department-of-veterans-affairs/vsp-identity
 spec/support/validation_helpers.rb @department-of-veterans-affairs/vsp-identity
 spec/support/va_profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/vcr_cassettes/apps @department-of-veterans-affairs/lighthouse-pivot @department-of-veterans-affairs/lighthouse-banana-peels
+spec/support/vcr_cassettes/apps @department-of-veterans-affairs/lighthouse-pivot
 spec/support/vcr_cassettes/ask_va_api/dynamics @department-of-veterans-affairs/ask-va-team @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 spec/support/vcr_cassettes/avs @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/after-visit-summary
 spec/support/vcr_cassettes/bb_client @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1838,7 +1836,7 @@ spec/support/vcr_cassettes/dmc/submit_fsr_error.yml @department-of-veterans-affa
 spec/support/vcr_cassettes/dmc/submit_fsr.yml @department-of-veterans-affairs/vsa-debt-resolution
 spec/support/vcr_cassettes/evss/dependents  @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 spec/support/vcr_cassettes/evss/disability_compensation_form @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/vcr_cassettes/evss/documents/get_claim_documents.yml @department-of-veterans-affairs/lighthouse-banana-peels
+spec/support/vcr_cassettes/evss/documents/get_claim_documents.yml
 spec/support/vcr_cassettes/evss/gi_bill_status @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/evss/intent_to_file @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/evss/letters @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1846,8 +1844,8 @@ spec/support/vcr_cassettes/evss/ppiu @department-of-veterans-affairs/vfs-authent
 spec/support/vcr_cassettes/evss/reference_data @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/facilities @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/form526_backup @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/vcr_cassettes/forms/200_all_forms.yml @department-of-veterans-affairs/lighthouse-banana-peels
-spec/support/vcr_cassettes/forms/200_form_query.yml @department-of-veterans-affairs/lighthouse-banana-peels
+spec/support/vcr_cassettes/forms/200_all_forms.yml
+spec/support/vcr_cassettes/forms/200_form_query.yml
 spec/support/vcr_cassettes/gi_client @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/GI_SearchClient @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/govdelivery_emails.yml @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1882,7 +1880,7 @@ spec/support/vcr_cassettes/okta @department-of-veterans-affairs/lighthouse-pivot
 spec/support/vcr_cassettes/pagerduty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/preneeds @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/RapidReadyForDecision_DisabilityCompensationJob @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/vcr_cassettes/rrd @department-of-veterans-affairs/lighthouse-banana-peels
+spec/support/vcr_cassettes/rrd
 spec/support/vcr_cassettes/rx_client @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/mobile-api-team
 spec/support/vcr_cassettes/s3 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/saml @department-of-veterans-affairs/vsp-identity
@@ -1907,8 +1905,8 @@ spec/support/vcr_cassettes/vetext @department-of-veterans-affairs/mobile-api-tea
 spec/support/vcr_cassettes/virtual_agent @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/virtual_regional_office @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/chip/ @department-of-veterans-affairs/vsa-healthcare-health-quest-1-backend @department-of-veterans-affairs/patient-check-in @department-of-veterans-affairs/backend-review-group
-spec/support/vcr_multipart_matcher_helper.rb @department-of-veterans-affairs/lighthouse-banana-peels
-spec/support/vcr.rb @department-of-veterans-affairs/lighthouse-banana-peels
+spec/support/vcr_multipart_matcher_helper.rb
+spec/support/vcr.rb
 spec/swagger_helper.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/uploaders/evss_claim_document_uploader_base_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/uploaders/evss_claim_document_uploader_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,11 +7,11 @@ Dangerfile @department-of-veterans-affairs/backend-review-group
 Dockerfile @department-of-veterans-affairs/backend-review-group
 Gemfile @department-of-veterans-affairs/backend-review-group
 Gemfile.lock @department-of-veterans-affairs/backend-review-group
-app/controllers/appeals_base_controller.rb
-app/controllers/appeals_base_controller_v1.rb
+app/controllers/appeals_base_controller.rb @department-of-veterans-affairs/backend-review-group
+app/controllers/appeals_base_controller_v1.rb @department-of-veterans-affairs/backend-review-group
 app/controllers/application_controller.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/bb_controller.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/controllers/claims_base_controller.rb
+app/controllers/claims_base_controller.rb @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/accountable.rb @department-of-veterans-affairs/vsp-identity
 app/controllers/concerns/authentication_and_sso_concerns.rb @department-of-veterans-affairs/vsp-identity
 app/controllers/concerns/exception_handling.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -158,8 +158,8 @@ app/mailers/dependents_application_failure_mailer.rb @department-of-veterans-aff
 app/mailers/direct_deposit_mailer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/failed_claims_report_mailer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/hca_submission_failure_mailer.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/mailers/rrd_alert_mailer.rb
-app/mailers/rrd_mas_notification_mailer.rb
+app/mailers/rrd_alert_mailer.rb @department-of-veterans-affairs/backend-review-group
+app/mailers/rrd_mas_notification_mailer.rb @department-of-veterans-affairs/backend-review-group
 app/mailers/school_certifying_officials_mailer.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/spool10203_submissions_report_mailer.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/spool_submissions_report_mailer.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -173,8 +173,8 @@ app/mailers/views/dependents_application_failure.erb @department-of-veterans-aff
 app/mailers/views/direct_deposit.html.erb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/mailers/views/failed_claims_report.erb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/mailers/views/hca_submission_failure.html.erb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/mailers/views/rrd_alert_mailer.html.erb
-app/mailers/views/rrd_mas_notification_mailer.html.erb
+app/mailers/views/rrd_alert_mailer.html.erb @department-of-veterans-affairs/backend-review-group
+app/mailers/views/rrd_mas_notification_mailer.html.erb @department-of-veterans-affairs/backend-review-group
 app/mailers/views/school_certifying_officials.html.erb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/views/stem_applicant_confirmation.html.erb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/mailers/views/stem_applicant_denial.html.erb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -192,14 +192,14 @@ app/models/async_transaction/base.rb @department-of-veterans-affairs/vfs-authent
 app/models/async_transaction/va_profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/models/async_transaction/vet360 @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/models/attachment.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/models/backend_status.rb
+app/models/backend_status.rb @department-of-veterans-affairs/backend-review-group
 app/models/bank_name.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/base_facility.rb @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/bgs_dependents @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 app/models/central_mail_claim.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/central_mail_submission.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/models/claims_api
-app/models/claims_api/claim_submission.rb
+app/models/claims_api @department-of-veterans-affairs/backend-review-group
+app/models/claims_api/claim_submission.rb @department-of-veterans-affairs/backend-review-group
 app/models/concerns/async_request.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/concerns/authorization.rb @department-of-veterans-affairs/backend-review-group
 app/models/concerns/form526_claim_fast_tracking_concern.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -266,7 +266,7 @@ app/models/identifier_index.rb @department-of-veterans-affairs/vsa-debt-resoluti
 app/models/inherited_proofing @department-of-veterans-affairs/vsp-identity
 app/models/inherited_proof_verified_user_account.rb @department-of-veterans-affairs/vsp-identity
 app/models/in_progress_form.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/models/lighthouse_document.rb
+app/models/lighthouse_document.rb @department-of-veterans-affairs/backend-review-group
 app/models/maintenance_window.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/message_draft.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/message.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -346,7 +346,7 @@ app/models/webhooks/notification_attempt.rb @department-of-veterans-affairs/back
 app/models/webhooks/notification.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/webhooks/subscription.rb @department-of-veterans-affairs/backend-review-group
 app/models/webhooks/utilities.rb @department-of-veterans-affairs/backend-review-group
-app/policies/appeals_policy.rb
+app/policies/appeals_policy.rb @department-of-veterans-affairs/backend-review-group
 app/policies/bgs_policy.rb  @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 app/policies/ch33_dd_policy.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/policies/coe_policy.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -356,7 +356,7 @@ app/policies/debt_policy.rb @department-of-veterans-affairs/vsa-debt-resolution 
 app/policies/demographics_policy.rb@department-of-veterans-affairs/mobile-api-team
 app/policies/form1095_policy.rb @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/policies/hca_disability_rating_policy.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/policies/lighthouse_policy.rb
+app/policies/lighthouse_policy.rb @department-of-veterans-affairs/backend-review-group
 app/policies/meb_policy.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/policies/medical_copays_policy.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 app/policies/mhv_health_records_policy.rb @department-of-veterans-affairs/vfs-health-modernization-initiative @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -372,7 +372,7 @@ app/serializers/attachment_serializer.rb @department-of-veterans-affairs/vfs-10-
 app/serializers/backend_statuses_serializer.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/backend_status_serializer.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/cemetery_serializer.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/serializers/central_mail_submission_serializer.rb
+app/serializers/central_mail_submission_serializer.rb @department-of-veterans-affairs/backend-review-group
 app/serializers/ch33_bank_account_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/communication_groups_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/decision_review_evidence_attachment_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -421,7 +421,7 @@ app/serializers/prescription_preference_serializer.rb @department-of-veterans-af
 app/serializers/prescription_serializer.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/profile_photo_attachment_serializer.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/rated_disabilities_serializer.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/serializers/rating_info_serializer.rb
+app/serializers/rating_info_serializer.rb @department-of-veterans-affairs/backend-review-group
 app/serializers/receive_application_serializer.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/saved_claim_serializer.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/serializers/search_serializer.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -466,7 +466,7 @@ app/services/sign_in @department-of-veterans-affairs/vsp-identity
 app/services/terms_of_use/ @department-of-veterans-affairs/vsp-identity
 app/services/users @department-of-veterans-affairs/vsp-identity
 app/swagger/readme.md @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/swagger/swagger/requests/appeals
+app/swagger/swagger/requests/appeals @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/backend_statuses.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/bb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/bb/health_records.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -521,7 +521,7 @@ app/swagger/swagger/requests/user.rb @department-of-veterans-affairs/vsp-identit
 app/swagger/swagger/requests/veteran_readiness_employment_claims.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/virtual_agent_token.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/responses/ch33_bank_account_info.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/swagger/swagger/schemas/appeals
+app/swagger/swagger/schemas/appeals @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/schemas/async_transaction @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/schemas/async_transaction/vet360.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/schemas/bb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -582,8 +582,8 @@ app/swagger/swagger/schemas/vet360/zipcodes.rb @department-of-veterans-affairs/v
 app/swagger/swagger/schemas/virtual_agent_webchat_token.rb @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/v1/requests/facilities.rb  @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/v1/requests/income_limits.rb @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/swagger/swagger/v1/requests/appeals/appeals.rb
-app/swagger/swagger/v1/schemas/appeals
+app/swagger/swagger/v1/requests/appeals/appeals.rb @department-of-veterans-affairs/backend-review-group
+app/swagger/swagger/v1/schemas/appeals @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/v1/schemas/facilities.rb @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/v1/schemas/income_limits.rb @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/async_processing.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -595,21 +595,21 @@ app/uploaders/evss_claim_document_uploader.rb @department-of-veterans-affairs/Be
 app/uploaders/form1010cg @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/form1010cg/poa_uploader.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/hca_attachment_uploader.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/uploaders/lighthouse_document_uploader_base.rb
-app/uploaders/lighthouse_document_uploader.rb
+app/uploaders/lighthouse_document_uploader_base.rb @department-of-veterans-affairs/backend-review-group
+app/uploaders/lighthouse_document_uploader.rb @department-of-veterans-affairs/backend-review-group
 app/uploaders/preneed_attachment_uploader.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/set_aws_config.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/supporting_evidence_attachment_uploader.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/uploader_virus_scan.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/validate_pdf.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/uploaders/vets_shrine.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/validators/token_util.rb
+app/validators/token_util.rb @department-of-veterans-affairs/backend-review-group
 app/sidekiq/account_login_statistics_job.rb @department-of-veterans-affairs/vsp-identity
 app/sidekiq/bgs @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/central_mail/delete_old_claims.rb @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/central_mail/submit_career_counseling_job.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/central_mail/submit_form4142_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/sidekiq/central_mail/submit_saved_claim_job.rb
+app/sidekiq/central_mail/submit_saved_claim_job.rb @department-of-veterans-affairs/backend-review-group
 app/sidekiq/central_mail/submit_central_form686c_job.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-dependents-management
 app/sidekiq/copay_notifications @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 app/sidekiq/cypress_viewport_updater @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
@@ -643,7 +643,7 @@ app/sidekiq/identity @department-of-veterans-affairs/vsp-identity
 app/sidekiq/income_limits @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/in_progress_form_cleaner.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/kms_key_rotation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/sidekiq/lighthouse
+app/sidekiq/lighthouse @department-of-veterans-affairs/backend-review-group
 app/sidekiq/mhv @department-of-veterans-affairs/vsp-identity
 app/sidekiq/pager_duty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/preneeds @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -823,7 +823,7 @@ lib/claim_letters @department-of-veterans-affairs/benefits-management-tools-be @
 lib/common/client/concerns/mhv_fhir_session_client.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/common/client/concerns/mhv_jwt_session_client.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/common/client/concerns/mhv_locked_session_client.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-lib/common/client/middleware/request/multipart_request.rb
+lib/common/client/middleware/request/multipart_request.rb @department-of-veterans-affairs/backend-review-group
 lib/common/exceptions/open_id_service_error.rb @department-of-veterans-affairs/lighthouse-pivot
 lib/debt_management_center @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 lib/decision_review @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -867,7 +867,7 @@ lib/form526_backup_submission/service.rb @department-of-veterans-affairs/Benefit
 lib/form526_backup_submission/utilities @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/form526_backup_submission/utilities/convert_to_pdf.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/formatters @department-of-veterans-affairs/vsp-identity
-lib/forms
+lib/form @department-of-veterans-affairs/backend-review-group
 lib/generators @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/gi/client.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/gi/configuration.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -889,7 +889,7 @@ lib/lgy @department-of-veterans-affairs/benefits-non-disability @department-of-v
 lib/lgy/configuration.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lgy/service.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lgy/tag_sentry.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-lib/lighthouse
+lib/lighthouse @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/benefit_claims @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/mail_automation @department-of-veterans-affairs/vfs-benefits-delivery @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -970,8 +970,8 @@ modules/vba_documents @department-of-veterans-affairs/lighthouse-banana-peels
 modules/veteran @department-of-veterans-affairs/lighthouse-pivot @department-of-veterans-affairs/accredited-representation-management
 public @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 modules/veteran_confirmation @department-of-veterans-affairs/lighthouse-ninjapigs @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-rakelib/appeals_api_oauth.rake
-rakelib/breakers_outage.rake
+rakelib/appeals_api_oauth.rake @department-of-veterans-affairs/backend-review-group
+rakelib/breakers_outage.rake @department-of-veterans-affairs/backend-review-group
 rakelib/connectivity.rake @department-of-veterans-affairs/vsp-identity
 rakelib/covid_vaccine.rake @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
 rakelib/decision_review_repl.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1179,7 +1179,7 @@ spec/fixtures/form1010_ezr @department-of-veterans-affairs/vfs-10-10 @department
 spec/fixtures/identity_dashboard @department-of-veterans-affairs/vsp-identity
 spec/fixtures/idme @department-of-veterans-affairs/vsp-identity
 spec/fixtures/json/detailed_schema_errors_schema.json @department-of-veterans-affairs/lighthouse-banana-peels
-spec/fixtures/json/evss_with_poa.json
+spec/fixtures/json/evss_with_poa.json @department-of-veterans-affairs/backend-review-group
 spec/fixtures/json/get_active_rxs.json @department-of-veterans-affairs/vfs-mhv-medications
 spec/fixtures/json/get_determination_not_eligible.json @department-of-veterans-affairs/vfs-mhv-medications
 spec/fixtures/json/get_history_rxs.json @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1188,10 +1188,10 @@ spec/fixtures/logingov @department-of-veterans-affairs/vsp-identity
 spec/fixtures/logingov/logingov_oauth_pub.pem @department-of-veterans-affairs/vsp-identity
 spec/fixtures/map @department-of-veterans-affairs/vsp-identity
 spec/fixtures/medical_copays @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
-spec/fixtures/notice_of_disagreements
-spec/fixtures/notice_of_disagreements/NOD_contestable_issues_response_200.json
-spec/fixtures/notice_of_disagreements/NOD_show_response_200.json
-spec/fixtures/notice_of_disagreements/valid_NOD_create_request.json
+spec/fixtures/notice_of_disagreements @department-of-veterans-affairs/backend-review-group
+spec/fixtures/notice_of_disagreements/NOD_contestable_issues_response_200.json @department-of-veterans-affairs/backend-review-group
+spec/fixtures/notice_of_disagreements/NOD_show_response_200.json @department-of-veterans-affairs/backend-review-group
+spec/fixtures/notice_of_disagreements/valid_NOD_create_request.json @department-of-veterans-affairs/backend-review-group
 spec/fixtures/okta @department-of-veterans-affairs/lighthouse-pivot
 spec/fixtures/okta/okta_callback_request_idme_1567760195.json @department-of-veterans-affairs/lighthouse-pivot
 spec/fixtures/pdf_fill/10-10CG @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1219,8 +1219,8 @@ spec/fixtures/vbms @department-of-veterans-affairs/benefits-dependents-managemen
 spec/sidekiq/account_login_statistics_job_spec.rb @department-of-veterans-affairs/vsp-identity
 spec/sidekiq/bgs @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-dependents-management
 spec/sidekiq/central_mail/submit_career_counseling_job_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/sidekiq/central_mail/submit_form4142_job_spec.rb
-spec/sidekiq/central_mail/submit_saved_claim_job_spec.rb
+spec/sidekiq/central_mail/submit_form4142_job_spec.rb @department-of-veterans-affairs/backend-review-group
+spec/sidekiq/central_mail/submit_saved_claim_job_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/central_mail/submit_central_form686c_job_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-dependents-management
 spec/sidekiq/copay_notifications @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/decision_review @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1234,7 +1234,7 @@ spec/sidekiq/evss/disability_compensation_form/submit_form526_spec.rb @departmen
 spec/sidekiq/evss/disability_compensation_form/submit_form8940_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/sidekiq/evss/document_upload_spec.rb
+spec/sidekiq/evss/document_upload_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/failed_claims_report_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/retrieve_claims_from_remote_job_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/evss/update_claim_from_remote_job_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1306,7 +1306,7 @@ spec/lib/faraday_adapter_socks @department-of-veterans-affairs/va-api-engineers 
 spec/lib/flipper @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/form526_backup_submission @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/formatters/date_formatter_spec.rb @department-of-veterans-affairs/vsp-identity
-spec/lib/forms/client_spec.rb
+spec/lib/forms/client_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/lib/generators @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/gi/client_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/gi/configuration_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1322,18 +1322,18 @@ spec/lib/ihub @department-of-veterans-affairs/va-api-engineers @department-of-ve
 spec/lib/inherited_proofing @department-of-veterans-affairs/vsp-identity
 spec/lib/json_schema @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lgy @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/lighthouse
+spec/lib/lighthouse @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/auth @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/benefits_claims @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/lighthouse/benefits_documents
-spec/lib/lighthouse/benefits_documents/service_spec.rb
+spec/lib/lighthouse/benefits_documents @department-of-veterans-affairs/backend-review-group
+spec/lib/lighthouse/benefits_documents/service_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/direct_deposit @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/dbex-trex @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/direct_deposit/payment_account_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/facilities @department-of-veterans-affairs/vfs-facilities
 spec/lib/lighthouse/facilities/client_spec.rb @department-of-veterans-affairs/vfs-facilities
 spec/lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/lighthouse/veterans_health
-spec/lib/lighthouse/veteran_verification
+spec/lib/lighthouse/veterans_health @department-of-veterans-affairs/backend-review-group
+spec/lib/lighthouse/veteran_verification @department-of-veterans-affairs/backend-review-group
 spec/lib/mail_automation @department-of-veterans-affairs/vfs-benefits-delivery  @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/map/ @department-of-veterans-affairs/vsp-identity
 spec/lib/mdot @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
@@ -1349,7 +1349,7 @@ spec/lib/okta/configuration_spec.rb @department-of-veterans-affairs/lighthouse-p
 spec/lib/okta/directory_service_spec.rb @department-of-veterans-affairs/lighthouse-pivot
 spec/lib/olive_branch_patch_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/pagerduty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/pdf_fill
+spec/lib/pdf_fill @department-of-veterans-affairs/backend-review-group
 spec/lib/pdf_info/metadata_spec.rb @department-of-veterans-affairs/lighthouse-banana-peels
 spec/lib/pdf_utilities @department-of-veterans-affairs/lighthouse-banana-peels
 spec/lib/pension_burial @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1407,7 +1407,7 @@ spec/mailers/previews/school_certifying_officials_mailer_preview.rb @department-
 spec/mailers/previews/stem_applicant_confirmation_mailer_preview.rb @department-of-veterans-affairs/my-education-benefits
 spec/mailers/previews/stem_applicant_denial_mailer_preview.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/mailers/previews/stem_applicant_sco_mailer_preview.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/mailers/rrd_mas_notification_mailer_spec.rb
+spec/mailers/rrd_mas_notification_mailer_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/mailers/school_certifying_officials_mailer_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/mailers/spool10203_submissions_report_mailer_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/mailers/spool_submissions_report_mailer_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1478,14 +1478,14 @@ spec/models/user_spec.rb @department-of-veterans-affairs/vsp-identity
 spec/models/user_verification_spec.rb @department-of-veterans-affairs/vsp-identity
 spec/models/va_profile_redis @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/webhooks @department-of-veterans-affairs/lighthouse-banana-peels
-spec/policies/appeals_policy_spec.rb
+spec/policies/appeals_policy_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/policies/bgs_policy_spec.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 spec/policies/ch33_dd_policy_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/policies/coe_policy_spec.rb @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/policies/debt_policy_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/policies/form1095_policy_spec.rb @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/policies/hca_disability_rating_policy_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/policies/lighthouse_policy_spec.rb
+spec/policies/lighthouse_policy_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/policies/meb_policy_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/policies/medical_copays_policy_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/policies/mpi_policy_spec.rb @department-of-veterans-affairs/vsp-identity
@@ -1502,7 +1502,7 @@ spec/rakelib/vet360_spec.rb @department-of-veterans-affairs/vfs-authenticated-ex
 spec/requests/address_request_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/admin_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/alternate_phone_request_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/requests/appeals_request_spec.rb
+spec/requests/appeals_request_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/requests/appointments_request_spec.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/attachments_request_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/authentication/standard_authentication_spec.rb @department-of-veterans-affairs/vsp-identity
@@ -1618,10 +1618,10 @@ spec/spec_helper.rb @department-of-veterans-affairs/va-api-engineers @department
 spec/support/authenticated_session_helper.rb @department-of-veterans-affairs/vsp-identity
 spec/support/aws_helpers.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/bb_client_helpers.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/certificates/lhdd-fake-private.pem
-spec/support/certificates/lhdd-fake-public.pem
-spec/support/certificates/notification-private.pem
-spec/support/certificates/notification-public.pem
+spec/support/certificates/lhdd-fake-private.pem @department-of-veterans-affairs/backend-review-group
+spec/support/certificates/lhdd-fake-public.pem @department-of-veterans-affairs/backend-review-group
+spec/support/certificates/notification-private.pem @department-of-veterans-affairs/backend-review-group
+spec/support/certificates/notification-public.pem @department-of-veterans-affairs/backend-review-group
 spec/support/certificates/ruby-saml.crt @department-of-veterans-affairs/vsp-identity
 spec/support/certificates/ruby-saml.key @department-of-veterans-affairs/vsp-identity
 spec/support/certificates/vic-signing-cert.pem @department-of-veterans-affairs/vsp-identity
@@ -1632,7 +1632,7 @@ spec/support/default_configuration_helper.rb @department-of-veterans-affairs/va-
 spec/support/disability_compensation_form @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/error_details.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/factory_bot.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/fake_api_key_for_lighthouse.txt
+spec/support/fake_api_key_for_lighthouse.txt @department-of-veterans-affairs/backend-review-group
 spec/support/financial_status_report_helpers.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/support/fixture_helpers.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/form1010cg_helpers @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1645,7 +1645,7 @@ spec/support/mpi @department-of-veterans-affairs/vsp-identity
 spec/support/mr_client_helpers.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/okta_users_helpers.rb @department-of-veterans-affairs/lighthouse-pivot
 spec/support/pagerduty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/pdf_fill_helper.rb
+spec/support/pdf_fill_helper.rb @department-of-veterans-affairs/backend-review-group
 spec/support/poa_stub.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/ppiu @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/rakelib/users_serialized.json @department-of-veterans-affairs/vsp-identity
@@ -1654,17 +1654,17 @@ spec/support/rswag/text_helpers.rb @department-of-veterans-affairs/lighthouse-da
 spec/support/rx_client_helpers.rb @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/mobile-api-team
 spec/support/saml @department-of-veterans-affairs/vsp-identity
 spec/support/schemas/amendment.json @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/schemas/appeals_alert.json
-spec/support/schemas/appeals_event.json
-spec/support/schemas/appeals_evidence.json
-spec/support/schemas/appeals_issue.json
-spec/support/schemas/appeals.json
-spec/support/schemas/appeals_status.json
+spec/support/schemas/appeals_alert.json @department-of-veterans-affairs/backend-review-group
+spec/support/schemas/appeals_event.json @department-of-veterans-affairs/backend-review-group
+spec/support/schemas/appeals_evidence.json @department-of-veterans-affairs/backend-review-group
+spec/support/schemas/appeals_issue.json @department-of-veterans-affairs/backend-review-group
+spec/support/schemas/appeals.json @department-of-veterans-affairs/backend-review-group
+spec/support/schemas/appeals_status.json @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/appointments_response.json @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/backend_statuses.json @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/schemas_camelized/appointments_response.json @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/schemas_camelized/backend_statuses.json @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/schemas_camelized/claims_api
+spec/support/schemas_camelized/claims_api @department-of-veterans-affairs/backend-review-group
 spec/support/schemas_camelized/control_information.json @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 spec/support/schemas_camelized/delete_all_user_preferences.json @department-of-veterans-affairs/vsp-identity
 spec/support/schemas_camelized/dgi @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1836,7 +1836,7 @@ spec/support/vcr_cassettes/dmc/submit_fsr_error.yml @department-of-veterans-affa
 spec/support/vcr_cassettes/dmc/submit_fsr.yml @department-of-veterans-affairs/vsa-debt-resolution
 spec/support/vcr_cassettes/evss/dependents  @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 spec/support/vcr_cassettes/evss/disability_compensation_form @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/vcr_cassettes/evss/documents/get_claim_documents.yml
+spec/support/vcr_cassettes/evss/documents/get_claim_documents.yml @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/evss/gi_bill_status @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/evss/intent_to_file @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/evss/letters @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1844,8 +1844,8 @@ spec/support/vcr_cassettes/evss/ppiu @department-of-veterans-affairs/vfs-authent
 spec/support/vcr_cassettes/evss/reference_data @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/facilities @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/form526_backup @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/vcr_cassettes/forms/200_all_forms.yml
-spec/support/vcr_cassettes/forms/200_form_query.yml
+spec/support/vcr_cassettes/forms/200_all_forms.yml @department-of-veterans-affairs/backend-review-group
+spec/support/vcr_cassettes/forms/200_form_query.yml @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/gi_client @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/GI_SearchClient @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/govdelivery_emails.yml @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1880,7 +1880,7 @@ spec/support/vcr_cassettes/okta @department-of-veterans-affairs/lighthouse-pivot
 spec/support/vcr_cassettes/pagerduty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/preneeds @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/RapidReadyForDecision_DisabilityCompensationJob @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/support/vcr_cassettes/rrd
+spec/support/vcr_cassettes/rrd @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/rx_client @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/mobile-api-team
 spec/support/vcr_cassettes/s3 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/saml @department-of-veterans-affairs/vsp-identity
@@ -1905,8 +1905,8 @@ spec/support/vcr_cassettes/vetext @department-of-veterans-affairs/mobile-api-tea
 spec/support/vcr_cassettes/virtual_agent @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/virtual_regional_office @department-of-veterans-affairs/Benefits-Team-1 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/chip/ @department-of-veterans-affairs/vsa-healthcare-health-quest-1-backend @department-of-veterans-affairs/patient-check-in @department-of-veterans-affairs/backend-review-group
-spec/support/vcr_multipart_matcher_helper.rb
-spec/support/vcr.rb
+spec/support/vcr_multipart_matcher_helper.rb @department-of-veterans-affairs/backend-review-group
+spec/support/vcr.rb @department-of-veterans-affairs/backend-review-group
 spec/swagger_helper.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/uploaders/evss_claim_document_uploader_base_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/uploaders/evss_claim_document_uploader_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group


### PR DESCRIPTION
## Summary

Semi-recently, team Banana Peels was added as codeowner to a large number of files and folders that they are not responsible for nor own. This has caused multiple teams to be blocked by the unnecessary need for Banana Peels' PR approval.

NOTE: The CODEOWNERS error does not seem to be related to this commit.

## Testing Done
I did my best to go through and look at the commit history of any entry I changed to see if Banana Peels had historically had a hand in them. I tried to be conservative with the changes.

## Related issue(s)
* https://dsva.slack.com/archives/C053U7BUT27/p1701369389899689
* https://dsva.slack.com/archives/CBU0KDSB1/p1697466964935119
* https://github.com/department-of-veterans-affairs/vets-api/pull/13963/files