### PR TITLE
Add exhaustion logging for 526 jobs (1 of 2)

### DIFF
--- a/app/sidekiq/central_mail/submit_form4142_job.rb
+++ b/app/sidekiq/central_mail/submit_form4142_job.rb
@@ -21,9 +21,9 @@ module CentralMail
       }
     )
 
-    STATSD_KEY_PREFIX = 'worker.evss.submit_form4142'
+    STATSD_KEY_PREFIX = 'worker.evss.submit_form4142.exhausted'
 
-    # Sidekiq has built in exponential back-off functionality for retrys
+    # Sidekiq has built in exponential back-off functionality for retries
     # A max retry attempt of 10 will result in a run time of ~8 hours
     # This job is invoked from 526 background job, ICMHS is reliable
     # and hence this value is set at a lower value
@@ -33,13 +33,49 @@ module CentralMail
 
     class CentralMailResponseError < Common::Exceptions::BackendServiceException; end
 
-    # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
     sidekiq_retries_exhausted do |msg, _ex|
-      Rails.logger.send(
-        :error,
-        "Failed all retries on Form4142 submit, last error: #{msg['error_message']}"
+      job_id = msg['jid']
+      error_class = msg['error_class']
+      error_message = msg['error_message']
+      timestamp = Time.now.utc
+      form526_submission_id = msg['args'].first
+
+      form_job_status = Form526JobStatus.find_by(job_id:)
+      bgjob_errors = form_job_status.bgjob_errors || {}
+      new_error = {
+        "#{timestamp.to_i}": {
+          caller_method: __method__.to_s,
+          error_class:,
+          error_message:,
+          timestamp:,
+          form526_submission_id:
+        }
+      }
+      form_job_status.update(
+        status: Form526JobStatus::STATUS[:exhausted],
+        bgjob_errors: bgjob_errors.merge(new_error)
       )
-      EVSS::DisabilityCompensationForm::Metrics.new(STATSD_KEY_PREFIX).increment_exhausted
+
+      StatsD.increment(STATSD_KEY_PREFIX)
+
+      ::Rails.logger.warn(
+        'Submit Form 4142 Retries exhausted',
+        { job_id:, error_class:, error_message:, timestamp:, form526_submission_id: }
+      )
+    rescue => e
+      ::Rails.logger.error(
+        'Failure in SubmitForm4142#sidekiq_retries_exhausted',
+        {
+          messaged_content: e.message,
+          job_id:,
+          submission_id: form526_submission_id,
+          pre_exhaustion_failure: {
+            error_class:,
+            error_message:
+          }
+        }
+      )
+      raise e
     end
 
     # Performs an asynchronous job for submitting a Form 4142 to central mail service

--- a/app/sidekiq/evss/disability_compensation_form/submit_form0781.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form0781.rb
@@ -32,22 +32,58 @@ module EVSS
         FORM_ID_0781A => { docType: 'L229' }
       }.freeze
 
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form0781'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form0781.exhausted'
 
-      # Sidekiq has built in exponential back-off functionality for retrys
+      # Sidekiq has built in exponential back-off functionality for retries
       # A max retry attempt of 10 will result in a run time of ~8 hours
       # This job is invoked from 526 background job
       RETRY = 10
 
       sidekiq_options retry: RETRY
 
-      # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
       sidekiq_retries_exhausted do |msg, _ex|
-        Rails.logger.send(
-          :error,
-          "Failed all retries on SubmitForm0781 submit, last error: #{msg['error_message']}"
+        job_id = msg['jid']
+        error_class = msg['error_class']
+        error_message = msg['error_message']
+        timestamp = Time.now.utc
+        form526_submission_id = msg['args'].first
+
+        form_job_status = Form526JobStatus.find_by(job_id:)
+        bgjob_errors = form_job_status.bgjob_errors || {}
+        new_error = {
+          "#{timestamp.to_i}": {
+            caller_method: __method__.to_s,
+            error_class:,
+            error_message:,
+            timestamp:,
+            form526_submission_id:
+          }
+        }
+        form_job_status.update(
+          status: Form526JobStatus::STATUS[:exhausted],
+          bgjob_errors: bgjob_errors.merge(new_error)
         )
-        Metrics.new(STATSD_KEY_PREFIX, msg['jid']).increment_exhausted
+
+        StatsD.increment(STATSD_KEY_PREFIX)
+
+        ::Rails.logger.warn(
+          'Submit Form 0781 Retries exhausted',
+          { job_id:, error_class:, error_message:, timestamp:, form526_submission_id: }
+        )
+      rescue => e
+        ::Rails.logger.error(
+          'Failure in SubmitForm0781#sidekiq_retries_exhausted',
+          {
+            messaged_content: e.message,
+            job_id:,
+            submission_id: form526_submission_id,
+            pre_exhaustion_failure: {
+              error_class:,
+              error_message:
+            }
+          }
+        )
+        raise e
       end
 
       # This method generates the PDF documents but does NOT send them anywhere.

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -13,12 +13,12 @@ module EVSS
 
       attr_accessor :submission_id
 
-      # Sidekiq has built in exponential back-off functionality for retrys
+      # Sidekiq has built in exponential back-off functionality for retries
       # A max retry attempt of 15 will result in a run time of ~36 hours
       # Changed from 15 -> 14 ~ Jan 19, 2023
       # This change reduces the run-time from ~36 hours to ~24 hours
       RETRY = 14
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form526'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form526.exhausted'
 
       wrap_with_logging(
         :submit_complete_form,

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526_cleanup.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526_cleanup.rb
@@ -6,14 +6,52 @@ module EVSS
   module DisabilityCompensationForm
     class SubmitForm526Cleanup < Job
       include Sidekiq::Job
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_cleanup'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form526_cleanup.exhausted'
 
-      # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
-      # :nocov:
       sidekiq_retries_exhausted do |msg, _ex|
-        job_exhausted(msg, STATSD_KEY_PREFIX)
+        job_id = msg['jid']
+        error_class = msg['error_class']
+        error_message = msg['error_message']
+        timestamp = Time.now.utc
+        form526_submission_id = msg['args'].first
+
+        form_job_status = Form526JobStatus.find_by(job_id:)
+        bgjob_errors = form_job_status.bgjob_errors || {}
+        new_error = {
+          "#{timestamp.to_i}": {
+            caller_method: __method__.to_s,
+            error_class:,
+            error_message:,
+            timestamp:,
+            form526_submission_id:
+          }
+        }
+        form_job_status.update(
+          status: Form526JobStatus::STATUS[:exhausted],
+          bgjob_errors: bgjob_errors.merge(new_error)
+        )
+
+        StatsD.increment(STATSD_KEY_PREFIX)
+
+        ::Rails.logger.warn(
+          'Submit Form 526 Cleanup Retries exhausted',
+          { job_id:, error_class:, error_message:, timestamp:, form526_submission_id: }
+        )
+      rescue => e
+        ::Rails.logger.error(
+          'Failure in SubmitForm526Cleanup#sidekiq_retries_exhausted',
+          {
+            messaged_content: e.message,
+            job_id:,
+            submission_id: form526_submission_id,
+            pre_exhaustion_failure: {
+              error_class:,
+              error_message:
+            }
+          }
+        )
+        raise e
       end
-      # :nocov:
 
       # Cleans up a 526 submission by removing its {InProgressForm} and deleting the
       # active Intent to File record (via EVSS)

--- a/app/sidekiq/evss/disability_compensation_form/submit_form8940.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form8940.rb
@@ -7,22 +7,58 @@ module EVSS
     class SubmitForm8940 < Job
       extend Logging::ThirdPartyTransaction::MethodWrapper
 
-      STATSD_KEY_PREFIX = 'worker.evss.submit_form8940'
+      STATSD_KEY_PREFIX = 'worker.evss.submit_form8940.exhausted'
 
-      # Sidekiq has built in exponential back-off functionality for retrys
+      # Sidekiq has built in exponential back-off functionality for retries
       # A max retry attempt of 10 will result in a run time of ~8 hours
       # This job is invoked from 526 background job
       RETRY = 10
 
       sidekiq_options retry: RETRY
 
-      # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
       sidekiq_retries_exhausted do |msg, _ex|
-        Rails.logger.send(
-          :error,
-          "Failed all retries on SubmitForm8940 submit, last error: #{msg['error_message']}"
+        job_id = msg['jid']
+        error_class = msg['error_class']
+        error_message = msg['error_message']
+        timestamp = Time.now.utc
+        form526_submission_id = msg['args'].first
+
+        form_job_status = Form526JobStatus.find_by(job_id:)
+        bgjob_errors = form_job_status.bgjob_errors || {}
+        new_error = {
+          "#{timestamp.to_i}": {
+            caller_method: __method__.to_s,
+            error_class:,
+            error_message:,
+            timestamp:,
+            form526_submission_id:
+          }
+        }
+        form_job_status.update(
+          status: Form526JobStatus::STATUS[:exhausted],
+          bgjob_errors: bgjob_errors.merge(new_error)
         )
-        Metrics.new(STATSD_KEY_PREFIX, msg['jid']).increment_exhausted
+
+        StatsD.increment(STATSD_KEY_PREFIX)
+
+        ::Rails.logger.warn(
+          'Submit Form 8940 Retries exhausted',
+          { job_id:, error_class:, error_message:, timestamp:, form526_submission_id: }
+        )
+      rescue => e
+        ::Rails.logger.error(
+          'Failure in SubmitForm8940#sidekiq_retries_exhausted',
+          {
+            messaged_content: e.message,
+            job_id:,
+            submission_id: form526_submission_id,
+            pre_exhaustion_failure: {
+              error_class:,
+              error_message:
+            }
+          }
+        )
+        raise e
       end
 
       attr_accessor :submission_id

--- a/lib/sidekiq/form526_backup_submission_process/submit.rb
+++ b/lib/sidekiq/form526_backup_submission_process/submit.rb
@@ -21,7 +21,7 @@ module Sidekiq
       include Sidekiq::Job
 
       sidekiq_options retry: 14
-      STATSD_KEY = 'worker.evss.form526_backup_submission_process.exhausted'
+      STATSD_KEY_PREFIX = 'worker.evss.form526_backup_submission_process.exhausted'
 
       sidekiq_retries_exhausted do |msg, _ex|
         job_id = msg['jid']
@@ -46,14 +46,14 @@ module Sidekiq
           bgjob_errors: bgjob_errors.merge(new_error)
         )
 
-        StatsD.increment(STATSD_KEY)
+        StatsD.increment(STATSD_KEY_PREFIX)
 
-        Rails.logger.warn(
+        ::Rails.logger.warn(
           'Form 526 Backup Submission Retries exhausted',
           { job_id:, error_class:, error_message:, timestamp:, form526_submission_id: }
         )
       rescue => e
-        Rails.logger.error(
+        ::Rails.logger.error(
           'Failure in Form526BackupSubmission#sidekiq_retries_exhausted',
           {
             messaged_content: e.message,
@@ -81,7 +81,7 @@ module Sidekiq
         job_status.update(status: Form526JobStatus::STATUS[:success])
       rescue => e
         ::Rails.logger.error(
-          message: "FORM526 BACKUP SUMBISSION FAILURE. Investigate immedietly: #{e.message}.",
+          message: "FORM526 BACKUP SUBMISSION FAILURE. Investigate immediately: #{e.message}.",
           backtrace: e.backtrace,
           submission_id: form526_submission_id
         )

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
       let!(:form526_submission) { create(:form526_submission) }
       let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
 
-      it 'updates a StatsD counter and updates the status on and exhaustion event' do
+      it 'updates a StatsD counter and updates the status on an exhaustion event' do
         subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
-          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY)
+          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
           expect(Rails).to receive(:logger).and_call_original
         end
         form526_job_status.reload

--- a/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
+++ b/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
@@ -90,4 +90,20 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
       end
     end
   end
+
+  context 'catastrophic failure state' do
+    describe 'when all retries are exhausted' do
+      let!(:form526_submission) { create(:form526_submission) }
+      let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
+
+      it 'updates a StatsD counter and updates the status on an exhaustion event' do
+        subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
+          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(Rails).to receive(:logger).and_call_original
+        end
+        form526_job_status.reload
+        expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
+      end
+    end
+  end
 end

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
@@ -80,4 +80,20 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
       end
     end
   end
+
+  context 'catastrophic failure state' do
+    describe 'when all retries are exhausted' do
+      let!(:form526_submission) { create(:form526_submission) }
+      let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
+
+      it 'updates a StatsD counter and updates the status on an exhaustion event' do
+        subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
+          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(Rails).to receive(:logger).and_call_original
+        end
+        form526_job_status.reload
+        expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
+      end
+    end
+  end
 end

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_cleanup_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_cleanup_spec.rb
@@ -31,4 +31,20 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526Cleanup, type: :jo
       end
     end
   end
+
+  context 'catastrophic failure state' do
+    describe 'when all retries are exhausted' do
+      let!(:form526_submission) { create(:form526_submission) }
+      let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
+
+      it 'updates a StatsD counter and updates the status on an exhaustion event' do
+        subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
+          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(Rails).to receive(:logger).and_call_original
+        end
+        form526_job_status.reload
+        expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
+      end
+    end
+  end
 end

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form8940_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form8940_spec.rb
@@ -77,4 +77,20 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm8940, type: :job do
       end
     end
   end
+
+  context 'catastrophic failure state' do
+    describe 'when all retries are exhausted' do
+      let!(:form526_submission) { create(:form526_submission) }
+      let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
+
+      it 'updates a StatsD counter and updates the status on an exhaustion event' do
+        subject.within_sidekiq_retries_exhausted_block({ 'jid' => form526_job_status.job_id }) do
+          expect(StatsD).to receive(:increment).with(subject::STATSD_KEY_PREFIX)
+          expect(Rails).to receive(:logger).and_call_original
+        end
+        form526_job_status.reload
+        expect(form526_job_status.status).to eq(Form526JobStatus::STATUS[:exhausted])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- add / update / homogenize on-exhaustion hooks for 526 related sidekiq async jobs.  This allows for logs that can be aggregated on in Datadog, as well as the addition of stats D metrics.
- fix existing syntax issue with `Rails.logger` vs `::Rails.logger`

### Note: PR is part 2 of 2
- [PR 2 of 2](https://github.com/department-of-veterans-affairs/vets-api/pull/14735)

## Related issue(s)
- [ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/67288)

## Testing done

- added RSpec tests
- manual click through and instantiation

## What areas of the site does it impact?
- 526 Async submission

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
