### PR TITLE
MHV-48196: Physician procedure note loinc updated

### DIFF
--- a/lib/medical_records/client.rb
+++ b/lib/medical_records/client.rb
@@ -16,7 +16,7 @@ module MedicalRecords
     DEFAULT_COUNT = 9999
 
     # LOINC codes for clinical notes
-    PHYSICIAN_PROCEDURE_NOTE = '11505-5' # Physician procedure note
+    PHYSICIAN_PROCEDURE_NOTE = '11506-3' # Physician procedure note
     DISCHARGE_SUMMARY = '18842-5' # Discharge summary
 
     # LOINC codes for vitals

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11505-5,18842-5"
+      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&type=11506-3,18842-5"
       body:
         encoding: US-ASCII
         string: ""
@@ -54,7 +54,7 @@ http_interactions:
             "total": 11,
             "link": [ {
               "relation": "self",
-              "url": "<MHV_MR_HOST>/fhir/DocumentReference?patient=1174378&type=11505-5%2C18842-5"
+              "url": "<MHV_MR_HOST>/fhir/DocumentReference?patient=1174378&type=11506-3%2C18842-5"
             } ],
             "entry": [ {
               "fullUrl": "<MHV_MR_HOST>/fhir/DocumentReference/1175305",


### PR DESCRIPTION
## Summary
I updated the loinc code for care summaries and notes/physician procedure notes to 11506-3. This was based on advice received from @JohnMoehrke after he did work on mapping coordination with KBS. The loinc code was previously 11505-5. 

## Related issue(s)
### [MHV-48196](https://jira.devops.va.gov/browse/MHV-48196) - Implement front end data gap fixes for Care Summaries/Notes ###

<img width="925" alt="Screenshot 2023-12-03 at 4 35 06 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/a65ca1a8-848e-4934-900b-3097f07005e2">
<img width="923" alt="Screenshot 2023-12-03 at 4 35 14 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/2437e9dc-8658-42b7-b918-2891c22cb3a3">

## Testing done

- Unit tests were updated with the new loinc code (11506-3)

## Screenshots
No UI changes. 

## What areas of the site does it impact?
MHV medical records - care summaries and notes

## Acceptance criteria
AC1 Make sure all the fields listed in the comments are mapped appropriately
AC2 Don't access the contained[] resources directly – do a lookup via performer/reaction respectively (see allergy for reference).
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
