### PR TITLE
Simple forms - 21-4142 - handle date stamp for resubmission

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -12,6 +12,14 @@ module SimpleFormsApi
         stamp_method = "stamp#{data['form_number'].gsub('-', '')}".downcase
         send(stamp_method, stamped_template_path, data)
       end
+
+      # This is a one-off case where we need to stamp a date on the first page of 21-4142 when resubmitting
+      if data['in_progress_form_created_at'] && data['form_number'] == '21-4142'
+        date_title = 'Application Submitted:'
+        date_text = data['in_progress_form_created_at']
+        stamp214142_date_stamp_for_resubmission(stamped_template_path, date_title, date_text)
+      end
+
       current_time = Time.current.in_time_zone('America/Chicago').strftime('%H:%M:%S')
       stamp_text = SUBMISSION_TEXT + current_time
       desired_stamps = [[10, 10, stamp_text]]
@@ -36,6 +44,26 @@ module SimpleFormsApi
       ]
 
       multistamp(stamped_template_path, signature_text, page_configuration)
+    end
+
+    def self.stamp214142_date_stamp_for_resubmission(stamped_template_path, date_title, date_text)
+      date_title_stamp_position = [440, 710]
+      date_text_stamp_position = [440, 690]
+      page_configuration = [
+        { type: :text, position: date_title_stamp_position },
+        { type: :new_page },
+        { type: :new_page }
+      ]
+
+      multistamp(stamped_template_path, date_title, page_configuration, 12)
+
+      page_configuration = [
+        { type: :text, position: date_text_stamp_position },
+        { type: :new_page },
+        { type: :new_page }
+      ]
+
+      multistamp(stamped_template_path, date_text, page_configuration, 12)
     end
 
     def self.stamp2110210(stamped_template_path, data)
@@ -96,13 +124,13 @@ module SimpleFormsApi
       multistamp(stamped_template_path, signature_text, page_configuration)
     end
 
-    def self.multistamp(stamped_template_path, signature_text, page_configuration)
+    def self.multistamp(stamped_template_path, signature_text, page_configuration, font_size = 16)
       stamp_path = Common::FileHelpers.random_file_path
       Prawn::Document.generate(stamp_path, margin: [0, 0]) do |pdf|
         page_configuration.each do |config|
           case config[:type]
           when :text
-            pdf.draw_text signature_text, at: config[:position], size: 16
+            pdf.draw_text signature_text, at: config[:position], size: font_size
           when :new_page
             pdf.start_new_page
           end

--- a/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/pdf_stamper.rb
@@ -13,13 +13,6 @@ module SimpleFormsApi
         send(stamp_method, stamped_template_path, data)
       end
 
-      # This is a one-off case where we need to stamp a date on the first page of 21-4142 when resubmitting
-      if data['in_progress_form_created_at'] && data['form_number'] == '21-4142'
-        date_title = 'Application Submitted:'
-        date_text = data['in_progress_form_created_at']
-        stamp214142_date_stamp_for_resubmission(stamped_template_path, date_title, date_text)
-      end
-
       current_time = Time.current.in_time_zone('America/Chicago').strftime('%H:%M:%S')
       stamp_text = SUBMISSION_TEXT + current_time
       desired_stamps = [[10, 10, stamp_text]]
@@ -44,6 +37,13 @@ module SimpleFormsApi
       ]
 
       multistamp(stamped_template_path, signature_text, page_configuration)
+
+      # This is a one-off case where we need to stamp a date on the first page of 21-4142 when resubmitting
+      if data['in_progress_form_created_at']
+        date_title = 'Application Submitted:'
+        date_text = data['in_progress_form_created_at']
+        stamp214142_date_stamp_for_resubmission(stamped_template_path, date_title, date_text)
+      end
     end
 
     def self.stamp214142_date_stamp_for_resubmission(stamped_template_path, date_title, date_text)

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_21_4142_resubmission.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_21_4142_resubmission.json
@@ -1,0 +1,144 @@
+{
+  "form_number": "21-4142",
+  "in_progress_form_created_at": "11/28/2023 13:08 CST",
+  "veteran": {
+    "full_name": {
+      "first": "Veteran",
+      "middle": "B",
+      "last": "Surname",
+      "suffix": "III"
+    },
+    "address": {
+      "country": "USA",
+      "street": "1 First Ln",
+      "street2": "Suite 22",
+      "street3": "Room 3",
+      "city": "Place",
+      "state": "AL",
+      "postal_code": "12345"
+    },
+    "date_of_birth": "1987-02-20",
+    "ssn": "333558888",
+    "va_file_number": "987654321",
+    "veteran_service_number": "AA987654",
+    "home_phone": "987-654-3213",
+    "international_phone": "987-654-321312312",
+    "email": "veteran.surname@address.com"
+  },
+  "patient_identification": {
+    "is_requesting_own_medical_records": true,
+    "patient_full_name": {
+      "first": "Child",
+      "middle": "C",
+      "last": "Surname",
+      "suffix": "IV"
+    },
+    "patient_ssn": "222554444",
+    "patient_va_file_number": "123456789"
+  },
+  "acknowledge_to_release_information": true,
+  "provider_facility": [
+    {
+      "provider_facility_name": "Super Health Hospital",
+      "provider_facility_address": {
+        "country": "USA",
+        "street": "1 Care Rd",
+        "street2": "Bldg 2",
+        "city": "Helpful",
+        "state": "KY",
+        "postal_code": "33211"
+      },
+      "conditions_treated": "this, and, that",
+      "treatment_date_range": {
+        "from": "2014-02-19",
+        "to": "2015-10-15"
+      }
+    },
+    {
+      "provider_facility_name": "Supreme Health Service",
+      "provider_facility_address": {
+        "country": "USA",
+        "street": "2 Recovery Dr",
+        "street2": "Unit 15",
+        "city": "Good",
+        "state": "SC",
+        "postal_code": "98123"
+      },
+      "conditions_treated": "some of everything",
+      "treatment_date_range": {
+        "from": "2017-03-13",
+        "to": "2018-08-21"
+      }
+    },
+    {
+      "provider_facility_name": "Ultra Care Facility",
+      "provider_facility_address": {
+        "country": "USA",
+        "street": "3 Plain old good Blvd",
+        "street2": "#33",
+        "city": "Best",
+        "state": "WI",
+        "postal_code": "65712"
+      },
+      "conditions_treated": "all kinds of ailments",
+      "treatment_date_range": {
+        "from": "2019-10-14",
+        "to": "2020-01-17"
+      }
+    },
+    {
+      "provider_facility_name": "Top Notch Care Hospital",
+      "provider_facility_address": {
+        "country": "USA",
+        "street": "4 Convalescence Way",
+        "street2": "Facility 443",
+        "city": "Nursing",
+        "state": "IA",
+        "postal_code": "02234"
+      },
+      "conditions_treated": "Severe stomach issues",
+      "treatment_date_range": {
+        "from": "2022-03-16",
+        "to": "2022-08-21"
+      }
+    },
+    {
+      "provider_facility_name": "University Care Center",
+      "provider_facility_address": {
+        "country": "USA",
+        "street": "5 Medication Ave",
+        "street2": "Car 581",
+        "city": "Everbetter",
+        "state": "WY",
+        "postal_code": "91723"
+      },
+      "conditions_treated": "the last touches of health",
+      "treatment_date_range": {
+        "from": "2022-11-19",
+        "to": "2023-02-21"
+      }
+    }
+  ],
+  "limited_consent": "lots of things to say here",
+  "preparer_identification": {
+    "preparer_address": {
+      "street": "10 Top third",
+      "street2": "Third Party",
+      "city": "Tertiary pl",
+      "country": "USA",
+      "state": "TN",
+      "postal_code": "44444"
+    },
+    "preparer_full_name": {
+      "first": "Third",
+      "middle": "Tertiary",
+      "last": "Terra",
+      "suffix": "II"
+    },
+    "preparer_title": "Title",
+    "preparer_organization": "Top Org",
+    "court_appointment_info": "Representing court stuff like...Representing court stuff like...Representing court stuff like...Representing court stuff like...Representing court stuff like...Representing court stuff like...",
+    "relationship_to_veteran": "Veteran Service Officer"
+  },
+  "statement_of_truth_signature": "Third Tertiary Terra II"
+}

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -94,7 +94,14 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
       it 'generates the right PDF' do
         VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
           VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
-            fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_4142_resubmission.json')
+            fixture_path = Rails.root.join(
+              'modules',
+              'simple_forms_api',
+              'spec',
+              'fixtures',
+              'form_json',
+              'vba_21_4142_resubmission.json'
+            )
             data = JSON.parse(fixture_path.read)
 
             post '/simple_forms_api/v1/simple_forms', params: data

--- a/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/v1/uploads_spec.rb
@@ -90,6 +90,24 @@ RSpec.describe 'Dynamic forms uploader', type: :request do
       end
     end
 
+    describe '21-4142 form resubmission' do
+      it 'generates the right PDF' do
+        VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
+          VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
+            fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_4142_resubmission.json')
+            data = JSON.parse(fixture_path.read)
+
+            post '/simple_forms_api/v1/simple_forms', params: data
+
+            expect(response).to have_http_status(:ok)
+          ensure
+            metadata_file = Dir['tmp/*.SimpleFormsApi.metadata.json'][0]
+            Common::FileHelpers.delete_file_if_exists(metadata_file) if defined?(metadata_file)
+          end
+        end
+      end
+    end
+
     def self.test_submit_supporting_documents
       it 'renders the attachment as json' do
         allow(ClamScan::Client).to receive(:scan)


### PR DESCRIPTION
## Summary
This PR is useful _only_ for our resubmission process for 21-4142 (to be completed by EOD tomorrow, Tuesday, hopefully). It handles forms that get passed in with an extra piece of data, `'in_progress_form_created_at'`. If a 21-4142 form has this flag set to something, then the stamper will add an extra date stamp (see screenshot below).

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/71085


## Testing done

Tested locally and lookin' good 😎 

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-api/assets/10481391/e0d731ec-e488-4927-9f81-7ffe01c73b0e)


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
