### PR TITLE
Remove oktokit hold and bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem 'mini_magick'
 gem 'net-sftp'
 gem 'nokogiri'
 gem 'notifications-ruby-client'
-gem 'octokit', '4.21.0'
+gem 'octokit'
 gem 'oj' # Amazon Linux `json` gem causes conflicts, but `multi_json` will prefer `oj` if installed
 gem 'okcomputer'
 gem 'olive_branch'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,18 +306,18 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    danger (8.6.1)
+    danger (9.4.0)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
       cork (~> 0.1)
-      faraday (>= 0.9.0, < 2.0)
+      faraday (>= 0.9.0, < 3.0)
       faraday-http-cache (~> 2.0)
-      git (~> 1.7)
+      git (~> 1.13)
       kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
-      octokit (~> 4.7)
+      octokit (>= 6.0, < 8.0)
       terminal-table (>= 1, < 4)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
@@ -418,7 +418,7 @@ GEM
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
-    faraday-http-cache (2.2.0)
+    faraday-http-cache (2.5.0)
       faraday (>= 0.8)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.4)
@@ -661,9 +661,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-    octokit (4.21.0)
-      faraday (>= 0.9)
-      sawyer (~> 0.8.0, >= 0.5.3)
+    octokit (7.2.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
     oj (3.16.1)
     okcomputer (1.18.4)
     olive_branch (4.0.1)
@@ -723,7 +723,7 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    public_suffix (5.0.3)
+    public_suffix (5.0.4)
     puma (6.4.0)
       nio4r (~> 2.0)
     puma (6.4.0-java)
@@ -908,9 +908,9 @@ GEM
       nokogiri (>= 1.8.1)
       nori (~> 2.4)
       wasabi (~> 3.4)
-    sawyer (0.8.2)
+    sawyer (0.9.2)
       addressable (>= 2.3.5)
-      faraday (> 0.8, < 2.0)
+      faraday (>= 0.17.3, < 3)
     script_utils (0.0.4)
     seedbank (0.5.0)
       rake (>= 10.0)
@@ -1139,7 +1139,7 @@ DEPENDENCIES
   net-sftp
   nokogiri
   notifications-ruby-client
-  octokit (= 4.21.0)
+  octokit
   oj
   okcomputer
   olive_branch


### PR DESCRIPTION
Octokit was originally held back [here](https://github.com/department-of-veterans-affairs/vets-api/pull/8948) because Faraday was behind. We should be able to catch up now