### PR TITLE
Mhv 52044 new app token va gov

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -42,7 +42,9 @@ module V0
       client_file_name = file_name_for_pdf(@claim.veteran_data)
       file_contents    = File.read(source_file_path)
 
-      File.delete(source_file_path)
+      # rubocop:disable Lint/NonAtomicFileOperation
+      File.delete(source_file_path) if File.exist?(source_file_path)
+      # rubocop:enable Lint/NonAtomicFileOperation
 
       auditor.record(:pdf_download)
 

--- a/app/models/prescription_details.rb
+++ b/app/models/prescription_details.rb
@@ -26,4 +26,30 @@ class PrescriptionDetails < Prescription
   attribute :rx_rf_records, Array[String]
   attribute :tracking, Boolean
   attribute :orderable_item, String
+  attribute :sorted_dispensed_date
+
+  def sorted_dispensed_date
+    has_refills = try(:rx_rf_records).present?
+    last_refill_date = Date.new(0)
+
+    if has_refills
+      refills = rx_rf_records[0][1]
+
+      refills.each do |r|
+        last_dispensed = r.try(:[], :dispensed_date)
+        next if last_dispensed.nil?
+
+        refill_date = Date.parse(r.try(:[], :dispensed_date))
+        last_refill_date = refill_date if refill_date.present? && refill_date > last_refill_date
+      end
+    end
+
+    if has_refills && last_refill_date.present?
+      last_refill_date.to_date
+    elsif dispensed_date.present?
+      dispensed_date.to_date
+    else
+      Date.new(0)
+    end
+  end
 end

--- a/app/swagger/swagger/schemas/health/prescriptions.rb
+++ b/app/swagger/swagger/schemas/health/prescriptions.rb
@@ -60,6 +60,7 @@ module Swagger
             property :quantity, type: :integer
             property :expiration_date, type: :string, format: :date
             property :dispensed_date, type: %i[string null], format: :date
+            property :sorted_dispensed_date, type: :string, format: :date
             property :station_number, type: :string
             property :is_refillable, type: :boolean
             property :is_trackable, type: :boolean

--- a/lib/common/client/concerns/mhv_session_based_client.rb
+++ b/lib/common/client/concerns/mhv_session_based_client.rb
@@ -84,6 +84,12 @@ module Common
         def auth_headers
           config.base_request_headers.merge('appToken' => config.app_token, 'mhvCorrelationId' => session.user_id.to_s)
         end
+
+        protected
+
+        def token_headers_va_gov
+          config.base_request_headers.merge('Token' => session.token)
+        end
       end
     end
   end

--- a/lib/rx/configuration.rb
+++ b/lib/rx/configuration.rb
@@ -25,6 +25,10 @@ module Rx
       Settings.mhv.rx.app_token
     end
 
+    def app_token_va_gov
+      Settings.mhv.rx.app_token_va_gov
+    end
+
     ##
     # @return [String] Base path for dependent URLs
     #

--- a/lib/rx/medications_client.rb
+++ b/lib/rx/medications_client.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'common/client/base'
+require 'common/client/concerns/mhv_session_based_client'
+require 'rx/configuration'
+require 'rx/client_session'
+require 'rx/rx_gateway_timeout'
+require 'active_support/core_ext/hash/slice'
+
+module Rx
+  ##
+  # Core class responsible for Rx API interface operations on va.gov
+  #
+    class MedicationsClient < Rx::Client
+      include Common::Client::Concerns::MHVSessionBasedClient
+      configuration Rx::Configuration
+      client_session Rx::ClientSession
+
+      def token_headers
+        config.base_request_headers.merge('Token' => Settings.mhv.rx.app_token_va_gov)
+      end
+    end
+end
+
+ 

--- a/modules/my_health/app/controllers/my_health/rx_controller.rb
+++ b/modules/my_health/app/controllers/my_health/rx_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rx/client'
+require 'rx/medications_client'
 
 module MyHealth
   class RxController < ApplicationController
@@ -11,7 +12,7 @@ module MyHealth
     protected
 
     def client
-      @client ||= Rx::Client.new(session: { user_id: current_user.mhv_correlation_id })
+      @client ||= Rx::MedicationsClient.new.new(session: { user_id: current_user.mhv_correlation_id })
     end
 
     def authorize

--- a/modules/my_health/app/serializers/my_health/v1/prescription_details_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/prescription_details_serializer.rb
@@ -29,6 +29,7 @@ module MyHealth
       attribute :rx_rf_records
       attribute :tracking
       attribute :orderable_item
+      attribute :sorted_dispensed_date
     end
   end
 end

--- a/spec/support/schemas/my_health/prescriptions/v1/prescription_details.json
+++ b/spec/support/schemas/my_health/prescriptions/v1/prescription_details.json
@@ -48,7 +48,9 @@
         "tracking_list",
         "rx_rf_records",
         "tracking",
-        "orderable_item"],
+        "orderable_item",
+        "sorted_dispensed_date"
+      ],
       "properties": {
         "prescription_id": { "type": ["integer", "null"] },
         "prescription_number": { "type": ["string", "null"] },
@@ -162,7 +164,8 @@
           }
         },
         "tracking": { "type": ["boolean", "null"] },
-        "orderable_item": { "type": ["string", "null"] }
+        "orderable_item": { "type": ["string", "null"] },
+        "sorted_dispensed_date": { "type": "string", "format": "date" }
       }
     },
     "links": {

--- a/spec/support/schemas_camelized/my_health/prescriptions/v1/prescription_details.json
+++ b/spec/support/schemas_camelized/my_health/prescriptions/v1/prescription_details.json
@@ -48,7 +48,9 @@
         "trackingList",
         "rxRfRecords",
         "tracking",
-        "orderableItem"],
+        "orderableItem",
+        "sortedDispensedDate"
+      ],
       "properties": {
         "prescriptionId": { "type": ["integer", "null"] },
         "prescriptionNumber": { "type": ["string", "null"] },
@@ -163,7 +165,8 @@
           }
         },
         "tracking": { "type": ["boolean", "null"] },
-        "orderableItem": { "type": ["string", "null"] }
+        "orderableItem": { "type": ["string", "null"] },
+        "sortedDispensedDate": { "type": "string", "format": "date" }
       }
     },
     "links": {

--- a/spec/support/vcr_cassettes/rx_client/prescriptions/gets_a_sorted_by_custom_field_list_of_all_prescriptions_v1.yml
+++ b/spec/support/vcr_cassettes/rx_client/prescriptions/gets_a_sorted_by_custom_field_list_of_all_prescriptions_v1.yml
@@ -1,0 +1,2043 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<MHV_HOST>/mhv-api/patient/v1/prescription/medications"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Token: "<SESSION_TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 27 Nov 2023 18:59:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '324860'
+      X-Amzn-Requestid:
+      - d6969a51-9197-4133-a608-247475d7acce
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - PEkOKFT3vHMFt0Q=
+      X-Amzn-Remapped-Date:
+      - Mon, 27 Nov 2023 18:59:51 GMT
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: ASCII-8BIT
+      string: '{"failedStationList":"","successfulStationList":null,"lastUpdatedTime":"Mon,
+        27 Nov 2023 10:31:47 EST","medicationList":{"medication":[{"refillStatus":"hold","refillSubmitDate":"Thu,
+        25 Aug 2022 15:55:30 EDT","refillDate":"Tue, 06 Sep 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21142490,"sig":"TAKE
+        ONE TABLET BY MOUTH AT BEDTIME FOR 30 DAYS","orderedDate":"Mon, 06 Jun 2022
+        00:00:00 EDT","quantity":30,"expirationDate":"Wed, 07 Jun 2023 00:00:00 EDT","prescriptionNumber":"3636859","prescriptionName":"FAMOTIDINE
+        40MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142490,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 14 Aug 2023 14:02:19 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        On Hold","ndc":"00172-5729-60","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"FAMOTIDINE 40MG","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"active","refillSubmitDate":null,"refillDate":"Tue,
+        01 Feb 2022 00:00:00 EST","refillRemaining":null,"facilityName":"SLC10 TEST
+        LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21142491,"sig":"10MG
+        ORAL DAILY","orderedDate":"Tue, 22 Feb 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"1","prescriptionName":"YASMIN
+        TAB,28","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142491,"userId":17621060,"providerFirstName":"BHAVIN","providerLastName":"PATEL","remarks":"TEST
+        COMMENT 02222022","divisionName":null,"modifiedDate":"Mon, 27 Nov 2023 10:31:45
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Non-VA","ndc":"50419-0402-03","reason":null,"prescriptionNumberIndex":"NV","prescriptionSource":"NV","disclaimer":"TEST
+        DISCLAIMER 02222022","indicationForUse":null,"indicationForUseFlag":null,"category":"Documented
+        by VA","orderableItem":"ETHINYL ESTRADIOL 0.03-DROSPIRENONE 3MG","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"active","refillSubmitDate":null,"refillDate":"Fri,
+        27 May 2022 00:00:00 EDT","refillRemaining":null,"facilityName":"SLC10 TEST
+        LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21142494,"sig":"
+        MOUTH DAILY","orderedDate":"Wed, 01 Jun 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"4","prescriptionName":"L-ARGININE
+        500MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142494,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":null,"modifiedDate":"Mon,
+        27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Non-VA","ndc":"00904-4215-51","reason":null,"prescriptionNumberIndex":"NV","prescriptionSource":"NV","disclaimer":null,"indicationForUse":"TEST","indicationForUseFlag":null,"category":"Documented
+        by VA","orderableItem":"L-ARGININE 500MG","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"active","refillSubmitDate":null,"refillDate":"Mon,
+        02 May 2022 00:00:00 EDT","refillRemaining":null,"facilityName":"SLC10 TEST
+        LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21142495,"sig":"10MG
+        ORAL DAILY","orderedDate":"Fri, 27 May 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"5","prescriptionName":"KETAMINE
+        10MG/ML INJ 20ML","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142495,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":null,"modifiedDate":"Mon,
+        27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Non-VA","ndc":"61570-0581-10","reason":null,"prescriptionNumberIndex":"NV","prescriptionSource":"NV","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Documented
+        by VA","orderableItem":"K PHOSPHATE 305-NA PHOSTATE 700MG","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"active","refillSubmitDate":null,"refillDate":"Sun,
+        22 May 2022 00:00:00 EDT","refillRemaining":null,"facilityName":"SLC10 TEST
+        LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21142496,"sig":"
+        TOP DAILY","orderedDate":"Wed, 01 Jun 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"6","prescriptionName":null,"dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142496,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":null,"modifiedDate":"Mon,
+        27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Non-VA","ndc":null,"reason":null,"prescriptionNumberIndex":"NV","prescriptionSource":"NV","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Documented
+        by VA","orderableItem":"MAFENIDE ACETATE 8.5% 480GM","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"transferred","refillSubmitDate":"Wed,
+        09 Nov 2022 14:40:35 EST","refillDate":"Wed, 09 Nov 2022 00:00:00 EST","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21142513,"sig":"APPLY
+        1ML TO AFFECTED AREA DAILY FOR 30 DAYS","orderedDate":"Sat, 16 Apr 2022 00:00:00
+        EDT","quantity":1,"expirationDate":"Mon, 17 Apr 2023 00:00:00 EDT","prescriptionNumber":"2720330","prescriptionName":"KARAYA
+        PASTE (2 OUNCES)","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142513,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        14 Aug 2023 14:02:20 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Transferred","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"KARAYA","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"transferred","refillSubmitDate":null,"refillDate":"Sat,
+        16 Apr 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21480096,"sig":null,"orderedDate":"Wed,
+        09 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720330","prescriptionName":"KARAYA
+        PASTE (2 OUNCES)","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21480096,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Transferred","ndc":null,"reason":null,"prescriptionNumberIndex":"RF3","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"transferred","refillSubmitDate":null,"refillDate":"Sat,
+        16 Apr 2022 00:00:00 EDT","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21259016,"sig":null,"orderedDate":"Sun,
+        07 Aug 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720330","prescriptionName":"KARAYA
+        PASTE (2 OUNCES)","dispensedDate":"Tue, 06 Sep 2022 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21259016,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Transferred","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"transferred","refillSubmitDate":null,"refillDate":"Sat,
+        16 Apr 2022 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21142514,"sig":null,"orderedDate":"Fri,
+        06 May 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720330","prescriptionName":"KARAYA
+        PASTE (2 OUNCES)","dispensedDate":"Sun, 03 Jul 2022 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142514,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Transferred","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"active","refillSubmitDate":null,"refillDate":"Tue,
+        01 Feb 2022 00:00:00 EST","refillRemaining":null,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21142515,"sig":"10MG
+        ORAL DAILY","orderedDate":"Tue, 22 Feb 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"1","prescriptionName":"WARFARIN
+        (COUMADIN) 10MG TAB U/D","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142515,"userId":17621060,"providerFirstName":"BHAVIN","providerLastName":"PATEL","remarks":"TEST
+        COMMENT 02222022","divisionName":null,"modifiedDate":"Mon, 27 Nov 2023 10:31:46
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Non-VA","ndc":null,"reason":null,"prescriptionNumberIndex":"NV","prescriptionSource":"NV","disclaimer":"TEST
+        DISCLAIMER 02222022","indicationForUse":null,"indicationForUseFlag":null,"category":"Documented
+        by VA","orderableItem":"WARFARIN","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"active","refillSubmitDate":null,"refillDate":"Thu,
+        17 Mar 2022 00:00:00 EDT","refillRemaining":null,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21142518,"sig":"HIGH
+        MOUTH DAILY","orderedDate":"Mon, 21 Mar 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"4","prescriptionName":"SAW
+        PALMETTO","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142518,"userId":17621060,"providerFirstName":"BHAVIN","providerLastName":"PATEL","remarks":null,"divisionName":null,"modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Non-VA","ndc":null,"reason":null,"prescriptionNumberIndex":"NV","prescriptionSource":"NV","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Documented
+        by VA","orderableItem":"SAW PALMETTO","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"active","refillSubmitDate":null,"refillDate":"Sun,
+        20 Mar 2022 00:00:00 EDT","refillRemaining":null,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21142519,"sig":"HIGH
+        ORAL DAILY","orderedDate":"Tue, 22 Mar 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"5","prescriptionName":null,"dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142519,"userId":17621060,"providerFirstName":"BHAVIN","providerLastName":"PATEL","remarks":null,"divisionName":null,"modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Non-VA","ndc":null,"reason":null,"prescriptionNumberIndex":"NV","prescriptionSource":"NV","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Documented
+        by VA","orderableItem":"GABAPENTIN","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"active","refillSubmitDate":null,"refillDate":"Tue,
+        22 Mar 2022 00:00:00 EDT","refillRemaining":null,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21142520,"sig":"LOW
+        TOP DAILY","orderedDate":"Wed, 23 Mar 2022 00:00:00 EDT","quantity":null,"expirationDate":"Mon,
+        19 Sep 2022 00:00:00 EDT","prescriptionNumber":"6","prescriptionName":null,"dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142520,"userId":17621060,"providerFirstName":"BHAVIN","providerLastName":"PATEL","remarks":null,"divisionName":null,"modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Non-VA","ndc":null,"reason":null,"prescriptionNumberIndex":"NV","prescriptionSource":"NV","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Documented
+        by VA","orderableItem":"HALCINONIDE","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"active","refillSubmitDate":null,"refillDate":"Wed,
+        23 Mar 2022 00:00:00 EDT","refillRemaining":null,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21142521,"sig":"HIGH
+        TOP WEEKLY","orderedDate":"Wed, 23 Mar 2022 00:00:00 EDT","quantity":null,"expirationDate":"Sun,
+        22 May 2022 00:00:00 EDT","prescriptionNumber":"8","prescriptionName":"BAB
+        OTIC SOL","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21142521,"userId":17621060,"providerFirstName":"BHAVIN","providerLastName":"PATEL","remarks":null,"divisionName":null,"modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Non-VA","ndc":null,"reason":null,"prescriptionNumberIndex":"NV","prescriptionSource":"NV","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Documented
+        by VA","orderableItem":"BACID","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Mon,
+        29 Aug 2022 14:36:05 EDT","refillDate":"Thu, 25 Aug 2022 00:00:00 EDT","refillRemaining":11,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21227553,"sig":"TAKE
+        5G DAILY FOR 30 DAYS TEST TEST INDICATION TEST","orderedDate":"Thu, 25 Aug
+        2022 00:00:00 EDT","quantity":30,"expirationDate":"Sat, 26 Aug 2023 00:00:00
+        EDT","prescriptionNumber":"2720245A","prescriptionName":"ACITRETIN 25MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21227553,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720245","divisionName":"DAYTON","modifiedDate":"Sun, 27 Aug 2023
+        20:43:55 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00004-0214-57","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION TEST","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"ACITRETIN","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Tue,
+        20 Sep 2022 11:21:40 EDT","refillDate":"Tue, 20 Sep 2022 00:00:00 EDT","refillRemaining":11,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21296515,"sig":"TAKE
+        5G DAILY FOR 30 DAYS TEST TEST INDICATION TEST","orderedDate":"Tue, 20 Sep
+        2022 00:00:00 EDT","quantity":30,"expirationDate":"Thu, 21 Sep 2023 00:00:00
+        EDT","prescriptionNumber":"2720245B","prescriptionName":"ACITRETIN 25MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":"(542)272-0245","cmopNdcNumber":"00013264681","id":21296515,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720245A","divisionName":"DAYTON","modifiedDate":"Fri, 22 Sep 2023
+        00:05:07 EDT","institutionId":null,"dialCmopDivisionPhone":"5422720245","dispStatus":"Expired","ndc":"00004-0214-57","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION TEST","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"ACITRETIN","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Tue,
+        15 Nov 2022 12:58:24 EST","refillDate":"Tue, 15 Nov 2022 00:00:00 EST","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21296516,"sig":"TAKE
+        ONE CAPSULE DAILY FOR 30 DAYS TEST","orderedDate":"Tue, 20 Sep 2022 00:00:00
+        EDT","quantity":30,"expirationDate":"Thu, 21 Sep 2023 00:00:00 EDT","prescriptionNumber":"2720298A","prescriptionName":"ACYCLOVIR
+        200MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21296516,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720298","divisionName":"DAYTON","modifiedDate":"Fri, 22 Sep 2023
+        00:05:07 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00172-4266-70","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION TEST","indicationForUseFlag":null,"category":"Rx Medication","orderableItem":"ACYCLOVIR","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        20 Sep 2022 00:00:00 EDT","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21489396,"sig":null,"orderedDate":"Tue,
+        15 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720298A","prescriptionName":"ACYCLOVIR
+        200MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21489396,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Tue,
+        08 Nov 2022 14:12:04 EST","refillDate":"Tue, 08 Nov 2022 00:00:00 EST","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21296517,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 30 DAYS","orderedDate":"Tue, 20 Sep 2022 00:00:00
+        EDT","quantity":30,"expirationDate":"Thu, 21 Sep 2023 00:00:00 EDT","prescriptionNumber":"2720290A","prescriptionName":"AMITRIPTYLINE
+        HCL 10MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":"00013264681","id":21296517,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720290","divisionName":"DAYTON","modifiedDate":"Fri, 22 Sep 2023
+        00:05:07 EDT","institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Expired","ndc":"00603-2212-32","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"AMITRIPTYLINE","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Tue,
+        18 Oct 2022 16:12:26 EDT","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":10,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21296518,"sig":"TAKE
+        THIS IS FOR TESTING %% BY MOUTH WEEKLY HALF ## FOR 1 MINUTE, AND TAKE 50%
+        TAKE 50% FOR 1 HOUR FOLLOW INSTRUCTIONS CAREFULLY ","orderedDate":"Tue, 20
+        Sep 2022 00:00:00 EDT","quantity":10,"expirationDate":"Thu, 21 Sep 2023 00:00:00
+        EDT","prescriptionNumber":"2720326A","prescriptionName":"DISULFIRAM (ANTABUSE)
+        500MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21296518,"userId":17621060,"providerFirstName":"RACHNA","providerLastName":"CHOUDHRY","remarks":"RENEWED
+        FROM RX # 2720326","divisionName":"DAYTON","modifiedDate":"Fri, 22 Sep 2023
+        00:05:07 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00046-0810-50","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"DISULFIRAM","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        20 Sep 2022 00:00:00 EDT","refillRemaining":10,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21409695,"sig":null,"orderedDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720326A","prescriptionName":"DISULFIRAM
+        (ANTABUSE) 500MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21409695,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Tue,
+        08 Nov 2022 14:12:04 EST","refillDate":"Tue, 08 Nov 2022 00:00:00 EST","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21296519,"sig":"TAKE
+        1MG WEEKLY FOR 30 DAYS","orderedDate":"Tue, 20 Sep 2022 00:00:00 EDT","quantity":4,"expirationDate":"Thu,
+        21 Sep 2023 00:00:00 EDT","prescriptionNumber":"2720305A","prescriptionName":"IODOQUINOL
+        650MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":"00013264681","id":21296519,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720305","divisionName":"DAYTON","modifiedDate":"Fri, 22 Sep 2023
+        00:05:07 EDT","institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Expired","ndc":"00516-0093-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"IODOQUINOL","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Fri,
+        04 Nov 2022 10:29:30 EDT","refillDate":"Fri, 04 Nov 2022 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21296557,"sig":"TAKE
+        ONE TABLET EVERY DAY FOR 30 DAYS","orderedDate":"Tue, 20 Sep 2022 00:00:00
+        EDT","quantity":30,"expirationDate":"Thu, 21 Sep 2023 00:00:00 EDT","prescriptionNumber":"3636841A","prescriptionName":"KETOCONAZOLE
+        200MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21296557,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 3636841","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Fri,
+        22 Sep 2023 00:05:06 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"51672-4026-06","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"KETOCONAZOLE 200MG","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Tue,
+        08 Nov 2022 14:11:24 EST","refillDate":"Tue, 08 Nov 2022 00:00:00 EST","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21296558,"sig":"TAKE
+        ONE-HALF TABLET EVERY TWELVE (12) HOURS FOR 30 DAYS","orderedDate":"Tue, 20
+        Sep 2022 00:00:00 EDT","quantity":30,"expirationDate":"Thu, 21 Sep 2023 00:00:00
+        EDT","prescriptionNumber":"3636845A","prescriptionName":"LAMIVUDINE 100MG
+        TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":"(178)636-6871","cmopNdcNumber":"00113002239","id":21296558,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 3636845","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Fri,
+        22 Sep 2023 00:05:06 EDT","institutionId":null,"dialCmopDivisionPhone":"1786366871","dispStatus":"Expired","ndc":"00173-0662-00","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LAMIVUDINE 100MG","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"unknown","refillSubmitDate":"Tue,
+        08 Nov 2022 14:11:24 EST","refillDate":"Tue, 08 Nov 2022 00:00:00 EST","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21296559,"sig":"TAKE
+        ONE TABLET TWO (2) TIMES PER DAY, WITH FOOD FOR 30 DAYS","orderedDate":"Tue,
+        20 Sep 2022 00:00:00 EDT","quantity":60,"expirationDate":"Thu, 21 Sep 2023
+        00:00:00 EDT","prescriptionNumber":"3636827A","prescriptionName":"NAPROXEN
+        250MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21296559,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 3636827","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Fri,
+        22 Sep 2023 00:05:06 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Unknown","ndc":"53746-0188-10","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"NAPROXEN 250MG","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Mon,
+        31 Oct 2022 11:50:45 EDT","refillDate":"Mon, 31 Oct 2022 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21296560,"sig":"TAKE
+        ONE TABLET EVERY DAY FOR 30 DAYS","orderedDate":"Tue, 20 Sep 2022 00:00:00
+        EDT","quantity":30,"expirationDate":"Thu, 21 Sep 2023 00:00:00 EDT","prescriptionNumber":"3636831A","prescriptionName":"PANTOPRAZOLE
+        NA 40MG EC TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21296560,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 3636831","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Fri,
+        22 Sep 2023 00:05:06 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00008-0841-81","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"PANTOPRAZOLE NA 40MG","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Mon,
+        13 Mar 2023 15:56:27 EDT","refillDate":"Fri, 10 Mar 2023 00:00:00 EST","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21430917,"sig":"TAKE
+        1MG BY MOUTH EVERY DAY FOR 30 DAYS","orderedDate":"Sat, 01 Oct 2022 00:00:00
+        EDT","quantity":30,"expirationDate":"Mon, 02 Oct 2023 00:00:00 EDT","prescriptionNumber":"3636878","prescriptionName":"PANCREASE
+        MT 16 EC CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21430917,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Tue, 03 Oct 2023 12:06:08 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00045-0343-60","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"PANCREASE MT 16","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Mon,
+        13 Mar 2023 15:56:27 EDT","refillDate":"Sat, 01 Oct 2022 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21895796,"sig":null,"orderedDate":"Fri,
+        10 Mar 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636878","prescriptionName":"PANCREASE
+        MT 16 EC CAP","dispensedDate":"Fri, 10 Mar 2023 00:00:00 EST","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(198)636-6878","cmopNdcNumber":"00113002239","id":21895796,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"1986366878","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF3","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Sat,
+        01 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21544348,"sig":null,"orderedDate":"Thu,
+        01 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636878","prescriptionName":"PANCREASE
+        MT 16 EC CAP","dispensedDate":"Thu, 01 Dec 2022 00:00:00 EST","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21544348,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Sat,
+        01 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21431051,"sig":null,"orderedDate":"Fri,
+        21 Oct 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636878","prescriptionName":"PANCREASE
+        MT 16 EC CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21431051,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Mon,
+        31 Oct 2022 11:50:45 EDT","refillDate":"Mon, 31 Oct 2022 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21430735,"sig":"INJECT
+        1ML INTRAVENOUS ONCE FOR 30 DAYS","orderedDate":"Thu, 01 Sep 2022 00:00:00
+        EDT","quantity":1,"expirationDate":"Sat, 02 Sep 2023 00:00:00 EDT","prescriptionNumber":"3636877","prescriptionName":"PAMIDRONATE
+        DISODIUM 3MG/ML INJ 10ML","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21430735,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Tue, 05 Sep 2023 09:43:58 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"55390-0129-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"PAMIDRONATE DISODIUM","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Thu,
+        03 Nov 2022 14:12:03 EDT","refillDate":"Mon, 21 Nov 2022 00:00:00 EST","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21435637,"sig":"TAKE
+        10MG BY MOUTH 30 MINUTES BEFORE MEALS AND AT BEDTIME FOR 30 DAYS","orderedDate":"Sun,
+        02 Oct 2022 00:00:00 EDT","quantity":30,"expirationDate":"Tue, 03 Oct 2023
+        00:00:00 EDT","prescriptionNumber":"3636884","prescriptionName":"TACRINE HCL
+        10MG CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":"(178)636-6871","cmopNdcNumber":null,"id":21435637,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Wed, 04 Oct 2023 16:10:24 EDT","institutionId":null,"dialCmopDivisionPhone":"1786366871","dispStatus":"Expired","ndc":"00071-0096-25","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"TACRINE HCL 10MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Thu,
+        03 Nov 2022 14:12:03 EDT","refillDate":"Sun, 02 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21445446,"sig":null,"orderedDate":"Mon,
+        21 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636884","prescriptionName":"TACRINE
+        HCL 10MG CAP","dispensedDate":"Wed, 02 Nov 2022 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(178)636-6871","cmopNdcNumber":"00113002239","id":21445446,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"1786366871","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Sun,
+        02 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21436944,"sig":null,"orderedDate":"Sun,
+        30 Oct 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636884","prescriptionName":"TACRINE
+        HCL 10MG CAP","dispensedDate":"Sun, 30 Oct 2022 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(178)636-6871","cmopNdcNumber":null,"id":21436944,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"1786366871","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Mon, 21 Nov 2022 00:00:00 EST","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21435638,"sig":"APPLY
+        APPLICATION(S) TO THE AFFECTED AREA TWO (2) TIMES A DAY FOR 60 DAYS","orderedDate":"Sun,
+        02 Oct 2022 00:00:00 EDT","quantity":1,"expirationDate":"Tue, 03 Oct 2023
+        00:00:00 EDT","prescriptionNumber":"3636885","prescriptionName":"TACROLIMUS
+        0.1% TOP OINT","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21435638,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Wed, 04 Oct 2023 16:10:24 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00469-5202-30","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"TACROLIMUS 0.1%","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Sun, 02 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21494033,"sig":null,"orderedDate":"Mon,
+        21 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636885","prescriptionName":"TACROLIMUS
+        0.1% TOP OINT","dispensedDate":"Mon, 14 Nov 2022 00:00:00 EST","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21494033,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Sun,
+        02 Oct 2022 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21436945,"sig":null,"orderedDate":"Sun,
+        30 Oct 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636885","prescriptionName":"TACROLIMUS
+        0.1% TOP OINT","dispensedDate":"Sun, 30 Oct 2022 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21436945,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Mon,
+        13 Mar 2023 16:01:28 EDT","refillDate":"Mon, 13 Mar 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21435639,"sig":"TAKE
+        ONE TABLET BY MOUTH EVERY TWELVE (12) HOURS FOR 30 DAYS","orderedDate":"Sun,
+        02 Oct 2022 00:00:00 EDT","quantity":60,"expirationDate":"Tue, 03 Oct 2023
+        00:00:00 EDT","prescriptionNumber":"3636886","prescriptionName":"TAMOXIFEN
+        CITRATE 10MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21435639,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Wed, 04 Oct 2023 16:10:24 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00378-0144-91","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"TAMOXIFEN 10MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Mon,
+        13 Mar 2023 16:01:28 EDT","refillDate":"Sun, 02 Oct 2022 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21900309,"sig":null,"orderedDate":"Mon,
+        13 Mar 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636886","prescriptionName":"TAMOXIFEN
+        CITRATE 10MG TAB","dispensedDate":"Mon, 13 Mar 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21900309,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF3","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Sun,
+        02 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21647474,"sig":null,"orderedDate":"Sun,
+        18 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636886","prescriptionName":"TAMOXIFEN
+        CITRATE 10MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21647474,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Sun,
+        02 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21436946,"sig":null,"orderedDate":"Sun,
+        30 Oct 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636886","prescriptionName":"TAMOXIFEN
+        CITRATE 10MG TAB","dispensedDate":"Sun, 30 Oct 2022 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21436946,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Wed,
+        16 Nov 2022 14:03:44 EST","refillDate":"Tue, 06 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21489541,"sig":"APPLY
+        SMALL AMOUNT TO AFFECTED AREA DAILY FOR 30 DAYS","orderedDate":"Mon, 17 Oct
+        2022 00:00:00 EDT","quantity":2,"expirationDate":"Wed, 18 Oct 2023 00:00:00
+        EDT","prescriptionNumber":"2720412","prescriptionName":"HALCINONIDE 0.1% OINT","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21489541,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Thu,
+        19 Oct 2023 07:16:18 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00003-0248-20","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"HALCINONIDE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Wed,
+        16 Nov 2022 14:03:44 EST","refillDate":"Mon, 17 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21489877,"sig":null,"orderedDate":"Tue,
+        06 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720412","prescriptionName":"HALCINONIDE
+        0.1% OINT","dispensedDate":"Mon, 14 Nov 2022 00:00:00 EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21489877,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Mon,
+        17 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21489569,"sig":null,"orderedDate":"Mon,
+        14 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720412","prescriptionName":"HALCINONIDE
+        0.1% OINT","dispensedDate":"Mon, 14 Nov 2022 00:00:00 EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21489569,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Mon,
+        19 Dec 2022 16:29:59 EST","refillDate":"Mon, 19 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21489829,"sig":"INSTILL
+        1 DROP IN AFFECTED EAR WEEKLY FOR 30 DAYS","orderedDate":"Mon, 17 Oct 2022
+        00:00:00 EDT","quantity":2,"expirationDate":"Wed, 18 Oct 2023 00:00:00 EDT","prescriptionNumber":"2720413","prescriptionName":"HC
+        1%/NEOMYCIN 3.5MG/POLYMYXIN OTIC SUSP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21489829,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Thu,
+        19 Oct 2023 07:16:18 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"24208-0635-62","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"CORTISPORIN","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Mon,
+        19 Dec 2022 16:29:59 EST","refillDate":"Mon, 17 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21647480,"sig":null,"orderedDate":"Mon,
+        19 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720413","prescriptionName":"HC
+        1%/NEOMYCIN 3.5MG/POLYMYXIN OTIC SUSP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21647480,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Mon,
+        17 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21489878,"sig":null,"orderedDate":"Sun,
+        13 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720413","prescriptionName":"HC
+        1%/NEOMYCIN 3.5MG/POLYMYXIN OTIC SUSP","dispensedDate":"Sun, 13 Nov 2022 00:00:00
+        EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21489878,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 14:41:49 EST","refillDate":"Wed, 07 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21492981,"sig":"TAKE
+        1 TABLET BY MOUTH DAILY FOR 30 DAYS","orderedDate":"Tue, 18 Oct 2022 00:00:00
+        EDT","quantity":30,"expirationDate":"Thu, 19 Oct 2023 00:00:00 EDT","prescriptionNumber":"2720414","prescriptionName":"HCTZ
+        12.5/LISINOPRIL 10MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":null,"id":21492981,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Fri,
+        20 Oct 2023 09:51:40 EDT","institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Expired","ndc":"00591-0860-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"HYDROCHLOROTHIAZIDE/LISINOPRIL","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 14:41:49 EST","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21493924,"sig":null,"orderedDate":"Wed,
+        07 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720414","prescriptionName":"HCTZ
+        12.5/LISINOPRIL 10MG TAB","dispensedDate":"Thu, 10 Nov 2022 00:00:00 EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":"00013264681","id":21493924,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21493006,"sig":null,"orderedDate":"Tue,
+        15 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720414","prescriptionName":"HCTZ
+        12.5/LISINOPRIL 10MG TAB","dispensedDate":"Tue, 15 Nov 2022 00:00:00 EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":null,"id":21493006,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Mon,
+        10 Apr 2023 17:00:49 EDT","refillDate":"Thu, 27 Apr 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493054,"sig":"WASH
+        DROP(S) THE AFFECTED AREA WEEKLY FOR 30 DAYS","orderedDate":"Tue, 18 Oct 2022
+        00:00:00 EDT","quantity":2,"expirationDate":"Thu, 19 Oct 2023 00:00:00 EDT","prescriptionNumber":"3636892","prescriptionName":"SALICYLIC
+        ACID 2% WASH","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493054,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Fri, 20 Oct 2023 09:51:39 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"02993-6077-06","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"SALICYLIC ACID 2%","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Mon,
+        10 Apr 2023 17:00:49 EDT","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21997578,"sig":null,"orderedDate":"Thu,
+        27 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636892","prescriptionName":"SALICYLIC
+        ACID 2% WASH","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21997578,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF3","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21995864,"sig":null,"orderedDate":"Fri,
+        07 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636892","prescriptionName":"SALICYLIC
+        ACID 2% WASH","dispensedDate":"Fri, 07 Apr 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(443)636-6892","cmopNdcNumber":"00113002239","id":21995864,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4436366892","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21647476,"sig":null,"orderedDate":"Sun,
+        18 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636892","prescriptionName":"SALICYLIC
+        ACID 2% WASH","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21647476,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Wed, 07 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493332,"sig":"INSERT
+        10MG IN RECTUM WEEKLY FOR 30 DAYS","orderedDate":"Tue, 18 Oct 2022 00:00:00
+        EDT","quantity":30,"expirationDate":"Thu, 19 Oct 2023 00:00:00 EDT","prescriptionNumber":"3636893","prescriptionName":"HEMORRHOIDAL
+        RTL SUPP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493332,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Fri, 20 Oct 2023 09:51:39 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00904-7688-22","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"HEMORRHOIDAL","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493832,"sig":null,"orderedDate":"Wed,
+        07 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636893","prescriptionName":"HEMORRHOIDAL
+        RTL SUPP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493832,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493370,"sig":null,"orderedDate":"Wed,
+        16 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636893","prescriptionName":"HEMORRHOIDAL
+        RTL SUPP","dispensedDate":"Wed, 16 Nov 2022 00:00:00 EST","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493370,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Wed, 07 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493770,"sig":"TAKE
+        ONE TABLET EVERY DAY, 30 MINUTES BEFORE A MEAL FOR 30 DAYS","orderedDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","quantity":30,"expirationDate":"Thu, 19 Oct 2023
+        00:00:00 EDT","prescriptionNumber":"3636894","prescriptionName":"RABEPRAZOLE
+        NA 20MG EC TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493770,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Fri, 20 Oct 2023 09:51:39 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"62856-0243-90","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"RABEPRAZOLE NA 20MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21494034,"sig":null,"orderedDate":"Wed,
+        07 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636894","prescriptionName":"RABEPRAZOLE
+        NA 20MG EC TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21494034,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493833,"sig":null,"orderedDate":"Wed,
+        16 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636894","prescriptionName":"RABEPRAZOLE
+        NA 20MG EC TAB","dispensedDate":"Wed, 16 Nov 2022 00:00:00 EST","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493833,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Wed, 07 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493771,"sig":"INJECT
+        1ML INTO THE MUSCLE ONCE FOR 30 DAYS","orderedDate":"Tue, 18 Oct 2022 00:00:00
+        EDT","quantity":1,"expirationDate":"Thu, 19 Oct 2023 00:00:00 EDT","prescriptionNumber":"3636895","prescriptionName":"RABIES
+        VACCINE 2.5 UNITS/VIAL KIT","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493771,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Fri, 20 Oct 2023 09:51:39 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"53905-0501-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"RABIES 2.5 UNITS VACCINE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21494035,"sig":null,"orderedDate":"Wed,
+        07 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636895","prescriptionName":"RABIES
+        VACCINE 2.5 UNITS/VIAL KIT","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21494035,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493834,"sig":null,"orderedDate":"Wed,
+        16 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636895","prescriptionName":"RABIES
+        VACCINE 2.5 UNITS/VIAL KIT","dispensedDate":"Wed, 16 Nov 2022 00:00:00 EST","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493834,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Wed, 07 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493772,"sig":"TAKE
+        1MG FOUR TIMES A DAY IF NEEDED FOR 60 DAYS * SAFE IF SWALLOWED. AVOID FOOD
+        OR DRINK FOR AT LEAST ONE (1) HOUR FOLLOWING USE.*","orderedDate":"Tue, 18
+        Oct 2022 00:00:00 EDT","quantity":1,"expirationDate":"Thu, 19 Oct 2023 00:00:00
+        EDT","prescriptionNumber":"3636896","prescriptionName":"RADIACARE WOUND RINSE
+        SUSP ORAL","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493772,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Fri, 20 Oct 2023 09:51:39 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"53303-0011-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"RADIACARE WOUND RINSE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21494036,"sig":null,"orderedDate":"Wed,
+        07 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636896","prescriptionName":"RADIACARE
+        WOUND RINSE SUSP ORAL","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21494036,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493835,"sig":null,"orderedDate":"Wed,
+        16 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636896","prescriptionName":"RADIACARE
+        WOUND RINSE SUSP ORAL","dispensedDate":"Wed, 16 Nov 2022 00:00:00 EST","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493835,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Tue,
+        07 Feb 2023 09:17:03 EST","refillDate":"Tue, 07 Feb 2023 00:00:00 EST","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21437087,"sig":"INJECT
+        1ML IVP WEEKLY FOR 30 DAYS","orderedDate":"Fri, 07 Oct 2022 00:00:00 EDT","quantity":4,"expirationDate":"Sun,
+        08 Oct 2023 00:00:00 EDT","prescriptionNumber":"2720407","prescriptionName":"LABETALOL
+        5MG/ML INJ 20ML","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":null,"id":21437087,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        09 Oct 2023 09:50:42 EDT","institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Expired","ndc":"00085-0362-07","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LABETALOL","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Tue,
+        07 Feb 2023 09:17:03 EST","refillDate":"Fri, 07 Oct 2022 00:00:00 EDT","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21787651,"sig":null,"orderedDate":"Tue,
+        07 Feb 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720407","prescriptionName":"LABETALOL
+        5MG/ML INJ 20ML","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21787651,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF3","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Fri,
+        07 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21544351,"sig":null,"orderedDate":"Wed,
+        30 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720407","prescriptionName":"LABETALOL
+        5MG/ML INJ 20ML","dispensedDate":"Wed, 30 Nov 2022 00:00:00 EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":null,"id":21544351,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Fri,
+        07 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21437319,"sig":null,"orderedDate":"Thu,
+        27 Oct 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720407","prescriptionName":"LABETALOL
+        5MG/ML INJ 20ML","dispensedDate":"Thu, 27 Oct 2022 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":null,"id":21437319,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Tue,
+        01 Nov 2022 14:53:29 EDT","refillDate":"Thu, 01 Dec 2022 00:00:00 EST","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21437088,"sig":"TAKE
+        15ML BY MOUTH DAILY FOR 30 DAYS","orderedDate":"Wed, 12 Oct 2022 00:00:00
+        EDT","quantity":2,"expirationDate":"Fri, 13 Oct 2023 00:00:00 EDT","prescriptionNumber":"2720408","prescriptionName":"LACTULOSE
+        10GM/15ML SYRUP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":null,"id":21437088,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Sat,
+        14 Oct 2023 09:52:44 EDT","institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Expired","ndc":"00032-1602-78","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LACTULOSE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Tue,
+        01 Nov 2022 14:53:29 EDT","refillDate":"Wed, 12 Oct 2022 00:00:00 EDT","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21437320,"sig":null,"orderedDate":"Thu,
+        01 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720408","prescriptionName":"LACTULOSE
+        10GM/15ML SYRUP","dispensedDate":"Tue, 25 Oct 2022 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":"00013264681","id":21437320,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Wed,
+        12 Oct 2022 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21437229,"sig":null,"orderedDate":"Tue,
+        01 Nov 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720408","prescriptionName":"LACTULOSE
+        10GM/15ML SYRUP","dispensedDate":"Thu, 27 Oct 2022 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":null,"id":21437229,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Thu,
+        01 Dec 2022 11:58:47 EST","refillDate":"Sat, 26 Nov 2022 00:00:00 EST","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21437089,"sig":"INJECT
+        1ML IVPB WEEKLY","orderedDate":"Sun, 02 Oct 2022 00:00:00 EDT","quantity":1,"expirationDate":"Tue,
+        03 Oct 2023 00:00:00 EDT","prescriptionNumber":"2720409","prescriptionName":"LACTATED
+        RINGER''S INJ 1000ML","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21437089,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Wed,
+        04 Oct 2023 16:10:25 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00264-1750-00","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LACTATED RINGER''S 1000ML","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Thu,
+        01 Dec 2022 11:58:47 EST","refillDate":"Sun, 02 Oct 2022 00:00:00 EDT","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21532503,"sig":null,"orderedDate":"Sat,
+        26 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720409","prescriptionName":"LACTATED
+        RINGER''S INJ 1000ML","dispensedDate":"Sat, 26 Nov 2022 00:00:00 EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21532503,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Sun,
+        02 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21437262,"sig":null,"orderedDate":"Sat,
+        22 Oct 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720409","prescriptionName":"LACTATED
+        RINGER''S INJ 1000ML","dispensedDate":"Sat, 22 Oct 2022 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21437262,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Wed, 07 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493773,"sig":"TAKE
+        ONE TABLET EVERY DAY FOR 30 DAYS","orderedDate":"Tue, 18 Oct 2022 00:00:00
+        EDT","quantity":30,"expirationDate":"Thu, 19 Oct 2023 00:00:00 EDT","prescriptionNumber":"3636897","prescriptionName":"RALOXIFENE
+        HCL 60MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493773,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Fri, 20 Oct 2023 09:51:39 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00002-4165-02","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"RALOXIFENE HCL 60MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21494037,"sig":null,"orderedDate":"Wed,
+        07 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636897","prescriptionName":"RALOXIFENE
+        HCL 60MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21494037,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493836,"sig":null,"orderedDate":"Wed,
+        16 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636897","prescriptionName":"RALOXIFENE
+        HCL 60MG TAB","dispensedDate":"Wed, 16 Nov 2022 00:00:00 EST","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493836,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Wed, 07 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493774,"sig":"TAKE
+        ONE CAPSULE WEEKLY FOR 30 DAYS","orderedDate":"Tue, 18 Oct 2022 00:00:00 EDT","quantity":1,"expirationDate":"Thu,
+        19 Oct 2023 00:00:00 EDT","prescriptionNumber":"3636898","prescriptionName":"RAMIPRIL
+        1.25MG CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493774,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Fri, 20 Oct 2023 09:51:39 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"61570-0110-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"RAMIPRIL 1.25MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Thu,
+        17 Nov 2022 15:00:05 EST","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21494038,"sig":null,"orderedDate":"Wed,
+        07 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636898","prescriptionName":"RAMIPRIL
+        1.25MG CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21494038,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21493837,"sig":null,"orderedDate":"Wed,
+        16 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636898","prescriptionName":"RAMIPRIL
+        1.25MG CAP","dispensedDate":"Wed, 16 Nov 2022 00:00:00 EST","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493837,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Fri,
+        09 Dec 2022 11:35:20 EST","refillDate":"Fri, 09 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21493893,"sig":"TAKE
+        1 TEASPOONFUL BY MOUTH DAILY FOR 30 DAYS","orderedDate":"Tue, 18 Oct 2022
+        00:00:00 EDT","quantity":30,"expirationDate":"Thu, 19 Oct 2023 00:00:00 EDT","prescriptionNumber":"2720415","prescriptionName":"SALIVART
+        2.5 OZ","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493893,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Fri,
+        20 Oct 2023 09:51:40 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00386-0009-75","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"SALIVA","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Fri,
+        09 Dec 2022 11:35:20 EST","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21574114,"sig":null,"orderedDate":"Fri,
+        09 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720415","prescriptionName":"SALIVART
+        2.5 OZ","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21574114,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21493925,"sig":null,"orderedDate":"Wed,
+        16 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720415","prescriptionName":"SALIVART
+        2.5 OZ","dispensedDate":"Wed, 16 Nov 2022 00:00:00 EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493925,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Fri,
+        16 Dec 2022 16:37:23 EST","refillDate":"Fri, 16 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21493894,"sig":"USE
+        1 INHALATION BY ORAL INHALATION WEEKLY FOR 30 DAYS","orderedDate":"Tue, 18
+        Oct 2022 00:00:00 EDT","quantity":30,"expirationDate":"Thu, 19 Oct 2023 00:00:00
+        EDT","prescriptionNumber":"2720416","prescriptionName":"SALMETEROL 50MCG/BLSTR
+        PO INHL DISKUS 60","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493894,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Fri,
+        20 Oct 2023 09:51:40 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00173-0521-00","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"SALMETEROL DISKUS","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Fri,
+        16 Dec 2022 16:37:23 EST","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21598635,"sig":null,"orderedDate":"Fri,
+        16 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720416","prescriptionName":"SALMETEROL
+        50MCG/BLSTR PO INHL DISKUS 60","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21598635,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21493926,"sig":null,"orderedDate":"Wed,
+        16 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720416","prescriptionName":"SALMETEROL
+        50MCG/BLSTR PO INHL DISKUS 60","dispensedDate":"Wed, 16 Nov 2022 00:00:00
+        EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493926,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Mon,
+        19 Dec 2022 16:29:59 EST","refillDate":"Mon, 19 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21493895,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 30 DAYS","orderedDate":"Tue, 18 Oct 2022 00:00:00
+        EDT","quantity":30,"expirationDate":"Thu, 19 Oct 2023 00:00:00 EDT","prescriptionNumber":"2720417","prescriptionName":"SALSALATE
+        750MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493895,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Fri,
+        20 Oct 2023 09:51:40 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"53265-0133-50","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"SALSALATE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Mon,
+        19 Dec 2022 16:29:59 EST","refillDate":"Tue, 18 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21647481,"sig":null,"orderedDate":"Mon,
+        19 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720417","prescriptionName":"SALSALATE
+        750MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21647481,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        18 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21493927,"sig":null,"orderedDate":"Wed,
+        16 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720417","prescriptionName":"SALSALATE
+        750MG TAB","dispensedDate":"Wed, 16 Nov 2022 00:00:00 EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21493927,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Mon,
+        07 Nov 2022 13:24:04 EST","refillDate":"Mon, 07 Nov 2022 00:00:00 EST","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21457694,"sig":"APPLY
+        1 CONTENTS TO THE AFFECTED AREA WEEKLY FOR 30 DAYS TEST INDICATION","orderedDate":"Sat,
+        08 Oct 2022 00:00:00 EDT","quantity":2,"expirationDate":"Mon, 09 Oct 2023
+        00:00:00 EDT","prescriptionNumber":"3636887","prescriptionName":"OATMEAL,COLLOIDAL
+        100% BATH PWDR","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":"(178)636-6871","cmopNdcNumber":"00113002239","id":21457694,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Tue, 10 Oct 2023
+        09:02:34 EDT","institutionId":null,"dialCmopDivisionPhone":"1786366871","dispStatus":"Expired","ndc":"04650-0034-30","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"OATMEAL,
+        COLLODIAL 100% BATH","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Tue,
+        14 Feb 2023 11:29:06 EST","refillDate":"Sun, 12 Feb 2023 00:00:00 EST","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21457695,"sig":"INJECT
+        10MG UNDER THE SKIN EVERY TWELVE (12) HOURS FOR 60 DAYS TEST INDICATION TEST
+        PATIENT INSTRUCTIONS","orderedDate":"Sat, 08 Oct 2022 00:00:00 EDT","quantity":3,"expirationDate":"Mon,
+        09 Oct 2023 00:00:00 EDT","prescriptionNumber":"3636888","prescriptionName":"OCTREOTIDE
+        ACETATE 1000MCG/ML INJ *SUBQ*","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":"(178)636-6871","cmopNdcNumber":null,"id":21457695,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Tue, 10 Oct 2023
+        09:02:34 EDT","institutionId":null,"dialCmopDivisionPhone":"1786366871","dispStatus":"Expired","ndc":"00078-0184-25","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"OCTREOTIDE
+        ACETATE 1000MCG/ML","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Sat,
+        08 Oct 2022 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21801650,"sig":null,"orderedDate":"Sun,
+        12 Feb 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636888","prescriptionName":"OCTREOTIDE
+        ACETATE 1000MCG/ML INJ *SUBQ*","dispensedDate":"Sun, 12 Feb 2023 00:00:00
+        EST","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21801650,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF3","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Sat,
+        08 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22219746,"sig":null,"orderedDate":"Sun,
+        18 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636888","prescriptionName":"OCTREOTIDE
+        ACETATE 1000MCG/ML INJ *SUBQ*","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22219746,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Sat,
+        08 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21457801,"sig":null,"orderedDate":"Fri,
+        28 Oct 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636888","prescriptionName":"OCTREOTIDE
+        ACETATE 1000MCG/ML INJ *SUBQ*","dispensedDate":"Sat, 05 Nov 2022 00:00:00
+        EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(178)636-6871","cmopNdcNumber":null,"id":21457801,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"1786366871","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Thu,
+        01 Dec 2022 14:02:29 EST","refillDate":"Tue, 01 Nov 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21462351,"sig":"APPLY,
+        A SEGMENT(S) INSIDE, LOWER LID OF EYE WEEKLY FOR 30 DAYS TEST INDICATION TEST
+        PATIENT INTRUCTIONS","orderedDate":"Sun, 09 Oct 2022 00:00:00 EDT","quantity":1,"expirationDate":"Tue,
+        10 Oct 2023 00:00:00 EDT","prescriptionNumber":"3636889","prescriptionName":"BACITRACIN
+        500 UNT/GM OPH OINT","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21462351,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Wed, 11 Oct 2023
+        11:24:23 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00168-0026-38","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"BACITRACIN
+        500 UNIT/GM 3.5GM","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":null,"refillDate":"Sun,
+        18 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21462578,"sig":null,"orderedDate":"Tue,
+        01 Nov 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636889","prescriptionName":"BACITRACIN
+        500 UNT/GM OPH OINT","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21462578,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Thu,
+        01 Dec 2022 14:02:29 EST","refillDate":"Wed, 30 Nov 2022 00:00:00 EST","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21462352,"sig":"DEVICE(S)
+        MISC WEEKLY FOR 30 DAYS","orderedDate":"Tue, 08 Nov 2022 00:00:00 EST","quantity":1,"expirationDate":"Thu,
+        09 Nov 2023 00:00:00 EST","prescriptionNumber":"3636794A","prescriptionName":"YANKAUER
+        SUCTION TIP (EA)","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21462352,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 3636794","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Fri,
+        10 Nov 2023 09:51:42 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"SUCTION TIP YANKAUER  ","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"expired","refillSubmitDate":"Thu,
+        01 Dec 2022 14:02:29 EST","refillDate":"Tue, 08 Nov 2022 00:00:00 EST","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21543288,"sig":null,"orderedDate":"Wed,
+        30 Nov 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"3636794A","prescriptionName":"YANKAUER
+        SUCTION TIP (EA)","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21543288,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Mon,
+        19 Dec 2022 16:29:59 EST","refillDate":"Mon, 19 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21462355,"sig":"APPLY
+        10ML TO AFFECTED AREA DAILY FOR 60 DAYS","orderedDate":"Sun, 09 Oct 2022 00:00:00
+        EDT","quantity":1,"expirationDate":"Tue, 10 Oct 2023 00:00:00 EDT","prescriptionNumber":"2720410","prescriptionName":"BACT-NEOMY-POLYMIX
+        TOP OINT (OZ)","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21462355,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Wed,
+        11 Oct 2023 11:24:24 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00168-0012-31","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"BACITRACIN/NEOMYCIN/POLYMYXIN B","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":"Mon,
+        19 Dec 2022 16:29:59 EST","refillDate":"Sun, 09 Oct 2022 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21647479,"sig":null,"orderedDate":"Mon,
+        19 Dec 2022 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720410","prescriptionName":"BACT-NEOMY-POLYMIX
+        TOP OINT (OZ)","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21647479,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":null,"refillDate":"Sun,
+        09 Oct 2022 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21462581,"sig":null,"orderedDate":"Sat,
+        29 Oct 2022 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720410","prescriptionName":"BACT-NEOMY-POLYMIX
+        TOP OINT (OZ)","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21462581,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":"Tue,
+        08 Nov 2022 14:12:04 EST","refillDate":"Tue, 08 Nov 2022 00:00:00 EST","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21462356,"sig":"USE
+        BAG AS DIRECTED MONTHLY FOR 30 DAYS","orderedDate":"Sun, 09 Oct 2022 00:00:00
+        EDT","quantity":1,"expirationDate":"Tue, 10 Oct 2023 00:00:00 EDT","prescriptionNumber":"2720411","prescriptionName":"BAG,
+        LEG 24OZ #4153 (DAVOL)","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21462356,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Wed,
+        11 Oct 2023 11:24:24 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"URINARY LEG ","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        19 Jan 2023 11:40:35 EST","refillDate":"Sun, 29 Jan 2023 00:00:00 EST","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21668157,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 30 DAYS TEST INDICATION TEST PATIENT INSTRUCTIONS","orderedDate":"Sat,
+        10 Dec 2022 00:00:00 EST","quantity":30,"expirationDate":"Mon, 11 Dec 2023
+        00:00:00 EST","prescriptionNumber":"2720433","prescriptionName":"RABEPRAZOLE
+        NA 20MG EC TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":"(983)272-0433","cmopNdcNumber":null,"id":21668157,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46
+        EST","institutionId":null,"dialCmopDivisionPhone":"9832720433","dispStatus":"Active:
+        Refill in Process","ndc":"62856-0243-90","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"RABEPRAZOLE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        19 Jan 2023 11:40:35 EST","refillDate":"Sat, 10 Dec 2022 00:00:00 EST","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21705083,"sig":null,"orderedDate":"Sun,
+        29 Jan 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720433","prescriptionName":"RABEPRAZOLE
+        NA 20MG EC TAB","dispensedDate":"Tue, 17 Jan 2023 00:00:00 EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-2433","cmopNdcNumber":"00113002239","id":21705083,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832722433","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Sat,
+        10 Dec 2022 00:00:00 EST","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21668287,"sig":null,"orderedDate":"Sat,
+        07 Jan 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720433","prescriptionName":"RABEPRAZOLE
+        NA 20MG EC TAB","dispensedDate":"Sat, 07 Jan 2023 00:00:00 EST","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0433","cmopNdcNumber":null,"id":21668287,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720433","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Wed,
+        29 Mar 2023 15:02:10 EDT","refillDate":"Mon, 27 Mar 2023 00:00:00 EDT","refillRemaining":5,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21760139,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 30 DAYS --TAKE WITH FOOD--","orderedDate":"Wed,
+        01 Feb 2023 00:00:00 EST","quantity":30,"expirationDate":"Fri, 02 Feb 2024
+        00:00:00 EST","prescriptionNumber":"2720311A","prescriptionName":"BACLOFEN
+        10MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21760139,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720311","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00603-2408-32","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"BACLOFEN","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":null,"refillDate":"Wed,
+        01 Feb 2023 00:00:00 EST","refillRemaining":5,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21956964,"sig":null,"orderedDate":"Mon,
+        27 Mar 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720311A","prescriptionName":"BACLOFEN
+        10MG TAB","dispensedDate":"Mon, 27 Mar 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":"00013264681","id":21956964,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Tue,
+        11 Apr 2023 18:20:39 EDT","refillDate":"Tue, 21 Mar 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21871320,"sig":"TAKE
+        10MG BY MOUTH DAILY FOR 30 DAYS","orderedDate":"Sat, 04 Feb 2023 00:00:00
+        EST","quantity":30,"expirationDate":"Mon, 05 Feb 2024 00:00:00 EST","prescriptionNumber":"2720466","prescriptionName":"ABACAVIR
+        SO4 600MG/LAMIVUDINE 300MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21871320,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00173-0742-00","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ABACAVIR/LAMIVUDINE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":null,"refillDate":"Sat,
+        04 Feb 2023 00:00:00 EST","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21926353,"sig":null,"orderedDate":"Tue,
+        21 Mar 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720466","prescriptionName":"ABACAVIR
+        SO4 600MG/LAMIVUDINE 300MG TAB","dispensedDate":"Tue, 21 Mar 2023 00:00:00
+        EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0466","cmopNdcNumber":"00013264681","id":21926353,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720466","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        14 Apr 2023 15:19:56 EDT","refillDate":"Sun, 30 Apr 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21997544,"sig":"DEVICE(S)
+        TRACH WEEKLY FOR 30 DAYS","orderedDate":"Sat, 11 Mar 2023 00:00:00 EST","quantity":1,"expirationDate":"Mon,
+        11 Mar 2024 00:00:00 EDT","prescriptionNumber":"3636919","prescriptionName":"LARYNG
+        TUBE, CANNULA  #8 LGT","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21997544,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LARYNG TUBE, CANNULA  #8 LGT","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Fri,
+        14 Apr 2023 15:19:56 EDT","refillDate":"Sat, 11 Mar 2023 00:00:00 EST","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22013715,"sig":null,"orderedDate":"Sun,
+        30 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636919","prescriptionName":"LARYNG
+        TUBE, CANNULA  #8 LGT","dispensedDate":"Wed, 12 Apr 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22013715,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Sat,
+        11 Mar 2023 00:00:00 EST","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":21997579,"sig":null,"orderedDate":"Fri,
+        07 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636919","prescriptionName":"LARYNG
+        TUBE, CANNULA  #8 LGT","dispensedDate":"Fri, 07 Apr 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(443)636-6919","cmopNdcNumber":"00113002239","id":21997579,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4436366919","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        25 Apr 2023 14:09:47 EDT","refillDate":"Tue, 02 May 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22006307,"sig":"TAKE
+        10MG BY MOUTH DAILY FOR 30 DAYS TEST INDICATION TEST PATIENT INTRUCTIONS","orderedDate":"Mon,
+        13 Mar 2023 00:00:00 EDT","quantity":30,"expirationDate":"Wed, 13 Mar 2024
+        00:00:00 EDT","prescriptionNumber":"2720477","prescriptionName":"LANSOPRAZOLE
+        30MG SA CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22006307,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00300-3046-13","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"LANSOPRAZOLE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        25 Apr 2023 14:09:47 EDT","refillDate":"Mon, 13 Mar 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22057357,"sig":null,"orderedDate":"Tue,
+        02 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720477","prescriptionName":"LANSOPRAZOLE
+        30MG SA CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22057357,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Mon,
+        13 Mar 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22006373,"sig":null,"orderedDate":"Sun,
+        09 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720477","prescriptionName":"LANSOPRAZOLE
+        30MG SA CAP","dispensedDate":"Sun, 09 Apr 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22006373,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        30 May 2023 13:25:02 EDT","refillDate":"Tue, 30 May 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22006308,"sig":"TUBE
+        AS DIRECTED WEEKLY FOR 30 DAYS","orderedDate":"Mon, 13 Mar 2023 00:00:00 EDT","quantity":1,"expirationDate":"Wed,
+        13 Mar 2024 00:00:00 EDT","prescriptionNumber":"2720478","prescriptionName":"LARYNGECTOMY
+        TUBE STAIN STL SIZE 8","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22006308,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LARYNGECTOMY STAIN STL","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        30 May 2023 13:25:02 EDT","refillDate":"Mon, 13 Mar 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22097624,"sig":null,"orderedDate":"Tue,
+        30 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720478","prescriptionName":"LARYNGECTOMY
+        TUBE STAIN STL SIZE 8","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22097624,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Mon,
+        13 Mar 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22006374,"sig":null,"orderedDate":"Sun,
+        09 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720478","prescriptionName":"LARYNGECTOMY
+        TUBE STAIN STL SIZE 8","dispensedDate":"Mon, 10 Apr 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0478","cmopNdcNumber":"00013264681","id":22006374,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720478","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        02 May 2023 15:21:58 EDT","refillDate":"Tue, 02 May 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21959160,"sig":"APPLY
+        10ML TO AFFECTED AREA DAILY FOR 30 DAYS","orderedDate":"Mon, 27 Feb 2023 00:00:00
+        EST","quantity":1,"expirationDate":"Wed, 28 Feb 2024 00:00:00 EST","prescriptionNumber":"2720475","prescriptionName":"XEROFORM
+        DRESSING 5X9 IN","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":21959160,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"XEROFORM 5X9","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        02 May 2023 15:21:58 EDT","refillDate":"Mon, 27 Feb 2023 00:00:00 EST","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22082586,"sig":null,"orderedDate":"Tue,
+        02 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720475","prescriptionName":"XEROFORM
+        DRESSING 5X9 IN","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22082586,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Mon,
+        27 Feb 2023 00:00:00 EST","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":21959187,"sig":null,"orderedDate":"Mon,
+        27 Mar 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720475","prescriptionName":"XEROFORM
+        DRESSING 5X9 IN","dispensedDate":"Mon, 27 Mar 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0389","cmopNdcNumber":"00013264681","id":21959187,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720389","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        04 May 2023 15:13:13 EDT","refillDate":"Fri, 02 Jun 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22009800,"sig":"APPLY
+        10MG TO URETHRA WEEKLY FOR 30 DAYS","orderedDate":"Tue, 14 Mar 2023 00:00:00
+        EDT","quantity":1,"expirationDate":"Thu, 14 Mar 2024 00:00:00 EDT","prescriptionNumber":"3636920","prescriptionName":"LIDOCAINE
+        HCL 2% JELLY UROJECT 10ML","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22009800,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00548-3013-00","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LIDOCAINE HCL 2% (URO-JET) 10ML","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        04 May 2023 15:13:13 EDT","refillDate":"Tue, 14 Mar 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22083210,"sig":null,"orderedDate":"Fri,
+        02 Jun 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636920","prescriptionName":"LIDOCAINE
+        HCL 2% JELLY UROJECT 10ML","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22083210,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF3","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Tue,
+        14 Mar 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22083153,"sig":null,"orderedDate":"Wed,
+        03 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636920","prescriptionName":"LIDOCAINE
+        HCL 2% JELLY UROJECT 10ML","dispensedDate":"Tue, 02 May 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(198)636-6888","cmopNdcNumber":"00113002239","id":22083153,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"1986366888","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Tue,
+        14 Mar 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22009874,"sig":null,"orderedDate":"Sun,
+        09 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636920","prescriptionName":"LIDOCAINE
+        HCL 2% JELLY UROJECT 10ML","dispensedDate":"Sun, 09 Apr 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22009874,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Mon,
+        26 Jun 2023 11:02:23 EDT","refillDate":"Fri, 30 Jun 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22009801,"sig":"TAKE
+        ONE TABLET WEEKLY","orderedDate":"Thu, 16 Mar 2023 00:00:00 EDT","quantity":30,"expirationDate":"Sat,
+        16 Mar 2024 00:00:00 EDT","prescriptionNumber":"3636921","prescriptionName":"LEUCOVORIN
+        CALCIUM 5MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22009801,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00081-0631-55","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LEUCOVORIN CALCIUM 5MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Mon,
+        26 Jun 2023 11:02:23 EDT","refillDate":"Thu, 16 Mar 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22230977,"sig":null,"orderedDate":"Fri,
+        30 Jun 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636921","prescriptionName":"LEUCOVORIN
+        CALCIUM 5MG TAB","dispensedDate":"Sun, 25 Jun 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6934","cmopNdcNumber":"00013264681","id":22230977,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366934","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF3","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Thu,
+        16 Mar 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22219747,"sig":null,"orderedDate":"Sat,
+        10 Jun 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636921","prescriptionName":"LEUCOVORIN
+        CALCIUM 5MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22219747,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Thu,
+        16 Mar 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22009875,"sig":null,"orderedDate":"Sun,
+        09 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636921","prescriptionName":"LEUCOVORIN
+        CALCIUM 5MG TAB","dispensedDate":"Mon, 10 Apr 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22009875,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Mon,
+        24 Apr 2023 09:48:28 EDT","refillDate":"Mon, 08 May 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22009802,"sig":"TAKE
+        TWO TABLETS EVERY DAY FOR 60 DAYS","orderedDate":"Sun, 19 Mar 2023 00:00:00
+        EDT","quantity":60,"expirationDate":"Tue, 19 Mar 2024 00:00:00 EDT","prescriptionNumber":"3636922","prescriptionName":"LETROZOLE
+        2.5MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22009802,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00078-0249-15","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LETROZOLE 2.5MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Mon,
+        24 Apr 2023 09:48:28 EDT","refillDate":"Sun, 19 Mar 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22046629,"sig":null,"orderedDate":"Mon,
+        08 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636922","prescriptionName":"LETROZOLE
+        2.5MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22046629,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Sun,
+        19 Mar 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22009876,"sig":null,"orderedDate":"Sun,
+        09 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636922","prescriptionName":"LETROZOLE
+        2.5MG TAB","dispensedDate":"Mon, 10 Apr 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22009876,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Mon,
+        17 Apr 2023 20:00:15 EDT","refillDate":"Thu, 04 May 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22013799,"sig":"INJECT
+        10MG UNDER THE SKIN EVERY THREE (3) MONTHS FOR 30 DAYS","orderedDate":"Wed,
+        15 Mar 2023 00:00:00 EDT","quantity":1,"expirationDate":"Fri, 15 Mar 2024
+        00:00:00 EDT","prescriptionNumber":"3636923","prescriptionName":"LEUPROLIDE
+        ACETATE 22.5MG/KIT SA SUSP IJ","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22013799,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00300-3346-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LEUPROLIDE ACETATE 22.5MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Mon,
+        17 Apr 2023 20:00:15 EDT","refillDate":"Wed, 15 Mar 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22046630,"sig":null,"orderedDate":"Thu,
+        04 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636923","prescriptionName":"LEUPROLIDE
+        ACETATE 22.5MG/KIT SA SUSP IJ","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22046630,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Wed,
+        15 Mar 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22013834,"sig":null,"orderedDate":"Wed,
+        12 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636923","prescriptionName":"LEUPROLIDE
+        ACETATE 22.5MG/KIT SA SUSP IJ","dispensedDate":"Wed, 12 Apr 2023 00:00:00
+        EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22013834,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        21 Apr 2023 16:28:01 EDT","refillDate":"Thu, 04 May 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22013800,"sig":"TAKE
+        10MG BY MOUTH EVERY SIX (6) HOURS FOR 60 DAYS TEST INDICATION AS DIRECTED
+        \"SHAKE WELL\" BEFORE USING AND CLEAN MOUTHPIECE WEEKLY.","orderedDate":"Wed,
+        15 Mar 2023 00:00:00 EDT","quantity":1,"expirationDate":"Fri, 15 Mar 2024
+        00:00:00 EDT","prescriptionNumber":"3636924","prescriptionName":"LEVALBUTEROL
+        45MCG 200D HFA ORAL INHL","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22013800,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023
+        10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"63402-0510-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"LEVALBUTEROL
+        45MCG 200D HFA","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Fri,
+        21 Apr 2023 16:28:01 EDT","refillDate":"Wed, 15 Mar 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22046631,"sig":null,"orderedDate":"Thu,
+        04 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636924","prescriptionName":"LEVALBUTEROL
+        45MCG 200D HFA ORAL INHL","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22046631,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Wed,
+        15 Mar 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22013835,"sig":null,"orderedDate":"Wed,
+        12 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636924","prescriptionName":"LEVALBUTEROL
+        45MCG 200D HFA ORAL INHL","dispensedDate":"Wed, 12 Apr 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22013835,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        21 Jul 2023 14:56:13 EDT","refillDate":"Wed, 19 Jul 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22116215,"sig":"TAKE
+        ONE CAPSULE EVERY DAY FOR 30 DAYS TEST PATIENT INTRUCTIONS","orderedDate":"Sat,
+        15 Apr 2023 00:00:00 EDT","quantity":30,"expirationDate":"Mon, 15 Apr 2024
+        00:00:00 EDT","prescriptionNumber":"3636931","prescriptionName":"GABAPENTIN
+        100MG CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22116215,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023
+        10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00228-2665-50","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION NO APPEND TO SIG","indicationForUseFlag":"0","category":"Rx Medication","orderableItem":"GABAPENTIN
+        100MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Fri,
+        21 Jul 2023 14:56:13 EDT","refillDate":"Sat, 15 Apr 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22330144,"sig":null,"orderedDate":"Wed,
+        19 Jul 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636931","prescriptionName":"GABAPENTIN
+        100MG CAP","dispensedDate":"Mon, 17 Jul 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6934","cmopNdcNumber":"00113002239","id":22330144,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366934","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF3","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Sat,
+        15 Apr 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22230978,"sig":null,"orderedDate":"Sat,
+        24 Jun 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636931","prescriptionName":"GABAPENTIN
+        100MG CAP","dispensedDate":"Sun, 25 Jun 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22230978,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Sat,
+        15 Apr 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22116704,"sig":null,"orderedDate":"Mon,
+        15 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636931","prescriptionName":"GABAPENTIN
+        100MG CAP","dispensedDate":"Mon, 15 May 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22116704,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Mon,
+        12 Jun 2023 12:04:42 EDT","refillDate":"Sat, 24 Jun 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22057639,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 30 DAYS TEST TEST","orderedDate":"Mon, 27 Mar
+        2023 00:00:00 EDT","quantity":30,"expirationDate":"Wed, 27 Mar 2024 00:00:00
+        EDT","prescriptionNumber":"2720494","prescriptionName":"REPAGLINIDE 0.5MG
+        TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22057639,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST","divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00169-0081-81","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST","indicationForUseFlag":"1","category":"Rx
+        Medication","orderableItem":"REPAGLINIDE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Mon,
+        12 Jun 2023 12:04:42 EDT","refillDate":"Mon, 27 Mar 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22201395,"sig":null,"orderedDate":"Sat,
+        24 Jun 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720494","prescriptionName":"REPAGLINIDE
+        0.5MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22201395,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF3","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Mon,
+        27 Mar 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22086180,"sig":null,"orderedDate":"Sun,
+        04 Jun 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720494","prescriptionName":"REPAGLINIDE
+        0.5MG TAB","dispensedDate":"Mon, 05 Jun 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0478","cmopNdcNumber":"00013264681","id":22086180,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720478","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Mon,
+        27 Mar 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22057668,"sig":null,"orderedDate":"Wed,
+        26 Apr 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720494","prescriptionName":"REPAGLINIDE
+        0.5MG TAB","dispensedDate":"Wed, 26 Apr 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22057668,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"activeParked","refillSubmitDate":"Fri,
+        23 Jun 2023 09:48:10 EDT","refillDate":"Fri, 23 Jun 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22083122,"sig":"TAKE
+        TWO TABLETS TWO (2) TIMES A DAY FOR 30 DAYS TEST INDICATION TEST PATIENT INTRUCTIONS","orderedDate":"Tue,
+        04 Apr 2023 00:00:00 EDT","quantity":120,"expirationDate":"Thu, 04 Apr 2024
+        00:00:00 EDT","prescriptionNumber":"3636928","prescriptionName":"NEFAZODONE
+        100MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22083122,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023
+        10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Parked","ndc":"00087-0032-31","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"NEFAZODONE
+        HCL 100MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"activeParked","refillSubmitDate":null,"refillDate":"Tue,
+        04 Apr 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22225417,"sig":null,"orderedDate":"Fri,
+        23 Jun 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636928","prescriptionName":"NEFAZODONE
+        100MG TAB","dispensedDate":"Thu, 22 Jun 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6934","cmopNdcNumber":"00013264681","id":22225417,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366934","dispStatus":"Active:
+        Parked","ndc":null,"reason":null,"prescriptionNumberIndex":"RF3","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"activeParked","refillSubmitDate":null,"refillDate":"Tue,
+        04 Apr 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22083211,"sig":null,"orderedDate":"Mon,
+        29 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636928","prescriptionName":"NEFAZODONE
+        100MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22083211,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Parked","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"activeParked","refillSubmitDate":null,"refillDate":"Tue,
+        04 Apr 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22219748,"sig":null,"orderedDate":"Tue,
+        02 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636928","prescriptionName":"NEFAZODONE
+        100MG TAB","dispensedDate":"Wed, 03 May 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22219748,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Parked","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Tue,
+        09 May 2023 09:46:12 EDT","refillDate":"Mon, 29 May 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22096623,"sig":"TAKE
+        ONE CAPSULE BY MOUTH EVERY DAY FOR 30 DAYS TEST INDICATION TEST PATIENT INSTRUCTIONS","orderedDate":"Sun,
+        09 Apr 2023 00:00:00 EDT","quantity":30,"expirationDate":"Tue, 09 Apr 2024
+        00:00:00 EDT","prescriptionNumber":"3636929","prescriptionName":"DANAZOL 200MG
+        CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22096623,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023
+        10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00024-0305-06","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"DANAZOL
+        200MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":"Tue,
+        09 May 2023 09:46:12 EDT","refillDate":"Sun, 09 Apr 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22096742,"sig":null,"orderedDate":"Mon,
+        29 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636929","prescriptionName":"DANAZOL
+        200MG CAP","dispensedDate":"Mon, 08 May 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22096742,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Mon,
+        05 Jun 2023 14:20:09 EDT","refillDate":"Mon, 05 Jun 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22177889,"sig":"APPLY
+        1MG TO MOUTH DAILY FOR 30 DAYS TEST INDICATION 06052023 - C & A TEST PATIENT
+        INTRUCTIONS","orderedDate":"Sat, 06 May 2023 00:00:00 EDT","quantity":1,"expirationDate":"Mon,
+        06 May 2024 00:00:00 EDT","prescriptionNumber":"2720511","prescriptionName":"CADEXOMER
+        IODINE 0.9% TOP GEL","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22177889,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"08213-0100-40","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION 06052023 - C & A","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"CADEXOMER
+        IODINE 0.9%","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        09 Jun 2023 10:42:14 EDT","refillDate":"Sun, 25 Jun 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22177890,"sig":"TAKE
+        1 TABLET BY MOUTH WEEKLY FOR 30 DAYS","orderedDate":"Sat, 06 May 2023 00:00:00
+        EDT","quantity":30,"expirationDate":"Mon, 06 May 2024 00:00:00 EDT","prescriptionNumber":"2720512","prescriptionName":"CAFFEINE
+        100/ERGOTAMINE 1MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22177890,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00078-0034-28","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION 06052023 NO SIG","indicationForUseFlag":"0","category":"Rx Medication","orderableItem":"ERGOTAMINE/CAFFEINE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Fri,
+        09 Jun 2023 10:42:14 EDT","refillDate":"Sat, 06 May 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22195348,"sig":null,"orderedDate":"Sun,
+        25 Jun 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720512","prescriptionName":"CAFFEINE
+        100/ERGOTAMINE 1MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22195348,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Sat,
+        06 May 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22179202,"sig":null,"orderedDate":"Wed,
+        31 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720512","prescriptionName":"CAFFEINE
+        100/ERGOTAMINE 1MG TAB","dispensedDate":"Sat, 03 Jun 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0478","cmopNdcNumber":"00013264681","id":22179202,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720478","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"active","refillSubmitDate":null,"refillDate":"Fri,
+        26 May 2023 00:00:00 EDT","refillRemaining":null,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22177891,"sig":"120
+        ML TOPICAL WEEKLY","orderedDate":"Wed, 31 May 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"9","prescriptionName":"CALAMINE
+        LOTION","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22177891,"userId":17621060,"providerFirstName":"BHAVIN","providerLastName":"PATEL","remarks":"TEST
+        COMMENTS 06052023","divisionName":null,"modifiedDate":"Mon, 27 Nov 2023 10:31:46
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Non-VA","ndc":"0242-2127-65","reason":null,"prescriptionNumberIndex":"NV","prescriptionSource":"NV","disclaimer":"TEST
+        DISCLAIMER 06052023","indicationForUse":"TEST INDICATION NON-VA MEDS 06052023","indicationForUseFlag":null,"category":"Documented
+        by VA","orderableItem":"CALAMINE","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        09 Jun 2023 10:20:00 EDT","refillDate":"Fri, 09 Jun 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22181714,"sig":"TAKE
+        1MG BY MOUTH DAILY FOR 30 DAYS TEST INDICATION WITH & CHAR TEST PATIENT INTRUCTION
+        WITH & CHAR","orderedDate":"Sun, 07 May 2023 00:00:00 EDT","quantity":30,"expirationDate":"Tue,
+        07 May 2024 00:00:00 EDT","prescriptionNumber":"2720513","prescriptionName":"CALCIFEDIOL
+        20MCG CAPS","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22181714,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS WITH & CHAR","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00052-0472-60","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION WITH & CHAR","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"CALCIFEDIOL","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Fri,
+        09 Jun 2023 10:20:00 EDT","refillDate":"Sun, 07 May 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22195349,"sig":null,"orderedDate":"Fri,
+        09 Jun 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720513","prescriptionName":"CALCIFEDIOL
+        20MCG CAPS","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22195349,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"activeParked","refillSubmitDate":"Thu,
+        29 Jun 2023 13:09:33 EDT","refillDate":"Thu, 29 Jun 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22244915,"sig":"TAKE
+        1MG BY MOUTH DAILY FOR 30 DAYS TEST PARK INDI TEST PARK","orderedDate":"Tue,
+        30 May 2023 00:00:00 EDT","quantity":30,"expirationDate":"Thu, 30 May 2024
+        00:00:00 EDT","prescriptionNumber":"2720518","prescriptionName":"BUTALBITAL
+        ACETAMINOPHEN 50/325MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22244915,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        PARK","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Parked","ndc":"65234-0050-10","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        PARK INDI","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"ACETAMINOPHEN/BUTALBITAL
+        325/50","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"activeParked","refillSubmitDate":"Thu,
+        29 Jun 2023 13:09:33 EDT","refillDate":"Tue, 30 May 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22245017,"sig":null,"orderedDate":"Thu,
+        29 Jun 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720518","prescriptionName":"BUTALBITAL
+        ACETAMINOPHEN 50/325MG TAB","dispensedDate":"Thu, 29 Jun 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22245017,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Parked","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":null,"refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22245262,"sig":"INJECT
+        1ML IV WEEKLY FOR 30 DAYS","orderedDate":"Tue, 30 May 2023 00:00:00 EDT","quantity":1,"expirationDate":"Thu,
+        29 Jun 2023 00:00:00 EDT","prescriptionNumber":"2720519","prescriptionName":"PACLITAXEL
+        6MG/ML INJ 5ML","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22245262,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        14 Aug 2023 14:02:20 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"00015-3475-30","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"PACLITAXEL","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Wed,
+        02 Aug 2023 15:53:52 EDT","refillDate":"Tue, 08 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22324956,"sig":"TAKE
+        10MG BY MOUTH EVERY EIGHT (8) HOURS FOR 60 DAYS TEST IND TEST P & I","orderedDate":"Sun,
+        16 Jul 2023 00:00:00 EDT","quantity":30,"expirationDate":"Tue, 16 Jul 2024
+        00:00:00 EDT","prescriptionNumber":"3636943","prescriptionName":"ZALCITABINE
+        (ddC) 0.75MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22324956,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00004-0221-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        IND","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"ZALCITABINE
+        0.75MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Wed,
+        02 Aug 2023 15:53:52 EDT","refillDate":"Wed, 19 Jul 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22355965,"sig":null,"orderedDate":"Tue,
+        08 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636943","prescriptionName":"ZALCITABINE
+        (ddC) 0.75MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22355965,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Wed,
+        19 Jul 2023 15:32:15 EDT","refillDate":"Mon, 17 Jul 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22324959,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 30 DAYS TEST INDICATION TEST PATIENT INSTILL","orderedDate":"Mon,
+        19 Jun 2023 00:00:00 EDT","quantity":30,"expirationDate":"Wed, 19 Jun 2024
+        00:00:00 EDT","prescriptionNumber":"2720536","prescriptionName":"ZAFIRLUKAST
+        20MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22324959,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        remarks","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00310-0402-60","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"ZAFIRLUKAST","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Wed,
+        19 Jul 2023 15:32:15 EDT","refillDate":"Wed, 21 Jun 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22325078,"sig":null,"orderedDate":"Mon,
+        17 Jul 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720536","prescriptionName":"ZAFIRLUKAST
+        20MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22325078,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        22 Jun 2023 11:31:58 EDT","refillDate":"Tue, 11 Jul 2023 00:00:00 EDT","refillRemaining":9,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22221064,"sig":"TAKE
+        ONE TABLET BY MOUTH EVERY EIGHT (8) HOURS FOR 30 DAYS TEST INDICATION 06212023
+        TEST PATIENT INS","orderedDate":"Mon, 22 May 2023 00:00:00 EDT","quantity":90,"expirationDate":"Wed,
+        22 May 2024 00:00:00 EDT","prescriptionNumber":"3636938","prescriptionName":"FAMCICLOVIR
+        500MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22221064,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00078-0368-15","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION 06212023","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"FAMCICLOVIR
+        500MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        22 Jun 2023 11:31:58 EDT","refillDate":"Mon, 22 May 2023 00:00:00 EDT","refillRemaining":9,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22223419,"sig":null,"orderedDate":"Tue,
+        11 Jul 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636938","prescriptionName":"FAMCICLOVIR
+        500MG TAB","dispensedDate":"Thu, 22 Jun 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22223419,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Mon,
+        22 May 2023 00:00:00 EDT","refillRemaining":10,"facilityName":"SLC10 TEST
+        LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22221132,"sig":null,"orderedDate":"Wed,
+        14 Jun 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636938","prescriptionName":"FAMCICLOVIR
+        500MG TAB","dispensedDate":"Thu, 15 Jun 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6934","cmopNdcNumber":"00113002239","id":22221132,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366934","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        11 Aug 2023 09:59:45 EDT","refillDate":"Fri, 11 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22326523,"sig":"TAKE
+        10MG BY MOUTH DAILY FOR 30 DAYS TEST INDICATION --AVOID ANTACIDS--","orderedDate":"Tue,
+        20 Jun 2023 00:00:00 EDT","quantity":30,"expirationDate":"Thu, 20 Jun 2024
+        00:00:00 EDT","prescriptionNumber":"2720537","prescriptionName":"ZALCITABINE
+        0.375MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22326523,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00004-0220-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"ZALCITABINE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Fri,
+        11 Aug 2023 09:59:45 EDT","refillDate":"Thu, 22 Jun 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22378409,"sig":null,"orderedDate":"Fri,
+        11 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720537","prescriptionName":"ZALCITABINE
+        0.375MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22378409,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Wed,
+        02 Aug 2023 17:04:29 EDT","refillDate":"Wed, 02 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22330445,"sig":"TAKE
+        ONE CAPSULE BY MOUTH EVERY DAY FOR 60 DAYS TEST INDI TEST PI","orderedDate":"Wed,
+        21 Jun 2023 00:00:00 EDT","quantity":30,"expirationDate":"Fri, 21 Jun 2024
+        00:00:00 EDT","prescriptionNumber":"3636944","prescriptionName":"ZINC SULFATE
+        220MG CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22330445,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023
+        10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00904-5332-60","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDI","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"ZINC
+        SULFATE 220MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Wed,
+        02 Aug 2023 17:04:29 EDT","refillDate":"Fri, 23 Jun 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22356357,"sig":null,"orderedDate":"Wed,
+        02 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636944","prescriptionName":"ZINC
+        SULFATE 220MG CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22356357,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Tue,
+        11 Jul 2023 10:17:16 EDT","refillDate":"Tue, 11 Jul 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22298072,"sig":"IRRIGATE
+        1 SOLUTION AFFECTED AREA DAILY FOR 60 DAYS TEST INDICATION TEST PATIENT INSTRUCTIONS","orderedDate":"Sun,
+        11 Jun 2023 00:00:00 EDT","quantity":1,"expirationDate":"Tue, 11 Jun 2024
+        00:00:00 EDT","prescriptionNumber":"2720526","prescriptionName":"ACETIC ACID
+        0.25% IRRG SOLN","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22298072,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        REMARKS","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00264-2304-00","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ACETIC ACID","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":null,"refillDate":"Sun,
+        11 Jun 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22298096,"sig":null,"orderedDate":"Tue,
+        11 Jul 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720526","prescriptionName":"ACETIC
+        ACID 0.25% IRRG SOLN","dispensedDate":"Wed, 12 Jul 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22298096,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Thu,
+        27 Jul 2023 15:09:55 EDT","refillDate":"Sun, 09 Jul 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22298200,"sig":"TAKE
+        ONE CAPSULE BY MOUTH DAILY FOR 30 DAYS TEST I TEST PLACE","orderedDate":"Sun,
+        11 Jun 2023 00:00:00 EDT","quantity":1,"expirationDate":"Tue, 11 Jun 2024
+        00:00:00 EDT","prescriptionNumber":"2720527","prescriptionName":"ACEBUTOLOL
+        HCL 400MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22298200,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        R","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ACEBUTOLOL","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":null,"refillDate":"Sun,
+        11 Jun 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22298272,"sig":null,"orderedDate":"Sun,
+        09 Jul 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720527","prescriptionName":"ACEBUTOLOL
+        HCL 400MG CAP","dispensedDate":"Mon, 10 Jul 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0478","cmopNdcNumber":"00013264681","id":22298272,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720478","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":null,"refillDate":"Wed,
+        09 Aug 2023 00:00:00 EDT","refillRemaining":5,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22332183,"sig":"TAKE
+        ONE CAPSULE DAILY FOR 30 DAYS","orderedDate":"Tue, 08 Aug 2023 00:00:00 EDT","quantity":30,"expirationDate":"Thu,
+        08 Aug 2024 00:00:00 EDT","prescriptionNumber":"2720540","prescriptionName":"ZIPRASIDONE
+        HCL 40MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22332183,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00049-3970-60","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ZIPRASIDONE","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Mon,
+        24 Jul 2023 09:44:13 EDT","refillDate":"Tue, 15 Aug 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22332184,"sig":"INJECT
+        10MG INTRAVENEOUS USE WEEKLY FOR 30 DAYS","orderedDate":"Sat, 24 Jun 2023
+        00:00:00 EDT","quantity":4,"expirationDate":"Mon, 24 Jun 2024 00:00:00 EDT","prescriptionNumber":"2720541","prescriptionName":"ZOLEDRONIC
+        ACID 4MG VI","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22332184,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00078-0350-84","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ZOLEDRONIC","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Mon,
+        24 Jul 2023 09:44:13 EDT","refillDate":"Mon, 26 Jun 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22332269,"sig":null,"orderedDate":"Tue,
+        15 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720541","prescriptionName":"ZOLEDRONIC
+        ACID 4MG VI","dispensedDate":"Sun, 23 Jul 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22332269,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Mon,
+        26 Jun 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22332224,"sig":null,"orderedDate":"Sun,
+        16 Jul 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720541","prescriptionName":"ZOLEDRONIC
+        ACID 4MG VI","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22332224,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        25 Jul 2023 11:11:55 EDT","refillDate":"Sat, 22 Jul 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22335400,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 30 DAYS TEST INDI TEST PI","orderedDate":"Sun,
+        25 Jun 2023 00:00:00 EDT","quantity":5,"expirationDate":"Tue, 25 Jun 2024
+        00:00:00 EDT","prescriptionNumber":"2720543","prescriptionName":"ZOLMITRIPTAN
+        5MG DISINTEGR TAB PKG 3","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22335400,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        RE","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00030-0213-21","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDI","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"ZOLMITRIPTAN
+        5MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        25 Jul 2023 11:11:55 EDT","refillDate":"Tue, 27 Jun 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22335484,"sig":null,"orderedDate":"Sat,
+        22 Jul 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720543","prescriptionName":"ZOLMITRIPTAN
+        5MG DISINTEGR TAB PKG 3","dispensedDate":"Sun, 23 Jul 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22335484,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        10 Aug 2023 14:00:37 EDT","refillDate":"Sun, 27 Aug 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22357576,"sig":"PLACE
+        1 DROP INTO EYE WEEKLY FOR 30 DAYS TEST IND TEST PI","orderedDate":"Tue, 04
+        Jul 2023 00:00:00 EDT","quantity":1,"expirationDate":"Thu, 04 Jul 2024 00:00:00
+        EDT","prescriptionNumber":"3636946","prescriptionName":"LATANOPROST 0.005%
+        OPH SOLN","dispensedDate":"Fri, 07 Jul 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22357576,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        RE","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00013-8303-04","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        IND","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"LATANOPROST
+        0.005% 2.5ML","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        10 Aug 2023 14:00:37 EDT","refillDate":"Wed, 05 Jul 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22376296,"sig":null,"orderedDate":"Sun,
+        27 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636946","prescriptionName":"LATANOPROST
+        0.005% OPH SOLN","dispensedDate":"Tue, 08 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6946","cmopNdcNumber":"00113002239","id":22376296,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366946","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Wed,
+        05 Jul 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22376267,"sig":null,"orderedDate":"Mon,
+        07 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636946","prescriptionName":"LATANOPROST
+        0.005% OPH SOLN","dispensedDate":"Tue, 08 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6934","cmopNdcNumber":"00113002239","id":22376267,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366934","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":null,"refillDate":"Sun,
+        20 Aug 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22357591,"sig":"TAKE
+        1 TABLESPOONFUL BY MOUTH EVERY DAY FOR 30 DAYS","orderedDate":"Fri, 18 Aug
+        2023 00:00:00 EDT","quantity":1,"expirationDate":"Sun, 18 Aug 2024 00:00:00
+        EDT","prescriptionNumber":"3636947","prescriptionName":"LIDOCAINE HCL 2% VISCOUS
+        LIQUID","dispensedDate":"Tue, 01 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22357591,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00054-3500-49","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LIDOCAINE HCL 2% VISCOUS 100ML","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        10 Aug 2023 14:00:37 EDT","refillDate":"Thu, 10 Aug 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22376268,"sig":"TAKE
+        ONE TABLET EVERY TWELVE (12) HOURS FOR 45 DAYS TEST IN TEST PI","orderedDate":"Tue,
+        11 Jul 2023 00:00:00 EDT","quantity":60,"expirationDate":"Thu, 11 Jul 2024
+        00:00:00 EDT","prescriptionNumber":"3636950","prescriptionName":"LABETALOL
+        HCL 300MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22376268,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TESt
+        RE","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00172-4366-60","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        IN","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"LABETALOL
+        HCL 300MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        10 Aug 2023 14:00:37 EDT","refillDate":"Wed, 12 Jul 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22376297,"sig":null,"orderedDate":"Thu,
+        10 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636950","prescriptionName":"LABETALOL
+        HCL 300MG TAB","dispensedDate":"Thu, 10 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22376297,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        10 Aug 2023 14:00:37 EDT","refillDate":"Sat, 05 Aug 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22376353,"sig":"USE
+        LANCET INTRADERMAL SUBCUTANEOUS FOUR (4) TIMES A DAY, BEFORE MEALS AND AT
+        BEDTIME FOR 60 DAYS","orderedDate":"Thu, 06 Jul 2023 00:00:00 EDT","quantity":1,"expirationDate":"Sat,
+        06 Jul 2024 00:00:00 EDT","prescriptionNumber":"3636951","prescriptionName":"LANCET","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22376353,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"S09454-2151-15","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"BLOOD GLUCOSE 100''s","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        10 Aug 2023 14:00:37 EDT","refillDate":"Fri, 07 Jul 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22376384,"sig":null,"orderedDate":"Sat,
+        05 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636951","prescriptionName":"LANCET","dispensedDate":"Sun,
+        06 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6946","cmopNdcNumber":"00113002239","id":22376384,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366946","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        11 Aug 2023 09:59:45 EDT","refillDate":"Wed, 30 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22376397,"sig":"CHEW
+        ONE TABLET BY MOUTH THREE (3) TIMES A DAY FOR 30 DAYS","orderedDate":"Thu,
+        10 Aug 2023 00:00:00 EDT","quantity":90,"expirationDate":"Sat, 10 Aug 2024
+        00:00:00 EDT","prescriptionNumber":"3636952","prescriptionName":"LANTHANUM
+        CARBONATE 500MG TAB","dispensedDate":"Thu, 10 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22376397,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"54092-0249-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LANTHANUM CARBONATE 500MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Fri,
+        11 Aug 2023 09:59:45 EDT","refillDate":"Thu, 10 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22409139,"sig":null,"orderedDate":"Wed,
+        30 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636952","prescriptionName":"LANTHANUM
+        CARBONATE 500MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22409139,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Fri,
+        11 Aug 2023 09:59:45 EDT","refillDate":"Wed, 09 Aug 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22377604,"sig":"TAKE
+        10ML EVERY DAY FOR 30 DAYS","orderedDate":"Wed, 12 Jul 2023 00:00:00 EDT","quantity":1,"expirationDate":"Fri,
+        12 Jul 2024 00:00:00 EDT","prescriptionNumber":"3636953","prescriptionName":"LEVOCARNITINE
+        1GM/10ML LIQUID","dispensedDate":"Fri, 14 Jul 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22377604,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"54482-0145-08","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LEVOCARNITINE 1GM/10ML","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":"Fri,
+        11 Aug 2023 09:59:45 EDT","refillDate":"Thu, 13 Jul 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22377632,"sig":null,"orderedDate":"Wed,
+        09 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636953","prescriptionName":"LEVOCARNITINE
+        1GM/10ML LIQUID","dispensedDate":"Thu, 10 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6953","cmopNdcNumber":"00113002239","id":22377632,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366953","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        24 Aug 2023 16:29:33 EDT","refillDate":"Mon, 21 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22378337,"sig":"TAKE
+        2 UNITS BY THE AFFECTED AREA ONCE FOR 30 DAYS TEST INI CHILL WELL","orderedDate":"Sun,
+        02 Jul 2023 00:00:00 EDT","quantity":1,"expirationDate":"Tue, 02 Jul 2024
+        00:00:00 EDT","prescriptionNumber":"3636957","prescriptionName":"MAGNESIUM
+        CITRATE LIQUID","dispensedDate":"Wed, 05 Jul 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22378337,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        RE","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00869-2635-08","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INI","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"MAGNESIUM
+        CITRATE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        24 Aug 2023 16:29:33 EDT","refillDate":"Mon, 03 Jul 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22409140,"sig":null,"orderedDate":"Mon,
+        21 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636957","prescriptionName":"MAGNESIUM
+        CITRATE LIQUID","dispensedDate":"Tue, 22 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6957","cmopNdcNumber":"00113002239","id":22409140,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366957","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        11 Aug 2023 12:53:49 EDT","refillDate":"Mon, 21 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22378338,"sig":"INJECT
+        10ML INTRAVENOUS ONCE FOR 30 DAYS","orderedDate":"Mon, 17 Jul 2023 00:00:00
+        EDT","quantity":1,"expirationDate":"Wed, 17 Jul 2024 00:00:00 EDT","prescriptionNumber":"3636958","prescriptionName":"MAGNESIUM
+        SULFATE 50% INJ 10ML SDV","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22378338,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00517-2610-25","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"MAGNESIUM SULFATE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Fri,
+        11 Aug 2023 12:53:49 EDT","refillDate":"Tue, 18 Jul 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22409141,"sig":null,"orderedDate":"Mon,
+        21 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636958","prescriptionName":"MAGNESIUM
+        SULFATE 50% INJ 10ML SDV","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22409141,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        11 Aug 2023 12:55:57 EDT","refillDate":"Fri, 11 Aug 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22378341,"sig":"TAKE
+        1 TABLET BY MOUTH DAILY FOR 30 DAYS TEST INDI TEST PI","orderedDate":"Fri,
+        07 Jul 2023 00:00:00 EDT","quantity":30,"expirationDate":"Sun, 07 Jul 2024
+        00:00:00 EDT","prescriptionNumber":"2720555","prescriptionName":"MAALOX NO.
+        2 TAB ","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22378341,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        RE","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDI","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"MAALOX
+        N0.2","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Fri,
+        11 Aug 2023 12:55:57 EDT","refillDate":"Sat, 08 Jul 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22378410,"sig":null,"orderedDate":"Fri,
+        11 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720555","prescriptionName":"MAALOX
+        NO. 2 TAB ","dispensedDate":"Fri, 11 Aug 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22378410,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        11 Aug 2023 12:50:30 EDT","refillDate":"Fri, 11 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22378342,"sig":"APPLY
+        SMALL AMOUNT TO AFFECTED AREA WEEKLY FOR 45 DAYS","orderedDate":"Wed, 12 Jul
+        2023 00:00:00 EDT","quantity":1,"expirationDate":"Fri, 12 Jul 2024 00:00:00
+        EDT","prescriptionNumber":"2720556","prescriptionName":"MAFENIDE CREAM (OZ)","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22378342,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"MAFENIDE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Fri,
+        11 Aug 2023 12:50:30 EDT","refillDate":"Thu, 13 Jul 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22378411,"sig":null,"orderedDate":"Fri,
+        11 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720556","prescriptionName":"MAFENIDE
+        CREAM (OZ)","dispensedDate":"Fri, 11 Aug 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22378411,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Fri,
+        08 Sep 2023 16:24:09 EDT","refillDate":"Tue, 29 Aug 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22436660,"sig":"TAKE
+        ONE CAPSULE EVERY DAY FOR 30 DAYS","orderedDate":"Sun, 06 Aug 2023 00:00:00
+        EDT","quantity":30,"expirationDate":"Tue, 06 Aug 2024 00:00:00 EDT","prescriptionNumber":"3636961","prescriptionName":"ETOPOSIDE
+        50MG CAP","dispensedDate":"Tue, 08 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22436660,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"51079-0965-05","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ETOPOSIDE 50MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":null,"refillDate":"Sun,
+        06 Aug 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22436715,"sig":null,"orderedDate":"Tue,
+        29 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636961","prescriptionName":"ETOPOSIDE
+        50MG CAP","dispensedDate":"Thu, 31 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6961","cmopNdcNumber":"00113002239","id":22436715,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366961","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"active","refillSubmitDate":null,"refillDate":"Thu,
+        31 Aug 2023 00:00:00 EDT","refillRemaining":null,"facilityName":"SLC10 TEST
+        LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22443916,"sig":"50MG
+        ORAL DAILY","orderedDate":"Thu, 07 Sep 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"7","prescriptionName":"IMIPRAMINE
+        HCL 50MG TAB","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22443916,"userId":17621060,"providerFirstName":"BHAVIN","providerLastName":"PATEL","remarks":null,"divisionName":null,"modifiedDate":"Mon,
+        27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Non-VA","ndc":"00781-1766-10","reason":null,"prescriptionNumberIndex":"NV","prescriptionSource":"NV","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":null,"category":"Documented by VA","orderableItem":"IMIPRAMINE
+        HCL 50MG","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Wed,
+        13 Sep 2023 17:17:39 EDT","refillDate":"Thu, 28 Sep 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22446391,"sig":"TAKE
+        10ML EVERY DAY FOR 30 DAYS","orderedDate":"Fri, 08 Sep 2023 00:00:00 EDT","quantity":1,"expirationDate":"Sun,
+        08 Sep 2024 00:00:00 EDT","prescriptionNumber":"3636953A","prescriptionName":"LEVOCARNITINE
+        1GM/10ML LIQUID","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22446391,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 3636953","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon,
+        27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"54482-0145-08","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"LEVOCARNITINE 1GM/10ML","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Wed,
+        13 Sep 2023 17:17:39 EDT","refillDate":"Fri, 08 Sep 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22487103,"sig":null,"orderedDate":"Thu,
+        28 Sep 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636953A","prescriptionName":"LEVOCARNITINE
+        1GM/10ML LIQUID","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22487103,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Wed,
+        13 Sep 2023 19:08:32 EDT","refillDate":"Fri, 15 Sep 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22446392,"sig":"TAKE
+        10MG BY MOUTH TWO (2) TIMES A DAY FOR 30 DAYS TEST INDI MORNING AND NIGHT.","orderedDate":"Tue,
+        25 Jul 2023 00:00:00 EDT","quantity":30,"expirationDate":"Thu, 25 Jul 2024
+        00:00:00 EDT","prescriptionNumber":"3636963","prescriptionName":"QUETIAPINE
+        FUMAR TABS STARTER 11''S(PG)","dispensedDate":"Thu, 27 Jul 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22446392,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00310-0276-90","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDI","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"QUETIAPINE
+        FUMARATE STARTER 11''S","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Wed,
+        13 Sep 2023 19:08:32 EDT","refillDate":"Wed, 26 Jul 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22487104,"sig":null,"orderedDate":"Fri,
+        15 Sep 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636963","prescriptionName":"QUETIAPINE
+        FUMAR TABS STARTER 11''S(PG)","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22487104,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":null,"refillDate":"Wed,
+        26 Jul 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22446432,"sig":null,"orderedDate":"Sat,
+        26 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636963","prescriptionName":"QUETIAPINE
+        FUMAR TABS STARTER 11''S(PG)","dispensedDate":"Sun, 27 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6963","cmopNdcNumber":"00113002239","id":22446432,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366963","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        08 Sep 2023 12:15:25 EDT","refillDate":"Fri, 08 Sep 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22447544,"sig":"TAKE
+        ONE TABLET BY MOUTH EVERY DAY FOR 30 DAYS","orderedDate":"Wed, 09 Aug 2023
+        00:00:00 EDT","quantity":30,"expirationDate":"Fri, 09 Aug 2024 00:00:00 EDT","prescriptionNumber":"3636964","prescriptionName":"QUINAPRIL
+        HCL 10MG TAB","dispensedDate":"Thu, 10 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22447544,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00071-0530-23","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"QUINAPRIL HCL 10MG","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Fri,
+        08 Sep 2023 12:23:30 EDT","refillDate":"Fri, 08 Sep 2023 00:00:00 EDT","refillRemaining":5,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22447628,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 45 DAYS --TAKE WITH FOOD/AVOID GRAPEFRUIT JUICE/DO
+        NOT CRUSH OR CHEW/AVOID ANTACIDS--","orderedDate":"Sat, 19 Aug 2023 00:00:00
+        EDT","quantity":30,"expirationDate":"Mon, 19 Aug 2024 00:00:00 EDT","prescriptionNumber":"2720589","prescriptionName":"QUINIDINE
+        GLUCONATE 324MG SA TAB","dispensedDate":"Fri, 08 Sep 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22447628,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"47679-0452-35","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"QUINIDINE","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        31 Aug 2023 14:25:47 EDT","refillDate":"Thu, 31 Aug 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22425840,"sig":"TAKE
+        10MG BY MOUTH DAILY FOR 30 DAYS TEST INDI 08312023 TEST PI 08312023","orderedDate":"Thu,
+        27 Jul 2023 00:00:00 EDT","quantity":30,"expirationDate":"Sat, 27 Jul 2024
+        00:00:00 EDT","prescriptionNumber":"2720576","prescriptionName":"VALACYCLOVIR
+        HCL 1GM TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22425840,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        RE 08312023","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46
+        EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDI 08312023","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"VALACYCLOVIR","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        31 Aug 2023 14:25:47 EDT","refillDate":"Thu, 27 Jul 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22428731,"sig":null,"orderedDate":"Thu,
+        31 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720576","prescriptionName":"VALACYCLOVIR
+        HCL 1GM TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22428731,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        31 Aug 2023 15:17:03 EDT","refillDate":"Thu, 31 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22425841,"sig":"TAKE
+        ONE CAPSULE BY MOUTH WEEKLY FOR 60 DAYS --TAKE WITH FOOD TO DECREASE GI DISTRESS/DO
+        NOT CRUSH OR CHEW--","orderedDate":"Tue, 01 Aug 2023 00:00:00 EDT","quantity":5,"expirationDate":"Thu,
+        01 Aug 2024 00:00:00 EDT","prescriptionNumber":"2720577","prescriptionName":"VALPROIC
+        ACID 250MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22425841,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00074-5681-13","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"VALPROIC ACID","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        31 Aug 2023 15:17:03 EDT","refillDate":"Wed, 02 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22428732,"sig":null,"orderedDate":"Thu,
+        31 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720577","prescriptionName":"VALPROIC
+        ACID 250MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22428732,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        31 Aug 2023 15:32:58 EDT","refillDate":"Thu, 31 Aug 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22425842,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 45 DAYS","orderedDate":"Sun, 06 Aug 2023 00:00:00
+        EDT","quantity":30,"expirationDate":"Tue, 06 Aug 2024 00:00:00 EDT","prescriptionNumber":"2720578","prescriptionName":"VALSARTAN
+        160MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22425842,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00078-0359-05","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"VALSARTAN","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        31 Aug 2023 15:32:58 EDT","refillDate":"Mon, 07 Aug 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22428733,"sig":null,"orderedDate":"Thu,
+        31 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720578","prescriptionName":"VALSARTAN
+        160MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22428733,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        31 Aug 2023 18:13:29 EDT","refillDate":"Fri, 01 Sep 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22425843,"sig":"INJECT
+        10ML IV WEEKLY FOR 30 DAYS TEST INDI TEST PI","orderedDate":"Fri, 11 Aug 2023
+        00:00:00 EDT","quantity":1,"expirationDate":"Sun, 11 Aug 2024 00:00:00 EDT","prescriptionNumber":"2720579","prescriptionName":"VANCOMYCIN
+        1000MG INJ","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22425843,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00074-6533-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDI","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"VANCOMYCIN","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        31 Aug 2023 18:13:29 EDT","refillDate":"Sat, 12 Aug 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22428734,"sig":null,"orderedDate":"Fri,
+        01 Sep 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720579","prescriptionName":"VANCOMYCIN
+        1000MG INJ","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22428734,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        31 Aug 2023 18:28:31 EDT","refillDate":"Thu, 31 Aug 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22425844,"sig":"APPLY
+        SMALL AMOUNT TO AFFECTED AREA DAILY FOR 30 DAYS","orderedDate":"Tue, 08 Aug
+        2023 00:00:00 EDT","quantity":1,"expirationDate":"Thu, 08 Aug 2024 00:00:00
+        EDT","prescriptionNumber":"2720580","prescriptionName":"VELVACHOL CREAM  16
+        OZ","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22425844,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"30229-3932-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"VELVACHOL","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        31 Aug 2023 14:26:47 EDT","refillDate":"Thu, 31 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22425845,"sig":"TAKE
+        1MG BY MOUTH WEEKLY FOR 60 DAYS","orderedDate":"Thu, 03 Aug 2023 00:00:00
+        EDT","quantity":1,"expirationDate":"Sat, 03 Aug 2024 00:00:00 EDT","prescriptionNumber":"2720581","prescriptionName":"VENLAFAXINE
+        HCL 150MG SA CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22425845,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00008-0836-01","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"VENLAFAXINE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        31 Aug 2023 14:26:47 EDT","refillDate":"Fri, 04 Aug 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22428735,"sig":null,"orderedDate":"Thu,
+        31 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720581","prescriptionName":"VENLAFAXINE
+        HCL 150MG SA CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22428735,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"expired","refillSubmitDate":null,"refillDate":"Tue,
+        01 Aug 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"SLC10 TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22426211,"sig":"TAKE
+        ONE CAPSULE BY MOUTH EVERY DAY FOR 30 DAYS","orderedDate":"Tue, 01 Aug 2023
+        00:00:00 EDT","quantity":30,"expirationDate":"Thu, 31 Aug 2023 00:00:00 EDT","prescriptionNumber":"3636959","prescriptionName":"THALIDOMIDE
+        50MG CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22426211,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Fri, 01 Sep 2023 08:54:55 EDT","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Expired","ndc":"59572-0205-94","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"THALIDOMIDE 50MG","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Thu,
+        31 Aug 2023 10:20:13 EDT","refillDate":"Thu, 31 Aug 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22426212,"sig":"INJECT
+        2 MILLIGRAMS UNDER THE SKIN ONCE FOR 30 DAYS","orderedDate":"Tue, 01 Aug 2023
+        00:00:00 EDT","quantity":1,"expirationDate":"Thu, 01 Aug 2024 00:00:00 EDT","prescriptionNumber":"3636960","prescriptionName":"TERBUTALINE
+        1MG/ML INJ 1ML","dispensedDate":"Thu, 03 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22426212,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"55390-0101-10","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"TERBUTALINE 1MG/ML","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        31 Aug 2023 10:20:13 EDT","refillDate":"Wed, 02 Aug 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22426254,"sig":null,"orderedDate":"Thu,
+        31 Aug 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636960","prescriptionName":"TERBUTALINE
+        1MG/ML INJ 1ML","dispensedDate":"Thu, 31 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22426254,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        05 Sep 2023 15:00:42 EDT","refillDate":"Tue, 05 Sep 2023 00:00:00 EDT","refillRemaining":5,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22399906,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 30 DAYS TEST IND TEST PI","orderedDate":"Sat,
+        22 Jul 2023 00:00:00 EDT","quantity":30,"expirationDate":"Mon, 22 Jul 2024
+        00:00:00 EDT","prescriptionNumber":"2720573","prescriptionName":"POTASSIUM
+        CHLORIDE 8MEQ SA TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22399906,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"TEST
+        RE","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00245-0040-55","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        IND","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"POTASSIUM
+        CHLORIDE","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        14 Nov 2023 14:15:05 EST","refillDate":"Mon, 20 Nov 2023 00:00:00 EST","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22625964,"sig":"TAKE
+        10MG BY MOUTH DAILY FOR 30 DAYS","orderedDate":"Tue, 31 Oct 2023 00:00:00
+        EDT","quantity":30,"expirationDate":"Thu, 31 Oct 2024 00:00:00 EDT","prescriptionNumber":"2720466B","prescriptionName":"ABACAVIR
+        SO4 600MG/LAMIVUDINE 300MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22625964,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720466A","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00173-0742-00","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ABACAVIR/LAMIVUDINE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        14 Nov 2023 14:15:05 EST","refillDate":"Tue, 31 Oct 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22656197,"sig":null,"orderedDate":"Mon,
+        20 Nov 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720466B","prescriptionName":"ABACAVIR
+        SO4 600MG/LAMIVUDINE 300MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22656197,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"hold","refillSubmitDate":"Mon,
+        06 Nov 2023 16:02:35 EST","refillDate":"Mon, 20 Nov 2023 00:00:00 EST","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22625965,"sig":"TAKE
+        ONE CAPSULE BY MOUTH DAILY FOR 30 DAYS TEST I TEST PLACE","orderedDate":"Tue,
+        31 Oct 2023 00:00:00 EDT","quantity":1,"expirationDate":"Thu, 31 Oct 2024
+        00:00:00 EDT","prescriptionNumber":"2720527B","prescriptionName":"ACEBUTOLOL
+        HCL 400MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22625965,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720527A","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        On Hold","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ACEBUTOLOL","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"hold","refillSubmitDate":"Mon,
+        06 Nov 2023 16:02:35 EST","refillDate":"Tue, 31 Oct 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22637805,"sig":null,"orderedDate":"Mon,
+        20 Nov 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720527B","prescriptionName":"ACEBUTOLOL
+        HCL 400MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22637805,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        On Hold","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":null,"refillDate":"Mon,
+        06 Nov 2023 00:00:00 EST","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22625966,"sig":"IRRIGATE
+        1 SOLUTION AFFECTED AREA DAILY FOR 60 DAYS TEST INDICATION TEST PATIENT INSTRUCTIONS","orderedDate":"Tue,
+        31 Oct 2023 00:00:00 EDT","quantity":1,"expirationDate":"Thu, 31 Oct 2024
+        00:00:00 EDT","prescriptionNumber":"2720526B","prescriptionName":"ACETIC ACID
+        0.25% IRRG SOLN","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22625966,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720526A","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00264-2304-00","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ACETIC ACID","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        14 Nov 2023 14:16:02 EST","refillDate":"Mon, 20 Nov 2023 00:00:00 EST","refillRemaining":10,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22625967,"sig":"TAKE
+        5G DAILY FOR 30 DAYS TEST TEST INDICATION TEST","orderedDate":"Tue, 31 Oct
+        2023 00:00:00 EDT","quantity":30,"expirationDate":"Thu, 31 Oct 2024 00:00:00
+        EDT","prescriptionNumber":"2720245D","prescriptionName":"ACITRETIN 25MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22625967,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720245C","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00004-0214-57","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION TEST","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"ACITRETIN","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        14 Nov 2023 14:16:02 EST","refillDate":"Tue, 31 Oct 2023 00:00:00 EDT","refillRemaining":10,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22656198,"sig":null,"orderedDate":"Mon,
+        20 Nov 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720245D","prescriptionName":"ACITRETIN
+        25MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22656198,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        14 Nov 2023 14:16:09 EST","refillDate":"Mon, 20 Nov 2023 00:00:00 EST","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22625968,"sig":"TAKE
+        ONE CAPSULE DAILY FOR 30 DAYS TEST","orderedDate":"Tue, 31 Oct 2023 00:00:00
+        EDT","quantity":30,"expirationDate":"Thu, 31 Oct 2024 00:00:00 EDT","prescriptionNumber":"2720298C","prescriptionName":"ACYCLOVIR
+        200MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22625968,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720298B","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00172-4266-70","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION TEST","indicationForUseFlag":null,"category":"Rx Medication","orderableItem":"ACYCLOVIR","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        14 Nov 2023 14:16:09 EST","refillDate":"Tue, 31 Oct 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22656199,"sig":null,"orderedDate":"Mon,
+        20 Nov 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720298C","prescriptionName":"ACYCLOVIR
+        200MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22656199,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        17 Oct 2023 13:36:48 EDT","refillDate":"Wed, 18 Oct 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22585447,"sig":"TAKE
+        ONE CAPSULE BY MOUTH EVERY DAY FOR 30 DAYS TEST INDICATION TEST PATIENT INSTRUCTIONS","orderedDate":"Fri,
+        22 Sep 2023 00:00:00 EDT","quantity":30,"expirationDate":"Sun, 22 Sep 2024
+        00:00:00 EDT","prescriptionNumber":"3636929B","prescriptionName":"DANAZOL
+        200MG CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22585447,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 3636929A","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon,
+        27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00024-0305-06","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"DANAZOL
+        200MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        17 Oct 2023 13:36:48 EDT","refillDate":"Sat, 23 Sep 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22588268,"sig":null,"orderedDate":"Wed,
+        18 Oct 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636929B","prescriptionName":"DANAZOL
+        200MG CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22588268,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Tue,
+        24 Oct 2023 15:06:22 EDT","refillDate":"Tue, 12 Sep 2023 00:00:00 EDT","refillRemaining":3,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22565799,"sig":"TAKE
+        10MG BY MOUTH DAILY FOR 30 DAYS","orderedDate":"Mon, 11 Sep 2023 00:00:00
+        EDT","quantity":30,"expirationDate":"Wed, 11 Sep 2024 00:00:00 EDT","prescriptionNumber":"2720466A","prescriptionName":"ABACAVIR
+        SO4 600MG/LAMIVUDINE 300MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22565799,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720466","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00173-0742-00","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ABACAVIR/LAMIVUDINE","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Mon,
+        16 Oct 2023 09:33:11 EDT","refillDate":"Sun, 08 Oct 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22565800,"sig":"TAKE
+        ONE CAPSULE BY MOUTH DAILY FOR 30 DAYS TEST I TEST PLACE","orderedDate":"Wed,
+        06 Sep 2023 00:00:00 EDT","quantity":1,"expirationDate":"Fri, 06 Sep 2024
+        00:00:00 EDT","prescriptionNumber":"2720527A","prescriptionName":"ACEBUTOLOL
+        HCL 400MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22565800,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720527","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ACEBUTOLOL","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":"Wed,
+        11 Oct 2023 12:03:05 EDT","refillDate":"Thu, 07 Sep 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22566024,"sig":null,"orderedDate":"Sun,
+        08 Oct 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720527A","prescriptionName":"ACEBUTOLOL
+        HCL 400MG CAP","dispensedDate":"Mon, 09 Oct 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(983)272-0527","cmopNdcNumber":"00013264681","id":22566024,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"9832720527","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Thu,
+        19 Oct 2023 19:44:02 EDT","refillDate":"Sat, 07 Oct 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22565801,"sig":"IRRIGATE
+        1 SOLUTION AFFECTED AREA DAILY FOR 60 DAYS TEST INDICATION TEST PATIENT INSTRUCTIONS","orderedDate":"Sat,
+        16 Sep 2023 00:00:00 EDT","quantity":1,"expirationDate":"Mon, 16 Sep 2024
+        00:00:00 EDT","prescriptionNumber":"2720526A","prescriptionName":"ACETIC ACID
+        0.25% IRRG SOLN","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22565801,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720526","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00264-2304-00","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ACETIC ACID","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":"Mon,
+        16 Oct 2023 09:32:46 EDT","refillDate":"Sun, 17 Sep 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22584152,"sig":null,"orderedDate":"Sat,
+        07 Oct 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720526A","prescriptionName":"ACETIC
+        ACID 0.25% IRRG SOLN","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22584152,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Mon,
+        16 Oct 2023 16:38:30 EDT","refillDate":"Mon, 16 Oct 2023 00:00:00 EDT","refillRemaining":11,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22565802,"sig":"TAKE
+        5G DAILY FOR 30 DAYS TEST TEST INDICATION TEST","orderedDate":"Wed, 11 Oct
+        2023 00:00:00 EDT","quantity":30,"expirationDate":"Fri, 11 Oct 2024 00:00:00
+        EDT","prescriptionNumber":"2720245C","prescriptionName":"ACITRETIN 25MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22565802,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720245B","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00004-0214-57","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION TEST","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"ACITRETIN","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Tue,
+        24 Oct 2023 11:29:29 EDT","refillDate":"Tue, 24 Oct 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22565803,"sig":"TAKE
+        ONE CAPSULE DAILY FOR 30 DAYS TEST","orderedDate":"Wed, 11 Oct 2023 00:00:00
+        EDT","quantity":30,"expirationDate":"Fri, 11 Oct 2024 00:00:00 EDT","prescriptionNumber":"2720298B","prescriptionName":"ACYCLOVIR
+        200MG CAP","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22565803,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720298A","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00172-4266-70","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION TEST","indicationForUseFlag":null,"category":"Rx Medication","orderableItem":"ACYCLOVIR","trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        31 Oct 2023 08:45:36 EDT","refillDate":"Sat, 11 Nov 2023 00:00:00 EST","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22565804,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 30 DAYS","orderedDate":"Thu, 21 Sep 2023 00:00:00
+        EDT","quantity":30,"expirationDate":"Sat, 21 Sep 2024 00:00:00 EDT","prescriptionNumber":"2720290B","prescriptionName":"AMITRIPTYLINE
+        HCL 10MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22565804,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720290A","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00603-2212-32","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"AMITRIPTYLINE","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        31 Oct 2023 08:45:36 EDT","refillDate":"Fri, 22 Sep 2023 00:00:00 EDT","refillRemaining":0,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22625963,"sig":null,"orderedDate":"Sat,
+        11 Nov 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720290B","prescriptionName":"AMITRIPTYLINE
+        HCL 10MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22625963,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":"Thu,
+        19 Oct 2023 09:22:21 EDT","refillDate":"Fri, 22 Sep 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22593429,"sig":null,"orderedDate":"Mon,
+        16 Oct 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720290B","prescriptionName":"AMITRIPTYLINE
+        HCL 10MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22593429,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Mon,
+        20 Nov 2023 13:21:41 EST","refillDate":"Mon, 20 Nov 2023 00:00:00 EST","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22565805,"sig":"APPLY
+        10ML TO AFFECTED AREA DAILY FOR 60 DAYS","orderedDate":"Wed, 13 Sep 2023 00:00:00
+        EDT","quantity":1,"expirationDate":"Fri, 13 Sep 2024 00:00:00 EDT","prescriptionNumber":"2720410A","prescriptionName":"BACT-NEOMY-POLYMIX
+        TOP OINT (OZ)","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22565805,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720410","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00168-0012-31","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"BACITRACIN/NEOMYCIN/POLYMYXIN B","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Mon,
+        20 Nov 2023 13:21:41 EST","refillDate":"Thu, 14 Sep 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22676760,"sig":null,"orderedDate":"Mon,
+        20 Nov 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720410A","prescriptionName":"BACT-NEOMY-POLYMIX
+        TOP OINT (OZ)","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22676760,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        14 Nov 2023 14:16:21 EST","refillDate":"Tue, 14 Nov 2023 00:00:00 EST","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22545165,"sig":"TAKE
+        ONE TABLET BY MOUTH DAILY FOR 30 DAYS AUTO TEST --TAKE WITH FOOD--","orderedDate":"Mon,
+        04 Sep 2023 00:00:00 EDT","quantity":30,"expirationDate":"Wed, 04 Sep 2024
+        00:00:00 EDT","prescriptionNumber":"2720604","prescriptionName":"BACLOFEN
+        10MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22545165,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00603-2408-32","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"AUTO
+        TEST","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"BACLOFEN","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        14 Nov 2023 14:16:21 EST","refillDate":"Mon, 04 Sep 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22656196,"sig":null,"orderedDate":"Tue,
+        14 Nov 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720604","prescriptionName":"BACLOFEN
+        10MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22656196,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Wed,
+        04 Oct 2023 16:46:54 EDT","refillDate":"Wed, 04 Oct 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22545166,"sig":"TAKE
+        ONE TABLET DAILY FOR 30 DAYS TEST --AVOID ANTACIDS--","orderedDate":"Mon,
+        04 Sep 2023 00:00:00 EDT","quantity":30,"expirationDate":"Wed, 04 Sep 2024
+        00:00:00 EDT","prescriptionNumber":"2720605","prescriptionName":"GABAPENTIN
+        600MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22545166,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"DAYTON","modifiedDate":"Mon,
+        27 Nov 2023 10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00071-0513-24","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST","indicationForUseFlag":"1","category":"Rx
+        Medication","orderableItem":"GABAPENTIN","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Wed,
+        04 Oct 2023 16:46:54 EDT","refillDate":"Mon, 04 Sep 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22547960,"sig":null,"orderedDate":"Wed,
+        04 Oct 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720605","prescriptionName":"GABAPENTIN
+        600MG TAB","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22547960,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Mon,
+        20 Nov 2023 13:27:20 EST","refillDate":"Thu, 23 Nov 2023 00:00:00 EST","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22631590,"sig":"APPLY
+        1MG TO MOUTH DAILY FOR 30 DAYS TEST INDICATION 06052023 - C & A TEST PATIENT
+        INTRUCTIONS","orderedDate":"Fri, 29 Sep 2023 00:00:00 EDT","quantity":1,"expirationDate":"Sun,
+        29 Sep 2024 00:00:00 EDT","prescriptionNumber":"2720511A","prescriptionName":"CADEXOMER
+        IODINE 0.9% TOP GEL","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22631590,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 2720511","divisionName":"DAYTON","modifiedDate":"Mon, 27 Nov 2023
+        10:31:46 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"08213-0100-40","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION 06052023 - C & A","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"CADEXOMER
+        IODINE 0.9%","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Mon,
+        20 Nov 2023 13:27:20 EST","refillDate":"Sat, 30 Sep 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22676761,"sig":null,"orderedDate":"Thu,
+        23 Nov 2023 00:00:00 EST","quantity":null,"expirationDate":null,"prescriptionNumber":"2720511A","prescriptionName":"CADEXOMER
+        IODINE 0.9% TOP GEL","dispensedDate":null,"stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22676761,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF2","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false},{"refillStatus":"suspended","refillSubmitDate":"Fri,
+        03 Nov 2023 14:56:08 EDT","refillDate":"Sat, 30 Sep 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"DAYT29","isRefillable":false,"isTrackable":false,"prescriptionId":22631628,"sig":null,"orderedDate":"Fri,
+        03 Nov 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"2720511A","prescriptionName":"CADEXOMER
+        IODINE 0.9% TOP GEL","dispensedDate":"Fri, 03 Nov 2023 00:00:00 EDT","stationNumber":"989","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22631628,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Mon,
+        02 Oct 2023 16:21:22 EDT","refillDate":"Sun, 01 Oct 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22534598,"sig":"TAKE
+        10ML BY MOUTH EVERY DAY FOR 30 DAYS TEST INDI TEST PI","orderedDate":"Sat,
+        02 Sep 2023 00:00:00 EDT","quantity":1,"expirationDate":"Mon, 02 Sep 2024
+        00:00:00 EDT","prescriptionNumber":"3636979","prescriptionName":"ACETYLCYSTEINE
+        20% INHL SOLN 30ML","dispensedDate":"Mon, 04 Sep 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22534598,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":null,"divisionName":"VAMC
+        SLC-OUTPTRX","modifiedDate":"Mon, 27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00409-3308-03","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDI","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"ACETYLCYSTEINE
+        20% 30ML","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Mon,
+        02 Oct 2023 16:21:22 EDT","refillDate":"Sun, 03 Sep 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22534649,"sig":null,"orderedDate":"Sun,
+        01 Oct 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636979","prescriptionName":"ACETYLCYSTEINE
+        20% INHL SOLN 30ML","dispensedDate":"Mon, 02 Oct 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22534649,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        26 Sep 2023 16:10:24 EDT","refillDate":"Sat, 23 Sep 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22510593,"sig":"APPLY,
+        A SEGMENT(S) INSIDE, LOWER LID OF EYE WEEKLY FOR 30 DAYS TEST INDICATION TEST
+        PATIENT INTRUCTIONS","orderedDate":"Sun, 27 Aug 2023 00:00:00 EDT","quantity":1,"expirationDate":"Tue,
+        27 Aug 2024 00:00:00 EDT","prescriptionNumber":"3636889A","prescriptionName":"BACITRACIN
+        500 UNT/GM OPH OINT","dispensedDate":"Tue, 29 Aug 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22510593,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 3636889","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon,
+        27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"00168-0026-38","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"BACITRACIN
+        500 UNIT/GM 3.5GM","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        26 Sep 2023 16:10:24 EDT","refillDate":"Mon, 28 Aug 2023 00:00:00 EDT","refillRemaining":1,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22510635,"sig":null,"orderedDate":"Sat,
+        23 Sep 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636889A","prescriptionName":"BACITRACIN
+        500 UNT/GM OPH OINT","dispensedDate":"Sun, 24 Sep 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":"(410)636-6899","cmopNdcNumber":"00113002239","id":22510635,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"4106366899","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"discontinued","refillSubmitDate":"Mon,
+        02 Oct 2023 16:21:22 EDT","refillDate":"Wed, 27 Sep 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22510594,"sig":"TAKE
+        ONE CAPSULE BY MOUTH EVERY DAY FOR 30 DAYS TEST INDICATION TEST PATIENT INSTRUCTIONS","orderedDate":"Fri,
+        01 Sep 2023 00:00:00 EDT","quantity":30,"expirationDate":"Sun, 01 Sep 2024
+        00:00:00 EDT","prescriptionNumber":"3636929A","prescriptionName":"DANAZOL
+        200MG CAP","dispensedDate":"Sun, 03 Sep 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22510594,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 3636929","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon,
+        27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":"00024-0305-06","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":"TEST
+        INDICATION","indicationForUseFlag":"1","category":"Rx Medication","orderableItem":"DANAZOL
+        200MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"discontinued","refillSubmitDate":"Mon,
+        02 Oct 2023 15:49:42 EDT","refillDate":"Sat, 02 Sep 2023 00:00:00 EDT","refillRemaining":4,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22534150,"sig":null,"orderedDate":"Wed,
+        27 Sep 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636929A","prescriptionName":"DANAZOL
+        200MG CAP","dispensedDate":"Fri, 29 Sep 2023 00:00:00 EDT","stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22534150,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Discontinued","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false},{"refillStatus":"refillinprocess","refillSubmitDate":"Tue,
+        17 Oct 2023 13:31:30 EDT","refillDate":"Wed, 18 Oct 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22585396,"sig":"TAKE
+        ONE CAPSULE EVERY DAY FOR 30 DAYS","orderedDate":"Wed, 27 Sep 2023 00:00:00
+        EDT","quantity":30,"expirationDate":"Fri, 27 Sep 2024 00:00:00 EDT","prescriptionNumber":"3636961A","prescriptionName":"ETOPOSIDE
+        50MG CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":"A
+        refill request cannot be submitted at this time. Please review the prescription
+        status and fill date. If you need more of this medication, please call the
+        pharmacy phone number on your prescription label.","cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22585396,"userId":17621060,"providerFirstName":"MOHAMMAD","providerLastName":"ISLAM","remarks":"RENEWED
+        FROM RX # 3636961","divisionName":"VAMC SLC-OUTPTRX","modifiedDate":"Mon,
+        27 Nov 2023 10:31:45 EST","institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Active:
+        Refill in Process","ndc":"51079-0965-05","reason":null,"prescriptionNumberIndex":"RX","prescriptionSource":"RX","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":"ETOPOSIDE 50MG","trackingList":null,"rxRFRecords":{"rfRecord":[{"refillStatus":"suspended","refillSubmitDate":"Tue,
+        17 Oct 2023 13:31:30 EDT","refillDate":"Thu, 28 Sep 2023 00:00:00 EDT","refillRemaining":2,"facilityName":"SLC10
+        TEST LAB","isRefillable":false,"isTrackable":false,"prescriptionId":22588267,"sig":null,"orderedDate":"Wed,
+        18 Oct 2023 00:00:00 EDT","quantity":null,"expirationDate":null,"prescriptionNumber":"3636961A","prescriptionName":"ETOPOSIDE
+        50MG CAP","dispensedDate":null,"stationNumber":"979","inCernerTransition":false,"notRefillableDisplayMessage":null,"cmopDivisionPhone":null,"cmopNdcNumber":null,"id":22588267,"userId":17621060,"providerFirstName":null,"providerLastName":null,"remarks":null,"divisionName":null,"modifiedDate":null,"institutionId":null,"dialCmopDivisionPhone":"","dispStatus":"Suspended","ndc":null,"reason":null,"prescriptionNumberIndex":"RF1","prescriptionSource":"RF","disclaimer":null,"indicationForUse":null,"indicationForUseFlag":null,"category":"Rx
+        Medication","orderableItem":null,"trackingList":null,"rxRFRecords":null,"tracking":false}]},"tracking":false}]},"errors":[],"infoMessages":[]}'
+  recorded_at: Mon, 27 Nov 2023 18:59:51 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary

Added a new token to param store that is to be used by the va.gov rx app. Since the mobile team shares the `lib/rx/client.rb` , I needed to create a new client that inherits the existing client but configures the app headers to add the new token. This new client will be used by the  `modules/my_health/app/controllers/my_health/rx_controller.rb`. which is used solely by the va.gov rx app `/my-health/medications/.` 

## Related issue(s)

[AAL new token for VA.gov](https://jira.devops.va.gov/browse/MHV-52044)

> Need to update token on the VA.gov side so the AAL entry shows as Remote System: VA.gov instead of VAHB. 

## Testing done

manually checked that the token was being retrieved from local development setings.local.yml. However this change will require the [devops](https://github.com/department-of-veterans-affairs/devops/pull/13773) pr to get merged first, in order to retrieve the app token for staging and prod environments.

## Screenshots

## What areas of the site does it impact?

mhv prescriptions controller for rx app used by va.gov site.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
