### PR TITLE
deregistering job that is deleting old CM claims v2

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -59,9 +59,6 @@ PERIODIC_JOBS = lambda { |mgr|
   # Clear out EVSS disability claims that have not been updated in 24 hours
   mgr.register('20 2 * * *', 'DeleteOldPiiLogsJob')
   # Clear out old personal information logs
-  mgr.register('30 2 * * *', 'CentralMail::DeleteOldClaims')
-  # Clear out central mail claims older than 2 months
-
   mgr.register('0 3 * * MON-FRI', 'EducationForm::CreateDailySpoolFiles')
 
   mgr.register('0 3 * * *', 'DeleteOldTransactionsJob')


### PR DESCRIPTION
## Summary

- Deletes the CentralMail::DeleteOldClaims cron registery so that we stop deleting old claims that may need remediation. 