### PR TITLE
Update native setup Sidekiq docs

### DIFF
--- a/docs/setup/native.md
+++ b/docs/setup/native.md
@@ -37,7 +37,7 @@ Steps 2-4 must be repeated if the repo's Ruby version is updated later.
    cd vets-api; bundle install
    ```
 
-   More information about installing _with_ Sidekiq Enterprise as well as our credentials are on the internal system [here](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Platform/Vets-API/Sidekiq%20Enterprise%20Setup.md)
+   More information about installing _with_ Sidekiq Enterprise as well as our credentials are on the internal system [here](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/platform/engineering/sidekiq-enterprise-setup.md)
 
 1. Make sure you have the [vets-api-mockdata](https://github.com/department-of-veterans-affairs/vets-api-mockdata) repo locally installed, preferably in a sibling directory to `vets-api`.
 


### PR DESCRIPTION
## Summary

- Update native setup Sidekiq docs
- Steps to reproduce: Follow this link in the docs and notice that it 404s: https://github.com/department-of-veterans-affairs/vets-api/blob/master/docs/setup/native.md?plain=1#L40
- Solution: Update to the correct link: https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/platform/engineering/sidekiq-enterprise-setup.md
- My team: VSO Fast Track Claims (we do not own the maintenance of these docs)
- Flipper: N/A

## Related issue(s)
- Closes https://github.com/department-of-veterans-affairs/vets-api/issues/14693


## Testing done

- Old behavior: Wrong / missing docs linked
- Verifying correctness: Follow the new link and see that it is correct
- Automated tests: N/A


## What areas of the site does it impact?
N/A. Just docs.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature