### PR TITLE
Faraday 1.10 Patch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -824,6 +824,7 @@ lib/common/client/base.rb @department-of-veterans-affairs/va-api-engineers @depa
 lib/common/client/concerns/mhv_fhir_session_client.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/common/client/concerns/mhv_jwt_session_client.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/common/client/concerns/mhv_locked_session_client.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+lib/common/client/configuration/base.rb @department-of-veterans-affairs/backend-review-group
 lib/common/client/middleware/request/multipart_request.rb @department-of-veterans-affairs/backend-review-group
 lib/common/client/middleware/request/remove_cookies.rb @department-of-veterans-affairs/backend-review-group
 lib/common/exceptions/open_id_service_error.rb @department-of-veterans-affairs/lighthouse-pivot

--- a/lib/common/client/configuration/base.rb
+++ b/lib/common/client/configuration/base.rb
@@ -114,8 +114,7 @@ module Common
               (500..599).cover?(exception.response_values[:status])
             when Common::Client::Errors::HTTPError
               (500..599).cover?(exception.status)
-            when Faraday::ClientError
-              # we're not yet using Faraday > 1.0, but when we do, 500 errors will be Faraday::ServerError
+            when Faraday::ServerError
               (500..599).cover?(exception.response&.[](:status))
             else
               false

--- a/modules/check_in/app/services/v2/chip/client.rb
+++ b/modules/check_in/app/services/v2/chip/client.rb
@@ -116,7 +116,7 @@ module V2
                                   uuid: check_in_session.uuid
                                 },
                                 { external_service: service_name, team: 'check-in' })
-        Faraday::Response.new(body: e.original_body, status: e.original_status)
+        Faraday::Response.new(response_body: e.original_body, status: e.original_status)
       end
 
       ##
@@ -204,7 +204,7 @@ module V2
                                   uuid: check_in_session.uuid
                                 },
                                 { external_service: service_name, team: 'check-in' })
-        Faraday::Response.new(body: e.original_body, status: e.original_status)
+        Faraday::Response.new(response_body: e.original_body, status: e.original_status)
       end
 
       private

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -423,7 +423,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
       context 'with an upstream service error' do
         it 'sets the transaction to "retrying"' do
           VCR.use_cassette('evss/disability_compensation_form/submit_500_with_err_msg') do
-            expect(Rails.logger).to receive(:error)
+            expect(Rails.logger).to receive(:error).twice
             expect_retryable_error(EVSS::DisabilityCompensationForm::ServiceException)
           end
         end
@@ -432,7 +432,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
       context 'with an upstream bad gateway' do
         it 'sets the transaction to "retrying"' do
           VCR.use_cassette('evss/disability_compensation_form/submit_502') do
-            expect(Rails.logger).to receive(:error)
+            expect(Rails.logger).to receive(:error).twice
             expect_retryable_error(Common::Exceptions::BackendServiceException)
           end
         end
@@ -441,7 +441,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
       context 'with an upstream service unavailable' do
         it 'sets the transaction to "retrying"' do
           VCR.use_cassette('evss/disability_compensation_form/submit_503') do
-            expect(Rails.logger).to receive(:error)
+            expect(Rails.logger).to receive(:error).twice
             expect_retryable_error(EVSS::DisabilityCompensationForm::ServiceUnavailableException)
           end
         end


### PR DESCRIPTION
Addition to https://github.com/department-of-veterans-affairs/vets-api/pull/14552/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f

* update `ClientError` to `ServerError`
* `body` should be `response_body` in this context, but tests aren't properly catching issue