### PR TITLE
MHV-51341 Change 404 status to 202 when Patient record is not ready

### DIFF
--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -501,12 +501,17 @@ en:
         <<: *external_defaults
         code: "MEDICALRECORDS_401"
         detail: "Authentication failed on the upstream server"
-        status: 401
+        status: 400
       MEDICALRECORDS_403:
         <<: *external_defaults
         code: "MEDICALRECORDS_403"
         detail: "This user is forbidden from performing requests on the upstream server"
         status: 403
+      MEDICALRECORDS_404:
+        <<: *external_defaults
+        code: "MEDICALRECORDS_404"
+        detail: "The resource could not be found"
+        status: 404
       HCA422:
         <<: *external_defaults
         code: 'HCA422'

--- a/lib/medical_records/client.rb
+++ b/lib/medical_records/client.rb
@@ -4,6 +4,7 @@ require 'common/client/base'
 require 'common/client/concerns/mhv_fhir_session_client'
 require 'medical_records/client_session'
 require 'medical_records/configuration'
+require 'medical_records/patient_not_found'
 
 module MedicalRecords
   ##
@@ -274,27 +275,25 @@ module MedicalRecords
     end
 
     def handle_api_errors(result)
-      body = JSON.parse(result.body)
-      diagnostics = body['issue']&.first&.fetch('diagnostics', nil)
-      diagnostics = "Error fetching data#{": #{diagnostics}" if diagnostics}"
+      if result.code.present? && result.code >= 400
+        body = JSON.parse(result.body)
+        diagnostics = body['issue']&.first&.fetch('diagnostics', nil)
+        diagnostics = "Error fetching data#{": #{diagnostics}" if diagnostics}"
 
-      exception_class = case result.code
-                        when 401
-                          Common::Exceptions::Unauthorized
-                        when 403
-                          Common::Exceptions::Forbidden
-                        when 500
-                          if diagnostics.include? 'HAPI-1363'
-                            # HAPI-1363: Either No patient or multiple patient found
-                            Common::Exceptions::ResourceNotFound
-                          else
-                            Common::Exceptions::BadRequest
-                          end
-                        else
-                          Common::Exceptions::BadRequest
-                        end
+        # Special-case exception handling
+        if result.code == 500 && diagnostics.include?('HAPI-1363')
+          # "HAPI-1363: Either No patient or multiple patient found"
+          raise MedicalRecords::PatientNotFound
+        end
 
-      raise exception_class, { detail: diagnostics } if exception_class
+        # Default exception handling
+        raise Common::Exceptions::BackendServiceException.new(
+          "MEDICALRECORDS_#{result.code}",
+          status: result.code,
+          detail: diagnostics,
+          source: self.class.to_s
+        )
+      end
     end
 
     ##

--- a/lib/medical_records/patient_not_found.rb
+++ b/lib/medical_records/patient_not_found.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+##
+# This error is being used to convey that the user's patient FHIR record likely has not yet been created.
+#
+module MedicalRecords
+  class PatientNotFound < StandardError
+  end
+end

--- a/modules/my_health/app/controllers/my_health/v1/allergies_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/allergies_controller.rb
@@ -6,12 +6,16 @@ module MyHealth
       def index
         resource = client.list_allergies
         render json: resource.to_json
+      rescue ::MedicalRecords::PatientNotFound
+        render body: nil, status: :accepted
       end
 
       def show
         allergy_id = params[:id].try(:to_i)
         resource = client.get_allergy(allergy_id)
         render json: resource.to_json
+      rescue ::MedicalRecords::PatientNotFound
+        render body: nil, status: :accepted
       end
     end
   end

--- a/modules/my_health/app/controllers/my_health/v1/vaccines_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/vaccines_controller.rb
@@ -5,17 +5,17 @@ module MyHealth
     class VaccinesController < MrController
       def index
         resource = client.list_vaccines
-        raise Common::Exceptions::InternalServerError if resource.blank?
-
         render json: resource.to_json
+      rescue ::MedicalRecords::PatientNotFound
+        render body: nil, status: :accepted
       end
 
       def show
         vaccine_id = params[:id].try(:to_i)
         resource = client.get_vaccine(vaccine_id)
-        raise Common::Exceptions::InternalServerError if resource.blank?
-
         render json: resource.to_json
+      rescue ::MedicalRecords::PatientNotFound
+        render body: nil, status: :accepted
       end
     end
   end


### PR DESCRIPTION
## Summary
When a user accesses their FHIR records for the first time, their patient record has not yet been created. The FHIR server returns a specific 500-error in this case. In the frontend, if we receive this response, we poll the backend until we stop getting that error.

Previously we were translating that 500 error into a 404. This PR changes it to be a 202. It is an expected part of the application flow, so should not be an error.

Also made some general error-handling improvements.

Frontend Component: https://github.com/department-of-veterans-affairs/vets-website/pull/27005

## Related issue(s)
### [MHV-51341](https://jira.devops.va.gov/browse/MHV-51341) - Change vets-api response for Patient Record Not Found ###

> Change vets-api response for Patient Record Not Found
> 
> When a patient's records are accessed for the first time, they will not have a Patient Record until it is created. During that time, the backend will return 404s, which is not desirable for an expected response. Research to implement a better method. Perhaps use 202 instead.
> 
> User Story: As a Medical Record user, I want to see the correct response while my patient record is being created when I log in for the first time, so that I understand why there is a delay .
> 
> GIVEN:
> WHEN:
> THEN:
> 
> Feature Flag Y/N ? N
> Manual Testing Y/N ? N
> Automated Testing Y/N ? N
> Accessibility Testing Y/N ? N
> 
> Acceptance Criteria:
> AC1 Research is complete to develop a desirable response while the patient record is being created
> AC2 Implementation is complete,
> AC3 Question: Should this be documented in the PHR refresh documentation?
> Mike Moyer is documenting here:
> https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/digital-health-modernization/mhv-to-va.gov/medical-records/process/phr-refresh.md
> AC4 Development tickets created in Jira if changes are needed
> 
> Links to UCD:
> Sketch Link:
> Other Design Notes
> 
> Architectural Notes:

## Testing done

- Wrote spec tests to test the new error-handling functionality

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
