### PR TITLE
Use I18n.transliterate in metadata validator

### DIFF
--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -13,14 +13,14 @@ module SimpleFormsApiSubmission
 
     def self.validate_first_name(metadata)
       validate_presence_and_stringiness(metadata['veteranFirstName'], 'veteran first name')
-      I18n.transliterate(metadata['veteranFirstName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
+      metadata['veteranFirstName'] = I18n.transliterate(metadata['veteranFirstName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
 
       metadata
     end
 
     def self.validate_last_name(metadata)
       validate_presence_and_stringiness(metadata['veteranLastName'], 'veteran last name')
-      I18n.transliterate(metadata['veteranLastName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
+      metadata['veteranLastName'] = I18n.transliterate(metadata['veteranLastName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
 
       metadata
     end

--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -13,14 +13,14 @@ module SimpleFormsApiSubmission
 
     def self.validate_first_name(metadata)
       validate_presence_and_stringiness(metadata['veteranFirstName'], 'veteran first name')
-      I18n.transliterate(metadata['veteranFirstName']).gsub(%r{[^a-zA-Z\-\s]}, '').strip.first(50)
+      I18n.transliterate(metadata['veteranFirstName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
 
       metadata
     end
 
     def self.validate_last_name(metadata)
       validate_presence_and_stringiness(metadata['veteranLastName'], 'veteran last name')
-      I18n.transliterate(metadata['veteranLastName']).gsub(%r{[^a-zA-Z\-\s]}, '').strip.first(50)
+      I18n.transliterate(metadata['veteranLastName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
 
       metadata
     end

--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -13,14 +13,16 @@ module SimpleFormsApiSubmission
 
     def self.validate_first_name(metadata)
       validate_presence_and_stringiness(metadata['veteranFirstName'], 'veteran first name')
-      metadata['veteranFirstName'] = I18n.transliterate(metadata['veteranFirstName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
+      metadata['veteranFirstName'] =
+        I18n.transliterate(metadata['veteranFirstName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
 
       metadata
     end
 
     def self.validate_last_name(metadata)
       validate_presence_and_stringiness(metadata['veteranLastName'], 'veteran last name')
-      metadata['veteranLastName'] = I18n.transliterate(metadata['veteranLastName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
+      metadata['veteranLastName'] =
+        I18n.transliterate(metadata['veteranLastName']).gsub(/[^a-zA-Z\-\s]/, '').strip.first(50)
 
       metadata
     end

--- a/lib/simple_forms_api_submission/metadata_validator.rb
+++ b/lib/simple_forms_api_submission/metadata_validator.rb
@@ -13,16 +13,14 @@ module SimpleFormsApiSubmission
 
     def self.validate_first_name(metadata)
       validate_presence_and_stringiness(metadata['veteranFirstName'], 'veteran first name')
-      metadata['veteranFirstName'] = metadata['veteranFirstName'][0..49]
-      metadata['veteranFirstName'] = metadata['veteranFirstName'].gsub(%r{[^a-zA-Z\-\/\s]}, '')
+      I18n.transliterate(metadata['veteranFirstName']).gsub(%r{[^a-zA-Z\-\s]}, '').strip.first(50)
 
       metadata
     end
 
     def self.validate_last_name(metadata)
       validate_presence_and_stringiness(metadata['veteranLastName'], 'veteran last name')
-      metadata['veteranLastName'] = metadata['veteranLastName'][0..49]
-      metadata['veteranLastName'] = metadata['veteranLastName'].gsub(%r{[^a-zA-Z\-\/\s]}, '')
+      I18n.transliterate(metadata['veteranLastName']).gsub(%r{[^a-zA-Z\-\s]}, '').strip.first(50)
 
       metadata
     end

--- a/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
+++ b/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
@@ -72,9 +72,9 @@ describe SimpleFormsApiSubmission::MetadataValidator do
     end
 
     describe 'contains disallowed characters' do
-      it 'returns metadata with disallowed characters of veteran first name stripped' do
+      it 'returns metadata with disallowed characters of veteran first name stripped or corrected' do
         metadata = {
-          'veteranFirstName' => '2John~! - Jo/hn?\\',
+          'veteranFirstName' => '2Jöhn~! - Jo/hn?\\',
           'veteranLastName' => 'Doe',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
@@ -133,10 +133,10 @@ describe SimpleFormsApiSubmission::MetadataValidator do
     end
 
     describe 'contains disallowed characters' do
-      it 'returns metadata with disallowed characters of veteran last name stripped' do
+      it 'returns metadata with disallowed characters of veteran last name stripped or corrected' do
         metadata = {
           'veteranFirstName' => 'John',
-          'veteranLastName' => '2John~! - Jo/hn?\\',
+          'veteranLastName' => '2Jöhn~! - Jo/hn?\\',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
           'source' => 'VA Platform Digital Forms',

--- a/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
+++ b/spec/lib/simple_forms_api_submission/metadata_validator_spec.rb
@@ -83,7 +83,7 @@ describe SimpleFormsApiSubmission::MetadataValidator do
           'businessLine' => 'CMP'
         }
         expected_metadata = {
-          'veteranFirstName' => 'John - Jo/hn',
+          'veteranFirstName' => 'John - John',
           'veteranLastName' => 'Doe',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
@@ -145,7 +145,7 @@ describe SimpleFormsApiSubmission::MetadataValidator do
         }
         expected_metadata = {
           'veteranFirstName' => 'John',
-          'veteranLastName' => 'John - Jo/hn',
+          'veteranLastName' => 'John - John',
           'fileNumber' => '444444444',
           'zipCode' => '12345',
           'source' => 'VA Platform Digital Forms',


### PR DESCRIPTION
## Summary

This PR improves the metadata validator by running strings through `I18n.transliterate` before conforming to the strict regex required by Lighthouse. The transliteration involves converting letters like `ö` to `o` or `ñ` to `n` instead of just stripping them as the prior implementation would have done.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/71306


## Testing done

Test updated to exercise `ö` converting to `o`.

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
So far just Simple Forms API.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
