### PR TITLE
Allow same day as submission treatment dates

### DIFF
--- a/modules/appeals_api/app/models/concerns/appeals_api/model_validations.rb
+++ b/modules/appeals_api/app/models/concerns/appeals_api/model_validations.rb
@@ -105,7 +105,7 @@ module AppealsApi
             start_date = Date.parse(start_date_str)
             end_date = Date.parse(end_date_str)
 
-            valid_date_ranges = start_date <= end_date && start_date < Time.zone.today && end_date < Time.zone.today
+            valid_date_ranges = start_date <= end_date && start_date <= Time.zone.today && end_date <= Time.zone.today
 
             add_date_range_error(schema_pointer, start_date, end_date) unless valid_date_ranges
           end

--- a/modules/appeals_api/spec/models/supplemental_claim_spec.rb
+++ b/modules/appeals_api/spec/models/supplemental_claim_spec.rb
@@ -190,6 +190,34 @@ describe AppealsApi::SupplementalClaim, type: :model do
                                       'Both dates must also be in the past.'
         end
       end
+
+      context "when 'evidenceSubmission.retrieveFrom.endDate' is in the future" do
+        it 'errors with a point to the offending evidenceDates index' do
+          retrieve_from = appeal.form_data['data']['attributes']['evidenceSubmission']['retrieveFrom']
+          end_date = (Time.zone.today + 1.day).to_s
+          retrieve_from[2]['attributes']['evidenceDates'][0]['endDate'] = end_date
+
+          expect(appeal.valid?).to be false
+          expect(appeal.errors.size).to eq 1
+          error = appeal.errors.first
+          expect(error.attribute)
+            .to eq(:"/data/attributes/evidenceSubmission/retrieveFrom[2]/attributes/evidenceDates[0]")
+          expect(error.message).to eq "2020-04-10 must before or the same day as #{end_date}. " \
+                                      'Both dates must also be in the past.'
+        end
+      end
+
+      context "when 'evidenceSubmission.retrieveFrom.endDate' is same as submission date" do
+        it 'does not errort' do
+          retrieve_from = appeal.form_data['data']['attributes']['evidenceSubmission']['retrieveFrom']
+          end_date = (Time.zone.today).to_s
+          retrieve_from[2]['attributes']['evidenceDates'][0]['endDate'] = end_date
+
+          expect(appeal.valid?).to be true
+          expect(appeal.errors.size).to eq 0
+        end
+      end
+
     end
 
     describe '#veteran_dob_month' do

--- a/modules/appeals_api/spec/models/supplemental_claim_spec.rb
+++ b/modules/appeals_api/spec/models/supplemental_claim_spec.rb
@@ -210,14 +210,13 @@ describe AppealsApi::SupplementalClaim, type: :model do
       context "when 'evidenceSubmission.retrieveFrom.endDate' is same as submission date" do
         it 'does not errort' do
           retrieve_from = appeal.form_data['data']['attributes']['evidenceSubmission']['retrieveFrom']
-          end_date = (Time.zone.today).to_s
+          end_date = Time.zone.today.to_s
           retrieve_from[2]['attributes']['evidenceDates'][0]['endDate'] = end_date
 
           expect(appeal.valid?).to be true
           expect(appeal.errors.size).to eq 0
         end
       end
-
     end
 
     describe '#veteran_dob_month' do


### PR DESCRIPTION
## Summary

We decided to allow retrieve evidence end dates to be on or before the submission date.  Occasionally, we get vets that visits a medical provider and files a supplemental claim on the same day.  It's not clear where the original restriction(had to be before submission date) came from, we think it was added just as a sanity check, but after considering the situation, this seems like a reasonable change.

Team banana peels, we own this code

## Related issue(s)
Original ticket that introduced the rule:
https://jira.devops.va.gov/browse/API-17448

Ticket for this change:
https://jira.devops.va.gov/browse/API-31707


## Testing done

- Unit test coverage


## What areas of the site does it impact?
*Supp Claims evidence retrieval start date and end date validation

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs


