### PR TITLE
Claims API: Adds POA v2 routes

### DIFF
--- a/modules/claims_api/config/routes.rb
+++ b/modules/claims_api/config/routes.rb
@@ -44,6 +44,11 @@ ClaimsApi::Engine.routes.draw do
       post '/:veteranId/claims/:id/5103', to: 'evidence_waiver#submit'
       ## 2122 Forms
       get '/:veteranId/power-of-attorney', to: 'power_of_attorney#show'
+      post '/:veteranId/2122/validate', to: 'power_of_attorney#validate_2122'
+      post '/:veteranId/2122', to: 'power_of_attorney#submit_2122'
+      post '/:veteranId/2122a/validate', to: 'power_of_attorney#validate_2122a'
+      post '/:veteranId/2122a', to: 'power_of_attorney#submit_2122a'
+      get '/:veteranId/power-of-attorney/:id', to: 'power_of_attorney#status'
       put '/:veteranId/power-of-attorney:appoint-organization', to: 'power_of_attorney#appoint_organization',
                                                                 constraints: { 'appoint-organization': /:appoint-organization/ } # rubocop:disable Layout/LineLength
       put '/:veteranId/power-of-attorney:appoint-individual', to: 'power_of_attorney#appoint_individual',

--- a/modules/claims_api/spec/routing/v2/veterans/power_of_attorney_routing_spec.rb
+++ b/modules/claims_api/spec/routing/v2/veterans/power_of_attorney_routing_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Claims API power of attorney routing', type: :routing do
+  base_path = '/services/claims/v2/'
+  expected_controller = 'claims_api/v2/veterans/power_of_attorney'
+
+  it "routes #{base_path}/veterans/:veteranId/power-of-attorney to PowerOfAttorneyController#show" do
+    poa_path = "#{base_path}/veterans/123/power-of-attorney"
+
+    expect(get(poa_path)).to route_to(
+      format: 'json',
+      controller: expected_controller,
+      action: 'show',
+      veteranId: '123'
+    )
+  end
+
+  it "routes #{base_path}/veterans/:veteranId/2122/validate to PowerOfAttorneyController#validate_2122" do
+    validate_2122_path = "#{base_path}/veterans/123/2122/validate"
+
+    expect(post(validate_2122_path)).to route_to(
+      format: 'json',
+      controller: expected_controller,
+      action: 'validate_2122',
+      veteranId: '123'
+    )
+  end
+
+  it "routes #{base_path}/veterans/:veteranId/2122 to PowerOfAttorneyController#submit_2122" do
+    submit_2122_path = "#{base_path}/veterans/123/2122"
+
+    expect(post(submit_2122_path)).to route_to(
+      format: 'json',
+      controller: expected_controller,
+      action: 'submit_2122',
+      veteranId: '123'
+    )
+  end
+
+  it "routes #{base_path}/veterans/:veteranId/2122a/validate to PowerOfAttorneyController#validate_2122a" do
+    validate_2122a_path = "#{base_path}/veterans/123/2122a/validate"
+
+    expect(post(validate_2122a_path)).to route_to(
+      format: 'json',
+      controller: expected_controller,
+      action: 'validate_2122a',
+      veteranId: '123'
+    )
+  end
+
+  it "routes #{base_path}/veterans/:veteranId/2122a to PowerOfAttorneyController#submit_2122a" do
+    submit_2122a_path = "#{base_path}/veterans/123/2122a"
+
+    expect(post(submit_2122a_path)).to route_to(
+      format: 'json',
+      controller: expected_controller,
+      action: 'submit_2122a',
+      veteranId: '123'
+    )
+  end
+
+  it "routes #{base_path}/veterans/:veteranId/power-of-attorney/:id to PowerOfAttorneyController#status" do
+    poa_status_path = "#{base_path}/veterans/123/power-of-attorney/456"
+
+    expect(get(poa_status_path)).to route_to(
+      format: 'json',
+      controller: expected_controller,
+      action: 'status',
+      veteranId: '123',
+      id: '456'
+    )
+  end
+end


### PR DESCRIPTION
Adds routes for new Power of Attorney v2 endpoints.


## Summary

- Adds routes for new Power of Attorney v2 endpoints.
- Adds routing specs for the new routes

## Related issue(s)

- [API-32083](https://jira.devops.va.gov/browse/API-32083)

## Testing done

- RSpec request routes were added


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature