### PR TITLE
Adds trace service tags for disability rating endpoints

### DIFF
--- a/app/controllers/v0/rated_disabilities_controller.rb
+++ b/app/controllers/v0/rated_disabilities_controller.rb
@@ -4,6 +4,7 @@ require 'lighthouse/veteran_verification/service'
 
 module V0
   class RatedDisabilitiesController < ApplicationController
+    service_tag 'disability-rating'
     before_action { authorize :lighthouse, :access? }
 
     def show

--- a/app/controllers/v0/rated_disabilities_discrepancies_controller.rb
+++ b/app/controllers/v0/rated_disabilities_discrepancies_controller.rb
@@ -5,6 +5,7 @@ require 'lighthouse/veteran_verification/service'
 
 module V0
   class RatedDisabilitiesDiscrepanciesController < ApplicationController
+    service_tag 'disability-rating'
     before_action { authorize :evss, :access? }
     before_action { authorize :lighthouse, :access? }
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
Uses new Traceable concern to tag rated disability controllers so their spans will be categorized appropriately in Datadog.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/66141


## Testing done


## Screenshots
_Note: Optional_


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria


## Requested Feedback
