### PR TITLE
Bump betamocks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,13 +24,13 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/betamocks
-  revision: e4b71ca3cc32481392676d817120368c5af9e709
+  revision: 4a1e3ca30bd3a9df857534089a41c93236d51c73
   branch: master
   specs:
-    betamocks (0.9.1)
+    betamocks (0.10.0)
       activesupport (>= 4.2)
       adler32
-      faraday (>= 0.7.4, < 2.0)
+      faraday (>= 1, < 2.0)
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/bgs-ext.git


### PR DESCRIPTION
Bump Betamocks after bumping gem version [here](https://github.com/department-of-veterans-affairs/betamocks/pull/61)