### PR TITLE
Database changes for adding form submission models

### DIFF
--- a/db/migrate/20231207022742_create_form_submissions.rb
+++ b/db/migrate/20231207022742_create_form_submissions.rb
@@ -1,0 +1,19 @@
+class CreateFormSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :form_submissions do |t|
+      t.string :form_type, null: false
+      t.uuid :benefits_intake_uuid, null: false
+      t.uuid :submitted_claim_uuid
+      t.jsonb :form_data, default: {}
+      t.references :user_account, foreign_key: true, type: :uuid
+      t.references :saved_claim, foreign_key: true
+      t.references :in_progress_form, foreign_key: true
+      t.text :encrypted_kms_key
+
+      t.timestamps
+    end
+
+    add_index :form_submissions, :benefits_intake_uuid
+    add_index :form_submissions, :submitted_claim_uuid
+  end
+end

--- a/db/migrate/20231207022742_create_form_submissions.rb
+++ b/db/migrate/20231207022742_create_form_submissions.rb
@@ -2,7 +2,7 @@ class CreateFormSubmissions < ActiveRecord::Migration[6.1]
   def change
     create_table :form_submissions do |t|
       t.string :form_type, null: false
-      t.uuid :benefits_intake_uuid, null: false
+      t.uuid :benefits_intake_uuid
       t.uuid :submitted_claim_uuid
       t.jsonb :form_data, default: {}
       t.references :user_account, foreign_key: true, type: :uuid

--- a/db/migrate/20231207022820_create_form_submission_attempts.rb
+++ b/db/migrate/20231207022820_create_form_submission_attempts.rb
@@ -1,0 +1,13 @@
+class CreateFormSubmissionAttempts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :form_submission_attempts do |t|
+      t.references :form_submission, foreign_key: true, null: false
+      t.jsonb :response
+      t.string :aasm_state
+      t.string :error_message
+      t.text :encrypted_kms_key
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_01_160018) do
+ActiveRecord::Schema.define(version: 2023_12_07_022820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -620,6 +620,35 @@ ActiveRecord::Schema.define(version: 2023_12_01_160018) do
     t.text "encrypted_kms_key"
     t.index ["guid", "type"], name: "index_form_attachments_on_guid_and_type", unique: true
     t.index ["id", "type"], name: "index_form_attachments_on_id_and_type"
+  end
+
+  create_table "form_submission_attempts", force: :cascade do |t|
+    t.bigint "form_submission_id", null: false
+    t.jsonb "response"
+    t.string "aasm_state"
+    t.string "error_message"
+    t.text "encrypted_kms_key"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["form_submission_id"], name: "index_form_submission_attempts_on_form_submission_id"
+  end
+
+  create_table "form_submissions", force: :cascade do |t|
+    t.string "form_type", null: false
+    t.uuid "benefits_intake_uuid", null: false
+    t.uuid "submitted_claim_uuid"
+    t.jsonb "form_data", default: {}
+    t.uuid "user_account_id"
+    t.bigint "saved_claim_id"
+    t.bigint "in_progress_form_id"
+    t.text "encrypted_kms_key"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["benefits_intake_uuid"], name: "index_form_submissions_on_benefits_intake_uuid"
+    t.index ["in_progress_form_id"], name: "index_form_submissions_on_in_progress_form_id"
+    t.index ["saved_claim_id"], name: "index_form_submissions_on_saved_claim_id"
+    t.index ["submitted_claim_uuid"], name: "index_form_submissions_on_submitted_claim_uuid"
+    t.index ["user_account_id"], name: "index_form_submissions_on_user_account_id"
   end
 
   create_table "gibs_not_found_users", id: :serial, force: :cascade do |t|
@@ -1255,6 +1284,10 @@ ActiveRecord::Schema.define(version: 2023_12_01_160018) do
   add_foreign_key "evss_claims", "user_accounts"
   add_foreign_key "form526_submissions", "user_accounts"
   add_foreign_key "form5655_submissions", "user_accounts"
+  add_foreign_key "form_submission_attempts", "form_submissions"
+  add_foreign_key "form_submissions", "in_progress_forms"
+  add_foreign_key "form_submissions", "saved_claims"
+  add_foreign_key "form_submissions", "user_accounts"
   add_foreign_key "health_quest_questionnaire_responses", "user_accounts"
   add_foreign_key "in_progress_forms", "user_accounts"
   add_foreign_key "inherited_proof_verified_user_accounts", "user_accounts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -635,7 +635,7 @@ ActiveRecord::Schema.define(version: 2023_12_07_022820) do
 
   create_table "form_submissions", force: :cascade do |t|
     t.string "form_type", null: false
-    t.uuid "benefits_intake_uuid", null: false
+    t.uuid "benefits_intake_uuid"
     t.uuid "submitted_claim_uuid"
     t.jsonb "form_data", default: {}
     t.uuid "user_account_id"


### PR DESCRIPTION
## Summary
This pulls out the database changes required for saving form submissions and form submission attempts from [this, old, PR](https://github.com/department-of-veterans-affairs/vets-api/pull/14798). The related model changes for this PR [are here](https://github.com/department-of-veterans-affairs/vets-api/pull/14802). Looks like we have protections against combining database changes and other application changes in one PR, so it's isolated here.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/71336