### PR TITLE
mobile - adds logging to claims and decisions letters

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -710,6 +710,10 @@ features:
     actor_type: user
     description: filters out doc type 27 decision letters out of list of decision letters for mobile
     enable_in_development: false
+  mobile_claims_log_decision_letter_sent:
+    actor_type: user
+    description: Logs decision letter info on both claims and decision letter endpoint
+    enable_in_development: true
   multiple_address_10_10ez:
     actor_type: cookie_id
     description: >

--- a/modules/mobile/app/controllers/mobile/v0/claims_and_appeals_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/claims_and_appeals_controller.rb
@@ -137,14 +137,14 @@ module Mobile
 
         return nil if decision_letters_sent.empty?
 
-        claims_decision_letters_sent = decision_letters_sent.select { |item| item.type == 'claim' }
-        appeals_decision_letters_sent = decision_letters_sent.select { |item| item.type == 'appeal' }
+        claims_decision_letters_sent = decision_letters_sent.count { |item| item.type == 'claim' }
+        appeals_decision_letters_sent = decision_letters_sent.count { |item| item.type == 'appeal' }
 
         Rails.logger.info('MOBILE CLAIM DECISION LETTERS SENT COUNT',
                           user_uuid: @current_user.uuid,
                           user_icn: @current_user.icn,
-                          claims_decision_letter_sent_count: claims_decision_letters_sent.count,
-                          appeals_decision_letter_sent_count: appeals_decision_letters_sent.count,
+                          claims_decision_letter_sent_count: claims_decision_letters_sent,
+                          appeals_decision_letter_sent_count: appeals_decision_letters_sent,
                           decision_letter_sent_ids: decision_letters_sent.map(&:id))
       end
 

--- a/modules/mobile/app/controllers/mobile/v0/claims_and_appeals_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/claims_and_appeals_controller.rb
@@ -137,9 +137,8 @@ module Mobile
 
         return nil if decision_letters_sent.empty?
 
-        claims_decision_letters_sent = decision_letters_sent.select{|item| item.type == 'claim'}
-        appeals_decision_letters_sent = decision_letters_sent.select{|item| item.type == 'appeal'}
-
+        claims_decision_letters_sent = decision_letters_sent.select { |item| item.type == 'claim' }
+        appeals_decision_letters_sent = decision_letters_sent.select { |item| item.type == 'appeal' }
 
         Rails.logger.info('MOBILE CLAIM DECISION LETTERS SENT COUNT',
                           user_uuid: @current_user.uuid,

--- a/modules/mobile/app/controllers/mobile/v0/claims_and_appeals_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/claims_and_appeals_controller.rb
@@ -119,6 +119,7 @@ module Mobile
         status = get_response_status(errors)
         list = filter_by_date(validated_params[:start_date], validated_params[:end_date], list)
         list = filter_by_completed(list) if params[:showCompleted].present?
+        log_decision_letter_sent(list) if Flipper.enabled?(:mobile_claims_log_decision_letter_sent)
         list, meta = paginate(list, validated_params)
 
         options = {
@@ -129,6 +130,18 @@ module Mobile
         }
 
         [Mobile::V0::ClaimOverviewSerializer.new(list, options), status]
+      end
+
+      def log_decision_letter_sent(list)
+        decision_letter_sent_claims = list.select(&:decision_letter_sent)
+
+        return nil if decision_letter_sent_claims.empty?
+
+        Rails.logger.info('MOBILE CLAIM DECISION LETTERS SENT COUNT',
+                          user_uuid: @current_user.uuid,
+                          user_icn: @current_user.icn,
+                          decision_letter_sent_count: decision_letter_sent_claims.count,
+                          decision_letter_sent_ids: decision_letter_sent_claims.map(&:id))
       end
 
       def fetch_claims_and_appeals

--- a/modules/mobile/app/controllers/mobile/v0/claims_and_appeals_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/claims_and_appeals_controller.rb
@@ -133,15 +133,20 @@ module Mobile
       end
 
       def log_decision_letter_sent(list)
-        decision_letter_sent_claims = list.select(&:decision_letter_sent)
+        decision_letters_sent = list.select(&:decision_letter_sent)
 
-        return nil if decision_letter_sent_claims.empty?
+        return nil if decision_letters_sent.empty?
+
+        claims_decision_letters_sent = decision_letters_sent.select{|item| item.type == 'claim'}
+        appeals_decision_letters_sent = decision_letters_sent.select{|item| item.type == 'appeal'}
+
 
         Rails.logger.info('MOBILE CLAIM DECISION LETTERS SENT COUNT',
                           user_uuid: @current_user.uuid,
                           user_icn: @current_user.icn,
-                          decision_letter_sent_count: decision_letter_sent_claims.count,
-                          decision_letter_sent_ids: decision_letter_sent_claims.map(&:id))
+                          claims_decision_letter_sent_count: claims_decision_letters_sent.count,
+                          appeals_decision_letter_sent_count: appeals_decision_letters_sent.count,
+                          decision_letter_sent_ids: decision_letters_sent.map(&:id))
       end
 
       def fetch_claims_and_appeals

--- a/modules/mobile/app/controllers/mobile/v0/decision_letters_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/decision_letters_controller.rb
@@ -9,7 +9,10 @@ module Mobile
 
       def index
         response = service.get_letters
-        render json: Mobile::V0::DecisionLetterSerializer.new(decision_letters_adapter.parse(response))
+        list = decision_letters_adapter.parse(response)
+        log_decision_letters(list) if Flipper.enabled?(:mobile_claims_log_decision_letter_sent)
+
+        render json: Mobile::V0::DecisionLetterSerializer.new(list)
       end
 
       def download
@@ -21,6 +24,18 @@ module Mobile
       end
 
       private
+
+      def log_decision_letters(list)
+
+        return nil if list.empty?
+
+        Rails.logger.info('MOBILE DECISION LETTERS COUNT',
+                          user_uuid: @current_user.uuid,
+                          user_icn: @current_user.icn,
+                          decision_letter_sent_count: list.count,
+                          decision_letter_doc_type: list.map(&:doc_type),
+                          filtered_out_doc_type_27: Flipper.enabled?(:mobile_filter_doc_27_decision_letters_out))
+      end
 
       def decision_letters_adapter
         Mobile::V0::Adapters::DecisionLetters.new

--- a/modules/mobile/app/controllers/mobile/v0/decision_letters_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/decision_letters_controller.rb
@@ -26,7 +26,6 @@ module Mobile
       private
 
       def log_decision_letters(list)
-
         return nil if list.empty?
 
         Rails.logger.info('MOBILE DECISION LETTERS COUNT',
@@ -34,7 +33,7 @@ module Mobile
                           user_icn: @current_user.icn,
                           decision_letter_sent_count: list.count,
                           decision_letter_doc_type: list.map(&:doc_type),
-                          filtered_out_doc_type_27: Flipper.enabled?(:mobile_filter_doc_27_decision_letters_out))
+                          filtered_out_doc_type27: Flipper.enabled?(:mobile_filter_doc_27_decision_letters_out))
       end
 
       def decision_letters_adapter

--- a/modules/mobile/spec/request/claims_and_appeals_overview_request_spec.rb
+++ b/modules/mobile/spec/request/claims_and_appeals_overview_request_spec.rb
@@ -16,6 +16,8 @@ RSpec.shared_examples 'claims and appeals overview' do |lighthouse_flag|
   end
 
   before do
+    Flipper.enable(:mobile_claims_log_decision_letter_sent)
+
     if lighthouse_flag
       token = 'abcdefghijklmnop'
       allow_any_instance_of(BenefitsClaims::Configuration).to receive(:access_token).and_return(token)
@@ -24,6 +26,8 @@ RSpec.shared_examples 'claims and appeals overview' do |lighthouse_flag|
       Flipper.disable(:mobile_lighthouse_claims)
     end
   end
+
+  after { Flipper.disable(:mobile_claims_log_decision_letter_sent) }
 
   describe '#index is polled an unauthorized user' do
     it 'and not user returns a 401 status' do

--- a/modules/mobile/spec/request/decision_letters_request_spec.rb
+++ b/modules/mobile/spec/request/decision_letters_request_spec.rb
@@ -12,11 +12,13 @@ RSpec.describe 'decision letters', type: :request do
 
   before do
     allow(VBMS::Client).to receive(:from_env_vars).and_return(FakeVBMS.new)
-    Flipper.disable('mobile_filter_doc_27_decision_letters_out')
+    Flipper.enable(:mobile_claims_log_decision_letter_sent)
+    Flipper.disable(:mobile_filter_doc_27_decision_letters_out)
   end
 
   after do
-    Flipper.disable('mobile_filter_doc_27_decision_letters_out')
+    Flipper.disable(:mobile_claims_log_decision_letter_sent)
+    Flipper.disable(:mobile_filter_doc_27_decision_letters_out)
   end
 
   # This endpoint's upstream service mocks it's own data for test env. HTTP client is not exposed by the


### PR DESCRIPTION
## Summary
this adds logs to determine if the flag `decisionLetterSent` in a claim, always matches up with a decision letter. This is two different logs that will have to be done manually by taking both logs and comparing the user icn or uuid and matching up the counts of letters

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/7234

## Testing done

- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *Describe the tests completed and the results*

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
