### PR TITLE
Mobile: Add in appeals to claims count

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/claims_and_appeals_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/claims_and_appeals_controller.rb
@@ -241,7 +241,7 @@ module Mobile
       end
 
       def active_claims_count(list)
-        list.count { |item| item.type == 'claim' && item.completed == false }
+        list.count { |item| item.completed == false }
       end
     end
   end

--- a/modules/mobile/spec/request/claims_and_appeals_overview_request_spec.rb
+++ b/modules/mobile/spec/request/claims_and_appeals_overview_request_spec.rb
@@ -258,7 +258,7 @@ RSpec.shared_examples 'claims and appeals overview' do |lighthouse_flag|
     end
 
     describe 'active_claims_count' do
-      it 'aggregates all incomplete claims into active_claims_count' do
+      it 'aggregates all incomplete claims and appeals into active_claims_count' do
         VCR.use_cassette(good_claims_response_vcr_path) do
           VCR.use_cassette('mobile/appeals/appeals') do
             get('/mobile/v0/claims-and-appeals-overview', headers: sis_headers, params:)
@@ -266,9 +266,9 @@ RSpec.shared_examples 'claims and appeals overview' do |lighthouse_flag|
         end
 
         expect(response).to have_http_status(:ok)
-        expected_count = lighthouse_flag ? 4 : 3
+        expected_count = lighthouse_flag ? 7 : 6
         active_claims_count = response.parsed_body['data'].count do |item|
-          item['type'] == 'claim' && item['attributes']['completed'] == false
+          item['attributes']['completed'] == false
         end
         expect(active_claims_count).to eq(expected_count)
         expect(response.parsed_body.dig('meta', 'activeClaimsCount')).to eq(expected_count)


### PR DESCRIPTION
## Summary
Adds in appeals to claims count for mobile

## Related issue(s)
- [department-of-veterans-affairs/va.gov-team#7468](https://github.com/department-of-veterans-affairs/va-mobile-app/issues/7468)


## Testing done
Changed test to check claims + appeals count

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
meta description of single mobile endpoint

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
