### PR TITLE
[DR-70429] update vets-json-schema to use version with timezone enums removed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,10 +57,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: cbff1da81e28edc6157931e1e1e53f2ad102e6bd
+  revision: 6b17e3975a42babafa14f4cfb9db7e376cd7fafe
   branch: master
   specs:
-    vets_json_schema (20.32.0)
+    vets_json_schema (20.33.5)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 


### PR DESCRIPTION
## Summary
This updates the vets-json-schema, where there were updates to the appeals (v1) schemas to remove the timezone enums — it was causing issues because it needed to be updated after Lighthouse updated their timezone schemas and we decided for better maintainability we would just rely on Lighthouse to validate the timezone value. 

> Which team do you work for
Benefits Decision Reviews


## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/70429


## Testing done

- Manual tests locally — went through each form and confirmed I could submit them all. I even hard coded the original timezone (`America/Ciudad_Juarez`) into the frontend to make sure that it could submit and it did.

**NOTE**: I'm not sure that it'll be a huge issue once we switch to v2 NOD, but v1 NOD is still being used and _that_ version uses an older set of timezones that are actually [defined in vets-api](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/decision_review/service.rb#L77) so in theory, if a veteran were to submit a v1 NOD request from a more newly defined timezone, they could run into the same issue as before. However, we could fix it easily (without having to go through vets-json-schema) if we really had to, _and_ the original veteran who had this problem seems to have found away to resubmit, so even if we do have that error before switching back to v2, we should be okay. I just wanted to flag it as something we might see. cc: @data-doge 

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
Appeals

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
