### PR TITLE
Raise exception if params don't have form number

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -72,10 +72,7 @@ module SimpleFormsApi
 
       def submit_form_to_central_mail
         parsed_form_data = form_is210966 ? handle_210966_data : JSON.parse(params.to_json)
-        form_number = params[:form_number]
-        raise 'missing form_number in params' unless form_number
-
-        form_id = FORM_NUMBER_MAP[form_number]
+        form_id = get_form_id
         filler = SimpleFormsApi::PdfFiller.new(form_number: form_id, data: parsed_form_data)
 
         file_path = filler.generate
@@ -154,6 +151,13 @@ module SimpleFormsApi
         end
 
         data
+      end
+
+      def get_form_id
+        form_number = params[:form_number]
+        raise 'missing form_number in params' unless form_number
+
+        FORM_NUMBER_MAP[form_number]
       end
     end
   end


### PR DESCRIPTION
## Summary

This raises an exception for a case that we saw on a mobbing session today. If, as often happens, we are doing the data mapping exercise and forget to add `"form_number"` to the test data, it'll give a better error now.

## Related issue(s)
N/A