### PR TITLE
Bump Betamocks -> 0.11.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,13 +24,13 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/betamocks
-  revision: 4a1e3ca30bd3a9df857534089a41c93236d51c73
+  revision: 8233129def00c29b33e56ac5ad6d08f5442d665c
   branch: master
   specs:
-    betamocks (0.10.0)
+    betamocks (0.11.0)
       activesupport (>= 4.2)
       adler32
-      faraday (>= 1, < 2.0)
+      faraday (>= 1.2.0, < 3.0)
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/bgs-ext.git


### PR DESCRIPTION
Bump Betamocks to new version after [this](https://github.com/department-of-veterans-affairs/betamocks/pull/62) PR