### PR TITLE
Create sidekiq attr package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -918,6 +918,7 @@ lib/rx @department-of-veterans-affairs/mobile-api-team
 lib/saml @department-of-veterans-affairs/vsp-identity
 lib/search @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/sftp_writer @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
+lib/sidekiq/attr_package.rb @department-of-veterans-affairs/vsp-identity @department-of-veterans-affairs/backend-review-group
 lib/sidekiq/error_tag.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 lib/sidekiq/form526_backup_submission_process @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 lib/sidekiq/form526_backup_submission_process/submit_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/dbex-trex @department-of-veterans-affairs/benefits-disability-2 @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
@@ -1370,6 +1371,7 @@ spec/lib/sentry @department-of-veterans-affairs/va-api-engineers @department-of-
 spec/lib/sftp_writer @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/sftp_writer/factory_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/sftp_writer/remote_spec.rb @department-of-veterans-affairs/backend-review-group
+spec/lib/sidekiq/attr_package_spec.rb @department-of-veterans-affairs/vsp-identity @department-of-veterans-affairs/backend-review-group
 spec/lib/sidekiq/error_tag_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/sidekiq/form526_backup_submission_process @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/dbex-trex @department-of-veterans-affairs/benefits-disability-2 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/dbex-trex @department-of-veterans-affairs/benefits-disability-2 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -193,6 +193,9 @@ development: &defaults
   va_profile_veteran_status:
     namespace: va_profile_veteran_status
     each_ttl: 86400
+  sidekiq_attr_package:
+    namespace: sidekiq_attr_package
+    each_ttl: 604800
 test:
   <<: *defaults
   redis:

--- a/lib/sidekiq/attr_package.rb
+++ b/lib/sidekiq/attr_package.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  class AttrPackage
+    REDIS_NAMESPACE = 'sidekiq_attr_package'
+
+    class << self
+      # Create a new attribute package
+      # @param expires_in [Integer] the expiration time in days
+      # @param attrs [Hash] the attributes to be stored
+      # @return [String] the key of the stored attributes
+      def create(expires_in: 7.days, **attrs)
+        json_attrs = attrs.to_json
+        key = Digest::SHA256.hexdigest(json_attrs)
+
+        redis.set(key, json_attrs, ex: expires_in)
+
+        key
+      rescue => e
+        raise AttrPackageError.new('create', e.message)
+      end
+
+      # Find an attribute package by key
+      # @param key [String] the key of the attribute package
+      # @return [Hash, nil] the found attributes, or nil if not found
+      def find(key)
+        json_value = redis.get(key)
+        return nil unless json_value
+
+        JSON.parse(json_value, symbolize_names: true).tap do
+          redis.del(key)
+        end
+      rescue => e
+        raise AttrPackageError.new('find', e.message)
+      end
+
+      private
+
+      def redis
+        @redis ||= Redis::Namespace.new(REDIS_NAMESPACE, redis: $redis) # rubocop:disable ThreadSafety/InstanceVariableInClassMethod
+      end
+    end
+  end
+
+  class AttrPackageError < StandardError
+    def initialize(method, message)
+      super("[Sidekiq] [AttrPackage] #{method} error: #{message}")
+    end
+  end
+end

--- a/spec/lib/sidekiq/attr_package_spec.rb
+++ b/spec/lib/sidekiq/attr_package_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/attr_package'
+
+RSpec.describe Sidekiq::AttrPackage do
+  let(:redis_double) { instance_double(Redis::Namespace) }
+
+  before do
+    allow(Redis::Namespace).to receive(:new).and_return(redis_double)
+    allow(redis_double).to receive(:set)
+    allow(redis_double).to receive(:get)
+    allow(redis_double).to receive(:del)
+  end
+
+  after do
+    described_class.instance_variable_set(:@redis, nil)
+  end
+
+  describe '.create' do
+    let(:attrs) { { foo: 'bar' } }
+    let(:expected_key) { Digest::SHA256.hexdigest(attrs.to_json) }
+
+    context 'when no expiration is provided' do
+      it 'stores attributes in Redis and returns a key' do
+        expect(redis_double).to receive(:set).with(expected_key, attrs.to_json, ex: 7.days)
+        key = described_class.create(**attrs)
+        expect(key).to eq(expected_key)
+      end
+    end
+
+    context 'when an expiration is provided' do
+      let(:expires_in) { 1.day }
+
+      it 'stores attributes in Redis and returns a key' do
+        expect(redis_double).to receive(:set).with(expected_key, attrs.to_json, ex: expires_in)
+        key = described_class.create(expires_in:, **attrs)
+        expect(key).to eq(expected_key)
+      end
+    end
+
+    context 'when an error occurs' do
+      let(:expected_error_message) { '[Sidekiq] [AttrPackage] create error: Redis error' }
+
+      before do
+        allow(redis_double).to receive(:set).and_raise('Redis error')
+      end
+
+      it 'raises an AttrPackageError' do
+        expect do
+          described_class.create(**attrs)
+        end.to raise_error(Sidekiq::AttrPackageError).with_message(expected_error_message)
+      end
+    end
+  end
+
+  describe '.find' do
+    let(:key) { 'some_key' }
+
+    context 'when the key exists' do
+      let(:json_attrs) { { foo: 'bar' }.to_json }
+
+      before do
+        allow(redis_double).to receive(:get).with(key).and_return(json_attrs)
+      end
+
+      it 'retrieves and deletes the attribute package from Redis' do
+        expect(redis_double).to receive(:del).with(key)
+
+        result = described_class.find(key)
+        expect(result).to eq({ foo: 'bar' })
+      end
+    end
+
+    context 'when the key does not exist' do
+      before do
+        allow(redis_double).to receive(:get).with(key).and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(described_class.find(key)).to be_nil
+      end
+    end
+
+    context 'when an error occurs' do
+      let(:expected_error_message) { '[Sidekiq] [AttrPackage] find error: Redis error' }
+
+      before do
+        allow(redis_double).to receive(:get).with(key).and_raise('Redis error')
+      end
+
+      it 'raises an AttrPackageError and does not delete the package' do
+        expect(redis_double).not_to receive(:del)
+        expect do
+          described_class.find(key)
+        end.to raise_error(Sidekiq::AttrPackageError).with_message(expected_error_message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This creates a new sidekiq class - `AttrPackage`

The goal of this class is the create an "attribute package" that could potentially contain PII or sensitive info, store it in redis, pass the redis key to your job and then inside your job retreive the package from redis and use the attributes in your job. The default expiration is 7 days but is an optional parameter

### How to use
```ruby
require 'sidekiq/attr_package'

# Store attr_package and get redis key
attr_package_key = Sidekiq::AttrPackage.create(icn: '123498767V234859', signature_name: 'John Doe', version: '1.0.0')

# Kick off your job passing the key
 TermsOfUse::SignUpServiceUpdaterJob.perform_async(attr_package_key)

# inside your job retrieve the attributes from redis 

def perform(attr_key)
  attrs = Sidekiq::AttrPackage.find(attr_key)
  # {:icn=>"123498767V234859", :signature_name=>"John Doe", :version=>"1.0.0"}

  @icn = attrs[:icn]
  @signature_name = attrs[:signature_name]
  @version = attrs[:version]
end 
```

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#70163

## Testing

- Open rails console - `rails c`
- Create a package and retrieve the key
   ```ruby
    require 'sidekiq/attr_package

   Sidekiq::AttrPackage.create(icn: '123498767V234859', signature_name: 'John Doe', version: '1.0.0')
   ```
- Find the package with key
   ```ruby
   Sidekiq::AttrPackage.find("key")
   ```




