### PR TITLE
API-32294 confinement date validation fix

### DIFF
--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_validation_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_validation_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'claims_api/v2/disability_compensation_validation'
+
+# Calling private methods so needed to wrap it in a class
+class TestDisabilityCompensationValidationClass
+  include ClaimsApi::V2::DisabilityCompensationValidation
+end
+
+describe TestDisabilityCompensationValidationClass do
+  subject(:test_526_validation_instance) { described_class.new }
+
+  let(:auto_claim) do
+    JSON.parse(
+      Rails.root.join(
+        'modules',
+        'claims_api',
+        'spec',
+        'fixtures',
+        'v2',
+        'veterans',
+        'disability_compensation',
+        'form_526_json_api.json'
+      ).read
+    )
+  end
+
+  let(:created_at) { Timecop.freeze(Time.zone.now) }
+  let(:form_attributes) { auto_claim.dig('data', 'attributes') || {} }
+
+  describe '#remove_chars' do
+    let(:date_string) { form_attributes['serviceInformation']['servicePeriods'][0]['activeDutyBeginDate'] }
+
+    it 'removes the -DD when the date string has a suffix of -DD' do
+      result = test_526_validation_instance.send(:remove_chars, date_string)
+      expect(result).to eq('2008-11')
+    end
+  end
+
+  describe '#date_has_day?' do
+    let(:date_string_with_day) { form_attributes['serviceInformation']['servicePeriods'][0]['activeDutyBeginDate'] }
+    let(:date_string_without_day) { form_attributes['serviceInformation']['confinements'][1]['approximateBeginDate'] }
+
+    it 'returns TRUE when the date is formatted YYYY-MM-DD' do
+      result = test_526_validation_instance.send(:date_has_day?, date_string_with_day)
+      expect(result).to eq(true)
+    end
+
+    it 'returns FALSE when the date is formatted YYYY-MM' do
+      result = test_526_validation_instance.send(:date_has_day?, date_string_without_day)
+      expect(result).to eq(false)
+    end
+  end
+end

--- a/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
@@ -2137,6 +2137,53 @@ RSpec.describe 'Disability Claims', type: :request do
           end
         end
 
+        context 'when there are multiple service periods and one contains the confinement period' do
+          let(:service_periods) do
+            [
+              {
+                serviceBranch: 'Air Force',
+                serviceComponent: 'Active',
+                activeDutyBeginDate: '1990-11-14',
+                activeDutyEndDate: '1999-10-30',
+                separationLocationCode: '98289'
+              },
+              {
+                serviceBranch: 'Army',
+                serviceComponent: 'Active',
+                activeDutyBeginDate: '2000-12-01',
+                activeDutyEndDate: '2005-11-10',
+                separationLocationCode: '123617'
+              },
+              {
+                serviceBranch: 'Air Force',
+                activeDutyBeginDate: '1990-02-05',
+                activeDutyEndDate: '2021-12-01',
+                serviceComponent: 'Active'
+              }
+            ]
+          end
+
+          let(:confinement) do
+            [
+              {
+                approximateBeginDate: '1995-02-01',
+                approximateEndDate: '1995-03-06'
+              }
+            ]
+          end
+
+          it 'responds with a 202' do
+            mock_ccg(scopes) do |auth_header|
+              json = JSON.parse(data)
+              json['data']['attributes']['serviceInformation']['servicePeriods'] = service_periods
+              json['data']['attributes']['serviceInformation']['confinements'] = confinement
+              data = json.to_json
+              post submit_path, params: data, headers: auth_header
+              expect(response).to have_http_status(:accepted)
+            end
+          end
+        end
+
         context 'when there are confinements with mixed date formatting and begin date is <= to end date' do
           let(:confinements) do
             [
@@ -3315,13 +3362,13 @@ RSpec.describe 'Disability Claims', type: :request do
           end
 
           context 'when activationDate is not after the earliest servicePeriod.activeDutyBeginDate' do
-            let(:title_10_activation_date) { '2005-05-05' }
+            let(:title_10_activation_date) { '1994-05-05' }
             let(:service_periods) do
               [
                 {
                   serviceBranch: 'Public Health Service',
-                  activeDutyBeginDate: '1980-02-05',
-                  activeDutyEndDate: '1990-01-02',
+                  activeDutyBeginDate: '1995-02-05',
+                  activeDutyEndDate: '1999-01-02',
                   serviceComponent: 'Reserves',
                   separationLocationCode: 'ABCDEFGHIJKLMN'
                 },

--- a/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
@@ -2137,53 +2137,6 @@ RSpec.describe 'Disability Claims', type: :request do
           end
         end
 
-        context 'when there are multiple service periods and one contains the confinement period' do
-          let(:service_periods) do
-            [
-              {
-                serviceBranch: 'Air Force',
-                serviceComponent: 'Active',
-                activeDutyBeginDate: '1990-11-14',
-                activeDutyEndDate: '1999-10-30',
-                separationLocationCode: '98289'
-              },
-              {
-                serviceBranch: 'Army',
-                serviceComponent: 'Active',
-                activeDutyBeginDate: '2000-12-01',
-                activeDutyEndDate: '2005-11-10',
-                separationLocationCode: '123617'
-              },
-              {
-                serviceBranch: 'Air Force',
-                activeDutyBeginDate: '1990-02-05',
-                activeDutyEndDate: '2021-12-01',
-                serviceComponent: 'Active'
-              }
-            ]
-          end
-
-          let(:confinement) do
-            [
-              {
-                approximateBeginDate: '1995-02-01',
-                approximateEndDate: '1995-03-06'
-              }
-            ]
-          end
-
-          it 'responds with a 202' do
-            mock_ccg(scopes) do |auth_header|
-              json = JSON.parse(data)
-              json['data']['attributes']['serviceInformation']['servicePeriods'] = service_periods
-              json['data']['attributes']['serviceInformation']['confinements'] = confinement
-              data = json.to_json
-              post submit_path, params: data, headers: auth_header
-              expect(response).to have_http_status(:accepted)
-            end
-          end
-        end
-
         context 'when there are confinements with mixed date formatting and begin date is <= to end date' do
           let(:confinements) do
             [


### PR DESCRIPTION
## Summary
* The only validation that needs to occur is to make sure the earliest confinement period comes after the earliest service beginDate. We do not need to verify it actually occurs inside an existing service block.   No other validations need to happen.
* removes some extra validating that was going on win regards to confinement periods and service duty periods Changes to be committed:
* Adds a spec file to handle testing validation methods directly

## Related issue(s)
[API-32294](https://jira.devops.va.gov/browse/API-32294)

## Testing done
* RSpec
* Postman

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
	modified:   modules/claims_api/spec/requests/v2/veterans/disability_compensation_request_spec.rb
    created:  modules/claims_api/spec/lib/claims_api/v2/disability_compensation_validation_spec.rb

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
