### PR TITLE
add list of mobile endpoints to mobile root endpoint

### DIFF
--- a/modules/mobile/app/controllers/mobile/discovery_controller.rb
+++ b/modules/mobile/app/controllers/mobile/discovery_controller.rb
@@ -5,7 +5,9 @@ module Mobile
     skip_before_action :authenticate
 
     def welcome
-      render json: { data: { attributes: { message: 'Welcome to the mobile API' } } }
+      routes = Mobile::Engine.app.routes.routes
+      endpoints = routes.collect { |r| "mobile#{r.path.spec.to_s[0...-10]}" }
+      render json: { data: { attributes: { message: 'Welcome to the mobile API.', endpoints: } } }
     end
   end
 end

--- a/modules/mobile/spec/request/discovery_request_spec.rb
+++ b/modules/mobile/spec/request/discovery_request_spec.rb
@@ -11,16 +11,10 @@ RSpec.describe 'discovery', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it 'returns a welcome message' do
-      expect(response.parsed_body).to eq(
-        {
-          'data' => {
-            'attributes' => {
-              'message' => 'Welcome to the mobile API'
-            }
-          }
-        }
-      )
+    it 'returns a welcome message and list of mobile endpoints' do
+      attributes = response.parsed_body.dig('data', 'attributes')
+      expect(attributes['message']).to eq('Welcome to the mobile API.')
+      expect(attributes['endpoints']).to include('mobile/v0/appeal/:id', 'mobile/v0/appointments')
     end
   end
 end


### PR DESCRIPTION
## Summary
instead of scraping mobile docs for list of endpoints, this adds all mobile endpoints to a list in the discovery root endpoint. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-mobile-app/issues/7039

## Testing done

- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *Describe the tests completed and the results*

## Screenshots
_Note: Optional_


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
