### PR TITLE
Accept ssn in addition to va file number for metadata

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -14,9 +14,16 @@ module SimpleFormsApi
       {
         'veteranFirstName' => @data.dig('full_name', 'first'),
         'veteranLastName' => @data.dig('full_name', 'last'),
-        'fileNumber' => @data.dig('citizen_id', 'ssn')
-          || @data.dig('citizen_id', 'va_file_number')
-          || @data.dig('non_citizen_id', 'arn'),
+        'fileNumber' => @data.dig(
+          'citizen_id',
+          'ssn'
+        ) || @data.dig(
+          'citizen_id',
+          'va_file_number'
+        ) || @data.dig(
+          'non_citizen_id',
+          'arn'
+        ),
         'zipCode' => @data.dig('address', 'postal_code'),
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -14,7 +14,9 @@ module SimpleFormsApi
       {
         'veteranFirstName' => @data.dig('full_name', 'first'),
         'veteranLastName' => @data.dig('full_name', 'last'),
-        'fileNumber' => @data.dig('citizen_id', 'ssn') || @data.dig('citizen_id', 'va_file_number') || @data.dig('non_citizen_id', 'arn'),
+        'fileNumber' => @data.dig('citizen_id', 'ssn')
+          || @data.dig('citizen_id', 'va_file_number')
+          || @data.dig('non_citizen_id', 'arn'),
         'zipCode' => @data.dig('address', 'postal_code'),
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -14,7 +14,7 @@ module SimpleFormsApi
       {
         'veteranFirstName' => @data.dig('full_name', 'first'),
         'veteranLastName' => @data.dig('full_name', 'last'),
-        'fileNumber' => @data.dig('citizen_id', 'va_file_number') || @data.dig('non_citizen_id', 'arn'),
+        'fileNumber' => @data.dig('citizen_id', 'ssn') || @data.dig('citizen_id', 'va_file_number') || @data.dig('non_citizen_id', 'arn'),
         'zipCode' => @data.dig('address', 'postal_code'),
         'source' => 'VA Platform Digital Forms',
         'docType' => @data['form_number'],


### PR DESCRIPTION
## Summary

This fixes a bug where we use `vaFileNumber` for metadata but the FE actually sends back `ssn`. Now the metadata will accept both.

## Related issue(s)
NA

