### PR TITLE
Run audit_service_tags on PRs to master

### DIFF
--- a/.github/workflows/audit_service_tags.yml
+++ b/.github/workflows/audit_service_tags.yml
@@ -1,5 +1,8 @@
 name: Audit Service Tags
-on: [push]
+on:
+  pull_request:
+    branches:
+      - 'master'
 permissions:
   contents: read
   checks: write


### PR DESCRIPTION
## Summary

- Follow-up to https://github.com/department-of-veterans-affairs/vets-api/pull/14239. I noticed this action was failing on the vets-api [k8s branch](https://github.com/department-of-veterans-affairs/vets-api/commits/k8s). (k8s is a temporary branch, but is essential to our deployments at the moment. The failure isn't blocking anything, but we don't want unnecessary failures muddying the water.)
- [Example failure](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/7173372814/job/19532591406)
- This PR makes a change so that the audit_service_tags action only runs when there is a pull request to master. 
- I'm on Platform product team. 


## Related issue(s)
- https://github.com/department-of-veterans-affairs/vets-api/pull/14239
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/67031


## Testing done

- I will monitor the PRs and commits to master and k8s post-merge. 
- 🎉 it ran on this PR
